### PR TITLE
fix: remove id attribute at formGroup outer tag

### DIFF
--- a/tools/ui-components/src/control-label/control-label.test.tsx
+++ b/tools/ui-components/src/control-label/control-label.test.tsx
@@ -18,7 +18,6 @@ describe('<ControlLabel>', () => {
 
     expect(labelElement).toBeInTheDocument();
     expect(formGroupElement).toContainElement(labelElement);
-    expect(formGroupElement).toHaveAttribute('id', id);
     expect(labelElement).toHaveAttribute('for', id);
   });
 });

--- a/tools/ui-components/src/form-group/form-group.tsx
+++ b/tools/ui-components/src/form-group/form-group.tsx
@@ -29,7 +29,6 @@ export const FormGroup = ({
       <Component
         className={classes}
         as={as}
-        id={controlId}
         {...props}
         validationstate={validationState}
       />


### PR DESCRIPTION
Checklist:


- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

closes #52848

<!-- Feel free to add any additional description of changes below this line -->
