### PR TITLE
Fix : Fix RPG game step 4 tests to be more flexible with spacing

### DIFF
--- a/curriculum/challenges/arabic/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a23c1d505bfa13747c8a9b.md
+++ b/curriculum/challenges/arabic/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a23c1d505bfa13747c8a9b.md
@@ -43,14 +43,14 @@ Your first `span` element should be wrapped around the text `0`.
 const stat = document.querySelectorAll('.stat')[0];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span.innerText, '0');
+assert.match(span.innerText, /0/);
 ```
 
 The text of your first `.stat` element should still be `XP: 0`.
 
 ```js
 const stat = document.querySelectorAll('.stat')[0];
-assert.equal(stat.innerText, 'XP: 0');
+assert.match(stat.innerText, /XP: 0/);
 ```
 
 You should add a `strong` element in your second `.stat` element.
@@ -76,7 +76,7 @@ Your second nested `span` element should have the `id` of `healthText`.
 const stat = document.querySelectorAll('.stat')[1];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span?.id, 'healthText');
+assert.match(span?.id, /healthText/);
 ```
 
 Your second `span` element should be wrapped around the text `100`.
@@ -85,14 +85,14 @@ Your second `span` element should be wrapped around the text `100`.
 const stat = document.querySelectorAll('.stat')[1];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span.innerText, '100');
+assert.match(span.innerText, /100/);
 ```
 
 The text of your second `.stat` element should still be `Health: 100`.
 
 ```js
 const stat = document.querySelectorAll('.stat')[1];
-assert.equal(stat.innerText, 'Health: 100');
+assert.match(stat.innerText, /Health: 100/);
 ```
 
 You should add a `strong` element in your third `.stat` element.
@@ -118,7 +118,7 @@ Your third nested `span` element should have the `id` of `goldText`.
 const stat = document.querySelectorAll('.stat')[2];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span?.id, 'goldText');
+assert.match(span?.id, /goldText/);
 ```
 
 Your third `span` element should be wrapped around the text `50`.
@@ -127,14 +127,14 @@ Your third `span` element should be wrapped around the text `50`.
 const stat = document.querySelectorAll('.stat')[2];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span.innerText, '50');
+assert.match(span.innerText, /50/);
 ```
 
 The text of your third `.stat` element should still be `Gold: 50`.
 
 ```js
 const stat = document.querySelectorAll('.stat')[2];
-assert.equal(stat.innerText, 'Gold: 50');
+assert.match(stat.innerText, /Gold: 50/);
 ```
 
 # --seed--

--- a/curriculum/challenges/arabic/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a23c1d505bfa13747c8a9b.md
+++ b/curriculum/challenges/arabic/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a23c1d505bfa13747c8a9b.md
@@ -34,7 +34,7 @@ Your first nested `span` element should have the `id` of `xpText`.
 const stat = document.querySelectorAll('.stat')[0];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span?.id, 'xpText');
+assert.match(span?.id, /xpText/);
 ```
 
 Your first `span` element should be wrapped around the text `0`.

--- a/curriculum/challenges/chinese-traditional/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a23c1d505bfa13747c8a9b.md
+++ b/curriculum/challenges/chinese-traditional/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a23c1d505bfa13747c8a9b.md
@@ -34,7 +34,7 @@ assert.exists(span);
 const stat = document.querySelectorAll('.stat')[0];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span?.id, 'xpText');
+assert.match(span?.id, /xpText/);
 ```
 
 第一個 `span` 元素應該包裹在文本 `0` 周圍。

--- a/curriculum/challenges/chinese-traditional/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a23c1d505bfa13747c8a9b.md
+++ b/curriculum/challenges/chinese-traditional/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a23c1d505bfa13747c8a9b.md
@@ -43,14 +43,14 @@ assert.match(span?.id, /xpText/);
 const stat = document.querySelectorAll('.stat')[0];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span.innerText, '0');
+assert.match(span.innerText, /0/);
 ```
 
 第一個 `.stat` 元素的文本仍應爲 `XP: 0`。
 
 ```js
 const stat = document.querySelectorAll('.stat')[0];
-assert.equal(stat.innerText, 'XP: 0');
+assert.match(stat.innerText, /XP: 0/);
 ```
 
 應該在第二個 `.stat` 元素中添加一個 `strong` 元素。
