### PR TITLE
fix: telephone number validator #results-div typo

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/build-a-telephone-number-validator-project/build-a-telephone-number-validator.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/build-a-telephone-number-validator-project/build-a-telephone-number-validator.md
@@ -33,33 +33,33 @@ Note that the area code is required. Also, if the country code is provided, you 
 1. When you click on the `#check-btn` element without entering a value into the `#user-input` element, an alert should appear with the text `Please provide a phone number`
 1. When you click on the `#clear-btn` element, the content within the `#results-div` element should be removed
 1. When the `#user-input` element contains `1 555-555-5555` and the `#check-btn` element is clicked, the `#results-div` element should contain the text `Valid US number: 1 555-555-5555`
-1. When the `#user-input` element contains `1 (555) 555-5555` and the `#check-btn` element is clicked, the `#result-div` element should contain the text `Valid US number: 1 (555) 555-5555`
-1. When the `#user-input` element contains `5555555555` and the `#check-btn` element is clicked, the `#result-div` element should contain the text `Valid US number: 5555555555`
-1. When the `#user-input` element contains `555-555-5555` and the `#check-btn` element is clicked, the `#result-div` element should contain the text `Valid US number: 555-555-5555`
-1. When the `#user-input` element contains `(555)555-5555` and the `#check-btn` element is clicked, the `#result-div` element should contain the text `Valid US number: (555)555-5555`
-1. When the `#user-input` element contains `1(555)555-5555` and the `#check-btn` element is clicked, the `#result-div` element should contain the text `Valid US number: 1(555)555-5555`
-1. When the `#user-input` element contains `555-5555` and the `#check-btn` element is clicked, the `#result-div` element should contain the text `Invalid US number: 555-5555`
-1. When the `#user-input` element contains `5555555` and the `#check-btn` element is clicked, the `#result-div` element should contain the text `Invalid US number: 5555555`
-1. When the `#user-input` element contains `1 555)555-5555` and the `#check-btn` element is clicked, the `#result-div` element should contain the text `Invalid US number: 1 555)555-5555`
-1. When the `#user-input` element contains `1 555 555 5555` and the `#check-btn` element is clicked, the `#result-div` element should contain the text `Valid US number: 1 555 555 5555`
-1. When the `#user-input` element contains `1 456 789 4444` and the `#check-btn` element is clicked, the `#result-div` element should contain the text `Valid US number: 1 456 789 4444`
-1. When `#user-input` contains `123**&!!asdf#` and `#check-btn` is clicked, `#result-div` should contain the text `Invalid US number: 123**&!!asdf#`
-1. When the `#user-input` element contains `55555555` and the `#check-btn` element is clicked, the `#result-div` element should contain the text `Invalid US number: 55555555`
-1. When the `#user-input` element contains `(6054756961)` and the `#check-btn` element is clicked, the `#result-div` element should contain the text `Invalid US number: (6054756961)`
-1. When the `#user-input` element contains `2 (757) 622-7382` and the `#check-btn` element is clicked, the `#result-div` element should contain the text `Invalid US number: 2 (757) 622-7382`
-1. When the `#user-input` element contains `0 (757) 622-7382` and the `#check-btn` element is clicked, the `#result-div` element should contain the text `Invalid US number: 0 (757) 622-7382`
-1. When the `#user-input` element contains `-1 (757) 622-7382` and the `#check-btn` element is clicked, the `#result-div` element should contain the text `Invalid US number: -1 (757) 622-7382`
-1. When the `#user-input` element contains `2 757 622-7382` and the `#check-btn` element is clicked, the `#result-div` element should contain the text `Invalid US number: 2 757 622-7382`
-1. When the `#user-input` element contains `10 (757) 622-7382` and the `#check-btn` element is clicked, the `#result-div` element should contain the text `Invalid US number: 10 (757) 622-7382`
-1. When the `#user-input` element contains `27576227382` and the `#check-btn` element is clicked, the `#result-div` element should contain the text `Invalid US number: 27576227382`
-1. When the `#user-input` element contains `(275)76227382` and the `#check-btn` element is clicked, the `#result-div` element should contain the text `Invalid US number: (275)76227382`
-1. When the `#user-input` element contains `2(757)6227382` and the `#check-btn` element is clicked, the `#result-div` element should contain the text `Invalid US number: 2(757)6227382`
-1. When the `#user-input` element contains `2(757)622-7382` and the `#check-btn` element is clicked, the `#result-div` element should contain the text `Invalid US number: 2(757)622-7382`
-1. When the `#user-input` element contains `555)-555-5555` and the `#check-btn` element is clicked, the `#result-div` element should contain the text `Invalid US number: 555)-555-5555`
-1. When the `#user-input` element contains `(555-555-5555` and the `#check-btn` element is clicked, the `#result-div` element should contain the text `Invalid US number: (555-555-5555`
-1. When `#user-input` contains `(555)5(55?)-5555` and `#check-btn` is clicked, `#result-div` should contain the text `Invalid US number: (555)5(55?)-5555`
-1. When the `#user-input` element contains `55 55-55-555-5` and the `#check-btn` element is clicked, the `#result-div` element should contain the text `Invalid US number: 55 55-55-555-5`
-1. When the `#user-input` element contains `11 555-555-5555` and the `#check-btn` element is clicked, the `#result-div` element should contain the text `Invalid US number: 11 555-555-5555`
+1. When the `#user-input` element contains `1 (555) 555-5555` and the `#check-btn` element is clicked, the `#results-div` element should contain the text `Valid US number: 1 (555) 555-5555`
+1. When the `#user-input` element contains `5555555555` and the `#check-btn` element is clicked, the `#results-div` element should contain the text `Valid US number: 5555555555`
+1. When the `#user-input` element contains `555-555-5555` and the `#check-btn` element is clicked, the `#results-div` element should contain the text `Valid US number: 555-555-5555`
+1. When the `#user-input` element contains `(555)555-5555` and the `#check-btn` element is clicked, the `#results-div` element should contain the text `Valid US number: (555)555-5555`
+1. When the `#user-input` element contains `1(555)555-5555` and the `#check-btn` element is clicked, the `#results-div` element should contain the text `Valid US number: 1(555)555-5555`
+1. When the `#user-input` element contains `555-5555` and the `#check-btn` element is clicked, the `#results-div` element should contain the text `Invalid US number: 555-5555`
+1. When the `#user-input` element contains `5555555` and the `#check-btn` element is clicked, the `#results-div` element should contain the text `Invalid US number: 5555555`
+1. When the `#user-input` element contains `1 555)555-5555` and the `#check-btn` element is clicked, the `#results-div` element should contain the text `Invalid US number: 1 555)555-5555`
+1. When the `#user-input` element contains `1 555 555 5555` and the `#check-btn` element is clicked, the `#results-div` element should contain the text `Valid US number: 1 555 555 5555`
+1. When the `#user-input` element contains `1 456 789 4444` and the `#check-btn` element is clicked, the `#results-div` element should contain the text `Valid US number: 1 456 789 4444`
+1. When `#user-input` contains `123**&!!asdf#` and `#check-btn` is clicked, `#results-div` should contain the text `Invalid US number: 123**&!!asdf#`
+1. When the `#user-input` element contains `55555555` and the `#check-btn` element is clicked, the `#results-div` element should contain the text `Invalid US number: 55555555`
+1. When the `#user-input` element contains `(6054756961)` and the `#check-btn` element is clicked, the `#results-div` element should contain the text `Invalid US number: (6054756961)`
+1. When the `#user-input` element contains `2 (757) 622-7382` and the `#check-btn` element is clicked, the `#results-div` element should contain the text `Invalid US number: 2 (757) 622-7382`
+1. When the `#user-input` element contains `0 (757) 622-7382` and the `#check-btn` element is clicked, the `#results-div` element should contain the text `Invalid US number: 0 (757) 622-7382`
+1. When the `#user-input` element contains `-1 (757) 622-7382` and the `#check-btn` element is clicked, the `#results-div` element should contain the text `Invalid US number: -1 (757) 622-7382`
+1. When the `#user-input` element contains `2 757 622-7382` and the `#check-btn` element is clicked, the `#results-div` element should contain the text `Invalid US number: 2 757 622-7382`
+1. When the `#user-input` element contains `10 (757) 622-7382` and the `#check-btn` element is clicked, the `#results-div` element should contain the text `Invalid US number: 10 (757) 622-7382`
+1. When the `#user-input` element contains `27576227382` and the `#check-btn` element is clicked, the `#results-div` element should contain the text `Invalid US number: 27576227382`
+1. When the `#user-input` element contains `(275)76227382` and the `#check-btn` element is clicked, the `#results-div` element should contain the text `Invalid US number: (275)76227382`
+1. When the `#user-input` element contains `2(757)6227382` and the `#check-btn` element is clicked, the `#results-div` element should contain the text `Invalid US number: 2(757)6227382`
+1. When the `#user-input` element contains `2(757)622-7382` and the `#check-btn` element is clicked, the `#results-div` element should contain the text `Invalid US number: 2(757)622-7382`
+1. When the `#user-input` element contains `555)-555-5555` and the `#check-btn` element is clicked, the `#results-div` element should contain the text `Invalid US number: 555)-555-5555`
+1. When the `#user-input` element contains `(555-555-5555` and the `#check-btn` element is clicked, the `#results-div` element should contain the text `Invalid US number: (555-555-5555`
+1. When `#user-input` contains `(555)5(55?)-5555` and `#check-btn` is clicked, `#results-div` should contain the text `Invalid US number: (555)5(55?)-5555`
+1. When the `#user-input` element contains `55 55-55-555-5` and the `#check-btn` element is clicked, the `#results-div` element should contain the text `Invalid US number: 55 55-55-555-5`
+1. When the `#user-input` element contains `11 555-555-5555` and the `#check-btn` element is clicked, the `#results-div` element should contain the text `Invalid US number: 11 555-555-5555`
 
 Fulfill the user stories and pass all the tests below to complete this project. Give it your own personal style. Happy Coding!
 
