### PR TITLE
fix(curriculum): modify test to allow for space between `=` and `(` in Spreadsheet Step 19

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-functional-programming-by-building-a-spreadsheet/643498755d54c6279ba09078.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-functional-programming-by-building-a-spreadsheet/643498755d54c6279ba09078.md
@@ -52,7 +52,7 @@ assert.notMatch(code, /const\s*sum\s*=\s*\(?\s*nums\s*\)?\s*=>\s*{/);
 Your `sum` function should return the result of calling `.reduce()` on `nums`.
 
 ```js
-assert.match(code, /const\s*sum\s*=\(?\s*nums\s*\)?\s*=>\s*nums\.reduce\(/);
+assert.match(code, /const\s*sum\s*=\s*\(?\s*nums\s*\)?\s*=>\s*nums\.reduce\(/);
 ```
 
 Your `sum` function should return the sum of all numbers in `nums`.


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Closes #52791 

Files Changed - 
- [Spreadsheet Step 19](https://github.com/freeCodeCamp/freeCodeCamp/blob/4a6b86a614a2fdda1191e1e1155094de18b44fcc/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-functional-programming-by-building-a-spreadsheet/643498755d54c6279ba09078.md?plain=1#L52-L55)

Changes implemented -
- Modified test to allow the space character
