### PR TITLE
fix(client): set Stripe promise correctly

### DIFF
--- a/client/src/components/Donation/stripe-card-form.tsx
+++ b/client/src/components/Donation/stripe-card-form.tsx
@@ -170,15 +170,17 @@ const StripeCardForm = ({
 };
 
 const CardFormWrapper = (props: FormPropTypes): JSX.Element | null => {
-  if (!stripePublicKey) {
-    return null;
-  } else {
-    return (
-      <Elements stripe={loadStripe(stripePublicKey)}>
-        <StripeCardForm {...props} />
-      </Elements>
-    );
-  }
+  const [stripePromise, _setStripePromise] = useState(() =>
+    stripePublicKey ? loadStripe(stripePublicKey) : null
+  );
+
+  if (!stripePromise) return null;
+
+  return (
+    <Elements stripe={stripePromise}>
+      <StripeCardForm {...props} />
+    </Elements>
+  );
 };
 
 export default CardFormWrapper;


### PR DESCRIPTION
Seems like we are setting the promise incorrectly.

<img width="774" alt="image" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/46919888/9f8f0457-516e-42da-9d62-1ca094e8ed78">

This should hopefully fix it:
https://stackoverflow.com/questions/64693509/unsupported-prop-change-on-elements-you-cannot-change-the-stripe-prop-after-s

Can't say for sure as I have not tested it.

ref #52910

<!-- Feel free to add any additional description of changes below this line -->