@@ -131,7 +131,7 @@ checkBtn.click();
 assert.strictEqual(resultsDiv.innerText.trim().toLowerCase(), 'valid us number: 1 555-555-5555');
 ```
 
-When the `#user-input` element contains `1 (555) 555-5555` and the `#check-btn` element is clicked, the `#result-div` element should contain the text `Valid US number: 1 (555) 555-5555`.
+When the `#user-input` element contains `1 (555) 555-5555` and the `#check-btn` element is clicked, the `#results-div` element should contain the text `Valid US number: 1 (555) 555-5555`.
 
 ```js
 const userInput = document.getElementById('user-input');
@@ -144,7 +144,7 @@ checkBtn.click();
 assert.strictEqual(resultsDiv.innerText.trim().toLowerCase(), 'valid us number: 1 (555) 555-5555');
 ```
 
-When the `#user-input` element contains `5555555555` and the `#check-btn` element is clicked, the `#result-div` element should contain the text `Valid US number: 5555555555`.
+When the `#user-input` element contains `5555555555` and the `#check-btn` element is clicked, the `#results-div` element should contain the text `Valid US number: 5555555555`.
 
 ```js
 const userInput = document.getElementById('user-input');
@@ -157,7 +157,7 @@ checkBtn.click();
 assert.strictEqual(resultsDiv.innerText.trim().toLowerCase(), 'valid us number: 5555555555');
 ```
 
