### PR TITLE
fix: reset input and destroy proxies

### DIFF
--- a/curriculum/challenges/english/20-upcoming-python/learn-python-by-building-a-blackjack-game/64a5229b99ff0e8250cd9a72.md
+++ b/curriculum/challenges/english/20-upcoming-python/learn-python-by-building-a-blackjack-game/64a5229b99ff0e8250cd9a72.md
@@ -20,6 +20,16 @@ Test 1
   } })
 ```
 
+Test 2
+
+```js
+({ input: ["Bob", "Carnes"], test: () => {
+  assert.equal( "Bob", __userGlobals.get("name"));
+  assert.equal( "Carnes", __userGlobals.get("last_name"));
+  } })
+```
+
+
 # --seed--
 
 ## --seed-contents--

--- a/tools/client-plugins/browser-scripts/python-test-evaluator.ts
+++ b/tools/client-plugins/browser-scripts/python-test-evaluator.ts
@@ -63,6 +63,11 @@ ctx.onmessage = async (e: PythonRunEvent) => {
 
   const assert = chai.assert;
   const __helpers = helpers;
+
+  // Create fresh globals for each test
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+  const __userGlobals = pyodide.globals.get('dict')() as PyProxy;
+
   /* eslint-enable @typescript-eslint/no-unused-vars */
   // uncomment the following line to inspect
   // the frame-runner as it runs tests
@@ -126,9 +131,7 @@ except (KeyError, NameError):
       input: testInput
       // print: () => {}
     });
-    // Create fresh globals for each test
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-    const __userGlobals = pyodide.globals.get('dict')() as PyProxy;
+
     // Some tests rely on __name__ being set to __main__ and we new dicts do not
     // have this set by default.
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call
@@ -174,5 +177,7 @@ except (KeyError, NameError):
         actual: (err as { actual?: string }).actual
       }
     });
+  } finally {
+    __userGlobals.destroy();
   }
 };

--- a/tools/client-plugins/browser-scripts/python-test-evaluator.ts
+++ b/tools/client-plugins/browser-scripts/python-test-evaluator.ts
@@ -109,6 +109,18 @@ ctx.onmessage = async (e: PythonRunEvent) => {
       }
     };
 
+    // Clear out the old import otherwise it will use the old input/print
+    // functions
+    pyodide.runPython(`
+import sys
+try:
+  del sys.modules['jscustom']
+  del jscustom
+except (KeyError, NameError):
+  pass
+
+`);
+
     // Make input available to python (print is not used yet)
     pyodide.registerJsModule('jscustom', {
       input: testInput

--- a/tools/client-plugins/browser-scripts/python-worker.ts
+++ b/tools/client-plugins/browser-scripts/python-worker.ts
@@ -135,8 +135,8 @@ function initRunPython() {
       return ""
   `);
   // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-  const getResetId = globals.get('__get_reset_id') as () => string;
-  return { runPython, getResetId };
+  const getResetId = globals.get('__get_reset_id') as PyProxy & (() => string);
+  return { runPython, getResetId, globals };
 }
 
 ctx.onmessage = (e: PythonRunEvent | ListenRequestEvent | CancelEvent) => {
@@ -165,7 +165,7 @@ function handleRunRequest(data: PythonRunEvent['data']) {
   // TODO: use reset-terminal for clarity?
   postMessage({ type: 'reset' });
 
-  const { runPython, getResetId } = initRunPython();
+  const { runPython, getResetId, globals } = initRunPython();
   // use pyodide.runPythonAsync if we want top-level await
   try {
     runPython(code);
@@ -184,5 +184,8 @@ function handleRunRequest(data: PythonRunEvent['data']) {
       // ...and tell the client that we're ignoring them.
       postMessage({ type: 'stopped', text: getResetId() });
     }
+  } finally {
+    getResetId.destroy();
+    globals.destroy();
   }
 }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This fixes a bug where the mock `input` could only be used once.

It also destroys the PyProxies I know are created. We will still need to fix tests if they're creating and not destroying them otherwise memory will leak.

<!-- Feel free to add any additional description of changes below this line -->
