### PR TITLE
fix(challenge tests): enable fail on initial contents

### DIFF
--- a/curriculum/challenges/arabic/07-scientific-computing-with-python/learn-list-comprehension-by-building-a-case-converter-program/657f4345abe7f2161f99f1ad.md
+++ b/curriculum/challenges/arabic/07-scientific-computing-with-python/learn-list-comprehension-by-building-a-case-converter-program/657f4345abe7f2161f99f1ad.md
@@ -22,7 +22,7 @@ You should declare an empty list named `snake_cased_char_list` within `convert_t
         const convert_to_snake_case = __helpers.python.getDef("\n" + transformedCode, "convert_to_snake_case");
         const { function_body } = convert_to_snake_case;
 
-        assert.match(function_body, / +snake_cased_char_list\s*=\s*\[\n*\s*\n*\]/);
+        assert.match(function_body, /clean_snake_cased_string\s+    snake_cased_char_list\s*=\s*\[\n*\s*\n*\]/);
     }
 })
 ```

--- a/curriculum/challenges/arabic/15-javascript-algorithms-and-data-structures-22/learn-asynchronous-programming-by-building-an-fcc-forum-leaderboard/645f958584305d02bf48fe5b.md
+++ b/curriculum/challenges/arabic/15-javascript-algorithms-and-data-structures-22/learn-asynchronous-programming-by-building-an-fcc-forum-leaderboard/645f958584305d02bf48fe5b.md
@@ -11,16 +11,10 @@ At the end of your `map` method, chain the `join()` method. For the separator, p
 
 # --hints--
 
-You should chain the `join` method to the `map` method.
+You should chain the `join` method to the `map` method and use an empty string for the separator.
 
 ```js
-assert.match(code, /\.join\s*\(\s*.*\s*\)\s*;?/);
-```
-
-You should pass in an empty string for the separator.
-
-```js
-const joinTest = /\.join\(\s*('|")\s*\1\s*\)/g;
+const joinTest = /\.\s*join\s*\(\s*('|")\1\s*\)\s*;?\s*}\s*;?\s*const\s+fetchData/g;
 assert(code.match(joinTest));
 ```
 

--- a/curriculum/challenges/arabic/15-javascript-algorithms-and-data-structures-22/learn-intermediate-algorithmic-thinking-by-building-a-dice-game/657e0846af6cff6cf9b792db.md
+++ b/curriculum/challenges/arabic/15-javascript-algorithms-and-data-structures-22/learn-intermediate-algorithmic-thinking-by-building-a-dice-game/657e0846af6cff6cf9b792db.md
@@ -14,7 +14,7 @@ The last part of your `resetGame` function is to call the `resetRadioOption` fun
 You should call the `resetRadioOption` function inside your `resetGame` function.
 
 ```js
-assert.match(code, /resetRadioOption\s*\(\s*\)\s*;?/);
+assert.match(code, /resetRadioOption\s*\(\s*\)\s*;?\s*}/);
 ```
 
 # --seed--

--- a/curriculum/challenges/arabic/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64c7561d44e2300a90a38ab6.md
+++ b/curriculum/challenges/arabic/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64c7561d44e2300a90a38ab6.md
@@ -28,7 +28,7 @@ x=4700 y=150
 You should include the rest of the values in the `platformPositions` array.
 
 ```js
-const platformPositions = [
+const platformPositionsClone = [
   { x: 500, y: 450 },
   { x: 700, y: 400 },
   { x: 850, y: 350 },
@@ -40,11 +40,10 @@ const platformPositions = [
   { x: 3900, y: 450 },
   { x: 4200, y: 400 },
   { x: 4400, y: 200 },
-  { x: 4700, y: 150 },
+  { x: 4700, y: 150 }
 ];
 
-assert.isArray(platformPositions);
-
+assert.deepEqual(platformPositions, platformPositionsClone);
 ```
 
 # --seed--

--- a/curriculum/challenges/chinese-traditional/07-scientific-computing-with-python/learn-list-comprehension-by-building-a-case-converter-program/657f4345abe7f2161f99f1ad.md
+++ b/curriculum/challenges/chinese-traditional/07-scientific-computing-with-python/learn-list-comprehension-by-building-a-case-converter-program/657f4345abe7f2161f99f1ad.md
@@ -22,7 +22,7 @@ You should declare an empty list named `snake_cased_char_list` within `convert_t
         const convert_to_snake_case = __helpers.python.getDef("\n" + transformedCode, "convert_to_snake_case");
         const { function_body } = convert_to_snake_case;
 
-        assert.match(function_body, / +snake_cased_char_list\s*=\s*\[\n*\s*\n*\]/);
+        assert.match(function_body, /clean_snake_cased_string\s+    snake_cased_char_list\s*=\s*\[\n*\s*\n*\]/);
     }
 })
 ```

--- a/curriculum/challenges/chinese-traditional/15-javascript-algorithms-and-data-structures-22/learn-asynchronous-programming-by-building-an-fcc-forum-leaderboard/645f958584305d02bf48fe5b.md
+++ b/curriculum/challenges/chinese-traditional/15-javascript-algorithms-and-data-structures-22/learn-asynchronous-programming-by-building-an-fcc-forum-leaderboard/645f958584305d02bf48fe5b.md
@@ -11,16 +11,10 @@ At the end of your `map` method, chain the `join()` method. For the separator, p
 
 # --hints--
 
