### PR TITLE
Fix : RPG game step 4 tests to be more flexible with spacing

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a23c1d505bfa13747c8a9b.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a23c1d505bfa13747c8a9b.md
@@ -34,7 +34,7 @@ Your first nested `span` element should have the `id` of `xpText`.
 const stat = document.querySelectorAll('.stat')[0];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span?.id, 'xpText');
+assert.match(span?.id, /xpText/);
 ```
 
 Your first `span` element should be wrapped around the text `0`.
@@ -43,14 +43,14 @@ Your first `span` element should be wrapped around the text `0`.
 const stat = document.querySelectorAll('.stat')[0];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span.innerText, '0');
+assert.match(span.innerText, /0/);
 ```
 
 The text of your first `.stat` element should still be `XP: 0`.
 
 ```js
 const stat = document.querySelectorAll('.stat')[0];
-assert.equal(stat.innerText, 'XP: 0');
+assert.match(stat.innerText, /XP: 0/);
 ```
 
 You should add a `strong` element in your second `.stat` element.
@@ -76,7 +76,7 @@ Your second nested `span` element should have the `id` of `healthText`.
 const stat = document.querySelectorAll('.stat')[1];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span?.id, 'healthText');
+assert.match(span?.id, /healthText/);
 ```
 
 Your second `span` element should be wrapped around the text `100`.
@@ -85,14 +85,14 @@ Your second `span` element should be wrapped around the text `100`.
 const stat = document.querySelectorAll('.stat')[1];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span.innerText, '100');
+assert.match(span.innerText, /100/);
 ```
 
 The text of your second `.stat` element should still be `Health: 100`.
 
 ```js
 const stat = document.querySelectorAll('.stat')[1];
-assert.equal(stat.innerText, 'Health: 100');
+assert.match(stat.innerText, /Health: 100/);
 ```
 
 You should add a `strong` element in your third `.stat` element.
@@ -118,7 +118,7 @@ Your third nested `span` element should have the `id` of `goldText`.
 const stat = document.querySelectorAll('.stat')[2];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span?.id, 'goldText');
+assert.match(span?.id, /goldText/);
 ```
 
 Your third `span` element should be wrapped around the text `50`.
@@ -127,14 +127,14 @@ Your third `span` element should be wrapped around the text `50`.
 const stat = document.querySelectorAll('.stat')[2];
 const strong = stat?.querySelector('strong');
 const span = strong?.querySelector('span');
-assert.equal(span.innerText, '50');
+assert.match(span.innerText, /50/);
 ```
 
 The text of your third `.stat` element should still be `Gold: 50`.
 
 ```js
 const stat = document.querySelectorAll('.stat')[2];
-assert.equal(stat.innerText, 'Gold: 50');
+assert.match(stat.innerText, /Gold: 50/);
 ```
 
 # --seed--


### PR DESCRIPTION
As suggested I used `assert.match` in place of `assert.equal` to compare and tested it on Gitpod.

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.


Closes #52666

![Screenshot1](https://github.com/freeCodeCamp/freeCodeCamp/assets/32094231/06221e75-3a09-4891-a857-cc151d13d845)

