### PR TITLE
feat(curriculum): add english block 6.1 challenges

### DIFF
--- a/curriculum/challenges/_meta/learn-how-to-help-a-coworker-troubleshoot-on-github/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-help-a-coworker-troubleshoot-on-github/meta.json
@@ -11,7 +11,7 @@
   "challengeOrder": [
     {
       "id": "655c131291cbcb8febf21e64",
-      "title": "Dialogue 1: Discussing issues on GitHub"
+      "title": "Dialogue 1: Discussing Issues on GitHub"
     },
     {
       "id": "656b732c8110ff8936f016de",
@@ -127,7 +127,7 @@
     },
     {
       "id": "656bd6dde3a62c205cb41b2d",
-      "title": "Dialogue 2: Talking About Pull Request"
+      "title": "Dialogue 2: Talking About Pull Requests"
     },
     {
       "id": "656bd701970c6c20a9c89b0f",
@@ -215,7 +215,7 @@
     },
     {
       "id": "65b2b0e08ec66535fa8542eb",
-      "title": "Dialogue 3 Talking about Debugging"
+      "title": "Dialogue 3: Talking About Debugging"
     },
     {
       "id": "65b2b181cb9b2136e833a17a",

--- a/curriculum/challenges/_meta/learn-how-to-help-a-coworker-troubleshoot-on-github/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-help-a-coworker-troubleshoot-on-github/meta.json
@@ -12,6 +12,82 @@
     {
       "id": "655c131291cbcb8febf21e64",
       "title": "Dialogue: Placeholder"
+    },
+    {
+      "id": "656b732c8110ff8936f016de",
+      "title": "Task 1"
+    },
+    {
+      "id": "656b74ab2a075f8a05c66f41",
+      "title": "Task 2"
+    },
+    {
+      "id": "656b757d8294618a5eefd710",
+      "title": "Task 3"
+    },
+    {
+      "id": "656bbba66c53330f4316fd9f",
+      "title": "Task 4"
+    },
+    {
+      "id": "656bbbe6d57609104b152625",
+      "title": "Task 5"
+    },
+    {
+      "id": "656bbcc8333087117b4d9153",
+      "title": "Task 6"
+    },
+    {
+      "id": "656bbd3dea715a11ce02b670",
+      "title": "Task 7"
+    },
+    {
+      "id": "656bbded100497126ccc6e5d",
+      "title": "Task 8"
+    },
+    {
+      "id": "656bbe4c45fc9512d58ba0e2",
+      "title": "Task 9"
+    },
+    {
+      "id": "656bbeb152c95913465476e3",
+      "title": "Task 10"
+    },
+    {
+      "id": "656bbf3a1b344e13bc7fa12c",
+      "title": "Task 11"
+    },
+    {
+      "id": "656bbfaf6cbc3f1418acca3c",
+      "title": "Task 12"
+    },
+    {
+      "id": "656bbfedb30479145d464e37",
+      "title": "Task 13"
+    },
+    {
+      "id": "656bc028a62f3a149ed36971",
+      "title": "Task 14"
+    },
+    {
+      "id": "656bc05be141d914dcc812c3",
+      "title": "Task 15"
+    },
+    {
+      "id": "656bc094df5acf151fb264d8",
+      "title": "Task 16"
+    },
+    {
+      "id": "656bc0bd4a112e155c589e33",
+      "title": "Task 17"
+    },
+    {
+      "id": "656bc0f87049dc159ce63187",
+      "title": "Task 18"
+    },
+    {
+      "id": "656bc15142eeeb15e31d258b",
+      "title": "Task 19"
     }
   ],
   "helpCategory": "English"

--- a/curriculum/challenges/_meta/learn-how-to-help-a-coworker-troubleshoot-on-github/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-help-a-coworker-troubleshoot-on-github/meta.json
@@ -180,6 +180,90 @@
     {
       "id": "65a9457392dfd7d564bc940e",
       "title": "Task 41"
+    },
+    {
+      "id": "65b28add2c939e25b1d9b0e1",
+      "title": "Task 42"
+    },
+    {
+      "id": "65b28bbe803df52c4e76dd15",
+      "title": "Task 43"
+    },
+    {
+      "id": "65b28d5f4b4c502d2b7917e1",
+      "title": "Task 44"
+    },
+    {
+      "id": "65b28e008537c42da87ace01",
+      "title": "Task 45"
+    },
+    {
+      "id": "65b28ee9c5a5972e8bb2a5f3",
+      "title": "Task 46"
+    },
+    {
+      "id": "65b28f840a0d962f2240e800",
+      "title": "Task 47"
+    },
+    {
+      "id": "65b2af1545e34334b7573de9",
+      "title": "Task 48"
+    },
+    {
+      "id": "65b2af807f713c351c5b9435",
+      "title": "Task 49"
+    },
+    {
+      "id": "65b2b0e08ec66535fa8542eb",
+      "title": "Dialogue 3 Talking about Debugging"
+    },
+    {
+      "id": "65b2b181cb9b2136e833a17a",
+      "title": "Task 50"
+    },
+    {
+      "id": "65b2b2781c59e837a5e0beb2",
+      "title": "Task 51"
+    },
+    {
+      "id": "65b2b383fb6406386dab3499",
+      "title": "Task 52"
+    },
+    {
+      "id": "65b2b3ea62a86838c216db73",
+      "title": "Task 53"
+    },
+    {
+      "id": "65b2b54bf7897c3954e20971",
+      "title": "Task 54"
+    },
+    {
+      "id": "65b2b6255fe7973a8bf80902",
+      "title": "Task 55"
+    },
+    {
+      "id": "65b2b6aef88e363af2749620",
+      "title": "Task 56"
+    },
+    {
+      "id": "65b2b74cb90a3d3b5d1acc48",
+      "title": "Task 57"
+    },
+    {
+      "id": "65b2b80774ecba3c156722aa",
+      "title": "Task 58"
+    },
+    {
+      "id": "65b2ba3323d6d33d470e5f53",
+      "title": "Task 59"
+    },
+    {
+      "id": "65b2bb073ac8d03dfe507810",
+      "title": "Task 60"
+    },
+    {
+      "id": "65b2bd42ca24dd3ede91aa41",
+      "title": "Task 61"
     }
   ],
   "helpCategory": "English"

--- a/curriculum/challenges/_meta/learn-how-to-help-a-coworker-troubleshoot-on-github/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-help-a-coworker-troubleshoot-on-github/meta.json
@@ -144,6 +144,42 @@
     {
       "id": "656bd968e52c34220164de8d",
       "title": "Task 32"
+    },
+    {
+      "id": "65a84bec88772eaff6e56679",
+      "title": "Task 33"
+    },
+    {
+      "id": "65a84dad1595bbbc2e9cd895",
+      "title": "Task 34"
+    },
+    {
+      "id": "65a84e922382a7bd112057ad",
+      "title": "Task 35"
+    },
+    {
+      "id": "65a84f2370686dbda3e53aff",
+      "title": "Task 36"
+    },
+    {
+      "id": "65a85090914872be8ca97793",
+      "title": "Task 37"
+    },
+    {
+      "id": "65a851a6389e6cbf2c2cf158",
+      "title": "Task 38"
+    },
+    {
+      "id": "65a853b498eb87c035f6da13",
+      "title": "Task 39"
+    },
+    {
+      "id": "65a85418ea38cdc0a334dab2",
+      "title": "Task 40"
+    },
+    {
+      "id": "65a9457392dfd7d564bc940e",
+      "title": "Task 41"
     }
   ],
   "helpCategory": "English"

--- a/curriculum/challenges/_meta/learn-how-to-help-a-coworker-troubleshoot-on-github/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-help-a-coworker-troubleshoot-on-github/meta.json
@@ -11,7 +11,7 @@
   "challengeOrder": [
     {
       "id": "655c131291cbcb8febf21e64",
-      "title": "Dialogue: Placeholder"
+      "title": "Dialogue 1: Discussing issues on GitHub"
     },
     {
       "id": "656b732c8110ff8936f016de",

--- a/curriculum/challenges/_meta/learn-how-to-help-a-coworker-troubleshoot-on-github/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-help-a-coworker-troubleshoot-on-github/meta.json
@@ -124,6 +124,26 @@
     {
       "id": "656bcaea19405d1c6f2accb9",
       "title": "Task 28"
+    },
+    {
+      "id": "656bd6dde3a62c205cb41b2d",
+      "title": "Dialogue 2: Talking About Pull Request"
+    },
+    {
+      "id": "656bd701970c6c20a9c89b0f",
+      "title": "Task 29"
+    },
+    {
+      "id": "656bd7723e1e4c21039f5916",
+      "title": "Task 30"
+    },
+    {
+      "id": "656bd80d58dd31216af64ddf",
+      "title": "Task 31"
+    },
+    {
+      "id": "656bd968e52c34220164de8d",
+      "title": "Task 32"
     }
   ],
   "helpCategory": "English"

--- a/curriculum/challenges/_meta/learn-how-to-help-a-coworker-troubleshoot-on-github/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-help-a-coworker-troubleshoot-on-github/meta.json
@@ -88,6 +88,42 @@
     {
       "id": "656bc15142eeeb15e31d258b",
       "title": "Task 19"
+    },
+    {
+      "id": "656bc3bd0a323317d4117a49",
+      "title": "Task 20"
+    },
+    {
+      "id": "656bc4c430704c19121c5eb4",
+      "title": "Task 21"
+    },
+    {
+      "id": "656bc54c7a049d197017b9c7",
+      "title": "Task 22"
+    },
+    {
+      "id": "656bc5a71b33ae19ad65166a",
+      "title": "Task 23"
+    },
+    {
+      "id": "656bc669dbd6561a22060cf0",
+      "title": "Task 24"
+    },
+    {
+      "id": "656bc75be35fb11a7c27a788",
+      "title": "Task 25"
+    },
+    {
+      "id": "656bc7f08edd541afdd87231",
+      "title": "Task 26"
+    },
+    {
+      "id": "656bc8f4928b351b8a6c4d53",
+      "title": "Task 27"
+    },
+    {
+      "id": "656bcaea19405d1c6f2accb9",
+      "title": "Task 28"
     }
   ],
   "helpCategory": "English"

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/655c131291cbcb8febf21e64.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/655c131291cbcb8febf21e64.md
@@ -1,9 +1,9 @@
 ---
 id: 655c131291cbcb8febf21e64
-title: "Dialogue 1: Discussing issues on GitHub"
+title: "Dialogue 1: Discussing Issues on GitHub"
 challengeType: 21
 videoId: nLDychdBwUg
-dashedName: dialogue-discussing-issues-on-github
+dashedName: dialogue-1-discussing-issues-on-github
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/655c131291cbcb8febf21e64.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/655c131291cbcb8febf21e64.md
@@ -1,9 +1,9 @@
 ---
 id: 655c131291cbcb8febf21e64
-title: "Dialogue: Placeholder"
+title: "Dialogue 1: Discussing issues on GitHub"
 challengeType: 21
 videoId: nLDychdBwUg
-dashedName: dialogue-placeholder
+dashedName: dialogue-discussing-issues-on-github
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656b732c8110ff8936f016de.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656b732c8110ff8936f016de.md
@@ -1,0 +1,40 @@
+---
+id: 656b732c8110ff8936f016de
+title: Task 1
+challengeType: 22
+dashedName: task-1
+audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
+
+---
+<!--
+AUDIO REFERENCE: 
+Bob: Hey, Sarah. I was checking the _ we worked on yesterday when I saw a problem.
+-->
+
+# --description--
+
+In software development, a `branch` is like a separate line of development. Think of it as a way to work on different versions of a project at the same time. 
+
+For instance, one `branch` can be for new features, while another is for fixing bugs. 
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`Hey, Sarah. I was checking the _ we worked on _ when I saw a problem.`
+
+## --blanks--
+
+`branch`
+
+### --feedback--
+
+A version of the project where specific changes are made.
+
+---
+
+`yesterday`
+
+### --feedback--
+
+The day before today.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656b74ab2a075f8a05c66f41.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656b74ab2a075f8a05c66f41.md
@@ -1,0 +1,32 @@
+---
+id: 656b74ab2a075f8a05c66f41
+title: Task 2
+challengeType: 22
+dashedName: task-2
+audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
+---
+
+<!--
+AUDIO REFERENCE: 
+Bob: Hey, Sarah. I was checking the branch we worked on yesterday when I saw a problem. I think we should _ an issue on GitHub.
+-->
+
+# --description--
+
+In the context of software development, to `open an issue` on platforms like GitHub means to create a report about a problem or a request for enhancement in a project. 
+
+It's like telling the team, "Here's something we need to look at or fix."
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`I think we should _ an issue on GitHub.`
+
+## --blanks--
+
+`open`
+
+### --feedback--
+
+To `open an issue` means to start a report or discussion about a specific problem.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656b757d8294618a5eefd710.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656b757d8294618a5eefd710.md
@@ -1,0 +1,30 @@
+---
+id: 656b757d8294618a5eefd710
+title: Task 3
+challengeType: 22
+dashedName: task-3
+audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
+---
+
+<!--
+AUDIO REFERENCE: 
+Bob: Hey, Sarah. I was checking the branch we worked on yesterday when I saw a problem. I think we should open an _ on GitHub.
+-->
+
+# --description--
+
+An `issue` on platforms like GitHub is a way to track tasks, enhancements, or bugs in a project. It's used to discuss and manage specific problems or ideas. For example, if there's a bug in the software, you can open an `issue` to describe and discuss how to fix it.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`I think we should open an _ on GitHub.`
+
+## --blanks--
+
+`issue`
+
+### --feedback--
+
+Refers to a report or discussion point in a project, such as a bug or a new feature idea.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bbba66c53330f4316fd9f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bbba66c53330f4316fd9f.md
@@ -1,0 +1,31 @@
+---
+id: 656bbba66c53330f4316fd9f
+title: Task 4
+challengeType: 22
+dashedName: task-4
+---
+
+<!--
+AUDIO REFERENCE: 
+Bob: Hey, Sarah. I was checking the branch we worked on yesterday when I saw a problem. I think we should open an issue on GitHub.
+-->
+
+# --description--
+
+`GitHub` is a web-based platform used for version control and collaboration in software development. It allows multiple people to work on a project at the same time, track changes, and discuss issues. 
+
+For example, developers use GitHub to manage code changes and collaborate on projects.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`I think we should open an issue on _.`
+
+## --blanks--
+
+`GitHub`
+
+### --feedback--
+
+`GitHub` is the platform where developers track and collaborate on software projects.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bbbe6d57609104b152625.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bbbe6d57609104b152625.md
@@ -1,0 +1,58 @@
+---
+id: 656bbbe6d57609104b152625
+title: Task 5
+challengeType: 19
+dashedName: task-5
+audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
+---
+
+<!--
+AUDIO REFERENCE: 
+Bob: Hey, Sarah. I was checking the branch we worked on yesterday when I saw a problem. I think we should open an issue on GitHub.
+-->
+
+# --description--
+
+Bob's statement uses the past continuous tense `I was checking` to describe an action that was ongoing in the past. 
+
+You can create sentences in the past continuous by combining the ver to be in the past `was` or `were` + `verb + ing`.
+
+He also uses the modal verb `should` to suggest a course of action.
+
+# --question--
+
+## --text--
+
+What does Bob want to communicate in his sentence?
+
+## --answers--
+
+`He was continuously working on the issue and is certain they must open an issue`
+
+### --feedback--
+
+Bob was checking the branch, not continuously working on the issue, and `should` is used for suggestions.
+
+---
+
+`He was in the process of checking the branch and thinks opening an issue is a good idea`
+
+---
+
+`He finished checking the branch and is not sure about opening an issue`
+
+### --feedback--
+
+Bob was still in the process of checking and he suggests opening an issue with `should`.
+
+---
+
+`He started checking the branch and doesn't think it's necessary to open an issue`
+
+### --feedback--
+
+Bob was already checking the branch and actually suggests opening an issue.
+
+## --video-solution--
+
+2

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bbbe6d57609104b152625.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bbbe6d57609104b152625.md
@@ -27,7 +27,7 @@ What does Bob want to communicate in his sentence?
 
 ## --answers--
 