@@ -76,7 +76,7 @@ assert.exists(span);
 const stat = document.querySelectorAll('.stat')[1];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span?.id, 'healthText');
+assert.match(span?.id, /healthText/);
 ```
 
 第二個 `span` 元素應包裹在文本 `100` 周圍。
@@ -85,14 +85,14 @@ assert.equal(span?.id, 'healthText');
 const stat = document.querySelectorAll('.stat')[1];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span.innerText, '100');
+assert.match(span.innerText, /100/);
 ```
 
 第二個 `.stat` 元素的文本仍應爲 `Health: 100`。
 
 ```js
 const stat = document.querySelectorAll('.stat')[1];
-assert.equal(stat.innerText, 'Health: 100');
+assert.match(stat.innerText, /Health: 100/);
 ```
 
 應該在第三個 `.stat` 元素中添加一個 `strong` 元素。
@@ -118,7 +118,7 @@ assert.exists(span);
 const stat = document.querySelectorAll('.stat')[2];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span?.id, 'goldText');
+assert.match(span?.id, /goldText/);
 ```
 
 第三個 `span` 元素應包裹在文本 `50` 周圍。
@@ -127,14 +127,14 @@ assert.equal(span?.id, 'goldText');
 const stat = document.querySelectorAll('.stat')[2];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span.innerText, '50');
+assert.match(span.innerText, /50/);
 ```
 
 第三個 `.stat` 元素的文本仍應爲 `Gold: 50`。
 
 ```js
 const stat = document.querySelectorAll('.stat')[2];
-assert.equal(stat.innerText, 'Gold: 50');
+assert.match(stat.innerText, /Gold: 50/);
 ```
 
 # --seed--

--- a/curriculum/challenges/chinese/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a23c1d505bfa13747c8a9b.md
+++ b/curriculum/challenges/chinese/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a23c1d505bfa13747c8a9b.md
@@ -43,14 +43,14 @@ assert.match(span?.id, /xpText/);
 const stat = document.querySelectorAll('.stat')[0];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span.innerText, '0');
+assert.match(span.innerText, /0/);
 ```
 
 第一个 `.stat` 元素的文本仍应为 `XP: 0`。
 
 ```js
 const stat = document.querySelectorAll('.stat')[0];
-assert.equal(stat.innerText, 'XP: 0');
+assert.match(stat.innerText, /XP: 0/);
 ```
 
 应该在第二个 `.stat` 元素中添加一个 `strong` 元素。
@@ -76,7 +76,7 @@ assert.exists(span);
 const stat = document.querySelectorAll('.stat')[1];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span?.id, 'healthText');
+assert.match(span?.id, /healthText/);
 ```
 
 第二个 `span` 元素应包裹在文本 `100` 周围。
@@ -85,14 +85,14 @@ assert.equal(span?.id, 'healthText');
 const stat = document.querySelectorAll('.stat')[1];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span.innerText, '100');
+assert.match(span.innerText, 100/);
 ```
 
 第二个 `.stat` 元素的文本仍应为 `Health: 100`。
 
 ```js
 const stat = document.querySelectorAll('.stat')[1];
-assert.equal(stat.innerText, 'Health: 100');
+assert.match(stat.innerText, /Health: 100/);
 ```
 
 应该在第三个 `.stat` 元素中添加一个 `strong` 元素。
@@ -118,7 +118,7 @@ assert.exists(span);
 const stat = document.querySelectorAll('.stat')[2];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span?.id, 'goldText');
+assert.match(span?.id, /goldText/);
 ```
 
 第三个 `span` 元素应包裹在文本 `50` 周围。
@@ -127,14 +127,14 @@ assert.equal(span?.id, 'goldText');
 const stat = document.querySelectorAll('.stat')[2];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span.innerText, '50');
+assert.match(span.innerText, /50/);
 ```
 
 第三个 `.stat` 元素的文本仍应为 `Gold: 50`。
 
 ```js
 const stat = document.querySelectorAll('.stat')[2];
