### PR TITLE
refactor(client): migrate Bootstrap components in update-stripe-card

### DIFF
--- a/client/src/components/Donation/card-update-alert-handler.tsx
+++ b/client/src/components/Donation/card-update-alert-handler.tsx
@@ -1,7 +1,7 @@
-import { Alert, Button } from '@freecodecamp/react-bootstrap';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import Spinner from 'react-spinkit';
+import { Alert } from '@freecodecamp/ui';
 
 type CardUpdateAlertHandlerProps = {
   error: string | null;
@@ -19,21 +19,15 @@ function CardUpdateAlertHandler({
   const { t } = useTranslation();
   const style = redirecting ? 'info' : success ? 'success' : 'danger';
 
-  const heading = redirecting
+  const message = redirecting
     ? `${t('donate.redirecting')}`
     : success
       ? `${t('donate.success-card-update')}`
       : `${t('donate.error-card-update')}`;
 
   return (
-    <Alert
-      bsStyle={style}
-      className='donation-completion'
-      closeLabel={t('buttons.close')}
-    >
-      <h4>
-        <b>{heading}</b>
-      </h4>
+    <Alert variant={style} className='donation-completion'>
+      <p>{message}</p>
       <div className='donation-completion-body'>
         {redirecting && (
           <Spinner
@@ -48,9 +42,9 @@ function CardUpdateAlertHandler({
       <div className='donation-completion-buttons'>
         {error && (
           <div>
-            <Button bsStyle='primary' onClick={reset}>
+            <button type='button' className='try-again-button' onClick={reset}>
               {t('buttons.try-again')}
-            </Button>
+            </button>
           </div>
         )}
       </div>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR:
- Updates the Update Stripe Card page to use `ui-components` components instead of Bootstrap
- Related to #52092 

(I'm having this change on a separate branch / PR since I'm quite scared of touching the donate workflow.)

## Steps to test

I visited /update-stripe-card and changed the conditional rendering logic of the alert box to have it displayed.

## Screenshots

| Before | After |
| --- | --- |
| <img width="593" alt="Screenshot 2023-12-29 at 14 37 04" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/e6e87de8-4e1c-4c36-a3d3-0c95aa1af0e8"> | <img width="602" alt="Screenshot 2023-12-29 at 14 22 55" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/286981ea-23c5-4507-a7b2-718dfccf3a95"> |

<!-- Feel free to add any additional description of changes below this line -->