-You should chain the `join` method to the `map` method.
+You should chain the `join` method to the `map` method and use an empty string for the separator.
 
 ```js
-assert.match(code, /\.join\s*\(\s*.*\s*\)\s*;?/);
-```
-
-You should pass in an empty string for the separator.
-
-```js
-const joinTest = /\.join\(\s*('|")\s*\1\s*\)/g;
+const joinTest = /\.\s*join\s*\(\s*('|")\1\s*\)\s*;?\s*}\s*;?\s*const\s+fetchData/g;
 assert(code.match(joinTest));
 ```
 

--- a/curriculum/challenges/chinese-traditional/15-javascript-algorithms-and-data-structures-22/learn-intermediate-algorithmic-thinking-by-building-a-dice-game/657e0846af6cff6cf9b792db.md
+++ b/curriculum/challenges/chinese-traditional/15-javascript-algorithms-and-data-structures-22/learn-intermediate-algorithmic-thinking-by-building-a-dice-game/657e0846af6cff6cf9b792db.md
@@ -14,7 +14,7 @@ The last part of your `resetGame` function is to call the `resetRadioOption` fun
 You should call the `resetRadioOption` function inside your `resetGame` function.
 
 ```js
-assert.match(code, /resetRadioOption\s*\(\s*\)\s*;?/);
+assert.match(code, /resetRadioOption\s*\(\s*\)\s*;?\s*}/);
 ```
 
 # --seed--

--- a/curriculum/challenges/chinese-traditional/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64c7561d44e2300a90a38ab6.md
+++ b/curriculum/challenges/chinese-traditional/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64c7561d44e2300a90a38ab6.md
@@ -28,7 +28,7 @@ x=4700 y=150
 You should include the rest of the values in the `platformPositions` array.
 
 ```js
-const platformPositions = [
+const platformPositionsClone = [
   { x: 500, y: 450 },
   { x: 700, y: 400 },
   { x: 850, y: 350 },
@@ -40,11 +40,10 @@ const platformPositions = [
   { x: 3900, y: 450 },
   { x: 4200, y: 400 },
   { x: 4400, y: 200 },
-  { x: 4700, y: 150 },
+  { x: 4700, y: 150 }
 ];
 
-assert.isArray(platformPositions);
-
+assert.deepEqual(platformPositions, platformPositionsClone);
 ```
 
 # --seed--

--- a/curriculum/challenges/chinese/07-scientific-computing-with-python/learn-list-comprehension-by-building-a-case-converter-program/657f4345abe7f2161f99f1ad.md
+++ b/curriculum/challenges/chinese/07-scientific-computing-with-python/learn-list-comprehension-by-building-a-case-converter-program/657f4345abe7f2161f99f1ad.md
@@ -22,7 +22,7 @@ You should declare an empty list named `snake_cased_char_list` within `convert_t
         const convert_to_snake_case = __helpers.python.getDef("\n" + transformedCode, "convert_to_snake_case");
         const { function_body } = convert_to_snake_case;
 
-        assert.match(function_body, / +snake_cased_char_list\s*=\s*\[\n*\s*\n*\]/);
+        assert.match(function_body, /clean_snake_cased_string\s+    snake_cased_char_list\s*=\s*\[\n*\s*\n*\]/);
     }
 })
 ```

--- a/curriculum/challenges/chinese/15-javascript-algorithms-and-data-structures-22/learn-asynchronous-programming-by-building-an-fcc-forum-leaderboard/645f958584305d02bf48fe5b.md
+++ b/curriculum/challenges/chinese/15-javascript-algorithms-and-data-structures-22/learn-asynchronous-programming-by-building-an-fcc-forum-leaderboard/645f958584305d02bf48fe5b.md
@@ -11,16 +11,10 @@ At the end of your `map` method, chain the `join()` method. For the separator, p
 
 # --hints--
 
-You should chain the `join` method to the `map` method.
+You should chain the `join` method to the `map` method and use an empty string for the separator.
 
 ```js
-assert.match(code, /\.join\s*\(\s*.*\s*\)\s*;?/);
-```
-
-You should pass in an empty string for the separator.
-
-```js
-const joinTest = /\.join\(\s*('|")\s*\1\s*\)/g;
+const joinTest = /\.\s*join\s*\(\s*('|")\1\s*\)\s*;?\s*}\s*;?\s*const\s+fetchData/g;
 assert(code.match(joinTest));
 ```
 

--- a/curriculum/challenges/chinese/15-javascript-algorithms-and-data-structures-22/learn-intermediate-algorithmic-thinking-by-building-a-dice-game/657e0846af6cff6cf9b792db.md
+++ b/curriculum/challenges/chinese/15-javascript-algorithms-and-data-structures-22/learn-intermediate-algorithmic-thinking-by-building-a-dice-game/657e0846af6cff6cf9b792db.md
@@ -14,7 +14,7 @@ The last part of your `resetGame` function is to call the `resetRadioOption` fun
 You should call the `resetRadioOption` function inside your `resetGame` function.
 
 ```js
-assert.match(code, /resetRadioOption\s*\(\s*\)\s*;?/);
+assert.match(code, /resetRadioOption\s*\(\s*\)\s*;?\s*}/);
 ```
 
 # --seed--

