### PR TITLE
fix: standardize growthbook GA events

### DIFF
--- a/client/src/components/Donation/donation-modal.tsx
+++ b/client/src/components/Donation/donation-modal.tsx
@@ -7,7 +7,6 @@ import { connect } from 'react-redux';
 import { goToAnchor } from 'react-scrollable-anchor';
 import { bindActionCreators, Dispatch, AnyAction } from 'redux';
 import { createSelector } from 'reselect';
-import { useFeature } from '@growthbook/growthbook-react';
 
 import BearProgressModal from '../../assets/images/components/bear-progress-modal';
 import BearBlockCompletion from '../../assets/images/components/bear-block-completion-modal';
@@ -123,8 +122,6 @@ function DonateModal({
   const handleProcessing = () => {
     setDonationAttempted(true);
   };
-
-  useFeature('aa-test-in-component');
 
   useEffect(() => {
     if (show) {

--- a/client/src/components/Donation/multi-tier-donation-form.tsx
+++ b/client/src/components/Donation/multi-tier-donation-form.tsx
@@ -7,8 +7,10 @@ import {
   Col,
   Row
 } from '@freecodecamp/ui';
+import { useFeature } from '@growthbook/growthbook-react';
 import { useTranslation } from 'react-i18next';
 import { Spacer } from '../helpers';
+
 import {
   PaymentContext,
   subscriptionAmounts,
@@ -39,6 +41,7 @@ function SelectionTabs({
   const switchTab = (value: string): void => {
     setDonationAmount(Number(value) as DonationAmount);
   };
+  useFeature('aa-test-in-component');
 
   return (
     <Row


### PR DESCRIPTION
The  trackingCallback in from the Growthbook setup was manually pushing to the Google Analytics datalayer.
I made it so it uses the executeGA similar to the rest of the codebase.
Additionally, 'experiment_viewed' for 'aa-test-in-component' was being fired on initial load, so I relocated it to the donation from. That way it only fires when donation from renders.


Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
