### PR TITLE
Fixing RPG game's hint on step 37

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a3c2fccf186146b59c6e96.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a3c2fccf186146b59c6e96.md
@@ -15,7 +15,7 @@ You can access properties in JavaScript a couple of different ways. The first is
 button.onclick
 ```
 
-Use dot notation to set the `onclick` property of your `button1` to the variable `goStore`. This variable will be something you write later. Note that `button1` is already declared, so you do not need to use `let` or `const`.
+Use dot notation to set the `onclick` property of your `button1` to the function reference of `goStore`. This function will be something you write later. Note that `button1` is already declared, so you do not need to use `let` or `const`.
 
 # --hints--
 
@@ -31,7 +31,7 @@ You should not use `let` or `const`.
 assert.notMatch(code, /(let|const)\s+button1\.onclick/);
 ```
 
-You should set the `onclick` property of `button1` to the variable `goStore`.
+You should assign the `goStore` function reference to `button1.onclick`.
 
 ```js
 assert.match(code, /button1\.onclick\s*=\s*goStore/);


### PR DESCRIPTION
In step 37 of the RPG, I just updated the description and the text of the third hint that is related to the 'goStore' function.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #52677

<!-- Feel free to add any additional description of changes below this line -->