--- a/curriculum/challenges/chinese/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64c7561d44e2300a90a38ab6.md
+++ b/curriculum/challenges/chinese/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64c7561d44e2300a90a38ab6.md
@@ -28,7 +28,7 @@ x=4700 y=150
 You should include the rest of the values in the `platformPositions` array.
 
 ```js
-const platformPositions = [
+const platformPositionsClone = [
   { x: 500, y: 450 },
   { x: 700, y: 400 },
   { x: 850, y: 350 },
@@ -40,11 +40,10 @@ const platformPositions = [
   { x: 3900, y: 450 },
   { x: 4200, y: 400 },
   { x: 4400, y: 200 },
-  { x: 4700, y: 150 },
+  { x: 4700, y: 150 }
 ];
 
-assert.isArray(platformPositions);
-
+assert.deepEqual(platformPositions, platformPositionsClone);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-list-comprehension-by-building-a-case-converter-program/657f4345abe7f2161f99f1ad.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-list-comprehension-by-building-a-case-converter-program/657f4345abe7f2161f99f1ad.md
@@ -22,7 +22,7 @@ You should declare an empty list named `snake_cased_char_list` within `convert_t
         const convert_to_snake_case = __helpers.python.getDef("\n" + transformedCode, "convert_to_snake_case");
         const { function_body } = convert_to_snake_case;
 
-        assert.match(function_body, / +snake_cased_char_list\s*=\s*\[\n*\s*\n*\]/);
+        assert.match(function_body, /clean_snake_cased_string\s+    snake_cased_char_list\s*=\s*\[\n*\s*\n*\]/);
     }
 })
 ```

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-asynchronous-programming-by-building-an-fcc-forum-leaderboard/645f958584305d02bf48fe5b.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-asynchronous-programming-by-building-an-fcc-forum-leaderboard/645f958584305d02bf48fe5b.md
@@ -11,16 +11,10 @@ At the end of your `map` method, chain the `join()` method. For the separator, p
 
 # --hints--
 
-You should chain the `join` method to the `map` method.
+You should chain the `join` method to the `map` method with an empty string for the separator.
 
 ```js