-When the `#user-input` element contains `555-555-5555` and the `#check-btn` element is clicked, the `#result-div` element should contain the text `Valid US number: 555-555-5555`.
+When the `#user-input` element contains `555-555-5555` and the `#check-btn` element is clicked, the `#results-div` element should contain the text `Valid US number: 555-555-5555`.
 
 ```js
 const userInput = document.getElementById('user-input');
@@ -170,7 +170,7 @@ checkBtn.click();
 assert.strictEqual(resultsDiv.innerText.trim().toLowerCase(), 'valid us number: 555-555-5555');
 ```
 
-When the `#user-input` element contains `(555)555-5555` and the `#check-btn` element is clicked, the `#result-div` element should contain the text `Valid US number: (555)555-5555`.
+When the `#user-input` element contains `(555)555-5555` and the `#check-btn` element is clicked, the `#results-div` element should contain the text `Valid US number: (555)555-5555`.
 
 ```js
 const userInput = document.getElementById('user-input');
@@ -183,7 +183,7 @@ checkBtn.click();
 assert.strictEqual(resultsDiv.innerText.trim().toLowerCase(), 'valid us number: (555)555-5555');
 ```
 
-When the `#user-input` element contains `1(555)555-5555` and the `#check-btn` element is clicked, the `#result-div` element should contain the text `Valid US number: 1(555)555-5555`.
+When the `#user-input` element contains `1(555)555-5555` and the `#check-btn` element is clicked, the `#results-div` element should contain the text `Valid US number: 1(555)555-5555`.
 
 ```js
 const userInput = document.getElementById('user-input');
@@ -196,7 +196,7 @@ checkBtn.click();
 assert.strictEqual(resultsDiv.innerText.trim().toLowerCase(), 'valid us number: 1(555)555-5555');
 ```
 
