### PR TITLE
fix(curriculum): allow truthy check the value of nickname

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-modern-javascript-methods-by-building-football-team-cards/63e9718d7d490bb3940d5a0a.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-modern-javascript-methods-by-building-football-team-cards/63e9718d7d490bb3940d5a0a.md
@@ -16,19 +16,19 @@ Use a ternary operator to check if `nickname` is not `null`. If the player has a
 You should use a ternary operator to check if `nickname` is not `null`.
 
 ```js
-assert.match(code, /\s*<p\s*>\s*Nickname:\s*\$\{\s*nickname\s*!==\s*null\s*\?/)
+assert.match(code, /\s*<p\s*>\s*Nickname:\s*\$\{\s*nickname\s*(?:!==\s*null)?\s*\?/)
 ```
 
 If your ternary is truthy, it should display the player's `nickname`.
 
 ```js
-assert.match(code, /\s*<p\s*>\s*Nickname:\s*\$\{\s*nickname\s*!==\s*null\s*\?\s*nickname\s*:/)
+assert.match(code, /\s*<p\s*>\s*Nickname:\s*\$\{\s*nickname\s*(?:!==\s*null)?\s*\?\s*nickname\s*:/)
 ```
 
 If your ternary is falsy, it should display the string `N/A`. 
 
 ```js
-assert.match(code, /\s*<p\s*>\s*Nickname:\s*\$\{\s*nickname\s*!==\s*null\s*\?\s*nickname\s*:\s*('|"|`)\N\/A\1}\s*<\/p>\s*/)
+assert.match(code, /\s*<p\s*>\s*Nickname:\s*\$\{\s*nickname\s*(?:!==\s*null)?\s*\?\s*nickname\s*:\s*('|"|`)\N\/A\1}\s*<\/p>\s*/)
 ```
 
 # --seed--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-modern-javascript-methods-by-building-football-team-cards/63e9718d7d490bb3940d5a0a.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-modern-javascript-methods-by-building-football-team-cards/63e9718d7d490bb3940d5a0a.md
@@ -13,7 +13,7 @@ Use a ternary operator to check if `nickname` is not `null`. If the player has a
 
 # --hints--
 
-You should use a ternary operator to check if `nickname` is not `null`.
+You should use a ternary operator to check if `nickname` is truthy.
 
 ```js
 assert.match(code, /\s*<p\s*>\s*Nickname:\s*\$\{\s*nickname\s*(?:!==\s*null)?\s*\?/)


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #52893

<!-- Feel free to add any additional description of changes below this line -->

Allowed both explicit check and truthiness check of nickname in the JavaScript Algorithms and Data Structures (Beta), Learn Modern JavaScript Methods By Building Football Team Cards Step 34.

In the updated regular expressions, (?:!==\s*null)? is a non-capturing group that matches the string "!== null" zero or one time. The ? after the group makes it optional, so the regular expression will match whether or not this string is present.

### ScreenShots

#### Before

![second_accept_truthy_n_not_eq_nall_before](https://github.com/freeCodeCamp/freeCodeCamp/assets/90121395/45e6ae38-bf51-49b9-a7da-5e69e2f89ad4)

#### After

![second_accept_truthy_n_not_eq_nall_after](https://github.com/freeCodeCamp/freeCodeCamp/assets/90121395/09fd3179-624d-4d53-b8a1-9c290c8762ef)