-`He was continuously working on the issue and is certain they must open an issue`
+He was continuously working on the issue and is certain they must open an issue
 
 ### --feedback--
 
@@ -35,11 +35,11 @@ Bob was checking the branch, not continuously working on the issue, and `should`
 
 ---
 
-`He was in the process of checking the branch and thinks opening an issue is a good idea`
+He was in the process of checking the branch and thinks opening an issue is a good idea
 
 ---
 
-`He finished checking the branch and is not sure about opening an issue`
+He finished checking the branch and is not sure about opening an issue
 
 ### --feedback--
 
@@ -47,7 +47,7 @@ Bob was still in the process of checking and he suggests opening an issue with `
 
 ---
 
-`He started checking the branch and doesn't think it's necessary to open an issue`
+He started checking the branch and doesn't think it's necessary to open an issue
 
 ### --feedback--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bbcc8333087117b4d9153.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bbcc8333087117b4d9153.md
@@ -23,11 +23,11 @@ What problem is Bob facing with the code?
 
 ## --answers--
 
-`The code won't compile and shows strange errors`
+The code won't compile and shows strange errors
 
 ---
 
-`The code is compiling without any errors`
+The code is compiling without any errors
 
 ### --feedback--
 
@@ -35,7 +35,7 @@ Bob actually says the code won't compile and there are errors.
 
 ---
 
-`He can't push changes to the repository`
+He can't push changes to the repository
 
 ### --feedback--
 
@@ -43,11 +43,11 @@ Bob managed to push changes, but the issue is with compiling the code.
 
 ---
 
-`The repository is not accepting any new changes`
+The repository is not accepting any new changes
 
 ### --feedback--
 
-Bob successfully pushed changes, but the issue arose afterward with the code compilation.
+Bob successfully pushed changes, the issue happened during the code compilation.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bbcc8333087117b4d9153.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bbcc8333087117b4d9153.md
@@ -1,0 +1,54 @@
+---
+id: 656bbcc8333087117b4d9153
+title: Task 6
+challengeType: 19
+dashedName: task-6
+audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
+---
+
+<!--
+AUDIO REFERENCE: 
+Bob: I pushed some changes to the repository earlier, but now the code won't compile. It's showing some strange errors.
+-->
+
+# --description--
+
+Bob talks about a technical issue. He mentions pushing changes to a repository, which means he uploaded new code. However, he's facing a problem.
+
+# --question--
+
+## --text--
+
+What problem is Bob facing with the code?
+
+## --answers--
+
+`The code won't compile and shows strange errors`
+
+---
+
+`The code is compiling without any errors`
+
+### --feedback--
+
+Bob actually says the code won't compile and there are errors.
+
+---
+
+`He can't push changes to the repository`
+
+### --feedback--
+
+Bob managed to push changes, but the issue is with compiling the code.
+
+---
+
+`The repository is not accepting any new changes`
+
+### --feedback--
+
+Bob successfully pushed changes, but the issue arose afterward with the code compilation.
+
+## --video-solution--
+
+1

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bbd3dea715a11ce02b670.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bbd3dea715a11ce02b670.md
@@ -1,0 +1,52 @@
+---
+id: 656bbd3dea715a11ce02b670
+title: Task 7
+challengeType: 19
+dashedName: task-7
+---
+
+# --description--
+
+In coding, especially when using version control systems like Git, `push` means to upload changes from a local repository to a remote one. 
+
+The past tense `pushed` indicates that this action has already been completed. 
+
+For example, `He pushed his code to the GitHub repository` means he uploaded his recent code changes to GitHub.
+
+# --question--
+
+## --text--
+
+What does `push` mean in the context of version control?
+
+## --answers--
+
+`To download changes from a remote repository`
+
+### --feedback--
+
+`Push` actually means to upload changes to a remote repository, not download.
+
+---
+
+`To delete changes from a repository`
+
+### --feedback--
+
+`Push` is not bout deleting changes from a repository.
+
+---
+
+`To review changes in a repository`
+
+### --feedback--
+
+`push` is not about reviewing changes in a repository.
+
+---
+`To upload changes to a remote repository`
+
+
+## --video-solution--
+
+4

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bbd3dea715a11ce02b670.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bbd3dea715a11ce02b670.md
@@ -7,7 +7,7 @@ dashedName: task-7
 
 # --description--
 
-In coding, especially when using version control systems like Git, `push` means to upload changes from a local repository to a remote one. 
+In coding, especially when using version control systems like `Git`, `push` means to upload changes from a local repository to a remote one. 
 
 The past tense `pushed` indicates that this action has already been completed. 
 
@@ -21,7 +21,7 @@ What does `push` mean in the context of version control?
 
 ## --answers--
 
-`To download changes from a remote repository`
+To download changes from a remote repository
 
 ### --feedback--
 
@@ -29,7 +29,7 @@ What does `push` mean in the context of version control?
 
 ---
 
-`To delete changes from a repository`
+To delete changes from a repository
 
 ### --feedback--
 
@@ -37,14 +37,14 @@ What does `push` mean in the context of version control?
 
 ---
 
-`To review changes in a repository`
+To review changes in a repository
 
 ### --feedback--
 
 `push` is not about reviewing changes in a repository.
 
 ---
-`To upload changes to a remote repository`
+To upload changes to a remote repository
 
 
 ## --video-solution--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bbded100497126ccc6e5d.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bbded100497126ccc6e5d.md
@@ -1,0 +1,52 @@
+---
+id: 656bbded100497126ccc6e5d
+title: Task 8
+challengeType: 19
+dashedName: task-8
+---
+
+# --description--
+
+In software development, a `repository` is a central location where data, often related to software or programming, is stored and managed. 
+
+It's like a database for your code, allowing for version control and collaboration. 
+
+For instance, `The team uses a GitHub repository to store all their project files.`
+
+# --question--
+
+## --text--
+
+What is a `repository` in the context of software development?
+
+## --answers--
+
+`A tool for editing code`
+
+### --feedback--
+
+A repository is not for editing code.
+
+---
+
+`A place to store and manage project files`
+
+---
+
+`A type of software bug`
+
+### --feedback--
+
+A repository is not a software bug.
+
+---
+
+`An online meeting space for programmers`
+
+### --feedback--
+
+A repository is not a meeting space.
+
+## --video-solution--
+
+2

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bbded100497126ccc6e5d.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bbded100497126ccc6e5d.md
@@ -7,11 +7,9 @@ dashedName: task-8
 
 # --description--
 
-In software development, a `repository` is a central location where data, often related to software or programming, is stored and managed. 
+A `repository` is a central location where data, often related to software or programming, is stored and managed. 
 
-It's like a database for your code, allowing for version control and collaboration. 
-
-For instance, `The team uses a GitHub repository to store all their project files.`
+It's like a database for your code, allowing for version control and collaboration. For instance, `The team uses a GitHub repository to store all their project files.`
 
 # --question--
 
@@ -20,20 +18,17 @@ For instance, `The team uses a GitHub repository to store all their project file
 What is a `repository` in the context of software development?
 
 ## --answers--
-
-`A tool for editing code`
+A tool for editing code
 
 ### --feedback--
 
 A repository is not for editing code.
 
 ---
-
-`A place to store and manage project files`
+A place to store and manage project files
 
 ---
-
-`A type of software bug`
+A type of software bug
 
 ### --feedback--
 
@@ -41,7 +36,7 @@ A repository is not a software bug.
 
 ---
 
-`An online meeting space for programmers`
+An online meeting space for programmers
 
 ### --feedback--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bbe4c45fc9512d58ba0e2.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bbe4c45fc9512d58ba0e2.md
@@ -19,31 +19,31 @@ What does `earlier` indicate in a sentence?
 
 ## --answers--
 
-`A future event`
+A future event
 
 ### --feedback--
 
-`Earlier` refers to a past time, not something in the future.
+`Earlier` doesn't refer to something in the future.
 
 ---
 
-`The present moment`
+The present moment
 
 ### --feedback--
 
-`Earlier` means a time before the present, not the current moment.
+`Earlier` doesn't refer to the current moment.
 
 ---
 
-`A past time compared to now`
+A past time compared to now
 
 ---
 
-`A scheduled plan`
+A scheduled plan
 
 ### --feedback--
 
-`Earlier` indicates a past time, not a planned future event.
+`Earlier` doesn't refer to a planned future event.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bbe4c45fc9512d58ba0e2.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bbe4c45fc9512d58ba0e2.md
@@ -1,0 +1,50 @@
+---
+id: 656bbe4c45fc9512d58ba0e2
+title: Task 9
+challengeType: 19
+dashedName: task-9
+---
+
+# --description--
+
+The word `earlier` is used to talk about a time before the current moment or the time being discussed. It's like saying `before now` or `some time ago`.
+
+For example, `If you finished your work earlier, you can relax now` means if you completed your work some time ago, you have time to relax now.
+
+# --question--
+
+## --text--
+
+What does `earlier` indicate in a sentence?
+
+## --answers--
+
+`A future event`
+
+### --feedback--
+
+`Earlier` refers to a past time, not something in the future.
+
+---
+
+`The present moment`
+
+### --feedback--
+
+`Earlier` means a time before the present, not the current moment.
+
+---
+
+`A past time compared to now`
+
+---
+
+`A scheduled plan`
+
+### --feedback--
+
+`Earlier` indicates a past time, not a planned future event.
+
+## --video-solution--
+
+3

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bbeb152c95913465476e3.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bbeb152c95913465476e3.md
@@ -21,7 +21,7 @@ What does `compile` mean in the context of programming?
 
 ## --answers--
 
-`To write and edit code`
+To write and edit code
 
 ### --feedback--
 
@@ -29,7 +29,7 @@ What does `compile` mean in the context of programming?
 
 ---
 
-`To test code for errors`
+To test code for errors
 
 ### --feedback--
 
@@ -37,7 +37,7 @@ What does `compile` mean in the context of programming?
 
 ---
 
-`To upload code to a repository`
+To upload code to a repository
 
 ### --feedback--
 
@@ -45,7 +45,7 @@ That's not it.
 
 ---
 
-`To transform code into a form computers understand`
+To transform code into a form computers understand
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bbeb152c95913465476e3.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bbeb152c95913465476e3.md
@@ -1,0 +1,52 @@
+---
+id: 656bbeb152c95913465476e3
+title: Task 10
+challengeType: 19
+dashedName: task-10
+---
+
+# --description--
+
+`Compile` in programming means changing code that people write into a form that computers can understand and use. 
+
+It's like turning a recipe written in one language into another language so that someone else can cook the meal. 
+
+For example, `When we compile Java code, it changes into a form that the computer can run.`
+
+# --question--
+
+## --text--
+
+What does `compile` mean in the context of programming?
+
+## --answers--
+
+`To write and edit code`
+
+### --feedback--
+
+`Compile` specifically refers to converting code into an executable format, not writing or editing it.
+
+---
+
+`To test code for errors`
+
+### --feedback--
+
+`Compile` refers to the process of converting code into an executable form.
+
+---
+
+`To upload code to a repository`
+
+### --feedback--
+
+That's not it.
+
+---
+
+`To transform code into a form computers understand`
+
+## --video-solution--
+
+4

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bbf3a1b344e13bc7fa12c.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bbf3a1b344e13bc7fa12c.md
@@ -6,11 +6,13 @@ dashedName: task-11
 ---
 # --description--
 
-`Strange` means unusual or not expected. It's like finding something different from what you normally see. For example, `A strange sound in a car might mean a problem.` 
+`Strange` means unusual or not expected. It's like finding something different from what you normally see. For example:
 
-An `error` is a mistake, especially one that stops something from working correctly. 
+`A strange sound in a car might mean a problem.` 
 
-For instance, `An error in a code means there is a mistake that needs fixing.`
+An `error` is a mistake, especially one that stops something from working correctly. For instance:
+
+`An error in a code means there is a mistake that needs fixing.`
 
 # --question--
 
@@ -20,11 +22,11 @@ What do `strange` and `error` imply in programming?
 
 ## --answers--
 
-`Something unusual and a mistake in the code`
+Something unusual and a mistake in the code
 
 ---
 
-`A new feature and a successful result`
+A new feature and a successful result
 
 ### --feedback--
 
@@ -32,7 +34,7 @@ What do `strange` and `error` imply in programming?
 
 ---
 
-`An easy task and a correct outcome`
+An easy task and a correct outcome
 
 ### --feedback--
 
@@ -40,7 +42,7 @@ What do `strange` and `error` imply in programming?
 
 ---
 
-`A regular process and an accurate calculation`
+A regular process and an accurate calculation
 
 ### --feedback--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bbf3a1b344e13bc7fa12c.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bbf3a1b344e13bc7fa12c.md
@@ -1,0 +1,51 @@
+---
+id: 656bbf3a1b344e13bc7fa12c
+title: Task 11
+challengeType: 19
+dashedName: task-11
+---
+# --description--
+
+`Strange` means unusual or not expected. It's like finding something different from what you normally see. For example, `A strange sound in a car might mean a problem.` 
+
+An `error` is a mistake, especially one that stops something from working correctly. 
+
+For instance, `An error in a code means there is a mistake that needs fixing.`
+
+# --question--
+
+## --text--
+
+What do `strange` and `error` imply in programming?
+
+## --answers--
+
+`Something unusual and a mistake in the code`
+
+---
+
+`A new feature and a successful result`
+
+### --feedback--
+
+`Strange` suggests something unexpected, and an `error` indicates a problem, not success.
+
+---
+
+`An easy task and a correct outcome`
+
+### --feedback--
+
+`Strange` points to something unusual, and an `error` means there's a mistake, not an easy task or correct outcome.
+
+---
+
+`A regular process and an accurate calculation`
+
+### --feedback--
+
+`Strange` means unusual, not regular, and an `error` in code implies a mistake, not accuracy.
+
+## --video-solution--
+
+1

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bbfaf6cbc3f1418acca3c.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bbfaf6cbc3f1418acca3c.md
@@ -13,7 +13,7 @@ Sarah: "Sure, Bob. What’s the problem?"
 
 # --description--
 
-Let's practice!
+Listen to the audio and complete the sentence.
 
 # --fillInTheBlank--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bbfaf6cbc3f1418acca3c.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bbfaf6cbc3f1418acca3c.md
@@ -1,0 +1,30 @@
+---
+id: 656bbfaf6cbc3f1418acca3c
+title: Task 12
+challengeType: 22
+dashedName: task-12
+audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
+---
+
+<!--
+AUDIO REFERENCE: 
+Sarah: "Sure, Bob. What’s the problem?"
+-->
+
+# --description--
+
+Let's practice!
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`Sure, Bob. _ the problem?`
+
+## --blanks--
+
+`What's`
+
+### --feedback--
+
+`What`and `is` are in abbreviated form. Remember to Capitalize `What`.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bbfaf6cbc3f1418acca3c.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bbfaf6cbc3f1418acca3c.md
@@ -27,4 +27,4 @@ Listen to the audio and complete the sentence.
 
 ### --feedback--
 
