### PR TITLE
fix: correct JavaScript Algorithms Certification title

### DIFF
--- a/client/config/cert-and-project-map.ts
+++ b/client/config/cert-and-project-map.ts
@@ -100,7 +100,7 @@ const allStandardCerts = [
   },
   {
     id: '658180220947283cdc0689ce',
-    title: 'JavaScript Algorithms and Data Structures (Beta)',
+    title: 'JavaScript Algorithms and Data Structures',
     certSlug: Certification.JsAlgoDataStructNew,
     projects: [
       {

--- a/client/src/components/settings/certification.tsx
+++ b/client/src/components/settings/certification.tsx
@@ -136,7 +136,7 @@ const isCertMapSelector = createSelector(
     'Example Certification': false,
     'Upcoming Python Certification': false,
     'A2 English for Developers': false,
-    'JavaScript Algorithms and Data Structures (Beta)': isJsAlgoDataStructCertV8
+    'JavaScript Algorithms and Data Structures': isJsAlgoDataStructCertV8
   })
 );
 

--- a/shared/config/certification-settings.ts
+++ b/shared/config/certification-settings.ts
@@ -251,8 +251,7 @@ export const certTypeTitleMap = {
   [certTypes.collegeAlgebraPyV8]: 'College Algebra with Python',
   [certTypes.foundationalCSharpV8]: 'Foundational C# with Microsoft',
   [certTypes.upcomingPythonV8]: 'Upcoming Python',
-  [certTypes.jsAlgoDataStructV8]:
-    'JavaScript Algorithms and Data Structures (Beta)'
+  [certTypes.jsAlgoDataStructV8]: 'JavaScript Algorithms and Data Structures'
 };
 
 export const oldDataVizId = '561add10cb82ac38a17513b3';

--- a/tools/challenge-editor/api/configs/super-block-list.ts
+++ b/tools/challenge-editor/api/configs/super-block-list.ts
@@ -52,7 +52,7 @@ export const superBlockList = [
     path: '14-responsive-web-design-22'
   },
   {
-    name: 'JavaScript Algorithms and Data Structures (Beta)',
+    name: 'JavaScript Algorithms and Data Structures',
     path: '15-javascript-algorithms-and-data-structures-22'
   },
   {


### PR DESCRIPTION
This should fix the inaccessibility for the new JavaScript certification.

It seems like the beta keyword should only be included in the `intro.json` file. At least that is what we do with the new Python Certification.


I am still not sure why this wasn't failing before.

ref: #52980