### PR TITLE
fix(curriculum): allow optional spaces

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-form-validation-by-building-a-calorie-counter/63c2164c0df38a382062c4af.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-form-validation-by-building-a-calorie-counter/63c2164c0df38a382062c4af.md
@@ -18,19 +18,19 @@ This will return a `NodeList` of all the text inputs in the form. You can then a
 You should pass the string `input[type="text"]` to the `querySelectorAll()` method.
 
 ```js
-assert.match(addEntry.toString(), /entryNumber\s*=\s*targetInputContainer\.querySelectorAll\(\s*'input\[type="text"]'\)/)
+assert.match(addEntry.toString(), /entryNumber\s*=\s*targetInputContainer\.querySelectorAll\(\s*'\s*input\s*\[\s*type\s*=\s*"text"\s*]\s*'\s*\)/)
 ```
 
 You should access the `length` property of your `querySelectorAll()`.
 
 ```js
-assert.match(addEntry.toString(), /\.querySelectorAll\(\s*'input\[type="text"]'\)\.length/)
+assert.match(addEntry.toString(), /\.querySelectorAll\(\s*'\s*input\s*\[\s*type\s*=\s*"text"\s*]\s*'\)\.length/)
 ```
 
 Your `entryNumber` variable should be the `length` of the `querySelectorAll`.
 
 ```js
-assert.match(addEntry.toString(), /entryNumber\s*=\s*targetInputContainer\.querySelectorAll\(\s*'input\[type="text"]'\)\.length/)
+assert.match(addEntry.toString(), /entryNumber\s*=\s*targetInputContainer\.querySelectorAll\(\s*'\s*input\s*\[\s*type\s*=\s*"text"\s*]\s*'\)\.length/)
 ```
 
 # --seed--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-form-validation-by-building-a-calorie-counter/63c21774193de43bbc6a769f.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-form-validation-by-building-a-calorie-counter/63c21774193de43bbc6a769f.md