-`What`and `is` are in abbreviated form. Remember to Capitalize `What`.
+`What`and `is` are in abbreviated form. Remember to capitalize `What`.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bbfedb30479145d464e37.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bbfedb30479145d464e37.md
@@ -1,0 +1,38 @@
+---
+id: 656bbfedb30479145d464e37
+title: Task 13
+challengeType: 22
+dashedName: task-13
+audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
+---
+
+<!--
+AUDIO REFERENCE: 
+Bob: "I pushed some changes to the repository earlier, but now the code won't compile."
+-->
+
+# --description--
+
+Let's practice! 
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`I _ some changes to the _ earlier, but now the code won't compile.`
+
+## --blanks--
+
+`pushed`
+
+### --feedback--
+
+Means Bob uploaded changes to the repository.
+
+---
+
+`repository`
+
+### --feedback--
+
+Where Bob's code changes are stored and managed.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bbfedb30479145d464e37.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bbfedb30479145d464e37.md
@@ -27,7 +27,7 @@ Listen to the audio and complete the sentence.
 
 ### --feedback--
 
-Means Bob uploaded changes to the repository.
+Means Bob uploaded changes to the repository. This verb is in the past tense.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bbfedb30479145d464e37.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bbfedb30479145d464e37.md
@@ -13,7 +13,7 @@ Bob: "I pushed some changes to the repository earlier, but now the code won't co
 
 # --description--
 
-Let's practice! 
+Listen to the audio and complete the sentence.
 
 # --fillInTheBlank--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc028a62f3a149ed36971.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc028a62f3a149ed36971.md
@@ -27,7 +27,7 @@ Listen to the audio and complete the sentence.
 
 ### --feedback--
 
-Indicates that Bob pushed the changes at a time before now.
+Indicates that Bob pushed the changes at a time before now. 
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc028a62f3a149ed36971.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc028a62f3a149ed36971.md
@@ -1,0 +1,38 @@
+---
+id: 656bc028a62f3a149ed36971
+title: Task 14
+challengeType: 22
+dashedName: task-14
+audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
+---
+
+<!--
+AUDIO REFERENCE: 
+Bob: "I pushed some changes to the repository earlier, but now the code won't compile. It's showing some strange error.”
+-->
+
+# --description--
+
+Let's practice!
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`I pushed some changes to the repository _, but now the code won't compile. It's showing some strange _.`
+
+## --blanks--
+
+`earlier`
+
+### --feedback--
+
+Indicates that Bob pushed the changes at a time before now.
+
+---
+
+`errors`
+
+### --feedback--
+
+Refer to the problems Bob is now seeing in the code. It is in plural form.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc028a62f3a149ed36971.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc028a62f3a149ed36971.md
@@ -13,7 +13,7 @@ Bob: "I pushed some changes to the repository earlier, but now the code won't co
 
 # --description--
 
-Let's practice!
+Listen to the audio and complete the sentence.
 
 # --fillInTheBlank--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc05be141d914dcc812c3.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc05be141d914dcc812c3.md
@@ -1,0 +1,38 @@
+---
+id: 656bc05be141d914dcc812c3
+title: Task 15
+challengeType: 22
+dashedName: task-15
+audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
+---
+
+<!--
+AUDIO REFERENCE: 
+Bob: "I pushed some _ to the repository earlier, but now the code won't compile. It's showing some _ errors."
+-->
+
+# --description--
+
+Let's practice!
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`I pushed some _ to the repository earlier, but now the code won't compile. It's showing some _ errors.`
+
+## --blanks--
+
+`changes`
+
+### --feedback--
+
+Refers to the modifications Bob made to the code.
+
+---
+
+`strange`
+
+### --feedback--
+
+Describes the errors as unusual or not typical.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc05be141d914dcc812c3.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc05be141d914dcc812c3.md
@@ -13,7 +13,7 @@ Bob: "I pushed some _ to the repository earlier, but now the code won't compile.
 
 # --description--
 
-Let's practice!
+Listen to the audio and complete the sentence.
 
 # --fillInTheBlank--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc05be141d914dcc812c3.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc05be141d914dcc812c3.md
@@ -27,7 +27,7 @@ Listen to the audio and complete the sentence.
 
 ### --feedback--
 
-Refers to the modifications Bob made to the code.
+Refers to the modifications Bob made to the code. It is in its plural form.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc094df5acf151fb264d8.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc094df5acf151fb264d8.md
@@ -13,7 +13,7 @@ Sarah: "I see. Let's open an _, then. What happened when you _ the changes?"
 
 # --description--
 
-Practice time!
+Listen to the audio and complete the sentence.
 
 # --fillInTheBlank--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc094df5acf151fb264d8.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc094df5acf151fb264d8.md
@@ -35,4 +35,4 @@ Used for reporting or discussing problems in the project.
 
 ### --feedback--
 
-It means uploaded changes to the repository.
+It means uploaded changes to the repository. It is conjugated in the past tense.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc094df5acf151fb264d8.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc094df5acf151fb264d8.md
@@ -1,0 +1,38 @@
+---
+id: 656bc094df5acf151fb264d8
+title: Task 16
+challengeType: 22
+dashedName: task-16
+audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
+---
+
+<!--
+AUDIO REFERENCE: 
+Sarah: "I see. Let's open an _, then. What happened when you _ the changes?"
+-->
+
+# --description--
+
+Practice time!
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`I see. Let's open an _, then. What happened when you _ the changes?`
+
+## --blanks--
+
+`issue`
+
+### --feedback--
+
+Used for reporting or discussing problems in the project.
+
+---
+
+`pushed`
+
+### --feedback--
+
+It means uploaded changes to the repository.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc0bd4a112e155c589e33.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc0bd4a112e155c589e33.md
@@ -13,7 +13,7 @@ Sarah: "I see. Let's open an issue, then."
 
 # --description--
 
-Sarah's response to Bob includes a specific phrase that shows she understands the problem he's facing. 
+Sarah's answer to Bob includes a specific phrase that shows she understands the problem he's facing. 
 
 # --question--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc0bd4a112e155c589e33.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc0bd4a112e155c589e33.md
@@ -1,0 +1,54 @@
+---
+id: 656bc0bd4a112e155c589e33
+title: Task 17
+challengeType: 19
+dashedName: task-17
+audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
+---
+
+<!--
+AUDIO REFERENCE: 
+Sarah: "I see. Let's open an issue, then."
+-->
+
+# --description--
+
+Sarah's response to Bob includes a specific phrase that shows she understands the problem he's facing. 
+
+# --question--
+
+## --text--
+
+Which part of Sarah's sentence shows that she understands the problem?
+
+## --answers--
+
+`I see`
+
+---
+
+`Let's open an issue`
+
+### --feedback--
+
+While this part suggests a solution, this is not the part that directly indicates understanding.
+
+---
+
+`Then`
+
+### --feedback--
+
+The word `then` is part of suggesting a solution, but it doesn't directly show understanding.
+
+---
+
+`An issue`
+
+### --feedback--
+
+The term `an issue` relates to the solution, not to the expression of understanding the problem.
+
+## --video-solution--
+
+1

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc0f87049dc159ce63187.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc0f87049dc159ce63187.md
@@ -1,0 +1,54 @@
+---
+id: 656bc0f87049dc159ce63187
+title: Task 18
+challengeType: 19
+dashedName: task-18
+audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
+---
+
+<!--
+AUDIO REFERENCE: 
+Sarah: "I see. Let's open an issue, then."
+-->
+
+# --description--
+
+Sarah responds to Bob's report of a problem in the code with a suggestion.
+
+# --question--
+
+## --text--
+
+What is Sarah's immediate suggestion after understanding the problem?
+
+## --answers--
+
+`To review the code again`
+
+### --feedback--
+
+Sarah directly suggests opening an issue, not reviewing the code.
+
+---
+
+`To ignore the problem for now`
+
+### --feedback--
+
+Sarah's response is about taking action, not ignoring the problem.
+
+---
+
+`To fix the errors immediately`
+
+### --feedback--
+
+Hher immediate suggestion is not to fix the errors right away.
+
+---
+
+`To open an issue for the problem`
+
+## --video-solution--
+
+4

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc0f87049dc159ce63187.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc0f87049dc159ce63187.md
@@ -23,7 +23,7 @@ What is Sarah's immediate suggestion after understanding the problem?
 
 ## --answers--
 
-`To review the code again`
+To review the code again
 
 ### --feedback--
 
@@ -31,7 +31,7 @@ Sarah directly suggests opening an issue, not reviewing the code.
 
 ---
 
-`To ignore the problem for now`
+To ignore the problem for now
 
 ### --feedback--
 
@@ -39,7 +39,7 @@ Sarah's response is about taking action, not ignoring the problem.
 
 ---
 
-`To fix the errors immediately`
+To fix the errors immediately
 
 ### --feedback--
 
@@ -47,7 +47,7 @@ Hher immediate suggestion is not to fix the errors right away.
 
 ---
 
-`To open an issue for the problem`
+To open an issue for the problem
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc15142eeeb15e31d258b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc15142eeeb15e31d258b.md
@@ -1,0 +1,54 @@
+---
+id: 656bc15142eeeb15e31d258b
+title: Task 19
+challengeType: 19
+dashedName: task-19
+audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
+---
+
+<!--
+AUDIO REFERENCE: 
+Sarah: "What happened when you pushed the changes?"
+-->
+
+# --description--
+
+Sarah is asking Bob for more information about the events that occurred after he uploaded changes to the repository. 
+
+# --question--
+
+## --text--
+
+What is Sarah asking Bob about the code?
+
+## --answers--
+
+`Why he pushed the changes`
+
+### --feedback--
+
+Sarah's question is not about why Bob pushed the changes.
+
+---
+
+`How he pushed the changes`
+
+### --feedback--
+
+She's not interested in how he did it.
+
+---
+
+`What occurred after the changes were pushed`
+
+---
+
+`Where he pushed the changes`
+
+### --feedback--
+
+Sarah's not focused on the location of the push.
+
+## --video-solution--
+
+3

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc15142eeeb15e31d258b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc15142eeeb15e31d258b.md
@@ -13,7 +13,7 @@ Sarah: "What happened when you pushed the changes?"
 
 # --description--
 
-Sarah is asking Bob for more information about the events that occurred after he uploaded changes to the repository. 
+Listen to the audio and answer the question. 
 
 # --question--
 
@@ -23,7 +23,7 @@ What is Sarah asking Bob about the code?
 
 ## --answers--
 
-`Why he pushed the changes`
+Why he pushed the changes
 
 ### --feedback--
 
@@ -31,7 +31,7 @@ Sarah's question is not about why Bob pushed the changes.
 
 ---
 
-`How he pushed the changes`
+How he pushed the changes
 
 ### --feedback--
 
@@ -39,11 +39,11 @@ She's not interested in how he did it.
 
 ---
 
