### PR TITLE
fix(curriculum): incorrect terminology for OOP game in steps 84 - end

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64caeb134c3cdc5498cd75b9.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64caeb134c3cdc5498cd75b9.md
@@ -7,11 +7,11 @@ dashedName: step-84
 
 # --description--
 
-Inside that array, add a conditional statement that checks if the player's `x` position is greater than or equal to the platform's `x` position minus half of the player's width.
+Inside that array, add a boolean expression that checks if the player's `x` position is greater than or equal to the platform's `x` position minus half of the player's width.
 
 # --hints--
 
-You should have a conditional statement that checks if the player's `x` position is greater than or equal to the platform's `x` position minus half of the player's width.
+You should have a boolean expression that checks if the player's `x` position is greater than or equal to the platform's `x` position minus half of the player's width.
 
 ```js
 assert.match(code, /const\s+platformDetectionRules\s+=\s*\[\s*player\.position\.x\s*>=\s*platform\.position\.x\s*-\s*player\.width\s*\/\s*2,?\s*\];?/)

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64caeeae2fa57756035d6012.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64caeeae2fa57756035d6012.md
@@ -7,11 +7,11 @@ dashedName: step-85
 
 # --description--
 
-Below that conditional statement, add another conditional statement that checks if the player's `x` position is less than or equal to the sum of the platform's `x` position plus the platform's width minus one-third of the player's width.
+Below that boolean expression, add another boolean expression that checks if the player's `x` position is less than or equal to the sum of the platform's `x` position plus the platform's width minus one-third of the player's width.
 
 # --hints--
 
-You should have a conditional statement that checks if the player's `x` position is less than or equal to the sum of the platform's `x` position and the platform's width minus one third of the player's width.
+You should have a boolean expression that checks if the player's `x` position is less than or equal to the sum of the platform's `x` position and the platform's width minus one third of the player's width.
 
 ```js
 assert.match(code, /const\s+platformDetectionRules\s+=\s*\[\s*player\.position\.x\s*>=\s*platform\.position\.x\s*-\s*player\.width\s*\/\s*2,?\s*player\.position\.x\s*<=\s*platform\.position\.x\s*\+\s*platform\.width\s*-\s*player\.width\s*\/\s*3,?\s*\];?/)

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64caf1be15606d5814c3387b.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64caf1be15606d5814c3387b.md
@@ -7,9 +7,9 @@ dashedName: step-86
 
 # --description--
 
-Add another conditional statement that checks if the player's `y` position plus the player's height is greater than or equal to the platform's `y` position.
+Add another boolean expression that checks if the player's `y` position plus the player's height is greater than or equal to the platform's `y` position.
 
-Below that, add another conditional statement that checks if the player's `y` position is less than or equal to the sum of the platform's `y` position plus the platform's height.
+Below that, add another boolean expression that checks if the player's `y` position is less than or equal to the sum of the platform's `y` position plus the platform's height.
 
 # --hints--
 
