### PR TITLE
docs: correct typo in 'Work on Codebase' page

### DIFF
--- a/docs/how-to-contribute-to-the-codebase.md
+++ b/docs/how-to-contribute-to-the-codebase.md
@@ -62,7 +62,7 @@ Follow these steps:
    git diff upstream/main
    ```
 
-   The resulting output should be empty. This process is important, because you will be rebase your branch on top of the latest `upstream/main` as often as possible to avoid conflicts later.
+   The resulting output should be empty. This process is important, because you will be rebasing your branch on top of the latest `upstream/main` as often as possible to avoid conflicts later.
 
 3. Create a fresh new branch:
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [ x] My pull request targets the `main` branch of freeCodeCamp.
- [ x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Closes #XXXXX -->

<!-- Feel free to add any additional description of changes below this line -->

I have replaced the word 'rebase' with the word 'rebasing' in the last statement of step 2 on the 'Work on Codebase' page (https://contribute.freecodecamp.org/#/how-to-contribute-to-the-codebase). The sentence should now read: 

The resulting output should be empty. This process is important, because you will be rebasing your branch on top of the latest upstream/main as often as possible to avoid conflicts later.


