### PR TITLE
fix(curriculum): test for step 12, div must be empty

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-form-validation-by-building-a-calorie-counter/63b60ca38c897f2721b27959.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-form-validation-by-building-a-calorie-counter/63b60ca38c897f2721b27959.md
@@ -33,7 +33,7 @@ assert.include(document.querySelector('.container > div')?.className.split(/\s+/
 Your new `div` should be empty.
 
 ```js
-assert.equal(document.querySelector('.container > div')?.innerHTML, '');
+assert.equal(document.querySelector('.container > div')?.innerHTML.trim(), '');
 ```
 
 # --seed--


### PR DESCRIPTION
Resolved Step 12 of calorie counter failing to treat white space as blank by trimming the innerHTML string before evaluating match.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #52698

<!-- Feel free to add any additional description of changes below this line -->
Ran through the first bug I could find to get a feel for the project. Would appreciate being pointed towards any more significant issues that would be good for an experienced developer to help out with the larger project without demanding too much immediate familiarity with the code base. I feel many of these are intended to help more junior/aspiring developers get some decent starter experience?