-`What happened after the changes were pushed`
+What happened after the changes were pushed
 
 ---
 
-`Where he pushed the changes`
+Where he pushed the changes
 
 ### --feedback--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc15142eeeb15e31d258b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc15142eeeb15e31d258b.md
@@ -39,7 +39,7 @@ She's not interested in how he did it.
 
 ---
 
-`What occurred after the changes were pushed`
+`What happened after the changes were pushed`
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc3bd0a323317d4117a49.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc3bd0a323317d4117a49.md
@@ -1,0 +1,54 @@
+---
+id: 656bc3bd0a323317d4117a49
+title: Task 20
+challengeType: 19
+dashedName: task-20
+---
+
+# --description--
+
+The past continuous tense is used to talk about actions that were ongoing in the past. 
+
+It is formed using `was` (`I, he, she, it`) or `were` (`you, we, they`) followed by a verb ending in `-ing`. 
+
+For example, `I was working` means the work was happening over a period of time in the past. 
+
+It's often used when an action is interrupted by another, as in `I was reading when the phone rang.`
+
+# --question--
+
+## --text--
+
+How is the past continuous tense formed and used?
+
+## --answers--
+
+`By using "was" or "were" with the base form of a verb`
+
+### --feedback--
+
+The past continuous requires `-ing` at the end of the verb, not just the base form.
+
+---
+
+`By using "was" or "were" with a verb ending in "ing"`
+
+---
+
+`By using "have" or "has" with a verb ending in "ed"`
+
+### --feedback--
+
+That's the form for present perfect, not past continuous.
+
+---
+
+`By using "did" with the base form of a verb`
+
+### --feedback--
+
+That's the form for simple past, not past continuous.
+
+## --video-solution--
+
+2

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc3bd0a323317d4117a49.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc3bd0a323317d4117a49.md
@@ -9,45 +9,45 @@ dashedName: task-20
 
 The past continuous tense is used to talk about actions that were ongoing in the past. 
 
-It is formed using `was` (`I, he, she, it`) or `were` (`you, we, they`) followed by a verb ending in `-ing`. 
+It is formed using `was`  for the pronouns `I, he, she, it`), or `were` for the pronouns `you, we, they` followed by a verb ending in `-ing`. For example:
 
-For example, `I was working` means the work was happening over a period of time in the past. 
+`I was reading` means the work was happening over a period of time in the past. 
 
-It's often used when an action is interrupted by another, as in `I was reading when the phone rang.`
+PAst continuous is often used when an action is interrupted by another, as in `I was reading when the phone rang.` The reading was interupted by the phone ringing.
 
 # --question--
 
 ## --text--
 
-How is the past continuous tense formed and used?
+Which of the following sentences correctly uses the past continuous tense?
 
 ## --answers--
 
-`By using "was" or "were" with the base form of a verb`
+`She was cook dinner when her friend called.`
 
 ### --feedback--
 
-The past continuous requires `-ing` at the end of the verb, not just the base form.
+Remember, the verb should be in its `-ing` form. The correct form should be `was cooking`.
 
 ---
 
-`By using "was" or "were" with a verb ending in "ing"`
+`They were watching a movie last night.`
 
 ---
 
-`By using "have" or "has" with a verb ending in "ed"`
+`He were studying for the exam when it started to rain.`
 
 ### --feedback--
 
-That's the form for present perfect, not past continuous.
+The correct form is `was studying` for the singular pronoun `he`.
 
 ---
 
-`By using "did" with the base form of a verb`
+`I was play the piano when the lights went out.`
 
 ### --feedback--
 
-That's the form for simple past, not past continuous.
+The verb should be in its `-ing` form. The correct sentence is `I was playing the piano when the lights went out.`
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc3bd0a323317d4117a49.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc3bd0a323317d4117a49.md
@@ -13,7 +13,7 @@ It is formed using `was`  for the pronouns `I, he, she, it`), or `were` for the 
 
 `I was reading` means the work was happening over a period of time in the past. 
 
-PAst continuous is often used when an action is interrupted by another, as in `I was reading when the phone rang.` The reading was interupted by the phone ringing.
+Past continuous is often used when an action is interrupted by another, as in `I was reading when the phone rang.` The reading was interrupted by the phone ringing.
 
 # --question--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc4c430704c19121c5eb4.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc4c430704c19121c5eb4.md
@@ -27,7 +27,7 @@ In this dialogue, Bob uses the past continuous tense to describe ongoing actions
 
 ### --feedback--
 
-`adding` in past continuous shows the ongoing action of introducing a new feature.
+The verb is `to add`. Remember to conjugate it.
 
 ---
 
@@ -35,4 +35,4 @@ In this dialogue, Bob uses the past continuous tense to describe ongoing actions
 
 ### --feedback--
 
-`pushing` in this context indicates the continuous action of uploading the feature.
+The verb is `to push`. Remember to conjugate it.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc4c430704c19121c5eb4.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc4c430704c19121c5eb4.md
@@ -1,0 +1,38 @@
+---
+id: 656bc4c430704c19121c5eb4
+title: Task 21
+challengeType: 22
+dashedName: task-21
+audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
+---
+
+<!--
+AUDIO REFERENCE: 
+Bob: "Well, I was _ a new feature. While I was _ it, I noticed that some of the tests were failing."
+-->
+
+# --description--
+
+In this dialogue, Bob uses the past continuous tense to describe ongoing actions in the past. 
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`Well, I was _ a new feature. While I was _ it, I noticed that some of the tests were failing.`
+
+## --blanks--
+
+`adding`
+
+### --feedback--
+
+`adding` in past continuous shows the ongoing action of introducing a new feature.
+
+---
+
+`pushing`
+
+### --feedback--
+
+`pushing` in this context indicates the continuous action of uploading the feature.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc54c7a049d197017b9c7.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc54c7a049d197017b9c7.md
@@ -1,0 +1,56 @@
+---
+id: 656bc54c7a049d197017b9c7
+title: Task 22
+challengeType: 19
+dashedName: task-22
+audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
+---
+
+<!--
+AUDIO REFERENCE: 
+Bob: "Well, I was adding a new feature. While I was pushing it, I noticed that some of the tests were failing."
+-->
+
+# --description--
+
+Bob's use of the past continuous tense describes ongoing actions when he noticed the failing tests. 
+
+Recognizing these details in a conversation is crucial for understanding the context and background of an issue.
+
+# --question--
+
+## --text--
+
+What was Bob doing when he noticed the problem?
+
+## --answers--
+
+`He was fixing the tests`
+
+### --feedback--
+
+Bob noticed the problem while adding and pushing a new feature, not fixing tests.
+
+---
+
+`He was planning a new feature`
+
+### --feedback--
+
+Bob was actively adding a new feature, not just planning it.
+
+---
+
+`He was adding and pushing a new feature`
+
+---
+
+`He was discussing the feature with Sarah`
+
+### --feedback--
+
+Bob was working on the feature, not discussing it, when he noticed the issue.
+
+## --video-solution--
+
+3

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc54c7a049d197017b9c7.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc54c7a049d197017b9c7.md
@@ -13,9 +13,7 @@ Bob: "Well, I was adding a new feature. While I was pushing it, I noticed that s
 
 # --description--
 
-Bob's use of the past continuous tense describes ongoing actions when he noticed the failing tests. 
-
-Recognizing these details in a conversation is crucial for understanding the context and background of an issue.
+Bob's use of the past continuous tense describes ongoing actions when he noticed the failing tests. Recognizing these details in a conversation is crucial for understanding the context and background of an issue.
 
 # --question--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc54c7a049d197017b9c7.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc54c7a049d197017b9c7.md
@@ -13,7 +13,7 @@ Bob: "Well, I was adding a new feature. While I was pushing it, I noticed that s
 
 # --description--
 
-Bob's use of the past continuous tense describes ongoing actions when he noticed the failing tests. Recognizing these details in a conversation is crucial for understanding the context and background of an issue.
+Listen to the audio and answer the question.
 
 # --question--
 
@@ -23,31 +23,31 @@ What was Bob doing when he noticed the problem?
 
 ## --answers--
 
-`He was fixing the tests`
+He was fixing the tests
 
 ### --feedback--
 
-Bob noticed the problem while adding and pushing a new feature, not fixing tests.
+Bob was not fixing tests.
 
 ---
 
-`He was planning a new feature`
+He was planning a new feature
 
 ### --feedback--
 
-Bob was actively adding a new feature, not just planning it.
+Bob was not planning the feature.
 
 ---
 
-`He was adding and pushing a new feature`
+He was adding and pushing a new feature
 
 ---
 
-`He was discussing the feature with Sarah`
+He was discussing the feature with Sarah
 
 ### --feedback--
 
-Bob was working on the feature, not discussing it, when he noticed the issue.
+Bob was not discussing the feature.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc5a71b33ae19ad65166a.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc5a71b33ae19ad65166a.md
@@ -13,7 +13,9 @@ Bob: "Well, I was adding a new feature. While I was _ it, I noticed that some of
 
 # --description--
 
-Notice how Bob use of past continuous can communicate multiple simultaneous actions in the narrative.
+Notice how Bob use of past continuous can communicate multiple simultaneous actions in the narrative. 
+
+Fill in the blank with the appropriate words.
 
 # --fillInTheBlank--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc5a71b33ae19ad65166a.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc5a71b33ae19ad65166a.md
@@ -1,0 +1,38 @@
+---
+id: 656bc5a71b33ae19ad65166a
+title: Task 23
+challengeType: 22
+dashedName: task-23
+audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
+---
+
+<!--
+AUDIO REFERENCE: 
+Bob: "Well, I was adding a new feature. While I was _ it, I noticed that some of the tests _ failing."
+-->
+
+# --description--
+
+Notice how Bob use of past continuous can communicate multiple simultaneous actions in the narrative.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`Well, I was adding a new feature. While I was _ it, I noticed that some of the tests _ failing.`
+
+## --blanks--
+
+`pushing`
+
+### --feedback--
+
+Indicates the ongoing action of uploading the feature at that time.
+
+---
+
+`were`
+
+### --feedback--
+
+Shows the tests were continuously failing while Bob was working.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc669dbd6561a22060cf0.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc669dbd6561a22060cf0.md
@@ -1,0 +1,54 @@
+---
+id: 656bc669dbd6561a22060cf0
+title: Task 24
+challengeType: 19
+dashedName: task-24
+audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
+---
+
+<!--
+AUDIO REFERENCE: 
+Bob: "Well, I was adding a new feature. While I was pushing it, I noticed that some of the tests were failing."
+-->
+
+# --description--
+
+Check your understanding.
+
+# --question--
+
+## --text--
+
+What does Bob's narrative tells about the sequence of events?
+
+## --answers--
+
+`He added a feature, then the tests started failing`
+
+### --feedback--
+
+Bob's narrative indicates these events were happening at the same time, not one after the other.
+
+---
+
+`He noticed the failing tests before adding the feature`
+
+### --feedback--
+
+Bob noticed the tests failing while he was pushing the new feature, not before adding it.
+
+---
+
+`The tests were failing while he was adding and pushing the feature`
+
+---
+
+`The feature caused the tests to fail immediately`
+
+### --feedback--
+
+While the tests were failing during his work, Bob doesn't imply an immediate cause from the feature.
+
+## --video-solution--
+
+3

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc669dbd6561a22060cf0.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc669dbd6561a22060cf0.md
@@ -23,7 +23,7 @@ What does Bob's narrative tells about the sequence of events?
 
 ## --answers--
 
-`He added a feature, then the tests started failing`
+He added a feature, then the tests started failing
 
 ### --feedback--
 
@@ -31,7 +31,7 @@ Bob's narrative indicates these events were happening at the same time, not one 
 
 ---
 
-`He noticed the failing tests before adding the feature`
+He noticed the failing tests before adding the feature
 
 ### --feedback--
 
@@ -39,16 +39,16 @@ Bob noticed the tests failing while he was pushing the new feature, not before a
 
 ---
 
-`The tests were failing while he was adding and pushing the feature`
-
----
-
-`The feature caused the tests to fail immediately`
+The feature caused the tests to fail immediately
 
 ### --feedback--
 
 While the tests were failing during his work, Bob doesn't imply an immediate cause from the feature.
 
+---
+
+The tests were failing while he was adding and pushing the feature
+
 ## --video-solution--
 
-3
+4

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc669dbd6561a22060cf0.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc669dbd6561a22060cf0.md
@@ -13,7 +13,7 @@ Bob: "Well, I was adding a new feature. While I was pushing it, I noticed that s
 
 # --description--
 
-Check your understanding.
+Listen to the audio and answer the question.
 
 # --question--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc75be35fb11a7c27a788.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc75be35fb11a7c27a788.md
@@ -22,11 +22,11 @@ What does `Got it` imply in a conversation?
 
 ## --answers--
 
-`I understand`
+I understand
 
 ---
 
-`I will think about it`
+I will think about it
 
 ### --feedback--
 
@@ -34,7 +34,7 @@ What does `Got it` imply in a conversation?
 
 ---
 
-`I don't know`
+I don't know
 
 ### --feedback--
 
@@ -42,7 +42,7 @@ What does `Got it` imply in a conversation?
 
 ---
 
-`Please explain again`
+Please explain again
 
 ### --feedback--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc75be35fb11a7c27a788.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc75be35fb11a7c27a788.md
@@ -1,0 +1,54 @@
+---
+id: 656bc75be35fb11a7c27a788
+title: Task 25
+challengeType: 19
+dashedName: task-25
+---
+
+# --description--
+
+The phrase `Got it` is often used in conversation to indicate that someone has understood something. It's a casual and quick way to acknowledge that you have received and comprehended the information. For example:
+
+Lucy: `You need to finish the report by tomorrow.`
+
+Bob: `Got it!` 
+
+means person Bob understands the instruction.
+
+# --question--
+
+## --text--
+
+What does `Got it` imply in a conversation?
+
+## --answers--
+
+`I understand`
+
+---
+
+`I will think about it`
+
+### --feedback--
+
+`Got it` is about understanding, not considering or thinking about it.
+
+---
+
+`I don't know`
+
+### --feedback--
+
+`Got it` actually means the opposite - that the person understands.
+
+---
+
+`Please explain again`
+
+### --feedback--
+
+`Got it` is used when no further explanation is needed, as the person already understands.
+
+## --video-solution--
+
+1

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc75be35fb11a7c27a788.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc75be35fb11a7c27a788.md
@@ -10,10 +10,9 @@ dashedName: task-25
 The phrase `Got it` is often used in conversation to indicate that someone has understood something. It's a casual and quick way to acknowledge that you have received and comprehended the information. For example:
 
 Lucy: `You need to finish the report by tomorrow.`