-assert.match(code, /\.join\s*\(\s*.*\s*\)\s*;?/);
-```
-
-You should pass in an empty string for the separator.
-
-```js
-const joinTest = /\.join\(\s*('|")\s*\1\s*\)/g;
+const joinTest = /\.\s*join\s*\(\s*('|")\1\s*\)\s*;?\s*}\s*;?\s*const\s+fetchData/g;
 assert(code.match(joinTest));
 ```
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-asynchronous-programming-by-building-an-fcc-forum-leaderboard/645f958584305d02bf48fe5b.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-asynchronous-programming-by-building-an-fcc-forum-leaderboard/645f958584305d02bf48fe5b.md
@@ -11,7 +11,7 @@ At the end of your `map` method, chain the `join()` method. For the separator, p
 
 # --hints--
 
-You should chain the `join` method to the `map` method with an empty string for the separator.
+You should chain the `join` method to the `map` method and use an empty string for the separator.
 
 ```js
 const joinTest = /\.\s*join\s*\(\s*('|")\1\s*\)\s*;?\s*}\s*;?\s*const\s+fetchData/g;

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-algorithmic-thinking-by-building-a-dice-game/657e0846af6cff6cf9b792db.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-algorithmic-thinking-by-building-a-dice-game/657e0846af6cff6cf9b792db.md
@@ -14,7 +14,7 @@ The last part of your `resetGame` function is to call the `resetRadioOption` fun
 You should call the `resetRadioOption` function inside your `resetGame` function.
 
 ```js
-assert.match(code, /resetRadioOption\s*\(\s*\)\s*;?/);
+assert.match(code, /resetRadioOption\s*\(\s*\)\s*;?\s*}/);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64c7561d44e2300a90a38ab6.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64c7561d44e2300a90a38ab6.md
@@ -28,7 +28,7 @@ x=4700 y=150
 You should include the rest of the values in the `platformPositions` array.
 
 ```js
-const platformPositions = [
+const platformPositionsClone = [
   { x: 500, y: 450 },
   { x: 700, y: 400 },
   { x: 850, y: 350 },
@@ -40,11 +40,10 @@ const platformPositions = [
   { x: 3900, y: 450 },
   { x: 4200, y: 400 },
   { x: 4400, y: 200 },
-  { x: 4700, y: 150 },
+  { x: 4700, y: 150 }
 ];
 
-assert.isArray(platformPositions);
-
+assert.deepEqual(platformPositions, platformPositionsClone);
 ```
 
 # --seed--

--- a/curriculum/challenges/espanol/07-scientific-computing-with-python/learn-list-comprehension-by-building-a-case-converter-program/657f4345abe7f2161f99f1ad.md
+++ b/curriculum/challenges/espanol/07-scientific-computing-with-python/learn-list-comprehension-by-building-a-case-converter-program/657f4345abe7f2161f99f1ad.md
@@ -22,7 +22,7 @@ You should declare an empty list named `snake_cased_char_list` within `convert_t
         const convert_to_snake_case = __helpers.python.getDef("\n" + transformedCode, "convert_to_snake_case");
         const { function_body } = convert_to_snake_case;
 
-        assert.match(function_body, / +snake_cased_char_list\s*=\s*\[\n*\s*\n*\]/);
+        assert.match(function_body, /clean_snake_cased_string\s+    snake_cased_char_list\s*=\s*\[\n*\s*\n*\]/);
     }
 })
 ```

--- a/curriculum/challenges/espanol/15-javascript-algorithms-and-data-structures-22/learn-asynchronous-programming-by-building-an-fcc-forum-leaderboard/645f958584305d02bf48fe5b.md
+++ b/curriculum/challenges/espanol/15-javascript-algorithms-and-data-structures-22/learn-asynchronous-programming-by-building-an-fcc-forum-leaderboard/645f958584305d02bf48fe5b.md
@@ -11,16 +11,10 @@ At the end of your `map` method, chain the `join()` method. For the separator, p
 
 # --hints--
 
-You should chain the `join` method to the `map` method.
+You should chain the `join` method to the `map` method and use an empty string for the separator.
 
 ```js
-assert.match(code, /\.join\s*\(\s*.*\s*\)\s*;?/);
-```
-
-You should pass in an empty string for the separator.
-
-```js
-const joinTest = /\.join\(\s*('|")\s*\1\s*\)/g;
+const joinTest = /\.\s*join\s*\(\s*('|")\1\s*\)\s*;?\s*}\s*;?\s*const\s+fetchData/g;
 assert(code.match(joinTest));
 ```
 

--- a/curriculum/challenges/espanol/15-javascript-algorithms-and-data-structures-22/learn-intermediate-algorithmic-thinking-by-building-a-dice-game/657e0846af6cff6cf9b792db.md
+++ b/curriculum/challenges/espanol/15-javascript-algorithms-and-data-structures-22/learn-intermediate-algorithmic-thinking-by-building-a-dice-game/657e0846af6cff6cf9b792db.md
@@ -14,7 +14,7 @@ The last part of your `resetGame` function is to call the `resetRadioOption` fun
 You should call the `resetRadioOption` function inside your `resetGame` function.
 
 ```js
-assert.match(code, /resetRadioOption\s*\(\s*\)\s*;?/);
+assert.match(code, /resetRadioOption\s*\(\s*\)\s*;?\s*}/);
 ```
 
 # --seed--

--- a/curriculum/challenges/espanol/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64c7561d44e2300a90a38ab6.md
+++ b/curriculum/challenges/espanol/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64c7561d44e2300a90a38ab6.md
@@ -28,7 +28,7 @@ x=4700 y=150
 You should include the rest of the values in the `platformPositions` array.
 
 ```js
-const platformPositions = [
+const platformPositionsClone = [
   { x: 500, y: 450 },
   { x: 700, y: 400 },
   { x: 850, y: 350 },
@@ -40,11 +40,10 @@ const platformPositions = [
   { x: 3900, y: 450 },
   { x: 4200, y: 400 },
   { x: 4400, y: 200 },
-  { x: 4700, y: 150 },
+  { x: 4700, y: 150 }
 ];
 
-assert.isArray(platformPositions);
-
+assert.deepEqual(platformPositions, platformPositionsClone);
 ```
 
 # --seed--

--- a/curriculum/challenges/german/07-scientific-computing-with-python/learn-list-comprehension-by-building-a-case-converter-program/657f4345abe7f2161f99f1ad.md
+++ b/curriculum/challenges/german/07-scientific-computing-with-python/learn-list-comprehension-by-building-a-case-converter-program/657f4345abe7f2161f99f1ad.md
@@ -22,7 +22,7 @@ You should declare an empty list named `snake_cased_char_list` within `convert_t
         const convert_to_snake_case = __helpers.python.getDef("\n" + transformedCode, "convert_to_snake_case");
         const { function_body } = convert_to_snake_case;
 
-        assert.match(function_body, / +snake_cased_char_list\s*=\s*\[\n*\s*\n*\]/);
+        assert.match(function_body, /clean_snake_cased_string\s+    snake_cased_char_list\s*=\s*\[\n*\s*\n*\]/);
     }
 })
 ```

--- a/curriculum/challenges/german/15-javascript-algorithms-and-data-structures-22/learn-asynchronous-programming-by-building-an-fcc-forum-leaderboard/645f958584305d02bf48fe5b.md
+++ b/curriculum/challenges/german/15-javascript-algorithms-and-data-structures-22/learn-asynchronous-programming-by-building-an-fcc-forum-leaderboard/645f958584305d02bf48fe5b.md
@@ -11,16 +11,10 @@ At the end of your `map` method, chain the `join()` method. For the separator, p
 
 # --hints--
 
-You should chain the `join` method to the `map` method.
+You should chain the `join` method to the `map` method and use an empty string for the separator.
 
 ```js
-assert.match(code, /\.join\s*\(\s*.*\s*\)\s*;?/);
-```
-
-You should pass in an empty string for the separator.
-
-```js
-const joinTest = /\.join\(\s*('|")\s*\1\s*\)/g;
+const joinTest = /\.\s*join\s*\(\s*('|")\1\s*\)\s*;?\s*}\s*;?\s*const\s+fetchData/g;
 assert(code.match(joinTest));
 ```
 

--- a/curriculum/challenges/german/15-javascript-algorithms-and-data-structures-22/learn-intermediate-algorithmic-thinking-by-building-a-dice-game/657e0846af6cff6cf9b792db.md
+++ b/curriculum/challenges/german/15-javascript-algorithms-and-data-structures-22/learn-intermediate-algorithmic-thinking-by-building-a-dice-game/657e0846af6cff6cf9b792db.md
@@ -14,7 +14,7 @@ The last part of your `resetGame` function is to call the `resetRadioOption` fun
 You should call the `resetRadioOption` function inside your `resetGame` function.
 
 ```js
-assert.match(code, /resetRadioOption\s*\(\s*\)\s*;?/);
+assert.match(code, /resetRadioOption\s*\(\s*\)\s*;?\s*}/);
 ```
 
 # --seed--

--- a/curriculum/challenges/german/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64c7561d44e2300a90a38ab6.md
+++ b/curriculum/challenges/german/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64c7561d44e2300a90a38ab6.md
@@ -28,7 +28,7 @@ x=4700 y=150
 You should include the rest of the values in the `platformPositions` array.
 
 ```js
-const platformPositions = [
+const platformPositionsClone = [
   { x: 500, y: 450 },
   { x: 700, y: 400 },
   { x: 850, y: 350 },
@@ -40,11 +40,10 @@ const platformPositions = [
   { x: 3900, y: 450 },
   { x: 4200, y: 400 },
   { x: 4400, y: 200 },
-  { x: 4700, y: 150 },
+  { x: 4700, y: 150 }
 ];
 
-assert.isArray(platformPositions);
-
+assert.deepEqual(platformPositions, platformPositionsClone);
 ```
 
 # --seed--

--- a/curriculum/challenges/italian/07-scientific-computing-with-python/learn-list-comprehension-by-building-a-case-converter-program/657f4345abe7f2161f99f1ad.md
+++ b/curriculum/challenges/italian/07-scientific-computing-with-python/learn-list-comprehension-by-building-a-case-converter-program/657f4345abe7f2161f99f1ad.md
@@ -22,7 +22,7 @@ You should declare an empty list named `snake_cased_char_list` within `convert_t
         const convert_to_snake_case = __helpers.python.getDef("\n" + transformedCode, "convert_to_snake_case");
         const { function_body } = convert_to_snake_case;
 
-        assert.match(function_body, / +snake_cased_char_list\s*=\s*\[\n*\s*\n*\]/);
+        assert.match(function_body, /clean_snake_cased_string\s+    snake_cased_char_list\s*=\s*\[\n*\s*\n*\]/);
     }
 })
 ```

--- a/curriculum/challenges/italian/15-javascript-algorithms-and-data-structures-22/learn-asynchronous-programming-by-building-an-fcc-forum-leaderboard/645f958584305d02bf48fe5b.md
+++ b/curriculum/challenges/italian/15-javascript-algorithms-and-data-structures-22/learn-asynchronous-programming-by-building-an-fcc-forum-leaderboard/645f958584305d02bf48fe5b.md
@@ -11,16 +11,10 @@ At the end of your `map` method, chain the `join()` method. For the separator, p
 
 # --hints--
 
-You should chain the `join` method to the `map` method.
+You should chain the `join` method to the `map` method and use an empty string for the separator.
 
 ```js
-assert.match(code, /\.join\s*\(\s*.*\s*\)\s*;?/);
-```
-
-You should pass in an empty string for the separator.
-
-```js
-const joinTest = /\.join\(\s*('|")\s*\1\s*\)/g;
+const joinTest = /\.\s*join\s*\(\s*('|")\1\s*\)\s*;?\s*}\s*;?\s*const\s+fetchData/g;
 assert(code.match(joinTest));
 ```
 

--- a/curriculum/challenges/italian/15-javascript-algorithms-and-data-structures-22/learn-intermediate-algorithmic-thinking-by-building-a-dice-game/657e0846af6cff6cf9b792db.md
+++ b/curriculum/challenges/italian/15-javascript-algorithms-and-data-structures-22/learn-intermediate-algorithmic-thinking-by-building-a-dice-game/657e0846af6cff6cf9b792db.md
@@ -14,7 +14,7 @@ The last part of your `resetGame` function is to call the `resetRadioOption` fun
 You should call the `resetRadioOption` function inside your `resetGame` function.
 
 ```js
-assert.match(code, /resetRadioOption\s*\(\s*\)\s*;?/);
+assert.match(code, /resetRadioOption\s*\(\s*\)\s*;?\s*}/);
 ```
 
 # --seed--

--- a/curriculum/challenges/italian/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64c7561d44e2300a90a38ab6.md
+++ b/curriculum/challenges/italian/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64c7561d44e2300a90a38ab6.md
@@ -28,7 +28,7 @@ x=4700 y=150
 You should include the rest of the values in the `platformPositions` array.
 
 ```js
-const platformPositions = [
+const platformPositionsClone = [
   { x: 500, y: 450 },
   { x: 700, y: 400 },
   { x: 850, y: 350 },
@@ -40,11 +40,10 @@ const platformPositions = [
   { x: 3900, y: 450 },
   { x: 4200, y: 400 },
   { x: 4400, y: 200 },
-  { x: 4700, y: 150 },
+  { x: 4700, y: 150 }
 ];
 
-assert.isArray(platformPositions);
-
+assert.deepEqual(platformPositions, platformPositionsClone);
 ```
 
 # --seed--

--- a/curriculum/challenges/japanese/07-scientific-computing-with-python/learn-list-comprehension-by-building-a-case-converter-program/657f4345abe7f2161f99f1ad.md
+++ b/curriculum/challenges/japanese/07-scientific-computing-with-python/learn-list-comprehension-by-building-a-case-converter-program/657f4345abe7f2161f99f1ad.md
@@ -22,7 +22,7 @@ You should declare an empty list named `snake_cased_char_list` within `convert_t
         const convert_to_snake_case = __helpers.python.getDef("\n" + transformedCode, "convert_to_snake_case");
         const { function_body } = convert_to_snake_case;
 
-        assert.match(function_body, / +snake_cased_char_list\s*=\s*\[\n*\s*\n*\]/);
+        assert.match(function_body, /clean_snake_cased_string\s+    snake_cased_char_list\s*=\s*\[\n*\s*\n*\]/);
     }
 })
 ```

--- a/curriculum/challenges/japanese/15-javascript-algorithms-and-data-structures-22/learn-asynchronous-programming-by-building-an-fcc-forum-leaderboard/645f958584305d02bf48fe5b.md
+++ b/curriculum/challenges/japanese/15-javascript-algorithms-and-data-structures-22/learn-asynchronous-programming-by-building-an-fcc-forum-leaderboard/645f958584305d02bf48fe5b.md
@@ -11,16 +11,10 @@ At the end of your `map` method, chain the `join()` method. For the separator, p
 
 # --hints--
 
-You should chain the `join` method to the `map` method.
+You should chain the `join` method to the `map` method and use an empty string for the separator.
 
 ```js
-assert.match(code, /\.join\s*\(\s*.*\s*\)\s*;?/);
-```
-
-You should pass in an empty string for the separator.
-
-```js
-const joinTest = /\.join\(\s*('|")\s*\1\s*\)/g;
+const joinTest = /\.\s*join\s*\(\s*('|")\1\s*\)\s*;?\s*}\s*;?\s*const\s+fetchData/g;
 assert(code.match(joinTest));
 ```
 

--- a/curriculum/challenges/japanese/15-javascript-algorithms-and-data-structures-22/learn-intermediate-algorithmic-thinking-by-building-a-dice-game/657e0846af6cff6cf9b792db.md
+++ b/curriculum/challenges/japanese/15-javascript-algorithms-and-data-structures-22/learn-intermediate-algorithmic-thinking-by-building-a-dice-game/657e0846af6cff6cf9b792db.md
@@ -14,7 +14,7 @@ The last part of your `resetGame` function is to call the `resetRadioOption` fun
 You should call the `resetRadioOption` function inside your `resetGame` function.
 
 ```js
-assert.match(code, /resetRadioOption\s*\(\s*\)\s*;?/);
+assert.match(code, /resetRadioOption\s*\(\s*\)\s*;?\s*}/);
 ```
 
 # --seed--

--- a/curriculum/challenges/japanese/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64c7561d44e2300a90a38ab6.md
+++ b/curriculum/challenges/japanese/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64c7561d44e2300a90a38ab6.md
@@ -28,7 +28,7 @@ x=4700 y=150
 You should include the rest of the values in the `platformPositions` array.
 
 ```js
-const platformPositions = [
+const platformPositionsClone = [
   { x: 500, y: 450 },
   { x: 700, y: 400 },
   { x: 850, y: 350 },
@@ -40,11 +40,10 @@ const platformPositions = [
   { x: 3900, y: 450 },
   { x: 4200, y: 400 },
   { x: 4400, y: 200 },
-  { x: 4700, y: 150 },
+  { x: 4700, y: 150 }
 ];
 
-assert.isArray(platformPositions);
-
+assert.deepEqual(platformPositions, platformPositionsClone);
 ```
 
 # --seed--

--- a/curriculum/challenges/portuguese/07-scientific-computing-with-python/learn-list-comprehension-by-building-a-case-converter-program/657f4345abe7f2161f99f1ad.md
+++ b/curriculum/challenges/portuguese/07-scientific-computing-with-python/learn-list-comprehension-by-building-a-case-converter-program/657f4345abe7f2161f99f1ad.md
@@ -22,7 +22,7 @@ You should declare an empty list named `snake_cased_char_list` within `convert_t
         const convert_to_snake_case = __helpers.python.getDef("\n" + transformedCode, "convert_to_snake_case");
         const { function_body } = convert_to_snake_case;
 
-        assert.match(function_body, / +snake_cased_char_list\s*=\s*\[\n*\s*\n*\]/);
+        assert.match(function_body, /clean_snake_cased_string\s+    snake_cased_char_list\s*=\s*\[\n*\s*\n*\]/);
     }
 })
 ```

--- a/curriculum/challenges/portuguese/15-javascript-algorithms-and-data-structures-22/learn-asynchronous-programming-by-building-an-fcc-forum-leaderboard/645f958584305d02bf48fe5b.md
+++ b/curriculum/challenges/portuguese/15-javascript-algorithms-and-data-structures-22/learn-asynchronous-programming-by-building-an-fcc-forum-leaderboard/645f958584305d02bf48fe5b.md
@@ -11,16 +11,10 @@ At the end of your `map` method, chain the `join()` method. For the separator, p
 
 # --hints--
 
-You should chain the `join` method to the `map` method.
+You should chain the `join` method to the `map` method and use an empty string for the separator.
 
 ```js
-assert.match(code, /\.join\s*\(\s*.*\s*\)\s*;?/);
-```
-
-You should pass in an empty string for the separator.
-
-```js
-const joinTest = /\.join\(\s*('|")\s*\1\s*\)/g;
+const joinTest = /\.\s*join\s*\(\s*('|")\1\s*\)\s*;?\s*}\s*;?\s*const\s+fetchData/g;
 assert(code.match(joinTest));
 ```
 

--- a/curriculum/challenges/portuguese/15-javascript-algorithms-and-data-structures-22/learn-intermediate-algorithmic-thinking-by-building-a-dice-game/657e0846af6cff6cf9b792db.md
+++ b/curriculum/challenges/portuguese/15-javascript-algorithms-and-data-structures-22/learn-intermediate-algorithmic-thinking-by-building-a-dice-game/657e0846af6cff6cf9b792db.md
@@ -14,7 +14,7 @@ The last part of your `resetGame` function is to call the `resetRadioOption` fun
 You should call the `resetRadioOption` function inside your `resetGame` function.
 
 ```js
-assert.match(code, /resetRadioOption\s*\(\s*\)\s*;?/);
+assert.match(code, /resetRadioOption\s*\(\s*\)\s*;?\s*}/);
 ```
 
 # --seed--

--- a/curriculum/challenges/portuguese/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64c7561d44e2300a90a38ab6.md
+++ b/curriculum/challenges/portuguese/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64c7561d44e2300a90a38ab6.md
@@ -28,7 +28,7 @@ x=4700 y=150
 You should include the rest of the values in the `platformPositions` array.
 
 ```js
-const platformPositions = [
+const platformPositionsClone = [
   { x: 500, y: 450 },
   { x: 700, y: 400 },
   { x: 850, y: 350 },
@@ -40,11 +40,10 @@ const platformPositions = [
   { x: 3900, y: 450 },
   { x: 4200, y: 400 },
   { x: 4400, y: 200 },
-  { x: 4700, y: 150 },
+  { x: 4700, y: 150 }
 ];
 
-assert.isArray(platformPositions);
-
+assert.deepEqual(platformPositions, platformPositionsClone);
 ```
 
 # --seed--

--- a/curriculum/challenges/swahili/07-scientific-computing-with-python/learn-list-comprehension-by-building-a-case-converter-program/657f4345abe7f2161f99f1ad.md
+++ b/curriculum/challenges/swahili/07-scientific-computing-with-python/learn-list-comprehension-by-building-a-case-converter-program/657f4345abe7f2161f99f1ad.md
@@ -22,7 +22,7 @@ You should declare an empty list named `snake_cased_char_list` within `convert_t
         const convert_to_snake_case = __helpers.python.getDef("\n" + transformedCode, "convert_to_snake_case");
         const { function_body } = convert_to_snake_case;
 
-        assert.match(function_body, / +snake_cased_char_list\s*=\s*\[\n*\s*\n*\]/);
+        assert.match(function_body, /clean_snake_cased_string\s+    snake_cased_char_list\s*=\s*\[\n*\s*\n*\]/);
     }
 })
 ```

--- a/curriculum/challenges/swahili/15-javascript-algorithms-and-data-structures-22/learn-asynchronous-programming-by-building-an-fcc-forum-leaderboard/645f958584305d02bf48fe5b.md
+++ b/curriculum/challenges/swahili/15-javascript-algorithms-and-data-structures-22/learn-asynchronous-programming-by-building-an-fcc-forum-leaderboard/645f958584305d02bf48fe5b.md
@@ -11,16 +11,10 @@ At the end of your `map` method, chain the `join()` method. For the separator, p
 
 # --hints--
 
-You should chain the `join` method to the `map` method.
+You should chain the `join` method to the `map` method and use an empty string for the separator.
 
 ```js
-assert.match(code, /\.join\s*\(\s*.*\s*\)\s*;?/);
-```
-
-You should pass in an empty string for the separator.
-
-```js
-const joinTest = /\.join\(\s*('|")\s*\1\s*\)/g;
+const joinTest = /\.\s*join\s*\(\s*('|")\1\s*\)\s*;?\s*}\s*;?\s*const\s+fetchData/g;
 assert(code.match(joinTest));
 ```
 

--- a/curriculum/challenges/swahili/15-javascript-algorithms-and-data-structures-22/learn-intermediate-algorithmic-thinking-by-building-a-dice-game/657e0846af6cff6cf9b792db.md
+++ b/curriculum/challenges/swahili/15-javascript-algorithms-and-data-structures-22/learn-intermediate-algorithmic-thinking-by-building-a-dice-game/657e0846af6cff6cf9b792db.md
@@ -14,7 +14,7 @@ The last part of your `resetGame` function is to call the `resetRadioOption` fun
 You should call the `resetRadioOption` function inside your `resetGame` function.
 
 ```js
-assert.match(code, /resetRadioOption\s*\(\s*\)\s*;?/);
+assert.match(code, /resetRadioOption\s*\(\s*\)\s*;?\s*}/);
 ```
 
 # --seed--

--- a/curriculum/challenges/swahili/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64c7561d44e2300a90a38ab6.md
+++ b/curriculum/challenges/swahili/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64c7561d44e2300a90a38ab6.md
@@ -28,7 +28,7 @@ x=4700 y=150
 You should include the rest of the values in the `platformPositions` array.
 
 ```js
-const platformPositions = [
+const platformPositionsClone = [
   { x: 500, y: 450 },
   { x: 700, y: 400 },
   { x: 850, y: 350 },
@@ -40,11 +40,10 @@ const platformPositions = [
   { x: 3900, y: 450 },
   { x: 4200, y: 400 },
   { x: 4400, y: 200 },
-  { x: 4700, y: 150 },
+  { x: 4700, y: 150 }
 ];
 
-assert.isArray(platformPositions);
-
+assert.deepEqual(platformPositions, platformPositionsClone);
 ```
 
 # --seed--

--- a/curriculum/challenges/ukrainian/07-scientific-computing-with-python/learn-list-comprehension-by-building-a-case-converter-program/657f4345abe7f2161f99f1ad.md
+++ b/curriculum/challenges/ukrainian/07-scientific-computing-with-python/learn-list-comprehension-by-building-a-case-converter-program/657f4345abe7f2161f99f1ad.md
@@ -22,7 +22,7 @@ You should declare an empty list named `snake_cased_char_list` within `convert_t
         const convert_to_snake_case = __helpers.python.getDef("\n" + transformedCode, "convert_to_snake_case");
         const { function_body } = convert_to_snake_case;
 
-        assert.match(function_body, / +snake_cased_char_list\s*=\s*\[\n*\s*\n*\]/);
+        assert.match(function_body, /clean_snake_cased_string\s+    snake_cased_char_list\s*=\s*\[\n*\s*\n*\]/);
     }
 })
 ```

--- a/curriculum/challenges/ukrainian/15-javascript-algorithms-and-data-structures-22/learn-asynchronous-programming-by-building-an-fcc-forum-leaderboard/645f958584305d02bf48fe5b.md
+++ b/curriculum/challenges/ukrainian/15-javascript-algorithms-and-data-structures-22/learn-asynchronous-programming-by-building-an-fcc-forum-leaderboard/645f958584305d02bf48fe5b.md
@@ -11,16 +11,10 @@ At the end of your `map` method, chain the `join()` method. For the separator, p
 
 # --hints--
 
-You should chain the `join` method to the `map` method.
+You should chain the `join` method to the `map` method and use an empty string for the separator.
 
 ```js
-assert.match(code, /\.join\s*\(\s*.*\s*\)\s*;?/);
-```
-
-You should pass in an empty string for the separator.
-
-```js
-const joinTest = /\.join\(\s*('|")\s*\1\s*\)/g;
+const joinTest = /\.\s*join\s*\(\s*('|")\1\s*\)\s*;?\s*}\s*;?\s*const\s+fetchData/g;
 assert(code.match(joinTest));
 ```
 

--- a/curriculum/challenges/ukrainian/15-javascript-algorithms-and-data-structures-22/learn-intermediate-algorithmic-thinking-by-building-a-dice-game/657e0846af6cff6cf9b792db.md
+++ b/curriculum/challenges/ukrainian/15-javascript-algorithms-and-data-structures-22/learn-intermediate-algorithmic-thinking-by-building-a-dice-game/657e0846af6cff6cf9b792db.md
@@ -14,7 +14,7 @@ The last part of your `resetGame` function is to call the `resetRadioOption` fun
 You should call the `resetRadioOption` function inside your `resetGame` function.
 
 ```js
-assert.match(code, /resetRadioOption\s*\(\s*\)\s*;?/);
+assert.match(code, /resetRadioOption\s*\(\s*\)\s*;?\s*}/);
 ```
 
 # --seed--

--- a/curriculum/challenges/ukrainian/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64c7561d44e2300a90a38ab6.md
+++ b/curriculum/challenges/ukrainian/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64c7561d44e2300a90a38ab6.md
@@ -28,7 +28,7 @@ x=4700 y=150
 You should include the rest of the values in the `platformPositions` array.
 
 ```js
-const platformPositions = [
+const platformPositionsClone = [
   { x: 500, y: 450 },
   { x: 700, y: 400 },
   { x: 850, y: 350 },
@@ -40,11 +40,10 @@ const platformPositions = [
   { x: 3900, y: 450 },
   { x: 4200, y: 400 },
   { x: 4400, y: 200 },
-  { x: 4700, y: 150 },
+  { x: 4700, y: 150 }
 ];
 
-assert.isArray(platformPositions);
-
+assert.deepEqual(platformPositions, platformPositionsClone);
 ```
 
 # --seed--

--- a/curriculum/test/test-challenges.js
+++ b/curriculum/test/test-challenges.js
@@ -424,7 +424,7 @@ function populateTestsForLang({ lang, challenges, meta, superBlocks }) {
               try {
                 testRunner = await createTestRunner(
                   challenge,
-                  [],
+                  challenge.challengeFiles,
                   buildChallenge
                 );
               } catch {


### PR DESCRIPTION
The defaults to the seed code when testing solutions so the "must fail on the initial contents" tests work.
Fixes the 4 challenges that weren't failing with their seed code across all i18n's

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #53049

<!-- Feel free to add any additional description of changes below this line -->