-assert.equal(stat.innerText, 'Gold: 50');
+assert.match(stat.innerText, /Gold: 50/);
 ```
 
 # --seed--

--- a/curriculum/challenges/chinese/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a23c1d505bfa13747c8a9b.md
+++ b/curriculum/challenges/chinese/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a23c1d505bfa13747c8a9b.md
@@ -34,7 +34,7 @@ assert.exists(span);
 const stat = document.querySelectorAll('.stat')[0];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span?.id, 'xpText');
+assert.match(span?.id, /xpText/);
 ```
 
 第一个 `span` 元素应该包裹在文本 `0` 周围。

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a23c1d505bfa13747c8a9b.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a23c1d505bfa13747c8a9b.md
@@ -43,14 +43,14 @@ Your first `span` element should be wrapped around the text `0`.
 const stat = document.querySelectorAll('.stat')[0];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span.innerText, '0');
+assert.match(span.innerText, /0/);
 ```
 
 The text of your first `.stat` element should still be `XP: 0`.
 
 ```js
 const stat = document.querySelectorAll('.stat')[0];
-assert.equal(stat.innerText, 'XP: 0');
+assert.match(stat.innerText, /XP: 0/);
 ```
 
 You should add a `strong` element in your second `.stat` element.
@@ -76,7 +76,7 @@ Your second nested `span` element should have the `id` of `healthText`.
 const stat = document.querySelectorAll('.stat')[1];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span?.id, 'healthText');
+assert.match(span?.id, /healthText/);
 ```
 
 Your second `span` element should be wrapped around the text `100`.
@@ -85,14 +85,14 @@ Your second `span` element should be wrapped around the text `100`.
 const stat = document.querySelectorAll('.stat')[1];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span.innerText, '100');
+assert.match(span.innerText, /100/);
 ```
 
 The text of your second `.stat` element should still be `Health: 100`.
 
 ```js
 const stat = document.querySelectorAll('.stat')[1];
-assert.equal(stat.innerText, 'Health: 100');
+assert.match(stat.innerText, /Health: 100/);
 ```
 
 You should add a `strong` element in your third `.stat` element.
@@ -118,7 +118,7 @@ Your third nested `span` element should have the `id` of `goldText`.
 const stat = document.querySelectorAll('.stat')[2];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span?.id, 'goldText');
+assert.match(span?.id, /goldText/);
 ```
 
 Your third `span` element should be wrapped around the text `50`.
@@ -127,14 +127,14 @@ Your third `span` element should be wrapped around the text `50`.
 const stat = document.querySelectorAll('.stat')[2];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span.innerText, '50');
+assert.match(span.innerText, /50/);
 ```
 
 The text of your third `.stat` element should still be `Gold: 50`.
 
 ```js
 const stat = document.querySelectorAll('.stat')[2];
-assert.equal(stat.innerText, 'Gold: 50');
+assert.match(stat.innerText, /Gold: 50/);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a23c1d505bfa13747c8a9b.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a23c1d505bfa13747c8a9b.md
@@ -34,7 +34,7 @@ Your first nested `span` element should have the `id` of `xpText`.
 const stat = document.querySelectorAll('.stat')[0];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span?.id, 'xpText');
+assert.match(span?.id, /xpText/);
 ```
 
 Your first `span` element should be wrapped around the text `0`.

--- a/curriculum/challenges/espanol/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a23c1d505bfa13747c8a9b.md
+++ b/curriculum/challenges/espanol/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a23c1d505bfa13747c8a9b.md
@@ -43,14 +43,14 @@ Your first `span` element should be wrapped around the text `0`.
 const stat = document.querySelectorAll('.stat')[0];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span.innerText, '0');
+assert.match(span.innerText, /0/);
 ```
 
 The text of your first `.stat` element should still be `XP: 0`.
 
 ```js
 const stat = document.querySelectorAll('.stat')[0];
-assert.equal(stat.innerText, 'XP: 0');
+assert.match(stat.innerText, /XP: 0/);
 ```
 
 You should add a `strong` element in your second `.stat` element.