-When the `#user-input` element contains `555-5555` and the `#check-btn` element is clicked, the `#result-div` element should contain the text `Invalid US number: 555-5555`.
+When the `#user-input` element contains `555-5555` and the `#check-btn` element is clicked, the `#results-div` element should contain the text `Invalid US number: 555-5555`.
 
 ```js
 const userInput = document.getElementById('user-input');
@@ -209,7 +209,7 @@ checkBtn.click();
 assert.strictEqual(resultsDiv.innerText.trim().toLowerCase(), 'invalid us number: 555-5555');
 ```
 
-When the `#user-input` element contains `5555555` and the `#check-btn` element is clicked, the `#result-div` element should contain the text `Invalid US number: 5555555`.
+When the `#user-input` element contains `5555555` and the `#check-btn` element is clicked, the `#results-div` element should contain the text `Invalid US number: 5555555`.
 
 ```js
 const userInput = document.getElementById('user-input');
@@ -222,7 +222,7 @@ checkBtn.click();
 assert.strictEqual(resultsDiv.innerText.trim().toLowerCase(), 'invalid us number: 5555555');
 ```
 
-When the `#user-input` element contains `1 555)555-5555` and the `#check-btn` element is clicked, the `#result-div` element should contain the text `Invalid US number: 1 555)555-5555`.
+When the `#user-input` element contains `1 555)555-5555` and the `#check-btn` element is clicked, the `#results-div` element should contain the text `Invalid US number: 1 555)555-5555`.
 
 ```js
 const userInput = document.getElementById('user-input');
@@ -235,7 +235,7 @@ checkBtn.click();
 assert.strictEqual(resultsDiv.innerText.trim().toLowerCase(), 'invalid us number: 1 555)555-5555');
 ```
 
-When the `#user-input` element contains `1 555 555 5555` and the `#check-btn` element is clicked, the `#result-div` element should contain the text `Valid US number: 1 555 555 5555`.
+When the `#user-input` element contains `1 555 555 5555` and the `#check-btn` element is clicked, the `#results-div` element should contain the text `Valid US number: 1 555 555 5555`.
 
 ```js
 const userInput = document.getElementById('user-input');
@@ -248,7 +248,7 @@ checkBtn.click();
 assert.strictEqual(resultsDiv.innerText.trim().toLowerCase(), 'valid us number: 1 555 555 5555');
 ```
 
-When the `#user-input` element contains `1 456 789 4444` and the `#check-btn` element is clicked, the `#result-div` element should contain the text `Valid US number: 1 456 789 4444`.
+When the `#user-input` element contains `1 456 789 4444` and the `#check-btn` element is clicked, the `#results-div` element should contain the text `Valid US number: 1 456 789 4444`.
 
 ```js
 const userInput = document.getElementById('user-input');
@@ -261,7 +261,7 @@ checkBtn.click();
 assert.strictEqual(resultsDiv.innerText.trim().toLowerCase(), 'valid us number: 1 456 789 4444');
 ```
 
-When `#user-input` contains `123**&!!asdf#` and `#check-btn` is clicked, `#result-div` should contain the text `Invalid US number: 123**&!!asdf#`.
+When `#user-input` contains `123**&!!asdf#` and `#check-btn` is clicked, `#results-div` should contain the text `Invalid US number: 123**&!!asdf#`.
 
 ```js
 const userInput = document.getElementById('user-input');
@@ -274,7 +274,7 @@ checkBtn.click();
 assert.strictEqual(resultsDiv.innerText.trim().toLowerCase(), 'invalid us number: 123**&!!asdf#');
 ```
 
-When the `#user-input` element contains `55555555` and the `#check-btn` element is clicked, the `#result-div` element should contain the text `Invalid US number: 55555555`.
+When the `#user-input` element contains `55555555` and the `#check-btn` element is clicked, the `#results-div` element should contain the text `Invalid US number: 55555555`.
 
 ```js
 const userInput = document.getElementById('user-input');
@@ -287,7 +287,7 @@ checkBtn.click();
 assert.strictEqual(resultsDiv.innerText.trim().toLowerCase(), 'invalid us number: 55555555');
 ```
 
-When the `#user-input` element contains `(6054756961)` and the `#check-btn` element is clicked, the `#result-div` element should contain the text `Invalid US number: (6054756961)`.
+When the `#user-input` element contains `(6054756961)` and the `#check-btn` element is clicked, the `#results-div` element should contain the text `Invalid US number: (6054756961)`.
 
 ```js
 const userInput = document.getElementById('user-input');
@@ -300,7 +300,7 @@ checkBtn.click();
 assert.strictEqual(resultsDiv.innerText.trim().toLowerCase(), 'invalid us number: (6054756961)');
 ```
 
