### PR TITLE
fix: add test case for regex in split() method

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-advanced-array-methods-by-building-a-statistics-calculator/63507bcbfe4ede356e624395.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-advanced-array-methods-by-building-a-statistics-calculator/63507bcbfe4ede356e624395.md
@@ -11,7 +11,7 @@ Now that you have the value of the input, you need to split it into an array of 
 
 The `.split()` method takes a string and splits it into an array of strings. You can pass it a string of characters or a RegEx to use as a separator. For example, `string.split(",")` would split the string at each comma and return an array of strings.
 
-Use a regex to split the `value` string by commas followed by any number of spaces. Store the array in an `array` variable.
+Use the `/,\s*/g` regex to split the `value` string by commas. You can tweak it based on the number of spaces seperating your values. Store the array in an `array` variable.
 
 # --hints--
 
@@ -31,6 +31,12 @@ Your `calculate` function should assign the result of the `.split()` method to t
 
 ```js
 assert.match(code.toString(),  /array\s*=\s*value\.split()/);
+```
+
+The `.split()` method should use a regex to split the `value` string by commas followed by any number of spaces. Use the `/,\s*/g` regex.
+
+```js
+assert.match(code.toString(), /value\.split\(\s*\/,\s*\\s*\*\s*\/g\)/);
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!-- Feel free to add any additional description of changes below this line -->

While testing [this lesson](https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures-v8/learn-advanced-array-methods-by-building-a-statistics-calculator/step-3), I noticed that there was no test for the regex code. I also edited the instruction to indicate the regex code. We can adjust the description and all, however, but I felt we should test for the regex code.
