### PR TITLE
fix/updated lesson description with numbers now enclosed within backticks

### DIFF
--- a/curriculum/challenges/arabic/07-scientific-computing-with-python/learn-data-structures-by-building-the-merge-sort-algorithm/657f3a661730891aa64f3568.md
+++ b/curriculum/challenges/arabic/07-scientific-computing-with-python/learn-data-structures-by-building-the-merge-sort-algorithm/657f3a661730891aa64f3568.md
@@ -7,7 +7,7 @@ dashedName: step-5
 
 # --description--
 
-Use the slice syntax to extract the right half of `array` and assign it to a variable named `right_array`.
+Use the slice syntax to extract the right half of `array` and assign it to a variable named `right_part`.
 
 # --hints--
 

--- a/curriculum/challenges/chinese-traditional/07-scientific-computing-with-python/learn-data-structures-by-building-the-merge-sort-algorithm/657f3a661730891aa64f3568.md
+++ b/curriculum/challenges/chinese-traditional/07-scientific-computing-with-python/learn-data-structures-by-building-the-merge-sort-algorithm/657f3a661730891aa64f3568.md
@@ -7,7 +7,7 @@ dashedName: step-5
 
 # --description--
 
-Use the slice syntax to extract the right half of `array` and assign it to a variable named `right_array`.
+Use the slice syntax to extract the right half of `array` and assign it to a variable named `right_part`.
 
 # --hints--
 

--- a/curriculum/challenges/chinese/07-scientific-computing-with-python/learn-data-structures-by-building-the-merge-sort-algorithm/657f3a661730891aa64f3568.md
+++ b/curriculum/challenges/chinese/07-scientific-computing-with-python/learn-data-structures-by-building-the-merge-sort-algorithm/657f3a661730891aa64f3568.md
@@ -7,7 +7,7 @@ dashedName: step-5
 
 # --description--
 
-Use the slice syntax to extract the right half of `array` and assign it to a variable named `right_array`.
+Use the slice syntax to extract the right half of `array` and assign it to a variable named `right_part`.
 
 # --hints--
 

--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-data-structures-by-building-the-merge-sort-algorithm/657f3a661730891aa64f3568.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-data-structures-by-building-the-merge-sort-algorithm/657f3a661730891aa64f3568.md
@@ -7,7 +7,7 @@ dashedName: step-5
 
 # --description--
 
-Use the slice syntax to extract the right half of `array` and assign it to a variable named `right_array`.
+Use the slice syntax to extract the right half of `array` and assign it to a variable named `right_part`.
 
 # --hints--
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62aa26cca3cd3d46c431e73b.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62aa26cca3cd3d46c431e73b.md
@@ -7,7 +7,7 @@ dashedName: step-164
 
 # --description--
 
-Inside your `while` loop, push a random number between 0 and 10 to the end of the `numbers` array. You can create this random number with `Math.floor(Math.random() * 11)`.
+Inside your `while` loop, push a random number between `0` and `10` to the end of the `numbers` array. You can create this random number with `Math.floor(Math.random() * 11)`.
 
 # --hints--
 

--- a/curriculum/challenges/espanol/07-scientific-computing-with-python/learn-data-structures-by-building-the-merge-sort-algorithm/657f3a661730891aa64f3568.md
+++ b/curriculum/challenges/espanol/07-scientific-computing-with-python/learn-data-structures-by-building-the-merge-sort-algorithm/657f3a661730891aa64f3568.md
@@ -7,7 +7,7 @@ dashedName: step-5
 
 # --description--
 
-Use the slice syntax to extract the right half of `array` and assign it to a variable named `right_array`.
+Use the slice syntax to extract the right half of `array` and assign it to a variable named `right_part`.
 
 # --hints--
 