@@ -76,7 +76,7 @@ Your second nested `span` element should have the `id` of `healthText`.
 const stat = document.querySelectorAll('.stat')[1];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span?.id, 'healthText');
+assert.match(span?.id, /healthText/);
 ```
 
 Your second `span` element should be wrapped around the text `100`.
@@ -85,14 +85,14 @@ Your second `span` element should be wrapped around the text `100`.
 const stat = document.querySelectorAll('.stat')[1];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span.innerText, '100');
+assert.match(span.innerText, /100/);
 ```
 
 The text of your second `.stat` element should still be `Health: 100`.
 
 ```js
 const stat = document.querySelectorAll('.stat')[1];
-assert.equal(stat.innerText, 'Health: 100');
+assert.match(stat.innerText, /Health: 100/);
 ```
 
 You should add a `strong` element in your third `.stat` element.
@@ -118,7 +118,7 @@ Your third nested `span` element should have the `id` of `goldText`.
 const stat = document.querySelectorAll('.stat')[2];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span?.id, 'goldText');
+assert.match(span?.id, /goldText/);
 ```
 
 Your third `span` element should be wrapped around the text `50`.
@@ -127,14 +127,14 @@ Your third `span` element should be wrapped around the text `50`.
 const stat = document.querySelectorAll('.stat')[2];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span.innerText, '50');
+assert.match(span.innerText, /50/);
 ```
 
 The text of your third `.stat` element should still be `Gold: 50`.
 
 ```js
 const stat = document.querySelectorAll('.stat')[2];
-assert.equal(stat.innerText, 'Gold: 50');
+assert.match(stat.innerText, /Gold: 50/);
 ```
 
 # --seed--

--- a/curriculum/challenges/espanol/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a23c1d505bfa13747c8a9b.md
+++ b/curriculum/challenges/espanol/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a23c1d505bfa13747c8a9b.md
@@ -34,7 +34,7 @@ Your first nested `span` element should have the `id` of `xpText`.
 const stat = document.querySelectorAll('.stat')[0];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span?.id, 'xpText');
+assert.match(span?.id, /xpText/);
 ```
 
 Your first `span` element should be wrapped around the text `0`.

--- a/curriculum/challenges/german/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a23c1d505bfa13747c8a9b.md
+++ b/curriculum/challenges/german/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a23c1d505bfa13747c8a9b.md
@@ -34,7 +34,7 @@ Dein erstes eingebettetes `span`-Element sollte die `id` von `xpText` haben.
 const stat = document.querySelectorAll('.stat')[0];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span?.id, 'xpText');
+assert.match(span?.id, /xpText/);
 ```
 
 Your first `span` element should be wrapped around the text `0`.

--- a/curriculum/challenges/german/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a23c1d505bfa13747c8a9b.md
+++ b/curriculum/challenges/german/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a23c1d505bfa13747c8a9b.md
@@ -43,14 +43,14 @@ Your first `span` element should be wrapped around the text `0`.
 const stat = document.querySelectorAll('.stat')[0];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span.innerText, '0');
+assert.match(span.innerText, /0/);
 ```
 
 The text of your first `.stat` element should still be `XP: 0`.
 
 ```js
 const stat = document.querySelectorAll('.stat')[0];
-assert.equal(stat.innerText, 'XP: 0');
+assert.match(stat.innerText, /XP: 0/);
 ```
 
 Du solltest ein `strong`-Element in deinem zweiten `.stat`-Element hinzufügen.
@@ -76,7 +76,7 @@ Your second nested `span` element should have the `id` of `healthText`.
 const stat = document.querySelectorAll('.stat')[1];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span?.id, 'healthText');
+assert.match(span?.id, /healthText/);
 ```
 
 Your second `span` element should be wrapped around the text `100`.
@@ -85,14 +85,14 @@ Your second `span` element should be wrapped around the text `100`.
 const stat = document.querySelectorAll('.stat')[1];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span.innerText, '100');
+assert.match(span.innerText, /100/);
 ```
 
 The text of your second `.stat` element should still be `Health: 100`.
 
 ```js
 const stat = document.querySelectorAll('.stat')[1];
