### PR TITLE
fix(curriculum): accept no space after the `#`

### DIFF
--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-recursion-by-solving-the-tower-of-hanoi-puzzle/64ddd65848a12919d7e1c7d0.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-recursion-by-solving-the-tower-of-hanoi-puzzle/64ddd65848a12919d7e1c7d0.md
@@ -16,7 +16,7 @@ You should move the code nested inside the first `if` statement (except the firs
 
 ```js
 ({ test: () => {
-  assert.match(code, /def\s+make_allowed_move\(rod1, rod2\):\s+forward\s+=\s+False\s+if\s+not\s+rods\[\s*target\s*\]\s*:\s+forward\s*=\s*True\s+elif\s+rods\[\s*source\s*\]\s+and\s+rods\[\s*source\s*\]\[-1\]\s<\srods\[\s*target\s*\]\[\s*-\s*1\s*\]:\s+forward\s*=\s*True\s+if\s+forward\s*:\s+print\(\s*f'Moving\sdisk\s\{\s*rods\[\s*source\s*\]\[\s*-\s*1\s*\]\s*\}\sfrom\s\{\s*source\s*\}\sto\s\{\s*target\s*\}'\s*\)\s+rods\[\s*target\s*\]\.append\(\s*rods\[\s*source\s*\]\.pop\(\s*\)\s*\)\s+else\s*:\s+print\(\s*f'Moving\sdisk\s\{\s*rods\[\s*target\s*\]\[\s*-\s*1\s*\]\}\sfrom\s\{\s*target\s*\}\sto\s\{\s*source\s*\}'\s*\)\s+rods\[\s*source\s*\].append\(\s*rods\[\s*target\s*\].pop\(\s*\)\s*\)\s+#\sdisplay\sour\sprogress\s+\print\(\s*rods\s*\)/);  
+  assert.match(code, /def\s+make_allowed_move\(rod1, rod2\):\s+forward\s+=\s+False\s+if\s+not\s+rods\[\s*target\s*\]\s*:\s+forward\s*=\s*True\s+elif\s+rods\[\s*source\s*\]\s+and\s+rods\[\s*source\s*\]\[-1\]\s<\srods\[\s*target\s*\]\[\s*-\s*1\s*\]:\s+forward\s*=\s*True\s+if\s+forward\s*:\s+print\(\s*f'Moving\sdisk\s\{\s*rods\[\s*source\s*\]\[\s*-\s*1\s*\]\s*\}\sfrom\s\{\s*source\s*\}\sto\s\{\s*target\s*\}'\s*\)\s+rods\[\s*target\s*\]\.append\(\s*rods\[\s*source\s*\]\.pop\(\s*\)\s*\)\s+else\s*:\s+print\(\s*f'Moving\sdisk\s\{\s*rods\[\s*target\s*\]\[\s*-\s*1\s*\]\}\sfrom\s\{\s*target\s*\}\sto\s\{\s*source\s*\}'\s*\)\s+rods\[\s*source\s*\].append\(\s*rods\[\s*target\s*\].pop\(\s*\)\s*\)\s+#\s*display\sour\sprogress\s+\print\(\s*rods\s*\)/);
   }
 })
 ```


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

- - -
- Allows skipping space after the `#` in comment
https://www.freecodecamp.org/learn/scientific-computing-with-python/learn-recursion-by-solving-the-tower-of-hanoi-puzzle/step-31
```python
def make_allowed_move(rod1, rod2):
    forward = False
    if not rods[target]:
        forward = True
    elif rods[source] and rods[source][-1] < rods[target][-1]:
        forward = True
    if forward:
        print(f'Moving disk {rods[source][-1]} from {source} to {target}')
        rods[target].append(rods[source].pop())
    else:
        print(f'Moving disk {rods[target][-1]} from {target} to {source}')
        rods[source].append(rods[target].pop())
    #display our progress
    print(rods)

def move(n, source, auxiliary, target):
    # display starting configuration
    print(rods)
    for i in range(number_of_moves):
        remainder = (i + 1) % 3
        if remainder == 1:
            print(f'Move {i + 1} allowed between {source} and {target}')
```