### PR TITLE
fix(curriculum): add check for closing tag in calorie counter step 9

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-form-validation-by-building-a-calorie-counter/63b60aaaa65f8922bfce6b7e.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-form-validation-by-building-a-calorie-counter/63b60aaaa65f8922bfce6b7e.md
@@ -55,10 +55,10 @@ Your new `select` element should have a `name` attribute set to `options`.
 assert.equal(document.querySelector('.controls > span > select')?.getAttribute('name'), 'options');
 ```
 
-Your `select` element should empty and close with `</select>` tag.
+Your `select` element should be empty and have a closing `</select>` tag.
 
 ```js
-assert.equal(document.querySelector('.controls > span > select')?.innerHTML, '');
+assert.equal(document.querySelector('.controls > span > select')?.innerHTML?.trim(), '');
 ```
 
 You should add a `button` element to your `span` element.

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-form-validation-by-building-a-calorie-counter/63b60aaaa65f8922bfce6b7e.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-form-validation-by-building-a-calorie-counter/63b60aaaa65f8922bfce6b7e.md
@@ -55,6 +55,12 @@ Your new `select` element should have a `name` attribute set to `options`.
 assert.equal(document.querySelector('.controls > span > select')?.getAttribute('name'), 'options');
 ```
 
+Your `select` element should empty and close with `</select>` tag.
+
+```js
+assert.equal(document.querySelector('.controls > span > select')?.innerHTML, '');
+```
+
 You should add a `button` element to your `span` element.
 
 ```js


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #52731

<!-- Feel free to add any additional description of changes below this line -->
The browser is automatically adding `</select>` tag for the self-closing tag `<select id="entry-dropdown" name="options" />` that contains some white spaces
So I added a check for the `select` tag that it should be empty(without white spaces)
The only way to pass the check is to manually use the closing tag `</select>`