### PR TITLE
fix(curriculum): allow new line inside span element

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-form-validation-by-building-a-calorie-counter/63c9e6b7c0303524af2d0bc2.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-form-validation-by-building-a-calorie-counter/63c9e6b7c0303524af2d0bc2.md
@@ -15,7 +15,7 @@ Your `span` should have the text `${remainingCalories} Calorie ${surplusOrDefici
 
 ```js
 const htmlString = code.split(/output\s*\.\s*innerHTML\s*=\s*/)[1].split(/`/)[1];
-assert.match(htmlString, /<span\s+class\s*=\s*"\$\{surplusOrDeficit\s*\.toLowerCase\(\s*\)\}"\s*>\$\{remainingCalories\} Calorie \$\{surplusOrDeficit\}<\/span>/);
+assert.match(htmlString, /<span\s+class\s*=\s*"\$\{surplusOrDeficit\s*\.toLowerCase\(\s*\)\}"\s*>\s*\$\{remainingCalories\} Calorie \$\{surplusOrDeficit\}\s*<\/span>/);
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

This is just to allow for HTML formatting like this

```
<span>
  content
</span>
```

If we only care about the element text (`innerText`) it would work the same way. You can't see the spaces anyway (on the page).

Forum: https://forum.freecodecamp.org/t/learn-form-validation-by-building-a-calorie-counter-step-80/664931