### PR TITLE
Fix: add note to explain number is not checked

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-advanced-array-methods-by-building-a-statistics-calculator/63507bcbfe4ede356e624395.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-advanced-array-methods-by-building-a-statistics-calculator/63507bcbfe4ede356e624395.md
@@ -33,7 +33,7 @@ Your `calculate` function should assign the result of the `.split()` method to t
 assert.match(code.toString(),  /array\s*=\s*value\.split()/);
 ```
 
-The `.split()` method should use a regex to split the `value` string by commas followed by any number of spaces. Use the `/,\s*/g` regex.
+You should use `/,\s*/g` for the `split()` method's separator.
 
 ```js
 assert.match(code.toString(), /value\.split\(\s*\/,\s*\\s*\*\s*\/g\)/);

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-advanced-array-methods-by-building-a-statistics-calculator/63507bcbfe4ede356e624395.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-advanced-array-methods-by-building-a-statistics-calculator/63507bcbfe4ede356e624395.md
@@ -11,7 +11,7 @@ Now that you have the value of the input, you need to split it into an array of 
 
 The `.split()` method takes a string and splits it into an array of strings. You can pass it a string of characters or a RegEx to use as a separator. For example, `string.split(",")` would split the string at each comma and return an array of strings.
 
-Use a regex to split the `value` string by commas followed by any number of spaces. Store the array in an `array` variable.
+Use the `/,\s*/g` regex to split the `value` string by commas. You can tweak it based on the number of spaces seperating your values. Store the array in an `array` variable.
 
 # --hints--
 
@@ -31,6 +31,12 @@ Your `calculate` function should assign the result of the `.split()` method to t
 
 ```js
 assert.match(code.toString(),  /array\s*=\s*value\.split()/);
+```
+
+The `.split()` method should use a regex to split the `value` string by commas followed by any number of spaces. Use the `/,\s*/g` regex.
+
+```js
+assert.match(code.toString(), /value\.split\(\s*\/,\s*\\s*\*\s*\/g\)/);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-advanced-array-methods-by-building-a-statistics-calculator/63507e4562cdde3a28e8de1b.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-advanced-array-methods-by-building-a-statistics-calculator/63507e4562cdde3a28e8de1b.md
@@ -32,7 +32,7 @@ assert.match(calculate.toString(), /numbers\.filter\(\(?\s*el\s*\)?\s*=>|numbers
 Your callback function should use `!` and `isNaN()` to check if `el` is NOT `NaN`.
 
 ```js
-assert.match(calculate.toString(), /!\s*isNaN\(\s*el\s*\)/);
+assert.match(calculate.toString(), /!\s*(Number\.)?isNaN\(\s*el\s*\)/);
 ```
 
 Your callback function should return elements that are not `NaN`.

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-advanced-array-methods-by-building-a-statistics-calculator/63507e4562cdde3a28e8de1b.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-advanced-array-methods-by-building-a-statistics-calculator/63507e4562cdde3a28e8de1b.md
@@ -17,7 +17,7 @@ array.filter(el => {
 
 The callback function needs to return a Boolean value, which indicates whether the element should be included in the new array. In this case, you want to return `true` if the element is not `NaN` (not a number).
 
-However, you cannot check for equality here, because `NaN` is not equal to itself. Instead, you can use the `Number.isNaN()` method, which returns `true` if the argument is `NaN`.
+However, you cannot check for equality here, because `NaN` is not equal to itself. Instead, you can use the `isNaN()` method, which returns `true` if the argument is `NaN`.
 
 Add a callback function to your `.filter()` method that returns `true` if the element is not `NaN`.
 
@@ -29,10 +29,10 @@ Your `.filter()` method should have a callback which accepts `el` as a parameter
 assert.match(calculate.toString(), /numbers\.filter\(\(?\s*el\s*\)?\s*=>|numbers\.filter\(function\s*\(?el\)\s*\{/)
 ```
 
-Your callback function should use `!` and `Number.isNaN()` to check if `el` is NOT `NaN`.
+Your callback function should use `!` and `isNaN()` to check if `el` is NOT `NaN`.
 
 ```js
-assert.match(calculate.toString(), /!(Number\.)?isNaN\(\s*el\s*\)/);
+assert.match(calculate.toString(), /!\s*isNaN\(\s*el\s*\)/);
 ```
 
 Your callback function should return elements that are not `NaN`.

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-advanced-array-methods-by-building-a-statistics-calculator/63507ebb0c50ce3b9d669cd9.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-advanced-array-methods-by-building-a-statistics-calculator/63507ebb0c50ce3b9d669cd9.md
@@ -17,8 +17,6 @@ The `.map()` method is called on the array, and then the `.filter()` method is c
 
 Following that example, remove your `filtered` variable, and chain your `.filter()` call to your `.map()` call above. Do not remove either of the callback functions.
 
-> Note: We are not using `!Number.isNaN()` here because we are chaining the `.filter()` method after the `.map()` method. The `.map()` method will return an array of numbers, so we can use the `!isNaN()` function without the `Number.` prefix.
-
 # --hints--
 
 You should remove the `filtered` variable.

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-advanced-array-methods-by-building-a-statistics-calculator/63507ebb0c50ce3b9d669cd9.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-advanced-array-methods-by-building-a-statistics-calculator/63507ebb0c50ce3b9d669cd9.md
@@ -17,6 +17,8 @@ The `.map()` method is called on the array, and then the `.filter()` method is c
 
 Following that example, remove your `filtered` variable, and chain your `.filter()` call to your `.map()` call above. Do not remove either of the callback functions.
 
+> Note: We are not using `!Number.isNaN()` here because we are chaining the `.filter()` method after the `.map()` method. The `.map()` method will return an array of numbers, so we can use the `!isNaN()` function without the `Number.` prefix.
+
 # --hints--
 
 You should remove the `filtered` variable.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!-- Feel free to add any additional description of changes below this line -->
In the previous step, we told users to create a variable to filter numbers using `!Number.isNaN(el)` but now in step 8 we plan on chaining both the `map()` and `filter()` method meaning we no longer need the `Number.` prefix. In this case — so a user in not confused — I think it makes sense to add a Note. Wdyt?