-assert.equal(stat.innerText, 'Health: 100');
+assert.match(stat.innerText, /Health: 100/);
 ```
 
 You should add a `strong` element in your third `.stat` element.
@@ -118,7 +118,7 @@ Your third nested `span` element should have the `id` of `goldText`.
 const stat = document.querySelectorAll('.stat')[2];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span?.id, 'goldText');
+assert.match(span?.id, /goldText/);
 ```
 
 Your third `span` element should be wrapped around the text `50`.
@@ -127,14 +127,14 @@ Your third `span` element should be wrapped around the text `50`.
 const stat = document.querySelectorAll('.stat')[2];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span.innerText, '50');
+assert.match(span.innerText, /50/);
 ```
 
 The text of your third `.stat` element should still be `Gold: 50`.
 
 ```js
 const stat = document.querySelectorAll('.stat')[2];
-assert.equal(stat.innerText, 'Gold: 50');
+assert.match(stat.innerText, /Gold: 50/);
 ```
 
 # --seed--

--- a/curriculum/challenges/italian/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a23c1d505bfa13747c8a9b.md
+++ b/curriculum/challenges/italian/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a23c1d505bfa13747c8a9b.md
@@ -43,14 +43,14 @@ Il primo elemento `span` dovrebbe circondare il testo `0`.
 const stat = document.querySelectorAll('.stat')[0];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span.innerText, '0');
+assert.match(span.innerText, /0/);
 ```
 
 Il testo del primo elemento `.stat` dovrebbe essere ancora `XP: 0`.
 
 ```js
 const stat = document.querySelectorAll('.stat')[0];
-assert.equal(stat.innerText, 'XP: 0');
+assert.match(stat.innerText, /XP: 0/);
 ```
 
 Dovresti aggiungere un elemento `strong` nel secondo elemento `.stat`.
@@ -76,7 +76,7 @@ Il secondo elemento `span` annidato dovrebbe avere un `id` con il valore `health
 const stat = document.querySelectorAll('.stat')[1];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span?.id, 'healthText');
+assert.match(span?.id, /healthText/);
 ```
 
 Il secondo elemento `span` dovrebbe circondare il testo `100`.
@@ -85,14 +85,14 @@ Il secondo elemento `span` dovrebbe circondare il testo `100`.
 const stat = document.querySelectorAll('.stat')[1];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span.innerText, '100');
+assert.match(span.innerText, /100/);
 ```
 
 Il testo del secondo elemento `.stat` dovrebbe essere ancora `Health: 100`.
 
 ```js
 const stat = document.querySelectorAll('.stat')[1];
-assert.equal(stat.innerText, 'Health: 100');
+assert.match(stat.innerText, /Health: 100/);
 ```
 
 Dovresti aggiungere un elemento `strong` nel terzo elemento `.stat`.
@@ -118,7 +118,7 @@ Il terzo elemento `span` annidato dovrebbe avere un `id` con il valore `goldText
 const stat = document.querySelectorAll('.stat')[2];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span?.id, 'goldText');
+assert.match(span?.id, /goldText/);
 ```
 
 Il terzo elemento `span` dovrebbe circondare il testo `50`.
@@ -127,14 +127,14 @@ Il terzo elemento `span` dovrebbe circondare il testo `50`.
 const stat = document.querySelectorAll('.stat')[2];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span.innerText, '50');
+assert.match(span.innerText, /50/);
 ```
 
 Il testo del terzo elemento `.stat` dovrebbe essere ancora `Gold: 50`.
 
 ```js
 const stat = document.querySelectorAll('.stat')[2];
-assert.equal(stat.innerText, 'Gold: 50');
+assert.match(stat.innerText, /Gold: 50/);
 ```
 
 # --seed--

--- a/curriculum/challenges/italian/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a23c1d505bfa13747c8a9b.md
+++ b/curriculum/challenges/italian/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a23c1d505bfa13747c8a9b.md
@@ -34,7 +34,7 @@ Il primo elemento `span` annidato dovrebbe avere un `id` con il valore `xpText`.
 const stat = document.querySelectorAll('.stat')[0];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span?.id, 'xpText');
