### PR TITLE
fix(curriculum): allow for an explicit \n

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-form-validation-by-building-a-calorie-counter/63c2171c1e5b6e3aa51768d0.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-form-validation-by-building-a-calorie-counter/63c2171c1e5b6e3aa51768d0.md
@@ -26,7 +26,7 @@ assert.match(code, /HTMLString\s*=\s*`\n\s*<label>.*<\/label>/);
 Your `label` element should have the text `Entry ${entryNumber} Name`.
 
 ```js
-assert.match(code, /HTMLString\s*=\s*`\n\s*<label>Entry\s\$\{entryNumber\}\sName<\/label>/);
+assert.match(code, /HTMLString\s*=\s*`(\n|\\n)\s*<label>Entry\s\$\{entryNumber\}\sName<\/label>/);
 ```
 
 # --seed--


### PR DESCRIPTION
Modified regex to allow for an explicit \n by the user, which matches as \\n, in addition to the implicit multi line string match when pressing enter (\n).

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #52741

<!-- Feel free to add any additional description of changes below this line -->
