### PR TITLE
fix(curriculum): fixing tests for step 111 of platformer project to allow for valid solutions

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/650757918a9e97418dc3d71a.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/650757918a9e97418dc3d71a.md
@@ -20,7 +20,7 @@ Congratulations! You have completed the platformer game project!
 You should add an `else if` clause to check is the player's `x` position is greater than or equal to the checkpoint's `x` position and less than or equal to the checkpoint's `x` position plus `40`.
 
 ```js
-assert.match(code, /if\s*\(\s*index\s*===\s*checkpoints\.length\s*-\s*1\s*\)\s*\{\s*isCheckpointCollisionDetectionActive\s*=\s*false;?\s*showCheckpointScreen\(("|'|`)You reached the final checkpoint!\1\);?\s*movePlayer\(\s*\1ArrowRight\1,\s*0,\s*false\);?\s*\}\s*else\s*if\s*\(\s*player\.position\.x\s*>=\s*checkpoint\.position\.x\s*&&\s*player\.position\.x\s*<=\s*checkpoint\.position\.x\s\+\s*40\s*\)\s*\{\s*/)
+assert.match(code, /if\s*\(\s*index\s*===\s*checkpoints\.length\s*-\s*1\s*\)\s*\{\s*isCheckpointCollisionDetectionActive\s*=\s*false;?\s*showCheckpointScreen\(("|'|`)You reached the final checkpoint!\1\);?\s*movePlayer\(\s*\1ArrowRight\1,\s*0,\s*false\);?\s*\}\s*else\s*if\s*\(\s*player\.position\.x\s*>=\s*checkpoint\.position\.x\s*&&\s*player\.position\.x\s*<=\s*checkpoint\.position\.x\s*\+\s*40\s*\)\s*\{\s*/)
 ```
 
 You should call the `showCheckpointScreen` function and pass in "You reached a checkpoint!" as an argument.


### PR DESCRIPTION
The regular expression for checking the user's solution expected a space before the plus sign in `checkpoint.position.x +40` , even though `checkpoint.position.x+40` should also be a valid answer.

Changed the regular expression from `\s\+\s*40` to `\s*\+\s*40`

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [ ] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