+assert.match(span?.id, /xpText/);
 ```
 
 Il primo elemento `span` dovrebbe circondare il testo `0`.

--- a/curriculum/challenges/japanese/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a23c1d505bfa13747c8a9b.md
+++ b/curriculum/challenges/japanese/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a23c1d505bfa13747c8a9b.md
@@ -43,14 +43,14 @@ Your first `span` element should be wrapped around the text `0`.
 const stat = document.querySelectorAll('.stat')[0];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span.innerText, '0');
+assert.match(span.innerText, /0/);
 ```
 
 The text of your first `.stat` element should still be `XP: 0`.
 
 ```js
 const stat = document.querySelectorAll('.stat')[0];
-assert.equal(stat.innerText, 'XP: 0');
+assert.match(stat.innerText, /XP: 0/);
 ```
 
 You should add a `strong` element in your second `.stat` element.
@@ -76,7 +76,7 @@ Your second nested `span` element should have the `id` of `healthText`.
 const stat = document.querySelectorAll('.stat')[1];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span?.id, 'healthText');
+assert.match(span?.id, /healthText/);
 ```
 
 Your second `span` element should be wrapped around the text `100`.
@@ -85,14 +85,14 @@ Your second `span` element should be wrapped around the text `100`.
 const stat = document.querySelectorAll('.stat')[1];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span.innerText, '100');
+assert.match(span.innerText, /100/);
 ```
 
 The text of your second `.stat` element should still be `Health: 100`.
 
 ```js
 const stat = document.querySelectorAll('.stat')[1];
-assert.equal(stat.innerText, 'Health: 100');
+assert.match(stat.innerText, /Health: 100/);
 ```
 
 You should add a `strong` element in your third `.stat` element.
@@ -118,7 +118,7 @@ Your third nested `span` element should have the `id` of `goldText`.
 const stat = document.querySelectorAll('.stat')[2];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span?.id, 'goldText');
+assert.match(span?.id, /goldText/);
 ```
 
 Your third `span` element should be wrapped around the text `50`.
@@ -127,14 +127,14 @@ Your third `span` element should be wrapped around the text `50`.
 const stat = document.querySelectorAll('.stat')[2];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span.innerText, '50');
+assert.match(span.innerText, /50/);
 ```
 
 The text of your third `.stat` element should still be `Gold: 50`.
 
 ```js
 const stat = document.querySelectorAll('.stat')[2];
-assert.equal(stat.innerText, 'Gold: 50');
+assert.match(stat.innerText, /Gold: 50/);
 ```
 
 # --seed--

--- a/curriculum/challenges/japanese/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a23c1d505bfa13747c8a9b.md
+++ b/curriculum/challenges/japanese/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a23c1d505bfa13747c8a9b.md
@@ -34,7 +34,7 @@ Your first nested `span` element should have the `id` of `xpText`.
 const stat = document.querySelectorAll('.stat')[0];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span?.id, 'xpText');
+assert.match(span?.id, /xpText/);
 ```
 
 Your first `span` element should be wrapped around the text `0`.

--- a/curriculum/challenges/portuguese/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a23c1d505bfa13747c8a9b.md
+++ b/curriculum/challenges/portuguese/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a23c1d505bfa13747c8a9b.md
@@ -43,14 +43,14 @@ O primeiro elemento `span` deve encapsular o texto `0`.
 const stat = document.querySelectorAll('.stat')[0];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span.innerText, '0');
+assert.match(span.innerText, /0/);
 ```
 
 O texto do primeiro elemento `.stat` ainda deve ser `XP: 0`.
 
 ```js
 const stat = document.querySelectorAll('.stat')[0];
-assert.equal(stat.innerText, 'XP: 0');
+assert.match(stat.innerText, /XP: 0/);
 ```
 
 Você deve adicionar um elemento `strong` dentro do segundo elemento `.stat`.
@@ -76,7 +76,7 @@ O segundo elemento `span` aninhado deve ter o `id` de `healthText`.
 const stat = document.querySelectorAll('.stat')[1];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span?.id, 'healthText');
