### PR TITLE
fix(curriculum): Use innerText for anchor text test

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-grid-by-building-a-magazine/614387cbefeeba5f3654a291.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-grid-by-building-a-magazine/614387cbefeeba5f3654a291.md
@@ -97,7 +97,7 @@ assert(document.querySelector('div')?.querySelector('p')?.firstElementChild?.get
 Your `a` element should surround the text `freeCodeCamp`.
 
 ```js
-assert(document.querySelector('div')?.querySelector('p')?.firstElementChild?.textContent === 'freeCodeCamp');
+assert(document.querySelector('div')?.querySelector('p')?.firstElementChild?.innerText === 'freeCodeCamp');
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

The below formatting will fail the last test because `textContent` includes the new line and spaces. The requirement is for the text content, which is correct using the below format.

```
<div class="author">
  <p class="author-name">
    By
    <a href="https://freecodecamp.org" target="_blank">
      freeCodeCamp
    </a>
  </p>
  <p class="publish-date">March 7, 2019</p>
</div>
```

Forum: https://forum.freecodecamp.org/t/learn-css-grid-by-building-a-magazine-step-7/662864/
