### PR TITLE
fix(playwright): skip real time test

### DIFF
--- a/client/src/components/profile/components/heat-map.test.tsx
+++ b/client/src/components/profile/components/heat-map.test.tsx
@@ -1,7 +1,12 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 
+import envData from '../../../../config/env.json';
+import { getLangCode } from '../../../../../shared/config/i18n';
 import HeatMap from './heat-map';
+
+const { clientLocale } = envData;
+const localeCode = getLangCode(clientLocale);
 
 // offset is used to shift the dates so that the calendar renders (for testing
 // purposes only) the same way in each timezone.
@@ -9,6 +14,7 @@ const offset = new Date().getTimezoneOffset() * 60;
 const date1 = 1580497504 + offset;
 const date2 = 1580597504 + offset;
 const date3 = 1580729769 + offset;
+const now = 1580729769714 + offset * 1000; // 2020-02-03T04:36:09.714Z
 
 const props: { calendar: { [key: number]: number } } = {
   calendar: {}
@@ -22,9 +28,7 @@ props.calendar[date3] = 1;
 let dateNowMockFn: jest.MockInstance<any, unknown[]>;
 
 beforeEach(() => {
-  dateNowMockFn = jest
-    .spyOn(Date, 'now')
-    .mockImplementation(() => 1580729769714 + offset * 1000);
+  dateNowMockFn = jest.spyOn(Date, 'now').mockImplementation(() => now);
 });
 
 afterEach(() => {
@@ -42,7 +46,24 @@ describe('<HeatMap/>', () => {
 
   it('displays the correct title', () => {
     render(<HeatMap {...props} />);
-    expect(screen.getByText('Aug 2019 - Feb 2020')).toBeInTheDocument();
+
+    const endDate = new Date(now);
+    const startDate = new Date('2019-08-04T04:36:09.714Z'); // subtract 6 months and add 1 day from endDate
+    const endOfCalendar = endDate.toLocaleDateString([localeCode, 'en-US'], {
+      year: 'numeric',
+      month: 'short'
+    });
+    const startOfCalendar = startDate.toLocaleDateString(
+      [localeCode, 'en-US'],
+      {
+        year: 'numeric',
+        month: 'short'
+      }
+    );
+
+    expect(
+      screen.getByText(`${startOfCalendar} - ${endOfCalendar}`)
+    ).toBeInTheDocument();
   });
 
   it('calculates the correct longest streak', () => {

--- a/client/src/components/profile/components/heat-map.test.tsx
+++ b/client/src/components/profile/components/heat-map.test.tsx
@@ -40,6 +40,11 @@ describe('<HeatMap/>', () => {
   });
   */
 
+  it('displays the correct title', () => {
+    render(<HeatMap {...props} />);
+    expect(screen.getByText('Aug 2019 - Feb 2020')).toBeInTheDocument();
+  });
+
   it('calculates the correct longest streak', () => {
     render(<HeatMap {...props} />);
     expect(screen.getByTestId('longest-streak')).toHaveTextContent(

--- a/e2e/profile.spec.ts
+++ b/e2e/profile.spec.ts
@@ -109,7 +109,12 @@ test.describe('Profile component', () => {
     await expect(page.getByText('Number of points: 1')).toBeVisible();
   });
 
-  test('renders the heat map correctly', async ({ page }) => {
+  // The date range computation in this test doesn't match the implementation code,
+  // and causes the test to fail in some cases.
+  // We would want to mock system time to keep the test stable,
+  // but Playwright currently doesn't offer a built-in mechanism for this.
+  // Ref: https://github.com/microsoft/playwright/issues/6347
+  test.skip('renders the heat map correctly', async ({ page }) => {
     const today = new Date();
     const currentMonth = today.toLocaleString('en-US', { month: 'short' });
     const sixMonthsAgo = new Date(today.setMonth(today.getMonth() - 6));


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

## Issue

There is a Playwright test case that uses real time. It was working fine for ~2 months, but is now running in to some edge case and failing.

The test expects that the user profile page would show a heat map with a title of "[current month - 6] [year of that month] - [current month] [year of current month]", which would be "Jun 2023 - Dec 2023". 

However, the heat map on the profile page is actually showing "Jul 2023 - Dec 2023", causing the test to fail.

<img width="823" alt="Screenshot 2023-12-31 at 00 35 03" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/5626ea64-2fbb-43ce-8e9b-f121036882e5">

Failure:

<img width="936" alt="Screenshot 2023-12-31 at 00 26 36" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/ee4a6faa-1936-4ad7-b071-c462009ce7bc">

Log: https://github.com/freeCodeCamp/freeCodeCamp/actions/runs/7363884394/job/20045180349?pr=52828

## Solution

Ideally we would want to stabilize the test by mocking the system time instead of dealing with real time, but Playwright doesn't have this feature yet (https://github.com/microsoft/playwright/issues/6347). I've tried applying the workarounds mentioned in the issue thread as well, but none of them works.

To unblock other PRs, I'm temporarily skipping this Playwright test case and add a unit test for the title instead (Jest allows us to mock the `Date` object, thankfully).

<!-- Feel free to add any additional description of changes below this line -->