+assert.match(span?.id, /healthText/);
 ```
 
 O segundo elemento `span` deve encapsular o texto `100`.
@@ -85,14 +85,14 @@ O segundo elemento `span` deve encapsular o texto `100`.
 const stat = document.querySelectorAll('.stat')[1];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span.innerText, '100');
+assert.match(span.innerText, /100/);
 ```
 
 O texto do segundo elemento `.stat` ainda deve ser `Health: 100`.
 
 ```js
 const stat = document.querySelectorAll('.stat')[1];
-assert.equal(stat.innerText, 'Health: 100');
+assert.match(stat.innerText, /Health: 100/);
 ```
 
 Você deve adicionar um elemento `strong` dentro do terceiro elemento `.stat`.
@@ -118,7 +118,7 @@ O terceiro elemento `span` aninhado deve ter o `id` de `goldText`.
 const stat = document.querySelectorAll('.stat')[2];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span?.id, 'goldText');
+assert.match(span?.id, /goldText/);
 ```
 
 O terceiro elemento `span` deve encapsular o texto `50`.
@@ -127,14 +127,14 @@ O terceiro elemento `span` deve encapsular o texto `50`.
 const stat = document.querySelectorAll('.stat')[2];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span.innerText, '50');
+assert.match(span.innerText, /50/);
 ```
 
 O texto do terceiro elemento `.stat` ainda deve ser `Gold: 50`.
 
 ```js
 const stat = document.querySelectorAll('.stat')[2];
-assert.equal(stat.innerText, 'Gold: 50');
+assert.match(stat.innerText, /Gold: 50/);
 ```
 
 # --seed--

--- a/curriculum/challenges/portuguese/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a23c1d505bfa13747c8a9b.md
+++ b/curriculum/challenges/portuguese/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a23c1d505bfa13747c8a9b.md
@@ -34,7 +34,7 @@ O primeiro elemento `span` aninhado deve ter o `id` of `xpText`.
 const stat = document.querySelectorAll('.stat')[0];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span?.id, 'xpText');
+assert.match(span?.id, /xpText/);
 ```
 
 O primeiro elemento `span` deve encapsular o texto `0`.

--- a/curriculum/challenges/swahili/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a23c1d505bfa13747c8a9b.md
+++ b/curriculum/challenges/swahili/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a23c1d505bfa13747c8a9b.md
@@ -43,14 +43,14 @@ Your first `span` element should be wrapped around the text `0`.
 const stat = document.querySelectorAll('.stat')[0];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span.innerText, '0');
+assert.match(span.innerText, /0/);
 ```
 
 The text of your first `.stat` element should still be `XP: 0`.
 
 ```js
 const stat = document.querySelectorAll('.stat')[0];
-assert.equal(stat.innerText, 'XP: 0');
+assert.match(stat.innerText, /XP: 0/);
 ```
 
 You should add a `strong` element in your second `.stat` element.
@@ -76,7 +76,7 @@ Your second nested `span` element should have the `id` of `healthText`.
 const stat = document.querySelectorAll('.stat')[1];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span?.id, 'healthText');
+assert.match(span?.id, /healthText/);
 ```
 
 Your second `span` element should be wrapped around the text `100`.
@@ -85,14 +85,14 @@ Your second `span` element should be wrapped around the text `100`.
 const stat = document.querySelectorAll('.stat')[1];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span.innerText, '100');
+assert.match(span.innerText, /100/);
 ```
 
 The text of your second `.stat` element should still be `Health: 100`.
 
 ```js
 const stat = document.querySelectorAll('.stat')[1];
-assert.equal(stat.innerText, 'Health: 100');
+assert.match(stat.innerText, /Health: 100/);
 ```
 
 You should add a `strong` element in your third `.stat` element.
@@ -118,7 +118,7 @@ Your third nested `span` element should have the `id` of `goldText`.
 const stat = document.querySelectorAll('.stat')[2];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span?.id, 'goldText');
