### PR TITLE
fix: iterate over test input inside python

### DIFF
--- a/tools/client-plugins/browser-scripts/python-test-evaluator.ts
+++ b/tools/client-plugins/browser-scripts/python-test-evaluator.ts
@@ -128,7 +128,7 @@ def __inputGen(xs):
 
   return input
 
-input = __inputGen(${JSON.stringify(input)})
+input = __inputGen(${JSON.stringify(input ?? [])})
 `);
 
     // Evaluates the learner's code so that any variables they define are

--- a/tools/client-plugins/browser-scripts/python-test-evaluator.ts
+++ b/tools/client-plugins/browser-scripts/python-test-evaluator.ts
@@ -103,35 +103,6 @@ ctx.onmessage = async (e: PythonRunEvent) => {
 
     const { input, test } = evaluatedTestString as EvaluatedTeststring;
 
-    const inputIterator = (input ?? []).values();
-    const testInput = () => {
-      const next = inputIterator.next();
-      if (next.done) {
-        // TODO: handle this error in the UI
-        throw new Error('Too many input calls');
-      } else {
-        return next.value;
-      }
-    };
-
-    // Clear out the old import otherwise it will use the old input/print
-    // functions
-    pyodide.runPython(`
-import sys
-try:
-  del sys.modules['jscustom']
-  del jscustom
-except (KeyError, NameError):
-  pass
-
-`);
-
-    // Make input available to python (print is not used yet)
-    pyodide.registerJsModule('jscustom', {
-      input: testInput
-      // print: () => {}
-    });
-
     // Some tests rely on __name__ being set to __main__ and we new dicts do not
     // have this set by default.
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call
@@ -146,12 +117,19 @@ except (KeyError, NameError):
       runPython
     };
 
-    runPython(
-      `
-  import jscustom
-  from jscustom import input
-  `
-    );
+    runPython(`
+def __inputGen(xs):
+  def gen():
+    for x in xs:
+      yield x
+  iter = gen()
+  def input(arg=None):
+    return next(iter)
+
+  return input
+
+input = __inputGen(${JSON.stringify(input)})
+`);
 
     // Evaluates the learner's code so that any variables they define are
     // available to the test.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This prevents the memory leak that occurs when registerJsModule is invoked multiple times. Each time that happened (i.e. every time a test ran), ~300k leaked.

I've tried various attempts to clean up input (`del sys.modules['jscustom']` and `unregisterJsModule`), but there was always a leftover reference I couldn't eliminate.

Instead, this relies entirely on python's garbage collector, which doesn't seem to have any issues clearing up.

<!-- Feel free to add any additional description of changes below this line -->
