### PR TITLE
fix(a11y): give fill in the blank input an accessible name

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -433,6 +433,7 @@
     "if-help-university": "We've already made a ton of progress. Support our charity with the long road ahead.",
     "preview-external-window": "Preview currently showing in external window.",
     "fill-in-the-blank": "Fill in the blank",
+    "blank": "blank",
     "exam": {
       "qualified": "Congratulations, you have completed all the requirements to qualify for the exam.",
       "not-qualified": "You have not met the requirements to be eligible for the exam. To qualify, please complete the following challenges:",

--- a/client/src/templates/Challenges/fill-in-the-blank/show.tsx
+++ b/client/src/templates/Challenges/fill-in-the-blank/show.tsx
@@ -363,6 +363,7 @@ class ShowFillInTheBlank extends Component<
                                       blankAnswers[node.value].length * 11 + 11
                                     }px`
                                   }}
+                                  aria-label={t('learn.blank')}
                                 />
                               );
                           })}


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Every input must have an accessible name. For the fill in the blank exercises, I think it makes sense to give them the accessible name "Blank" since that's what they represent. 