-
 Bob: `Got it!` 
 
-means person Bob understands the instruction.
+`Got it` means that Bob understands the instruction.
 
 # --question--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc7f08edd541afdd87231.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc7f08edd541afdd87231.md
@@ -26,7 +26,7 @@ What does Sarah indicate about her and the team's future actions?
 
 ## --answers--
 
-`They are currently creating the issue`
+They are currently creating the issue
 
 ### --feedback--
 
@@ -34,11 +34,11 @@ Sarah's plan to create the issue is for the future, not the present.
 
 ---
 
-`She will create the issue and they can attach the error messages`
+She will create the issue and they can attach the error messages
 
 ---
 
-`They have already attached the error messages`
+They have already attached the error messages
 
 ### --feedback--
 
@@ -46,7 +46,7 @@ Sarah suggests attaching the error messages as a future possibility, not somethi
 
 ---
 
-`She is not sure about creating the issue`
+She is not sure about creating the issue
 
 ### --feedback--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc7f08edd541afdd87231.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc7f08edd541afdd87231.md
@@ -1,0 +1,57 @@
+---
+id: 656bc7f08edd541afdd87231
+title: Task 26
+challengeType: 19
+dashedName: task-26
+audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
+---
+<!--
+AUDIO REFERENCE: 
+Sarah: Got it. I'll create the issue on GitHub and write out the details. We can attach the error messages too.
+-->
+
+# --description--
+
+Sarah's response includes future intentions using `I'll` and `We can`. 
+
+`I'll create` indicates a definite action she plans to take. 
+
+`We can` suggests a possible action they might take as a team. 
+
+# --question--
+
+## --text--
+
+What does Sarah indicate about her and the team's future actions?
+
+## --answers--
+
+`They are currently creating the issue`
+
+### --feedback--
+
+Sarah's plan to create the issue is for the future, not the present.
+
+---
+
+`She will create the issue and they can attach the error messages`
+
+---
+
+`They have already attached the error messages`
+
+### --feedback--
+
+Sarah suggests attaching the error messages as a future possibility, not something already done.
+
+---
+
+`She is not sure about creating the issue`
+
+### --feedback--
+
+Sarah expresses a definite intention to create the issue.
+
+## --video-solution--
+
+2

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc8f4928b351b8a6c4d53.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc8f4928b351b8a6c4d53.md
@@ -1,0 +1,39 @@
+---
+id: 656bc8f4928b351b8a6c4d53
+title: Task 27
+challengeType: 22
+dashedName: task-27
+audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
+---
+
+<!--
+AUDIO REFERENCE: 
+Sarah: "Got it. I'll create the issue on GitHub and write out the details. We can attach the _ messages too."
+-->
+
+# --description--
+
+`Attach` means to add something extra to something else. 
+
+In this case, Sarah talks about adding `error messages` to an issue on GitHub. 
+
+Error messages are notes that tell you what went wrong in the computer code. Attaching them to an issue helps others understand the problem better.
+
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`Got it. I'll create the issue on GitHub and write out the details. We can _ the _ messages too.`
+
+## --blanks--
+`attach`
+
+### --feedback--
+Means to add something extra to something else. 
+
+`error`
+
+### --feedback--
+
+Adding `error` messages to the issue gives more information about what's not working right.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc8f4928b351b8a6c4d53.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc8f4928b351b8a6c4d53.md
@@ -27,10 +27,13 @@ Error messages are notes that tell you what went wrong in the computer code. Att
 `Got it. I'll create the issue on GitHub and write out the details. We can _ the _ messages too.`
 
 ## --blanks--
+
 `attach`
 
 ### --feedback--
 Means to add something extra to something else. 
+
+---
 
 `error`
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc8f4928b351b8a6c4d53.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc8f4928b351b8a6c4d53.md
@@ -15,7 +15,7 @@ Sarah: "Got it. I'll create the issue on GitHub and write out the details. We ca
 
 `Attach` means to add something extra to something else. 
 
-In this case, Sarah talks about adding `error messages` to an issue on GitHub. `Error messages` are notes that tell you what went wrong in the computer code. Attaching them to an issue helps others understand the problem better.
+`Error messages` are notes that tell you what went wrong in the computer code. Attaching them to an issue helps others understand the problem better.
 
 
 # --fillInTheBlank--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc8f4928b351b8a6c4d53.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bc8f4928b351b8a6c4d53.md
@@ -15,9 +15,7 @@ Sarah: "Got it. I'll create the issue on GitHub and write out the details. We ca
 
 `Attach` means to add something extra to something else. 
 
-In this case, Sarah talks about adding `error messages` to an issue on GitHub. 
-
-Error messages are notes that tell you what went wrong in the computer code. Attaching them to an issue helps others understand the problem better.
+In this case, Sarah talks about adding `error messages` to an issue on GitHub. `Error messages` are notes that tell you what went wrong in the computer code. Attaching them to an issue helps others understand the problem better.
 
 
 # --fillInTheBlank--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bcaea19405d1c6f2accb9.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bcaea19405d1c6f2accb9.md
@@ -1,0 +1,69 @@
+---
+id: 656bcaea19405d1c6f2accb9
+title: Task 28
+challengeType: 22
+dashedName: task-28
+audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
+---
+
+<!-- audio reference 
+All Audio.
+-->
+
+# --description--
+
+This challenge tests your understanding of the conversation between Bob and Sarah. Listen carefully and fill in the blanks with correct terms or actions that they discuss. This checks your comprehension of the sequence of events and the actions they plan to take.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`Bob discovered a problem while he was _ the branch. He _ some changes to the repository, but the code didn't _. It was _ strange errors. Sarah said she will _ an issue on GitHub and suggests to _ the error messages for more information.`
+
+## --blanks--
+
+`checking`
+
+### --feedback--
+
+Bob was in the process of checking the branch when he noticed the issue.
+
+---
+
+`pushed`
+
+### --feedback--
+
+Bob pushed the changes, which led to issues with code compilation.
+
+---
+
+`compile`
+
+### --feedback--
+
+To convert source code written in a programming language into an executable program.
+
+---
+
+`showing`
+
+### --feedback--
+
+To be visible. Use `ing`.
+
+---
+
+`create`
+
+### --feedback--
+
+Sarah decides to create an issue on GitHub.
+
+---
+
+`attach`
+
+### --feedback--
+
+Sarah suggests attaching error messages to the issue.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bcaea19405d1c6f2accb9.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bcaea19405d1c6f2accb9.md
@@ -18,7 +18,7 @@ This challenge tests your understanding of the conversation between Bob and Sara
 
 ## --sentence--
 
-`Bob discovered a problem while he was _ the branch. He _ some changes to the repository, but the code didn't _. It was _ strange errors. Sarah said she will _ an issue on GitHub and suggests to _ the error messages for more information.`
+`Bob discovered a problem when he was _ the branch. He _ some changes to the repository, but the code didn't _. It was _ strange errors. Sarah said she will _ an issue on GitHub and suggests to _ the error messages for more information.`
 
 ## --blanks--
 
@@ -26,7 +26,7 @@ This challenge tests your understanding of the conversation between Bob and Sara
 
 ### --feedback--
 
-Bob was in the process of checking the branch when he noticed the issue.
+Bob was in the process of checking the branch when he noticed the issue. Verb ends with `-ing`
 
 ---
 
@@ -34,7 +34,7 @@ Bob was in the process of checking the branch when he noticed the issue.
 
 ### --feedback--
 
-Bob pushed the changes, which led to issues with code compilation.
+Bob pushed the changes, which led to issues with code compilation. Verb conjugated in the past simple.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bd6dde3a62c205cb41b2d.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bd6dde3a62c205cb41b2d.md
@@ -1,9 +1,9 @@
 ---
 id: 656bd6dde3a62c205cb41b2d
 videoId: nLDychdBwUg
-title: "Dialogue 2: Talking About Pull Request"
+title: "Dialogue 2: Talking About Pull Requests"
 challengeType: 21
-dashedName: dialogue-talking-about-pull-request
+dashedName: dialogue-2-talking-about-pull-requests
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bd6dde3a62c205cb41b2d.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bd6dde3a62c205cb41b2d.md
@@ -1,0 +1,15 @@
+---
+id: 656bd6dde3a62c205cb41b2d
+videoId: nLDychdBwUg
+title: "Dialogue 2: Talking About Pull Request"
+challengeType: 21
+dashedName: dialogue-talking-about-pull-request
+---
+
+# --description--
+
+Dialogue 2: Talking About Pull Request description.
+
+# --assignment--
+
+Dialogue 2: Talking About Pull Request assignment!

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bd6dde3a62c205cb41b2d.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bd6dde3a62c205cb41b2d.md
@@ -8,8 +8,8 @@ dashedName: dialogue-talking-about-pull-request
 
 # --description--
 
-Dialogue 2: Talking About Pull Request description.
+Watch the video above to understand the context of the upcoming lessons.
 
 # --assignment--
 
-Dialogue 2: Talking About Pull Request assignment!
+Watch the video

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bd701970c6c20a9c89b0f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bd701970c6c20a9c89b0f.md
@@ -1,0 +1,40 @@
+---
+id: 656bd701970c6c20a9c89b0f
+title: Task 29
+challengeType: 22
+dashedName: task-29
+audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
+---
+<!--
+AUDIO REFERENCE: 
+
+Tom: Hey Sarah, I saw your comment on the issue I opened. Thanks for your help.
+-->
+
+# --description--
+
+In this task, you will fill in the blanks with the correct past tense verbs. Listen to the sentence and pay attention to the context to choose the right words.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`Hey Sarah, I _ your comment on the issue I _. Thanks for your help.`
+
+## --blanks--
+
+`saw`
+
+### --feedback--
+
+The past tense of `see`.
+
+---
+
+`opened`
+
+### --feedback--
+
+The past tense of `open`. 
+
+---

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bd701970c6c20a9c89b0f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bd701970c6c20a9c89b0f.md
@@ -36,5 +36,3 @@ The past tense of `see`.
 ### --feedback--
 
 The past tense of `open`. 
-
----

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bd7723e1e4c21039f5916.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bd7723e1e4c21039f5916.md
@@ -36,5 +36,3 @@ Refers to an observation about a specific topic.
 ### --feedback--
 
 A term used to describe a problem or bug.
-
----

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bd7723e1e4c21039f5916.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bd7723e1e4c21039f5916.md
@@ -1,0 +1,40 @@
+---
+id: 656bd7723e1e4c21039f5916
+title: Task 30
+challengeType: 22
+dashedName: task-30
+audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3 
+---
+<!--
+AUDIO REFERENCE: 
+
+Tom: Hey Sarah, I saw your comment on the issue I opened. Thanks for your help.
+-->
+
+# --description--
+
+In this task, you will fill in the blanks with the correct words related to programming and project management. 
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`Hey Sarah, I saw your _ on the _ I opened. Thanks for your help.`
+
+## --blanks--
+
+`comment`
+
+### --feedback--
+
+Refers to an observation about a specific topic.
+
+---
+
+`issue`
+
+### --feedback--
+
+A term used to describe a problem or bug.
+
+---

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bd80d58dd31216af64ddf.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bd80d58dd31216af64ddf.md
@@ -1,0 +1,54 @@
+---
+id: 656bd80d58dd31216af64ddf
+title: Task 31
+challengeType: 19
+dashedName: task-31
+audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
+---
+<!--
+AUDIO REFERENCE: 
+
+Tom: Hey Sarah, I saw your comment on the issue I opened. Thanks for your help.
+-->
+
+# --description--
+
+This task checks if you understood what Tom said in the dialogue.
+
+# --question--
+
+## --text--
+
+`What did Tom say about Sarah in his sentence?`
+
+## --answers--
+
+`Sarah helped him with a problem he found`
+
+---
+
+`Sarah found a new problem`
+
+### --feedback--
+
+Tom talked about Sarah's comment on a problem he found, not about her finding a new one.
+
+---
+
+`Sarah solved the problem`
+
+### --feedback--
+
+Tom thanked Sarah for her comment, not for solving the problem.
+
+---
+
+`Sarah sent an email about the problem`
+
+### --feedback--
+
+Tom talked about Sarah's comment, not about receiving an email from her.
+
+## --video-solution--
+
+1

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bd80d58dd31216af64ddf.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bd80d58dd31216af64ddf.md
@@ -13,41 +13,41 @@ Tom: Hey Sarah, I saw your comment on the issue I opened. Thanks for your help.
 
 # --description--
 
-This task checks if you understood what Tom said in the dialogue.
+Listen to the audio and answer the question.
 
 # --question--
 
 ## --text--
 
-`What did Tom say about Sarah in his sentence?`
+What did Tom say about Sarah in his sentence?
 
 ## --answers--
 
-`Sarah helped him with a problem he found`
+Sarah helped him with a problem he found
 
 ---
 
-`Sarah found a new problem`
+Sarah found a new problem
 
 ### --feedback--
 
-Tom talked about Sarah's comment on a problem he found, not about her finding a new one.
+She didn't find a new problem.
 
 ---
 
-`Sarah solved the problem`
+Sarah solved a problem for him
 
 ### --feedback--
 
-Tom thanked Sarah for her comment, not for solving the problem.
+She didn't solve a problem for Tom.
 
 ---
 
-`Sarah sent an email about the problem`
+Sarah sent an email about the problem
 
 ### --feedback--
 
