### PR TITLE
fix(curriculum): consistency of using 'argument' and 'parameter'

### DIFF
--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-recursion-by-solving-the-tower-of-hanoi-puzzle/64df3f1011888113fbd3d81b.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-recursion-by-solving-the-tower-of-hanoi-puzzle/64df3f1011888113fbd3d81b.md
@@ -15,9 +15,9 @@ The final configuration with `n` disks piled up to the third rod in decreasing o
 - the largest disk from the source to the target
 - and then the `n - 1` disks from the auxiliary rod to the target.
 
-So, the first thing the `move` function should do is calling itself with `n - 1` as the first parameter. But if you try to do so without defining a base case, you will get a `RecursionError`. This happens because the function keeps calling itself indefinitely. 
+So, the first thing the `move` function should do is calling itself with `n - 1` as the first argument. But if you try to do so without defining a base case, you will get a `RecursionError`. This happens because the function keeps calling itself indefinitely.
 
-Before your comment and your `print()` call, add the recursive function call with `n - 1` as the first parameter and make sure the function body executes only when `n` is greater than zero. For now, leave the others parameters in the same order.
+Before your comment and your `print()` call, add the recursive function call with `n - 1` as the first argument and make sure the function body executes only when `n` is greater than zero. For now, leave the others argument in the same order.
 
 # --hints--
 

--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-recursion-by-solving-the-tower-of-hanoi-puzzle/64df3f1011888113fbd3d81b.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-recursion-by-solving-the-tower-of-hanoi-puzzle/64df3f1011888113fbd3d81b.md
@@ -17,7 +17,7 @@ The final configuration with `n` disks piled up to the third rod in decreasing o
 
 So, the first thing the `move` function should do is calling itself with `n - 1` as the first argument. But if you try to do so without defining a base case, you will get a `RecursionError`. This happens because the function keeps calling itself indefinitely.
 
-Before your comment and your `print()` call, add the recursive function call with `n - 1` as the first argument and make sure the function body executes only when `n` is greater than zero. For now, leave the others argument in the same order.
+Before your comment and your `print()` call, add the recursive function call with `n - 1` as the first argument and make sure the function body executes only when `n` is greater than zero. For now, leave the other arguments in the same order.
 
 # --hints--
 

--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-recursion-by-solving-the-tower-of-hanoi-puzzle/64df47b32b92301a815d5ef8.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-recursion-by-solving-the-tower-of-hanoi-puzzle/64df47b32b92301a815d5ef8.md
@@ -9,7 +9,7 @@ dashedName: step-49
 
 At first, the recursive call you have just added deals with the sub-problem of moving `n - 1` disks to the second rod.
 
-For that reason, the `target` arguments corresponds to your second rod, while the `auxiliary` arguments is the third rod. Keep in mind that those will keep swapping as the recursion proceeds.
+For that reason, the `target` argument corresponds to your second rod, while the `auxiliary` argument is the third rod. Keep in mind that those will keep swapping as the recursion proceeds.
 
 Fix the arguments order exchanging `target` and `auxiliary` in your recursive call.
 

--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-recursion-by-solving-the-tower-of-hanoi-puzzle/64df47b32b92301a815d5ef8.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-recursion-by-solving-the-tower-of-hanoi-puzzle/64df47b32b92301a815d5ef8.md
@@ -9,13 +9,13 @@ dashedName: step-49
 
 At first, the recursive call you have just added deals with the sub-problem of moving `n - 1` disks to the second rod.
 
-For that reason, the `target` parameter corresponds to your second rod, while the `auxiliary` parameter is the third rod. Keep in mind that those will keep swapping as the recursion proceeds.
+For that reason, the `target` arguments corresponds to your second rod, while the `auxiliary` arguments is the third rod. Keep in mind that those will keep swapping as the recursion proceeds.
 
-Fix the parameters order exchanging `target` and `auxiliary` in your recursive call.
+Fix the arguments order exchanging `target` and `auxiliary` in your recursive call.
 
 # --hints--
 
