### PR TITLE
fix(curriculum): typo in description of music player step 45

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-string-and-array-methods-by-building-a-music-player/655485321913feabbc5f00f8.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-string-and-array-methods-by-building-a-music-player/655485321913feabbc5f00f8.md
@@ -7,7 +7,7 @@ dashedName: step-45
 
 # --description--
 
-Add a `click` event listener to the `previousButton` element, then pass in `playPrevious` song as the second parameter.
+Add a `click` event listener to the `previousButton` element, then pass in `playPreviousSong` as the second parameter.
 
 # --hints--
 


### PR DESCRIPTION
Fixed the description to include the whole "playPreviousSong" variable, previously only included "playPrevious"

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
