### PR TITLE
fix(challenge-auditor): failing tests

### DIFF
--- a/shared/config/superblocks.ts
+++ b/shared/config/superblocks.ts
@@ -137,6 +137,7 @@ export const notAuditedSuperBlocks: NotAuditedSuperBlocks = {
   [Languages.Italian]: [
     SuperBlocks.FoundationalCSharp,
     SuperBlocks.JsAlgoDataStructNew,
+    SuperBlocks.ProjectEuler,
     SuperBlocks.TheOdinProject,
     SuperBlocks.UpcomingPython,
     SuperBlocks.A2English,
@@ -144,6 +145,7 @@ export const notAuditedSuperBlocks: NotAuditedSuperBlocks = {
   ],
   [Languages.Portuguese]: [
     SuperBlocks.JsAlgoDataStructNew,
+    SuperBlocks.ProjectEuler,
     SuperBlocks.UpcomingPython,
     SuperBlocks.A2English,
     SuperBlocks.PythonForEverybody


### PR DESCRIPTION
After we merged https://github.com/freeCodeCamp/freeCodeCamp/pull/52878, the i18n tests started failing on main. That PR renamed an Euler challenge - so all the i18n's are currently falling back to that English challenge since they don't have the renamed file. Italian and Portuguese had the Euler superblock audited - there's a test that checks that all audited superblocks have all the challenge files. That test is failing cause those two languages don't have the newly renamed file. I'm not sure if this is the best fix, but it works. Let me know if anyone has any other suggestions.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
