### PR TITLE
fix(curriculum): allow line breaks in option content in Calorie Counter step 10

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-form-validation-by-building-a-calorie-counter/63b60af1a0b9f7238a9dd294.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-form-validation-by-building-a-calorie-counter/63b60af1a0b9f7238a9dd294.md
@@ -22,7 +22,7 @@ assert.equal(document.querySelectorAll('.controls select option')?.length, 5);
 Your first `option` should have the text `Breakfast`.
 
 ```js
-assert.equal(document.querySelectorAll('.controls select option')?.[0]?.textContent, 'Breakfast');
+assert.equal(document.querySelectorAll('.controls select option')?.[0]?.textContent?.trim(), 'Breakfast');
 ```
 
 Your first `option` should have the `value` attribute set to `breakfast`.
@@ -34,7 +34,7 @@ assert.equal(document.querySelectorAll('.controls select option')?.[0]?.value, '
 Your second `option` should have the text `Lunch`.
 
 ```js
-assert.equal(document.querySelectorAll('.controls select option')?.[1]?.textContent, 'Lunch');
+assert.equal(document.querySelectorAll('.controls select option')?.[1]?.textContent?.trim(), 'Lunch');
 ```
 
 Your second `option` should have the `value` attribute set to `lunch`.
@@ -46,7 +46,7 @@ assert.equal(document.querySelectorAll('.controls select option')?.[1]?.value, '
 Your third `option` should have the text `Dinner`.
 
 ```js
-assert.equal(document.querySelectorAll('.controls select option')?.[2]?.textContent, 'Dinner');
+assert.equal(document.querySelectorAll('.controls select option')?.[2]?.textContent?.trim(), 'Dinner');
 ```
 
 Your third `option` should have the `value` attribute set to `dinner`.
@@ -58,7 +58,7 @@ assert.equal(document.querySelectorAll('.controls select option')?.[2]?.value, '
 Your fourth `option` should have the text `Snacks`.
 
 ```js
-assert.equal(document.querySelectorAll('.controls select option')?.[3]?.textContent, 'Snacks');
+assert.equal(document.querySelectorAll('.controls select option')?.[3]?.textContent?.trim(), 'Snacks');
 ```
 
 Your fourth `option` should have the `value` attribute set to `snacks`.
@@ -70,7 +70,7 @@ assert.equal(document.querySelectorAll('.controls select option')?.[3]?.value, '
 Your fifth `option` should have the text `Exercise`.
 
 ```js
-assert.equal(document.querySelectorAll('.controls select option')?.[4]?.textContent, 'Exercise');
+assert.equal(document.querySelectorAll('.controls select option')?.[4]?.textContent?.trim(), 'Exercise');
 ```
 
 Your fifth `option` should have the `value` attribute set to `exercise`.
@@ -82,7 +82,9 @@ assert.equal(document.querySelectorAll('.controls select option')?.[4]?.value, '
 Your first `option` should be selected by default.
 
 ```js
-assert.isTrue(document.querySelectorAll('.controls select option')?.[0]?.getAttributeNames()?.includes('selected'));
+const isFirstOptionSelected = document.querySelectorAll('.controls select option')?.[0]?.getAttributeNames()?.includes('selected');
+const selectedOptions = document.querySelectorAll('.controls select option[selected]');
+assert.isTrue(isFirstOptionSelected && selectedOptions.length === 1);
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This issue was discovered in Discord: https://discord.com/channels/692816967895220344/718214639669870683/1188445063878017065.

Link to the challenge: https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures-v8/learn-form-validation-by-building-a-calorie-counter/step-10

At the moment the check is too strict and would fail if the content of `option` is on a new line. This PR fixes it as well as improving the "Your first `option` should be selected by default." check to ensure there is only one option with `selected`.

## Testing

I tested the change with the following solutions:

### `option` content being on a new line

Currently fails in production, but it should pass.

```html
<div class="controls">
  <span>
    <label for="entry-dropdown">Add food or exercise:</label>
    <select id="entry-dropdown" name="options">
      <option value="breakfast" selected>
        Breakfast
      </option>
      <option value="lunch">
	    Lunch
      </option>
      <option value="dinner">
	  	Dinner
	  </option>
      <option value="snacks">
        Snacks
      </option>
      <option value="exercise">
		Exercise
	  </option>
    </select>
    <button type="button" id="add-entry">Add Entry</button>
  </span>
</div>
```

### Multiple `option`s being selected

Currently passes in production, but it should fail.

```html
<div class="controls">
  <span>
    <label for="entry-dropdown">Add food or exercise:</label>
    <select id="entry-dropdown" name="options">
      <option value="breakfast" selected>Breakfast</option>
      <option value="lunch" selected>Lunch</option>
      <option value="dinner">Dinner</option>
      <option value="snacks">Snacks</option>
      <option value="exercise">Exercise</option>
    </select>
    <button type="button" id="add-entry">Add Entry</button>
  </span>
</div>
```

<!-- Feel free to add any additional description of changes below this line -->
