### PR TITLE
fix: Renovate hogging CI

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": ["github>freecodecamp/renovate-config"],
-  "schedule": ["after 5pm on Monday"],
+  "rebaseWhen": "conflicted"
   "packageRules": [
     {
       "groupName": "Disabled",

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "extends": ["github>freecodecamp/renovate-config"],
+  "schedule": ["after 5pm on Monday"],
   "packageRules": [
     {
       "groupName": "Disabled",


### PR DESCRIPTION
This will hopefully stop Renovate from force pushing every time an update is made to learn. 

This pr is to hopefully reduce the CI load.
