### PR TITLE
fix(tools): make error message slightly less cryptic

### DIFF
--- a/curriculum/test/test-challenges.js
+++ b/curriculum/test/test-challenges.js
@@ -613,7 +613,9 @@ function replaceChallengeFilesContentsWithSolutions(
       ({ ext, name }) => ext === file.ext && file.name === name
     );
     if (!matchingSolutionFile) {
-      throw Error(`No matching solution file found`);
+      throw Error(
+        `No matching solution file found for ${file.name}.${file.ext} - this likely means the seed code for the next step is missing the ${file.ext} code block.`
+      );
     }
     return {
       ...file,


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

This error popped up in a PR, and it took me longer than I'd like to understand exactly why it was appearing. Hoping the updated message is significantly less cryptic, for the next time we see this.