### PR TITLE
fix(curriculum): update test to accept both single and double quotes

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-string-and-array-methods-by-building-a-music-player/6555de565387a2efe90a6ccc.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-string-and-array-methods-by-building-a-music-player/6555de565387a2efe90a6ccc.md
@@ -34,7 +34,7 @@ assert.match(code, /playButton\.setAttribute\(\s*('|")aria-label\1/)
 Your `setAttribute` method should have ``song?.title ? `Play ${song.title}` : "Play"`` as the second argument.
 
 ```js
-assert.match(code, /playButton\.setAttribute\(\s*('|")aria-label\1,\s*song\?\.title\s*\?\s*`Play\s*\$\{song\.title\}`\s*:\s*\1Play\1\s*\);?\s*/)
+assert.match(code, /playButton\.setAttribute\(\s*('|")aria-label\1,\s*song\?\.title\s*\?\s*`Play\s*\$\{song\.title\}`\s*:\s*('|")Play\1\s*\);?\s*/)
 ```
 
 # --seed--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-string-and-array-methods-by-building-a-music-player/6555de565387a2efe90a6ccc.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-string-and-array-methods-by-building-a-music-player/6555de565387a2efe90a6ccc.md
@@ -34,7 +34,7 @@ assert.match(code, /playButton\.setAttribute\(\s*('|")aria-label\1/)
 Your `setAttribute` method should have ``song?.title ? `Play ${song.title}` : "Play"`` as the second argument.
 
 ```js
-assert.match(code, /playButton\.setAttribute\(\s*('|")aria-label\1,\s*song\?\.title\s*\?\s*`Play\s*\$\{song\.title\}`\s*:\s*('|")Play\1\s*\);?\s*/)
+assert.match(code, /playButton\.setAttribute\(\s*('|")aria-label\1,\s*song\?\.title\s*\?\s*`Play\s*\$\{song\.title\}`\s*:\s*('|")Play\2\s*\);?\s*/)
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #52823 

<!-- Feel free to add any additional description of changes below this line -->
Files Changed:
- [Music Player Step 59](https://github.com/freeCodeCamp/freeCodeCamp/blob/72188ba85b57cadee5680630d9f154dd22839e8b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-string-and-array-methods-by-building-a-music-player/6555de565387a2efe90a6ccc.md?plain=1#L34-L38)

Changes Implemented: 
- Added `('|")` to allow both single and double quotes
