### PR TITLE
fix: button sizes for The Odin Project

### DIFF
--- a/client/src/templates/Challenges/odin/show.tsx
+++ b/client/src/templates/Challenges/odin/show.tsx
@@ -396,7 +396,7 @@ class ShowOdin extends Component<ShowOdinProps, ShowOdinState> {
                 <Spacer size='medium' />
                 <Button
                   block={true}
-                  bsSize='large'
+                  bsSize='medium'
                   bsStyle='primary'
                   onClick={() =>
                     this.handleSubmit(
@@ -410,7 +410,7 @@ class ShowOdin extends Component<ShowOdinProps, ShowOdinState> {
                 </Button>
                 <Button
                   block={true}
-                  bsSize='large'
+                  bsSize='medium'
                   bsStyle='primary'
                   className='btn-invert'
                   onClick={openHelpModal}


### PR DESCRIPTION
FIXS: Tool panel buttons of some courses are using the wrong size #52598

Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

This Pull Request Closes #52598