-Tom talked about Sarah's comment, not about receiving an email from her.
+Tom doesn't mention an email.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bd968e52c34220164de8d.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bd968e52c34220164de8d.md
@@ -23,19 +23,19 @@ What did Sarah do about the issue Tom mentioned?
 
 ## --answers--
 
-`Sarah has already tried a few things to solve it`
-
----
-
-`She is planning to solve it later`
+She is planning to solve it later
 
 ### --feedback--
 
-Sarah mentioned that she has already tried some things, not that she is planning to do it later.
+Sarah doesn't mention planning to do it later.
 
 ---
 
-`She asked someone else for help`
+Sarah has already tried a few things to solve it
+
+---
+
+She asked someone else for help
 
 ### --feedback--
 
@@ -43,7 +43,7 @@ There is no mention of Sarah asking for help from others in her response.
 
 ---
 
-`She did nothing about it`
+She did nothing about it
 
 ### --feedback--
 
@@ -51,4 +51,4 @@ Sarah stated that she already tried a few things, which means she did take some 
 
 ### --video-solution--
 
-1
+2

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bd968e52c34220164de8d.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bd968e52c34220164de8d.md
@@ -3,7 +3,7 @@ id: 656bd968e52c34220164de8d
 title: Task 32
 challengeType: 19
 dashedName: task-32
-audioPath: Add the path to the audio file here. Or, delete this if you don't have audio.
+audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 <!--
 AUDIO REFERENCE: 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65a84bec88772eaff6e56679.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65a84bec88772eaff6e56679.md
@@ -9,7 +9,7 @@ dashedName: task-33
 
 Imagine you're working on a project and have been trying different solutions over time. To express this ongoing effort, you cann use the present perfect tense. This tense connects past actions to the present moment. 
 
-The present perfect tense is formed using the auxiliary verb `have` (or `has` for `he`, `she`, and `it`) followed by the past participle of the main verb. For example, `I have working on this for a long time`.
+The present perfect tense is formed using the auxiliary verb `have` or `has` followed by the past participle of the main verb. For example, `I have working on this for a long time` or `he has worked on this for a long time`.
 
 Let's practice using the present perfect tense to talk about actions that started in the past and are still relevant now.
 
@@ -21,15 +21,11 @@ Which sentence correctly uses the present perfect tense?
 
 ## --answers--
 
-`I have tried a few things to solve the issue.`
-
----
-
-`I tried a few things to solve the issue.`
+`I has tried a few things to solve the issue.`
 
 ### --feedback--
 
-This sentence uses the past simple tense, which is for actions that happened and finished at a specific time in the past.
+`has` is used for the pronouns `he`, `she` or `it`.
 
 ---
 
@@ -47,6 +43,10 @@ This sentence is in the present continuous tense, used for actions happening rig
 
 This one is in the future simple tense, for actions that will happen later.
 
+---
+
+`I have tried a few things to solve the issue.`
+
 ## --video-solution--
 
-1
+4

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65a84bec88772eaff6e56679.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65a84bec88772eaff6e56679.md
@@ -1,0 +1,52 @@
+---
+id: 65a84bec88772eaff6e56679
+title: Task 33
+challengeType: 19
+dashedName: task-33
+---
+
+# --description--
+
+Imagine you're working on a project and have been trying different solutions over time. To express this ongoing effort, you cann use the present perfect tense. This tense connects past actions to the present moment. 
+
+The present perfect tense is formed using the auxiliary verb `have` (or `has` for `he`, `she`, and `it`) followed by the past participle of the main verb. For example, `I have working on this for a long time`.
+
+Let's practice using the present perfect tense to talk about actions that started in the past and are still relevant now.
+
+# --question--
+
+## --text--
+
+Which sentence correctly uses the present perfect tense?
+
+## --answers--
+
+`I have tried a few things to solve the issue.`
+
+---
+
+`I tried a few things to solve the issue.`
+
+### --feedback--
+
+This sentence uses the past simple tense, which is for actions that happened and finished at a specific time in the past.
+
+---
+
+`I am trying a few things to solve the issue.`
+
+### --feedback--
+
+This sentence is in the present continuous tense, used for actions happening right now.
+
+---
+
+`I will try a few things to solve the issue.`
+
+### --feedback--
+
+This one is in the future simple tense, for actions that will happen later.
+
+## --video-solution--
+
+1

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65a84bec88772eaff6e56679.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65a84bec88772eaff6e56679.md
@@ -7,9 +7,9 @@ dashedName: task-33
 
 # --description--
 
-Imagine you're working on a project and have been trying different solutions over time. To express this ongoing effort, you cann use the present perfect tense. This tense connects past actions to the present moment. 
+Imagine you're working on a project and have been trying different solutions over time. To express this ongoing effort, you can use the present perfect tense. This tense connects past actions to the present moment.
 
-The present perfect tense is formed using the auxiliary verb `have` or `has` followed by the past participle of the main verb. For example, `I have working on this for a long time` or `he has worked on this for a long time`.
+The present perfect tense is formed using the auxiliary verb `have` or `has` followed by the past participle of the main verb. For example, `I have been working on this for a long time` or `he has worked on this for a long time`.
 
 Let's practice using the present perfect tense to talk about actions that started in the past and are still relevant now.
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65a84dad1595bbbc2e9cd895.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65a84dad1595bbbc2e9cd895.md
@@ -1,0 +1,30 @@
+---
+id: 65a84dad1595bbbc2e9cd895
+title: Task 34
+challengeType: 22
+dashedName: task-34
+audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
+---
+<!--
+AUDIO REFERENCE: 
+
+Sarah: No problem, Tom. I noticed the issue you mentioned, and I’ve already tried a few things to solve it.
+-->
+
+# --description--
+
+People often use `have already` to talk about something they have done before now, and `have never` to talk about something they have not done at any time in the past. Let’s practice using these phrases.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`No problem, Tom. I noticed the issue you mentioned, and I’ve _ tried a few things to solve it.`
+
+## --blanks--
+
+`already`
+
+### --feedback--
+
+`Have already` is used to talk about something that has been done before this moment. Here, Sarah says she has already tried some things, meaning she has done them before now.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65a84e922382a7bd112057ad.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65a84e922382a7bd112057ad.md
@@ -1,0 +1,55 @@
+---
+id: 65a84e922382a7bd112057ad
+title: Task 35
+challengeType: 19
+dashedName: task-35
+audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
+---
+---
+<!--
+AUDIO REFERENCE: 
+
+Sarah: No problem, Tom. I noticed the issue you mentioned, and I’ve already tried a few things to solve it.
+-->
+
+# --description--
+
+Listen to the dialogue and answer the question.
+
+# --question--
+
+## --text--
+
+What has Sarah done about the issue Tom mentioned?
+
+## --answers--
+
+She plans to look at it later
+
+### --feedback--
+
+Sarah indicates that she has already taken action, not that she is planning to do it later.
+
+---
+
+She is waiting for more information
+
+### --feedback--
+
+The dialogue suggests that Sarah has already acted, not that she is waiting for more information.
+
+---
+
+She doesn't know about the issue
+
+### --feedback--
+
+Sarah acknowledges the issue and mentions her attempts to solve it, so she is aware of the issue.
+
+---
+
+She has already tried a few things to solve it
+
+## --video-solution--
+
+4

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65a84f2370686dbda3e53aff.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65a84f2370686dbda3e53aff.md
@@ -1,0 +1,38 @@
+---
+id: 65a84f2370686dbda3e53aff
+title: Task 36
+challengeType: 22
+dashedName: task-36
+audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
+---
+<!--
+AUDIO REFERENCE: 
+
+Tom: That's great. What did you find?
+-->
+
+# --description--
+
+In this task, listen to the question and choose the right verbs to complete it.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`That's great. What _ you _?`
+
+## --blanks--
+
+`did`
+
+### --feedback--
+
+Used here to form a past tense question. It helps ask about something that happened in the past.
+
+---
+
+`find`
+
+### --feedback--
+
+The main verb in the question, asking about what was discovered or learned.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65a85090914872be8ca97793.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65a85090914872be8ca97793.md
@@ -1,0 +1,55 @@
+---
+id: 65a85090914872be8ca97793
+title: Task 37
+challengeType: 19
+dashedName: task-37
+audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
+---
+
+<!--
+AUDIO REFERENCE: 
+
+Tom: That's great. What did you find?
+-->
+
+# --description--
+
+This task tests your comprehension of what Tom is asking Sarah.
+
+# --question--
+
+## --text--
+
+What is Tom asking Sarah about?
+
+## --answers--
+
+Why she didn’t solve the issue
+
+### --feedback--
+
+Tom's question is about what Sarah found, not about why she didn't solve the issue.
+
+---
+
+If she needs help with the issue
+
+### --feedback--
+
+Tom's question focuses on Sarah's findings, not on offering help.
+
+---
+
+What she discovered about the issue
+
+---
+
+If she knew about the issue
+
+### --feedback--
+
+Tom knows Sarah's aware of the issue.
+
+## --video-solution--
+
+3

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65a851a6389e6cbf2c2cf158.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65a851a6389e6cbf2c2cf158.md
@@ -1,0 +1,44 @@
+---
+id: 65a851a6389e6cbf2c2cf158
+title: Task 38
+challengeType: 22
+dashedName: task-38
+audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
+---
+
+<!--
+AUDIO REFERENCE: 
+
+Sarah: Well, I was investigating the code when I saw that the problem might be related to the recent updates.
+-->
+
+# --description--
+
+`To investigate` means to carefully examine something, and `to be related to` means to be connected or associated with something. For example:
+
+`He is investigating the error in the program`
+
+`Her success is related to her hard work.`
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`Well, I was _ the code when I saw that the problem might be _ to the recent updates.`
+
+## --blanks--
+
+`investigating`
+
+### --feedback--
+
+Means to carefully examine or look into something in detail. This verbs ends with 
+`ing`
+
+---
+
+`related`
+
+### --feedback--
+
+Means to have a connection or association with something.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65a853b498eb87c035f6da13.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65a853b498eb87c035f6da13.md
@@ -1,0 +1,54 @@
+---
+id: 65a853b498eb87c035f6da13
+title: Task 39
+challengeType: 19
+dashedName: task-39
+audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
+---
+<!--
+AUDIO REFERENCE: 
+
+Sarah: Well, I was investigating the code when I saw that the problem might be related to the recent updates.
+-->
+
+# --description--
+
+Listen to the audio and answer the question.
+
+# --question--
+
+## --text--
+
+Why was Sarah looking at the code, and what did she think was the reason for the problem?
+
+## --answers--
+
+To update it, because it was old.
+
+### --feedback--
+
+Sarah was searching for errors, not updating old code.
+
+---
+
+To write about it, thinking there was a mistake in writing.
+
+### --feedback--
+
+She was searching for problems in the code, not writing about it.
+
+---
+
+To teach coding, because she found a good example.
+
+### --feedback--
+
+Sarah was trying to find a problem, not teach coding.
+
+---
+
+To find errors, thinking new changes caused the problem.
+
+## --video-solution--
+
+4

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65a85418ea38cdc0a334dab2.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65a85418ea38cdc0a334dab2.md
@@ -13,9 +13,13 @@ Sarah: I tried rolling back to the previous version, but it didn't fix the issue
 
 # --description--
 
-`To Roll back` means going back to an earlier state or version of something. For example, `If the new app is not working, try rolling back to the old version.` 
+`To Roll back` means going back to an earlier state or version of something. For example:
 
-A `previous version` is an earlier form of something, like an older version of a software. It's like saying, `If the new app is not working, try rolling back to the previous version.`
+`If the new app is not working, try rolling back to the old version.` 
+
+A `previous version` is an earlier form of something, like an older version of a software. Let's use it in the same sentence as above:
+
+`If the new app is not working, try rolling back to the previous version.`
 
 # --fillInTheBlank--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65a85418ea38cdc0a334dab2.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65a85418ea38cdc0a334dab2.md
@@ -1,0 +1,40 @@
+---
+id: 65a85418ea38cdc0a334dab2
+title: Task 40
+challengeType: 22
+dashedName: task-40
+audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
+---
+<!--
+AUDIO REFERENCE: 
+
+Sarah: I tried rolling back to the previous version, but it didn't fix the issue.
+-->
+
+# --description--
+
+`To Roll back` means going back to an earlier state or version of something. For example, `If the new app is not working, try rolling back to the old version.` 
+
+A `previous version` is an earlier form of something, like an older version of a software. It's like saying, `If the new app is not working, try rolling back to the previous version.`
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`I tried _ back to the _ version, but it didn't fix the issue.`
+
+## --blanks--
+
+`rolling`
+
+### --feedback--
+
+Means going back to an earlier state. Sarah tried returning to an earlier version of the code. This verb uses `ing`
+
+---
+
+`previous`
+
+### --feedback--
+
+Refers to an earlier form or version. Sarah went back to an older version of the code.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65a85418ea38cdc0a334dab2.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65a85418ea38cdc0a334dab2.md
@@ -13,11 +13,11 @@ Sarah: I tried rolling back to the previous version, but it didn't fix the issue
 
 # --description--
 
-`To Roll back` means going back to an earlier state or version of something. For example:
+`To roll back` means going back to an earlier state or version of something. For example:
 
-`If the new app is not working, try rolling back to the old version.` 
+`If the new app is not working, try rolling back to the old version.`
 
