### PR TITLE
fix(clien): cleared alt text from .character-feature items

### DIFF
--- a/client/src/templates/Challenges/components/scene/character.tsx
+++ b/client/src/templates/Challenges/components/scene/character.tsx
@@ -101,32 +101,32 @@ export function Character({
         style={characterFeatureStyles}
         className='character-feature'
         src={base}
-        alt='Character Body'
+        alt=''
       />
       <img
         style={characterFeatureStyles}
         className='character-feature'
         src={brows}
-        alt='Character Brows'
+        alt=''
       />
       <img
         style={characterFeatureStyles}
         className='character-feature'
         src={eyesAreOpen ? eyesOpen : eyesClosed}
-        alt='Character Eyes'
+        alt=''
       />
       <img
         style={characterFeatureStyles}
         className='character-feature'
         src={mouthIsOpen ? mouthOpen : mouthClosed}
-        alt='Character Mouth'
+        alt=''
       />
       {glasses && (
         <img
           style={characterFeatureStyles}
           className='character-feature'
           src={glasses}
-          alt='Character Glasses'
+          alt=''
         />
       )}
     </div>


### PR DESCRIPTION
Alt text for the corresponding images is now empty as per discussion.

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #52554

<!-- Feel free to add any additional description of changes below this line -->