@@ -14,13 +14,13 @@ Give your `label` element a `for` attribute with the value `X-#-name`, where `X`
 Your `label` element should have a `for` attribute set to `${entryDropdown.value}-${entryNumber}-name`.
 
 ```js
-assert.match(code, /HTMLString\s*=\s*`\n\s*<label\s+for="\$\{entryDropdown.value\}-\$\{entryNumber\}-name"\s*>/)
+assert.match(code, /HTMLString\s*=\s*`\n\s*<label\s+for\s*=\s*"\$\{entryDropdown.value\}-\$\{entryNumber\}-name"\s*>/)
 ```
 
 Your `label` element should have the same text as before.
 
 ```js
-assert.match(code, /HTMLString\s*=\s*`\n\s*<label\s+for="\$\{entryDropdown.value\}-\$\{entryNumber\}-name"\s*>Entry\s\$\{entryNumber\}\sName<\/label>/);
+assert.match(code, /HTMLString\s*=\s*`\n\s*<label\s+for\s*=\s*"\$\{entryDropdown.value\}-\$\{entryNumber\}-name"\s*>Entry\s\$\{entryNumber\}\sName<\/label>/);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-form-validation-by-building-a-calorie-counter/63c217ccd939053ce4fa16d6.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-form-validation-by-building-a-calorie-counter/63c217ccd939053ce4fa16d6.md
@@ -14,37 +14,37 @@ After your `label` element, and on a new line in your template string, create an
 You should not modify your `label` element.
 
 ```js
-assert.match(code, /HTMLString\s*=\s*`\n\s*<label\s+for="\$\{entryDropdown.value\}-\$\{entryNumber\}-name"\s*>Entry\s\$\{entryNumber\}\sName<\/label>/);
+assert.match(code, /HTMLString\s*=\s*`\n\s*<label\s+for\s*=\s*"\$\{entryDropdown.value\}-\$\{entryNumber\}-name"\s*>Entry\s\$\{entryNumber\}\sName<\/label>/);
 ```
 
 You should add an `input` element on a new line.
 
 ```js
-assert.match(code, /HTMLString\s*=\s*`\n\s*<label\s+for="\$\{entryDropdown.value\}-\$\{entryNumber\}-name"\s*>Entry\s\$\{entryNumber\}\sName<\/label>\n\s*<input/);
+assert.match(code, /HTMLString\s*=\s*`\n\s*<label\s+for\s*=\s*"\$\{entryDropdown.value\}-\$\{entryNumber\}-name"\s*>Entry\s\$\{entryNumber\}\sName<\/label>\n\s*<input/);
 ```
 
 Your `input` element should have a `type` attribute set to `text`.
 
 ```js
-const HTMLstring = code.split("HTMLString =")[1];
+const HTMLstring = code.split(/HTMLString\s*=/)[1];
 const inputAttributes = HTMLstring.match(/<input\s+.*?>/)[0];
-assert.include(inputAttributes, 'type="text"');
+assert.match(inputAttributes, /type\s*=\s*"text"/);
 ```
 
 Your `input` element should have a `placeholder` attribute set to `Name`.
 
 ```js
-const HTMLstring = code.split("HTMLString =")[1];
+const HTMLstring = code.split(/HTMLString\s*=/)[1];
 const inputAttributes = HTMLstring.match(/<input\s+.*?>/)[0];
-assert.include(inputAttributes, 'placeholder="Name"');
+assert.match(inputAttributes, /placeholder\s*=\s*"Name"/);
 ```
 
 Your `input` element should have an `id` attribute set to `${entryDropdown.value}-${entryNumber}-name`.
 
 ```js
-const HTMLstring = code.split("HTMLString =")[1];
+const HTMLstring = code.split(/HTMLString\s*=/)[1];
 const inputAttributes = HTMLstring.match(/<input\s+.*?>/)[0];
-assert.include(inputAttributes, 'id="${entryDropdown.value}-${entryNumber}-name"');
+assert.match(inputAttributes, /id\s*=\s*"\${entryDropdown.value}-\${entryNumber}-name"/);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-form-validation-by-building-a-calorie-counter/63c21839f56eaf3ef4e027c4.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-form-validation-by-building-a-calorie-counter/63c21839f56eaf3ef4e027c4.md
@@ -14,21 +14,21 @@ Create another `label` element (on a new line) at the end of your `HTMLString`. 
 You should have two `label` elements in your `HTMLString`.
 
 ```js
-const HTMLstring = code.split("HTMLString =")[1];
+const HTMLstring = code.split(/HTMLString\s*=/)[1];
 assert.equal(HTMLstring.match(/<label/g).length, 2);
 ```
 
 Your new `label` element should be on a new line.
 
 ```js
-const HTMLstring = code.split("HTMLString =")[1];
+const HTMLstring = code.split(/HTMLString\s*=/)[1];
 assert.equal(HTMLstring.match(/\n\s*<label/g).length, 2);
 ```
 
 Your new `label` element should come after your `input` element.
 
 ```js
-const HTMLstring = code.split("HTMLString =")[1];
+const HTMLstring = code.split(/HTMLString\s*=/)[1];
 const inputIndex = HTMLstring.indexOf("<input");
 const labelIndex = HTMLstring.lastIndexOf("<label");
 assert.isBelow(inputIndex, labelIndex);
@@ -37,7 +37,7 @@ assert.isBelow(inputIndex, labelIndex);
 Your new `label` element should have a `for` attribute set to `${entryDropdown.value}-${entryNumber}-calories`.
 
 ```js
-const HTMLstring = code.split("HTMLString =")[1];
+const HTMLstring = code.split(/HTMLString\s*=/)[1];
 const label = HTMLstring.match(/<label.*>.*<\/label>/g)[1];
 assert.match(label, /<label\s+for="\$\{entryDropdown.value\}-\$\{entryNumber\}-calories"\s*>/)
 ```
@@ -45,7 +45,7 @@ assert.match(label, /<label\s+for="\$\{entryDropdown.value\}-\$\{entryNumber\}-c
 Your new `label` element should have the text `Entry ${entryNumber} Calories`.
 
 ```js
-const HTMLstring = code.split("HTMLString =")[1];
+const HTMLstring = code.split(/HTMLString\s*=/)[1];
 const label = HTMLstring.match(/<label.*>.*<\/label>/g)[1];
 assert.match(label, /<label\s+for="\$\{entryDropdown.value\}-\$\{entryNumber\}-calories"\s*>Entry\s\$\{entryNumber\}\sCalories<\/label>/);
 ```
@@ -53,7 +53,7 @@ assert.match(label, /<label\s+for="\$\{entryDropdown.value\}-\$\{entryNumber\}-c
 You should not modify your existing elements.
 
 ```js
-const HTMLstring = code.split("HTMLString =")[1];
+const HTMLstring = code.split(/HTMLString\s*=/)[1];
 assert.match(HTMLstring, /`\n\s*<label\s+for="\$\{entryDropdown.value\}-\$\{entryNumber\}-name"\s*>Entry\s\$\{entryNumber\}\sName<\/label>\n\s*<input\stype="text"\sid="\$\{entryDropdown.value\}-\$\{entryNumber\}-name"\splaceholder="Name"\s\/>\n\s*<label\s+for="\$\{entryDropdown.value\}-\$\{entryNumber\}-calories"\s*>Entry\s\$\{entryNumber\}\sCalories<\/label>/)
 ```
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-form-validation-by-building-a-calorie-counter/63c2187f55eb0f400269568f.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-form-validation-by-building-a-calorie-counter/63c2187f55eb0f400269568f.md
@@ -14,21 +14,21 @@ Finally, on a new line after your second `label`, create another `input` element
 You should have two `input` elements in your `HTMLString`.
 
 ```js
-const HTMLstring = code.split("HTMLString =")[1];
+const HTMLstring = code.split(/HTMLString\s*=/)[1];
 assert.equal(HTMLstring.match(/<input/g).length, 2);
 ```
 
 Your new `input` element should be on a new line.
 
 ```js
-const HTMLstring = code.split("HTMLString =")[1];
+const HTMLstring = code.split(/HTMLString\s*=/)[1];
 assert.equal(HTMLstring.match(/\n\s*<input/g).length, 2);
 ```
 
 Your new `input` element should come after your second `label` element.
 
 ```js
-const HTMLstring = code.split("HTMLString =")[1];
+const HTMLstring = code.split(/HTMLString\s*=/)[1];
 const inputIndex = HTMLstring.lastIndexOf("<input");
 const labelIndex = HTMLstring.lastIndexOf("<label");
 assert.isAbove(inputIndex, labelIndex);
@@ -37,33 +37,33 @@ assert.isAbove(inputIndex, labelIndex);
 Your new `input` element should have a `type` attribute set to `number`.
 
 ```js
-const HTMLstring = code.split("HTMLString =")[1];
+const HTMLstring = code.split(/HTMLString\s*=/)[1];
 const inputAttributes = HTMLstring.match(/<input\s+[^>]*>/g)[1];
-assert.include(inputAttributes, 'type="number"');
+assert.match(inputAttributes, /type\s*=\s*"number"/);
 ```
 
 Your `input` element should have a `placeholder` attribute set to `Calories`.
 
 ```js
-const HTMLstring = code.split("HTMLString =")[1];
+const HTMLstring = code.split(/HTMLString\s*=/)[1];
 const inputAttributes = HTMLstring.match(/<input\s+[^>]*>/g)[1];
-assert.include(inputAttributes, 'placeholder="Calories"');
+assert.match(inputAttributes, /placeholder\s*=\s*"Calories"/);
 ```
 
-Your `input` element should have an `id` attribute set to `${entryDropdown.value}-${entryNumber}-name`.
+Your `input` element should have an `id` attribute set to `${entryDropdown.value}-${entryNumber}-calories`.
 
 ```js
-const HTMLstring = code.split("HTMLString =")[1];
+const HTMLstring = code.split(/HTMLString\s*=/)[1];
 const inputAttributes = HTMLstring.match(/<input\s+[^>]*>/g)[1];
-assert.include(inputAttributes, 'id="${entryDropdown.value}-${entryNumber}-calories"');
+assert.match(inputAttributes, /id\s*=\s*"\${entryDropdown.value}-\${entryNumber}-calories"/);
 ```
 
 Your `input` element should have a `min` attribute set to `0`.
 
 ```js
-const HTMLstring = code.split("HTMLString =")[1];
+const HTMLstring = code.split(/HTMLString\s*=/)[1];
 const inputAttributes = HTMLstring.match(/<input\s+[^>]*>/g)[1];
-assert.include(inputAttributes, 'min="0"');
+assert.match(inputAttributes, /min\s*=\s*"0"/);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-form-validation-by-building-a-calorie-counter/63c2194dce265f429300c8b1.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-form-validation-by-building-a-calorie-counter/63c2194dce265f429300c8b1.md
@@ -16,7 +16,7 @@ This bug occurs because you are querying for `input[type="text"]` elements *befo
 You should add `1` to the `.length` of your `querySelectorAll()` method.
 
 ```js
-assert.match(addEntry.toString(), /entryNumber\s*=\s*targetInputContainer\.querySelectorAll\(\s*'input\[type="text"]'\)\.length\s*\+\s*1/)
+assert.match(addEntry.toString(), /entryNumber\s*=\s*targetInputContainer\.querySelectorAll\(\s*'\s*input\s*\[\s*type\s*=\s*"text"\s*]\s*'\s*\)\.length\s*\+\s*1/)
 ```
 
 # --seed--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-modern-javascript-methods-by-building-football-team-cards/63e95a45dce95baf41dd4f78.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-modern-javascript-methods-by-building-football-team-cards/63e95a45dce95baf41dd4f78.md
@@ -24,7 +24,7 @@ assert.match(code, /\s*<h2\s*>\s*\${\s*name\s*}\s*<\/h2>\s*/)
 Your `h2` should be nested in your `div`.
 
 ```js
-assert.match(code, /`\s*<div\s+class="\s*player-card\s*"\s*>\s*<h2\s*>\s*\${\s*name\s*}\s*<\/h2>\s*<\/div>\s*`\s*/)
+assert.match(code, /`\s*<div\s+class\s*=\s*"\s*player-card\s*"\s*>\s*<h2\s*>\s*\${\s*name\s*}\s*<\/h2>\s*<\/div>\s*`\s*/)
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

- - -
- Optional spaces around `=` added to few steps.
- Optional spaces added to `split` method.
- `assert.include` replaced with `assert.match` to allow optional spaces.
- One hint description corrected.