### PR TITLE
fix(curriculum): make the `select` and `button` element accessible

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/64061a98f704a014b44afdb2.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/64061a98f704a014b44afdb2.md
@@ -189,6 +189,7 @@ assert.match(code, /sortButton\s*=\s*document\.getElementById\(\s*('|"|`)sort\1\
   --gray-75: #3b3b4f;
   --gray-85: #1b1b32;
   --gray-90: #0a0a23;
+  --blue-50: #198eee;
   --error: #a94442;
   --danger-color: #850000;
   --danger-background: #ffadad;
@@ -263,7 +264,6 @@ select {
 }
 
 button {
-  outline: none;
   cursor: pointer;
   margin-top: 15px;
   text-decoration: none;
@@ -272,6 +272,11 @@ button {
   padding: 10px 16px;
   font-size: 23px;
   width: 100%;
+}
+
+select:focus-visible,
+button:focus-visible {
+  outline: 3px solid var(--blue-50);
 }
 
 .output-container {

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/64067c1041a80c366b852407.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/64067c1041a80c366b852407.md
@@ -199,6 +199,7 @@ assert.match(sortInputArray.toString(), /\(\s*event\s*\)\s*{\s*}/);
   --gray-75: #3b3b4f;
   --gray-85: #1b1b32;
   --gray-90: #0a0a23;
+  --blue-50: #198eee;
   --error: #a94442;
   --danger-color: #850000;
   --danger-background: #ffadad;
@@ -273,7 +274,6 @@ select {
 }
 
 button {
-  outline: none;
   cursor: pointer;
   margin-top: 15px;
   text-decoration: none;
@@ -282,6 +282,11 @@ button {
   padding: 10px 16px;
   font-size: 23px;
   width: 100%;
+}
+
+select:focus-visible,
+button:focus-visible {
+  outline: 3px solid var(--blue-50);
 }
 
 .output-container {

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6406a71d2b35103a340dba06.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6406a71d2b35103a340dba06.md
@@ -175,6 +175,7 @@ assert.match(sortInputArray.toString(), /event\.preventDefault\(\)/);
   --gray-75: #3b3b4f;
   --gray-85: #1b1b32;
   --gray-90: #0a0a23;
+  --blue-50: #198eee;
   --error: #a94442;
   --danger-color: #850000;
   --danger-background: #ffadad;
@@ -249,7 +250,6 @@ select {
 }
 
 button {
-  outline: none;
   cursor: pointer;
   margin-top: 15px;
   text-decoration: none;
@@ -258,6 +258,11 @@ button {
   padding: 10px 16px;
   font-size: 23px;
   width: 100%;
+}
+
+select:focus-visible,
+button:focus-visible {
+  outline: 3px solid var(--blue-50);
 }
 
 .output-container {

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6406a9945fa5d23c225d31cc.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6406a9945fa5d23c225d31cc.md
@@ -187,6 +187,7 @@ assert.match(code, /sortButton\s*\.\s*addEventListener\s*\(\s*('|"|`)click\1\s*,
   --gray-75: #3b3b4f;
   --gray-85: #1b1b32;
   --gray-90: #0a0a23;
+  --blue-50: #198eee;
   --error: #a94442;
   --danger-color: #850000;
   --danger-background: #ffadad;
@@ -261,7 +262,6 @@ select {
 }
 
 button {
-  outline: none;
   cursor: pointer;
   margin-top: 15px;
   text-decoration: none;
@@ -270,6 +270,11 @@ button {
   padding: 10px 16px;
   font-size: 23px;
   width: 100%;
+}
+
+select:focus-visible,
+button:focus-visible {
+  outline: 3px solid var(--blue-50);
 }
 
 .output-container {

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6406adbca6b41d3d7cef85ab.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6406adbca6b41d3d7cef85ab.md
@@ -189,6 +189,7 @@ assert.match(code, /const\s+inputValues\s*=\s*document\.getElementsByClassName\(
   --gray-75: #3b3b4f;
   --gray-85: #1b1b32;
   --gray-90: #0a0a23;
+  --blue-50: #198eee;
   --error: #a94442;
   --danger-color: #850000;
   --danger-background: #ffadad;
@@ -263,7 +264,6 @@ select {
 }
 
 button {
-  outline: none;
   cursor: pointer;
   margin-top: 15px;
   text-decoration: none;
@@ -272,6 +272,11 @@ button {
   padding: 10px 16px;
   font-size: 23px;
   width: 100%;
+}
+
+select:focus-visible,
+button:focus-visible {
+  outline: 3px solid var(--blue-50);
 }
 
 .output-container {

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6406bb32f9ed593f26c33b2b.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6406bb32f9ed593f26c33b2b.md
@@ -183,6 +183,7 @@ assert.match(code, /\[\s*\.\.\.document\.getElementsByClassName\(\s*('|"|`)value
   --gray-75: #3b3b4f;
   --gray-85: #1b1b32;
   --gray-90: #0a0a23;
+  --blue-50: #198eee;
   --error: #a94442;
   --danger-color: #850000;
   --danger-background: #ffadad;
@@ -257,7 +258,6 @@ select {
 }
 
 button {
-  outline: none;
   cursor: pointer;
   margin-top: 15px;
   text-decoration: none;
@@ -266,6 +266,11 @@ button {
   padding: 10px 16px;
   font-size: 23px;
   width: 100%;
+}
+
+select:focus-visible,
+button:focus-visible {
+  outline: 3px solid var(--blue-50);
 }
 
 .output-container {

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6407b940b8983005578d0824.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6407b940b8983005578d0824.md
@@ -195,6 +195,7 @@ assert.match(code, /inputValues\s*=\s*\[\s*\.\.\.document\.getElementsByClassNam
   --gray-75: #3b3b4f;
   --gray-85: #1b1b32;
   --gray-90: #0a0a23;
+  --blue-50: #198eee;
   --error: #a94442;
   --danger-color: #850000;
   --danger-background: #ffadad;
@@ -269,7 +270,6 @@ select {
 }
 
 button {
-  outline: none;
   cursor: pointer;
   margin-top: 15px;
   text-decoration: none;
@@ -278,6 +278,11 @@ button {
   padding: 10px 16px;
   font-size: 23px;
   width: 100%;
+}
+
+select:focus-visible,
+button:focus-visible {
+  outline: 3px solid var(--blue-50);
 }
 
 .output-container {

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6407c303b4272606c019f338.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6407c303b4272606c019f338.md
@@ -213,6 +213,7 @@ assert.match(code, /const\s+updateUI\s*=\s*\(\s*array\s*=\s*\[\s*\]\s*\)\s*=>\s*
   --gray-75: #3b3b4f;
   --gray-85: #1b1b32;
   --gray-90: #0a0a23;
+  --blue-50: #198eee;
   --error: #a94442;
   --danger-color: #850000;
   --danger-background: #ffadad;
@@ -287,7 +288,6 @@ select {
 }
 
 button {
-  outline: none;
   cursor: pointer;
   margin-top: 15px;
   text-decoration: none;
@@ -296,6 +296,11 @@ button {
   padding: 10px 16px;
   font-size: 23px;
   width: 100%;
+}
+
+select:focus-visible,
+button:focus-visible {
+  outline: 3px solid var(--blue-50);
 }
 
 .output-container {

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6407c4abf5be6d07d8c12ade.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6407c4abf5be6d07d8c12ade.md
@@ -195,6 +195,7 @@ assert.match(code, /array\.forEach\s*\(\s*\(\s*num\s*,\s*i\s*\)\s*=>\s*{\s*}\s*\
   --gray-75: #3b3b4f;
   --gray-85: #1b1b32;
   --gray-90: #0a0a23;
+  --blue-50: #198eee;
   --error: #a94442;
   --danger-color: #850000;
   --danger-background: #ffadad;
@@ -269,7 +270,6 @@ select {
 }
 
 button {
-  outline: none;
   cursor: pointer;
   margin-top: 15px;
   text-decoration: none;
@@ -278,6 +278,11 @@ button {
   padding: 10px 16px;
   font-size: 23px;
   width: 100%;
+}
+
+select:focus-visible,
+button:focus-visible {
+  outline: 3px solid var(--blue-50);
 }
 
 .output-container {

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6407c627ddc93708c8dee796.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6407c627ddc93708c8dee796.md
@@ -187,6 +187,7 @@ assert.match(code, /array\.forEach\s*\(\s*\(\s*num\s*,\s*i\s*\)\s*=>\s*\{\s*cons
   --gray-75: #3b3b4f;
   --gray-85: #1b1b32;
   --gray-90: #0a0a23;
+  --blue-50: #198eee;
   --error: #a94442;
   --danger-color: #850000;
   --danger-background: #ffadad;
@@ -261,7 +262,6 @@ select {
 }
 
 button {
-  outline: none;
   cursor: pointer;
   margin-top: 15px;
   text-decoration: none;
@@ -270,6 +270,11 @@ button {
   padding: 10px 16px;
   font-size: 23px;
   width: 100%;
+}
+
+select:focus-visible,
+button:focus-visible {
+  outline: 3px solid var(--blue-50);
 }
 
 .output-container {

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6407c6a2c2159309994779a5.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6407c6a2c2159309994779a5.md
@@ -181,6 +181,7 @@ assert.match(code, /array\.forEach\s*\(\s*\(\s*num\s*,\s*i\s*\)\s*=>\s*\{\s*cons
   --gray-75: #3b3b4f;
   --gray-85: #1b1b32;
   --gray-90: #0a0a23;
+  --blue-50: #198eee;
   --error: #a94442;
   --danger-color: #850000;
   --danger-background: #ffadad;
@@ -255,7 +256,6 @@ select {
 }
 
 button {
-  outline: none;
   cursor: pointer;
   margin-top: 15px;
   text-decoration: none;
@@ -264,6 +264,11 @@ button {
   padding: 10px 16px;
   font-size: 23px;
   width: 100%;
+}
+
+select:focus-visible,
+button:focus-visible {
+  outline: 3px solid var(--blue-50);
 }
 
 .output-container {

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6407c6d3f19c4e0a7ba320bb.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6407c6d3f19c4e0a7ba320bb.md
@@ -183,6 +183,7 @@ assert.match(sortInputArray.toString(), /updateUI\(\s*inputValues\s*\)/);
   --gray-75: #3b3b4f;
   --gray-85: #1b1b32;
   --gray-90: #0a0a23;
+  --blue-50: #198eee;
   --error: #a94442;
   --danger-color: #850000;
   --danger-background: #ffadad;
@@ -257,7 +258,6 @@ select {
 }
 
 button {
-  outline: none;
   cursor: pointer;
   margin-top: 15px;
   text-decoration: none;
@@ -266,6 +266,11 @@ button {
   padding: 10px 16px;
   font-size: 23px;
   width: 100%;
+}
+
+select:focus-visible,
+button:focus-visible {
+  outline: 3px solid var(--blue-50);
 }
 
 .output-container {

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6407c722498bc80b76d29073.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6407c722498bc80b76d29073.md
@@ -201,6 +201,7 @@ assert.match(code, /const\s+bubbleSort\s*=\s*\(?\s*array\s*\)?\s*=>\s*{\s*}/);
   --gray-75: #3b3b4f;
   --gray-85: #1b1b32;
   --gray-90: #0a0a23;
+  --blue-50: #198eee;
   --error: #a94442;
   --danger-color: #850000;
   --danger-background: #ffadad;
@@ -275,7 +276,6 @@ select {
 }
 
 button {
-  outline: none;
   cursor: pointer;
   margin-top: 15px;
   text-decoration: none;
@@ -284,6 +284,11 @@ button {
   padding: 10px 16px;
   font-size: 23px;
   width: 100%;
+}
+
+select:focus-visible,
+button:focus-visible {
+  outline: 3px solid var(--blue-50);
 }
 
 .output-container {

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6410da6df463a606dfade96f.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6410da6df463a606dfade96f.md
@@ -199,6 +199,7 @@ assert.match(code, /const\s+bubbleSort\s*=\s*\(\s*array\s*\)\s*=>\s*{\s*for\s*\(
   --gray-75: #3b3b4f;
   --gray-85: #1b1b32;
   --gray-90: #0a0a23;
+  --blue-50: #198eee;
   --error: #a94442;
   --danger-color: #850000;
   --danger-background: #ffadad;
@@ -273,7 +274,6 @@ select {
 }
 
 button {
-  outline: none;
   cursor: pointer;
   margin-top: 15px;
   text-decoration: none;
@@ -282,6 +282,11 @@ button {
   padding: 10px 16px;
   font-size: 23px;
   width: 100%;
+}
+
+select:focus-visible,
+button:focus-visible {
+  outline: 3px solid var(--blue-50);
 }
 
 .output-container {

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6410dfb965c72108196ef24a.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6410dfb965c72108196ef24a.md
@@ -199,6 +199,7 @@ assert.match(code, /const\s+bubbleSort\s*=\s*\(\s*array\s*\)\s*=>\s*{\s*for\s*\(
   --gray-75: #3b3b4f;
   --gray-85: #1b1b32;
   --gray-90: #0a0a23;
+  --blue-50: #198eee;
   --error: #a94442;
   --danger-color: #850000;
   --danger-background: #ffadad;
@@ -273,7 +274,6 @@ select {
 }
 
 button {
-  outline: none;
   cursor: pointer;
   margin-top: 15px;
   text-decoration: none;
@@ -282,6 +282,11 @@ button {
   padding: 10px 16px;
   font-size: 23px;
   width: 100%;
+}
+
+select:focus-visible,
+button:focus-visible {
+  outline: 3px solid var(--blue-50);
 }
 
 .output-container {

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6410e1b58efc2c091a13bcd9.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6410e1b58efc2c091a13bcd9.md
@@ -193,6 +193,7 @@ assert.match(code, /const\s+bubbleSort\s*=\s*\(\s*array\s*\)\s*=>\s*{\s*for\s*\(
   --gray-75: #3b3b4f;
   --gray-85: #1b1b32;
   --gray-90: #0a0a23;
+  --blue-50: #198eee;
   --error: #a94442;
   --danger-color: #850000;
   --danger-background: #ffadad;
@@ -267,7 +268,6 @@ select {
 }
 
 button {
-  outline: none;
   cursor: pointer;
   margin-top: 15px;
   text-decoration: none;
@@ -276,6 +276,11 @@ button {
   padding: 10px 16px;
   font-size: 23px;
   width: 100%;
+}
+
+select:focus-visible,
+button:focus-visible {
+  outline: 3px solid var(--blue-50);
 }
 
 .output-container {

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6410e3c19c21cd09c32dc7c6.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6410e3c19c21cd09c32dc7c6.md
@@ -195,6 +195,7 @@ assert.notMatch(code, /updateUI\s*\(\s*inputValues\s*\)/);
   --gray-75: #3b3b4f;
   --gray-85: #1b1b32;
   --gray-90: #0a0a23;
+  --blue-50: #198eee;
   --error: #a94442;
   --danger-color: #850000;
   --danger-background: #ffadad;
@@ -269,7 +270,6 @@ select {
 }
 
 button {
-  outline: none;
   cursor: pointer;
   margin-top: 15px;
   text-decoration: none;
@@ -278,6 +278,11 @@ button {
   padding: 10px 16px;
   font-size: 23px;
   width: 100%;
+}
+
+select:focus-visible,
+button:focus-visible {
+  outline: 3px solid var(--blue-50);
 }
 
 .output-container {

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6410e70c84bb660b4d2a5ea1.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6410e70c84bb660b4d2a5ea1.md
@@ -195,6 +195,7 @@ assert.match(code, /const\s+bubbleSort\s*=\s*\(\s*array\s*\)\s*=>\s*{\s*for\s*\(
   --gray-75: #3b3b4f;
   --gray-85: #1b1b32;
   --gray-90: #0a0a23;
+  --blue-50: #198eee;
   --error: #a94442;
   --danger-color: #850000;
   --danger-background: #ffadad;
@@ -269,7 +270,6 @@ select {
 }
 
 button {
-  outline: none;
   cursor: pointer;
   margin-top: 15px;
   text-decoration: none;
@@ -278,6 +278,11 @@ button {
   padding: 10px 16px;
   font-size: 23px;
   width: 100%;
+}
+
+select:focus-visible,
+button:focus-visible {
+  outline: 3px solid var(--blue-50);
 }
 
 .output-container {

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6410edb33eeaf50dd9a22ab4.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6410edb33eeaf50dd9a22ab4.md
@@ -195,6 +195,7 @@ assert.match(code, /const\s+bubbleSort\s*=\s*\(\s*array\s*\)\s*=>\s*{\s*for\s*\(
   --gray-75: #3b3b4f;
   --gray-85: #1b1b32;
   --gray-90: #0a0a23;
+  --blue-50: #198eee;
   --error: #a94442;
   --danger-color: #850000;
   --danger-background: #ffadad;
@@ -269,7 +270,6 @@ select {
 }
 
 button {
-  outline: none;
   cursor: pointer;
   margin-top: 15px;
   text-decoration: none;
@@ -278,6 +278,11 @@ button {
   padding: 10px 16px;
   font-size: 23px;
   width: 100%;
+}
+
+select:focus-visible,
+button:focus-visible {
+  outline: 3px solid var(--blue-50);
 }
 
 .output-container {

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6410efff0ae97c0f06856511.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6410efff0ae97c0f06856511.md
@@ -175,6 +175,7 @@ assert.match(code, /const\s+bubbleSort\s*=\s*\(\s*array\s*\)\s*=>\s*{\s*for\s*\(
   --gray-75: #3b3b4f;
   --gray-85: #1b1b32;
   --gray-90: #0a0a23;
+  --blue-50: #198eee;
   --error: #a94442;
   --danger-color: #850000;
   --danger-background: #ffadad;
@@ -249,7 +250,6 @@ select {
 }
 
 button {
-  outline: none;
   cursor: pointer;
   margin-top: 15px;
   text-decoration: none;
@@ -258,6 +258,11 @@ button {
   padding: 10px 16px;
   font-size: 23px;
   width: 100%;
+}
+
+select:focus-visible,
+button:focus-visible {
+  outline: 3px solid var(--blue-50);
 }
 
 .output-container {

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6410f149110ec60fd40fcfe1.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6410f149110ec60fd40fcfe1.md
@@ -201,6 +201,7 @@ assert.match(code, /const\s+selectionSort\s*=\s*\(?\s*array\s*\)?\s*=>\s*{\s*}/)
   --gray-75: #3b3b4f;
   --gray-85: #1b1b32;
   --gray-90: #0a0a23;
+  --blue-50: #198eee;
   --error: #a94442;
   --danger-color: #850000;
   --danger-background: #ffadad;
@@ -275,7 +276,6 @@ select {
 }
 
 button {
-  outline: none;
   cursor: pointer;
   margin-top: 15px;
   text-decoration: none;
@@ -284,6 +284,11 @@ button {
   padding: 10px 16px;
   font-size: 23px;
   width: 100%;
+}
+
+select:focus-visible,
+button:focus-visible {
+  outline: 3px solid var(--blue-50);
 }
 
 .output-container {

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6410f97a721cd1144804b7a8.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6410f97a721cd1144804b7a8.md
@@ -199,6 +199,7 @@ assert.match(code, /const\s+selectionSort\s*=\s*\(\s*array\s*\)\s*=>\s*{\s*for\s
   --gray-75: #3b3b4f;
   --gray-85: #1b1b32;
   --gray-90: #0a0a23;
+  --blue-50: #198eee;
   --error: #a94442;
   --danger-color: #850000;
   --danger-background: #ffadad;
@@ -273,7 +274,6 @@ select {
 }
 
 button {
-  outline: none;
   cursor: pointer;
   margin-top: 15px;
   text-decoration: none;
@@ -282,6 +282,11 @@ button {
   padding: 10px 16px;
   font-size: 23px;
   width: 100%;
+}
+
+select:focus-visible,
+button:focus-visible {
+  outline: 3px solid var(--blue-50);
 }
 
 .output-container {

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6410f9a443d57414ee50fada.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6410f9a443d57414ee50fada.md
@@ -178,6 +178,7 @@ assert.notMatch(bubbleSort.toString(), /console\.log\((?!"Potential infinite)/);
   --gray-75: #3b3b4f;
   --gray-85: #1b1b32;
   --gray-90: #0a0a23;
+  --blue-50: #198eee;
   --error: #a94442;
   --danger-color: #850000;
   --danger-background: #ffadad;
@@ -252,7 +253,6 @@ select {
 }
 
 button {
-  outline: none;
   cursor: pointer;
   margin-top: 15px;
   text-decoration: none;
@@ -261,6 +261,11 @@ button {
   padding: 10px 16px;
   font-size: 23px;
   width: 100%;
+}
+
+select:focus-visible,
+button:focus-visible {
+  outline: 3px solid var(--blue-50);
 }
 
 .output-container {

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6410fb3b68429716a810ea4b.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6410fb3b68429716a810ea4b.md
@@ -207,6 +207,7 @@ assert.match(code, /const\s+selectionSort\s*=\s*\(\s*array\s*\)\s*=>\s*{\s*for\s
   --gray-75: #3b3b4f;
   --gray-85: #1b1b32;
   --gray-90: #0a0a23;
+  --blue-50: #198eee;
   --error: #a94442;
   --danger-color: #850000;
   --danger-background: #ffadad;
@@ -281,7 +282,6 @@ select {
 }
 
 button {
-  outline: none;
   cursor: pointer;
   margin-top: 15px;
   text-decoration: none;
@@ -290,6 +290,11 @@ button {
   padding: 10px 16px;
   font-size: 23px;
   width: 100%;
+}
+
+select:focus-visible,
+button:focus-visible {
+  outline: 3px solid var(--blue-50);
 }
 
 .output-container {

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6410fcd1f731fd17cdb101a7.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6410fcd1f731fd17cdb101a7.md
@@ -213,6 +213,7 @@ assert.match(code, /const\s+selectionSort\s*=\s*\(\s*array\s*\)\s*=>\s*{\s*for\s
   --gray-75: #3b3b4f;
   --gray-85: #1b1b32;
   --gray-90: #0a0a23;
+  --blue-50: #198eee;
   --error: #a94442;
   --danger-color: #850000;
   --danger-background: #ffadad;
@@ -287,7 +288,6 @@ select {
 }
 
 button {
-  outline: none;
   cursor: pointer;
   margin-top: 15px;
   text-decoration: none;
@@ -296,6 +296,11 @@ button {
   padding: 10px 16px;
   font-size: 23px;
   width: 100%;
+}
+
+select:focus-visible,
+button:focus-visible {
+  outline: 3px solid var(--blue-50);
 }
 
 .output-container {

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6411024727181d190ef03166.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6411024727181d190ef03166.md
@@ -195,6 +195,7 @@ assert.match(code, /const\s+selectionSort\s*=\s*\(\s*array\s*\)\s*=>\s*{\s*for\s
   --gray-75: #3b3b4f;
   --gray-85: #1b1b32;
   --gray-90: #0a0a23;
+  --blue-50: #198eee;
   --error: #a94442;
   --danger-color: #850000;
   --danger-background: #ffadad;
@@ -269,7 +270,6 @@ select {
 }
 
 button {
-  outline: none;
   cursor: pointer;
   margin-top: 15px;
   text-decoration: none;
@@ -278,6 +278,11 @@ button {
   padding: 10px 16px;
   font-size: 23px;
   width: 100%;
+}
+
+select:focus-visible,
+button:focus-visible {
+  outline: 3px solid var(--blue-50);
 }
 
 .output-container {

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/64110377201e7b1a0de0d558.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/64110377201e7b1a0de0d558.md
@@ -181,6 +181,7 @@ assert.notMatch(code, /bubbleSort\s*\(/);
   --gray-75: #3b3b4f;
   --gray-85: #1b1b32;
   --gray-90: #0a0a23;
+  --blue-50: #198eee;
   --error: #a94442;
   --danger-color: #850000;
   --danger-background: #ffadad;
@@ -255,7 +256,6 @@ select {
 }
 
 button {
-  outline: none;
   cursor: pointer;
   margin-top: 15px;
   text-decoration: none;
@@ -264,6 +264,11 @@ button {
   padding: 10px 16px;
   font-size: 23px;
   width: 100%;
+}
+
+select:focus-visible,
+button:focus-visible {
+  outline: 3px solid var(--blue-50);
 }
 
 .output-container {

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/64110727cefd3d1d9bdb0128.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/64110727cefd3d1d9bdb0128.md
@@ -175,6 +175,7 @@ assert.match(code, /const\s+selectionSort\s*=\s*\(\s*array\s*\)\s*=>\s*{\s*for\s
   --gray-75: #3b3b4f;
   --gray-85: #1b1b32;
   --gray-90: #0a0a23;
+  --blue-50: #198eee;
   --error: #a94442;
   --danger-color: #850000;
   --danger-background: #ffadad;
@@ -249,7 +250,6 @@ select {
 }
 
 button {
-  outline: none;
   cursor: pointer;
   margin-top: 15px;
   text-decoration: none;
@@ -258,6 +258,11 @@ button {
   padding: 10px 16px;
   font-size: 23px;
   width: 100%;
+}
+
+select:focus-visible,
+button:focus-visible {
+  outline: 3px solid var(--blue-50);
 }
 
 .output-container {

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6411083020a3101e9514a0f5.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6411083020a3101e9514a0f5.md
@@ -176,6 +176,7 @@ assert.notMatch(selectionSort.toString(), /console\.log\((?!"Potential infinite)
   --gray-75: #3b3b4f;
   --gray-85: #1b1b32;
   --gray-90: #0a0a23;
+  --blue-50: #198eee;
   --error: #a94442;
   --danger-color: #850000;
   --danger-background: #ffadad;
@@ -250,7 +251,6 @@ select {
 }
 
 button {
-  outline: none;
   cursor: pointer;
   margin-top: 15px;
   text-decoration: none;
@@ -259,6 +259,11 @@ button {
   padding: 10px 16px;
   font-size: 23px;
   width: 100%;
+}
+
+select:focus-visible,
+button:focus-visible {
+  outline: 3px solid var(--blue-50);
 }
 
 .output-container {

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/64110998bc00321fd8052ab5.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/64110998bc00321fd8052ab5.md
@@ -201,6 +201,7 @@ assert.match(code, /const\s+insertionSort\s*=\s*\(?\s*array\s*\)?\s*=>\s*{\s*}/)
   --gray-75: #3b3b4f;
   --gray-85: #1b1b32;
   --gray-90: #0a0a23;
+  --blue-50: #198eee;
   --error: #a94442;
   --danger-color: #850000;
   --danger-background: #ffadad;
@@ -275,7 +276,6 @@ select {
 }
 
 button {
-  outline: none;
   cursor: pointer;
   margin-top: 15px;
   text-decoration: none;
@@ -284,6 +284,11 @@ button {
   padding: 10px 16px;
   font-size: 23px;
   width: 100%;
+}
+
+select:focus-visible,
+button:focus-visible {
+  outline: 3px solid var(--blue-50);
 }
 
 .output-container {

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/64110a03f6a450209b01f45c.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/64110a03f6a450209b01f45c.md
@@ -181,6 +181,7 @@ assert.notMatch(code, /selectionSort\s*\(/);
   --gray-75: #3b3b4f;
   --gray-85: #1b1b32;
   --gray-90: #0a0a23;
+  --blue-50: #198eee;
   --error: #a94442;
   --danger-color: #850000;
   --danger-background: #ffadad;
@@ -255,7 +256,6 @@ select {
 }
 
 button {
-  outline: none;
   cursor: pointer;
   margin-top: 15px;
   text-decoration: none;
@@ -264,6 +264,11 @@ button {
   padding: 10px 16px;
   font-size: 23px;
   width: 100%;
+}
+
+select:focus-visible,
+button:focus-visible {
+  outline: 3px solid var(--blue-50);
 }
 
 .output-container {

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/64110b1849454521871243ca.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/64110b1849454521871243ca.md
@@ -199,6 +199,7 @@ assert.match(code, /const\s+insertionSort\s*=\s*\(\s*array\s*\)\s*=>\s*{\s*for\s
   --gray-75: #3b3b4f;
   --gray-85: #1b1b32;
   --gray-90: #0a0a23;
+  --blue-50: #198eee;
   --error: #a94442;
   --danger-color: #850000;
   --danger-background: #ffadad;
@@ -273,7 +274,6 @@ select {
 }
 
 button {
-  outline: none;
   cursor: pointer;
   margin-top: 15px;
   text-decoration: none;
@@ -282,6 +282,11 @@ button {
   padding: 10px 16px;
   font-size: 23px;
   width: 100%;
+}
+
+select:focus-visible,
+button:focus-visible {
+  outline: 3px solid var(--blue-50);
 }
 
 .output-container {

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6411108bc8b9c324f66aab4c.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6411108bc8b9c324f66aab4c.md
@@ -193,6 +193,7 @@ assert.match(code, /const\s+insertionSort\s*=\s*\(\s*array\s*\)\s*=>\s*{\s*for\s
   --gray-75: #3b3b4f;
   --gray-85: #1b1b32;
   --gray-90: #0a0a23;
+  --blue-50: #198eee;
   --error: #a94442;
   --danger-color: #850000;
   --danger-background: #ffadad;
@@ -267,7 +268,6 @@ select {
 }
 
 button {
-  outline: none;
   cursor: pointer;
   margin-top: 15px;
   text-decoration: none;
@@ -276,6 +276,11 @@ button {
   padding: 10px 16px;
   font-size: 23px;
   width: 100%;
+}
+
+select:focus-visible,
+button:focus-visible {
+  outline: 3px solid var(--blue-50);
 }
 
 .output-container {

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/641110e4fb696b259dbf0bcf.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/641110e4fb696b259dbf0bcf.md
@@ -204,6 +204,7 @@ assert.match(code, /const\s+insertionSort\s*=\s*\(\s*array\s*\)\s*=>\s*{\s*for\s
   --gray-75: #3b3b4f;
   --gray-85: #1b1b32;
   --gray-90: #0a0a23;
+  --blue-50: #198eee;
   --error: #a94442;
   --danger-color: #850000;
   --danger-background: #ffadad;
@@ -278,7 +279,6 @@ select {
 }
 
 button {
-  outline: none;
   cursor: pointer;
   margin-top: 15px;
   text-decoration: none;
@@ -287,6 +287,11 @@ button {
   padding: 10px 16px;
   font-size: 23px;
   width: 100%;
+}
+
+select:focus-visible,
+button:focus-visible {
+  outline: 3px solid var(--blue-50);
 }
 
 .output-container {

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6411135e9ee2fa26c882eb02.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6411135e9ee2fa26c882eb02.md
@@ -177,6 +177,7 @@ assert.match(code, /const\s+insertionSort\s*=\s*\(\s*array\s*\)\s*=>\s*{\s*for\s
   --gray-75: #3b3b4f;
   --gray-85: #1b1b32;
   --gray-90: #0a0a23;
+  --blue-50: #198eee;
   --error: #a94442;
   --danger-color: #850000;
   --danger-background: #ffadad;
@@ -251,7 +252,6 @@ select {
 }
 
 button {
-  outline: none;
   cursor: pointer;
   margin-top: 15px;
   text-decoration: none;
@@ -260,6 +260,11 @@ button {
   padding: 10px 16px;
   font-size: 23px;
   width: 100%;
+}
+
+select:focus-visible,
+button:focus-visible {
+  outline: 3px solid var(--blue-50);
 }
 
 .output-container {

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/64112c9cf53d632910ea2f9b.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/64112c9cf53d632910ea2f9b.md
@@ -177,6 +177,7 @@ assert.match(code, /const\s+insertionSort\s*=\s*\(\s*array\s*\)\s*=>\s*{\s*for\s
   --gray-75: #3b3b4f;
   --gray-85: #1b1b32;
   --gray-90: #0a0a23;
+  --blue-50: #198eee;
   --error: #a94442;
   --danger-color: #850000;
   --danger-background: #ffadad;
@@ -251,7 +252,6 @@ select {
 }
 
 button {
-  outline: none;
   cursor: pointer;
   margin-top: 15px;
   text-decoration: none;
@@ -260,6 +260,11 @@ button {
   padding: 10px 16px;
   font-size: 23px;
   width: 100%;
+}
+
+select:focus-visible,
+button:focus-visible {
+  outline: 3px solid var(--blue-50);
 }
 
 .output-container {

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/64112cea9e6ac22a314628b0.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/64112cea9e6ac22a314628b0.md
@@ -175,6 +175,7 @@ assert.match(code, /const\s+insertionSort\s*=\s*\(\s*array\s*\)\s*=>\s*{\s*for\s
   --gray-75: #3b3b4f;
   --gray-85: #1b1b32;
   --gray-90: #0a0a23;
+  --blue-50: #198eee;
   --error: #a94442;
   --danger-color: #850000;
   --danger-background: #ffadad;
@@ -249,7 +250,6 @@ select {
 }
 
 button {
-  outline: none;
   cursor: pointer;
   margin-top: 15px;
   text-decoration: none;
@@ -258,6 +258,11 @@ button {
   padding: 10px 16px;
   font-size: 23px;
   width: 100%;
+}
+
+select:focus-visible,
+button:focus-visible {
+  outline: 3px solid var(--blue-50);
 }
 
 .output-container {

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/64112d0943e1bb2aef11e2d1.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/64112d0943e1bb2aef11e2d1.md
@@ -187,6 +187,7 @@ assert.notMatch(code, /selectionSort\s*\(/);
   --gray-75: #3b3b4f;
   --gray-85: #1b1b32;
   --gray-90: #0a0a23;
+  --blue-50: #198eee;
   --error: #a94442;
   --danger-color: #850000;
   --danger-background: #ffadad;
@@ -261,7 +262,6 @@ select {
 }
 
 button {
-  outline: none;
   cursor: pointer;
   margin-top: 15px;
   text-decoration: none;
@@ -270,6 +270,11 @@ button {
   padding: 10px 16px;
   font-size: 23px;
   width: 100%;
+}
+
+select:focus-visible,
+button:focus-visible {
+  outline: 3px solid var(--blue-50);
 }
 
 .output-container {

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/64112fa63a0f812c66499a54.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/64112fa63a0f812c66499a54.md
@@ -189,6 +189,7 @@ assert.equal(option?.textContent, '10');
   --gray-75: #3b3b4f;
   --gray-85: #1b1b32;
   --gray-90: #0a0a23;
+  --blue-50: #198eee;
   --error: #a94442;
   --danger-color: #850000;
   --danger-background: #ffadad;
@@ -263,7 +264,6 @@ select {
 }
 
 button {
-  outline: none;
   cursor: pointer;
   margin-top: 15px;
   text-decoration: none;
@@ -272,6 +272,11 @@ button {
   padding: 10px 16px;
   font-size: 23px;
   width: 100%;
+}
+
+select:focus-visible,
+button:focus-visible {
+  outline: 3px solid var(--blue-50);
 }
 
 .output-container {

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/641130423e5f512d8972dae1.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/641130423e5f512d8972dae1.md
@@ -189,6 +189,7 @@ assert.match(code, /const\s+sortedValues\s*=\s*inputValues\s*\.\s*sort\s*\(\s*\(
   --gray-75: #3b3b4f;
   --gray-85: #1b1b32;
   --gray-90: #0a0a23;
+  --blue-50: #198eee;
   --error: #a94442;
   --danger-color: #850000;
   --danger-background: #ffadad;
@@ -263,7 +264,6 @@ select {
 }
 
 button {
-  outline: none;
   cursor: pointer;
   margin-top: 15px;
   text-decoration: none;
@@ -272,6 +272,11 @@ button {
   padding: 10px 16px;
   font-size: 23px;
   width: 100%;
+}
+
+select:focus-visible,
+button:focus-visible {
+  outline: 3px solid var(--blue-50);
 }
 
 .output-container {

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/64113124efd2852edafaf25f.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/64113124efd2852edafaf25f.md
@@ -187,6 +187,7 @@ assert.match(code, /const\s+sortedValues\s*=\s*inputValues\s*\.\s*sort\s*\(\s*\(
   --gray-75: #3b3b4f;
   --gray-85: #1b1b32;
   --gray-90: #0a0a23;
+  --blue-50: #198eee;
   --error: #a94442;
   --danger-color: #850000;
   --danger-background: #ffadad;
@@ -261,7 +262,6 @@ select {
 }
 
 button {
-  outline: none;
   cursor: pointer;
   margin-top: 15px;
   text-decoration: none;
@@ -270,6 +270,11 @@ button {
   padding: 10px 16px;
   font-size: 23px;
   width: 100%;
+}
+
+select:focus-visible,
+button:focus-visible {
+  outline: 3px solid var(--blue-50);
 }
 
 .output-container {

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/64113249bab9952fb2ce4469.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/64113249bab9952fb2ce4469.md
@@ -189,6 +189,7 @@ assert.equal(option?.textContent, '1');
   --gray-75: #3b3b4f;
   --gray-85: #1b1b32;
   --gray-90: #0a0a23;
+  --blue-50: #198eee;
   --error: #a94442;
   --danger-color: #850000;
   --danger-background: #ffadad;
@@ -263,7 +264,6 @@ select {
 }
 
 button {
-  outline: none;
   cursor: pointer;
   margin-top: 15px;
   text-decoration: none;
@@ -272,6 +272,11 @@ button {
   padding: 10px 16px;
   font-size: 23px;
   width: 100%;
+}
+
+select:focus-visible,
+button:focus-visible {
+  outline: 3px solid var(--blue-50);
 }
 
 .output-container {
@@ -547,6 +552,7 @@ sortButton.addEventListener("click", sortInputArray);
   --gray-75: #3b3b4f;
   --gray-85: #1b1b32;
   --gray-90: #0a0a23;
+  --blue-50: #198eee;
   --error: #a94442;
   --danger-color: #850000;
   --danger-background: #ffadad;
@@ -621,7 +627,6 @@ select {
 }
 
 button {
-  outline: none;
   cursor: pointer;
   margin-top: 15px;
   text-decoration: none;
@@ -630,6 +635,11 @@ button {
   padding: 10px 16px;
   font-size: 23px;
   width: 100%;
+}
+
+select:focus-visible,
+button:focus-visible {
+  outline: 3px solid var(--blue-50);
 }
 
 .output-container {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #52709

<!-- Feel free to add any additional description of changes below this line -->
This PR was opened to make the `select` and `button` element in the preview pane of [Learn Basic Algorithmic Thinking by Building a Number Sorter](https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures-v8/learn-basic-algorithmic-thinking-by-building-a-number-sorter/step-2) challenges accessible.

1. `The outline: none;` CSS property of the button element will be removed so it will be keyboard-focusable and complying the [WCAG SC 2.1.1](https://www.w3.org/WAI/WCAG21/Understanding/keyboard.html).
2. Then, applying the custom outline styles to the `select` and `button` element with using the `:focus-visible` pseudo-class so the outline will be sufficiently visible for people who is visually impaired or have low vision, especially in Firefox browser.