### PR TITLE
fix(UI): changed order of exit modal buttons

### DIFF
--- a/client/src/templates/Challenges/exam/components/exit-exam-modal.tsx
+++ b/client/src/templates/Challenges/exam/components/exit-exam-modal.tsx
@@ -59,20 +59,20 @@ function ExitExamModal({
       </Modal.Body>
       <Modal.Footer className='reset-modal-footer'>
         <Button
-          data-cy='exit-exam-modal-confirm'
-          block={true}
-          bsStyle='danger'
-          onClick={exitExam}
-        >
-          {t('learn.exam.exit-yes')}
-        </Button>
-        <Button
           data-cy='exit-exam-modal-deny'
           block={true}
           bsStyle='primary'
           onClick={closeExitExamModal}
         >
           {t('learn.exam.exit-no')}
+        </Button>
+        <Button
+          data-cy='exit-exam-modal-confirm'
+          block={true}
+          bsStyle='danger'
+          onClick={exitExam}
+        >
+          {t('learn.exam.exit-yes')}
         </Button>
       </Modal.Footer>
     </Modal>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #52615

<!-- Feel free to add any additional description of changes below this line -->

exit-exam model buttons filpped
![Screenshot from 2023-12-22 11-38-29](https://github.com/freeCodeCamp/freeCodeCamp/assets/72297945/29363ab0-3257-448c-a11c-ab4b3c31d96f)

