### PR TITLE
fix(a11y, ui-components): duplicate ID in FormGroup

### DIFF
--- a/tools/ui-components/src/control-label/control-label.test.tsx
+++ b/tools/ui-components/src/control-label/control-label.test.tsx
@@ -4,21 +4,30 @@ import { render, screen } from '@testing-library/react';
 import { FormGroup } from '../form-group';
 import { ControlLabel } from '.';
 
-const id = 'foo';
 describe('<ControlLabel>', () => {
-  it('inherit id', () => {
+  it('should inherit `controlId` from FormGroup', () => {
     render(
-      <FormGroup role='group' controlId={id}>
-        <ControlLabel>Label in formgroup</ControlLabel>
+      <FormGroup controlId='foo'>
+        <ControlLabel>Label</ControlLabel>
       </FormGroup>
     );
 
-    const labelElement = screen.getByText('Label in formgroup');
-    const formGroupElement = screen.getByRole('group');
+    const labelElement = screen.getByText('Label');
 
     expect(labelElement).toBeInTheDocument();
-    expect(formGroupElement).toContainElement(labelElement);
-    expect(formGroupElement).toHaveAttribute('id', id);
-    expect(labelElement).toHaveAttribute('for', id);
+    expect(labelElement).toHaveAttribute('for', 'foo');
+  });
+
+  it('should use `htmlFor` over `controlId` if both are specified', () => {
+    render(
+      <FormGroup controlId='foo'>
+        <ControlLabel htmlFor='bar'>Label</ControlLabel>
+      </FormGroup>
+    );
+
+    const labelElement = screen.getByText('Label');
+
+    expect(labelElement).toBeInTheDocument();
+    expect(labelElement).toHaveAttribute('for', 'bar');
   });
 });

--- a/tools/ui-components/src/form-control/form-control.test.tsx
+++ b/tools/ui-components/src/form-control/form-control.test.tsx
@@ -1,12 +1,26 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 
+import { FormGroup } from '../form-group';
 import { FormControl } from '.';
 
 describe('<FormControl />', () => {
   it('should render correctly', () => {
     render(<FormControl aria-label='test' />);
     expect(screen.getByLabelText('test')).toBeInTheDocument();
+  });
+
+  it('should use `id` over `controlId` if both are specified', () => {
+    render(
+      <FormGroup controlId='foo'>
+        <FormControl id='bar' />
+      </FormGroup>
+    );
+
+    const input = screen.getByRole('textbox');
+
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveAttribute('id', 'bar');
   });
 });
 

--- a/tools/ui-components/src/form-group/form-group.test.tsx
+++ b/tools/ui-components/src/form-group/form-group.test.tsx
@@ -2,8 +2,11 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 
 import { FormControl } from '../form-control/.';
+import { ControlLabel } from '../control-label';
 import { FormGroup } from '.';
+
 const sameNumberOfChildren = 2;
+
 describe('<FormGroup>', () => {
   it('renders children', () => {
     render(
@@ -23,13 +26,20 @@ describe('<FormGroup>', () => {
     });
   });
 
-  it('provided controlId to label and control', () => {
+  it('should pass `controlId` to the label and input elements', () => {
     render(
-      <FormGroup controlId='my-control' data-testid='test-id'>
-        <FormControl aria-label='test' />
+      <FormGroup controlId='foo'>
+        <ControlLabel>Foo</ControlLabel>
+        <FormControl />
       </FormGroup>
     );
-    const input = screen.getByLabelText('test');
-    expect(input.id).toBe('my-control');
+
+    const label = screen.getByText('Foo');
+    const input = screen.getByLabelText('Foo');
+
+    expect(label).toBeInTheDocument();
+    expect(label).toHaveAttribute('for', 'foo');
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveAttribute('id', 'foo');
   });
 });

--- a/tools/ui-components/src/form-group/form-group.tsx
+++ b/tools/ui-components/src/form-group/form-group.tsx
@@ -29,7 +29,6 @@ export const FormGroup = ({
       <Component
         className={classes}
         as={as}
-        id={controlId}
         {...props}
         validationstate={validationState}
       />


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

The `FormGroup` component is supposed to receive an ID and pass the ID down to the child `label` and `input`. However, it is also assigning the ID to the wrapper `div`, causing the HTML to be invalid due to the duplicate ID and resulting an accessibility issue.

This PR:
- Fixes the issue by removing the `id` from the wrapper `div`
- Adds tests to ensure that the child `label` and `input` of `FormGroup` are associated correctly
- Adds tests for the case where both `id` and `controlId` are specified 

Closes #52848

## Testing

Tested on the Update Email page.

| Before | After |
| --- | --- |
| <img width="1221" alt="Screenshot 2023-12-31 at 16 00 53" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/c14455bc-476b-470b-b125-5e0738a92c7b"> | <img width="1222" alt="Screenshot 2024-01-01 at 15 19 12" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/e63995c3-a3ac-4298-9cea-0c342f0ad57d"> |

<!-- Feel free to add any additional description of changes below this line -->
