### PR TITLE
fix(curriculum): don't force comparison order

### DIFF
--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-algorithm-design-by-building-a-shortest-path-algorithm/65577a17564ce8a8e06c1460.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-algorithm-design-by-building-a-shortest-path-algorithm/65577a17564ce8a8e06c1460.md
@@ -22,8 +22,8 @@ You should use the dictionary comprehension syntax to give a value to your `dist
 ```js
 ({ test: () =>  {
     const shortest = __helpers.python.getDef(code, "shortest_path");
-    const {function_body} = shortest;    
-    assert(function_body.match(/^\s{4}distances\s*=\s*\{\s*(\w+)\s*:\s*0\s+if\s+\1\s*==\s*start\s+else\s+float\s*\(\s*("|')inf\2\s*\)\s+for\s+\1\s+in\s+graph\s*\}/m));
+    const {function_body} = shortest;
+    assert(function_body.match(/^\s{4}distances\s*=\s*\{\s*(\w+)\s*:\s*0\s+if\s+(?:\1\s*==\s*start|start\s*==\s*\1)\s+else\s+float\s*\(\s*("|')inf\2\s*\)\s+for\s+\1\s+in\s+graph\s*\}/m));
   }
 })
 ```


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

- - -
- Allows other order in the comparison.
https://www.freecodecamp.org/learn/scientific-computing-with-python/learn-algorithm-design-by-building-a-shortest-path-algorithm/step-30
```python
def shortest_path(graph, start):
    unvisited = list(graph)
    distances = {node: 0 if start == node else float('inf') for node in graph}
    paths = {node: [] for node in graph}
    print(f'Unvisited: {unvisited}\nDistances: {distances}')
    
shortest_path(my_graph, 'A')
```