### PR TITLE
fix(client): use tabSize 4 for python

### DIFF
--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -304,7 +304,7 @@ const Editor = (props: EditorProps): JSX.Element => {
     parameterHints: {
       enabled: false
     },
-    tabSize: 2,
+    tabSize: props.challengeType !== challengeTypes.python ? 2 : 4,
     dragAndDrop: true,
     lightbulb: {
       enabled: false


### PR DESCRIPTION
Checklist:
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

- - -
- Changes default `tabSize` in editor to `4` for python challenges. That's consistent with the python convention and upcoming python challenges formatting.
