### PR TITLE
fix(curriculum): Remove parentheses from onChange, update text

### DIFF
--- a/curriculum/challenges/english/03-front-end-development-libraries/react/create-a-controlled-input.md
+++ b/curriculum/challenges/english/03-front-end-development-libraries/react/create-a-controlled-input.md
@@ -16,7 +16,7 @@ The code editor has the skeleton of a component called `ControlledInput` to crea
 
 First, create a method called `handleChange()` that has a parameter called `event`. When the method is called, it receives an `event` object that contains a string of text from the `input` element. You can access this string with `event.target.value` inside the method. Update the `input` property of the component's `state` with this new string.
 
-In the `render` method, create the `input` element above the `h4` tag. Add a `value` attribute which is equal to the `input` property of the component's `state`. Then add an `onChange()` event handler set to the `handleChange()` method.
+In the `render` method, create the `input` element above the `h4` tag. Add a `value` attribute which is equal to the `input` property of the component's `state`. Then add an `onChange` property set to the `handleChange()` event handler method.
 
 When you type in the input box, that text is processed by the `handleChange()` method, set as the `input` property in the local `state`, and rendered as the value in the `input` box on the page. The component `state` is the single source of truth regarding the input data.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

It should not show `onChange()` but just `onChange` to avoid any confusion.

I altered the sentence a bit as well. After having read it back a few times, I'm not sure if I like it or not. But it seems more correct.

1. `onChange` is not an event handler, it is an attribute/property assigned an event handler.
2. `handleChange` is the event handler.


Forum: https://forum.freecodecamp.org/t/reach-create-a-controlled-input-lesson-onchange/658346