+assert.match(span?.id, /goldText/);
 ```
 
 Your third `span` element should be wrapped around the text `50`.
@@ -127,14 +127,14 @@ Your third `span` element should be wrapped around the text `50`.
 const stat = document.querySelectorAll('.stat')[2];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span.innerText, '50');
+assert.match(span.innerText, /50/);
 ```
 
 The text of your third `.stat` element should still be `Gold: 50`.
 
 ```js
 const stat = document.querySelectorAll('.stat')[2];
-assert.equal(stat.innerText, 'Gold: 50');
+assert.match(stat.innerText, /Gold: 50/);
 ```
 
 # --seed--

--- a/curriculum/challenges/swahili/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a23c1d505bfa13747c8a9b.md
+++ b/curriculum/challenges/swahili/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a23c1d505bfa13747c8a9b.md
@@ -34,7 +34,7 @@ Your first nested `span` element should have the `id` of `xpText`.
 const stat = document.querySelectorAll('.stat')[0];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span?.id, 'xpText');
+assert.match(span?.id, /xpText/);
 ```
 
 Your first `span` element should be wrapped around the text `0`.

--- a/curriculum/challenges/ukrainian/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a23c1d505bfa13747c8a9b.md
+++ b/curriculum/challenges/ukrainian/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a23c1d505bfa13747c8a9b.md
@@ -34,7 +34,7 @@ assert.exists(span);
 const stat = document.querySelectorAll('.stat')[0];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span?.id, 'xpText');
+assert.match(span?.id, /xpText/);
 ```
 
 Ваш перший елемент `span` повинен бути обгорнутий навколо тексту `0`.

--- a/curriculum/challenges/ukrainian/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a23c1d505bfa13747c8a9b.md
+++ b/curriculum/challenges/ukrainian/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a23c1d505bfa13747c8a9b.md
@@ -43,14 +43,14 @@ assert.match(span?.id, /xpText/);
 const stat = document.querySelectorAll('.stat')[0];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span.innerText, '0');
+assert.match(span.innerText, /0/);
 ```
 
 Текстом вашого першого елемента `.stat` досі повинен бути `XP: 0`.
 
 ```js
 const stat = document.querySelectorAll('.stat')[0];
-assert.equal(stat.innerText, 'XP: 0');
+assert.match(stat.innerText, /XP: 0/);
 ```
 
 Ви повинні додати елемент `strong` до другого елемента `.stat`.
@@ -76,7 +76,7 @@ assert.exists(span);
 const stat = document.querySelectorAll('.stat')[1];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span?.id, 'healthText');
+assert.match(span?.id, /healthText/);
 ```
 
 Ваш другий елемент `span` повинен бути обгорнутий навколо тексту `100`.
@@ -85,14 +85,14 @@ assert.equal(span?.id, 'healthText');
 const stat = document.querySelectorAll('.stat')[1];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span.innerText, '100');
+assert.match(span.innerText, /100/);
 ```
 
 Текстом вашого другого елемента `.stat` досі повинен бути `Health: 100`.
 
 ```js
 const stat = document.querySelectorAll('.stat')[1];
-assert.equal(stat.innerText, 'Health: 100');
+assert.match(stat.innerText, /Health: 100/);
 ```
 
 Ви повинні додати елемент `strong` до третього елемента `.stat`.
@@ -118,7 +118,7 @@ assert.exists(span);
 const stat = document.querySelectorAll('.stat')[2];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span?.id, 'goldText');
+assert.match(span?.id, /goldText/);
 ```
 
 Ваш третій елемент `span` повинен бути обгорнутий навколо тексту `50`.
@@ -127,14 +127,14 @@ assert.equal(span?.id, 'goldText');
 const stat = document.querySelectorAll('.stat')[2];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span.innerText, '50');
+assert.match(span.innerText, /50/);
 ```
 
 Текстом вашого третього елемента `.stat` досі повинен бути `Gold: 50`.
 
 ```js
 const stat = document.querySelectorAll('.stat')[2];
-assert.equal(stat.innerText, 'Gold: 50');
+assert.match(stat.innerText, /Gold: 50/);
 ```
 
 # --seed--


### PR DESCRIPTION
As suggested I used `assert.match`  in place of `assert.equal`to compare and tested it on Gitpod.
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Closes  #52666

I am attaching a screenshot of my test on Gitpod.