### PR TITLE
refactor(client): migrate Bootstrap button in challenge templates

### DIFF
--- a/client/src/components/landing/landing.css
+++ b/client/src/components/landing/landing.css
@@ -9,10 +9,6 @@
   white-space: pre-line;
 }
 
-.cert-btn {
-  margin-top: 40px;
-}
-
 .landing-page ul {
   list-style: none;
   padding-inline-start: 0;

--- a/client/src/templates/Challenges/classic/lower-jaw.tsx
+++ b/client/src/templates/Challenges/classic/lower-jaw.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Button } from '@freecodecamp/react-bootstrap';
 
 import { createSelector } from 'reselect';
 import { connect } from 'react-redux';
@@ -21,8 +20,6 @@ import {
   challengeMetaSelector,
   completedPercentageSelector
 } from '../redux/selectors';
-
-const lowerJawButtonStyle = 'btn-block btn';
 
 interface LowerJawPanelProps extends ShareProps {
   resetButtonText: string;
@@ -297,18 +294,17 @@ const LowerJaw = ({
   return (
     <div className='action-row-container'>
       {showSignInButton && (
-        <Button
+        <a
           data-cy='sign-in-button'
-          block={true}
           href={`${apiLocation}/signin`}
-          className='btn-cta'
+          className='btn-cta btn btn-block'
         >
           {t('learn.sign-in-save')}
-        </Button>
+        </a>
       )}
       <button
         data-playwright-test-label='lowerJaw-submit-button'
-        className={lowerJawButtonStyle}
+        className='btn-block btn'
         data-cy='submit-lowerJaw-button'
         onClick={tryToSubmitChallenge}
         {...(!challengeIsCompleted && { 'aria-hidden': true })}
@@ -318,7 +314,7 @@ const LowerJaw = ({
       </button>
       <button
         data-playwright-test-label='lowerJaw-check-button'
-        className={lowerJawButtonStyle}
+        className='btn-block btn'
         data-cy='check-lowerJaw-button'
         onClick={tryToExecuteChallenge}
         {...(challengeIsCompleted &&

--- a/client/src/templates/Challenges/codeally/show.tsx
+++ b/client/src/templates/Challenges/codeally/show.tsx
@@ -1,5 +1,4 @@
 // Package Utilities
-import { Button } from '@freecodecamp/react-bootstrap';
 import { graphql } from 'gatsby';
 import React, { Component } from 'react';
 import Helmet from 'react-helmet';
@@ -9,7 +8,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import type { Dispatch } from 'redux';
 import { createSelector } from 'reselect';
-import { Container, Col, Row, Alert } from '@freecodecamp/ui';
+import { Container, Col, Row, Alert, Button } from '@freecodecamp/ui';
 
 // Local Utilities
 import Spacer from '../../../components/helpers/spacer';
@@ -317,7 +316,7 @@ class ShowCodeAlly extends Component<ShowCodeAllyProps> {
                 <Button
                   aria-describedby='codeally-cookie-warning'
                   block={true}
-                  bsStyle='primary'
+                  variant='primary'
                   data-cy='start-codeally'
                   onClick={tryToShowCodeAlly}
                 >

--- a/client/src/templates/Challenges/components/completion-modal.tsx
+++ b/client/src/templates/Challenges/components/completion-modal.tsx
@@ -1,12 +1,13 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/restrict-template-expressions */
-import { Button, Modal } from '@freecodecamp/react-bootstrap';
+import { Modal } from '@freecodecamp/react-bootstrap';
 import { noop } from 'lodash-es';
 import React, { Component } from 'react';
 import type { TFunction } from 'i18next';
 import { withTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
+import { Button } from '@freecodecamp/ui';
 
 import Login from '../../../components/Header/components/login';
 import { executeGA } from '../../../redux/actions';
@@ -198,8 +199,8 @@ class CompletionModal extends Component<
           )}
           <Button
             block={true}
-            bsSize='large'
-            bsStyle='primary'
+            size='large'
+            variant='primary'
             disabled={isSubmitting}
             data-cy='submit-challenge'
             onClick={() => submitChallenge()}
@@ -210,9 +211,8 @@ class CompletionModal extends Component<
           {this.state.downloadURL ? (
             <Button
               block={true}
-              bsSize='lg'
-              bsStyle='primary'
-              className='btn-invert'
+              size='large'
+              variant='primary'
               download={`${dashedName}.txt`}
               href={this.state.downloadURL}
             >

--- a/client/src/templates/Challenges/components/help-modal.tsx
+++ b/client/src/templates/Challenges/components/help-modal.tsx
@@ -1,10 +1,11 @@
 import { faExclamationCircle } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { Button, Modal } from '@freecodecamp/react-bootstrap';
+import { Modal } from '@freecodecamp/react-bootstrap';
 import React from 'react';
 import { Trans, withTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
 import { bindActionCreators, Dispatch } from 'redux';
+import { Button } from '@freecodecamp/ui';
 
 import envData from '../../../../config/env.json';
 import { executeGA } from '../../../redux/actions';
@@ -93,16 +94,16 @@ function HelpModal({
         </div>
         <Button
           block={true}
-          bsSize='lg'
-          bsStyle='primary'
+          size='large'
+          variant='primary'
           onClick={createQuestion}
         >
           {t('buttons.create-post')}
         </Button>
         <Button
           block={true}
-          bsSize='lg'
-          bsStyle='primary'
+          size='large'
+          variant='primary'
           onClick={closeHelpModal}
         >
           {t('buttons.cancel')}

--- a/client/src/templates/Challenges/components/project-preview-modal.tsx
+++ b/client/src/templates/Challenges/components/project-preview-modal.tsx
@@ -1,6 +1,7 @@
-import { Button, Modal } from '@freecodecamp/react-bootstrap';
+import { Modal } from '@freecodecamp/react-bootstrap';
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
+import { Button } from '@freecodecamp/ui';
 
 import type { CompletedChallenge } from '../../../redux/prop-types';
 import {
@@ -87,8 +88,8 @@ function ProjectPreviewModal({
       <Modal.Footer>
         <Button
           block={true}
-          bsSize='lg'
-          bsStyle='primary'
+          size='large'
+          variant='primary'
           data-playwright-test-label='project-preview-modal-closeButton'
           onClick={() => {
             closeModal('projectPreview');

--- a/client/src/templates/Challenges/components/reset-modal.tsx
+++ b/client/src/templates/Challenges/components/reset-modal.tsx
@@ -1,10 +1,11 @@
 // Package Utilities
-import { Button, Modal } from '@freecodecamp/react-bootstrap';
+import { Modal } from '@freecodecamp/react-bootstrap';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
 import { bindActionCreators, Dispatch } from 'redux';
 import { createSelector } from 'reselect';
+import { Button } from '@freecodecamp/ui';
 
 // Local Utilities
 import { executeGA } from '../../../redux/actions';
@@ -74,8 +75,8 @@ function ResetModal({ reset, close, isOpen }: ResetModalProps): JSX.Element {
         <Button
           data-cy='reset-modal-confirm'
           block={true}
-          bsSize='large'
-          bsStyle='danger'
+          size='large'
+          variant='danger'
           onClick={withActions(reset, close)}
         >
           {t('buttons.reset-lesson')}

--- a/client/src/templates/Challenges/components/shortcuts-modal.tsx
+++ b/client/src/templates/Challenges/components/shortcuts-modal.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import { Button, Modal } from '@freecodecamp/react-bootstrap';
+import { Modal } from '@freecodecamp/react-bootstrap';
 import { withTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
 import { bindActionCreators, Dispatch } from 'redux';
 import { createSelector } from 'reselect';
+import { Button } from '@freecodecamp/ui';
 
 import { closeModal } from '../redux/actions';
 import { isShortcutsModalOpenSelector } from '../redux/selectors';
@@ -103,8 +104,8 @@ function ShortcutsModal({
         />
         <Button
           block={true}
-          bsSize='sm'
-          bsStyle='primary'
+          size='small'
+          variant='primary'
           onClick={closeShortcutsModal}
         >
           {t('buttons.close')}

--- a/client/src/templates/Challenges/components/tool-panel.tsx
+++ b/client/src/templates/Challenges/components/tool-panel.tsx
@@ -1,5 +1,4 @@
-import { Button } from '@freecodecamp/react-bootstrap';
-import { Dropdown, MenuItem } from '@freecodecamp/ui';
+import { Dropdown, MenuItem, Button } from '@freecodecamp/ui';
 import { faExternalLinkAlt } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import React from 'react';
@@ -77,7 +76,7 @@ function ToolPanel({
       <Button
         aria-label='Run the tests use shortcut Ctrl+enter'
         block={true}
-        bsStyle='primary'
+        variant='primary'
         onClick={handleRunTests}
       >
         {isMobile ? t('buttons.run') : t('buttons.run-test')}
@@ -85,21 +84,15 @@ function ToolPanel({
       {isSignedIn && challengeType === challengeTypes.multifileCertProject && (
         <Button
           block={true}
-          bsStyle='primary'
+          variant='primary'
           data-cy='save-code-to-database-btn'
-          className='btn-invert'
           onClick={saveChallenge}
         >
           {isMobile ? t('buttons.save') : t('buttons.save-code')}
         </Button>
       )}
       {challengeType !== challengeTypes.multifileCertProject && (
-        <Button
-          block={true}
-          bsStyle='primary'
-          className='btn-invert'
-          onClick={openResetModal}
-        >
+        <Button block={true} variant='primary' onClick={openResetModal}>
           {isMobile ? t('buttons.reset') : t('buttons.reset-lesson')}
         </Button>
       )}

--- a/client/src/templates/Challenges/exam/components/exam-results.tsx
+++ b/client/src/templates/Challenges/exam/components/exam-results.tsx
@@ -1,6 +1,7 @@
-import { Button } from '@freecodecamp/react-bootstrap';
 import React, { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Button } from '@freecodecamp/ui';
+
 import Spacer from '../../../../components/helpers/spacer';
 import { formatSecondsToTime } from '../../../../utils/format-seconds';
 import { GeneratedExamResults } from '../../../../redux/prop-types';
@@ -97,8 +98,7 @@ ${t('learn.exam.time', { t: formatSecondsToTime(examTimeInSeconds) })}
       <div className='exam-results-buttons'>
         <Button
           block={true}
-          bsStyle='primary'
-          className='btn-invert'
+          variant='primary'
           data-playwright-test-label='download-exam-results'
           download={`${dashedName}.txt`}
           href={downloadURL}
@@ -107,7 +107,7 @@ ${t('learn.exam.time', { t: formatSecondsToTime(examTimeInSeconds) })}
         </Button>
         <Button
           block={true}
-          bsStyle='primary'
+          variant='primary'
           data-cy='exit-exam'
           data-playwright-test-label='exit-exam'
           onClick={exitExam}

--- a/client/src/templates/Challenges/exam/components/exit-exam-modal.tsx
+++ b/client/src/templates/Challenges/exam/components/exit-exam-modal.tsx
@@ -1,10 +1,11 @@
 // Package Utilities
-import { Button, Modal } from '@freecodecamp/react-bootstrap';
+import { Modal } from '@freecodecamp/react-bootstrap';
 import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators, Dispatch } from 'redux';
 import { createSelector } from 'reselect';
 import { useTranslation } from 'react-i18next';
+import { Button } from '@freecodecamp/ui';
 
 // Local Utilities
 import { closeModal } from '../../redux/actions';
@@ -61,7 +62,7 @@ function ExitExamModal({
         <Button
           data-cy='exit-exam-modal-confirm'
           block={true}
-          bsStyle='danger'
+          variant='danger'
           onClick={exitExam}
         >
           {t('learn.exam.exit-yes')}
@@ -69,7 +70,7 @@ function ExitExamModal({
         <Button
           data-cy='exit-exam-modal-deny'
           block={true}
-          bsStyle='primary'
+          variant='primary'
           onClick={closeExitExamModal}
         >
           {t('learn.exam.exit-no')}

--- a/client/src/templates/Challenges/exam/components/finish-exam-modal.tsx
+++ b/client/src/templates/Challenges/exam/components/finish-exam-modal.tsx
@@ -1,10 +1,11 @@
 // Package Utilities
-import { Button, Modal } from '@freecodecamp/react-bootstrap';
+import { Modal } from '@freecodecamp/react-bootstrap';
 import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators, Dispatch } from 'redux';
 import { createSelector } from 'reselect';
 import { useTranslation } from 'react-i18next';
+import { Button } from '@freecodecamp/ui';
 
 // Local Utilities
 import { closeModal } from '../../redux/actions';
@@ -61,8 +62,8 @@ function FinishExamModal({
         <Button
           data-cy='finish-exam-modal-confirm'
           block={true}
-          bsSize='medium'
-          bsStyle='primary'
+          size='medium'
+          variant='primary'
           onClick={finishExam}
         >
           {t('learn.exam.finish-yes')}
@@ -70,8 +71,8 @@ function FinishExamModal({
         <Button
           data-cy='finish-exam-modal-deny'
           block={true}
-          bsSize='medium'
-          bsStyle='primary'
+          size='medium'
+          variant='primary'
           onClick={closeFinishExamModal}
         >
           {t('learn.exam.finish-no')}

--- a/client/src/templates/Challenges/exam/show.tsx
+++ b/client/src/templates/Challenges/exam/show.tsx
@@ -1,5 +1,4 @@
 // Package Utilities
-import { Button } from '@freecodecamp/react-bootstrap';
 import { graphql, navigate } from 'gatsby';
 
 import React, { Component, RefObject } from 'react';
@@ -10,7 +9,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import type { Dispatch } from 'redux';
 import { createSelector } from 'reselect';
-import { Container, Col, Alert, Row } from '@freecodecamp/ui';
+import { Container, Col, Alert, Row, Button } from '@freecodecamp/ui';
 import { micromark } from 'micromark';
 
 // Local Utilities
@@ -468,7 +467,7 @@ class ShowExam extends Component<ShowExamProps, ShowExamState> {
                     block={true}
                     className='exam-button'
                     disabled={currentQuestionIndex <= 0}
-                    bsStyle='primary'
+                    variant='primary'
                     data-cy='previous-exam-question-btn'
                     onClick={this.goToPreviousQuestion}
                   >
@@ -483,7 +482,7 @@ class ShowExam extends Component<ShowExamProps, ShowExamState> {
                         !userExamQuestions[currentQuestionIndex].answer.id
                       }
                       className='exam-button'
-                      bsStyle='primary'
+                      variant='primary'
                       data-cy='finish-exam-btn'
                       onClick={openFinishExamModal}
                     >
@@ -496,7 +495,7 @@ class ShowExam extends Component<ShowExamProps, ShowExamState> {
                         !userExamQuestions[currentQuestionIndex].answer.id
                       }
                       className='exam-button'
-                      bsStyle='primary'
+                      variant='primary'
                       data-cy='next-exam-question-btn'
                       onClick={this.goToNextQuestion}
                     >
@@ -511,7 +510,7 @@ class ShowExam extends Component<ShowExamProps, ShowExamState> {
                   <Button
                     block={true}
                     className='exam-button'
-                    bsStyle='primary'
+                    variant='primary'
                     data-cy='exit-exam-btn'
                     onClick={openExitExamModal}
                   >
@@ -566,10 +565,10 @@ class ShowExam extends Component<ShowExamProps, ShowExamState> {
 
                 <Button
                   block={true}
-                  bsStyle='primary'
+                  variant='primary'
                   data-cy='start-exam-btn'
                   disabled={!qualifiedForExam}
-                  onClick={this.runExam}
+                  onClick={void this.runExam}
                 >
                   {t('buttons.click-start-exam')}
                 </Button>

--- a/client/src/templates/Challenges/fill-in-the-blank/show.tsx
+++ b/client/src/templates/Challenges/fill-in-the-blank/show.tsx
@@ -1,5 +1,4 @@
 // Package Utilities
-import { Button } from '@freecodecamp/react-bootstrap';
 import { graphql } from 'gatsby';
 import React, { Component, Fragment } from 'react';
 import Helmet from 'react-helmet';
@@ -10,7 +9,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import type { Dispatch } from 'redux';
 import { createSelector } from 'reselect';
-import { Container, Col, Row } from '@freecodecamp/ui';
+import { Container, Col, Row, Button } from '@freecodecamp/ui';
 
 // Local Utilities
 import Spacer from '../../../components/helpers/spacer';
@@ -382,18 +381,13 @@ class ShowFillInTheBlank extends Component<
                 <Spacer size='medium' />
                 <Button
                   block={true}
-                  bsStyle='primary'
+                  variant='primary'
                   disabled={!allBlanksFilled}
                   onClick={() => this.handleSubmit()}
                 >
                   {t('buttons.check-answer')}
                 </Button>
-                <Button
-                  block={true}
-                  bsStyle='primary'
-                  className='btn-invert'
-                  onClick={openHelpModal}
-                >
+                <Button block={true} variant='primary' onClick={openHelpModal}>
                   {t('buttons.ask-for-help')}
                 </Button>
                 <Spacer size='large' />

--- a/client/src/templates/Challenges/ms-trophy/link-ms-user.tsx
+++ b/client/src/templates/Challenges/ms-trophy/link-ms-user.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { Button } from '@freecodecamp/react-bootstrap';
 import { ConnectedProps, connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import type { Dispatch } from 'redux';
@@ -9,7 +8,8 @@ import {
   ControlLabel,
   FormControl,
   FormGroup,
-  HelpBlock
+  HelpBlock,
+  Button
 } from '@freecodecamp/ui';
 
 import { Spacer } from '../../../components/helpers';
@@ -101,8 +101,7 @@ function LinkMsUser({
           <p>{t('learn.ms.linked', { msUsername })}</p>
           <Button
             block={true}
-            bsStyle='primary'
-            className='btn-invert'
+            variant='primary'
             disabled={isProcessing}
             onClick={unlinkMsUsername}
           >
@@ -164,8 +163,7 @@ function LinkMsUser({
             <Button
               disabled={isDisabled}
               block={true}
-              bsStyle='primary'
-              className='btn-invert'
+              variant='primary'
               onClick={handleLinkUsername}
             >
               {t('buttons.link-account')}

--- a/client/src/templates/Challenges/ms-trophy/show.tsx
+++ b/client/src/templates/Challenges/ms-trophy/show.tsx
@@ -1,4 +1,3 @@
-import { Col, Row, Button } from '@freecodecamp/react-bootstrap';
 import { graphql } from 'gatsby';
 import React, { Component } from 'react';
 import Helmet from 'react-helmet';
@@ -9,7 +8,7 @@ import { bindActionCreators } from 'redux';
 import type { Dispatch } from 'redux';
 import { createSelector } from 'reselect';
 
-import { Container } from '@freecodecamp/ui';
+import { Container, Col, Row, Button } from '@freecodecamp/ui';
 import Spacer from '../../../components/helpers/spacer';
 import LearnLayout from '../../../components/layouts/learn';
 import { ChallengeNode, ChallengeMeta } from '../../../redux/prop-types';
@@ -204,9 +203,8 @@ class MsTrophy extends Component<MsTrophyProps> {
                 <hr />
                 <Button
                   block={true}
-                  bsStyle='primary'
+                  variant='primary'
                   data-playwright-test-label='verify-trophy-button'
-                  className='btn-invert'
                   disabled={!msUsername || isProcessing}
                   onClick={this.handleSubmit}
                 >
@@ -214,9 +212,8 @@ class MsTrophy extends Component<MsTrophyProps> {
                 </Button>
                 <Button
                   block={true}
-                  bsStyle='primary'
+                  variant='primary'
                   data-playwright-test-label='ask-for-help-button'
-                  className='btn-invert'
                   onClick={openHelpModal}
                 >
                   {t('buttons.ask-for-help')}

--- a/client/src/templates/Challenges/odin/show.tsx
+++ b/client/src/templates/Challenges/odin/show.tsx
@@ -1,5 +1,4 @@
 // Package Utilities
-import { Button } from '@freecodecamp/react-bootstrap';
 import { graphql } from 'gatsby';
 import React, { Component } from 'react';
 import Helmet from 'react-helmet';
@@ -10,7 +9,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import type { Dispatch } from 'redux';
 import { createSelector } from 'reselect';
-import { Container, Col, Row } from '@freecodecamp/ui';
+import { Container, Col, Row, Button } from '@freecodecamp/ui';
 
 // Local Utilities
 import Loader from '../../../components/helpers/loader';
@@ -388,8 +387,8 @@ class ShowOdin extends Component<ShowOdinProps, ShowOdinState> {
                 <Spacer size='medium' />
                 <Button
                   block={true}
-                  bsSize='large'
-                  bsStyle='primary'
+                  size='large'
+                  variant='primary'
                   data-playwright-test-label='check-answer-button'
                   onClick={() =>
                     this.handleSubmit(
@@ -403,9 +402,8 @@ class ShowOdin extends Component<ShowOdinProps, ShowOdinState> {
                 </Button>
                 <Button
                   block={true}
-                  bsSize='large'
-                  bsStyle='primary'
-                  className='btn-invert'
+                  size='large'
+                  variant='primary'
                   data-playwright-test-label='ask-for-help-button'
                   onClick={openHelpModal}
                 >

--- a/client/src/templates/Challenges/projects/tool-panel.tsx
+++ b/client/src/templates/Challenges/projects/tool-panel.tsx
@@ -1,9 +1,9 @@
-import { Button } from '@freecodecamp/react-bootstrap';
 import React from 'react';
 import type { TFunction } from 'i18next';
 import { withTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
 import { bindActionCreators, Dispatch } from 'redux';
+import { Button } from '@freecodecamp/ui';
 
 import { openModal } from '../redux/actions';
 
@@ -31,22 +31,11 @@ function ToolPanel({
   return (
     <>
       {guideUrl && (
-        <Button
-          block={true}
-          bsStyle='primary'
-          className='btn-invert'
-          href={guideUrl}
-          target='_blank'
-        >
+        <Button block={true} variant='primary' href={guideUrl} target='_blank'>
           {t('buttons.get-hint')}
         </Button>
       )}
-      <Button
-        block={true}
-        bsStyle='primary'
-        className='btn-invert'
-        onClick={openHelpModal}
-      >
+      <Button block={true} variant='primary' onClick={openHelpModal}>
         {t('buttons.ask-for-help')}
       </Button>
     </>

--- a/client/src/templates/Challenges/video/show.tsx
+++ b/client/src/templates/Challenges/video/show.tsx
@@ -1,5 +1,4 @@
 // Package Utilities
-import { Button } from '@freecodecamp/react-bootstrap';
 import { graphql } from 'gatsby';
 import React, { Component } from 'react';
 import Helmet from 'react-helmet';
@@ -10,7 +9,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import type { Dispatch } from 'redux';
 import { createSelector } from 'reselect';
-import { Container, Col, Row } from '@freecodecamp/ui';
+import { Container, Col, Row, Button } from '@freecodecamp/ui';
 
 // Local Utilities
 import Loader from '../../../components/helpers/loader';
@@ -319,19 +318,14 @@ class ShowVideo extends Component<ShowVideoProps, ShowVideoState> {
                 <Spacer size='medium' />
                 <Button
                   block={true}
-                  bsStyle='primary'
+                  variant='primary'
                   onClick={() =>
                     this.handleSubmit(solution, openCompletionModal)
                   }
                 >
                   {t('buttons.check-answer')}
                 </Button>
-                <Button
-                  block={true}
-                  bsStyle='primary'
-                  className='btn-invert'
-                  onClick={openHelpModal}
-                >
+                <Button block={true} variant='primary' onClick={openHelpModal}>
                   {t('buttons.ask-for-help')}
                 </Button>
                 <Spacer size='large' />

--- a/client/src/templates/Introduction/components/cert-challenge.tsx
+++ b/client/src/templates/Introduction/components/cert-challenge.tsx
@@ -1,9 +1,10 @@
-import { Button } from '@freecodecamp/react-bootstrap';
 import { navigate } from 'gatsby-link';
 import React, { useState, useEffect, MouseEvent } from 'react';
 import { useTranslation, withTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
+import { Button } from '@freecodecamp/ui';
+
 import {
   certSlugTypeMap,
   superBlockCertTypeMap
@@ -127,8 +128,7 @@ const CertChallenge = ({
       {isSignedIn && (
         <Button
           block={true}
-          bsStyle='primary'
-          className='cert-btn'
+          variant='primary'
           href={isCertified ? certLocation : `/settings#certification-settings`}
           onClick={() => (isCertified ? createClickHandler(certSlug) : false)}
         >

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-basic-css-by-building-a-cafe-menu/5f3c866d28d7ad0de6470505.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-basic-css-by-building-a-cafe-menu/5f3c866d28d7ad0de6470505.md
@@ -16,19 +16,22 @@ Add the class name `flavor` to the `French Vanilla` `p` element.
 You should add the `flavor` class to your `p` element.
 
 ```js
-assert(code.match(/<p\s*class\s*=\s*('|")flavor\1\s*>/i));
+const el = document.querySelector("p.flavor");
+assert.exists(el);
 ```
 
 You should only have one element with the `flavor` class.
 
 ```js
-assert($('.flavor').length === 1);
+const elements = document.querySelectorAll('.flavor');
+assert.lengthOf(elements, 1);
 ```
 
 Your `flavor` class should be on the `p` element with the text `French Vanilla`.
 
 ```js
-assert($('.flavor')[0].innerText.match(/French Vanilla/i));
+const el = document.querySelector(".flavor");
+assert.equal(el.innerText, "French Vanilla");
 ```
 
 # --seed--

--- a/tools/ui-components/src/button/button.tsx
+++ b/tools/ui-components/src/button/button.tsx
@@ -59,6 +59,10 @@ const computeClassNames = ({
           : [
               'hover:bg-foreground-danger',
               'hover:text-background-danger',
+              // This hover rule is redundant for the component library,
+              // but is needed to override the border color set in client's `global.css`.
+              // We can remove it once we have completely removed the CSS overrides in client.
+              'hover:border-foreground-danger',
               'dark:hover:bg-background-danger',
               'dark:hover:text-foreground-danger'
             ])
@@ -74,6 +78,10 @@ const computeClassNames = ({
           : [
               'hover:bg-foreground-info',
               'hover:text-background-info',
+              // This hover rule is redundant for the component library,
+              // but is needed to override the border color set in client's `global.css`.
+              // We can remove it once we have completely removed the CSS overrides in client.
+              'hover:border-foreground-info',
               'dark:hover:bg-background-info',
               'dark:hover:text-foreground-info'
             ])
@@ -90,6 +98,10 @@ const computeClassNames = ({
           : [
               'hover:bg-foreground-primary',
               'hover:text-background-primary',
+              // This hover rule is redundant for the component library,
+              // but is needed to override the border color set in client's `global.css`.
+              // We can remove it once we have completely removed the CSS overrides in client.
+              'hover:border-foreground-secondary',
               'dark:hover:bg-background-primary',
               'dark:hover:text-foreground-primary'
             ])


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR 
- Replaces Bootstrap button with ui-components button component in challenge templates
- Is related to #52092

<!-- Feel free to add any additional description of changes below this line -->
