### PR TITLE
fix: comments forum post

### DIFF
--- a/client/src/templates/Challenges/redux/create-question-epic.js
+++ b/client/src/templates/Challenges/redux/create-question-epic.js
@@ -42,9 +42,18 @@ function filesToMarkdown(challengeFiles = []) {
 export function insertEditableRegions(challengeFiles = []) {
   if (challengeFiles?.some(file => file.editableRegionBoundaries?.length > 0)) {
     const editableRegionStrings = fileExtension => {
-      const startComment = fileExtension === 'html' ? '<!--' : '/*';
-      const endComment = fileExtension === 'html' ? '-->' : '*/';
-      return `\n${startComment} User Editable Region ${endComment}\n`;
+      switch (fileExtension) {
+        case 'html':
+          return '\n<!-- User Editable Region -->\n';
+        case 'css':
+          return '\n/* User Editable Region */\n';
+        case 'py':
+          return '\n# User Editable Region\n';
+        case 'js':
+          return '\n// User Editable Region\n';
+        default:
+          return '\nUser Editable Region\n';
+      }
     };
 
     const filesWithEditableRegions = challengeFiles.map(file => {


### PR DESCRIPTION
This resolves incorrect comments being added to a Python based file. It seems a little more excessive but also adds some semantics so it's easier to understand.

Another option would be to check for python file first and then assign the value to the `startComment` variable. Then check for the rest.

Closes #52721