@@ -20,14 +20,14 @@ assert.match(code, /const\s+platformDetectionRules\s+=\s*\[\s*player\.position\.
 
 ```
 
-You should have a conditional statement that checks if the player's `y` position plus the player's height is greater than or equal to the platform's `y` position.
+You should have a boolean expression that checks if the player's `y` position plus the player's height is greater than or equal to the platform's `y` position.
 
 ```js
 assert.match(code, /const\s+platformDetectionRules\s+=\s*\[\s*player\.position\.x\s*>=\s*platform\.position\.x\s*-\s*player\.width\s*\/\s*2,?\s*player\.position\.x\s*<=\s*platform\.position\.x\s*\+\s*platform\.width\s*-\s*player\.width\s*\/\s*3,\s*player\.position\.y\s*\+\s*player\.height\s*>=\s*platform\.position\.y,\s*.*\s*\];?/)
 
 ```
 
-You should have a conditional statement that checks if the player's `y` position is less than or equal to the sum of the platform's `y` position plus the platform's height.
+You should have a boolean expression that checks if the player's `y` position is less than or equal to the sum of the platform's `y` position plus the platform's height.
 
 ```js
 assert.match(code, /const\s+platformDetectionRules\s+=\s*\[\s*player\.position\.x\s*>=\s*platform\.position\.x\s*-\s*player\.width\s*\/\s*2,?\s*player\.position\.x\s*<=\s*platform\.position\.x\s*\+\s*platform\.width\s*-\s*player\.width\s*\/\s*3,\s*player\.position\.y\s*\+\s*player\.height\s*>=\s*platform\.position\.y,\s*player\.position\.y\s*<=\s*platform\.position\.y\s*\+\s*platform\.height,?\s*\];?/)

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64cb522509ffb274daf9fd9e.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64cb522509ffb274daf9fd9e.md
@@ -9,7 +9,7 @@ dashedName: step-105
 
 Create a new `const` variable called `checkpointDetectionRules` and assign it an empty array. 
 
-Inside that array, add a conditional statement that checks if the player's `position.x` is greater than or equal to the checkpoint's `position.x`.
+Inside that array, add a boolean expression that checks if the player's `position.x` is greater than or equal to the checkpoint's `position.x`.
 
 # --hints--
 
@@ -19,7 +19,7 @@ You should use const to create an empty `checkpointDetectionRules` array.
 assert.match(code, /const\s+checkpointDetectionRules\s*=\s*\[\s*/)
 ```
 
-You should have a conditional statement that checks if the player's `position.x` is greater than or equal to the checkpoint's `position.x` inside the `checkpointDetectionRules` array.
+You should have a boolean expression that checks if the player's `position.x` is greater than or equal to the checkpoint's `position.x` inside the `checkpointDetectionRules` array.
 
 ```js
 assert.match(code, /const\s+checkpointDetectionRules\s*=\s*\[\s*player\.position\.x\s*>=\s*checkpoint\.position\.x,?\s*\]/)

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64cb583dadb33a77595797bd.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64cb583dadb33a77595797bd.md
@@ -7,22 +7,22 @@ dashedName: step-106
 
 # --description--
 
-Add another conditional statement that checks if the player's `position.y` is greater than or equal to the checkpoint's `position.y`.
+Add another boolean expression that checks if the player's `position.y` is greater than or equal to the checkpoint's `position.y`.
 
-Below that statement, add another conditional statement that checks if the player's `position.y` plus the player's `height` is less than or equal to the checkpoint's `position.y` plus the checkpoint's `height`.
+Below that statement, add another boolean expression that checks if the player's `position.y` plus the player's `height` is less than or equal to the checkpoint's `position.y` plus the checkpoint's `height`.
 
 For the last array item, add the `isCheckpointCollisionDetectionActive` variable.
 
 # --hints--
 
-You should have a conditional statement that checks if the player's `position.y` is greater than or equal to the checkpoint's `position.y`
+You should have a boolean expression that checks if the player's `position.y` is greater than or equal to the checkpoint's `position.y`
 
 ```js
 assert.match(code, /player\.position\.y\s*>=\s*checkpoint\.position\.y,/)
 
 ```
 
-You should have a conditional statement that checks if the player's `position.y` plus the player's height is less than or equal to the checkpoint's `position.y` plus the checkpoint's height.
+You should have a boolean expression that checks if the player's `position.y` plus the player's height is less than or equal to the checkpoint's `position.y` plus the checkpoint's height.
 
 ```js
 assert.match(code, /player\.position\.y\s*>=\s*checkpoint\.position\.y,\s*player\.position\.y\s*\+\s*player\.height\s*<=\s*checkpoint\.position\.y\s*\+\s*checkpoint\.height,/)


### PR DESCRIPTION
## Summary of changes

Replaces uses of conditional statement to use boolean expression instead. 

Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.



