### PR TITLE
fix: ensure only one python test runner is created

### DIFF
--- a/client/src/templates/Challenges/rechallenge/transformers.js
+++ b/client/src/templates/Challenges/rechallenge/transformers.js
@@ -18,7 +18,7 @@ import {
   setExt,
   compileHeadTail
 } from '../../../../../shared/utils/polyvinyl';
-import createWorker from '../utils/worker-executor';
+import { WorkerExecutor } from '../utils/worker-executor';
 
 const { filename: sassCompile } = sassData;
 
@@ -173,7 +173,7 @@ function getBabelOptions(
   return presets;
 }
 
-const sassWorker = createWorker(sassCompile);
+const sassWorkerExecutor = new WorkerExecutor(sassCompile);
 async function transformSASS(documentElement) {
   // we only teach scss syntax, not sass. Also the compiler does not seem to be
   // able to deal with sass.
@@ -184,7 +184,8 @@ async function transformSASS(documentElement) {
   await Promise.all(
     [].map.call(styleTags, async style => {
       style.type = 'text/css';
-      style.innerHTML = await sassWorker.execute(style.innerHTML, 5000).done;
+      style.innerHTML = await sassWorkerExecutor.execute(style.innerHTML, 5000)
+        .done;
     })
   );
 }

--- a/client/src/templates/Challenges/utils/build.ts
+++ b/client/src/templates/Challenges/utils/build.ts
@@ -23,7 +23,7 @@ import {
   Context,
   Source
 } from './frame';
-import createWorker from './worker-executor';
+import { WorkerExecutor } from './worker-executor';
 
 interface ChallengeFile extends PropTypesChallengeFile {
   source: string;
@@ -198,20 +198,20 @@ function getWorkerTestRunner(
     original: sources.original
   };
 
-  const testWorker = createWorker(testEvaluator, { terminateWorker });
+  const testWorkerExecutor = new WorkerExecutor(testEvaluator, {
+    terminateWorker
+  });
 
-  type CreateWorker = ReturnType<typeof createWorker>;
-
-  interface TestWorker extends CreateWorker {
+  interface TestWorkerExecutor extends WorkerExecutor {
     on: (event: string, listener: (...args: string[]) => void) => void;
     done: () => void;
   }
 
   return (testString: string, testTimeout: number, firstTest = true) => {
-    const result = testWorker.execute(
+    const result = testWorkerExecutor.execute(
       { build, testString, code, sources, firstTest, removeComments },
       testTimeout
-    ) as TestWorker;
+    ) as TestWorkerExecutor;
 
     result.on('LOG', proxyLogger);
     return result.done;

--- a/client/src/templates/Challenges/utils/worker-executor.js
+++ b/client/src/templates/Challenges/utils/worker-executor.js
@@ -1,4 +1,4 @@
-class WorkerExecutor {
+export class WorkerExecutor {
   constructor(
     workerName,
     { location = '/js/', maxWorkers = 2, terminateWorker = false } = {}
@@ -147,7 +147,3 @@ const eventify = self => {
 
   return self;
 };
-
-export default function createWorkerExecutor(workerName, options) {
-  return new WorkerExecutor(workerName, options);
-}

--- a/client/src/templates/Challenges/utils/worker-executor.test.js
+++ b/client/src/templates/Challenges/utils/worker-executor.test.js
@@ -2,7 +2,7 @@
  * @jest-environment node
  */
 
-import createWorker from './worker-executor';
+import { WorkerExecutor } from './worker-executor';
 
 function mockWorker({ init, postMessage, terminate } = {}) {
   global.Worker = jest.fn(function () {
@@ -31,7 +31,7 @@ afterEach(() => {
 it('Worker executor should successfully execute one task', async () => {
   const terminateHandler = jest.fn();
   mockWorker({ terminate: terminateHandler });
-  const testWorker = createWorker('test');
+  const testWorker = new WorkerExecutor('test');
   expect(testWorker).not.toBeUndefined();
 
   const task = testWorker.execute('test');
@@ -57,7 +57,7 @@ it('Worker executor should successfully execute one task', async () => {
 it('Worker executor should successfully execute two tasks in parallel', async () => {
   const terminateHandler = jest.fn();
   mockWorker({ terminate: terminateHandler });
-  const testWorker = createWorker('test');
+  const testWorker = new WorkerExecutor('test');
 
   const task1 = testWorker.execute('test1');
   const handler1 = jest.fn();
@@ -90,7 +90,7 @@ it('Worker executor should successfully execute two tasks in parallel', async ()
 
 it('Worker executor should successfully execute 3 tasks in parallel and use two workers', async () => {
   mockWorker();
-  const testWorker = createWorker('test');
+  const testWorker = new WorkerExecutor('test');
 
   const task1 = testWorker.execute('test1');
   const task2 = testWorker.execute('test2');
@@ -105,7 +105,7 @@ it('Worker executor should successfully execute 3 tasks in parallel and use two 
 it('Worker executor should successfully execute 3 tasks, use 3 workers and terminate each worker', async () => {
   const terminateHandler = jest.fn();
   mockWorker({ terminate: terminateHandler });
-  const testWorker = createWorker('test', { terminateWorker: true });
+  const testWorker = new WorkerExecutor('test', { terminateWorker: true });
 
   const task1 = testWorker.execute('test1');
   const task2 = testWorker.execute('test2');
@@ -120,7 +120,7 @@ it('Worker executor should successfully execute 3 tasks, use 3 workers and termi
 
 it('Worker executor should successfully execute 3 tasks in parallel and use 3 workers', async () => {
   mockWorker();
-  const testWorker = createWorker('test', { maxWorkers: 3 });
+  const testWorker = new WorkerExecutor('test', { maxWorkers: 3 });
 
   const task1 = testWorker.execute('test1');
   const task2 = testWorker.execute('test2');
@@ -134,7 +134,7 @@ it('Worker executor should successfully execute 3 tasks in parallel and use 3 wo
 
 it('Worker executor should successfully execute 3 tasks and use 1 worker', async () => {
   mockWorker();
-  const testWorker = createWorker('test', { maxWorkers: 1 });
+  const testWorker = new WorkerExecutor('test', { maxWorkers: 1 });
 
   const task1 = testWorker.execute('test1');
   const task2 = testWorker.execute('test2');
@@ -153,7 +153,7 @@ it('Worker executor should reject task', async () => {
       throw error;
     }
   });
-  const testWorker = createWorker('test');
+  const testWorker = new WorkerExecutor('test');
 
   const task = testWorker.execute('test');
   const errorHandler = jest.fn();
@@ -181,7 +181,7 @@ it('Worker executor should emit LOG events', async () => {
       });
     }
   });
-  const testWorker = createWorker('test');
+  const testWorker = new WorkerExecutor('test');
 
   const task = testWorker.execute('test');
   const handler = jest.fn();
@@ -209,7 +209,7 @@ it('Worker executor should reject task on timeout', async () => {
     postMessage: () => {},
     terminate: terminateHandler
   });
-  const testWorker = createWorker('test');
+  const testWorker = new WorkerExecutor('test');
 
   const task = testWorker.execute('test', 0);
   const errorHandler = jest.fn();
@@ -224,7 +224,9 @@ it('Worker executor should reject task on timeout', async () => {
 
 it('Worker executor should get worker from specified location', async () => {
   mockWorker();
-  const testWorker = createWorker('test', { location: '/other/location/' });
+  const testWorker = new WorkerExecutor('test', {
+    location: '/other/location/'
+  });
 
   const task = testWorker.execute('test');
   await expect(task.done).resolves.toBe('test processed');
@@ -235,7 +237,7 @@ it('Worker executor should get worker from specified location', async () => {
 
 it('Task should only emit handler once', () => {
   mockWorker();
-  const testWorker = createWorker('test');
+  const testWorker = new WorkerExecutor('test');
   const task = testWorker.execute('test');
   const handler = jest.fn();
   task.once('testOnce', handler);

--- a/curriculum/test/test-challenges.js
+++ b/curriculum/test/test-challenges.js
@@ -29,7 +29,7 @@ const {
   buildPythonChallenge
 } = require('../../client/src/templates/Challenges/utils/build');
 const {
-  default: createWorker
+  WorkerExecutor
 } = require('../../client/src/templates/Challenges/utils/worker-executor');
 const { challengeTypes } = require('../../shared/config/challenge-types');
 // the config files are created during the build, but not before linting
@@ -145,7 +145,7 @@ async function setup() {
   });
   global.Worker = createPseudoWorker(await newPageContext(browser));
 
-  pythonWorker = createWorker(pythonTestEvaluator, {
+  pythonWorker = new WorkerExecutor(pythonTestEvaluator, {
     terminateWorker: false
   });
   page = await newPageContext(browser);
@@ -466,7 +466,7 @@ function populateTestsForLang({ lang, challenges, meta }) {
               const solutionFiles = cloneDeep(nextChallenge.challengeFiles);
               if (!solutionFiles) {
                 throw Error(
-                  `No solution found. 
+                  `No solution found.
 Check the next challenge (${nextChallenge.title}): it should have a seed which solves the current challenge.
 For example:
 
@@ -651,7 +651,7 @@ async function getWorkerEvaluator(
   // sys, since sys.modules is not being reset.
   const testWorker = runsInPythonWorker
     ? pythonWorker
-    : createWorker(javaScriptTestEvaluator, { terminateWorker: true });
+    : new WorkerExecutor(javaScriptTestEvaluator, { terminateWorker: true });
   return {
     evaluate: async (testString, timeout) =>
       await testWorker.execute(


### PR DESCRIPTION
- refactor: use WorkerExecutor directly
- fix: only create one python worker at most

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This fixes the most egregious memory leak in the python test evaluator - creating a new worker for each test and never cleaning them up. 

<!-- Feel free to add any additional description of changes below this line -->