-When the `#user-input` element contains `2 (757) 622-7382` and the `#check-btn` element is clicked, the `#result-div` element should contain the text `Invalid US number: 2 (757) 622-7382`.
+When the `#user-input` element contains `2 (757) 622-7382` and the `#check-btn` element is clicked, the `#results-div` element should contain the text `Invalid US number: 2 (757) 622-7382`.
 
 ```js
 const userInput = document.getElementById('user-input');
@@ -313,7 +313,7 @@ checkBtn.click();
 assert.strictEqual(resultsDiv.innerText.trim().toLowerCase(), 'invalid us number: 2 (757) 622-7382');
 ```
 
-When the `#user-input` element contains `0 (757) 622-7382` and the `#check-btn` element is clicked, the `#result-div` element should contain the text `Invalid US number: 0 (757) 622-7382`.
+When the `#user-input` element contains `0 (757) 622-7382` and the `#check-btn` element is clicked, the `#results-div` element should contain the text `Invalid US number: 0 (757) 622-7382`.
 
 ```js
 const userInput = document.getElementById('user-input');
@@ -326,7 +326,7 @@ checkBtn.click();
 assert.strictEqual(resultsDiv.innerText.trim().toLowerCase(), 'invalid us number: 0 (757) 622-7382');
 ```
 
-When the `#user-input` element contains `-1 (757) 622-7382` and the `#check-btn` element is clicked, the `#result-div` element should contain the text `Invalid US number: -1 (757) 622-7382`.
+When the `#user-input` element contains `-1 (757) 622-7382` and the `#check-btn` element is clicked, the `#results-div` element should contain the text `Invalid US number: -1 (757) 622-7382`.
 
 ```js
 const userInput = document.getElementById('user-input');
@@ -339,7 +339,7 @@ checkBtn.click();
 assert.strictEqual(resultsDiv.innerText.trim().toLowerCase(), 'invalid us number: -1 (757) 622-7382');
 ```
 
-When the `#user-input` element contains `2 757 622-7382` and the `#check-btn` element is clicked, the `#result-div` element should contain the text `Invalid US number: 2 757 622-7382`.
+When the `#user-input` element contains `2 757 622-7382` and the `#check-btn` element is clicked, the `#results-div` element should contain the text `Invalid US number: 2 757 622-7382`.
 
 ```js
 const userInput = document.getElementById('user-input');
@@ -352,7 +352,7 @@ checkBtn.click();
 assert.strictEqual(resultsDiv.innerText.trim().toLowerCase(), 'invalid us number: 2 757 622-7382');
 ```
 
-When the `#user-input` element contains `10 (757) 622-7382` and the `#check-btn` element is clicked, the `#result-div` element should contain the text `Invalid US number: 10 (757) 622-7382`.
+When the `#user-input` element contains `10 (757) 622-7382` and the `#check-btn` element is clicked, the `#results-div` element should contain the text `Invalid US number: 10 (757) 622-7382`.
 
 ```js
 const userInput = document.getElementById('user-input');
@@ -365,7 +365,7 @@ checkBtn.click();
 assert.strictEqual(resultsDiv.innerText.trim().toLowerCase(), 'invalid us number: 10 (757) 622-7382');
 ```
 
-When the `#user-input` element contains `27576227382` and the `#check-btn` element is clicked, the `#result-div` element should contain the text `Invalid US number: 27576227382`.
+When the `#user-input` element contains `27576227382` and the `#check-btn` element is clicked, the `#results-div` element should contain the text `Invalid US number: 27576227382`.
 
 ```js
 const userInput = document.getElementById('user-input');
@@ -378,7 +378,7 @@ checkBtn.click();
 assert.strictEqual(resultsDiv.innerText.trim().toLowerCase(), 'invalid us number: 27576227382');
 ```
 
-When the `#user-input` element contains `(275)76227382` and the `#check-btn` element is clicked, the `#result-div` element should contain the text `Invalid US number: (275)76227382`.
+When the `#user-input` element contains `(275)76227382` and the `#check-btn` element is clicked, the `#results-div` element should contain the text `Invalid US number: (275)76227382`.
 
 ```js
 const userInput = document.getElementById('user-input');
@@ -391,7 +391,7 @@ checkBtn.click();
 assert.strictEqual(resultsDiv.innerText.trim().toLowerCase(), 'invalid us number: (275)76227382');
 ```
 
