### PR TITLE
fix(curriculum): fix typos in Music Player

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-string-and-array-methods-by-building-a-music-player/65521badc7b7470edf952372.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-string-and-array-methods-by-building-a-music-player/65521badc7b7470edf952372.md
@@ -9,7 +9,7 @@ dashedName: step-32
 
 Now you need to work on pausing the currently playing song.
 
-Define a `pauseSong` function using the `const` keyword and arrow function sysntax. The function should take no parameters.
+Define a `pauseSong` function using the `const` keyword and arrow function syntax. The function should take no parameters.
 
 # --hints--
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-string-and-array-methods-by-building-a-music-player/65521ec3bb117c195c4f6cb5.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-string-and-array-methods-by-building-a-music-player/65521ec3bb117c195c4f6cb5.md
@@ -7,7 +7,7 @@ dashedName: step-33
 
 # --description--
 
-To store the current time of the song when it is paused paused, set the `songCurrentTime` of the `userData` object to the `currentTime` of the `audio` variable.
+To store the current time of the song when it is paused, set the `songCurrentTime` of the `userData` object to the `currentTime` of the `audio` variable.
 
 # --hints--
 


### PR DESCRIPTION
Corrected the spelling of syntax in [this](https://github.com/freeCodeCamp/freeCodeCamp/blob/main/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-string-and-array-methods-by-building-a-music-player/65521badc7b7470edf952372.md)

Removed one of the two paused from [this](https://github.com/freeCodeCamp/freeCodeCamp/blob/main/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-string-and-array-methods-by-building-a-music-player/65521ec3bb117c195c4f6cb5.md)

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #52853

Closed #52854

<!-- Feel free to add any additional description of changes below this line -->

I tried to fix both the typos with this one PR. I hope that's okay. 