-A `previous version` is an earlier form of something, like an older version of a software. Let's use it in the same sentence as above:
+A `previous version` is an earlier form of something, like an older version of software. Let's use it in the same sentence as above:
 
 `If the new app is not working, try rolling back to the previous version.`
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65a9457392dfd7d564bc940e.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65a9457392dfd7d564bc940e.md
@@ -1,0 +1,55 @@
+---
+id: 65a9457392dfd7d564bc940e
+title: Task 41
+challengeType: 19
+dashedName: task-41
+audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
+---
+
+<!--
+AUDIO REFERENCE: 
+
+Sarah: I tried rolling back to the previous version, but it didn't fix the issue.
+-->
+
+# --description--
+
+Understanding the result of actions in technical situations is key. This task focuses on what happened when Sarah tried one solution and what it means for her problem.
+
+# --question--
+
+## --text--
+
+`What happened when Sarah went back to the older version, and what does this mean for the problem?`
+
+## --answers--
+
+`It didn't solve the problem, showing the older version is not the issue.`
+
+---
+
+`It caused more problems, showing the current version is the issue.`
+
+### --feedback--
+
+Sarah said that going back didn’t solve the issue, not that it caused more problems.
+
+---
+
+`It solved the problem, meaning the new updates were the problem.`
+
+### --feedback--
+
+The line clearly states that going back did not solve the issue.
+
+---
+
+`It changed nothing, suggesting the problem might be somewhere else.`
+
+### --feedback--
+
+While it didn't solve the issue, this doesn't directly suggest the problem is elsewhere.
+
+## --video-solution--
+
+1

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65a9457392dfd7d564bc940e.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65a9457392dfd7d564bc940e.md
@@ -14,21 +14,21 @@ Sarah: I tried rolling back to the previous version, but it didn't fix the issue
 
 # --description--
 
-Understanding the result of actions in technical situations is key. This task focuses on what happened when Sarah tried one solution and what it means for her problem.
+Listen to the audio and answer the question.
 
 # --question--
 
 ## --text--
 
-`What happened when Sarah went back to the older version, and what does this mean for the problem?`
+What happened when Sarah went back to the older version, and what does this mean for the problem?
 
 ## --answers--
 
-`It didn't solve the problem, showing the older version is not the issue.`
+It didn't solve the problem, showing the older version is not the issue.
 
 ---
 
-`It caused more problems, showing the current version is the issue.`
+It caused more problems, showing the current version is the issue.
 
 ### --feedback--
 
@@ -36,7 +36,7 @@ Sarah said that going back didn’t solve the issue, not that it caused more pro
 
 ---
 
-`It solved the problem, meaning the new updates were the problem.`
+It solved the problem, meaning the new updates were the problem.
 
 ### --feedback--
 
@@ -44,7 +44,7 @@ The line clearly states that going back did not solve the issue.
 
 ---
 
-`It changed nothing, suggesting the problem might be somewhere else.`
+It changed nothing, suggesting the problem might be somewhere else.
 
 ### --feedback--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65b28add2c939e25b1d9b0e1.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65b28add2c939e25b1d9b0e1.md
@@ -1,0 +1,56 @@
+---
+id: 65b28add2c939e25b1d9b0e1
+title: Task 42
+challengeType: 19
+dashedName: task-42
+audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
+---
+
+<!--
+AUDIO REFERENCE: 
+
+Previous line: Sarah: Well, I was investigating the code when I saw that the problem might be related to the recent updates.
+Current line: Sarah: I tried rolling back to the previous version, but it didn't fix the issue.
+-->
+
+# --description--
+
+Understanding how different steps in solving a problem are connected is key.
+
+# --question--
+
+## --text--
+
+How do Sarah's two actions of looking at the code and going back to an older version connect?
+
+## --answers--
+
+Looking was to find the problem; going back was for a new change.
+
+### --feedback--
+
+Both steps were to solve the issue, not for new changes.
+
+---
+
+Both were ways to try and solve the same problem.
+
+---
+
+Looking was for a report; going back was to solve the problem.
+
+### --feedback--
+
+Both steps were aimed at fixing the issue, not reporting.
+
+---
+
+Looking was her first try, and going back was not linked.
+
+### --feedback--
+
+Going back was related to her first step and part of trying to solve the issue.
+
+## --video-solution--
+
+2

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65b28bbe803df52c4e76dd15.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65b28bbe803df52c4e76dd15.md
@@ -1,0 +1,42 @@
+---
+id: 65b28bbe803df52c4e76dd15
+title: Task 43
+challengeType: 22
+dashedName: task-43
+audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
+---
+<!--
+AUDIO REFERENCE: 
+
+Tom: I see. We might have to talk to the team to see if they can help us.
+-->
+
+# --description--
+
+Modal verbs like `might` and `can` are used to express possibility and ability. 
+
+`Might` is used for something that could happen or be true, like saying, `It might rain today`. 
+
+`Can` is used to talk about someone's ability to do something, like, `She can speak three languages`. Let’s practice using these words in sentences.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`I see. We _ have to talk to the team to see if they _ help us.`
+
+## --blanks--
+
+`might`
+
+### --feedback--
+
+It shows possibility. Tom is saying it's possible they will need to talk to the team.
+
+---
+
+`can`
+
+### --feedback--
+
+It shows ability. Tom is wondering if the team has the ability to help.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65b28d5f4b4c502d2b7917e1.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65b28d5f4b4c502d2b7917e1.md
@@ -1,0 +1,54 @@
+---
+id: 65b28d5f4b4c502d2b7917e1
+title: Task 44
+challengeType: 19
+dashedName: task-44
+audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
+---
+<!--
+AUDIO REFERENCE: 
+
+Tom: I see. We might have to talk to the team to see if they can help us.
+-->
+
+# --description--
+
+Listen to the audio and answer the question.
+
+# --question--
+
+## --text--
+
+What is Tom suggesting they do about the issue?
+
+## --answers--
+
+They should work on the issue alone.
+
+### --feedback--
+
+Tom suggests talking to the team, not working on it alone.
+
+---
+
+They might need to discuss the issue with the team.
+
+---
+
+They will wait for the team to notice the issue.
+
+### --feedback--
+
+Tom talks about actively talking to the team, not waiting for them to notice.
+
+---
+
+They can fix the issue without any help.
+
+### --feedback--
+
+Tom is considering getting help from the team, not fixing it alone.
+
+## --video-solution--
+
+2

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65b28e008537c42da87ace01.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65b28e008537c42da87ace01.md
@@ -1,0 +1,51 @@
+---
+id: 65b28e008537c42da87ace01
+title: Task 45
+challengeType: 19
+dashedName: task-45
+
+---
+
+# --description--
+
+`Additional` means extra or more, like saying, `She added additional sugar to the cake`. 
+
+`Logs` in technology refer to records of events or processes, like, `The system logs show when the app was used`.
+
+# --question--
+
+## --text--
+
+What does `additional logs` mean?
+
+## --answers--
+
+Extra records for more information
+
+---
+
+Old records from the past
+
+### --feedback--
+
+`Additional` means extra or more, not old or from the past.
+
+---
+
+New problems to solve
+
+### --feedback--
+
+`Logs` refers to records or data, not problems.
+
+---
+
+Less important details
+
+### --feedback--
+
+`Additional` suggests more importance or quantity, not less.
+
+## --video-solution--
+
+1

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65b28ee9c5a5972e8bb2a5f3.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65b28ee9c5a5972e8bb2a5f3.md
@@ -1,0 +1,50 @@
+---
+id: 65b28ee9c5a5972e8bb2a5f3
+title: Task 46
+challengeType: 19
+dashedName: task-46
+---
+
+# --description--
+
+`Debugging` is a common term in programming. It means finding and fixing problems or `bugs` in software. For example:
+
+`The programmer spent the morning debugging the new app.` 
+
+# --question--
+
+## --text--
+
+What does `debugging` mean in the context of programming?
+
+## --answers--
+
+Making a program run faster
+
+### --feedback--
+
+Debugging is about fixing problems, not necessarily making a program run faster.
+
+---
+
+Finding and fixing problems in software
+
+---
+
+Adding new features to a program
+
+### --feedback--
+
+Debugging involves fixing existing features, not adding new ones.
+
+---
+
+Testing a program for the first time
+
+### --feedback--
+
+Debugging happens after initial tests to fix identified issues.
+
+## --video-solution--
+
+2

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65b28f840a0d962f2240e800.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65b28f840a0d962f2240e800.md
@@ -1,0 +1,46 @@
+---
+id: 65b28f840a0d962f2240e800
+title: Task 47
+challengeType: 22
+dashedName: task-47
+audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
+---
+<!--
+AUDIO REFERENCE: 
+
+Sarah: Agreed. I’ll create a PR with the rollback and some additional logs for debugging. That may help us find what the problem is.
+-->
+
+# --description--
+
+In this task, you'll practice filling in key verbs and adjectives used in technical discussions. Listening carefully to how these words are used in sentences helps you understand and use them correctly.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`Agreed. I’ll _ a PR with the rollback and some _ logs for _. That may help us find what the problem is.`
+
+## --blanks--
+
+`create`
+
+### --feedback--
+
+Means to make something new. Here, Sarah talks about making a new `PR` (`Pull Request`).
+
+---
+
+`additional`
+
+### --feedback--
+
+Means extra or more. Sarah is talking about adding more logs for more information.
+
+---
+
+`debugging`
+
+### --feedback--
+
+The process of finding and fixing problems. Sarah plans to use extra logs to help with this process.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65b2af1545e34334b7573de9.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65b2af1545e34334b7573de9.md
@@ -1,0 +1,55 @@
+---
+id: 65b2af1545e34334b7573de9
+title: Task 48
+challengeType: 19
+dashedName: task-48
+audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
+
+---
+<!--
+AUDIO REFERENCE: 
+
+Sarah: Agreed. I’ll create a PR with the rollback and some additional logs for debugging. That may help us find what the problem is.
+-->
+
+# --description--
+
+Listen to the audio and answer the question. 
+
+# --question--
+
+## --text--
+
+What is Sarah planning to do, and how does she think it will help?
+
+## --answers--
+
+She plans to update the PR and thinks it will fix the issue immediately.
+
+### --feedback--
+
+Sarah's plan is to create a new PR with a rollback, not just to update it, and she hopes it will help find the problem.
+
+---
+
+She intends to delete the PR and believes it will identify the problem.
+
+### --feedback--
+
+Instead of deleting, Sarah plans to create a new PR for debugging, aiming to find the problem.
+
+---
+
+She's making a new PR with a rollback and extra logs to find the issue.
+
+---
+
+She wants to consult the team, thinking they can solve the issue quickly.
+
+### --feedback--
+
+Sarah's immediate plan is to create a PR, not to consult the team at this stage.
+
+## --video-solution--
+
+3

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65b2af807f713c351c5b9435.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65b2af807f713c351c5b9435.md
@@ -1,0 +1,69 @@
+---
+id: 65b2af807f713c351c5b9435
+title: Task 49
+challengeType: 22
+dashedName: task-49
+audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
+
+---
+<!--
+AUDIO REFERENCE: 
+
+Entire Dialogue:
+Tom: Hey Sarah, I saw your comment on the issue I opened. Thanks for your help.
+Sarah: No problem, Tom. I noticed the issue you mentioned, and I’ve already tried a few things to solve it.
+Tom: That's great. What did you find?
+Sarah: Well, I was investigating the code when I saw that the problem might be related to the recent updates. I tried rolling back to the previous version, but it didn't fix the issue.
+Tom: I see. We might have to talk to the team to see if they can help us.
+Sarah: Agreed. I’ll create a PR with the rollback and some additional logs for debugging. That may help us find what the problem is.
+-->
+
+# --description--
+
+Understanding a complete conversation and summarizing it is a valuable skill. This task requires you to listen to the entire dialogue and fill in the blanks in a summary sentence using key words from the conversation.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`Tom thanked Sarah for her _ on the issue. Sarah was _ the code and tried _ back, but the problem persisted. They considered _ the team for help and planned to _ a PR for more insights.`
+
+## --blanks--
+
+`comment`
+
+### --feedback--
+
+It refers to Sarah's observation on the issue.
+
+---
+
+`investigating`
+
+### --feedback--
+
+Means closely examining or looking into something. This verb ends with `-ing`
+
+---
+
+`rolling`
+
+### --feedback--
+
+To go back to a previous state or version. This verb ends with `-ing`
+
+---
+
+`asking`
+
+### --feedback--
+
+Requestiong assistance or advice from someone. This verb ends with `-ing`
+
+---
+
+`create`
+
+### --feedback--
+
+Make something new, in this case, a PR (Pull Request).

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65b2b0e08ec66535fa8542eb.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65b2b0e08ec66535fa8542eb.md
@@ -1,0 +1,15 @@
+---
+id: 65b2b0e08ec66535fa8542eb
+title: "Dialogue 3: Talking about Debugging"
+challengeType: 21
+dashedName: dialogue-3-talking-about-debugging
+videoId: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
+---
+
+# --description--
+
+Watch the video above to understand the context of the upcoming lessons.
+
+# --assignment--
+
+Watch the video

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65b2b0e08ec66535fa8542eb.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65b2b0e08ec66535fa8542eb.md
@@ -1,6 +1,6 @@
 ---
 id: 65b2b0e08ec66535fa8542eb
-title: "Dialogue 3: Talking about Debugging"
+title: "Dialogue 3: Talking About Debugging"
 challengeType: 21
 dashedName: dialogue-3-talking-about-debugging
 videoId: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65b2b181cb9b2136e833a17a.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65b2b181cb9b2136e833a17a.md
