### PR TITLE
fix(curriculum): use numbers in english challenges

### DIFF
--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/651dd5ae6ffb500e3f2ce47c.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/651dd5ae6ffb500e3f2ce47c.md
@@ -48,8 +48,8 @@ Watch the video
     },
     {
       "character": "Sarah",
-      "startTime": "1.0",
-      "finishTime": "3.7",
+      "startTime": 1.0,
+      "finishTime": 3.7,
       "dialogue": {
       "text": "Hi, Tom! Are you happy with the workplace so far?",
       "align": "left"
@@ -57,8 +57,8 @@ Watch the video
     },
     {
       "character": "Tom",
-      "startTime": "4.2",
-      "finishTime": "5.2",
+      "startTime": 4.2,
+      "finishTime": 5.2,
       "dialogue": {
       "text": "Yes, it's great!",
       "align": "right"
@@ -66,8 +66,8 @@ Watch the video
     },
     {
       "character": "Tom",
-      "startTime": "5.4",
-      "finishTime": "6.7",
+      "startTime": 5.4,
+      "finishTime": 6.7,
       "dialogue": {
       "text": "Everyone is friendly.",
       "align": "right"
@@ -75,8 +75,8 @@ Watch the video
     },
     {
       "character": "Tom",
-      "startTime": "6.9",
-      "finishTime": "10.4",
+      "startTime": 6.9,
+      "finishTime": 10.4,
       "dialogue": {
       "text": "Listen, how about the team-building activities here? Are they cool?",
       "align": "right"
@@ -84,8 +84,8 @@ Watch the video
     },
     {
       "character": "Sarah",
-      "startTime": "10.6",
-      "finishTime": "13.0",
+      "startTime": 10.6,
+      "finishTime": 13.0,
       "dialogue": {
       "text": "Yes, we go out with the team sometimes.",
       "align": "left"
@@ -93,8 +93,8 @@ Watch the video
     },
     {
       "character": "Sarah",
-      "startTime": "13.2",
-      "finishTime": "14.5",
+      "startTime": 13.2,
+      "finishTime": 14.5,
       "dialogue": {
       "text": "Are you into these activities?",
       "align": "left"
@@ -102,8 +102,8 @@ Watch the video
     },
     {
       "character": "Tom",
-      "startTime": "14.7",
-      "finishTime": "16.7",
+      "startTime": 14.7,
+      "finishTime": 16.7,
       "dialogue": {
       "text": "Absolutely! They're really fun.",
       "align": "right"
@@ -111,8 +111,8 @@ Watch the video
     },
     {
       "character": "Tom",
-      "startTime": "16.9",
-      "finishTime": "18.1",
+      "startTime": 16.9,
+      "finishTime": 18.1,
       "dialogue": {
       "text": "What's the team's favorite?",
       "align": "right"
@@ -120,8 +120,8 @@ Watch the video
     },
     {
       "character": "Sarah",
-      "startTime": "18.6",
-      "finishTime": "20.6",
+      "startTime": 18.6,
+      "finishTime": 20.6,
       "dialogue": {
       "text": "Many of us enjoy the monthly game night.",
       "align": "left"
@@ -129,8 +129,8 @@ Watch the video
     },
     {
       "character": "Sarah",
-      "startTime": "20.8",
-      "finishTime": "22.1",
+      "startTime": 20.8,
+      "finishTime": 22.1,
       "dialogue": {
       "text": "Are you into board games?",
       "align": "left"
@@ -138,8 +138,8 @@ Watch the video
     },
     {
       "character": "Tom",
-      "startTime": "22.3",
-      "finishTime": "23.8",
+      "startTime": 22.3,
+      "finishTime": 23.8,
       "dialogue": {
       "text": "Yes, I love board games!",
       "align": "right"
@@ -147,8 +147,8 @@ Watch the video
     },
     {
       "character": "Sarah",
-      "startTime": "24.0",
-      "finishTime": "27.0",
+      "startTime": 24.0,
+      "finishTime": 27.0,
       "dialogue": {
       "text": "'Monopoly' and 'Ticket To Ride' are popular choices.",
       "align": "left"
@@ -156,8 +156,8 @@ Watch the video
     },
     {
       "character": "Sarah",
-      "startTime": "27.2",
-      "finishTime": "28.2",
+      "startTime": 27.2,
+      "finishTime": 28.2,
       "dialogue": {
       "text": "Are you familiar with them?",
       "align": "left"
@@ -165,8 +165,8 @@ Watch the video
     },
     {
       "character": "Tom",
-      "startTime": "28.4",
-      "finishTime": "30.9",
+      "startTime": 28.4,
+      "finishTime": 30.9,
       "dialogue": {
       "text": "Yes, I've played both before. Great choices.",
       "align": "right"
@@ -174,8 +174,8 @@ Watch the video
     },
     {
       "character": "Tom",
-      "startTime": "31.1",
-      "finishTime": "35.1",
+      "startTime": 31.1,
+      "finishTime": 35.1,
       "dialogue": {
       "text": "Is the team into playing games on computers as well, like 'Gartic'?",
       "align": "right"
@@ -183,8 +183,8 @@ Watch the video
     },
     {
       "character": "Sarah",
-      "startTime": "35.3",
-      "finishTime": "38.3",
+      "startTime": 35.3,
+      "finishTime": 38.3,
       "dialogue": {
       "text": "Oh, yeah! 'Gartic' is another favorite.",
       "align": "left"
@@ -192,8 +192,8 @@ Watch the video
     },
     {
       "character": "Sarah",
-      "startTime": "38.5",
-      "finishTime": "40.5",
+      "startTime": 38.5,
+      "finishTime": 40.5,
       "dialogue": {
       "text": "Maybe we can play 'Gartic' on the next game night?",
       "align": "left"
@@ -201,8 +201,8 @@ Watch the video
     },
     {
       "character": "Tom",
-      "startTime": "40.7",
-      "finishTime": "42.7",
+      "startTime": 40.7,
+      "finishTime": 42.7,
       "dialogue": {
       "text": "That sounds like a plan, Sarah!",
       "align": "right"
@@ -210,8 +210,8 @@ Watch the video
     },
     {
       "character": "Tom",
-      "startTime": "42.9",
-      "finishTime": "44.1",
+      "startTime": 42.9,
+      "finishTime": 44.1,
       "dialogue": {
       "text": "Thanks for the suggestions.",
       "align": "right"

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657b3136477b8ac802088c97.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657b3136477b8ac802088c97.md
@@ -48,8 +48,8 @@ Watch the video
     },
     {
         "character": "Sophie",
-        "startTime": "1.0",
-        "finishTime": "4.5",
+        "startTime": 1.0,
+        "finishTime": 4.5,
         "dialogue": {
         "text": "Hey, Tom! I saw you taking lots of pics with your cell phone outside the building.",
         "align": "left"
@@ -57,8 +57,8 @@ Watch the video
     },
     {
         "character": "Sophie",
-        "startTime": "4.7",
-        "finishTime": "5.7",
+        "startTime": 4.7,
+        "finishTime": 5.7,
         "dialogue": {
         "text": "Are you into photography?",
         "align": "left"
@@ -66,8 +66,8 @@ Watch the video
     },
     {
         "character": "Tom",
-        "startTime": "5.9",
-        "finishTime": "6.9",
+        "startTime": 5.9,
+        "finishTime": 6.9,
         "dialogue": {
         "text": "Yes, I love it.",
         "align": "right"
@@ -75,8 +75,8 @@ Watch the video
     },
     {
         "character": "Tom",
-        "startTime": "7.1",
-        "finishTime": "8.6",
+        "startTime": 7.1,
+        "finishTime": 8.6,
         "dialogue": {
         "text": "But I'm only practicing.",
         "align": "right"
@@ -84,8 +84,8 @@ Watch the video
     },
     {
         "character": "Tom",
-        "startTime": "8.8",
-        "finishTime": "10.8",
+        "startTime": 8.8,
+        "finishTime": 10.8,
         "dialogue": {
         "text": "How about you? Do you have any hobbies?",
         "align": "right"
@@ -93,8 +93,8 @@ Watch the video
     },
     {
         "character": "Sophie",
-        "startTime": "11.0",
-        "finishTime": "12.0",
+        "startTime": 11.0,
+        "finishTime": 12.0,
         "dialogue": {
         "text": "That's cool!",
         "align": "left"
@@ -102,8 +102,8 @@ Watch the video
     },
     {
         "character": "Sophie",
-        "startTime": "12.2",
-        "finishTime": "14.2",
+        "startTime": 12.2,
+        "finishTime": 14.2,
         "dialogue": {
         "text": "I like photography, but I don't think of it as a hobby.",
         "align": "left"
@@ -111,8 +111,8 @@ Watch the video
     },
     {
         "character": "Sophie",
-        "startTime": "14.4",
-        "finishTime": "15.9",
+        "startTime": 14.4,
+        "finishTime": 15.9,
         "dialogue": {
         "text": "I play the guitar in my free time.",
         "align": "left"
@@ -120,8 +120,8 @@ Watch the video
     },
     {
         "character": "Tom",
-        "startTime": "16.1",
-        "finishTime": "18.1",
+        "startTime": 16.1,
+        "finishTime": 18.1,
         "dialogue": {
         "text": "Wow! Electric or acoustic?",
         "align": "right"
@@ -129,8 +129,8 @@ Watch the video
     },
     {
         "character": "Sophie",
-        "startTime": "18.3",
-        "finishTime": "19.9",
+        "startTime": 18.3,
+        "finishTime": 19.9,
         "dialogue": {
         "text": "Electric, for sure!",
         "align": "left"
@@ -138,8 +138,8 @@ Watch the video
     },
     {
         "character": "Sophie",
-        "startTime": "20.1",
-        "finishTime": "21.7",
+        "startTime": 20.1,
+        "finishTime": 21.7,
         "dialogue": {
         "text": "Back to your hobbies, though.",
         "align": "left"
@@ -147,8 +147,8 @@ Watch the video
     },
     {
         "character": "Sophie",
-        "startTime": "21.9",
-        "finishTime": "23.9",
+        "startTime": 21.9,
+        "finishTime": 23.9,
         "dialogue": {
         "text": "Do you have any favorite photography themes?",
         "align": "left"
@@ -156,8 +156,8 @@ Watch the video
     },
     {
         "character": "Tom",
-        "startTime": "24.1",
-        "finishTime": "26.7",
+        "startTime": 24.1,
+        "finishTime": 26.7,
         "dialogue": {
         "text": "I like landscapes and street photography, mostly.",
         "align": "right"
@@ -165,8 +165,8 @@ Watch the video
     },
     {
         "character": "Tom",
-        "startTime": "26.9",
-        "finishTime": "30.3",
+        "startTime": 26.9,
+        "finishTime": 30.3,
         "dialogue": {
         "text": "And you? What kind of music do you like to play on your guitar?",
         "align": "right"
@@ -174,8 +174,8 @@ Watch the video
     },
     {
         "character": "Sophie",
-        "startTime": "30.5",
-        "finishTime": "32.5",
+        "startTime": 30.5,
+        "finishTime": 32.5,
         "dialogue": {
         "text": "I enjoy classic rock.",
         "align": "left"
@@ -183,8 +183,8 @@ Watch the video
     },
     {
         "character": "Sophie",
-        "startTime": "32.7",
-        "finishTime": "34.2",
+        "startTime": 32.7,
+        "finishTime": 34.2,
         "dialogue": {
         "text": "But any nice tune makes my day.",
         "align": "left"
@@ -192,8 +192,8 @@ Watch the video
     },
     {
         "character": "Tom",
-        "startTime": "34.7",
-        "finishTime": "36.7",
+        "startTime": 34.7,
+        "finishTime": 36.7,
         "dialogue": {
         "text": "Cool! I want to hear you play some day.",
         "align": "right"
@@ -201,8 +201,8 @@ Watch the video
     },
     {
         "character": "Sophie",
-        "startTime": "36.9",
-        "finishTime": "39.2",
+        "startTime": 36.9,
+        "finishTime": 39.2,
         "dialogue": {
         "text": "Only if you show me your favorite pics.",
         "align": "left"
@@ -210,8 +210,8 @@ Watch the video
     },
     {
         "character": "Tom",
-        "startTime": "39.4",
-        "finishTime": "40.2",
+        "startTime": 39.4,
+        "finishTime": 40.2,
         "dialogue": {
         "text": "It's a deal!",
         "align": "right"

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657b97be2621d55d1b8dc9a1.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657b97be2621d55d1b8dc9a1.md
@@ -48,8 +48,8 @@ Watch the video
     },
     {
         "character": "Tom",
-        "startTime": "1.0",
-        "finishTime": "3.8",
+        "startTime": 1.0,
+        "finishTime": 3.8,
         "dialogue": {
         "text": "Hey, Sophie! Tell me about our team lead, Maria.",
         "align": "right"
@@ -57,8 +57,8 @@ Watch the video
     },
     {
         "character": "Tom",
-        "startTime": "4.0",
-        "finishTime": "5.0",
+        "startTime": 4.0,
+        "finishTime": 5.0,
         "dialogue": {
         "text": "What is she like?",
         "align": "right"
@@ -66,8 +66,8 @@ Watch the video
     },
     {
         "character": "Sophie",
-        "startTime": "5.2",
-        "finishTime": "8.8",
+        "startTime": 5.2,
+        "finishTime": 8.8,
         "dialogue": {
         "text": "Well, she's very proactive and she likes everything in order.",
         "align": "left"
@@ -75,8 +75,8 @@ Watch the video
     },
     {
         "character": "Sophie",
-        "startTime": "9.0",
-        "finishTime": "12.5",
+        "startTime": 9.0,
+        "finishTime": 12.5,
         "dialogue": {
         "text": "I think she has a passion for technology, and she enjoys leading our team.",
         "align": "left"
@@ -84,8 +84,8 @@ Watch the video
     },
     {
         "character": "Tom",
-        "startTime": "12.7",
-        "finishTime": "15.7",
+        "startTime": 12.7,
+        "finishTime": 15.7,
         "dialogue": {
         "text": "Those are great traits for someone in her position, I think.",
         "align": "right"
@@ -93,8 +93,8 @@ Watch the video
     },
     {
         "character": "Tom",
-        "startTime": "15.9",
-        "finishTime": "17.7",
+        "startTime": 15.9,
+        "finishTime": 17.7,
         "dialogue": {
         "text": "What does she do as the team lead?",
         "align": "right"
@@ -102,8 +102,8 @@ Watch the video
     },
     {
         "character": "Sophie",
-        "startTime": "17.9",
-        "finishTime": "20.4",
+        "startTime": 17.9,
+        "finishTime": 20.4,
         "dialogue": {
         "text": "Maria coordinates our projects.",
         "align": "left"
@@ -111,8 +111,8 @@ Watch the video
     },
     {
         "character": "Sophie",
-        "startTime": "20.6",
-        "finishTime": "23.6",
+        "startTime": 20.6,
+        "finishTime": 23.6,
         "dialogue": {
         "text": "She assigns tasks and makes sure everything runs well.",
         "align": "left"
@@ -120,8 +120,8 @@ Watch the video
     },
     {
         "character": "Tom",
-        "startTime": "23.8",
-        "finishTime": "27.3",
+        "startTime": 23.8,
+        "finishTime": 27.3,
         "dialogue": {
         "text": "That sounds important. Where does she usually work from?",
         "align": "right"
@@ -129,8 +129,8 @@ Watch the video
     },
     {
         "character": "Sophie",
-        "startTime": "27.5",
-        "finishTime": "31.5",
+        "startTime": 27.5,
+        "finishTime": 31.5,
         "dialogue": {
         "text": "She works from her office most of the time, but she's also in meetings a lot.",
         "align": "left"
@@ -138,8 +138,8 @@ Watch the video
     },
     {
         "character": "Tom",
-        "startTime": "31.7",
-        "finishTime": "34.7",
+        "startTime": 31.7,
+        "finishTime": 34.7,
         "dialogue": {
         "text": "I see. When does she usually hold team meetings?",
         "align": "right"
@@ -147,8 +147,8 @@ Watch the video
     },
     {
         "character": "Sophie",
-        "startTime": "34.9",
-        "finishTime": "38.4",
+        "startTime": 34.9,
+        "finishTime": 38.4,
         "dialogue": {
         "text": "She schedules team meetings every Monday morning to plan the week ahead.",
         "align": "left"
@@ -156,8 +156,8 @@ Watch the video
     },
     {
         "character": "Tom",
-        "startTime": "38.6",
-        "finishTime": "42.1",
+        "startTime": 38.6,
+        "finishTime": 42.1,
         "dialogue": {
         "text": "Got it! How does she handle challenges in our projects?",
         "align": "right"
@@ -165,8 +165,8 @@ Watch the video
     },
     {
         "character": "Sophie",
-        "startTime": "42.3",
-        "finishTime": "47.3",
+        "startTime": 42.3,
+        "finishTime": 47.3,
         "dialogue": {
         "text": "Maria thinks challenges are positive. She encourages us to find solutions together.",
         "align": "left"
@@ -174,8 +174,8 @@ Watch the video
     },
     {
         "character": "Tom",
-        "startTime": "47.5",
-        "finishTime": "50.5",
+        "startTime": 47.5,
+        "finishTime": 50.5,
         "dialogue": {
         "text": "Great. And do you enjoy working with her?",
         "align": "right"
@@ -183,8 +183,8 @@ Watch the video
     },
     {
         "character": "Sophie",
-        "startTime": "50.7",
-        "finishTime": "53.7",
+        "startTime": 50.7,
+        "finishTime": 53.7,
         "dialogue": {
         "text": "I do. She's supportive and she helps us a lot.",
         "align": "left"
@@ -192,8 +192,8 @@ Watch the video
     },
     {
         "character": "Tom",
-        "startTime": "53.9",
-        "finishTime": "56.4",
+        "startTime": 53.9,
+        "finishTime": 56.4,
         "dialogue": {
         "text": "Nice! Thanks for the information, Sophie.",
         "align": "right"
@@ -201,8 +201,8 @@ Watch the video
     },
     {
         "character": "Sophie",
-        "startTime": "56.6",
-        "finishTime": "61.6",
+        "startTime": 56.6,
+        "finishTime": 61.6,
         "dialogue": {
         "text": "You're welcome. Maria is a fantastic leader to have. I think you're in good hands.",
         "align": "left"

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657cfff65708189adb524933.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657cfff65708189adb524933.md
@@ -48,8 +48,8 @@ Watch the video
     },
     {
       "character": "Tom",
-      "startTime": "1.0",
-      "finishTime": "4.4",
+      "startTime": 1.0,
+      "finishTime": 4.4,
       "dialogue": {
         "text": "Tell me about our team meetings, Sophie. Do they happen every week?",
         "align": "left"
@@ -57,8 +57,8 @@ Watch the video
     },
     {
       "character": "Sophie",
-      "startTime": "4.5",
-      "finishTime": "7.5",
+      "startTime": 4.5,
+      "finishTime": 7.5,
       "dialogue": {
         "text": "Yes, they do. We have meetings on Monday mornings.",
         "align": "right"
@@ -66,8 +66,8 @@ Watch the video
     },
     {
       "character": "Tom",
-      "startTime": "7.7",
-      "finishTime": "13.2",
+      "startTime": 7.7,
+      "finishTime": 13.2,
       "dialogue": {
         "text": "Hmm… Do we discuss all our ongoing projects in these meetings?",
         "align": "left"
@@ -75,8 +75,8 @@ Watch the video
     },
     {
       "character": "Sophie",
-      "startTime": "13.4",
-      "finishTime": "17.4",
+      "startTime": 13.4,
+      "finishTime": 17.4,
       "dialogue": {
         "text": "We do. It's a chance to update everyone on project progress.",
         "align": "right"
@@ -84,8 +84,8 @@ Watch the video
     },
     {
       "character": "Tom",
-      "startTime": "17.6",
-      "finishTime": "20.1",
+      "startTime": 17.6,
+      "finishTime": 20.1,
       "dialogue": {
         "text": "Awesome! Do they usually last long?",
         "align": "left"
@@ -93,8 +93,8 @@ Watch the video
     },
     {
       "character": "Sophie",
-      "startTime": "20.8",
-      "finishTime": "23.8",
+      "startTime": 20.8,
+      "finishTime": 23.8,
       "dialogue": {
         "text": "Not too long. They usually take about 30 to 45 minutes.",
         "align": "right"
@@ -102,8 +102,8 @@ Watch the video
     },
     {
       "character": "Tom",
-      "startTime": "24.0",
-      "finishTime": "27.5",
+      "startTime": 24.0,
+      "finishTime": 27.5,
       "dialogue": {
         "text": "That's reasonable. Do we have an agenda for each meeting?",
         "align": "left"
@@ -111,8 +111,8 @@ Watch the video
     },
     {
       "character": "Sophie",
-      "startTime": "27.7",
-      "finishTime": "31.2",
+      "startTime": 27.7,
+      "finishTime": 31.2,
       "dialogue": {
         "text": "Yes, we do. Maria prepares the agenda in advance.",
         "align": "right"
@@ -120,8 +120,8 @@ Watch the video
     },
     {
       "character": "Tom",
-      "startTime": "31.4",
-      "finishTime": "35.2",
+      "startTime": 31.4,
+      "finishTime": 35.2,
       "dialogue": {
         "text": "Good to know! Do the meetings involve everyone on the team?",
         "align": "left"
@@ -129,8 +129,8 @@ Watch the video
     },
     {
       "character": "Sophie",
-      "startTime": "35.4",
-      "finishTime": "38.7",
+      "startTime": 35.4,
+      "finishTime": 38.7,
       "dialogue": {
         "text": "Absolutely! All the team members have a chance to speak,",
         "align": "right"
@@ -138,8 +138,8 @@ Watch the video
     },
     {
       "character": "Sophie",
-      "startTime": "38.7",
-      "finishTime": "40.4",
+      "startTime": 38.7,
+      "finishTime": 40.4,
       "dialogue": {
         "text": "so everyone knows what the others are doing.",
         "align": "right"
@@ -147,8 +147,8 @@ Watch the video
     },
     {
       "character": "Tom",
-      "startTime": "40.6",
-      "finishTime": "45.1",
+      "startTime": 40.6,
+      "finishTime": 45.1,
       "dialogue": {
         "text": "That's important. Does Maria assign tasks during these meetings?",
         "align": "left"
@@ -156,8 +156,8 @@ Watch the video
     },
     {
       "character": "Sophie",
-      "startTime": "45.3",
-      "finishTime": "49.3",
+      "startTime": 45.3,
+      "finishTime": 49.3,
       "dialogue": {
         "text": "Sometimes, but we normally discuss tasks we plan on tackling for the week.",
         "align": "right"
@@ -165,8 +165,8 @@ Watch the video
     },
     {
       "character": "Tom",
-      "startTime": "49.5",
-      "finishTime": "52.0",
+      "startTime": 49.5,
+      "finishTime": 52.0,
       "dialogue": {
         "text": "Does this include brainstorming sessions?",
         "align": "left"
@@ -174,8 +174,8 @@ Watch the video
     },
     {
       "character": "Sophie",
-      "startTime": "52.2",
-      "finishTime": "55.2",
+      "startTime": 52.2,
+      "finishTime": 55.2,
       "dialogue": {
         "text": "Occasionally, yeah. It depends on the project's needs.",
         "align": "right"
@@ -183,8 +183,8 @@ Watch the video
     },
     {
       "character": "Tom",
-      "startTime": "55.5",
-      "finishTime": "58.3",
+      "startTime": 55.5,
+      "finishTime": 58.3,
       "dialogue": {
         "text": "I can't wait for the first meeting I'll attend.",
         "align": "left"
@@ -192,8 +192,8 @@ Watch the video
     },
     {
       "character": "Sophie",
-      "startTime": "58.5",
-      "finishTime": "59.5",
+      "startTime": 58.5,
+      "finishTime": 59.5,
       "dialogue": {
         "text": "Probably next Monday.",
         "align": "right"

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657dcafa1e1a4a62dc03cb76.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657dcafa1e1a4a62dc03cb76.md
@@ -48,8 +48,8 @@ Watch the video
     },
     {
       "character": "Tom",
-      "startTime": "1.0",
-      "finishTime": "3.2",
+      "startTime": 1.0,
+      "finishTime": 3.2,
       "dialogue": {
         "text": "Hi Maria! I'm still getting to know the area.",
         "align": "left"
@@ -57,8 +57,8 @@ Watch the video
     },
     {
       "character": "Tom",
-      "startTime": "3.4",
-      "finishTime": "4.9",
+      "startTime": 3.4,
+      "finishTime": 4.9,
       "dialogue": {
         "text": "Is there an ATM nearby?",
         "align": "left"
@@ -66,8 +66,8 @@ Watch the video
     },
     {
       "character": "Maria",
-      "startTime": "5.7",
-      "finishTime": "8.2",
+      "startTime": 5.7,
+      "finishTime": 8.2,
       "dialogue": {
         "text": "Yes, there is a bank just a few blocks away.",
         "align": "right"
@@ -75,8 +75,8 @@ Watch the video
     },
     {
       "character": "Tom",
-      "startTime": "8.4",
-      "finishTime": "9.7",
+      "startTime": 8.4,
+      "finishTime": 9.7,
       "dialogue": {
         "text": "That's good to know.",
         "align": "left"
@@ -84,8 +84,8 @@ Watch the video
     },
     {
       "character": "Tom",
-      "startTime": "9.9",
-      "finishTime": "11.5",
+      "startTime": 9.9,
+      "finishTime": 11.5,
       "dialogue": {
         "text": "Are there any parks around here?",
         "align": "left"
@@ -93,8 +93,8 @@ Watch the video
     },
     {
       "character": "Maria",
-      "startTime": "11.7",
-      "finishTime": "14.2",
+      "startTime": 11.7,
+      "finishTime": 14.2,
       "dialogue": {
         "text": "Yes, there are a couple of parks near here.",
         "align": "right"
@@ -102,8 +102,8 @@ Watch the video
     },
     {
       "character": "Maria",
-      "startTime": "14.4",
-      "finishTime": "15.7",
+      "startTime": 14.4,
+      "finishTime": 15.7,
       "dialogue": {
         "text": "They're great for a break.",
         "align": "right"
@@ -111,8 +111,8 @@ Watch the video
     },
     {
       "character": "Tom",
-      "startTime": "15.9",
-      "finishTime": "17.1",
+      "startTime": 15.9,
+      "finishTime": 17.1,
       "dialogue": {
         "text": "How about restaurants?",
         "align": "left"
@@ -120,8 +120,8 @@ Watch the video
     },
     {
       "character": "Tom",
-      "startTime": "17.3",
-      "finishTime": "19.3",
+      "startTime": 17.3,
+      "finishTime": 19.3,
       "dialogue": {
         "text": "Are there any good restaurants in this neighborhood?",
         "align": "left"
@@ -129,8 +129,8 @@ Watch the video
     },
     {
       "character": "Maria",
-      "startTime": "19.5",
-      "finishTime": "22.5",
+      "startTime": 19.5,
+      "finishTime": 22.5,
       "dialogue": {
         "text": "Yes, there are many restaurants within walking distance.",
         "align": "right"
@@ -138,8 +138,8 @@ Watch the video
     },
     {
       "character": "Tom",
-      "startTime": "22.7",
-      "finishTime": "26.7",
+      "startTime": 22.7,
+      "finishTime": 26.7,
       "dialogue": {
         "text": "Fantastic! Is there anything else interesting to check out?",
         "align": "left"
@@ -147,8 +147,8 @@ Watch the video
     },
     {
       "character": "Maria",
-      "startTime": "26.9",
-      "finishTime": "28.7",
+      "startTime": 26.9,
+      "finishTime": 28.7,
       "dialogue": {
         "text": "Absolutely! There's a gym.",
         "align": "right"
@@ -156,8 +156,8 @@ Watch the video
     },
     {
       "character": "Maria",
-      "startTime": "28.9",
-      "finishTime": "31.7",
+      "startTime": 28.9,
+      "finishTime": 31.7,
       "dialogue": {
         "text": "There are also great coffee shops not too far away.",
         "align": "right"
@@ -165,8 +165,8 @@ Watch the video
     },
     {
       "character": "Tom",
-      "startTime": "31.9",
-      "finishTime": "34.4",
+      "startTime": 31.9,
+      "finishTime": 34.4,
       "dialogue": {
         "text": "How about bookstores or theaters?",
         "align": "left"
@@ -174,8 +174,8 @@ Watch the video
     },
     {
       "character": "Maria",
-      "startTime": "34.9",
-      "finishTime": "38.4",
+      "startTime": 34.9,
+      "finishTime": 38.4,
       "dialogue": {
         "text": "Hmm… there isn't any theater around here that I know of.",
         "align": "right"
@@ -183,8 +183,8 @@ Watch the video
     },
     {
       "character": "Maria",
-      "startTime": "38.9",
-      "finishTime": "40.9",
+      "startTime": 38.9,
+      "finishTime": 40.9,
       "dialogue": {
         "text": "The bookstores I remember are all downtown.",
         "align": "right"
@@ -192,8 +192,8 @@ Watch the video
     },
     {
       "character": "Maria",
-      "startTime": "41.1",
-      "finishTime": "43.1",
+      "startTime": 41.1,
+      "finishTime": 43.1,
       "dialogue": {
         "text": "There's a bus that stops two blocks away.",
         "align": "right"
@@ -201,8 +201,8 @@ Watch the video
     },
     {
       "character": "Tom",
-      "startTime": "43.3",
-      "finishTime": "45.3",
+      "startTime": 43.3,
+      "finishTime": 45.3,
       "dialogue": {
         "text": "Oh, how about a shopping mall?",
         "align": "left"
@@ -210,8 +210,8 @@ Watch the video
     },
     {
       "character": "Maria",
-      "startTime": "45.5",
-      "finishTime": "47.5",
+      "startTime": 45.5,
+      "finishTime": 47.5,
       "dialogue": {
         "text": "Malls are everywhere.",
         "align": "right"
@@ -219,8 +219,8 @@ Watch the video
     },
     {
       "character": "Maria",
-      "startTime": "47.7",
-      "finishTime": "49.7",
+      "startTime": 47.7,
+      "finishTime": 49.7,
       "dialogue": {
         "text": "I'm sure you can find them just by walking around a bit.",
         "align": "right"
@@ -228,8 +228,8 @@ Watch the video
     },
     {
       "character": "Tom",
-      "startTime": "49.9",
-      "finishTime": "51.4",
+      "startTime": 49.9,
+      "finishTime": 51.4,
       "dialogue": {
         "text": "Thanks for your help, Maria.",
         "align": "left"
@@ -237,8 +237,8 @@ Watch the video
     },
     {
       "character": "Maria",
-      "startTime": "51.9",
-      "finishTime": "52.7",
+      "startTime": 51.9,
+      "finishTime": 52.7,
       "dialogue": {
         "text": "You're welcome, Tom.",
         "align": "right"

--- a/curriculum/schema/__snapshots__/challenge-schema.test.js.snap
+++ b/curriculum/schema/__snapshots__/challenge-schema.test.js.snap
@@ -8,7 +8,8 @@ const { challengeTypes } = require('../../shared/config/challenge-types');
 const {
   availableCharacters,
   availableBackgrounds,
-  availableAudios
+  availableAudios,
+  availableAlignments
 } = require('./scene-assets');
 
 const slugRE = new RegExp('^[a-z0-9-]+$');
@@ -35,9 +36,9 @@ const prerequisitesJoi = Joi.object().keys({
 });
 
 const positionJoi = Joi.object().keys({
-  x: Joi.number().required(),
-  y: Joi.number().required(),
-  z: Joi.number().required()
+  x: Joi.number().required().strict(),
+  y: Joi.number().required().strict(),
+  z: Joi.number().required().strict()
 });
 
 const setupCharacterJoi = Joi.object().keys({
@@ -45,16 +46,16 @@ const setupCharacterJoi = Joi.object().keys({
     .valid(...availableCharacters)
     .required(),
   position: positionJoi.required(),
-  opacity: Joi.number()
+  opacity: Joi.number().strict()
 });
 
 const setupAudioJoi = Joi.object().keys({
   filename: Joi.string()
     .valid(...availableAudios)
     .required(),
-  startTime: Joi.number().required(),
-  startTimestamp: Joi.number(),
-  finishTimestamp: Joi.number()
+  startTime: Joi.number().required().strict(),
+  startTimestamp: Joi.number().strict(),
+  finishTimestamp: Joi.number().strict()
 });
 
 const setupJoi = Joi.object().keys({
@@ -68,7 +69,7 @@ const setupJoi = Joi.object().keys({
 
 const DialogueJoi = Joi.object().keys({
   text: Joi.string().required(),
-  align: Joi.string()
+  align: Joi.string().valid(...availableAlignments)
 });
 
 const commandJoi = Joi.object().keys({
@@ -77,9 +78,9 @@ const commandJoi = Joi.object().keys({
     .valid(...availableCharacters)
     .required(),
   position: positionJoi,
-  opacity: Joi.number(),
-  startTime: Joi.number().required(),
-  finishTime: Joi.number(),
+  opacity: Joi.number().strict(),
+  startTime: Joi.number().required().strict(),
+  finishTime: Joi.number().strict(),
   dialogue: DialogueJoi
 });
 

--- a/curriculum/schema/challenge-schema.js
+++ b/curriculum/schema/challenge-schema.js
@@ -5,7 +5,8 @@ const { challengeTypes } = require('../../shared/config/challenge-types');
 const {
   availableCharacters,
   availableBackgrounds,
-  availableAudios
+  availableAudios,
+  availableAlignments
 } = require('./scene-assets');
 
 const slugRE = new RegExp('^[a-z0-9-]+$');
@@ -32,9 +33,9 @@ const prerequisitesJoi = Joi.object().keys({
 });
 
 const positionJoi = Joi.object().keys({
-  x: Joi.number().required(),
-  y: Joi.number().required(),
-  z: Joi.number().required()
+  x: Joi.number().required().strict(),
+  y: Joi.number().required().strict(),
+  z: Joi.number().required().strict()
 });
 
 const setupCharacterJoi = Joi.object().keys({
@@ -42,16 +43,16 @@ const setupCharacterJoi = Joi.object().keys({
     .valid(...availableCharacters)
     .required(),
   position: positionJoi.required(),
-  opacity: Joi.number()
+  opacity: Joi.number().strict()
 });
 
 const setupAudioJoi = Joi.object().keys({
   filename: Joi.string()
     .valid(...availableAudios)
     .required(),
-  startTime: Joi.number().required(),
-  startTimestamp: Joi.number(),
-  finishTimestamp: Joi.number()
+  startTime: Joi.number().required().strict(),
+  startTimestamp: Joi.number().strict(),
+  finishTimestamp: Joi.number().strict()
 });
 
 const setupJoi = Joi.object().keys({
@@ -65,7 +66,7 @@ const setupJoi = Joi.object().keys({
 
 const DialogueJoi = Joi.object().keys({
   text: Joi.string().required(),
-  align: Joi.string()
+  align: Joi.string().valid(...availableAlignments)
 });
 
 const commandJoi = Joi.object().keys({
@@ -74,9 +75,9 @@ const commandJoi = Joi.object().keys({
     .valid(...availableCharacters)
     .required(),
   position: positionJoi,
-  opacity: Joi.number(),
-  startTime: Joi.number().required(),
-  finishTime: Joi.number(),
+  opacity: Joi.number().strict(),
+  startTime: Joi.number().required().strict(),
+  finishTime: Joi.number().strict(),
   dialogue: DialogueJoi
 });
 

--- a/curriculum/schema/scene-assets.js
+++ b/curriculum/schema/scene-assets.js
@@ -87,8 +87,11 @@ const availableAudios = [
   '1.3-5.mp3'
 ];
 
+const availableAlignments = ['left', 'center', 'right'];
+
 module.exports = {
   availableCharacters,
   availableBackgrounds,
-  availableAudios
+  availableAudios,
+  availableAlignments
 };


### PR DESCRIPTION
We were getting gatsby warnings about types in the english curriculum:

<img width="1035" alt="Screenshot 2024-01-04 at 9 51 23 AM" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/20648924/5fa85240-1fe0-464e-99a7-420ca35b0050">

This fixes the challenge files and forces the types.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
