### PR TITLE
fix(client): source element is void, correct type attribute

### DIFF
--- a/client/src/templates/Challenges/fill-in-the-blank/show.tsx
+++ b/client/src/templates/Challenges/fill-in-the-blank/show.tsx
@@ -309,8 +309,8 @@ class ShowFillInTheBlank extends Component<
                     <audio className='audio' controls>
                       <source
                         src={`https://cdn.freecodecamp.org/${audioPath}`}
-                        type='audio/mp3'
-                      ></source>
+                        type='audio/mpeg'
+                      />
                     </audio>
                     <Spacer size='medium' />
                   </>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

The `source` element is a void element.

Don't believe `type="audio/mp3"` follows the specs. It should be `type="audio/mpeg"`.

---

Not sure if the `type` might somehow be related to the playback issue reported in #53165 but I guess a browser may skip the source file if it thinks it can't play the specified type. I can't test it on the device from the issue, but I just wanted to mention it.

https://www.iana.org/assignments/media-types/media-types.xhtml#audio

https://developer.mozilla.org/en-US/docs/Web/Media/Formats/codecs_parameter#container_format_mime_types