@@ -1,0 +1,46 @@
+---
+id: 65b2b181cb9b2136e833a17a
+title: Task 50
+challengeType: 22
+dashedName: task-50
+audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
+---
+
+<!--
+AUDIO REFERENCE: 
+Maria: "Tom, I saw that you’ve fixed the issue on GitHub. Great job!"
+-->
+
+# --description--
+
+The present perfect tense is used to describe actions that have a connection to the present. 
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`Tom, I _ that you’ve _ the issue on GitHub. Great _!`
+
+## --blanks--
+
+`saw`
+
+### --feedback--
+
+The past of `see`.
+
+---
+
+`fixed`
+
+### --feedback--
+
+The past  participle of `fix`.
+
+---
+
+`job`
+
+### --feedback--
+
+This sentence is used to congratulate someone on their work.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65b2b2781c59e837a5e0beb2.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65b2b2781c59e837a5e0beb2.md
@@ -1,0 +1,53 @@
+---
+id: 65b2b2781c59e837a5e0beb2
+title: Task 51
+challengeType: 19
+dashedName: task-51
+audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
+---
+<!--
+AUDIO REFERENCE: 
+Maria: "Tom, I saw that you’ve fixed the issue on GitHub. Great job!"
+-->
+
+# --description--
+
+`Already` suggests something has happened sooner than expected, while `never` means something has not happened at any time in the past.
+
+# --question--
+
+## --text--
+
+Has Tom already fixed the issue on GitHub?
+
+## --answers--
+
+`Yes, he has just finished it now`
+
+### --feedback--
+
+`Just` means that something was finished a few moments ago. That is not the case.
+
+---
+
+`No, he has never fixed an issue`
+
+### --feedback--
+
+`Never` implies that he has not fixed any issue ever, which contradicts Maria's statement.
+
+---
+
+`Yes, he has already fixed it`
+
+---
+
+`No, he always fixes issues quickly`
+
+### --feedback--
+
+`Always` is not suitable here as the question is about a specific issue, not general habits.
+
+## --video-solution--
+
+3

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65b2b383fb6406386dab3499.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65b2b383fb6406386dab3499.md
@@ -1,0 +1,50 @@
+---
+id: 65b2b383fb6406386dab3499
+title: Task 52
+challengeType: 19
+dashedName: task-52
+
+---
+# --description--
+
+`Configuration` in software and coding refers to the setup or arrangement of a system or an application's components. It often involves settings that determine how a program operates. 
+
+For example, changing the `configuration` of a software can adjust how it performs or interacts with other systems.
+
+# --question--
+
+## --text--
+
+What does `configuration` mean in the context of software development?
+
+## --answers--
+
+The process of writing code for a program
+
+### --feedback--
+
+Configuration is more about setting up or arranging existing components, not writing code.
+
+---
+
+The setup or arrangement of a system's components
+
+---
+
+The act of fixing bugs in a software
+
+### --feedback--
+
+While important, fixing bugs is different from configuring the setup of a system.
+
+---
+
+The design of a software's user interface
+
+### --feedback--
+
+Configuration involves operational settings, not just the design of the user interface.
+
+## --video-solution--
+
+2

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65b2b3ea62a86838c216db73.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65b2b3ea62a86838c216db73.md
@@ -12,9 +12,9 @@ Tom: "Thanks, Maria. I _ debugging it when I _ it was a simple configuration err
 
 # --description--
 
-In this sentence, Tom uses the past continuous tense (`I was debugging`) to describe an ongoing action in the past. 
+In this sentence, Tom uses the past continuous tense `I was debugging` to describe an ongoing action in the past. 
 
-He then switches to simple past (`I realized`) to state a specific action completed in the past. 
+He then switches to simple past `I realized` to state a specific action completed in the past. 
 
 Understanding how these tenses work together helps clarify the sequence of events.
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65b2b3ea62a86838c216db73.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65b2b3ea62a86838c216db73.md
@@ -1,0 +1,41 @@
+---
+id: 65b2b3ea62a86838c216db73
+title: Task 53
+challengeType: 22
+dashedName: task-53
+audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
+---
+<!--
+AUDIO REFERENCE: 
+Tom: "Thanks, Maria. I _ debugging it when I _ it was a simple configuration error in the code."
+-->
+
+# --description--
+
+In this sentence, Tom uses the past continuous tense (`I was debugging`) to describe an ongoing action in the past. 
+
+He then switches to simple past (`I realized`) to state a specific action completed in the past. 
+
+Understanding how these tenses work together helps clarify the sequence of events.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`Thanks, Maria. I _ debugging it when I _ it was a simple configuration error in the code.`
+
+## --blanks--
+
+`was`
+
+### --feedback--
+
+Part of the past continuous tense, showing the ongoing action of debugging.
+
+---
+
+`realized`
+
+### --feedback--
+
+Simple past indicates the moment Tom understood the problem.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65b2b54bf7897c3954e20971.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65b2b54bf7897c3954e20971.md
@@ -1,0 +1,54 @@
+---
+id: 65b2b54bf7897c3954e20971
+title: Task 54
+challengeType: 19
+dashedName: task-54
+audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
+---
+
+<!--
+AUDIO REFERENCE: 
+Tom: "Thanks, Maria. I was debugging it when I realized it was a simple configuration error in the code."
+-->
+
+# --description--
+
+Listen to the audio and answer the question.
+
+# --question--
+
+## --text--
+
+What did Tom discover while debugging?
+
+## --answers--
+
+A complex software bug that needed elaborate fixing
+
+### --feedback--
+
+Tom actually found the issue to be simpler.
+
+---
+
+That he needed assistance from another developer
+
+### --feedback--
+
+Tom doesn't mention needing help.
+
+---
+
+That the software needed a complete change.
+
+### --feedback--
+
+Tom doesn't mention the need for a complete change.
+
+---
+
+A simple configuration error in the code
+
+## --video-solution--
+
+4

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65b2b6255fe7973a8bf80902.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65b2b6255fe7973a8bf80902.md
@@ -1,0 +1,50 @@
+---
+id: 65b2b6255fe7973a8bf80902
+title: Task 55
+challengeType: 19
+dashedName: task-55
+audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
+---
+# --description--
+
+The word `complicated` is used to describe something that is difficult to understand or deal with due to its complexity or many parts.
+
+In a technical context, a problem being `complicated` means it can be challenging to solve or understand.
+
+# --question--
+
+## --text--
+
+What does `complicated` mean in the context of problem-solving?
+
+## --answers--
+
+Easy to solve or understand
+
+### --feedback--
+
+'Complicated' actually means the opposite – it indicates difficulty or complexity.
+
+---
+
+Difficult to understand or solve
+
+---
+
+Unimportant or trivial
+
+### --feedback--
+
+'Complicated' suggests complexity and difficulty, not triviality.
+
+---
+
+Quick to fix
+
+### --feedback--
+
+A complicated issue typically takes longer to fix due to its complexity.
+
+## --video-solution--
+
+2

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65b2b6aef88e363af2749620.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65b2b6aef88e363af2749620.md
@@ -1,0 +1,53 @@
+---
+id: 65b2b6aef88e363af2749620
+title: Task 56
+challengeType: 19
+dashedName: task-56
+audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
+---
+<!--
+AUDIO REFERENCE: 
+Maria: "That's good to hear. I was worried it might be something more complicated."
+-->
+
+# --description--
+
+Listen to the dialogue and answer the question.
+
+# --question--
+
+## --text--
+
+What was Maria's initial concern about the issue?
+
+## --answers--
+
+That it was a minor error
+
+### --feedback--
+
+A minor error wouldn't worry Maria.
+
+---
+
+That it might be something more complicated
+
+---
+
+That Tom couldn't fix it
+
+### --feedback--
+
+Maria was not worried about Tom's ability to fix the issue.
+
+---
+
+That it would require a new software
+
+### --feedback--
+
+Her concern was not about needing new software.
+
+## --video-solution--
+
+2

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65b2b74cb90a3d3b5d1acc48.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65b2b74cb90a3d3b5d1acc48.md
@@ -1,0 +1,53 @@
+---
+id: 65b2b74cb90a3d3b5d1acc48
+title: Task 57
+challengeType: 19
+dashedName: task-57
+---
+
+# --description--
+
+In a professional context, the verb `to document` means to record information for future use. It involves writing details, steps, or important points. 
+
+`Future reference` refers to the use of this recorded information at a later time, often to solve problems or recall procedures. For example:
+
+`They are documenting their studies for future reference.`
+
+
+# --question--
+
+## --text--
+
+What does `documenting something for future reference` mean in a work environment?
+
+## --answers--
+
+To sign official papers for upcoming events
+
+### --feedback--
+
+Documenting is not about just signing papers for events.
+
+---
+
+To record information for later use
+
+---
+
+To plan meetings and appointments
+
+### --feedback--
+
+While planning is important, it's not the same as documenting for future reference.
+
+---
+
+To predict future trends in the industry
+
+### --feedback--
+
+Documenting and future reference involve recording current information, not predicting trends.
+
+## --video-solution--
+
+2

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65b2b80774ecba3c156722aa.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65b2b80774ecba3c156722aa.md
@@ -1,0 +1,42 @@
+---
+id: 65b2b80774ecba3c156722aa
+title: Task 58
+challengeType: 22
+dashedName: task-58
+audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
+---
+
+<!--
+AUDIO REFERENCE: 
+Tom: "It happens to all of us, Maria. I’ll make sure to document this for future reference, so we won't _ into the _ problem again."
+-->
+
+# --description--
+
+`To run into` often means to meet someone unexpectedly or to encounter a problem. For example, `I ran into my friend at the store` means you met your friend without planning to.
+
+The expression `run into the same problem` specifically refers to facing the same difficulty or issue again. It's a way to talk about facing a repeated challenge, especially one that you have experienced before and want to avoid.
+
+For example, if a software crashes due to a specific bug, and you fix it, you would document the solution to ensure you don't `run into the same problem` in the future.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`It happens to all of us, Maria. I’ll make sure to document this for future reference, so we won't _ into the _ problem again.`
+
+## --blanks--
+
+`run`
+
+### --feedback--
+
+In this context, it means to face a problem.
+
+---
+
+`same`
+
+### --feedback--
+
+This word ndicates it is the exact issue that was faced before.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65b2ba3323d6d33d470e5f53.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65b2ba3323d6d33d470e5f53.md
@@ -1,0 +1,55 @@
+---
+id: 65b2ba3323d6d33d470e5f53
+title: Task 59
+challengeType: 19
+dashedName: task-59
+audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
+---
+<!--
+AUDIO REFERENCE: 
+Tom: "It happens to all of us, Maria. I’ll make sure to document this for future reference, so we won't run into the same problem again."
+-->
+
+# --description--
+
+Tom uses `I’ll` (short for `I will`) to talk about what he plans to do later. 
+
+`Will` is often used when someone decides to do something in the future. For example, `I’ll call you later` means the person plans to call sometime after now.
+
+# --question--
+
+## --text--
+
+What does Tom plan to do later?
+
+## --answers--
+
+He plans not to do anything about the issue
+
+### --feedback--
+
+Tom actually plans to do something important.
+
+---
+
+He will make sure to document the issue
+
+---
+
+He already finished documenting the issue
+
+### --feedback--
+
+Tom is talking about what he will do in the future, not what he has already done.
+
+---
+
+He will forget to document the issue
+
+### --feedback--
+
+Tom says `I’ll make sure`, which means he is certain about doing something.
+
+## --video-solution--
+
+2

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65b2bb073ac8d03dfe507810.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65b2bb073ac8d03dfe507810.md
@@ -1,0 +1,54 @@
+---
+id: 65b2bb073ac8d03dfe507810
+title: Task 60
+challengeType: 19
+dashedName: task-60
+audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
+---
+
+<!--
+AUDIO REFERENCE: 
+Tom: "It happens to all of us, Maria. I’ll make sure to document this for future reference, so we won't run into the same problem again."
+-->
+
+# --description--
+
+Listen to the audio and answer the question.
+
+# --question--
+
+## --text--
+
+Why does Tom want to document the issue?
+
+## --answers--
+
+To help prevent the same issue in the future
+
+---
+
+To remember the problem for his personal notes
+
+### --feedback--
+
+Tom's purpose is not focused only on his individual needs.
+
+---
+
+Because he enjoys writing documentation
+
+### --feedback--
+
+Tom's reason is not related to enjoyment.
+
+---
+
+To share the issue with people outside his team
+
+### --feedback--
+
+He is focused on his team.
+
+## --video-solution--
+
+1

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65b2bd42ca24dd3ede91aa41.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65b2bd42ca24dd3ede91aa41.md
@@ -1,0 +1,54 @@
+---
+id: 65b2bd42ca24dd3ede91aa41
+title: Task 61
+challengeType: 22
+dashedName: task-61
+audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
+---
+
+<!--
+AUDIO REFERENCE: 
+The entire conversation between Tom and Maria.
+-->
+
+# --description--
+
+Listen to the entire conversation between Tom and Maria and fill in the blanks. This challenge focuses on key points they discussed, including solving a technical issue and planning to prevent future problems.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`Maria was happy Tom _ the GitHub issue, and Tom explained it was a _ error. He plans to _ the steps taken to fix it for _ reference, so the same issue won't happen again.`
+
+## --blanks--
+
+`fixed`
+
+### --feedback--
+
+Tom fixed an issue on GitHub. This ber ends with `-ing`
+
+---
+
+`configuration`
+
+### --feedback--
+
+The issue was due to a simple configuration error.
+
+---
+
+`document`
+
+### --feedback--
+
+Tom intends to document the process to help in the future.
+
+---
+
+`future`
+
+### --feedback--
+
+Documenting for future reference means to prevent repeating the same problem.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/task-32.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/task-32.md
@@ -1,0 +1,54 @@
+---
+id: 656bd968e52c34220164de8d
+title: Task 32
+challengeType: 19
+dashedName: task-32
+audioPath: Add the path to the audio file here. Or, delete this if you don't have audio.
+---
+<!--
+AUDIO REFERENCE: 
+
+Sarah: No problem, Tom. I noticed the issue you mentioned, and I’ve already tried a few things to solve it.
+-->
+
+# --description--
+
+It's important to understand responses and actions in a conversation. This task focuses on what Sarah did after noticing the issue.
+
+# --question--
+
+## --text--
+
+What did Sarah do about the issue Tom mentioned?
+
+## --answers--
+
+`Sarah has already tried a few things to solve it`
+
+---
+
+`She is planning to solve it later`
+
+### --feedback--
+
+Sarah mentioned that she has already tried some things, not that she is planning to do it later.
+
+---
+
+`She asked someone else for help`
+
+### --feedback--
+
+There is no mention of Sarah asking for help from others in her response.
+
+---
+
+`She did nothing about it`
+
+### --feedback--
+
+Sarah stated that she already tried a few things, which means she did take some action.
+
+### --video-solution--
+
+1


### PR DESCRIPTION
I've created the challenges for the block 6.1 of the English Curriculum. There are three dialogues and 61 tasks.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->