--- a/curriculum/challenges/german/07-scientific-computing-with-python/learn-data-structures-by-building-the-merge-sort-algorithm/657f3a661730891aa64f3568.md
+++ b/curriculum/challenges/german/07-scientific-computing-with-python/learn-data-structures-by-building-the-merge-sort-algorithm/657f3a661730891aa64f3568.md
@@ -7,7 +7,7 @@ dashedName: step-5
 
 # --description--
 
-Use the slice syntax to extract the right half of `array` and assign it to a variable named `right_array`.
+Use the slice syntax to extract the right half of `array` and assign it to a variable named `right_part`.
 
 # --hints--
 

--- a/curriculum/challenges/italian/07-scientific-computing-with-python/learn-data-structures-by-building-the-merge-sort-algorithm/657f3a661730891aa64f3568.md
+++ b/curriculum/challenges/italian/07-scientific-computing-with-python/learn-data-structures-by-building-the-merge-sort-algorithm/657f3a661730891aa64f3568.md
@@ -7,7 +7,7 @@ dashedName: step-5
 
 # --description--
 
-Use the slice syntax to extract the right half of `array` and assign it to a variable named `right_array`.
+Use the slice syntax to extract the right half of `array` and assign it to a variable named `right_part`.
 
 # --hints--
 

--- a/curriculum/challenges/japanese/07-scientific-computing-with-python/learn-data-structures-by-building-the-merge-sort-algorithm/657f3a661730891aa64f3568.md
+++ b/curriculum/challenges/japanese/07-scientific-computing-with-python/learn-data-structures-by-building-the-merge-sort-algorithm/657f3a661730891aa64f3568.md
@@ -7,7 +7,7 @@ dashedName: step-5
 
 # --description--
 
-Use the slice syntax to extract the right half of `array` and assign it to a variable named `right_array`.
+Use the slice syntax to extract the right half of `array` and assign it to a variable named `right_part`.
 
 # --hints--
 

--- a/curriculum/challenges/portuguese/07-scientific-computing-with-python/learn-data-structures-by-building-the-merge-sort-algorithm/657f3a661730891aa64f3568.md
+++ b/curriculum/challenges/portuguese/07-scientific-computing-with-python/learn-data-structures-by-building-the-merge-sort-algorithm/657f3a661730891aa64f3568.md
@@ -7,7 +7,7 @@ dashedName: step-5
 
 # --description--
 
-Use the slice syntax to extract the right half of `array` and assign it to a variable named `right_array`.
+Use the slice syntax to extract the right half of `array` and assign it to a variable named `right_part`.
 
 # --hints--
 

--- a/curriculum/challenges/swahili/07-scientific-computing-with-python/learn-data-structures-by-building-the-merge-sort-algorithm/657f3a661730891aa64f3568.md
+++ b/curriculum/challenges/swahili/07-scientific-computing-with-python/learn-data-structures-by-building-the-merge-sort-algorithm/657f3a661730891aa64f3568.md
@@ -7,7 +7,7 @@ dashedName: step-5
 
 # --description--
 
-Use the slice syntax to extract the right half of `array` and assign it to a variable named `right_array`.
+Use the slice syntax to extract the right half of `array` and assign it to a variable named `right_part`.
 
 # --hints--
 

--- a/curriculum/challenges/ukrainian/07-scientific-computing-with-python/learn-data-structures-by-building-the-merge-sort-algorithm/657f3a661730891aa64f3568.md
+++ b/curriculum/challenges/ukrainian/07-scientific-computing-with-python/learn-data-structures-by-building-the-merge-sort-algorithm/657f3a661730891aa64f3568.md
@@ -7,7 +7,7 @@ dashedName: step-5
 
 # --description--
 
-Use the slice syntax to extract the right half of `array` and assign it to a variable named `right_array`.
+Use the slice syntax to extract the right half of `array` and assign it to a variable named `right_part`.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #53020

<!-- Feel free to add any additional description of changes below this line -->
Previously the numbers present in the description were not in backticks, now this PR encloses those numbers within backticks.