### PR TITLE
fix(curriculum): allow spreading "allSongs" in next line or space in step 9 of the music player project

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-string-and-array-methods-by-building-a-music-player/656071d679089ebd9d5035a0.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-string-and-array-methods-by-building-a-music-player/656071d679089ebd9d5035a0.md
@@ -26,7 +26,7 @@ Inside the `userData` object create a `songs` property. For the value, spread `a
 Your `userData` object should have a `songs` key set to `[...allSongs]`.
 
 ```js
-assert.match(code, /songs\s*:\s*\[\.\.\.allSongs\],?/);
+assert.match(code, /songs\s*:\s*\[\s*\.\.\.allSongs\s*\],?/);
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #53011

<!-- Feel free to add any additional description of changes below this line -->
here I have provided screenshot that shows it is working with modified code
![Capture](https://github.com/Kashinathpat/freeCodeCamp/assets/100040786/094b76d9-0980-4c61-9a21-8e81b9f77f15)
