### PR TITLE
fix(curriculum): removing incorrect use of aria labels in TODO app

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64e4e4c4ec263b62ae7bf54d.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64e4e4c4ec263b62ae7bf54d.md
@@ -76,7 +76,7 @@ assert.match(code, /const\s+openTaskFormBtn\s*=\s*document\.getElementById\(\s*(
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>
@@ -89,7 +89,7 @@ assert.match(code, /const\s+openTaskFormBtn\s*=\s*document\.getElementById\(\s*(
           <textarea class="form-control" id="description-input" cols="30" rows="5"></textarea>
         </div>
         <div class="task-form-footer">
-          <button id="add-or-update-task-btn" class="btn large-btn" type="submit" aria-label="add task">
+          <button id="add-or-update-task-btn" class="btn large-btn" type="submit">
             Add Task
           </button>
         </div>
@@ -98,10 +98,10 @@ assert.match(code, /const\s+openTaskFormBtn\s*=\s*document\.getElementById\(\s*(
         <form method="dialog">
           <p class="discard-message-text">Discard unsaved changes?</p>
           <div class="confirm-close-dialog-btn-container">
-            <button id="cancel-btn" class="btn" aria-label="cancel">
+            <button id="cancel-btn" class="btn">
               Cancel
             </button>
-            <button id="discard-btn" class="btn" aria-label="discard">
+            <button id="discard-btn" class="btn">
               Discard
             </button>
           </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64e4e4c4ec263b62ae7bf54d.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64e4e4c4ec263b62ae7bf54d.md
@@ -76,7 +76,7 @@ assert.match(code, /const\s+openTaskFormBtn\s*=\s*document\.getElementById\(\s*(
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64e4e6c86954de67a3e44ee3.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64e4e6c86954de67a3e44ee3.md
@@ -72,7 +72,7 @@ assert.match(code, /const\s+cancelBtn\s*=\s*document\.getElementById\(\s*('|"|`)
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>
@@ -85,7 +85,7 @@ assert.match(code, /const\s+cancelBtn\s*=\s*document\.getElementById\(\s*('|"|`)
           <textarea class="form-control" id="description-input" cols="30" rows="5"></textarea>
         </div>
         <div class="task-form-footer">
-          <button id="add-or-update-task-btn" class="btn large-btn" type="submit" aria-label="add task">
+          <button id="add-or-update-task-btn" class="btn large-btn" type="submit">
             Add Task
           </button>
         </div>
@@ -94,10 +94,10 @@ assert.match(code, /const\s+cancelBtn\s*=\s*document\.getElementById\(\s*('|"|`)
         <form method="dialog">
           <p class="discard-message-text">Discard unsaved changes?</p>
           <div class="confirm-close-dialog-btn-container">
-            <button id="cancel-btn" class="btn" aria-label="cancel">
+            <button id="cancel-btn" class="btn">
               Cancel
             </button>
-            <button id="discard-btn" class="btn" aria-label="discard">
+            <button id="discard-btn" class="btn">
               Discard
             </button>
           </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64e4e6c86954de67a3e44ee3.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64e4e6c86954de67a3e44ee3.md
@@ -72,7 +72,7 @@ assert.match(code, /const\s+cancelBtn\s*=\s*document\.getElementById\(\s*('|"|`)
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64e4e6fe78b5aa67ef2fc3e7.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64e4e6fe78b5aa67ef2fc3e7.md
@@ -72,7 +72,7 @@ assert.match(code, /const\s+titleInput\s*=\s*document\.getElementById\(\s*('|"|`
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64e4e6fe78b5aa67ef2fc3e7.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64e4e6fe78b5aa67ef2fc3e7.md
@@ -72,7 +72,7 @@ assert.match(code, /const\s+titleInput\s*=\s*document\.getElementById\(\s*('|"|`
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>
@@ -85,7 +85,7 @@ assert.match(code, /const\s+titleInput\s*=\s*document\.getElementById\(\s*('|"|`
           <textarea class="form-control" id="description-input" cols="30" rows="5"></textarea>
         </div>
         <div class="task-form-footer">
-          <button id="add-or-update-task-btn" class="btn large-btn" type="submit" aria-label="add task">
+          <button id="add-or-update-task-btn" class="btn large-btn" type="submit">
             Add Task
           </button>
         </div>
@@ -94,10 +94,10 @@ assert.match(code, /const\s+titleInput\s*=\s*document\.getElementById\(\s*('|"|`
         <form method="dialog">
           <p class="discard-message-text">Discard unsaved changes?</p>
           <div class="confirm-close-dialog-btn-container">
-            <button id="cancel-btn" class="btn" aria-label="cancel">
+            <button id="cancel-btn" class="btn">
               Cancel
             </button>
-            <button id="discard-btn" class="btn" aria-label="discard">
+            <button id="discard-btn" class="btn">
               Discard
             </button>
           </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64e4e7241f52bb682eeb8211.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64e4e7241f52bb682eeb8211.md
@@ -60,7 +60,7 @@ assert.match(code, /const\s+descriptionInput\s*=\s*document\.getElementById\(\s*
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64e4e7241f52bb682eeb8211.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64e4e7241f52bb682eeb8211.md
@@ -60,7 +60,7 @@ assert.match(code, /const\s+descriptionInput\s*=\s*document\.getElementById\(\s*
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>
@@ -73,7 +73,7 @@ assert.match(code, /const\s+descriptionInput\s*=\s*document\.getElementById\(\s*
           <textarea class="form-control" id="description-input" cols="30" rows="5"></textarea>
         </div>
         <div class="task-form-footer">
-          <button id="add-or-update-task-btn" class="btn large-btn" type="submit" aria-label="add task">
+          <button id="add-or-update-task-btn" class="btn large-btn" type="submit">
             Add Task
           </button>
         </div>
@@ -82,10 +82,10 @@ assert.match(code, /const\s+descriptionInput\s*=\s*document\.getElementById\(\s*
         <form method="dialog">
           <p class="discard-message-text">Discard unsaved changes?</p>
           <div class="confirm-close-dialog-btn-container">
-            <button id="cancel-btn" class="btn" aria-label="cancel">
+            <button id="cancel-btn" class="btn">
               Cancel
             </button>
-            <button id="discard-btn" class="btn" aria-label="discard">
+            <button id="discard-btn" class="btn">
               Discard
             </button>
           </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64e4e74d0fb4f0687bf4145d.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64e4e74d0fb4f0687bf4145d.md
@@ -50,7 +50,7 @@ assert.match(code, /let\s+currentTask\s*=\s*\{\};?/)
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64e4e74d0fb4f0687bf4145d.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64e4e74d0fb4f0687bf4145d.md
@@ -50,7 +50,7 @@ assert.match(code, /let\s+currentTask\s*=\s*\{\};?/)
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>
@@ -63,7 +63,7 @@ assert.match(code, /let\s+currentTask\s*=\s*\{\};?/)
           <textarea class="form-control" id="description-input" cols="30" rows="5"></textarea>
         </div>
         <div class="task-form-footer">
-          <button id="add-or-update-task-btn" class="btn large-btn" type="submit" aria-label="add task">
+          <button id="add-or-update-task-btn" class="btn large-btn" type="submit">
             Add Task
           </button>
         </div>
@@ -72,10 +72,10 @@ assert.match(code, /let\s+currentTask\s*=\s*\{\};?/)
         <form method="dialog">
           <p class="discard-message-text">Discard unsaved changes?</p>
           <div class="confirm-close-dialog-btn-container">
-            <button id="cancel-btn" class="btn" aria-label="cancel">
+            <button id="cancel-btn" class="btn">
               Cancel
             </button>
-            <button id="discard-btn" class="btn" aria-label="discard">
+            <button id="discard-btn" class="btn">
               Discard
             </button>
           </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64e4e78a7ea4a168de4e6a38.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64e4e78a7ea4a168de4e6a38.md
@@ -58,7 +58,7 @@ assert.match(code, /openTaskFormBtn\.addEventListener\(('|"|`)click\1\,\s*\(\)\s
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>
@@ -71,7 +71,7 @@ assert.match(code, /openTaskFormBtn\.addEventListener\(('|"|`)click\1\,\s*\(\)\s
           <textarea class="form-control" id="description-input" cols="30" rows="5"></textarea>
         </div>
         <div class="task-form-footer">
-          <button id="add-or-update-task-btn" class="btn large-btn" type="submit" aria-label="add task">
+          <button id="add-or-update-task-btn" class="btn large-btn" type="submit">
             Add Task
           </button>
         </div>
@@ -80,10 +80,10 @@ assert.match(code, /openTaskFormBtn\.addEventListener\(('|"|`)click\1\,\s*\(\)\s
         <form method="dialog">
           <p class="discard-message-text">Discard unsaved changes?</p>
           <div class="confirm-close-dialog-btn-container">
-            <button id="cancel-btn" class="btn" aria-label="cancel">
+            <button id="cancel-btn" class="btn">
               Cancel
             </button>
-            <button id="discard-btn" class="btn" aria-label="discard">
+            <button id="discard-btn" class="btn">
               Discard
             </button>
           </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64e4e78a7ea4a168de4e6a38.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64e4e78a7ea4a168de4e6a38.md
@@ -58,7 +58,7 @@ assert.match(code, /openTaskFormBtn\.addEventListener\(('|"|`)click\1\,\s*\(\)\s
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64e4e7bbedb22d6939001ad3.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64e4e7bbedb22d6939001ad3.md
@@ -56,7 +56,7 @@ assert.match(code, /closeTaskFormBtn\.addEventListener\(["'`]click["'`],\s*\(.*\
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>
@@ -69,7 +69,7 @@ assert.match(code, /closeTaskFormBtn\.addEventListener\(["'`]click["'`],\s*\(.*\
           <textarea class="form-control" id="description-input" cols="30" rows="5"></textarea>
         </div>
         <div class="task-form-footer">
-          <button id="add-or-update-task-btn" class="btn large-btn" type="submit" aria-label="add task">
+          <button id="add-or-update-task-btn" class="btn large-btn" type="submit">
             Add Task
           </button>
         </div>
@@ -78,10 +78,10 @@ assert.match(code, /closeTaskFormBtn\.addEventListener\(["'`]click["'`],\s*\(.*\
         <form method="dialog">
           <p class="discard-message-text">Discard unsaved changes?</p>
           <div class="confirm-close-dialog-btn-container">
-            <button id="cancel-btn" class="btn" aria-label="cancel">
+            <button id="cancel-btn" class="btn">
               Cancel
             </button>
-            <button id="discard-btn" class="btn" aria-label="discard">
+            <button id="discard-btn" class="btn">
               Discard
             </button>
           </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64e4e7bbedb22d6939001ad3.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64e4e7bbedb22d6939001ad3.md
@@ -56,7 +56,7 @@ assert.match(code, /closeTaskFormBtn\.addEventListener\(["'`]click["'`],\s*\(.*\
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64e4eaaa9070a66aecbfe603.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64e4eaaa9070a66aecbfe603.md
@@ -58,7 +58,7 @@ assert.match(code, /cancelBtn\.addEventListener\(('|"|`)click\1\,\s*\(\)\s*\s*=>
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64e4eaaa9070a66aecbfe603.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64e4eaaa9070a66aecbfe603.md
@@ -58,7 +58,7 @@ assert.match(code, /cancelBtn\.addEventListener\(('|"|`)click\1\,\s*\(\)\s*\s*=>
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>
@@ -71,7 +71,7 @@ assert.match(code, /cancelBtn\.addEventListener\(('|"|`)click\1\,\s*\(\)\s*\s*=>
           <textarea class="form-control" id="description-input" cols="30" rows="5"></textarea>
         </div>
         <div class="task-form-footer">
-          <button id="add-or-update-task-btn" class="btn large-btn" type="submit" aria-label="add task">
+          <button id="add-or-update-task-btn" class="btn large-btn" type="submit">
             Add Task
           </button>
         </div>
@@ -80,10 +80,10 @@ assert.match(code, /cancelBtn\.addEventListener\(('|"|`)click\1\,\s*\(\)\s*\s*=>
         <form method="dialog">
           <p class="discard-message-text">Discard unsaved changes?</p>
           <div class="confirm-close-dialog-btn-container">
-            <button id="cancel-btn" class="btn" aria-label="cancel">
+            <button id="cancel-btn" class="btn">
               Cancel
             </button>
-            <button id="discard-btn" class="btn" aria-label="discard">
+            <button id="discard-btn" class="btn">
               Discard
             </button>
           </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64e4ebc7eabc5a6babd479cd.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64e4ebc7eabc5a6babd479cd.md
@@ -68,7 +68,7 @@ assert.match(code, /discardBtn\.addEventListener\(('|"|`)click\1,\s*\(\)\s*=>\s*
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>
@@ -81,7 +81,7 @@ assert.match(code, /discardBtn\.addEventListener\(('|"|`)click\1,\s*\(\)\s*=>\s*
           <textarea class="form-control" id="description-input" cols="30" rows="5"></textarea>
         </div>
         <div class="task-form-footer">
-          <button id="add-or-update-task-btn" class="btn large-btn" type="submit" aria-label="add task">
+          <button id="add-or-update-task-btn" class="btn large-btn" type="submit">
             Add Task
           </button>
         </div>
@@ -90,10 +90,10 @@ assert.match(code, /discardBtn\.addEventListener\(('|"|`)click\1,\s*\(\)\s*=>\s*
         <form method="dialog">
           <p class="discard-message-text">Discard unsaved changes?</p>
           <div class="confirm-close-dialog-btn-container">
-            <button id="cancel-btn" class="btn" aria-label="cancel">
+            <button id="cancel-btn" class="btn">
               Cancel
             </button>
-            <button id="discard-btn" class="btn" aria-label="discard">
+            <button id="discard-btn" class="btn">
               Discard
             </button>
           </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64e4ebc7eabc5a6babd479cd.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64e4ebc7eabc5a6babd479cd.md
@@ -68,7 +68,7 @@ assert.match(code, /discardBtn\.addEventListener\(('|"|`)click\1,\s*\(\)\s*=>\s*
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64e4ecd7735a566c9266a338.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64e4ecd7735a566c9266a338.md
@@ -62,7 +62,7 @@ assert.match(code, /taskForm\.addEventListener\(('|"|`)submit\1,\s*\(e\)\s*=>\s*
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>
@@ -75,7 +75,7 @@ assert.match(code, /taskForm\.addEventListener\(('|"|`)submit\1,\s*\(e\)\s*=>\s*
           <textarea class="form-control" id="description-input" cols="30" rows="5"></textarea>
         </div>
         <div class="task-form-footer">
-          <button id="add-or-update-task-btn" class="btn large-btn" type="submit" aria-label="add task">
+          <button id="add-or-update-task-btn" class="btn large-btn" type="submit">
             Add Task
           </button>
         </div>
@@ -84,10 +84,10 @@ assert.match(code, /taskForm\.addEventListener\(('|"|`)submit\1,\s*\(e\)\s*=>\s*
         <form method="dialog">
           <p class="discard-message-text">Discard unsaved changes?</p>
           <div class="confirm-close-dialog-btn-container">
-            <button id="cancel-btn" class="btn" aria-label="cancel">
+            <button id="cancel-btn" class="btn">
               Cancel
             </button>
-            <button id="discard-btn" class="btn" aria-label="discard">
+            <button id="discard-btn" class="btn">
               Discard
             </button>
           </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64e4ecd7735a566c9266a338.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64e4ecd7735a566c9266a338.md
@@ -62,7 +62,7 @@ assert.match(code, /taskForm\.addEventListener\(('|"|`)submit\1,\s*\(e\)\s*=>\s*
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64e4eec13546c06d61a63d59.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64e4eec13546c06d61a63d59.md
@@ -69,7 +69,7 @@ assert.match(code, /const dataArrIndex\s*=\s*taskData\.findIndex\(\(?item\)?\s*=
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64e4eec13546c06d61a63d59.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64e4eec13546c06d61a63d59.md
@@ -69,7 +69,7 @@ assert.match(code, /const dataArrIndex\s*=\s*taskData\.findIndex\(\(?item\)?\s*=
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>
@@ -82,7 +82,7 @@ assert.match(code, /const dataArrIndex\s*=\s*taskData\.findIndex\(\(?item\)?\s*=
           <textarea class="form-control" id="description-input" cols="30" rows="5"></textarea>
         </div>
         <div class="task-form-footer">
-          <button id="add-or-update-task-btn" class="btn large-btn" type="submit" aria-label="add task">
+          <button id="add-or-update-task-btn" class="btn large-btn" type="submit">
             Add Task
           </button>
         </div>
@@ -91,10 +91,10 @@ assert.match(code, /const dataArrIndex\s*=\s*taskData\.findIndex\(\(?item\)?\s*=
         <form method="dialog">
           <p class="discard-message-text">Discard unsaved changes?</p>
           <div class="confirm-close-dialog-btn-container">
-            <button id="cancel-btn" class="btn" aria-label="cancel">
+            <button id="cancel-btn" class="btn">
               Cancel
             </button>
-            <button id="discard-btn" class="btn" aria-label="discard">
+            <button id="discard-btn" class="btn">
               Discard
             </button>
           </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64e4f01d6c72086e016a8626.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64e4f01d6c72086e016a8626.md
@@ -70,7 +70,7 @@ assert.match(code, /const\s+taskObj\s*=\s*\{\s*id:\s*`\$\{titleInput\.value\.toL
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>
@@ -83,7 +83,7 @@ assert.match(code, /const\s+taskObj\s*=\s*\{\s*id:\s*`\$\{titleInput\.value\.toL
           <textarea class="form-control" id="description-input" cols="30" rows="5"></textarea>
         </div>
         <div class="task-form-footer">
-          <button id="add-or-update-task-btn" class="btn large-btn" type="submit" aria-label="add task">
+          <button id="add-or-update-task-btn" class="btn large-btn" type="submit">
             Add Task
           </button>
         </div>
@@ -92,10 +92,10 @@ assert.match(code, /const\s+taskObj\s*=\s*\{\s*id:\s*`\$\{titleInput\.value\.toL
         <form method="dialog">
           <p class="discard-message-text">Discard unsaved changes?</p>
           <div class="confirm-close-dialog-btn-container">
-            <button id="cancel-btn" class="btn" aria-label="cancel">
+            <button id="cancel-btn" class="btn">
               Cancel
             </button>
-            <button id="discard-btn" class="btn" aria-label="discard">
+            <button id="discard-btn" class="btn">
               Discard
             </button>
           </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64e4f01d6c72086e016a8626.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64e4f01d6c72086e016a8626.md
@@ -70,7 +70,7 @@ assert.match(code, /const\s+taskObj\s*=\s*\{\s*id:\s*`\$\{titleInput\.value\.toL
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ec89ee549ecf802de2b3e2.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ec89ee549ecf802de2b3e2.md
@@ -54,7 +54,7 @@ assert.match(code, /description:\s*descriptionInput\.value,?/)
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>
@@ -67,7 +67,7 @@ assert.match(code, /description:\s*descriptionInput\.value,?/)
           <textarea class="form-control" id="description-input" cols="30" rows="5"></textarea>
         </div>
         <div class="task-form-footer">
-          <button id="add-or-update-task-btn" class="btn large-btn" type="submit" aria-label="add task">
+          <button id="add-or-update-task-btn" class="btn large-btn" type="submit">
             Add Task
           </button>
         </div>
@@ -76,10 +76,10 @@ assert.match(code, /description:\s*descriptionInput\.value,?/)
         <form method="dialog">
           <p class="discard-message-text">Discard unsaved changes?</p>
           <div class="confirm-close-dialog-btn-container">
-            <button id="cancel-btn" class="btn" aria-label="cancel">
+            <button id="cancel-btn" class="btn">
               Cancel
             </button>
-            <button id="discard-btn" class="btn" aria-label="discard">
+            <button id="discard-btn" class="btn">
               Discard
             </button>
           </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ec89ee549ecf802de2b3e2.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ec89ee549ecf802de2b3e2.md
@@ -54,7 +54,7 @@ assert.match(code, /description:\s*descriptionInput\.value,?/)
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ec8f717b261e824d82d6a5.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ec8f717b261e824d82d6a5.md
@@ -55,7 +55,7 @@ assert.match(code, /if\s*\(dataArrIndex\s*===\s*-1\)\s*\{\s*taskData\.unshift\(t
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>
@@ -68,7 +68,7 @@ assert.match(code, /if\s*\(dataArrIndex\s*===\s*-1\)\s*\{\s*taskData\.unshift\(t
           <textarea class="form-control" id="description-input" cols="30" rows="5"></textarea>
         </div>
         <div class="task-form-footer">
-          <button id="add-or-update-task-btn" class="btn large-btn" type="submit" aria-label="add task">
+          <button id="add-or-update-task-btn" class="btn large-btn" type="submit">
             Add Task
           </button>
         </div>
@@ -77,10 +77,10 @@ assert.match(code, /if\s*\(dataArrIndex\s*===\s*-1\)\s*\{\s*taskData\.unshift\(t
         <form method="dialog">
           <p class="discard-message-text">Discard unsaved changes?</p>
           <div class="confirm-close-dialog-btn-container">
-            <button id="cancel-btn" class="btn" aria-label="cancel">
+            <button id="cancel-btn" class="btn">
               Cancel
             </button>
-            <button id="discard-btn" class="btn" aria-label="discard">
+            <button id="discard-btn" class="btn">
               Discard
             </button>
           </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ec8f717b261e824d82d6a5.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ec8f717b261e824d82d6a5.md
@@ -55,7 +55,7 @@ assert.match(code, /if\s*\(dataArrIndex\s*===\s*-1\)\s*\{\s*taskData\.unshift\(t
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ec9145e424d8835a4e0f28.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ec9145e424d8835a4e0f28.md
@@ -50,7 +50,7 @@ assert.match(code, /taskData\.forEach\(\s*\(\s*\{\s*(?:id\s*,\s*title\s*,\s*date
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ec9145e424d8835a4e0f28.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ec9145e424d8835a4e0f28.md
@@ -50,7 +50,7 @@ assert.match(code, /taskData\.forEach\(\s*\(\s*\{\s*(?:id\s*,\s*title\s*,\s*date
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>
@@ -63,7 +63,7 @@ assert.match(code, /taskData\.forEach\(\s*\(\s*\{\s*(?:id\s*,\s*title\s*,\s*date
           <textarea class="form-control" id="description-input" cols="30" rows="5"></textarea>
         </div>
         <div class="task-form-footer">
-          <button id="add-or-update-task-btn" class="btn large-btn" type="submit" aria-label="add task">
+          <button id="add-or-update-task-btn" class="btn large-btn" type="submit">
             Add Task
           </button>
         </div>
@@ -72,10 +72,10 @@ assert.match(code, /taskData\.forEach\(\s*\(\s*\{\s*(?:id\s*,\s*title\s*,\s*date
         <form method="dialog">
           <p class="discard-message-text">Discard unsaved changes?</p>
           <div class="confirm-close-dialog-btn-container">
-            <button id="cancel-btn" class="btn" aria-label="cancel">
+            <button id="cancel-btn" class="btn">
               Cancel
             </button>
-            <button id="discard-btn" class="btn" aria-label="discard">
+            <button id="discard-btn" class="btn">
               Discard
             </button>
           </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ec9282cd547785258cecf2.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ec9282cd547785258cecf2.md
@@ -54,7 +54,7 @@ assert.match(code, /taskData\.forEach\(\(\{.*\}\)\s*=>\s*(\s*\(?tasksContainer\.
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>
@@ -67,7 +67,7 @@ assert.match(code, /taskData\.forEach\(\(\{.*\}\)\s*=>\s*(\s*\(?tasksContainer\.
           <textarea class="form-control" id="description-input" cols="30" rows="5"></textarea>
         </div>
         <div class="task-form-footer">
-          <button id="add-or-update-task-btn" class="btn large-btn" type="submit" aria-label="add task">
+          <button id="add-or-update-task-btn" class="btn large-btn" type="submit">
             Add Task
           </button>
         </div>
@@ -76,10 +76,10 @@ assert.match(code, /taskData\.forEach\(\(\{.*\}\)\s*=>\s*(\s*\(?tasksContainer\.
         <form method="dialog">
           <p class="discard-message-text">Discard unsaved changes?</p>
           <div class="confirm-close-dialog-btn-container">
-            <button id="cancel-btn" class="btn" aria-label="cancel">
+            <button id="cancel-btn" class="btn">
               Cancel
             </button>
-            <button id="discard-btn" class="btn" aria-label="discard">
+            <button id="discard-btn" class="btn">
               Discard
             </button>
           </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ec9282cd547785258cecf2.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ec9282cd547785258cecf2.md
@@ -54,7 +54,7 @@ assert.match(code, /taskData\.forEach\(\(\{.*\}\)\s*=>\s*(\s*\(?tasksContainer\.
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ec9343769e8f85c1e17e05.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ec9343769e8f85c1e17e05.md
@@ -48,7 +48,7 @@ assert.match(code, /<div\s+class=('|")task\1\s*id=\1\$\{id\}\1>\s*<\/div>/)
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>
@@ -61,7 +61,7 @@ assert.match(code, /<div\s+class=('|")task\1\s*id=\1\$\{id\}\1>\s*<\/div>/)
           <textarea class="form-control" id="description-input" cols="30" rows="5"></textarea>
         </div>
         <div class="task-form-footer">
-          <button id="add-or-update-task-btn" class="btn large-btn" type="submit" aria-label="add task">
+          <button id="add-or-update-task-btn" class="btn large-btn" type="submit">
             Add Task
           </button>
         </div>
@@ -70,10 +70,10 @@ assert.match(code, /<div\s+class=('|")task\1\s*id=\1\$\{id\}\1>\s*<\/div>/)
         <form method="dialog">
           <p class="discard-message-text">Discard unsaved changes?</p>
           <div class="confirm-close-dialog-btn-container">
-            <button id="cancel-btn" class="btn" aria-label="cancel">
+            <button id="cancel-btn" class="btn">
               Cancel
             </button>
-            <button id="discard-btn" class="btn" aria-label="discard">
+            <button id="discard-btn" class="btn">
               Discard
             </button>
           </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ec9343769e8f85c1e17e05.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ec9343769e8f85c1e17e05.md
@@ -48,7 +48,7 @@ assert.match(code, /<div\s+class=('|")task\1\s*id=\1\$\{id\}\1>\s*<\/div>/)
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ec94f0de20c086e09b0fc3.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ec94f0de20c086e09b0fc3.md
@@ -61,7 +61,7 @@ assert.match(code, /<p><strong>Title:\s*<\/strong>\s*/)
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>
@@ -74,7 +74,7 @@ assert.match(code, /<p><strong>Title:\s*<\/strong>\s*/)
           <textarea class="form-control" id="description-input" cols="30" rows="5"></textarea>
         </div>
         <div class="task-form-footer">
-          <button id="add-or-update-task-btn" class="btn large-btn" type="submit" aria-label="add task">
+          <button id="add-or-update-task-btn" class="btn large-btn" type="submit">
             Add Task
           </button>
         </div>
@@ -83,10 +83,10 @@ assert.match(code, /<p><strong>Title:\s*<\/strong>\s*/)
         <form method="dialog">
           <p class="discard-message-text">Discard unsaved changes?</p>
           <div class="confirm-close-dialog-btn-container">
-            <button id="cancel-btn" class="btn" aria-label="cancel">
+            <button id="cancel-btn" class="btn">
               Cancel
             </button>
-            <button id="discard-btn" class="btn" aria-label="discard">
+            <button id="discard-btn" class="btn">
               Discard
             </button>
           </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ec94f0de20c086e09b0fc3.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ec94f0de20c086e09b0fc3.md
@@ -61,7 +61,7 @@ assert.match(code, /<p><strong>Title:\s*<\/strong>\s*/)
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ec959a76336c8767f5cd4d.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ec959a76336c8767f5cd4d.md
@@ -48,7 +48,7 @@ assert.match(code, /<p><strong>Date:\s*<\/strong>\s*/)
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ec959a76336c8767f5cd4d.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ec959a76336c8767f5cd4d.md
@@ -48,7 +48,7 @@ assert.match(code, /<p><strong>Date:\s*<\/strong>\s*/)
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>
@@ -61,7 +61,7 @@ assert.match(code, /<p><strong>Date:\s*<\/strong>\s*/)
           <textarea class="form-control" id="description-input" cols="30" rows="5"></textarea>
         </div>
         <div class="task-form-footer">
-          <button id="add-or-update-task-btn" class="btn large-btn" type="submit" aria-label="add task">
+          <button id="add-or-update-task-btn" class="btn large-btn" type="submit">
             Add Task
           </button>
         </div>
@@ -70,10 +70,10 @@ assert.match(code, /<p><strong>Date:\s*<\/strong>\s*/)
         <form method="dialog">
           <p class="discard-message-text">Discard unsaved changes?</p>
           <div class="confirm-close-dialog-btn-container">
-            <button id="cancel-btn" class="btn" aria-label="cancel">
+            <button id="cancel-btn" class="btn">
               Cancel
             </button>
-            <button id="discard-btn" class="btn" aria-label="discard">
+            <button id="discard-btn" class="btn">
               Discard
             </button>
           </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ec96761156a187ed32b274.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ec96761156a187ed32b274.md
@@ -50,7 +50,7 @@ assert.match(code, /<button\s+type=('|")button\1\s+class=('|")btn\2>Delete<\/but
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>
@@ -63,7 +63,7 @@ assert.match(code, /<button\s+type=('|")button\1\s+class=('|")btn\2>Delete<\/but
           <textarea class="form-control" id="description-input" cols="30" rows="5"></textarea>
         </div>
         <div class="task-form-footer">
-          <button id="add-or-update-task-btn" class="btn large-btn" type="submit" aria-label="add task">
+          <button id="add-or-update-task-btn" class="btn large-btn" type="submit">
             Add Task
           </button>
         </div>
@@ -72,10 +72,10 @@ assert.match(code, /<button\s+type=('|")button\1\s+class=('|")btn\2>Delete<\/but
         <form method="dialog">
           <p class="discard-message-text">Discard unsaved changes?</p>
           <div class="confirm-close-dialog-btn-container">
-            <button id="cancel-btn" class="btn" aria-label="cancel">
+            <button id="cancel-btn" class="btn">
               Cancel
             </button>
-            <button id="discard-btn" class="btn" aria-label="discard">
+            <button id="discard-btn" class="btn">
               Discard
             </button>
           </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ec96761156a187ed32b274.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ec96761156a187ed32b274.md
@@ -50,7 +50,7 @@ assert.match(code, /<button\s+type=('|")button\1\s+class=('|")btn\2>Delete<\/but
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ec9b10356c2d8aa05d9ce1.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ec9b10356c2d8aa05d9ce1.md
@@ -43,7 +43,7 @@ assert.match(splitter[1], /taskForm\.classList\.toggle\(('|")hidden\1\)/)
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>
@@ -56,7 +56,7 @@ assert.match(splitter[1], /taskForm\.classList\.toggle\(('|")hidden\1\)/)
           <textarea class="form-control" id="description-input" cols="30" rows="5"></textarea>
         </div>
         <div class="task-form-footer">
-          <button id="add-or-update-task-btn" class="btn large-btn" type="submit" aria-label="add task">
+          <button id="add-or-update-task-btn" class="btn large-btn" type="submit">
             Add Task
           </button>
         </div>
@@ -65,10 +65,10 @@ assert.match(splitter[1], /taskForm\.classList\.toggle\(('|")hidden\1\)/)
         <form method="dialog">
           <p class="discard-message-text">Discard unsaved changes?</p>
           <div class="confirm-close-dialog-btn-container">
-            <button id="cancel-btn" class="btn" aria-label="cancel">
+            <button id="cancel-btn" class="btn">
               Cancel
             </button>
-            <button id="discard-btn" class="btn" aria-label="discard">
+            <button id="discard-btn" class="btn">
               Discard
             </button>
           </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ec9b10356c2d8aa05d9ce1.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ec9b10356c2d8aa05d9ce1.md
@@ -43,7 +43,7 @@ assert.match(splitter[1], /taskForm\.classList\.toggle\(('|")hidden\1\)/)
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ec9c55fdeef78bacd2fc3b.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ec9c55fdeef78bacd2fc3b.md
@@ -52,7 +52,7 @@ assert.match(reset.toString(), /\(\)\s*\{\s*\}/);
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>
@@ -65,7 +65,7 @@ assert.match(reset.toString(), /\(\)\s*\{\s*\}/);
           <textarea class="form-control" id="description-input" cols="30" rows="5"></textarea>
         </div>
         <div class="task-form-footer">
-          <button id="add-or-update-task-btn" class="btn large-btn" type="submit" aria-label="add task">
+          <button id="add-or-update-task-btn" class="btn large-btn" type="submit">
             Add Task
           </button>
         </div>
@@ -74,10 +74,10 @@ assert.match(reset.toString(), /\(\)\s*\{\s*\}/);
         <form method="dialog">
           <p class="discard-message-text">Discard unsaved changes?</p>
           <div class="confirm-close-dialog-btn-container">
-            <button id="cancel-btn" class="btn" aria-label="cancel">
+            <button id="cancel-btn" class="btn">
               Cancel
             </button>
-            <button id="discard-btn" class="btn" aria-label="discard">
+            <button id="discard-btn" class="btn">
               Discard
             </button>
           </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ec9c55fdeef78bacd2fc3b.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ec9c55fdeef78bacd2fc3b.md
@@ -52,7 +52,7 @@ assert.match(reset.toString(), /\(\)\s*\{\s*\}/);
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fac365aeb8ad70b69b366f.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fac365aeb8ad70b69b366f.md
@@ -68,7 +68,7 @@ assert.match(reset.toString(), /currentTask\s*=\s*\{\};?/)
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fac365aeb8ad70b69b366f.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fac365aeb8ad70b69b366f.md
@@ -68,7 +68,7 @@ assert.match(reset.toString(), /currentTask\s*=\s*\{\};?/)
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>
@@ -81,7 +81,7 @@ assert.match(reset.toString(), /currentTask\s*=\s*\{\};?/)
           <textarea class="form-control" id="description-input" cols="30" rows="5"></textarea>
         </div>
         <div class="task-form-footer">
-          <button id="add-or-update-task-btn" class="btn large-btn" type="submit" aria-label="add task">
+          <button id="add-or-update-task-btn" class="btn large-btn" type="submit">
             Add Task
           </button>
         </div>
@@ -90,10 +90,10 @@ assert.match(reset.toString(), /currentTask\s*=\s*\{\};?/)
         <form method="dialog">
           <p class="discard-message-text">Discard unsaved changes?</p>
           <div class="confirm-close-dialog-btn-container">
-            <button id="cancel-btn" class="btn" aria-label="cancel">
+            <button id="cancel-btn" class="btn">
               Cancel
             </button>
-            <button id="discard-btn" class="btn" aria-label="discard">
+            <button id="discard-btn" class="btn">
               Discard
             </button>
           </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fac4d1773e7a719b1254de.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fac4d1773e7a719b1254de.md
@@ -49,7 +49,7 @@ assert.match(code, /reset\(\)/)
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fac4d1773e7a719b1254de.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fac4d1773e7a719b1254de.md
@@ -49,7 +49,7 @@ assert.match(code, /reset\(\)/)
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>
@@ -62,7 +62,7 @@ assert.match(code, /reset\(\)/)
           <textarea class="form-control" id="description-input" cols="30" rows="5"></textarea>
         </div>
         <div class="task-form-footer">
-          <button id="add-or-update-task-btn" class="btn large-btn" type="submit" aria-label="add task">
+          <button id="add-or-update-task-btn" class="btn large-btn" type="submit">
             Add Task
           </button>
         </div>
@@ -71,10 +71,10 @@ assert.match(code, /reset\(\)/)
         <form method="dialog">
           <p class="discard-message-text">Discard unsaved changes?</p>
           <div class="confirm-close-dialog-btn-container">
-            <button id="cancel-btn" class="btn" aria-label="cancel">
+            <button id="cancel-btn" class="btn">
               Cancel
             </button>
-            <button id="discard-btn" class="btn" aria-label="discard">
+            <button id="discard-btn" class="btn">
               Discard
             </button>
           </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fac6a497811572b338e5e5.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fac6a497811572b338e5e5.md
@@ -49,7 +49,7 @@ assert.match(code, /confirmCloseDialog\.close\(\);?\s*reset\(\);?/)
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fac6a497811572b338e5e5.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fac6a497811572b338e5e5.md
@@ -49,7 +49,7 @@ assert.match(code, /confirmCloseDialog\.close\(\);?\s*reset\(\);?/)
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>
@@ -62,7 +62,7 @@ assert.match(code, /confirmCloseDialog\.close\(\);?\s*reset\(\);?/)
           <textarea class="form-control" id="description-input" cols="30" rows="5"></textarea>
         </div>
         <div class="task-form-footer">
-          <button id="add-or-update-task-btn" class="btn large-btn" type="submit" aria-label="add task">
+          <button id="add-or-update-task-btn" class="btn large-btn" type="submit">
             Add Task
           </button>
         </div>
@@ -71,10 +71,10 @@ assert.match(code, /confirmCloseDialog\.close\(\);?\s*reset\(\);?/)
         <form method="dialog">
           <p class="discard-message-text">Discard unsaved changes?</p>
           <div class="confirm-close-dialog-btn-container">
-            <button id="cancel-btn" class="btn" aria-label="cancel">
+            <button id="cancel-btn" class="btn">
               Cancel
             </button>
-            <button id="discard-btn" class="btn" aria-label="discard">
+            <button id="discard-btn" class="btn">
               Discard
             </button>
           </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64faca774fd9fd74bc084cc9.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64faca774fd9fd74bc084cc9.md
@@ -44,7 +44,7 @@ assert.match(code, /const\s*formInputsContainValues\s*=\s*titleInput\.value\s*\|
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>
@@ -57,7 +57,7 @@ assert.match(code, /const\s*formInputsContainValues\s*=\s*titleInput\.value\s*\|
           <textarea class="form-control" id="description-input" cols="30" rows="5"></textarea>
         </div>
         <div class="task-form-footer">
-          <button id="add-or-update-task-btn" class="btn large-btn" type="submit" aria-label="add task">
+          <button id="add-or-update-task-btn" class="btn large-btn" type="submit">
             Add Task
           </button>
         </div>
@@ -66,10 +66,10 @@ assert.match(code, /const\s*formInputsContainValues\s*=\s*titleInput\.value\s*\|
         <form method="dialog">
           <p class="discard-message-text">Discard unsaved changes?</p>
           <div class="confirm-close-dialog-btn-container">
-            <button id="cancel-btn" class="btn" aria-label="cancel">
+            <button id="cancel-btn" class="btn">
               Cancel
             </button>
-            <button id="discard-btn" class="btn" aria-label="discard">
+            <button id="discard-btn" class="btn">
               Discard
             </button>
           </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64faca774fd9fd74bc084cc9.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64faca774fd9fd74bc084cc9.md
@@ -44,7 +44,7 @@ assert.match(code, /const\s*formInputsContainValues\s*=\s*titleInput\.value\s*\|
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64facf6180824876f70a2e86.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64facf6180824876f70a2e86.md
@@ -60,7 +60,7 @@ assert.match(code, /if\s*\(formInputsContainValues\)\s*\{\s*confirmCloseDialog\.
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64facf6180824876f70a2e86.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64facf6180824876f70a2e86.md
@@ -60,7 +60,7 @@ assert.match(code, /if\s*\(formInputsContainValues\)\s*\{\s*confirmCloseDialog\.
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>
@@ -73,7 +73,7 @@ assert.match(code, /if\s*\(formInputsContainValues\)\s*\{\s*confirmCloseDialog\.
           <textarea class="form-control" id="description-input" cols="30" rows="5"></textarea>
         </div>
         <div class="task-form-footer">
-          <button id="add-or-update-task-btn" class="btn large-btn" type="submit" aria-label="add task">
+          <button id="add-or-update-task-btn" class="btn large-btn" type="submit">
             Add Task
           </button>
         </div>
@@ -82,10 +82,10 @@ assert.match(code, /if\s*\(formInputsContainValues\)\s*\{\s*confirmCloseDialog\.
         <form method="dialog">
           <p class="discard-message-text">Discard unsaved changes?</p>
           <div class="confirm-close-dialog-btn-container">
-            <button id="cancel-btn" class="btn" aria-label="cancel">
+            <button id="cancel-btn" class="btn">
               Cancel
             </button>
-            <button id="discard-btn" class="btn" aria-label="discard">
+            <button id="discard-btn" class="btn">
               Discard
             </button>
           </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fad07f43a101779cb8692a.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fad07f43a101779cb8692a.md
@@ -63,7 +63,7 @@ assert.match(code, /const\s+addOrUpdateTask\s*=\s*\(\)\s*=>\s*\{\s*const\s+dataA
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fad07f43a101779cb8692a.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fad07f43a101779cb8692a.md
@@ -63,7 +63,7 @@ assert.match(code, /const\s+addOrUpdateTask\s*=\s*\(\)\s*=>\s*\{\s*const\s+dataA
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>
@@ -76,7 +76,7 @@ assert.match(code, /const\s+addOrUpdateTask\s*=\s*\(\)\s*=>\s*\{\s*const\s+dataA
           <textarea class="form-control" id="description-input" cols="30" rows="5"></textarea>
         </div>
         <div class="task-form-footer">
-          <button id="add-or-update-task-btn" class="btn large-btn" type="submit" aria-label="add task">
+          <button id="add-or-update-task-btn" class="btn large-btn" type="submit">
             Add Task
           </button>
         </div>
@@ -85,10 +85,10 @@ assert.match(code, /const\s+addOrUpdateTask\s*=\s*\(\)\s*=>\s*\{\s*const\s+dataA
         <form method="dialog">
           <p class="discard-message-text">Discard unsaved changes?</p>
           <div class="confirm-close-dialog-btn-container">
-            <button id="cancel-btn" class="btn" aria-label="cancel">
+            <button id="cancel-btn" class="btn">
               Cancel
             </button>
-            <button id="discard-btn" class="btn" aria-label="discard">
+            <button id="discard-btn" class="btn">
               Discard
             </button>
           </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fad9cd2eeb1e7ca2ca8c8b.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fad9cd2eeb1e7ca2ca8c8b.md
@@ -48,7 +48,7 @@ assert.match(code, /const\s+updateTaskContainer\s*=\s*\(\)\s*=>\s*\{\s*taskData\
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>
@@ -61,7 +61,7 @@ assert.match(code, /const\s+updateTaskContainer\s*=\s*\(\)\s*=>\s*\{\s*taskData\
           <textarea class="form-control" id="description-input" cols="30" rows="5"></textarea>
         </div>
         <div class="task-form-footer">
-          <button id="add-or-update-task-btn" class="btn large-btn" type="submit" aria-label="add task">
+          <button id="add-or-update-task-btn" class="btn large-btn" type="submit">
             Add Task
           </button>
         </div>
@@ -70,10 +70,10 @@ assert.match(code, /const\s+updateTaskContainer\s*=\s*\(\)\s*=>\s*\{\s*taskData\
         <form method="dialog">
           <p class="discard-message-text">Discard unsaved changes?</p>
           <div class="confirm-close-dialog-btn-container">
-            <button id="cancel-btn" class="btn" aria-label="cancel">
+            <button id="cancel-btn" class="btn">
               Cancel
             </button>
-            <button id="discard-btn" class="btn" aria-label="discard">
+            <button id="discard-btn" class="btn">
               Discard
             </button>
           </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fad9cd2eeb1e7ca2ca8c8b.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fad9cd2eeb1e7ca2ca8c8b.md
@@ -48,7 +48,7 @@ assert.match(code, /const\s+updateTaskContainer\s*=\s*\(\)\s*=>\s*\{\s*taskData\
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fadae4f2d51b7d5d8b98d8.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fadae4f2d51b7d5d8b98d8.md
@@ -48,7 +48,7 @@ assert.match(code, /updateTaskContainer\(\);?\s*reset\(\);?\s*/)
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>
@@ -61,7 +61,7 @@ assert.match(code, /updateTaskContainer\(\);?\s*reset\(\);?\s*/)
           <textarea class="form-control" id="description-input" cols="30" rows="5"></textarea>
         </div>
         <div class="task-form-footer">
-          <button id="add-or-update-task-btn" class="btn large-btn" type="submit" aria-label="add task">
+          <button id="add-or-update-task-btn" class="btn large-btn" type="submit">
             Add Task
           </button>
         </div>
@@ -70,10 +70,10 @@ assert.match(code, /updateTaskContainer\(\);?\s*reset\(\);?\s*/)
         <form method="dialog">
           <p class="discard-message-text">Discard unsaved changes?</p>
           <div class="confirm-close-dialog-btn-container">
-            <button id="cancel-btn" class="btn" aria-label="cancel">
+            <button id="cancel-btn" class="btn">
               Cancel
             </button>
-            <button id="discard-btn" class="btn" aria-label="discard">
+            <button id="discard-btn" class="btn">
               Discard
             </button>
           </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fadae4f2d51b7d5d8b98d8.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fadae4f2d51b7d5d8b98d8.md
@@ -48,7 +48,7 @@ assert.match(code, /updateTaskContainer\(\);?\s*reset\(\);?\s*/)
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fadff23375f27ff06c6d40.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fadff23375f27ff06c6d40.md
@@ -42,7 +42,7 @@ assert.match(code, /addOrUpdateTask\(\)/)
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>
@@ -55,7 +55,7 @@ assert.match(code, /addOrUpdateTask\(\)/)
           <textarea class="form-control" id="description-input" cols="30" rows="5"></textarea>
         </div>
         <div class="task-form-footer">
-          <button id="add-or-update-task-btn" class="btn large-btn" type="submit" aria-label="add task">
+          <button id="add-or-update-task-btn" class="btn large-btn" type="submit">
             Add Task
           </button>
         </div>
@@ -64,10 +64,10 @@ assert.match(code, /addOrUpdateTask\(\)/)
         <form method="dialog">
           <p class="discard-message-text">Discard unsaved changes?</p>
           <div class="confirm-close-dialog-btn-container">
-            <button id="cancel-btn" class="btn" aria-label="cancel">
+            <button id="cancel-btn" class="btn">
               Cancel
             </button>
-            <button id="discard-btn" class="btn" aria-label="discard">
+            <button id="discard-btn" class="btn">
               Discard
             </button>
           </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fadff23375f27ff06c6d40.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fadff23375f27ff06c6d40.md
@@ -42,7 +42,7 @@ assert.match(code, /addOrUpdateTask\(\)/)
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fae068bcdc9c805bd8399e.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fae068bcdc9c805bd8399e.md
@@ -50,7 +50,7 @@ assert.match(code, /<button\s*onclick=('|")deleteTask\(this\)\1\s*type=\1button\
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>
@@ -63,7 +63,7 @@ assert.match(code, /<button\s*onclick=('|")deleteTask\(this\)\1\s*type=\1button\
           <textarea class="form-control" id="description-input" cols="30" rows="5"></textarea>
         </div>
         <div class="task-form-footer">
-          <button id="add-or-update-task-btn" class="btn large-btn" type="submit" aria-label="add task">
+          <button id="add-or-update-task-btn" class="btn large-btn" type="submit">
             Add Task
           </button>
         </div>
@@ -72,10 +72,10 @@ assert.match(code, /<button\s*onclick=('|")deleteTask\(this\)\1\s*type=\1button\
         <form method="dialog">
           <p class="discard-message-text">Discard unsaved changes?</p>
           <div class="confirm-close-dialog-btn-container">
-            <button id="cancel-btn" class="btn" aria-label="cancel">
+            <button id="cancel-btn" class="btn">
               Cancel
             </button>
-            <button id="discard-btn" class="btn" aria-label="discard">
+            <button id="discard-btn" class="btn">
               Discard
             </button>
           </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fae068bcdc9c805bd8399e.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fae068bcdc9c805bd8399e.md
@@ -50,7 +50,7 @@ assert.match(code, /<button\s*onclick=('|")deleteTask\(this\)\1\s*type=\1button\
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64faedcd16a1e985c4c2dc94.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64faedcd16a1e985c4c2dc94.md
@@ -54,7 +54,7 @@ assert.match(deleteTask.toString(), /\(\s*buttonEl\s*\)\s*\{\s*\}/);
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>
@@ -67,7 +67,7 @@ assert.match(deleteTask.toString(), /\(\s*buttonEl\s*\)\s*\{\s*\}/);
           <textarea class="form-control" id="description-input" cols="30" rows="5"></textarea>
         </div>
         <div class="task-form-footer">
-          <button id="add-or-update-task-btn" class="btn large-btn" type="submit" aria-label="add task">
+          <button id="add-or-update-task-btn" class="btn large-btn" type="submit">
             Add Task
           </button>
         </div>
@@ -76,10 +76,10 @@ assert.match(deleteTask.toString(), /\(\s*buttonEl\s*\)\s*\{\s*\}/);
         <form method="dialog">
           <p class="discard-message-text">Discard unsaved changes?</p>
           <div class="confirm-close-dialog-btn-container">
-            <button id="cancel-btn" class="btn" aria-label="cancel">
+            <button id="cancel-btn" class="btn">
               Cancel
             </button>
-            <button id="discard-btn" class="btn" aria-label="discard">
+            <button id="discard-btn" class="btn">
               Discard
             </button>
           </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64faedcd16a1e985c4c2dc94.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64faedcd16a1e985c4c2dc94.md
@@ -54,7 +54,7 @@ assert.match(deleteTask.toString(), /\(\s*buttonEl\s*\)\s*\{\s*\}/);
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64faf0418e828c0114a558a7.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64faf0418e828c0114a558a7.md
@@ -45,7 +45,7 @@ assert.match(code, /tasksContainer\.innerHTML\s*=\s*("|')\1;?/)
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64faf0418e828c0114a558a7.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64faf0418e828c0114a558a7.md
@@ -45,7 +45,7 @@ assert.match(code, /tasksContainer\.innerHTML\s*=\s*("|')\1;?/)
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>
@@ -58,7 +58,7 @@ assert.match(code, /tasksContainer\.innerHTML\s*=\s*("|')\1;?/)
           <textarea class="form-control" id="description-input" cols="30" rows="5"></textarea>
         </div>
         <div class="task-form-footer">
-          <button id="add-or-update-task-btn" class="btn large-btn" type="submit" aria-label="add task">
+          <button id="add-or-update-task-btn" class="btn large-btn" type="submit">
             Add Task
           </button>
         </div>
@@ -67,10 +67,10 @@ assert.match(code, /tasksContainer\.innerHTML\s*=\s*("|')\1;?/)
         <form method="dialog">
           <p class="discard-message-text">Discard unsaved changes?</p>
           <div class="confirm-close-dialog-btn-container">
-            <button id="cancel-btn" class="btn" aria-label="cancel">
+            <button id="cancel-btn" class="btn">
               Cancel
             </button>
-            <button id="discard-btn" class="btn" aria-label="discard">
+            <button id="discard-btn" class="btn">
               Discard
             </button>
           </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64faf65b22ad8d07df9be14d.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64faf65b22ad8d07df9be14d.md
@@ -63,7 +63,7 @@ assert.match(code, /const\s*deleteTask\s*=\s*\(buttonEl\)\s*=>\s*\{\s*const data
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64faf65b22ad8d07df9be14d.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64faf65b22ad8d07df9be14d.md
@@ -63,7 +63,7 @@ assert.match(code, /const\s*deleteTask\s*=\s*\(buttonEl\)\s*=>\s*\{\s*const data
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>
@@ -76,7 +76,7 @@ assert.match(code, /const\s*deleteTask\s*=\s*\(buttonEl\)\s*=>\s*\{\s*const data
           <textarea class="form-control" id="description-input" cols="30" rows="5"></textarea>
         </div>
         <div class="task-form-footer">
-          <button id="add-or-update-task-btn" class="btn large-btn" type="submit" aria-label="add task">
+          <button id="add-or-update-task-btn" class="btn large-btn" type="submit">
             Add Task
           </button>
         </div>
@@ -85,10 +85,10 @@ assert.match(code, /const\s*deleteTask\s*=\s*\(buttonEl\)\s*=>\s*\{\s*const data
         <form method="dialog">
           <p class="discard-message-text">Discard unsaved changes?</p>
           <div class="confirm-close-dialog-btn-container">
-            <button id="cancel-btn" class="btn" aria-label="cancel">
+            <button id="cancel-btn" class="btn">
               Cancel
             </button>
-            <button id="discard-btn" class="btn" aria-label="discard">
+            <button id="discard-btn" class="btn">
               Discard
             </button>
           </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64faf874364ec308f875f636.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64faf874364ec308f875f636.md
@@ -76,7 +76,7 @@ assert.match(deleteTask.toString(), /taskData\.splice\(dataArrIndex,\s*1\);?/)
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64faf874364ec308f875f636.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64faf874364ec308f875f636.md
@@ -76,7 +76,7 @@ assert.match(deleteTask.toString(), /taskData\.splice\(dataArrIndex,\s*1\);?/)
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>
@@ -89,7 +89,7 @@ assert.match(deleteTask.toString(), /taskData\.splice\(dataArrIndex,\s*1\);?/)
           <textarea class="form-control" id="description-input" cols="30" rows="5"></textarea>
         </div>
         <div class="task-form-footer">
-          <button id="add-or-update-task-btn" class="btn large-btn" type="submit" aria-label="add task">
+          <button id="add-or-update-task-btn" class="btn large-btn" type="submit">
             Add Task
           </button>
         </div>
@@ -98,10 +98,10 @@ assert.match(deleteTask.toString(), /taskData\.splice\(dataArrIndex,\s*1\);?/)
         <form method="dialog">
           <p class="discard-message-text">Discard unsaved changes?</p>
           <div class="confirm-close-dialog-btn-container">
-            <button id="cancel-btn" class="btn" aria-label="cancel">
+            <button id="cancel-btn" class="btn">
               Cancel
             </button>
-            <button id="discard-btn" class="btn" aria-label="discard">
+            <button id="discard-btn" class="btn">
               Discard
             </button>
           </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fafac95328110a69bcb75f.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fafac95328110a69bcb75f.md
@@ -54,7 +54,7 @@ assert.match(editTask.toString(), /\(\s*buttonEl\s*\)\s*\{\s*\}/);
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fafac95328110a69bcb75f.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fafac95328110a69bcb75f.md
@@ -54,7 +54,7 @@ assert.match(editTask.toString(), /\(\s*buttonEl\s*\)\s*\{\s*\}/);
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>
@@ -67,7 +67,7 @@ assert.match(editTask.toString(), /\(\s*buttonEl\s*\)\s*\{\s*\}/);
           <textarea class="form-control" id="description-input" cols="30" rows="5"></textarea>
         </div>
         <div class="task-form-footer">
-          <button id="add-or-update-task-btn" class="btn large-btn" type="submit" aria-label="add task">
+          <button id="add-or-update-task-btn" class="btn large-btn" type="submit">
             Add Task
           </button>
         </div>
@@ -76,10 +76,10 @@ assert.match(editTask.toString(), /\(\s*buttonEl\s*\)\s*\{\s*\}/);
         <form method="dialog">
           <p class="discard-message-text">Discard unsaved changes?</p>
           <div class="confirm-close-dialog-btn-container">
-            <button id="cancel-btn" class="btn" aria-label="cancel">
+            <button id="cancel-btn" class="btn">
               Cancel
             </button>
-            <button id="discard-btn" class="btn" aria-label="discard">
+            <button id="discard-btn" class="btn">
               Discard
             </button>
           </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fb0fa0968f2b113b2d90e9.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fb0fa0968f2b113b2d90e9.md
@@ -62,7 +62,7 @@ assert.match(code, /const\s*editTask\s+=\s*\(buttonEl\)\s*=>\s*\{\s*const\s+data
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>
@@ -75,7 +75,7 @@ assert.match(code, /const\s*editTask\s+=\s*\(buttonEl\)\s*=>\s*\{\s*const\s+data
           <textarea class="form-control" id="description-input" cols="30" rows="5"></textarea>
         </div>
         <div class="task-form-footer">
-          <button id="add-or-update-task-btn" class="btn large-btn" type="submit" aria-label="add task">
+          <button id="add-or-update-task-btn" class="btn large-btn" type="submit">
             Add Task
           </button>
         </div>
@@ -84,10 +84,10 @@ assert.match(code, /const\s*editTask\s+=\s*\(buttonEl\)\s*=>\s*\{\s*const\s+data
         <form method="dialog">
           <p class="discard-message-text">Discard unsaved changes?</p>
           <div class="confirm-close-dialog-btn-container">
-            <button id="cancel-btn" class="btn" aria-label="cancel">
+            <button id="cancel-btn" class="btn">
               Cancel
             </button>
-            <button id="discard-btn" class="btn" aria-label="discard">
+            <button id="discard-btn" class="btn">
               Discard
             </button>
           </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fb0fa0968f2b113b2d90e9.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fb0fa0968f2b113b2d90e9.md
@@ -62,7 +62,7 @@ assert.match(code, /const\s*editTask\s+=\s*\(buttonEl\)\s*=>\s*\{\s*const\s+data
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fb1061ca838611ed6a7d6b.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fb1061ca838611ed6a7d6b.md
@@ -42,7 +42,7 @@ assert.match(code, /currentTask\s*=\s*taskData\[dataArrIndex\];?/)
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fb1061ca838611ed6a7d6b.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fb1061ca838611ed6a7d6b.md
@@ -42,7 +42,7 @@ assert.match(code, /currentTask\s*=\s*taskData\[dataArrIndex\];?/)
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>
@@ -55,7 +55,7 @@ assert.match(code, /currentTask\s*=\s*taskData\[dataArrIndex\];?/)
           <textarea class="form-control" id="description-input" cols="30" rows="5"></textarea>
         </div>
         <div class="task-form-footer">
-          <button id="add-or-update-task-btn" class="btn large-btn" type="submit" aria-label="add task">
+          <button id="add-or-update-task-btn" class="btn large-btn" type="submit">
             Add Task
           </button>
         </div>
@@ -64,10 +64,10 @@ assert.match(code, /currentTask\s*=\s*taskData\[dataArrIndex\];?/)
         <form method="dialog">
           <p class="discard-message-text">Discard unsaved changes?</p>
           <div class="confirm-close-dialog-btn-container">
-            <button id="cancel-btn" class="btn" aria-label="cancel">
+            <button id="cancel-btn" class="btn">
               Cancel
             </button>
-            <button id="discard-btn" class="btn" aria-label="discard">
+            <button id="discard-btn" class="btn">
               Discard
             </button>
           </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fb1321e189a6136d200f77.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fb1321e189a6136d200f77.md
@@ -54,7 +54,7 @@ assert.match(editTask.toString(), /descriptionInput\.value\s*=\s*currentTask\.de
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>
@@ -67,7 +67,7 @@ assert.match(editTask.toString(), /descriptionInput\.value\s*=\s*currentTask\.de
           <textarea class="form-control" id="description-input" cols="30" rows="5"></textarea>
         </div>
         <div class="task-form-footer">
-          <button id="add-or-update-task-btn" class="btn large-btn" type="submit" aria-label="add task">
+          <button id="add-or-update-task-btn" class="btn large-btn" type="submit">
             Add Task
           </button>
         </div>
@@ -76,10 +76,10 @@ assert.match(editTask.toString(), /descriptionInput\.value\s*=\s*currentTask\.de
         <form method="dialog">
           <p class="discard-message-text">Discard unsaved changes?</p>
           <div class="confirm-close-dialog-btn-container">
-            <button id="cancel-btn" class="btn" aria-label="cancel">
+            <button id="cancel-btn" class="btn">
               Cancel
             </button>
-            <button id="discard-btn" class="btn" aria-label="discard">
+            <button id="discard-btn" class="btn">
               Discard
             </button>
           </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fb1321e189a6136d200f77.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fb1321e189a6136d200f77.md
@@ -54,7 +54,7 @@ assert.match(editTask.toString(), /descriptionInput\.value\s*=\s*currentTask\.de
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fb1436adef3e145b4c3501.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fb1436adef3e145b4c3501.md
@@ -42,7 +42,7 @@ assert.match(editTask.toString(), /addOrUpdateTaskBtn\.innerText\s*=\s*("|')Upda
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fb1436adef3e145b4c3501.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fb1436adef3e145b4c3501.md
@@ -7,7 +7,7 @@ dashedName: step-43
 
 # --description--
 
-Set the `innerText` of the `addOrUpdateTaskBtn` button to `Update Task` and its `aria-label` to `Update Task` as well.
+Set the `innerText` of the `addOrUpdateTaskBtn` button to `Update Task`.
 
 # --hints--
 
@@ -15,12 +15,6 @@ You should set the inner text of the `addOrUpdateTaskBtn` button to `Update Task
 
 ```js
 assert.match(editTask.toString(), /addOrUpdateTaskBtn\.innerText\s*=\s*("|')Update Task\1;?/)
-```
-
-You should set the `ariaLabel` of the `addOrUpdateTaskBtn` button to `Update Task`
-
-```js
-assert.match(editTask.toString(), /addOrUpdateTaskBtn\.ariaLabel\s*=\s*("|')Update Task\1;?/)
 ```
 
 # --seed--
@@ -48,7 +42,7 @@ assert.match(editTask.toString(), /addOrUpdateTaskBtn\.ariaLabel\s*=\s*("|')Upda
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>
@@ -61,7 +55,7 @@ assert.match(editTask.toString(), /addOrUpdateTaskBtn\.ariaLabel\s*=\s*("|')Upda
           <textarea class="form-control" id="description-input" cols="30" rows="5"></textarea>
         </div>
         <div class="task-form-footer">
-          <button id="add-or-update-task-btn" class="btn large-btn" type="submit" aria-label="add task">
+          <button id="add-or-update-task-btn" class="btn large-btn" type="submit">
             Add Task
           </button>
         </div>
@@ -70,10 +64,10 @@ assert.match(editTask.toString(), /addOrUpdateTaskBtn\.ariaLabel\s*=\s*("|')Upda
         <form method="dialog">
           <p class="discard-message-text">Discard unsaved changes?</p>
           <div class="confirm-close-dialog-btn-container">
-            <button id="cancel-btn" class="btn" aria-label="cancel">
+            <button id="cancel-btn" class="btn">
               Cancel
             </button>
-            <button id="discard-btn" class="btn" aria-label="discard">
+            <button id="discard-btn" class="btn">
               Discard
             </button>
           </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fb14d890415c14f93069ce.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fb14d890415c14f93069ce.md
@@ -42,7 +42,7 @@ assert.match(editTask.toString(), /taskForm\.classList\.toggle\(('|")hidden\1\);
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fb14d890415c14f93069ce.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fb14d890415c14f93069ce.md
@@ -42,7 +42,7 @@ assert.match(editTask.toString(), /taskForm\.classList\.toggle\(('|")hidden\1\);
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>
@@ -55,7 +55,7 @@ assert.match(editTask.toString(), /taskForm\.classList\.toggle\(('|")hidden\1\);
           <textarea class="form-control" id="description-input" cols="30" rows="5"></textarea>
         </div>
         <div class="task-form-footer">
-          <button id="add-or-update-task-btn" class="btn large-btn" type="submit" aria-label="add task">
+          <button id="add-or-update-task-btn" class="btn large-btn" type="submit">
             Add Task
           </button>
         </div>
@@ -64,10 +64,10 @@ assert.match(editTask.toString(), /taskForm\.classList\.toggle\(('|")hidden\1\);
         <form method="dialog">
           <p class="discard-message-text">Discard unsaved changes?</p>
           <div class="confirm-close-dialog-btn-container">
-            <button id="cancel-btn" class="btn" aria-label="cancel">
+            <button id="cancel-btn" class="btn">
               Cancel
             </button>
-            <button id="discard-btn" class="btn" aria-label="discard">
+            <button id="discard-btn" class="btn">
               Discard
             </button>
           </div>
@@ -342,7 +342,6 @@ const editTask = (buttonEl) => {
   descriptionInput.value = currentTask.description;
 
   addOrUpdateTaskBtn.innerText = "Update Task";
-  addOrUpdateTaskBtn.ariaLabel = "Update Task";
   
   
 }

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fb154a7c48cd159924bb18.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fb154a7c48cd159924bb18.md
@@ -48,7 +48,7 @@ assert.match(code, /if\s*\(dataArrIndex\s*===\s*-1\)\s*\{\s*taskData\.unshift\(t
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>
@@ -61,7 +61,7 @@ assert.match(code, /if\s*\(dataArrIndex\s*===\s*-1\)\s*\{\s*taskData\.unshift\(t
           <textarea class="form-control" id="description-input" cols="30" rows="5"></textarea>
         </div>
         <div class="task-form-footer">
-          <button id="add-or-update-task-btn" class="btn large-btn" type="submit" aria-label="add task">
+          <button id="add-or-update-task-btn" class="btn large-btn" type="submit">
             Add Task
           </button>
         </div>
@@ -70,10 +70,10 @@ assert.match(code, /if\s*\(dataArrIndex\s*===\s*-1\)\s*\{\s*taskData\.unshift\(t
         <form method="dialog">
           <p class="discard-message-text">Discard unsaved changes?</p>
           <div class="confirm-close-dialog-btn-container">
-            <button id="cancel-btn" class="btn" aria-label="cancel">
+            <button id="cancel-btn" class="btn">
               Cancel
             </button>
-            <button id="discard-btn" class="btn" aria-label="discard">
+            <button id="discard-btn" class="btn">
               Discard
             </button>
           </div>
@@ -350,7 +350,6 @@ const editTask = (buttonEl) => {
   descriptionInput.value = currentTask.description;
 
   addOrUpdateTaskBtn.innerText = "Update Task";
-  addOrUpdateTaskBtn.ariaLabel = "Update Task";
 
   taskForm.classList.toggle("hidden");  
 }

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fb154a7c48cd159924bb18.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fb154a7c48cd159924bb18.md
@@ -48,7 +48,7 @@ assert.match(code, /if\s*\(dataArrIndex\s*===\s*-1\)\s*\{\s*taskData\.unshift\(t
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fb1c4dc0feb219149a7c7d.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fb1c4dc0feb219149a7c7d.md
@@ -56,7 +56,7 @@ assert.match(code, /const\s*formInputValuesUpdated\s*=\s*titleInput\.value\s*!==
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>
@@ -69,7 +69,7 @@ assert.match(code, /const\s*formInputValuesUpdated\s*=\s*titleInput\.value\s*!==
           <textarea class="form-control" id="description-input" cols="30" rows="5"></textarea>
         </div>
         <div class="task-form-footer">
-          <button id="add-or-update-task-btn" class="btn large-btn" type="submit" aria-label="add task">
+          <button id="add-or-update-task-btn" class="btn large-btn" type="submit">
             Add Task
           </button>
         </div>
@@ -78,10 +78,10 @@ assert.match(code, /const\s*formInputValuesUpdated\s*=\s*titleInput\.value\s*!==
         <form method="dialog">
           <p class="discard-message-text">Discard unsaved changes?</p>
           <div class="confirm-close-dialog-btn-container">
-            <button id="cancel-btn" class="btn" aria-label="cancel">
+            <button id="cancel-btn" class="btn">
               Cancel
             </button>
-            <button id="discard-btn" class="btn" aria-label="discard">
+            <button id="discard-btn" class="btn">
               Discard
             </button>
           </div>
@@ -357,7 +357,6 @@ const editTask = (buttonEl) => {
   descriptionInput.value = currentTask.description;
 
   addOrUpdateTaskBtn.innerText = "Update Task";
-  addOrUpdateTaskBtn.ariaLabel = "Update Task";
 
   taskForm.classList.toggle("hidden");  
 }

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fb1c4dc0feb219149a7c7d.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fb1c4dc0feb219149a7c7d.md
@@ -56,7 +56,7 @@ assert.match(code, /const\s*formInputValuesUpdated\s*=\s*titleInput\.value\s*!==
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fb285637fa1e1c222033e3.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fb285637fa1e1c222033e3.md
@@ -44,7 +44,7 @@ assert.match(code.split("if (formInputsContainValues"), /\s*&&\s*formInputValues
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>
@@ -57,7 +57,7 @@ assert.match(code.split("if (formInputsContainValues"), /\s*&&\s*formInputValues
           <textarea class="form-control" id="description-input" cols="30" rows="5"></textarea>
         </div>
         <div class="task-form-footer">
-          <button id="add-or-update-task-btn" class="btn large-btn" type="submit" aria-label="add task">
+          <button id="add-or-update-task-btn" class="btn large-btn" type="submit">
             Add Task
           </button>
         </div>
@@ -66,10 +66,10 @@ assert.match(code.split("if (formInputsContainValues"), /\s*&&\s*formInputValues
         <form method="dialog">
           <p class="discard-message-text">Discard unsaved changes?</p>
           <div class="confirm-close-dialog-btn-container">
-            <button id="cancel-btn" class="btn" aria-label="cancel">
+            <button id="cancel-btn" class="btn">
               Cancel
             </button>
-            <button id="discard-btn" class="btn" aria-label="discard">
+            <button id="discard-btn" class="btn">
               Discard
             </button>
           </div>
@@ -345,7 +345,6 @@ const editTask = (buttonEl) => {
   descriptionInput.value = currentTask.description;
 
   addOrUpdateTaskBtn.innerText = "Update Task";
-  addOrUpdateTaskBtn.ariaLabel = "Update Task";
 
   taskForm.classList.toggle("hidden");  
 }

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fb285637fa1e1c222033e3.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fb285637fa1e1c222033e3.md
@@ -44,7 +44,7 @@ assert.match(code.split("if (formInputsContainValues"), /\s*&&\s*formInputValues
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fb29348a60361ccd45c1e2.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fb29348a60361ccd45c1e2.md
@@ -60,7 +60,7 @@ assert.match(code, /localStorage\.setItem\(("|')data\1,\s*myTaskArr\);?/)
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fb29348a60361ccd45c1e2.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fb29348a60361ccd45c1e2.md
@@ -60,7 +60,7 @@ assert.match(code, /localStorage\.setItem\(("|')data\1,\s*myTaskArr\);?/)
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>
@@ -73,7 +73,7 @@ assert.match(code, /localStorage\.setItem\(("|')data\1,\s*myTaskArr\);?/)
           <textarea class="form-control" id="description-input" cols="30" rows="5"></textarea>
         </div>
         <div class="task-form-footer">
-          <button id="add-or-update-task-btn" class="btn large-btn" type="submit" aria-label="add task">
+          <button id="add-or-update-task-btn" class="btn large-btn" type="submit">
             Add Task
           </button>
         </div>
@@ -82,10 +82,10 @@ assert.match(code, /localStorage\.setItem\(("|')data\1,\s*myTaskArr\);?/)
         <form method="dialog">
           <p class="discard-message-text">Discard unsaved changes?</p>
           <div class="confirm-close-dialog-btn-container">
-            <button id="cancel-btn" class="btn" aria-label="cancel">
+            <button id="cancel-btn" class="btn">
               Cancel
             </button>
-            <button id="discard-btn" class="btn" aria-label="discard">
+            <button id="discard-btn" class="btn">
               Discard
             </button>
           </div>
@@ -361,7 +361,6 @@ const editTask = (buttonEl) => {
   descriptionInput.value = currentTask.description;
 
   addOrUpdateTaskBtn.innerText = "Update Task";
-  addOrUpdateTaskBtn.ariaLabel = "Update Task";
 
   taskForm.classList.toggle("hidden");  
 }

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fefebad99209211ec30537.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fefebad99209211ec30537.md
@@ -50,7 +50,7 @@ assert.match(code, /localStorage\.setItem\(("|')data\1,\s*JSON\.stringify\(myTas
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fefebad99209211ec30537.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fefebad99209211ec30537.md
@@ -50,7 +50,7 @@ assert.match(code, /localStorage\.setItem\(("|')data\1,\s*JSON\.stringify\(myTas
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>
@@ -63,7 +63,7 @@ assert.match(code, /localStorage\.setItem\(("|')data\1,\s*JSON\.stringify\(myTas
           <textarea class="form-control" id="description-input" cols="30" rows="5"></textarea>
         </div>
         <div class="task-form-footer">
-          <button id="add-or-update-task-btn" class="btn large-btn" type="submit" aria-label="add task">
+          <button id="add-or-update-task-btn" class="btn large-btn" type="submit">
             Add Task
           </button>
         </div>
@@ -72,10 +72,10 @@ assert.match(code, /localStorage\.setItem\(("|')data\1,\s*JSON\.stringify\(myTas
         <form method="dialog">
           <p class="discard-message-text">Discard unsaved changes?</p>
           <div class="confirm-close-dialog-btn-container">
-            <button id="cancel-btn" class="btn" aria-label="cancel">
+            <button id="cancel-btn" class="btn">
               Cancel
             </button>
-            <button id="discard-btn" class="btn" aria-label="discard">
+            <button id="discard-btn" class="btn">
               Discard
             </button>
           </div>
@@ -351,7 +351,6 @@ const editTask = (buttonEl) => {
   descriptionInput.value = currentTask.description;
 
   addOrUpdateTaskBtn.innerText = "Update Task";
-  addOrUpdateTaskBtn.ariaLabel = "Update Task";
 
   taskForm.classList.toggle("hidden");  
 }

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ff0313700dad264d19dfe4.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ff0313700dad264d19dfe4.md
@@ -50,7 +50,7 @@ assert.match(code, /console\.log\(getTaskArr\);?/)
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ff0313700dad264d19dfe4.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ff0313700dad264d19dfe4.md
@@ -50,7 +50,7 @@ assert.match(code, /console\.log\(getTaskArr\);?/)
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>
@@ -63,7 +63,7 @@ assert.match(code, /console\.log\(getTaskArr\);?/)
           <textarea class="form-control" id="description-input" cols="30" rows="5"></textarea>
         </div>
         <div class="task-form-footer">
-          <button id="add-or-update-task-btn" class="btn large-btn" type="submit" aria-label="add task">
+          <button id="add-or-update-task-btn" class="btn large-btn" type="submit">
             Add Task
           </button>
         </div>
@@ -72,10 +72,10 @@ assert.match(code, /console\.log\(getTaskArr\);?/)
         <form method="dialog">
           <p class="discard-message-text">Discard unsaved changes?</p>
           <div class="confirm-close-dialog-btn-container">
-            <button id="cancel-btn" class="btn" aria-label="cancel">
+            <button id="cancel-btn" class="btn">
               Cancel
             </button>
-            <button id="discard-btn" class="btn" aria-label="discard">
+            <button id="discard-btn" class="btn">
               Discard
             </button>
           </div>
@@ -351,7 +351,6 @@ const editTask = (buttonEl) => {
   descriptionInput.value = currentTask.description;
 
   addOrUpdateTaskBtn.innerText = "Update Task";
-  addOrUpdateTaskBtn.ariaLabel = "Update Task";
 
   taskForm.classList.toggle("hidden");  
 }

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ff04cc33779427a6412449.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ff04cc33779427a6412449.md
@@ -52,7 +52,7 @@ assert.match(code, /console\.log\(getTaskArrObj\);?/)
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ff04cc33779427a6412449.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ff04cc33779427a6412449.md
@@ -52,7 +52,7 @@ assert.match(code, /console\.log\(getTaskArrObj\);?/)
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>
@@ -65,7 +65,7 @@ assert.match(code, /console\.log\(getTaskArrObj\);?/)
           <textarea class="form-control" id="description-input" cols="30" rows="5"></textarea>
         </div>
         <div class="task-form-footer">
-          <button id="add-or-update-task-btn" class="btn large-btn" type="submit" aria-label="add task">
+          <button id="add-or-update-task-btn" class="btn large-btn" type="submit">
             Add Task
           </button>
         </div>
@@ -74,10 +74,10 @@ assert.match(code, /console\.log\(getTaskArrObj\);?/)
         <form method="dialog">
           <p class="discard-message-text">Discard unsaved changes?</p>
           <div class="confirm-close-dialog-btn-container">
-            <button id="cancel-btn" class="btn" aria-label="cancel">
+            <button id="cancel-btn" class="btn">
               Cancel
             </button>
-            <button id="discard-btn" class="btn" aria-label="discard">
+            <button id="discard-btn" class="btn">
               Discard
             </button>
           </div>
@@ -353,7 +353,6 @@ const editTask = (buttonEl) => {
   descriptionInput.value = currentTask.description;
 
   addOrUpdateTaskBtn.innerText = "Update Task";
-  addOrUpdateTaskBtn.ariaLabel = "Update Task";
 
   taskForm.classList.toggle("hidden");  
 }

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ff068e0426eb288874ed79.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ff068e0426eb288874ed79.md
@@ -44,7 +44,7 @@ assert.match(code, /localStorage\.removeItem\(('|")data\1\);?/)
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ff068e0426eb288874ed79.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ff068e0426eb288874ed79.md
@@ -44,7 +44,7 @@ assert.match(code, /localStorage\.removeItem\(('|")data\1\);?/)
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>
@@ -57,7 +57,7 @@ assert.match(code, /localStorage\.removeItem\(('|")data\1\);?/)
           <textarea class="form-control" id="description-input" cols="30" rows="5"></textarea>
         </div>
         <div class="task-form-footer">
-          <button id="add-or-update-task-btn" class="btn large-btn" type="submit" aria-label="add task">
+          <button id="add-or-update-task-btn" class="btn large-btn" type="submit">
             Add Task
           </button>
         </div>
@@ -66,10 +66,10 @@ assert.match(code, /localStorage\.removeItem\(('|")data\1\);?/)
         <form method="dialog">
           <p class="discard-message-text">Discard unsaved changes?</p>
           <div class="confirm-close-dialog-btn-container">
-            <button id="cancel-btn" class="btn" aria-label="cancel">
+            <button id="cancel-btn" class="btn">
               Cancel
             </button>
-            <button id="discard-btn" class="btn" aria-label="discard">
+            <button id="discard-btn" class="btn">
               Discard
             </button>
           </div>
@@ -345,7 +345,6 @@ const editTask = (buttonEl) => {
   descriptionInput.value = currentTask.description;
 
   addOrUpdateTaskBtn.innerText = "Update Task";
-  addOrUpdateTaskBtn.ariaLabel = "Update Task";
 
   taskForm.classList.toggle("hidden");  
 }

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ff23daf176a92de95f24dc.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ff23daf176a92de95f24dc.md
@@ -50,7 +50,7 @@ assert.match(code, /localStorage\.clear\(\);?/)
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ff23daf176a92de95f24dc.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ff23daf176a92de95f24dc.md
@@ -50,7 +50,7 @@ assert.match(code, /localStorage\.clear\(\);?/)
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>
@@ -63,7 +63,7 @@ assert.match(code, /localStorage\.clear\(\);?/)
           <textarea class="form-control" id="description-input" cols="30" rows="5"></textarea>
         </div>
         <div class="task-form-footer">
-          <button id="add-or-update-task-btn" class="btn large-btn" type="submit" aria-label="add task">
+          <button id="add-or-update-task-btn" class="btn large-btn" type="submit">
             Add Task
           </button>
         </div>
@@ -72,10 +72,10 @@ assert.match(code, /localStorage\.clear\(\);?/)
         <form method="dialog">
           <p class="discard-message-text">Discard unsaved changes?</p>
           <div class="confirm-close-dialog-btn-container">
-            <button id="cancel-btn" class="btn" aria-label="cancel">
+            <button id="cancel-btn" class="btn">
               Cancel
             </button>
-            <button id="discard-btn" class="btn" aria-label="discard">
+            <button id="discard-btn" class="btn">
               Discard
             </button>
           </div>
@@ -351,7 +351,6 @@ const editTask = (buttonEl) => {
   descriptionInput.value = currentTask.description;
 
   addOrUpdateTaskBtn.innerText = "Update Task";
-  addOrUpdateTaskBtn.ariaLabel = "Update Task";
 
   taskForm.classList.toggle("hidden");  
 }

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ff24b80431f62ec6b93f65.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ff24b80431f62ec6b93f65.md
@@ -42,7 +42,7 @@ assert.notMatch(code, /const\s*myTaskArr\s*=\s*\[\s*\{\s*task:\s"Walk\s*the\s*Do
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ff24b80431f62ec6b93f65.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ff24b80431f62ec6b93f65.md
@@ -42,7 +42,7 @@ assert.notMatch(code, /const\s*myTaskArr\s*=\s*\[\s*\{\s*task:\s"Walk\s*the\s*Do
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>
@@ -55,7 +55,7 @@ assert.notMatch(code, /const\s*myTaskArr\s*=\s*\[\s*\{\s*task:\s"Walk\s*the\s*Do
           <textarea class="form-control" id="description-input" cols="30" rows="5"></textarea>
         </div>
         <div class="task-form-footer">
-          <button id="add-or-update-task-btn" class="btn large-btn" type="submit" aria-label="add task">
+          <button id="add-or-update-task-btn" class="btn large-btn" type="submit">
             Add Task
           </button>
         </div>
@@ -64,10 +64,10 @@ assert.notMatch(code, /const\s*myTaskArr\s*=\s*\[\s*\{\s*task:\s"Walk\s*the\s*Do
         <form method="dialog">
           <p class="discard-message-text">Discard unsaved changes?</p>
           <div class="confirm-close-dialog-btn-container">
-            <button id="cancel-btn" class="btn" aria-label="cancel">
+            <button id="cancel-btn" class="btn">
               Cancel
             </button>
-            <button id="discard-btn" class="btn" aria-label="discard">
+            <button id="discard-btn" class="btn">
               Discard
             </button>
           </div>
@@ -343,7 +343,6 @@ const editTask = (buttonEl) => {
   descriptionInput.value = currentTask.description;
 
   addOrUpdateTaskBtn.innerText = "Update Task";
-  addOrUpdateTaskBtn.ariaLabel = "Update Task";
 
   taskForm.classList.toggle("hidden");  
 }

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/65003986d17d1e1865b269c0.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/65003986d17d1e1865b269c0.md
@@ -58,7 +58,7 @@ assert.match(code, /localStorage\.setItem\(('|")data\1,\s*JSON\.stringify\(taskD
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/65003986d17d1e1865b269c0.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/65003986d17d1e1865b269c0.md
@@ -58,7 +58,7 @@ assert.match(code, /localStorage\.setItem\(('|")data\1,\s*JSON\.stringify\(taskD
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>
@@ -71,7 +71,7 @@ assert.match(code, /localStorage\.setItem\(('|")data\1,\s*JSON\.stringify\(taskD
           <textarea class="form-control" id="description-input" cols="30" rows="5"></textarea>
         </div>
         <div class="task-form-footer">
-          <button id="add-or-update-task-btn" class="btn large-btn" type="submit" aria-label="add task">
+          <button id="add-or-update-task-btn" class="btn large-btn" type="submit">
             Add Task
           </button>
         </div>
@@ -80,10 +80,10 @@ assert.match(code, /localStorage\.setItem\(('|")data\1,\s*JSON\.stringify\(taskD
         <form method="dialog">
           <p class="discard-message-text">Discard unsaved changes?</p>
           <div class="confirm-close-dialog-btn-container">
-            <button id="cancel-btn" class="btn" aria-label="cancel">
+            <button id="cancel-btn" class="btn">
               Cancel
             </button>
-            <button id="discard-btn" class="btn" aria-label="discard">
+            <button id="discard-btn" class="btn">
               Discard
             </button>
           </div>
@@ -361,7 +361,6 @@ const editTask = (buttonEl) => {
   descriptionInput.value = currentTask.description;
 
   addOrUpdateTaskBtn.innerText = "Update Task";
-  addOrUpdateTaskBtn.ariaLabel = "Update Task";
 
   taskForm.classList.toggle("hidden");  
 }

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/650046832f92c01a35834bca.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/650046832f92c01a35834bca.md
@@ -59,7 +59,7 @@ assert.match(splitter[1], /localStorage\.setItem\(('|")data\1,\s*JSON\.stringify
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/650046832f92c01a35834bca.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/650046832f92c01a35834bca.md
@@ -59,7 +59,7 @@ assert.match(splitter[1], /localStorage\.setItem\(('|")data\1,\s*JSON\.stringify
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>
@@ -72,7 +72,7 @@ assert.match(splitter[1], /localStorage\.setItem\(('|")data\1,\s*JSON\.stringify
           <textarea class="form-control" id="description-input" cols="30" rows="5"></textarea>
         </div>
         <div class="task-form-footer">
-          <button id="add-or-update-task-btn" class="btn large-btn" type="submit" aria-label="add task">
+          <button id="add-or-update-task-btn" class="btn large-btn" type="submit">
             Add Task
           </button>
         </div>
@@ -81,10 +81,10 @@ assert.match(splitter[1], /localStorage\.setItem\(('|")data\1,\s*JSON\.stringify
         <form method="dialog">
           <p class="discard-message-text">Discard unsaved changes?</p>
           <div class="confirm-close-dialog-btn-container">
-            <button id="cancel-btn" class="btn" aria-label="cancel">
+            <button id="cancel-btn" class="btn">
               Cancel
             </button>
-            <button id="discard-btn" class="btn" aria-label="discard">
+            <button id="discard-btn" class="btn">
               Discard
             </button>
           </div>
@@ -364,7 +364,6 @@ const editTask = (buttonEl) => {
   descriptionInput.value = currentTask.description;
 
   addOrUpdateTaskBtn.innerText = "Update Task";
-  addOrUpdateTaskBtn.ariaLabel = "Update Task";
 
   taskForm.classList.toggle("hidden");  
 }

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/650048b0764f9c1b798200e2.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/650048b0764f9c1b798200e2.md
@@ -44,7 +44,7 @@ assert.match(code, /const\s*taskData\s*=\s*JSON.parse\(localStorage\.getItem\(('
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>
@@ -57,7 +57,7 @@ assert.match(code, /const\s*taskData\s*=\s*JSON.parse\(localStorage\.getItem\(('
           <textarea class="form-control" id="description-input" cols="30" rows="5"></textarea>
         </div>
         <div class="task-form-footer">
-          <button id="add-or-update-task-btn" class="btn large-btn" type="submit" aria-label="add task">
+          <button id="add-or-update-task-btn" class="btn large-btn" type="submit">
             Add Task
           </button>
         </div>
@@ -66,10 +66,10 @@ assert.match(code, /const\s*taskData\s*=\s*JSON.parse\(localStorage\.getItem\(('
         <form method="dialog">
           <p class="discard-message-text">Discard unsaved changes?</p>
           <div class="confirm-close-dialog-btn-container">
-            <button id="cancel-btn" class="btn" aria-label="cancel">
+            <button id="cancel-btn" class="btn">
               Cancel
             </button>
-            <button id="discard-btn" class="btn" aria-label="discard">
+            <button id="discard-btn" class="btn">
               Discard
             </button>
           </div>
@@ -349,7 +349,6 @@ const editTask = (buttonEl) => {
   descriptionInput.value = currentTask.description;
 
   addOrUpdateTaskBtn.innerText = "Update Task";
-  addOrUpdateTaskBtn.ariaLabel = "Update Task";
 
   taskForm.classList.toggle("hidden");  
 }

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/650048b0764f9c1b798200e2.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/650048b0764f9c1b798200e2.md
@@ -44,7 +44,7 @@ assert.match(code, /const\s*taskData\s*=\s*JSON.parse\(localStorage\.getItem\(('
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/65004ba581d03d1d5628b41c.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/65004ba581d03d1d5628b41c.md
@@ -54,7 +54,7 @@ assert.match(code, /if\s*\(taskData\.length\)\s*\{\s*updateTaskContainer\(\);?\s
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>
@@ -425,7 +425,7 @@ taskForm.addEventListener("submit", (e) => {
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/65004ba581d03d1d5628b41c.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/65004ba581d03d1d5628b41c.md
@@ -54,7 +54,7 @@ assert.match(code, /if\s*\(taskData\.length\)\s*\{\s*updateTaskContainer\(\);?\s
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>
@@ -67,7 +67,7 @@ assert.match(code, /if\s*\(taskData\.length\)\s*\{\s*updateTaskContainer\(\);?\s
           <textarea class="form-control" id="description-input" cols="30" rows="5"></textarea>
         </div>
         <div class="task-form-footer">
-          <button id="add-or-update-task-btn" class="btn large-btn" type="submit" aria-label="add task">
+          <button id="add-or-update-task-btn" class="btn large-btn" type="submit">
             Add Task
           </button>
         </div>
@@ -76,10 +76,10 @@ assert.match(code, /if\s*\(taskData\.length\)\s*\{\s*updateTaskContainer\(\);?\s
         <form method="dialog">
           <p class="discard-message-text">Discard unsaved changes?</p>
           <div class="confirm-close-dialog-btn-container">
-            <button id="cancel-btn" class="btn" aria-label="cancel">
+            <button id="cancel-btn" class="btn">
               Cancel
             </button>
-            <button id="discard-btn" class="btn" aria-label="discard">
+            <button id="discard-btn" class="btn">
               Discard
             </button>
           </div>
@@ -357,7 +357,6 @@ const editTask = (buttonEl) => {
   descriptionInput.value = currentTask.description;
 
   addOrUpdateTaskBtn.innerText = "Update Task";
-  addOrUpdateTaskBtn.ariaLabel = "Update Task";
 
   taskForm.classList.toggle("hidden");  
 }
@@ -426,7 +425,7 @@ taskForm.addEventListener("submit", (e) => {
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>
@@ -439,7 +438,7 @@ taskForm.addEventListener("submit", (e) => {
           <textarea class="form-control" id="description-input" cols="30" rows="5"></textarea>
         </div>
         <div class="task-form-footer">
-          <button id="add-or-update-task-btn" class="btn large-btn" type="submit" aria-label="add task">
+          <button id="add-or-update-task-btn" class="btn large-btn" type="submit">
             Add Task
           </button>
         </div>
@@ -448,10 +447,10 @@ taskForm.addEventListener("submit", (e) => {
         <form method="dialog">
           <p class="discard-message-text">Discard unsaved changes?</p>
           <div class="confirm-close-dialog-btn-container">
-            <button id="cancel-btn" class="btn" aria-label="cancel">
+            <button id="cancel-btn" class="btn">
               Cancel
             </button>
-            <button id="discard-btn" class="btn" aria-label="discard">
+            <button id="discard-btn" class="btn">
               Discard
             </button>
           </div>
@@ -729,7 +728,7 @@ const editTask = (buttonEl) => {
   descriptionInput.value = currentTask.description;
 
   addOrUpdateTaskBtn.innerText = "Update Task";
-  addOrUpdateTaskBtn.ariaLabel = "Update Task";
+  
 
   taskForm.classList.toggle("hidden");  
 }

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/650300a25b6f72964ab8aca6.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/650300a25b6f72964ab8aca6.md
@@ -48,7 +48,7 @@ assert.match(code, /const\s+taskObj\s*=\s*\{\s*id:\s*`\$\{titleInput\.value\.toL
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>
@@ -61,7 +61,7 @@ assert.match(code, /const\s+taskObj\s*=\s*\{\s*id:\s*`\$\{titleInput\.value\.toL
           <textarea class="form-control" id="description-input" cols="30" rows="5"></textarea>
         </div>
         <div class="task-form-footer">
-          <button id="add-or-update-task-btn" class="btn large-btn" type="submit" aria-label="add task">
+          <button id="add-or-update-task-btn" class="btn large-btn" type="submit">
             Add Task
           </button>
         </div>
@@ -70,10 +70,10 @@ assert.match(code, /const\s+taskObj\s*=\s*\{\s*id:\s*`\$\{titleInput\.value\.toL
         <form method="dialog">
           <p class="discard-message-text">Discard unsaved changes?</p>
           <div class="confirm-close-dialog-btn-container">
-            <button id="cancel-btn" class="btn" aria-label="cancel">
+            <button id="cancel-btn" class="btn">
               Cancel
             </button>
-            <button id="discard-btn" class="btn" aria-label="discard">
+            <button id="discard-btn" class="btn">
               Discard
             </button>
           </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/650300a25b6f72964ab8aca6.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/650300a25b6f72964ab8aca6.md
@@ -48,7 +48,7 @@ assert.match(code, /const\s+taskObj\s*=\s*\{\s*id:\s*`\$\{titleInput\.value\.toL
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/65099dbd8f137d58e5c0ff16.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/65099dbd8f137d58e5c0ff16.md
@@ -48,7 +48,7 @@ assert.match(code, /<p><strong>Description:\s*<\/strong>\s*/)
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/65099dbd8f137d58e5c0ff16.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/65099dbd8f137d58e5c0ff16.md
@@ -48,7 +48,7 @@ assert.match(code, /<p><strong>Description:\s*<\/strong>\s*/)
       </button>
       <form class="task-form hidden" id="task-form">
         <div class="task-form-header">
-          <button id="close-task-form-btn" class="close-task-form-btn" type="button" aria-label="close">
+          <button id="close-task-form-btn" class="close-task-form-btn" type="button">
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px"><path fill="#F44336" d="M21.5 4.5H26.501V43.5H21.5z" transform="rotate(45.001 24 24)" /><path fill="#F44336" d="M21.5 4.5H26.5V43.501H21.5z" transform="rotate(135.008 24 24)" /></svg>
           </button>
         </div>
@@ -61,7 +61,7 @@ assert.match(code, /<p><strong>Description:\s*<\/strong>\s*/)
           <textarea class="form-control" id="description-input" cols="30" rows="5"></textarea>
         </div>
         <div class="task-form-footer">
-          <button id="add-or-update-task-btn" class="btn large-btn" type="submit" aria-label="add task">
+          <button id="add-or-update-task-btn" class="btn large-btn" type="submit">
             Add Task
           </button>
         </div>
@@ -70,10 +70,10 @@ assert.match(code, /<p><strong>Description:\s*<\/strong>\s*/)
         <form method="dialog">
           <p class="discard-message-text">Discard unsaved changes?</p>
           <div class="confirm-close-dialog-btn-container">
-            <button id="cancel-btn" class="btn" aria-label="cancel">
+            <button id="cancel-btn" class="btn">
               Cancel
             </button>
-            <button id="discard-btn" class="btn" aria-label="discard">
+            <button id="discard-btn" class="btn">
               Discard
             </button>
           </div>


### PR DESCRIPTION
## Summary of changes

I removes all of the instances of aria label in the HTML and JS files since they were being used incorrectly based on the discussion from the linked issue. 

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #52981

<!-- Feel free to add any additional description of changes below this line -->
