### PR TITLE
fix(curriculum):  typo in hint 'elif == '5' (missing variable) Expense Tracker step 41

### DIFF
--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-lambda-functions-by-building-an-expense-tracker/6582687859366a618424d84b.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-lambda-functions-by-building-an-expense-tracker/6582687859366a618424d84b.md
@@ -13,7 +13,7 @@ Inside the new `elif` statement, print the string `Exiting the program.` to show
 
 # --hints--
 
-You should have `elif == '5':` in your code.
+You should have `elif choice == '5':` in your code.
 
 ```js
 ({ test: () =>


### PR DESCRIPTION
Hint: You should have elif == '5': in your code.

should be

elif choice == '5':

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