-You should modify the order of the parameters in your `move(n - 1, source, auxiliary, target)` call.
+You should modify the order of the arguments in your `move(n - 1, source, auxiliary, target)` call.
 
 ```js
 ({ test:  () => assert.match(code, /move\(\s*n\s*-\s*1\s*,\s*source\s*,\s*target\s*,\s*auxiliary\s*\)/) })

--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-recursion-by-solving-the-tower-of-hanoi-puzzle/64df496c6a8ddf1b38db1ed6.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-recursion-by-solving-the-tower-of-hanoi-puzzle/64df496c6a8ddf1b38db1ed6.md
@@ -11,7 +11,7 @@ In a previous step, you wrote the code to move the largest disk of the sub-probl
 
 Now, all you need to do is add another recursive call to move the `n - 1` disks you have already displaced. Copy the first recursive call and paste it at the end of the `if` block.
 
-Note that the function parameters are not in the right order. Try to figure out the correct order.
+Note that the function arguments are not in the right order. Try to figure out the correct order.
 
 # --hints--
 

--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-regular-expressions-by-building-a-password-generator/657db2114b4029241956f5d6.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-regular-expressions-by-building-a-password-generator/657db2114b4029241956f5d6.md
@@ -7,7 +7,7 @@ dashedName: step-68
 
 # --description--
 
-Modify your function declaration to take default arguments. Use `16` for the `length` and `1` for the other constraints.
+Modify your function declaration to take default parameters. Use `16` for the `length` and `1` for the other constraints.
 
 # --hints--
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-advanced-array-methods-by-building-a-statistics-calculator/63507c4b63731437227b0134.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-advanced-array-methods-by-building-a-statistics-calculator/63507c4b63731437227b0134.md
@@ -21,7 +21,7 @@ Add a callback function to your `.map()` method that converts each element to a 
 
 # --hints--
 
-Your `.map()` method should have a callback function which takes an `el` argument.
+Your `.map()` method should have a callback function which takes an `el` parameter.
 
 ```js
 assert.match(calculate.toString(), /array\.map\(\(?\s*el\s*\)?\s*=>|array\.map\(function\s*\(?el\)\s*\{/)

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-advanced-array-methods-by-building-a-statistics-calculator/63507e4562cdde3a28e8de1b.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-advanced-array-methods-by-building-a-statistics-calculator/63507e4562cdde3a28e8de1b.md
@@ -23,7 +23,7 @@ Add a callback function to your `.filter()` method that returns `true` if the el
 
 # --hints--
 
-Your `.filter()` method should have a callback which accepts `el` as an argument.
+Your `.filter()` method should have a callback which accepts `el` as a parameter.
 
 ```js
 assert.match(calculate.toString(), /numbers\.filter\(\(?\s*el\s*\)?\s*=>|numbers\.filter\(function\s*\(?el\)\s*\{/)

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-advanced-array-methods-by-building-a-statistics-calculator/63507fc6cc29083cc44df2fb.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-advanced-array-methods-by-building-a-statistics-calculator/63507fc6cc29083cc44df2fb.md
@@ -19,7 +19,7 @@ You should declare a `getMean` function.
 assert.isFunction(getMean);
 ```
 
-Your `getMean` function should take a single `array` argument.
+Your `getMean` function should take a single `array` parameter.
 
 ```js
 assert.match(getMean.toString(), /\(\s*array\s*\)/);

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-advanced-array-methods-by-building-a-statistics-calculator/6350805fe0fe283dd347b0dc.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-advanced-array-methods-by-building-a-statistics-calculator/6350805fe0fe283dd347b0dc.md
@@ -19,7 +19,7 @@ Your `getMean` function should have a `sum` variable.
 assert.match(getMean.toString(), /sum/);
 ```
 
-Your `getMean` function should use the `.reduce()` method of the `array` argument.
+Your `getMean` function should use the `.reduce()` method of the `array` parameter.
 
 ```js
 assert.match(getMean.toString(), /array\.reduce\(\)/);

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-advanced-array-methods-by-building-a-statistics-calculator/635080d80b72803e973841da.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-advanced-array-methods-by-building-a-statistics-calculator/635080d80b72803e973841da.md
@@ -19,7 +19,7 @@ For your `sum` variable, pass a callback to `.reduce()` that takes the accumulat
 
 # --hints--
 
-Your `reduce` method should have a callback function which takes an `acc` and an `el` argument.
+Your `reduce` method should have a callback function which takes an `acc` and an `el` parameters.
 
 ```js
 assert.match(getMean.toString(), /(array\.reduce\(\(acc\s*,\s*el\s*\)\s*=>|array\.reduce\(function\s*\(acc\s*,\s*el\)\s*\{)/)

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-advanced-array-methods-by-building-a-statistics-calculator/6350854411ffb73feb6bb84e.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-advanced-array-methods-by-building-a-statistics-calculator/6350854411ffb73feb6bb84e.md
@@ -7,7 +7,7 @@ dashedName: step-12
 
 # --description--
 
-The `.reduce()` method takes a second parameter that is used as the initial value of the accumulator. Without a second parameter, the `.reduce()` method uses the first element of the array as the accumulator, which can lead to unexpected results.
+The `.reduce()` method takes a second argument that is used as the initial value of the accumulator. Without a second argument, the `.reduce()` method uses the first element of the array as the accumulator, which can lead to unexpected results.
 
 To be safe, it's best to set an initial value. Here is an example of setting the initial value to an empty string:
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-advanced-array-methods-by-building-a-statistics-calculator/63508c898d753754757bd5e3.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-advanced-array-methods-by-building-a-statistics-calculator/63508c898d753754757bd5e3.md
@@ -9,13 +9,13 @@ dashedName: step-21
 
 By default, the `.sort()` method converts the elements of an array into strings, then sorts them alphabetically. This works well for strings, but not so well for numbers. For example, `10` comes before `2` when sorted as strings, but `2` comes before `10` when sorted as numbers.
 
-To fix this, you can pass in a callback function to the `.sort()` method. This function takes two parameters, which represent the two elements being compared. The function should return a value less than `0` if the first element should come before the second element, a value greater than `0` if the first element should come after the second element, and `0` if the two elements should remain in their current positions.
+To fix this, you can pass in a callback function to the `.sort()` method. This function takes two arguments, which represent the two elements being compared. The function should return a value less than `0` if the first element should come before the second element, a value greater than `0` if the first element should come after the second element, and `0` if the two elements should remain in their current positions.
 
 To sort your numbers from smallest to largest, pass a callback function that takes parameters `a` and `b`, and returns the result of subtracting `b` from `a`.
 
 # --hints--
 
-Your `sort` method should have a callback function which takes an `a` and a `b` argument.
+Your `sort` method should have a callback function which takes an `a` and a `b` parameters.
 
 ```js
 assert.match(getMedian.toString(), /(array\.sort\(\(\s*a\s*,\s*b\s*\)\s*=>|array\.sort\(function\s*\(\s*a\s*,\s*b\)\s*\{)/)

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-advanced-array-methods-by-building-a-statistics-calculator/6352e96d2604f813c656750b.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-advanced-array-methods-by-building-a-statistics-calculator/6352e96d2604f813c656750b.md
@@ -9,7 +9,7 @@ dashedName: step-27
 
 Remember that the `.forEach()` method allows you to run a callback function for each element in the array.
 
-Use the `.forEach()` method to loop through the `array`. In the callback, use the `el` argument to access the `counts` object and increment the count for each number.
+Use the `.forEach()` method to loop through the `array`. In the callback, use the `el` parameter to access the `counts` object and increment the count for each number.
 
 # --hints--
 
@@ -19,7 +19,7 @@ Your `getMode` function should use the `.forEach()` method.
 assert.match(getMode.toString(), /array\.forEach\(/);
 ```
 
-Your `.forEach()` method should have a callback function which takes an `el` argument.
+Your `.forEach()` method should have a callback function which takes an `el` parameter.
 
 ```js
 console.log(getMode.toString());

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-advanced-array-methods-by-building-a-statistics-calculator/6374249d3fbf2a5b079ba036.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-advanced-array-methods-by-building-a-statistics-calculator/6374249d3fbf2a5b079ba036.md
@@ -7,7 +7,7 @@ dashedName: step-50
 
 # --description--
 
-There is one last thing to fix. The `.sort()` method <dfn>mutates</dfn> the array it's called on. It is generally bad practice to mutate a function argument, which `array` is.
+There is one last thing to fix. The `.sort()` method <dfn>mutates</dfn> the array it's called on. It is generally bad practice to mutate a function parameter, which `array` is.
 
 To fix this, add an empty `.slice()` call before your `.sort()` method. The empty `.slice()` call will make a shallow copy of the `array`, which you are free to mutate.
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-asynchronous-programming-by-building-an-fcc-forum-leaderboard/6446d8f9fce0fa0172473964.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-asynchronous-programming-by-building-an-fcc-forum-leaderboard/6446d8f9fce0fa0172473964.md
@@ -11,7 +11,7 @@ The rest of the `allCategories` object has been completed for you.
 
 In the next few steps, you will create a function to retrieve the category name from the `allCategories` object. 
 
-Start by creating an arrow function named `forumCategory` and pass in `id` for the parameter name.
+Start by creating an arrow function named `forumCategory`, with `id` as the parameter name.
 
 # --hints--
 
@@ -21,7 +21,7 @@ You need to create an empty function named `forumCategory`.
 assert.match(code, /\s*const\s*forumCategory\s*=\s*\([^)]*\)\s*=>\s*{\s*}\s*/);
 ```
 
-You should pass a parameter named `id` for the `forumCategory` function.
+You should have a parameter named `id` in the `forumCategory` function.
 
 ```js
 assert.match(code, /\s*const\s+forumCategory\s*=\s*\(\s*id\s*\)\s*=>\s*{\s*}/);

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-asynchronous-programming-by-building-an-fcc-forum-leaderboard/645f06144bc0dc0143a5a3a2.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-asynchronous-programming-by-building-an-fcc-forum-leaderboard/645f06144bc0dc0143a5a3a2.md
@@ -9,7 +9,7 @@ dashedName: step-56
 
 Each forum post will include a list of user avatar images which represent all of the users participating in the conversation for that topic.
 
-Start by creating an arrow function called `avatars` and pass in two parameters called `posters` and `users`.
+Start by creating an arrow function called `avatars`, with two parameters called `posters` and `users`.
 
 # --hints--
 
@@ -19,7 +19,7 @@ You should have an empty arrow function called `avatars`.
 assert.match(code, /const\s*avatars\s*=\s*\([\s\S]*\)\s*=>\s*{\s*}/);
 ```
 
-You should pass the parameters named `posters` and `users` to the function named `avatars`.
+You should have the parameters named `posters` and `users` in the function named `avatars`.
 
 ```js
 assert.match(code, /const\s*avatars\s*=\s*\(\s*(posters|users)\s*,\s*(posters|users)\s*\)\s*=>\s*{\s*}/);

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-asynchronous-programming-by-building-an-fcc-forum-leaderboard/645f764c37de33015ded1273.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-asynchronous-programming-by-building-an-fcc-forum-leaderboard/645f764c37de33015ded1273.md
@@ -11,7 +11,7 @@ To customize the avatar's size, you can set it to a value of `30`.
 
 Start by creating a constant called `avatar`. Then assign it the result of using the `replace` method on `user.avatar_template`.
 
-For the `replace` method, use `/{size}/` for the first parameter and the number `30` for the second parameter. 
+For the `replace` method, use `/{size}/` for the first argument and the number `30` for the second argument.
 
 # --hints--
 
@@ -27,7 +27,7 @@ You should assign `user.avatar_template.replace()` to your `avatar` constant.
 assert(code.match(/const\s+avatar\s*=\s*user\.avatar_template\.replace\(\s*.*\s*\)/));
 ```
 
-You should have `/{size}/` for the first parameter and the number `30` for the second parameter for the `replace` method.
+You should have `/{size}/` for the first argument and the number `30` for the second argument for the `replace` method.
 
 ```js
 assert(code.match(/const\s+avatar\s*=\s*user\.avatar_template\.replace\(\s*([/'"]){size}\1\s*,\s*30\s*\)/));

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6410e3c19c21cd09c32dc7c6.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6410e3c19c21cd09c32dc7c6.md
@@ -9,7 +9,7 @@ dashedName: step-17
 
 In your `sortInputArray()` function, declare a `sortedValues` variable. Assign it the value of calling `bubbleSort` with your `inputValues` array.
 
-Then, update your `updateUI` call to take `sortedValues` as the parameter.
+Then, update your `updateUI` call to pass `sortedValues` as the argument.
 
 # --hints--
 
@@ -25,13 +25,13 @@ assert.match(code, /const\s+sortedValues\s*=/);
 assert.match(code, /const\s+sortedValues\s*=\s*bubbleSort\s*\(\s*inputValues\s*\)/);
 ```
 
-`updateUI` should be called with `sortedValues` as the parameter.
+`updateUI` should be called with `sortedValues` as the argument.
 
 ```js
 assert.match(code, /updateUI\s*\(\s*sortedValues\s*\)/);
 ```
 
-`updateUI` should not be called with `inputValues` as the parameter.
+`updateUI` should not be called with `inputValues` as the argument.
 
 ```js
 assert.notMatch(code, /updateUI\s*\(\s*inputValues\s*\)/);

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/641130423e5f512d8972dae1.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/641130423e5f512d8972dae1.md
@@ -9,7 +9,7 @@ dashedName: step-40
 
 Notice how the `10` value is placed at the beginning of the array. This is because the default behavior of `.sort()` is to convert the values to strings, and sort them alphabetically. And `10` comes before `2` alphabetically.
 
-To fix this, you can pass a callback function to the `.sort()` method. The callback function takes two arguments - for yours, use `a` and `b`. Leave the function empty for now.
+To fix this, you can pass a callback function to the `.sort()` method. The callback function have two parameters - for yours, use `a` and `b`. Leave the function empty for now.
 
 # --hints--
 
@@ -19,7 +19,7 @@ You should pass a callback function to the `.sort()` method. Remember to use arr
 assert.match(code, /const\s+sortedValues\s*=\s*inputValues\s*\.\s*sort\s*\(\s*\(?.*\)?\s*=>/);
 ```
 
-The callback function should take two arguments, `a` and `b`.
+The callback function should have two parameters, `a` and `b`.
 
 ```js
 assert.match(code, /const\s+sortedValues\s*=\s*inputValues\s*\.\s*sort\s*\(\s*\(\s*a\s*,\s*b\s*\)\s*=>/);

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/641130423e5f512d8972dae1.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/641130423e5f512d8972dae1.md
@@ -9,7 +9,7 @@ dashedName: step-40
 
 Notice how the `10` value is placed at the beginning of the array. This is because the default behavior of `.sort()` is to convert the values to strings, and sort them alphabetically. And `10` comes before `2` alphabetically.
 
-To fix this, you can pass a callback function to the `.sort()` method. The callback function have two parameters - for yours, use `a` and `b`. Leave the function empty for now.
+To fix this, you can pass a callback function to the `.sort()` method. The callback function has two parameters - for yours, use `a` and `b`. Leave the function empty for now.
 
 # --hints--
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a8b9770050d217d2247801.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a8b9770050d217d2247801.md
@@ -11,13 +11,13 @@ dashedName: step-65
 
 # --hints--
 
-You should access the first element of the `button text` property of the `location` argument.
+You should access the first element of the `button text` property of the `location` parameter.
 
 ```js
 assert.match(update.toString(), /location\[('|")button text\1\]\[0\]/);
 ```
 
-You should set the `button1.innerText` property to be the first element of the `button text` property of the `location` argument.
+You should set the `button1.innerText` property to be the first element of the `button text` property of the `location` parameter.
 
 ```js
 assert.match(update.toString(), /button1\.innerText\s*=\s*location\[('|")button text\1\]\[0\]/);

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a8c0c8313e891a15ec23e7.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a8c0c8313e891a15ec23e7.md
@@ -11,25 +11,25 @@ Now update `button2.innerText` and `button3.innerText` to be assigned the second
 
 # --hints--
 
-You should access the second element of the `button text` property of the `location` argument.
+You should access the second element of the `button text` property of the `location` parameter.
 
 ```js
 assert.match(update.toString(), /location\[('|")button text\1\]\[1\]/);
 ```
 
-You should set the `button2.innerText` property to be the second element of the `button text` property of the `location` argument.
+You should set the `button2.innerText` property to be the second element of the `button text` property of the `location` parameter.
 
 ```js
 assert.match(update.toString(), /button2\.innerText\s*=\s*location\[('|")button text\1\]\[1\]/);
 ```
 
-You should access the third element of the `button text` property of the `location` argument.
+You should access the third element of the `button text` property of the `location` parameter.
 
 ```js
 assert.match(update.toString(), /location\[('|")button text\1\]\[2\]/);
 ```
 
-You should set the `button3.innerText` property to be the third element of the `button text` property of the `location` argument.
+You should set the `button3.innerText` property to be the third element of the `button text` property of the `location` parameter.
 
 ```js
 assert.match(update.toString(), /button3\.innerText\s*=\s*location\[('|")button text\1\]\[2\]/);

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a8c1154d3ae11aee80353f.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a8c1154d3ae11aee80353f.md
@@ -11,37 +11,37 @@ Following the same pattern as you did for the button text, update the three butt
 
 # --hints--
 
-You should access the first element of the `button functions` property of the `location` argument.
+You should access the first element of the `button functions` property of the `location` parameter.
 
 ```js
 assert.match(update.toString(), /location\[('|")button functions\1\]\[0\]/);
 ```
 
-You should set the `button1.onclick` property to be the first element of the `button functions` property of the `location` argument.
+You should set the `button1.onclick` property to be the first element of the `button functions` property of the `location` parameter.
 
 ```js
 assert.match(update.toString(), /button1\.onclick\s*=\s*location\[('|")button functions\1\]\[0\]/);
 ```
 
-You should access the second element of the `button functions` property of the `location` argument.
+You should access the second element of the `button functions` property of the `location` parameter.
 
 ```js
 assert.match(update.toString(), /location\[('|")button functions\1\]\[1\]/);
 ```
 
-You should set the `button2.onclick` property to be the second element of the `button functions` property of the `location` argument.
+You should set the `button2.onclick` property to be the second element of the `button functions` property of the `location` parameter.
 
 ```js
 assert.match(update.toString(), /button2\.onclick\s*=\s*location\[('|")button functions\1\]\[1\]/);
 ```
 
-You should access the third element of the `button functions` property of the `location` argument.
+You should access the third element of the `button functions` property of the `location` parameter.
 
 ```js
 assert.match(update.toString(), /location\[('|")button functions\1\]\[2\]/);
 ```
 
-You should set the `button3.onclick` property to be the third element of the `button functions` property of the `location` argument.
+You should set the `button3.onclick` property to be the third element of the `button functions` property of the `location` parameter.
 
 ```js
 assert.match(update.toString(), /button3\.onclick\s*=\s*location\[('|")button functions\1\]\[2\]/);

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-string-and-array-methods-by-building-a-music-player/6552303a9a78704f8ff072e9.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-string-and-array-methods-by-building-a-music-player/6552303a9a78704f8ff072e9.md
@@ -9,7 +9,7 @@ dashedName: step-35
 
 You need to hook up the `pauseSong` function to an event listener to make it work.
 
-Add a `click` event listener to the `pauseButton` element, then pass in `pauseSong` as the second parameter of the event listener. This is the function the event listener will run.
+Add a `click` event listener to the `pauseButton` element, then pass in `pauseSong` as the second argument of the event listener. This is the function the event listener will run.
 
 # --hints--
 
@@ -25,7 +25,7 @@ Your event listener should listen for a `click` event.
 assert.match(code, /pauseButton\.addEventListener\(('|"|`)click\1/)
 ```
 
-You should pass in `pauseSong` as the second parameter of your `addEventListener` method.
+You should pass in `pauseSong` as the second argument of your `addEventListener` method.
 
 ```js
 assert.match(code, /pauseButton\.addEventListener\(('|"|`)click\1,\s*pauseSong\)/)

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-string-and-array-methods-by-building-a-music-player/65547ee197840478a1b95f4b.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-string-and-array-methods-by-building-a-music-player/65547ee197840478a1b95f4b.md
@@ -9,7 +9,7 @@ dashedName: step-41
 
 It's time to hook up the `playNextSong` function to an event listener.
 
-Add a `click` event listener to the `nextButton` element the pass in `playNextSong` as the second parameter of your event listener. This is the function the event listener will run.
+Add a `click` event listener to the `nextButton` element the pass in `playNextSong` as the second argument of your event listener. This is the function the event listener will run.
 
 # --hints--
 
@@ -25,7 +25,7 @@ Your event listener should listen for a `click` event.
 assert.match(code, /nextButton\.addEventListener\(('|"|`)click\1/)
 ```
 
-You should pass in `playNextSong` as the second parameter of your `addEventListener` method.
+You should pass in `playNextSong` as the second argument of your `addEventListener` method.
 
 ```js
 assert.match(code, /nextButton\.addEventListener\(('|"|`)click\1,\s*playNextSong\)/)

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-string-and-array-methods-by-building-a-music-player/655485321913feabbc5f00f8.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-string-and-array-methods-by-building-a-music-player/655485321913feabbc5f00f8.md
@@ -7,7 +7,7 @@ dashedName: step-45
 
 # --description--
 
-Add a `click` event listener to the `previousButton` element, then pass in `playPreviousSong` as the second parameter.
+Add a `click` event listener to the `previousButton` element, then pass in `playPreviousSong` as the second argument.
 
 # --hints--
 
@@ -23,7 +23,7 @@ Your event listener should listen for a `click` event.
 assert.match(code, /previousButton\.addEventListener\(('|"|`)click\1/)
 ```
 
-You should pass in `playPreviousSong` as the second parameter of your `addEventListener` method.
+You should pass in `playPreviousSong` as the second argument of your `addEventListener` method.
 
 ```js
 assert.match(code, /previousButton\.addEventListener\(('|"|`)click\1,\s*playPreviousSong\)/)

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-string-and-array-methods-by-building-a-music-player/655492e6b90c7a198c587943.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-string-and-array-methods-by-building-a-music-player/655492e6b90c7a198c587943.md
@@ -9,7 +9,7 @@ dashedName: step-50
 
 Now you need to add the attribute back to the currently playing song.
 
-Create an `if` statement with the condition `songToHighlight`. For the statement, use `setAttribute` on `songToHighlight` to pass in `"aria-current"` and `"true"` as the first and second parameters.
+Create an `if` statement with the condition `songToHighlight`. For the statement, use `setAttribute` on `songToHighlight` to pass in `"aria-current"` and `"true"` as the first and second arguments.
 
 # --hints--
 
@@ -25,7 +25,7 @@ You should use the `setAttribute()` method on `songToHighlight` inside your `if`
 assert.match(code, /if\s*\(songToHighlight\)\s*\{?\s*songToHighlight\.setAttribute\(/)
 ```
 
-You should pass in `"aria-current"` and `"true"` as the first and second parameter of your `setAttribute` method.
+You should pass in `"aria-current"` and `"true"` as the first and second argument of your `setAttribute` method.
 
 ```js
 assert.match(code, /if\s*\(songToHighlight\)\s*\{?\s*songToHighlight\.setAttribute\(('|")aria-current\1,\s*\1true\1\)\s*;?\s*\}?/)

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641da791d0c34a472b8d15b6.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641da791d0c34a472b8d15b6.md
@@ -9,7 +9,7 @@ dashedName: step-15
 
 Now `authorDataArr` is the same as the `data` you logged to the console a while ago. Log `authorDataArr` to the console to confirm this.
 
-Inside your `console.log()` statement, add the text `Author Data Array:` as the first parameter and `authorDataArr` as the second parameter. Use comma to separate the text from `authorDataArr`.
+Inside your `console.log()` statement, add the text `Author Data Array:` as the first argument and `authorDataArr` as the second argument. Use comma to separate the text from `authorDataArr`.
 
 # --hints--
 
@@ -31,7 +31,7 @@ You should use comma to separate your `Author Data Array:` text and `authorDataA
 assert.match(code, /console\.log\(("|'|`)Author\s+Data\s+Array:\s*\1\,/)
 ```
 
-`authorDataArr` should be the second parameter of your console log statement.
+`authorDataArr` should be the second argument of your console log statement.
 
 ```js
 assert.match(code, /console\.log\(("|'|`)Author\s+Data\s+Array:\s*\1\,\s*authorDataArr\);?/)

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641da97c987a514959ada414.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641da97c987a514959ada414.md
@@ -27,14 +27,14 @@ const afterAdd = code.split("endingIndex += 8;")[1];
 assert.match(afterAdd, /displayAuthors\(authorDataArr\.slice\(/)
 ```
 
-The first parameter of your `slice()` method should be `startingIndex`.
+The first argument of your `slice()` method should be `startingIndex`.
 
 ```js
 const afterAdd = code.split("endingIndex += 8;")[1];
 assert.match(afterAdd, /displayAuthors\(authorDataArr\.slice\(startingIndex/)
 ```
 
-The second parameter of your `slice()` method should be `endingIndex`.
+The second argument of your `slice()` method should be `endingIndex`.
 
 ```js
 const afterAdd = code.split("endingIndex += 8;")[1];

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-form-validation-by-building-a-calorie-counter/63b6152e6aff882db819fc1e.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-form-validation-by-building-a-calorie-counter/63b6152e6aff882db819fc1e.md
@@ -9,7 +9,7 @@ dashedName: step-18
 
 Even though you set an `input` element to be a number, JavaScript receives a string value. You need to write a function to clean the string value and ensure you have a number.
 
-Start by declaring a `cleanInputString` function that takes a `str` argument.
+Start by declaring a `cleanInputString` function that takes a `str` parameter.
 
 # --hints--
 
@@ -25,7 +25,7 @@ Your `cleanInputString` variable should be a function.
 assert.isFunction(cleanInputString);
 ```
 
-Your `cleanInputString` function should take a `str` argument.
+Your `cleanInputString` function should take a `str` parameter.
 
 ```js
 assert.match(cleanInputString?.toString(), /\(str\)/);

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-form-validation-by-building-a-calorie-counter/63c21dea919c8e4adb0df8e8.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-form-validation-by-building-a-calorie-counter/63c21dea919c8e4adb0df8e8.md
@@ -9,7 +9,7 @@ dashedName: step-50
 
 In the Role Playing Game project, you learned how to set a button's behavior by editing its `onclick` property. You can also edit an element's behavior by adding an event listener.
 
-Call the `.addEventListener()` method of the `addEntryButton`. This takes two arguments. The first is the event to listen to – you should pass the string `click`. The second is the callback function, or the function that runs when the event is triggered. Pass the `addEntry` function as the second argument. Note that you should not *call* `addEntry`, but pass the variable (or <dfn>function reference</dfn>) directly.
+Call the `.addEventListener()` method of the `addEntryButton`. It takes two arguments. The first is the event to listen to – you should pass the string `click`. The second is the callback function, or the function that runs when the event is triggered. Pass the `addEntry` function as the second argument. Note that you should not *call* `addEntry`, but pass the variable (or <dfn>function reference</dfn>) directly.
 
 # --hints--
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-form-validation-by-building-a-calorie-counter/63c8be904ffff922f3c6f8d0.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-form-validation-by-building-a-calorie-counter/63c8be904ffff922f3c6f8d0.md
@@ -19,7 +19,7 @@ Your `getCaloriesFromInputs` function should call your `cleanInputString` functi
 assert.match(getCaloriesFromInputs.toString(), /cleanInputString\(/);
 ```
 
-You should pass `list[i].value` as the parameter for `cleanInputString`.
+You should pass `list[i].value` as the argument for `cleanInputString`.
 
 ```js
 assert.match(getCaloriesFromInputs.toString(), /cleanInputString\(\s*list\[i\]\.value\)/);

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-form-validation-by-building-a-calorie-counter/63c8c00bfb671b23f9de4159.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-form-validation-by-building-a-calorie-counter/63c8c00bfb671b23f9de4159.md
@@ -23,7 +23,7 @@ You should assign the result of calling `isInvalidInput` to your `invalidInputMa
 assert.match(getCaloriesFromInputs.toString(), /invalidInputMatch\s*=\s*isInvalidInput\(/);
 ```
 
-You should pass `currVal` as the parameter to `isInvalidInput`.
+You should pass `currVal` as the argument to `isInvalidInput`.
 
 ```js
 assert.match(getCaloriesFromInputs.toString(), /invalidInputMatch\s*=\s*isInvalidInput\(\s*currVal\s*\)/);

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-functional-programming-by-building-a-spreadsheet/6434759f78ec812264ff8f34.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-functional-programming-by-building-a-spreadsheet/6434759f78ec812264ff8f34.md
@@ -9,7 +9,7 @@ dashedName: step-16
 
 In your callback, call `createLabel()` and pass `number` as the argument. You should see some numbers appear in your spreadsheet.
 
-Then call the `.forEach()` method on your `letters` array. Pass an empty callback function which takes a `letter` argument.
+Then call the `.forEach()` method on your `letters` array. Pass an empty callback function which takes a `letter` parameter.
 
 # --hints--
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-functional-programming-by-building-a-spreadsheet/6437124c4c03dd4c8fb35d56.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-functional-programming-by-building-a-spreadsheet/6437124c4c03dd4c8fb35d56.md
@@ -35,7 +35,7 @@ Your `isEven` function should use arrow syntax.
 assert.match(code, /const\s*isEven\s*=\s*\(?.*\)?\s*=>/);
 ```
 
-Your `isEven` function should have a `num` argument.
+Your `isEven` function should have a `num` parameter.
 
 ```js
 assert.match(code, /const\s*isEven\s*=\s*\(?\s*num\s*\)?\s*=>/);

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-functional-programming-by-building-a-spreadsheet/6449755666005520330cec5b.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-functional-programming-by-building-a-spreadsheet/6449755666005520330cec5b.md
@@ -7,7 +7,7 @@ dashedName: step-28
 
 # --description--
 
-Since your `update` event is running as a `change` event listener, the `event` argument will be a change event.
+Since your `update` event is running as a `change` event listener, the `event` parameter will be a change event.
 
 The `target` property of the change event represents the element that changed. Assign the `target` property to a new variable called `element`.
 
@@ -25,7 +25,7 @@ You should use `const` to declare your `element` variable.
 assert.match(code, /const\s+update\s*=\s*\(?\s*event\s*\)?\s*=>\s*\{\s*const\s+element/);
 ```
 
-You should assign the `target` property of the `event` argument to your `element` variable.
+You should assign the `target` property of the `event` parameter to your `element` variable.
 
 ```js
 assert.match(code, /const\s+update\s*=\s*\(?\s*event\s*\)?\s*=>\s*\{\s*const\s+element\s*=\s*event\.target/);

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-functional-programming-by-building-a-spreadsheet/646d3141790b3cb337dd611a.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-functional-programming-by-building-a-spreadsheet/646d3141790b3cb337dd611a.md
@@ -13,25 +13,25 @@ Give your callback function four more parameters to match those capture groups: 
 
 # --hints--
 
-You should pass `char1` as the second argument to your callback.
+Your callback function should have `char1` as the second parameter.
 
 ```js
 assert.match(code, /const\s*evalFormula\s*=\s*\(\s*x\s*,\s*cells\s*\)\s*=>\s*{\s*const\s+idToText\s*=\s*\(?\s*id\s*\)?\s*=>\s*cells\.find\(\s*\(?\s*cell\s*\)?\s*=>\s*(?:cell\.id\s*===\s*id|id\s*===\s*cell\.id)\s*\)\.value;?\s*const\s+rangeRegex\s*=\s*\/\(\[A-J\]\)\(\[1-9\]\[0-9\]\?\):\(\[A-J\]\)\(\[1-9\]\[0-9\]\?\)\/(gi|ig);?\s*const\s+rangeFromString\s*=\s*\(\s*num1\s*,\s*num2\s*\)\s*=>\s*range\(\s*parseInt\(\s*num1\s*\)\s*,\s*parseInt\(\s*num2\s*\)\s*\);?\s*const\s+elemValue\s*=\s*\(?\s*num\s*\)?\s*=>\s*\(?\s*character\s*\)?\s*=>\s*idToText\(\s*character\s*\+\s*num\s*\);?\s*const\s+addCharacters\s*=\s*\(?\s*character1\s*\)?\s*=>\s*\(?\s*character2\s*\)?\s*=>\s*\(?\s*num\s*\)?\s*=>\s*charRange\(\s*character1\s*,\s*character2\s*\)\.map\(\s*elemValue\(\s*num\s*\)\s*\);?\s*const\s+rangeExpanded\s*=\s*x\.replace\(\s*rangeRegex\s*,\s*\(\s*match\s*,\s*char1/);
 ```
 
-You should pass `num1` as the third argument to your callback.
+Your callback function should have `num1` as the third parameter.
 
 ```js
 assert.match(code, /const\s*evalFormula\s*=\s*\(\s*x\s*,\s*cells\s*\)\s*=>\s*{\s*const\s+idToText\s*=\s*\(?\s*id\s*\)?\s*=>\s*cells\.find\(\s*\(?\s*cell\s*\)?\s*=>\s*(?:cell\.id\s*===\s*id|id\s*===\s*cell\.id)\s*\)\.value;?\s*const\s+rangeRegex\s*=\s*\/\(\[A-J\]\)\(\[1-9\]\[0-9\]\?\):\(\[A-J\]\)\(\[1-9\]\[0-9\]\?\)\/(gi|ig);?\s*const\s+rangeFromString\s*=\s*\(\s*num1\s*,\s*num2\s*\)\s*=>\s*range\(\s*parseInt\(\s*num1\s*\)\s*,\s*parseInt\(\s*num2\s*\)\s*\);?\s*const\s+elemValue\s*=\s*\(?\s*num\s*\)?\s*=>\s*\(?\s*character\s*\)?\s*=>\s*idToText\(\s*character\s*\+\s*num\s*\);?\s*const\s+addCharacters\s*=\s*\(?\s*character1\s*\)?\s*=>\s*\(?\s*character2\s*\)?\s*=>\s*\(?\s*num\s*\)?\s*=>\s*charRange\(\s*character1\s*,\s*character2\s*\)\.map\(\s*elemValue\(\s*num\s*\)\s*\);?\s*const\s+rangeExpanded\s*=\s*x\.replace\(\s*rangeRegex\s*,\s*\(\s*match\s*,\s*char1\s*,\s*num1/);
 ```
 
-You should pass `char2` as the fourth argument to your callback.
+Your callback function should have `char2` as the fourth parameter.
 
 ```js
 assert.match(code, /const\s*evalFormula\s*=\s*\(\s*x\s*,\s*cells\s*\)\s*=>\s*{\s*const\s+idToText\s*=\s*\(?\s*id\s*\)?\s*=>\s*cells\.find\(\s*\(?\s*cell\s*\)?\s*=>\s*(?:cell\.id\s*===\s*id|id\s*===\s*cell\.id)\s*\)\.value;?\s*const\s+rangeRegex\s*=\s*\/\(\[A-J\]\)\(\[1-9\]\[0-9\]\?\):\(\[A-J\]\)\(\[1-9\]\[0-9\]\?\)\/(gi|ig);?\s*const\s+rangeFromString\s*=\s*\(\s*num1\s*,\s*num2\s*\)\s*=>\s*range\(\s*parseInt\(\s*num1\s*\)\s*,\s*parseInt\(\s*num2\s*\)\s*\);?\s*const\s+elemValue\s*=\s*\(?\s*num\s*\)?\s*=>\s*\(?\s*character\s*\)?\s*=>\s*idToText\(\s*character\s*\+\s*num\s*\);?\s*const\s+addCharacters\s*=\s*\(?\s*character1\s*\)?\s*=>\s*\(?\s*character2\s*\)?\s*=>\s*\(?\s*num\s*\)?\s*=>\s*charRange\(\s*character1\s*,\s*character2\s*\)\.map\(\s*elemValue\(\s*num\s*\)\s*\);?\s*const\s+rangeExpanded\s*=\s*x\.replace\(\s*rangeRegex\s*,\s*\(\s*match\s*,\s*char1\s*,\s*num1\s*,\s*char2/);
 ```
 
-You should pass `num2` as the fifth argument to your callback.
+Your callback function should have `num2` as the fifth parameter.
 
 ```js
 assert.match(code, /const\s*evalFormula\s*=\s*\(\s*x\s*,\s*cells\s*\)\s*=>\s*{\s*const\s+idToText\s*=\s*\(?\s*id\s*\)?\s*=>\s*cells\.find\(\s*\(?\s*cell\s*\)?\s*=>\s*(?:cell\.id\s*===\s*id|id\s*===\s*cell\.id)\s*\)\.value;?\s*const\s+rangeRegex\s*=\s*\/\(\[A-J\]\)\(\[1-9\]\[0-9\]\?\):\(\[A-J\]\)\(\[1-9\]\[0-9\]\?\)\/(gi|ig);?\s*const\s+rangeFromString\s*=\s*\(\s*num1\s*,\s*num2\s*\)\s*=>\s*range\(\s*parseInt\(\s*num1\s*\)\s*,\s*parseInt\(\s*num2\s*\)\s*\);?\s*const\s+elemValue\s*=\s*\(?\s*num\s*\)?\s*=>\s*\(?\s*character\s*\)?\s*=>\s*idToText\(\s*character\s*\+\s*num\s*\);?\s*const\s+addCharacters\s*=\s*\(?\s*character1\s*\)?\s*=>\s*\(?\s*character2\s*\)?\s*=>\s*\(?\s*num\s*\)?\s*=>\s*charRange\(\s*character1\s*,\s*character2\s*\)\.map\(\s*elemValue\(\s*num\s*\)\s*\);?\s*const\s+rangeExpanded\s*=\s*x\.replace\(\s*rangeRegex\s*,\s*\(\s*match\s*,\s*char1\s*,\s*num1\s*,\s*char2\s*,\s*num2\s*\)/);

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-functional-programming-by-building-a-spreadsheet/646d3e64b15f92be6e61704e.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-functional-programming-by-building-a-spreadsheet/646d3e64b15f92be6e61704e.md
@@ -25,7 +25,7 @@ Your callback function should access the `infixToFunction` object.
 assert.match(code, /const\s+infixEval\s*=\s*\(\s*str\s*,\s*regex\s*\)\s*=>\s*str\.replace\(\s*regex\s*,\s*\(\s*_match\s*,\s*arg1\s*,\s*operator\s*,\s*arg2\s*\)\s*=>\s*infixToFunction/);
 ```
 
-Your callback function should use bracket notation to access the property of the `infixToFunction` object that matches the value of the `operator` argument.
+Your callback function should use bracket notation to access the property of the `infixToFunction` object that matches the value of the `operator` parameter.
 
 ```js
 assert.match(code, /const\s+infixEval\s*=\s*\(\s*str\s*,\s*regex\s*\)\s*=>\s*str\.replace\(\s*regex\s*,\s*\(\s*_match\s*,\s*arg1\s*,\s*operator\s*,\s*arg2\s*\)\s*=>\s*infixToFunction\[\s*operator\s*\]\s*\)/);

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64cb2e5bdfb23a67272a07c7.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64cb2e5bdfb23a67272a07c7.md
@@ -11,7 +11,7 @@ Now you need to create a `draw` method for the `CheckPoint` class.
 
 Inside the `draw` method, add a `fillStyle` property to the `ctx` object and set it to `#f1be32`. 
 
-Below the `fillStyle` property, use the `fillRect` method on the `ctx` object and pass in the `x`, `y`, `width`, and `height` properties as parameters.
+Below the `fillStyle` property, use the `fillRect` method on the `ctx` object and pass in the `x`, `y`, `width`, and `height` properties as arguments.
 
 # --hints--
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64faf874364ec308f875f636.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64faf874364ec308f875f636.md
@@ -9,7 +9,7 @@ dashedName: step-38
 
 You need to remove the task from the DOM using `remove()` and from the `taskData` array using `splice()`.
 
-`splice()` is an array method that modifies arrays by removing, replacing, or adding elements at a specified index, while also returning the removed elements. It can take up to three parameters: the first one is the mandatory index at which to start, the second is the number of items to remove, and the third is an optional replacement element. Here's an example:
+`splice()` is an array method that modifies arrays by removing, replacing, or adding elements at a specified index, while also returning the removed elements. It can take up to three arguments: the first one is the mandatory index at which to start, the second is the number of items to remove, and the third is an optional replacement element. Here's an example:
 
 ```js
 const fruits = ["mango", "date", "cherry", "banana", "apple"];
@@ -21,7 +21,7 @@ console.log(fruits); // [ 'mango', 'banana', 'apple' ]
 console.log(removedFruits); // [ 'date', 'cherry' ]
 ```
 
-Use the `remove()` method to remove the `parentElement` of the `buttonEl` from the DOM. Then use `splice()` to remove the task from the `taskData` array. Pass in `dataArrIndex` and `1` as the parameters of your `splice()`.
+Use the `remove()` method to remove the `parentElement` of the `buttonEl` from the DOM. Then use `splice()` to remove the task from the `taskData` array. Pass in `dataArrIndex` and `1` as the arguments of your `splice()`.
 
 `dataArrIndex` is the index to start and `1` is the number of items to remove.
 
@@ -39,13 +39,13 @@ You should use `splice()` on the `taskData` array.
 assert.match(deleteTask.toString(), /taskData\.splice\(/)
 ```
 
-The first parameter of your `splice()` method should be `dataArrIndex`.
+The first argument of your `splice()` method should be `dataArrIndex`.
 
 ```js
 assert.match(deleteTask.toString(), /taskData\.splice\(dataArrIndex/)
 ```
 
-The second parameter of your `splice()` method should be `1`.
+The second argument of your `splice()` method should be `1`.
 
 ```js
 assert.match(deleteTask.toString(), /taskData\.splice\(dataArrIndex,\s*1\);?/)

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/65003986d17d1e1865b269c0.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/65003986d17d1e1865b269c0.md
@@ -9,7 +9,7 @@ dashedName: step-55
 
 Now you should save the task items to local storage when the user adds, updates, or removes a task.
 
-Inside the `addOrUpdateTask` function, use `setItem()` to save the tasks with a key of `data`, then pass the `taskData` array as its parameter. Ensure that you stringify the `taskData`.
+Inside the `addOrUpdateTask` function, use `setItem()` to save the tasks with a key of `data`, then pass the `taskData` array as its argument. Ensure that you stringify the `taskData`.
 
 This would persist data once the user adds or updates tasks.
 
@@ -21,13 +21,13 @@ You should use `localStorage.setItem()` to save the tasks to the browser `local 
 assert.match(code, /localStorage\.setItem\(/)
 ```
 
-You should pass in `"data"` as the first parameter of your `localStorage.setItem()`.
+You should pass in `"data"` as the first argument of your `localStorage.setItem()`.
 
 ```js
 assert.match(code, /localStorage\.setItem\(('|")data\1/)
 ```
 
-You should pass in `JSON.stringify(taskData)` as the second parameter of your `localStorage.setItem()`.
+You should pass in `JSON.stringify(taskData)` as the second argument of your `localStorage.setItem()`.
 
 ```js
 assert.match(code, /localStorage\.setItem\(('|")data\1,\s*JSON\.stringify\(taskData\)\);?/)

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/650046832f92c01a35834bca.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/650046832f92c01a35834bca.md
@@ -20,14 +20,14 @@ const splitter = code.split("taskData.splice(dataArrIndex, 1);")
 assert.match(splitter[1], /localStorage\.setItem\(/)
 ```
 
-You should pass in `"data"` as the first parameter of your `localStorage.setItem()`.
+You should pass in `"data"` as the first argument of your `localStorage.setItem()`.
 
 ```js
 const splitter = code.split("taskData.splice(dataArrIndex, 1);")
 assert.match(splitter[1], /localStorage\.setItem\(('|")data\1/)
 ```
 
-You should pass in `JSON.stringify(taskData)` as the second parameter of your `localStorage.setItem()`.
+You should pass in `JSON.stringify(taskData)` as the second argument of your `localStorage.setItem()`.
 
 ```js
 const splitter = code.split("taskData.splice(dataArrIndex, 1);")

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-recursion-by-building-a-decimal-to-binary-converter/640067f276acd525509646cc.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-recursion-by-building-a-decimal-to-binary-converter/640067f276acd525509646cc.md
@@ -9,7 +9,7 @@ dashedName: step-11
 
 Because the `input type="number"` element allows special characters like `.`, `+`, and `e`, users can input floats like `2.2`, equations like `2e+3`, or even just `e`, which you don't want to allow.
 
-A good way to check and normalize numbers in JavaScript is to use the built-in `parseInt()` function, which converts a string into an integer or whole number. `parseInt()` takes at least one parameter, a string to be converted into an integer, and returns either an integer or `NaN` which stands for `Not a Number`. For example:
+A good way to check and normalize numbers in JavaScript is to use the built-in `parseInt()` function, which converts a string into an integer or whole number. `parseInt()` takes at least one argument, a string to be converted into an integer, and returns either an integer or `NaN` which stands for `Not a Number`. For example:
 
 ```js
 parseInt(2.2); // 2

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-recursion-by-building-a-decimal-to-binary-converter/64007367d54d2a7efbf44fcf.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-recursion-by-building-a-decimal-to-binary-converter/64007367d54d2a7efbf44fcf.md
@@ -9,7 +9,7 @@ dashedName: step-12
 
 Next, you need to check if the value returned by the `parseInt()` function is a number or not.
 
-To do that, you can use the `isNaN()` function. This function takes in a string or number as a parameter, and returns `true` if it evaluates to `NaN`. For example:
+To do that, you can use the `isNaN()` function. This function takes in a string or number as an argument, and returns `true` if it evaluates to `NaN`. For example:
 
 ```js
 isNaN("test"); // true

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-recursion-by-building-a-decimal-to-binary-converter/646491d2c856afd17c2f380d.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-recursion-by-building-a-decimal-to-binary-converter/646491d2c856afd17c2f380d.md
@@ -9,7 +9,7 @@ dashedName: step-91
 
 Since you have the timing for each frame of animation stored in `addElDelay`, you can use that value with `setTimeout()` to set up the delay to add elements to the DOM.
 
-Within the body of the `.forEach()` method's callback function, add a `setTimeout()` function. Pass in an empty callback function as the first parameter, and `obj.addElDelay` as the second parameter.
+Within the body of the `.forEach()` method's callback function, add a `setTimeout()` function. Pass in an empty callback function as the first argument, and `obj.addElDelay` as the second argument.
 
 # --hints--
 
@@ -19,7 +19,7 @@ You should add the `setTimeout()` function within the body of your `.forEach()` 
 assert.match(String(showAnimation), /animationData\s*\.\s*forEach\([\s\S]+\{\s*setTimeout\(/);
 ```
 
-You should pass in an empty callback function as the first parameter to the `setTimeout()` function.
+You should pass in an empty callback function as the first argument to the `setTimeout()` function.
 
 ```js
 assert.match(String(showAnimation), /animationData\s*\.\s*forEach\([\s\S]+\{\s*setTimeout\(\s*\(\s*\)\s*=>\s*\{|animationData\s*\.\s*forEach\([\s\S]+\{\s*setTimeout\(\s*function\s*\(\s*\)\s*\{/);
@@ -31,7 +31,7 @@ The body of your `setTimeout()` function's callback function should be empty.
 assert.match(String(showAnimation), /animationData\s*\.\s*forEach\([\s\S]+\{\s*setTimeout\([\s\S]+\{\s*\}/);
 ```
 
-You should pass in `obj.addElDelay` as the second parameter to the `setTimeout()` function.
+You should pass in `obj.addElDelay` as the second argument to the `setTimeout()` function.
 
 ```js
 assert.match(String(showAnimation), /animationData\s*\.\s*forEach\([\s\S]+\{\s*setTimeout\([\s\S]+,\s*obj\s*\.\s*addElDelay\s*\)/);

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-recursion-by-building-a-decimal-to-binary-converter/6464abfb6cf778f3cb33d379.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-recursion-by-building-a-decimal-to-binary-converter/6464abfb6cf778f3cb33d379.md
@@ -9,7 +9,7 @@ dashedName: step-103
 
 For the next phase of the animation you'll update the paragraphs with the `msg` text. Since you have the delays for each step of the animation already, you can add your code to the same `.forEach()` loop.
 
-Add another `setTimeout()` function. Pass in an empty callback function as the first parameter, and pass in the `showMsgDelay` property of the current object as the second parameter.
+Add another `setTimeout()` function. Pass in an empty callback function as the first argument, and pass in the `showMsgDelay` property of the current object as the second argument.
 
 # --hints--
 
@@ -22,7 +22,7 @@ assert.lengthOf(
 );
 ```
 
-The new `setTimeout()` function should have an empty callback function as the first parameter.
+The new `setTimeout()` function should have an empty callback function as the first argument.
 
 ```js
 assert.match(
@@ -31,7 +31,7 @@ assert.match(
 );
 ```
 
-The new `setTimeout()` function should have the `showMsgDelay` property of the current object as the second parameter.
+The new `setTimeout()` function should have the `showMsgDelay` property of the current object as the second argument.
 
 ```js
 assert.match(

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-recursion-by-building-a-decimal-to-binary-converter/6464b25851863b0a119eb7b1.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-recursion-by-building-a-decimal-to-binary-converter/6464b25851863b0a119eb7b1.md
@@ -9,7 +9,7 @@ dashedName: step-106
 
 Next, you'll remove the paragraph elements from the `#show-animation` element after the delays you specified earlier.
 
-Add a `setTimeout()` function to your `.forEach()` loop. Pass in an empty callback function as the first parameter, and pass in the `removeElDelay` property of the current object as the second parameter.
+Add a `setTimeout()` function to your `.forEach()` loop. Pass in an empty callback function as the first argument, and pass in the `removeElDelay` property of the current object as the second argument.
 
 # --hints--
 
@@ -22,7 +22,7 @@ assert.lengthOf(
 );
 ```
 
-The new `setTimeout()` function should have an empty callback function as the first parameter.
+The new `setTimeout()` function should have an empty callback function as the first argument.
 
 ```js
 assert.match(
@@ -31,7 +31,7 @@ assert.match(
 );
 ```
 
-The new `setTimeout()` function should have the `removeElDelay` property of the current object as the second parameter.
+The new `setTimeout()` function should have the `removeElDelay` property of the current object as the second argument.
 
 ```js
 assert.match(

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-recursion-by-building-a-decimal-to-binary-converter/6464b8ccb1a5d612c2f857d1.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-recursion-by-building-a-decimal-to-binary-converter/6464b8ccb1a5d612c2f857d1.md
@@ -11,7 +11,7 @@ Now your animation is complete. When you enter `5` in the number input and click
 
 The last thing you need to do is add the result of converting the number `5` into binary to the page once the animation is complete.
 
-After the `.forEach()` method, add another `setTimeout()` function. Pass in an empty callback function as the first parameter, and a delay of `20000` milliseconds as the second parameter.
+After the `.forEach()` method, add another `setTimeout()` function. Pass in an empty callback function as the first argument, and a delay of `20000` milliseconds as the second argument.
 
 # --hints--
 
@@ -24,7 +24,7 @@ assert.lengthOf(
 );
 ```
 
-The new `setTimeout()` function should have an empty callback function as the first parameter.
+The new `setTimeout()` function should have an empty callback function as the first argument.
 
 ```js
 assert.match(
@@ -33,7 +33,7 @@ assert.match(
 );
 ```
 
-The new `setTimeout()` function should have a delay of `20000` milliseconds as the second parameter.
+The new `setTimeout()` function should have a delay of `20000` milliseconds as the second argument.
 
 ```js
 assert.match(


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

- - -
- Fixes incorrect usage of 'argument' in place of 'parameter', and 'parameter' in place of 'argument' in new JS and Python curriculum.
- I tried to do all of them and went through all occurrences in both curriculums. I'm assuming some still could escape due to specific wording, but the bulk of it is here.