### PR TITLE
fix: disable scientific python SB for mobile

### DIFF
--- a/tools/scripts/build/build-external-curricula-data.ts
+++ b/tools/scripts/build/build-external-curricula-data.ts
@@ -35,21 +35,21 @@ interface Block<T> {
 
 export const orderedSuperBlockInfo = [
   { dashedName: SuperBlocks.RespWebDesignNew, public: true },
-  { dashedName: SuperBlocks.SciCompPy, public: true },
   { dashedName: SuperBlocks.DataAnalysisPy, public: true },
   { dashedName: SuperBlocks.MachineLearningPy, public: true },
   { dashedName: SuperBlocks.RespWebDesign, public: true },
+  { dashedName: SuperBlocks.PythonForEverybody, public: true },
   { dashedName: SuperBlocks.JsAlgoDataStruct, public: false },
   { dashedName: SuperBlocks.FrontEndDevLibs, public: false },
   { dashedName: SuperBlocks.DataVis, public: false },
   { dashedName: SuperBlocks.BackEndDevApis, public: false },
   { dashedName: SuperBlocks.QualityAssurance, public: false },
+  { dashedName: SuperBlocks.SciCompPy, public: false },
   { dashedName: SuperBlocks.InfoSec, public: false },
   { dashedName: SuperBlocks.CodingInterviewPrep, public: false },
   { dashedName: SuperBlocks.ProjectEuler, public: false },
   { dashedName: SuperBlocks.RelationalDb, public: false },
-  { dashedName: SuperBlocks.RosettaCode, public: false },
-  { dashedName: SuperBlocks.PythonForEverybody, public: false }
+  { dashedName: SuperBlocks.RosettaCode, public: false }
 ];
 
 const dashedNames = orderedSuperBlockInfo.map(({ dashedName }) => dashedName);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->



<!-- Feel free to add any additional description of changes below this line -->

With PR #52628 in, the Scientific Python SB needs to be disabled for mobile as we don't support coding python challenges in the app yet.