-When the `#user-input` element contains `2(757)6227382` and the `#check-btn` element is clicked, the `#result-div` element should contain the text `Invalid US number: 2(757)6227382`.
+When the `#user-input` element contains `2(757)6227382` and the `#check-btn` element is clicked, the `#results-div` element should contain the text `Invalid US number: 2(757)6227382`.
 
 ```js
 const userInput = document.getElementById('user-input');
@@ -404,7 +404,7 @@ checkBtn.click();
 assert.strictEqual(resultsDiv.innerText.trim().toLowerCase(), 'invalid us number: 2(757)6227382');
 ```
 
-When the `#user-input` element contains `2(757)622-7382` and the `#check-btn` element is clicked, the `#result-div` element should contain the text `Invalid US number: 2(757)622-7382`.
+When the `#user-input` element contains `2(757)622-7382` and the `#check-btn` element is clicked, the `#results-div` element should contain the text `Invalid US number: 2(757)622-7382`.
 
 ```js
 const userInput = document.getElementById('user-input');
@@ -417,7 +417,7 @@ checkBtn.click();
 assert.strictEqual(resultsDiv.innerText.trim().toLowerCase(), 'invalid us number: 2(757)622-7382');
 ```
 
-When the `#user-input` element contains `555)-555-5555` and the `#check-btn` element is clicked, the `#result-div` element should contain the text `Invalid US number: 555)-555-5555`.
+When the `#user-input` element contains `555)-555-5555` and the `#check-btn` element is clicked, the `#results-div` element should contain the text `Invalid US number: 555)-555-5555`.
 
 ```js
 const userInput = document.getElementById('user-input');
@@ -430,7 +430,7 @@ checkBtn.click();
 assert.strictEqual(resultsDiv.innerText.trim().toLowerCase(), 'invalid us number: 555)-555-5555');
 ```
 
-When the `#user-input` element contains `(555-555-5555` and the `#check-btn` element is clicked, the `#result-div` element should contain the text `Invalid US number: (555-555-5555`.
+When the `#user-input` element contains `(555-555-5555` and the `#check-btn` element is clicked, the `#results-div` element should contain the text `Invalid US number: (555-555-5555`.
 
 ```js
 const userInput = document.getElementById('user-input');
@@ -443,7 +443,7 @@ checkBtn.click();
 assert.strictEqual(resultsDiv.innerText.trim().toLowerCase(), 'invalid us number: (555-555-5555');
 ```
 
-When `#user-input` contains `(555)5(55?)-5555` and `#check-btn` is clicked, `#result-div` should contain the text `Invalid US number: (555)5(55?)-5555`.
+When `#user-input` contains `(555)5(55?)-5555` and `#check-btn` is clicked, `#results-div` should contain the text `Invalid US number: (555)5(55?)-5555`.
 
 ```js
 const userInput = document.getElementById('user-input');
@@ -456,7 +456,7 @@ checkBtn.click();
 assert.strictEqual(resultsDiv.innerText.trim().toLowerCase(), 'invalid us number: (555)5(55?)-5555');
 ```
 
-When the `#user-input` element contains `55 55-55-555-5` and the `#check-btn` element is clicked, the `#result-div` element should contain the text `Invalid US number: 55 55-55-555-5`.
+When the `#user-input` element contains `55 55-55-555-5` and the `#check-btn` element is clicked, the `#results-div` element should contain the text `Invalid US number: 55 55-55-555-5`.
 
 ```js
 const userInput = document.getElementById('user-input');
@@ -469,7 +469,7 @@ checkBtn.click();
 assert.strictEqual(resultsDiv.innerText.trim().toLowerCase(), 'invalid us number: 55 55-55-555-5');
 ```
 
-When the `#user-input` element contains `11 555-555-5555` and the `#check-btn` element is clicked, the `#result-div` element should contain the text `Invalid US number: 11 555-555-5555`.
+When the `#user-input` element contains `11 555-555-5555` and the `#check-btn` element is clicked, the `#results-div` element should contain the text `Invalid US number: 11 555-555-5555`.
 
 ```js
 const userInput = document.getElementById('user-input');


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!-- Feel free to add any additional description of changes below this line -->
This is to fix a typo that was reported in the support inbox.

The tests expect a `#results-div` element, but many of the descriptions here list it as `#result-div`.