### PR TITLE
fix(curriculum): fixing and changing the confusing use of brackets in challenges text

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62aa226207f33d3ad4c6f546.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62aa226207f33d3ad4c6f546.md
@@ -7,7 +7,7 @@ dashedName: step-155
 
 # --description--
 
-Use the `+=` operator to add `Your [weapon] breaks.`, with a space in front of `Your`, to the end of `text.innerText`. Replace `[weapon]` with the last item in the `inventory` array using `inventory.pop()`, which will remove the last item in the array AND return it so it appears in your string.
+Use the `+=` operator to add `Your <weapon> breaks.`, with a space in front of `Your`, to the end of `text.innerText`. Replace `[weapon]` with the last item in the `inventory` array using `inventory.pop()`, which will remove the last item in the array AND return it so it appears in your string.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Closes #52809

<!-- Feel free to add any additional description of changes below this line -->

Changes the way the bracket notation is used in the code, so that the instructions are not misinterpreted.

Goes from ```Your [weapon] breaks.``` to ```Your <weapon> breaks.```