### PR TITLE
fix(curriculum): remove all lookbehinds

### DIFF
--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-algorithm-design-by-building-a-shortest-path-algorithm/65797670e0c0d016f17e7660.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-algorithm-design-by-building-a-shortest-path-algorithm/65797670e0c0d016f17e7660.md
@@ -14,7 +14,7 @@ Now, at the bottom of your code, print `copper`.
 You should print `copper` at the bottom of your code.
 
 ```js
-({ test: () => assert.match(code, /(?<!\}\s*)^print\s*\(\s*copper\s*\)/m) })
+assert.match(code, /print\s*\(\s*copper\s*\)/)
 ```
 
 # --seed--
@@ -28,5 +28,6 @@ copper = {
     'age': 2
 }
 copper['food'] = 'hay'
+
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-recursion-by-solving-the-tower-of-hanoi-puzzle/64dc976bf864693e668d67e8.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-recursion-by-solving-the-tower-of-hanoi-puzzle/64dc976bf864693e668d67e8.md
@@ -14,7 +14,7 @@ Now call your function and see the output on the terminal.
 You should call your `move()` function.
 
 ```js
-({test: () => assert.match(code, /(?<!def\s+)move\(\s*\)/) })
+({test: () => assert.match(code, /^move\(\s*\)/m) })
 ```
 
 # --seed--

--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-string-manipulation-by-building-a-cipher/65521fc818947e800bffe48a.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-string-manipulation-by-building-a-cipher/65521fc818947e800bffe48a.md
@@ -26,7 +26,7 @@ You should assign `alphabet.find(char)` to your new variable.
 You should declare your new `index` variable at the beginning of your `for` loop.
 
 ```js
-({ test: () => assert.match(code, /(?<=text:\s+)index\s*=\s*alphabet\.find\s*\(\s*char\s*\)/) })
+({ test: () => assert.match(code, /text:\s+index\s*=\s*alphabet\.find\s*\(\s*char\s*\)/) })
 ```
 
 # --seed--

--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-string-manipulation-by-building-a-cipher/65552a9593755e1fb2f5ab50.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-string-manipulation-by-building-a-cipher/65552a9593755e1fb2f5ab50.md
@@ -37,7 +37,7 @@ Your `decrypt` function should take `message` and `key` as the parameters.
 Your `decrypt` function should return `vigenere(message, key, -1)`.
 
 ```js
-({ test: () => assert.match(code, /(?<=def\s+decrypt.*)return\s+vigenere\s*\(\s*message\s*,\s*key\s*,\s*-\s*1\s*\)/s) })
+({ test: () => assert.match(code, /def\s+decrypt.*return\s+vigenere\s*\(\s*message\s*,\s*key\s*,\s*-\s*1\s*\)/s) })
 ```
 
 # --seed--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64c736a531835181349c27d2.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64c736a531835181349c27d2.md
@@ -14,7 +14,7 @@ Inside the callback function, call the `movePlayer` function and pass in `key`, 
 You should call the `movePlayer` function.
 
 ```js
-assert.match(code, /(?<=movePlayer\s*\(.*\)).+movePlayer\s*\(.*\)/s);
+assert.match(code, /movePlayer\s*\(.*\).+movePlayer\s*\(.*\)/s);
 ```
 
 You should pass in `key`, 0 and `false` as arguments.

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64c9db021d4d912906878f3a.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64c9db021d4d912906878f3a.md
@@ -16,7 +16,7 @@ Inside the loop, use the subtraction assignment operator to subtract 5 from the 
 You should have a `forEach` loop that iterates through the `platforms` array.
 
 ```js
-assert.match(code, /(?<=if\s*\(.*\)\s*{\s+)platforms\.forEach\(\s*\(.*\)\s*=>\s*{\s*(.*?)\s*}\s*\);?/);
+assert.match(code, /if\s*\(.*\)\s*{\s+platforms\.forEach\(\s*\(.*\)\s*=>\s*{\s*(.*?)\s*}\s*\);?/);
 ```
 
 You should use the subtraction assignment operator to subtract 5 from the platform's `x` position.

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64c9dc4bd63a92295347c449.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64c9dc4bd63a92295347c449.md
@@ -25,7 +25,7 @@ assert.match(code, /if\s*\(\s*keys\.rightKey\.pressed\s*&&\s*isCheckpointCollisi
 You should add a `forEach` loop that iterates through the `platforms` array.
 
 ```js
-assert.match(code, /(?<=else\sif\s*\(.*\)\s*{\s*)platforms\.forEach\(\s*\(platform\)\s*=>\s*{\s*(.*?)\s*}\s*\);?/);
+assert.match(code, /else\sif\s*\(.*\)\s*{\s*platforms\.forEach\(\s*\(platform\)\s*=>\s*{\s*(.*?)\s*}\s*\);?/);
 
 ```
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ec94f0de20c086e09b0fc3.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ec94f0de20c086e09b0fc3.md
@@ -26,13 +26,13 @@ assert.match(code, /<p>.*\$\{title\}<\/p>/)
 You should create a `strong` element after the opening tag of your `p` element.
 
 ```js
-assert.match(code, /(?<=<p>)<strong>/)
+assert.match(code, /<p><strong>/)
 ```
 
 Your `strong` element should have the text `Title:`.
 
 ```js
-assert.match(code, /(?<=<p>)<strong>Title:\s*<\/strong>\s*/)
+assert.match(code, /<p><strong>Title:\s*<\/strong>\s*/)
 ```
 
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ec959a76336c8767f5cd4d.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ec959a76336c8767f5cd4d.md
@@ -20,7 +20,7 @@ assert.match(code, /<p>.*\$\{date\}<\/p>/)
 You should create a `strong` element with the text `Date:` after the opening tag of your `p` element.
 
 ```js
-assert.match(code, /(?<=<p>)<strong>Date:\s*<\/strong>\s*/)
+assert.match(code, /<p><strong>Date:\s*<\/strong>\s*/)
 ```
 
 # --seed--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/65099dbd8f137d58e5c0ff16.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/65099dbd8f137d58e5c0ff16.md
@@ -20,7 +20,7 @@ assert.match(code, /<p>.*\$\{description\}<\/p>/)
 You should create a `strong` element with the text `Description:` after the opening tag of your `p` element.
 
 ```js
-assert.match(code, /(?<=<p>)<strong>Description:\s*<\/strong>\s*/)
+assert.match(code, /<p><strong>Description:\s*<\/strong>\s*/)
 ```
 
 # --seed--


### PR DESCRIPTION
All but the latest version of Safari supports lookbehinds.

A few of these escaped the reviews.

**Note:** About lookbehinds - if you are not using the matched string, then positive lookbehinds server no purpose.

Par Exemple

```javascript
const username = "ShaunSHamilton";
const p_lookbehind = /(?<=Shaun)S?Hamilton/;
const equivalent_re = /ShaunS?Hamilton/;
console.assert(username.match(p_lookbehind));
console.assert(username.match(equivalent_re));
```

vs

```javascript
const username = "ShaunSHamilton";
const p_lookbehind = /(?<=Shaun)S?Hamilton/;
const equivalent_re = /ShaunS?Hamilton/;

const SHamilton = username.match(p_lookbehind)[0];
const ShaunSHamilton = username.match(equivalent_re)[0];
```

Negative lookbehinds are a bit less equivalent, but, in most cases, you are better splitting your input based on what you do not want to match, then regexing without the negative lookbehind.

Also, it looks as though a few of the HTML tests could do with also checking for whitespace. E.g. `<p\s*>\s*<strong\s*>`