### PR TITLE
fix(ally): mobile links accessible name and lang

### DIFF
--- a/client/src/components/Footer/__snapshots__/footer.test.tsx.snap
+++ b/client/src/components/Footer/__snapshots__/footer.test.tsx.snap
@@ -345,7 +345,8 @@ exports[`<Footer /> matches snapshot 1`] = `
                 target="_blank"
               >
                 <img
-                  alt="Apple Store"
+                  alt="Download on the App Store"
+                  lang="en"
                   src={{}}
                 />
               </a>
@@ -357,7 +358,8 @@ exports[`<Footer /> matches snapshot 1`] = `
                 target="_blank"
               >
                 <img
-                  alt="Google Play"
+                  alt="Get it on Google Play"
+                  lang="en"
                   src={{}}
                 />
               </a>

--- a/client/src/components/Footer/index.tsx
+++ b/client/src/components/Footer/index.tsx
@@ -197,12 +197,20 @@ function Footer(): JSX.Element {
               <ul aria-labelledby='mobile-app' className='mobile-app-container'>
                 <li>
                   <Link to='https://apps.apple.com/us/app/freecodecamp/id6446908151?itsct=apps_box_link&itscg=30200'>
-                    <img src={appleStoreBadge} alt='Apple Store' />
+                    <img
+                      src={appleStoreBadge}
+                      lang='en'
+                      alt='Download on the App Store'
+                    />
                   </Link>
                 </li>
                 <li>
                   <Link to='https://play.google.com/store/apps/details?id=org.freecodecamp'>
-                    <img src={googlePlayBadge} alt='Google Play' />
+                    <img
+                      src={googlePlayBadge}
+                      lang='en'
+                      alt='Get it on Google Play'
+                    />
                   </Link>
                 </li>
               </ul>

--- a/e2e/footer.spec.ts
+++ b/e2e/footer.spec.ts
@@ -112,13 +112,13 @@ test.describe('Footer mobile app section', () => {
     const appleStoreLink = downloadLinks[0];
 
     await expect(
-      appleStoreLink.getByRole('img', { name: 'Apple Store' })
+      appleStoreLink.getByRole('img', { name: 'Download on the App Store' })
     ).toBeVisible();
     await expect(
-      appleStoreLink.getByRole('link', { name: 'Apple Store' })
+      appleStoreLink.getByRole('link', { name: 'Download on the App Store' })
     ).toBeVisible();
     await expect(
-      appleStoreLink.getByRole('link', { name: 'Apple Store' })
+      appleStoreLink.getByRole('link', { name: 'Download on the App Store' })
     ).toHaveAttribute(
       'href',
       'https://apps.apple.com/us/app/freecodecamp/id6446908151?itsct=apps_box_link&itscg=30200'
@@ -127,13 +127,13 @@ test.describe('Footer mobile app section', () => {
     const googlePlayLink = downloadLinks[1];
 
     await expect(
-      googlePlayLink.getByRole('img', { name: 'Google Play' })
+      googlePlayLink.getByRole('img', { name: 'Get it on Google Play' })
     ).toBeVisible();
     await expect(
-      googlePlayLink.getByRole('link', { name: 'Google Play' })
+      googlePlayLink.getByRole('link', { name: 'Get it on Google Play' })
     ).toBeVisible();
     await expect(
-      googlePlayLink.getByRole('link', { name: 'Google Play' })
+      googlePlayLink.getByRole('link', { name: 'Get it on Google Play' })
     ).toHaveAttribute(
       'href',
       'https://play.google.com/store/apps/details?id=org.freecodecamp'


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

To meet WCAG requirements, the accessible names for the two mobile app links in the footer must include all of the text in the image. Also, I've set the `lang` attribute on both images to `en` since the alt text for these images is always going to be in English.