### PR TITLE
Update .gitignore   Fix: removed extra blank between Line 64 and line…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,7 +63,6 @@ $RECYCLE.BIN/
 # Icon must end with two \r
 Icon
 
-
 # Thumbnails
 ._*
 


### PR DESCRIPTION
… 67 sections ofr .gitignore


Fix: removed extra blank between Line 64 and line 67 sections ofr .gitignore # Icon must end with two \r
Icon


# Thumbnails
._*

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [ ] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
