### PR TITLE
feat: provide sensible default title/dashedName

### DIFF
--- a/tools/challenge-helper-scripts/helpers/new-challenge-prompts.ts
+++ b/tools/challenge-helper-scripts/helpers/new-challenge-prompts.ts
@@ -1,11 +1,35 @@
 import { prompt } from 'inquirer';
 import { challengeTypes } from '../../../shared/config/challenge-types';
+import { getLastStep } from './get-last-step-file-number';
 
 export const newChallengePrompts = async (): Promise<{
   title: string;
   dashedName: string;
   challengeType: string;
 }> => {
+  const challengeType = await prompt<{ value: string }>({
+    name: 'value',
+    message: 'What type of challenge is this?',
+    type: 'list',
+    choices: Object.entries(challengeTypes).map(([key, value]) => ({
+      name: key,
+      value
+    }))
+  });
+
+  const lastStep = getLastStep().stepNum;
+  const challengeTypeNum = parseInt(challengeType.value, 10);
+  const isTaskStep =
+    challengeTypeNum === challengeTypes.fillInTheBlank ||
+    challengeTypeNum === challengeTypes.dialogue;
+
+  const defaultTitle = isTaskStep
+    ? `Task ${lastStep + 1}`
+    : `Step ${lastStep + 1}`;
+  const defaultDashedName = isTaskStep
+    ? `task-${lastStep + 1}`
+    : `step-${lastStep + 1}`;
+
   const dashedName = await prompt<{ value: string }>({
     name: 'value',
     message: 'What is the short name (in kebab-case) for this challenge?',
@@ -20,21 +44,13 @@ export const newChallengePrompts = async (): Promise<{
     },
     filter: (block: string) => {
       return block.toLowerCase();
-    }
+    },
+    default: defaultDashedName
   });
   const title = await prompt<{ value: string }>({
     name: 'value',
     message: 'What is the title of this challenge?',
-    default: (title: { value: string }) => title.value
-  });
-  const challengeType = await prompt<{ value: string }>({
-    name: 'value',
-    message: 'What type of challenge is this?',
-    type: 'list',
-    choices: Object.entries(challengeTypes).map(([key, value]) => ({
-      name: key,
-      value
-    }))
+    default: defaultTitle
   });
 
   return {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This changes the order of questions so that the helper script can use challengeType to infer the likely title and dashedName.


```
? What type of challenge is this? fillInTheBlank
? What is the short name (in kebab-case) for this challenge? (task-30) 
```
then 

```
? What type of challenge is this? fillInTheBlank
? What is the short name (in kebab-case) for this challenge? task-30
? What is the title of this challenge? (Task 30) 
```


<!-- Feel free to add any additional description of changes below this line -->
