### PR TITLE
fix(curriculum): fixing the potentially confusing use of brackets in challenges text.

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a8e35675c18c56354c08cf.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a8e35675c18c56354c08cf.md
@@ -7,7 +7,7 @@ dashedName: step-119
 
 # --description--
 
-Now you can build the `attack` function. First, update the `text` message to say `The [monster name] attacks.`, replacing `[monster name]` with the name of the monster. Remember you can use the concatenation operator for this.
+Now you can build the `attack` function. First, update the `text` message to say `The <monster name> attacks.`, replacing `<monster name>` with the name of the monster. Remember you can use the concatenation operator for this.
 
 # --hints--
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a8e41e2f190c58404dd46e.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a8e41e2f190c58404dd46e.md
@@ -7,7 +7,7 @@ dashedName: step-120
 
 # --description--
 
-On a new line, add the string ` You attack it with your [weapon].` to the `text` value, replacing `[weapon]` with the player's current weapon.
+On a new line, add the string ` You attack it with your <weapon>.` to the `text` value, replacing `<weapon>` with the player's current weapon.
 
 # --hints--
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a8eec45f77bc69e8775294.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a8eec45f77bc69e8775294.md
@@ -7,7 +7,7 @@ dashedName: step-128
 
 # --description--
 
-Inside the `dodge` function, set `text.innerText` equal to the string `You dodge the attack from the [monster]`. Replace `[monster]` with the name of the monster, using the `name` property.
+Inside the `dodge` function, set `text.innerText` equal to the string `You dodge the attack from the <monster>`. Replace `<monster>` with the name of the monster, using the `name` property.
 
 # --hints--
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62aa226207f33d3ad4c6f546.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62aa226207f33d3ad4c6f546.md
@@ -7,7 +7,7 @@ dashedName: step-155
 
 # --description--
 
-Use the `+=` operator to add `Your [weapon] breaks.`, with a space in front of `Your`, to the end of `text.innerText`. Replace `[weapon]` with the last item in the `inventory` array using `inventory.pop()`, which will remove the last item in the array AND return it so it appears in your string.
+Use the `+=` operator to add `Your <weapon> breaks.`, with a space in front of `Your`, to the end of `text.innerText`. Replace `<weapon>` with the last item in the `inventory` array using `inventory.pop()`, which will remove the last item in the array AND return it so it appears in your string.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Closes #52809

Changes the way the bracket notation is used in the code, so that the instructions are not misinterpreted.

Changes both instances where the instructions say ```[weapon]``` to ```[weapon]```
