### PR TITLE
docs: add Troubleshooting section to Cypress guide

### DIFF
--- a/docs/how-to-add-cypress-tests.md
+++ b/docs/how-to-add-cypress-tests.md
@@ -83,3 +83,38 @@ pnpm run cypress:install-build-tools
 - When prompted in the terminal, select your keyboard layout by language/area
 
 Now, [Cypress can be run](how-to-add-cypress-tests.md#_2-run-the-cypress-tests)
+
+## Troubleshooting
+
+### Unable to Connect to Port 8000
+
+If Cypress fails to run with the following error:
+
+```
+CypressError: `cy.visit()` failed trying to load:
+
+http://localhost:3000/signin
+
+We attempted to make an http request to this URL but the request failed without a response.
+
+We received this error at the network level:
+
+  > Error: connect ECONNREFUSED 127.0.0.1:8000
+
+Common situations why this would fail:
+  - you don't have internet access
+  - you forgot to run / boot your web server
+  - your web server isn't accessible
+  - you have weird network configuration settings on your computer
+
+This error occurred while creating the session. Because the session setup failed, we failed the test.
+```
+
+You can resolve the issue by:
+- Going to the root `package.json` file and adding `--host 0.0.0.0` to the `develop:client` command:
+    ```json
+    "scripts": {
+      "develop:client": "cd ./client && pnpm run develop --host 0.0.0.0"
+    }
+    ```
+- Then, re-running `pnpm run develop`


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR:
- Adds Troubleshooting section to the Cypress guide, with a workaround for the network error
- Closes #52635

## Screenshot

<img width="1121" alt="Screenshot 2024-01-14 at 16 45 35" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/27efce04-26f4-4a20-b538-fb627d1a6760">

<!-- Feel free to add any additional description of changes below this line -->
