### PR TITLE
fix(curriculum): python list comp step 9 typo

### DIFF
--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-list-comprehension-by-building-a-case-converter-program/657f0044be09db790b1eb1c5.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-list-comprehension-by-building-a-case-converter-program/657f0044be09db790b1eb1c5.md
@@ -7,7 +7,7 @@ dashedName: step-9
 
 # --description--
 
-Strings in camel case start with a capital character. Since you've converted all such characters to lowercase and prepended an underscore to them, chances are, the converted snake case string has a dangling underscode at the start.
+Strings in pascal case start with a capital character. Since you've converted all such characters to lowercase and prepended an underscore to them, chances are, the converted snake case string has a dangling underscode at the start.
 
 The easiest way to strip such unwanted character is by using the `.strip()` string method and passing an underscore to the method as argument.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

This is for:  Scientific Computing with Python (Beta)
And section:  Learn Python List Comprehension By Building a Case Converter Program

The Issue:
Step 1 gives these examples of what camel case and pascal case look like:
- camelCase
- PascalCase

However, in step 9 we are told that camel case strings start with a capital character: "Strings in camel case start with a capital character. Since you've converted all such characters to lowercase and prepended an underscore to them, chances are, the converted snake case string has a dangling underscore at the start." 

To be consistent, this should be changed to "Strings in pascal case..."

