### PR TITLE
fix(client): display assignment checked indicator

### DIFF
--- a/client/src/templates/Challenges/odin/show.css
+++ b/client/src/templates/Challenges/odin/show.css
@@ -3,15 +3,16 @@ input[type='checkbox'] {
   place-content: center;
   -webkit-appearance: none;
   appearance: none;
-  background-color: #fff;
+  background-color: var(--primary-background);
   min-width: 1.15em;
   min-height: 1.15em;
   max-width: 1.15em;
   max-height: 1.15em;
   margin-inline-end: 15px;
-  border: 2px solid black;
+  border: 2px solid var(--primary-color);
   border-radius: 0.15em;
   transform: translateY(-0.075em);
+  cursor: pointer;
 }
 
 input[type='checkbox']::before {
@@ -20,7 +21,7 @@ input[type='checkbox']::before {
   height: 0.65em;
   transform: scale(0);
   transition: 120ms transform ease-in-out;
-  box-shadow: inset 1em 1em black;
+  box-shadow: inset 1em 1em var(--primary-color);
 }
 
 input[type='checkbox']:checked::before {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

In the `odin/show.tsx` template, the assignment checkbox is using the same colors in both light and dark theme, while the colors should be reversed in order to communicate the check and unchecked state properly.

This PR improves the display of the checkbox by replacing color values with color tokens, whose values change with the theme.

## Testing

This template is used by some C#, College Agebra, Odin, and English challenges. I've tested the change on the following pages:
- `/learn/foundational-c-sharp-with-microsoft/write-your-first-code-using-c-sharp/write-your-first-c-sharp-code`
- `/learn/college-algebra-with-python/learn-ratios-and-proportions/introduction-to-college-algebra-with-python`
- `/learn/the-odin-project/top-learn-html-foundations/html-foundations-question-a`
- `/learn/a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/dialogue-1-maria-introduces-herself-to-tom`

## Screenshots

I'm adding screenshots of light theme for completeness / comparison, but only dark theme is changed.

| | Before | After |
| --- | --- | --- |
| Light - unchecked | <img width="818" alt="Screenshot 2023-12-25 at 15 58 41" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/d6c57960-bfea-470b-bef2-7a8896fde602"> | <img width="789" alt="Screenshot 2023-12-25 at 16 01 47" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/ef9a2279-2719-4bb8-9c3b-1870d6508f97"> |
| Light - checked | <img width="805" alt="Screenshot 2023-12-25 at 15 59 08" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/1aa44db8-14cc-4279-868d-459626b5b342"> | <img width="789" alt="Screenshot 2023-12-25 at 16 02 58" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/77d55bd8-79e8-406c-a8f1-99da275bce3b"> |
| Dark - unchecked | <img width="805" alt="Screenshot 2023-12-25 at 16 00 10" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/eb562ec9-2e7c-46f6-abb7-7830949eb106"> | <img width="791" alt="Screenshot 2023-12-25 at 16 03 59" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/4e7cb764-2628-4a39-86dd-55518f506701"> |
| Dark - checked | <img width="796" alt="Screenshot 2023-12-25 at 15 59 57" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/d088a4a1-4712-4bd3-a3c9-c8d5aaf236b5"> | <img width="780" alt="Screenshot 2023-12-25 at 16 03 36" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/4e542760-2a92-428b-9bc8-e356a0942260"> |
<!-- Feel free to add any additional description of changes below this line -->
