### PR TITLE
fix(client): increase line height of list items in challenge description

### DIFF
--- a/client/src/templates/Challenges/components/challenge-description.css
+++ b/client/src/templates/Challenges/components/challenge-description.css
@@ -13,5 +13,5 @@
 }
 
 #description ol li {
-  line-height: 1.7;
+  line-height: 1.5;
 }

--- a/client/src/templates/Challenges/components/challenge-description.css
+++ b/client/src/templates/Challenges/components/challenge-description.css
@@ -11,3 +11,7 @@
 #description ol li a {
   word-break: break-all;
 }
+
+#description ol li {
+  line-height: 1.7;
+}

--- a/client/src/templates/Challenges/components/test-suite.css
+++ b/client/src/templates/Challenges/components/test-suite.css
@@ -20,6 +20,7 @@
   display: flex;
   width: 100%;
   align-items: center;
+  line-height: 1.5;
 }
 
 .test-result:nth-child(odd) {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR increases the line height of the list items in challenge description to improve the readability.

## Testing

Tested on `/learn/javascript-algorithms-and-data-structures-v8/build-a-palindrome-checker-project/build-a-palindrome-checker`.

## Screenshots

| Before | After |
| --- | --- |
| <img width="613" alt="Screenshot 2024-01-01 at 13 33 51" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/7b360085-2728-4f6e-91b5-8379f07180e2"> | <img width="615" alt="Screenshot 2024-01-01 at 13 41 54" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/3fd60a7e-3f50-4ef1-b7fe-e5d148bec005"> |

<!-- Feel free to add any additional description of changes below this line -->
