### PR TITLE
fix(curriculum): allow changing order of multiplication factors in RPG - Step 128

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a8eefe2e68b66ac563816b.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a8eefe2e68b66ac563816b.md
@@ -22,13 +22,13 @@ assert.match(defeatMonster.toString(), /gold\s*\+=/);
 You should use `Math.floor()` to round the result of the monster's level times `6.7`.
 
 ```js
-assert.match(defeatMonster.toString(), /Math\.floor\(\s*monsters\[fighting\]\.level\s*\*\s*6\.7\s*\)/);
+assert.match(defeatMonster.toString(), /(Math\.floor\(\s*monsters\[fighting\]\.level\s*\*\s*6\.7\s*\))|(Math\.floor\(\s*6\.7\s*\*\s*monsters\[fighting\]\.level\s*\))/);
 ```
 
 You should add the result of `Math.floor(monsters[fighting].level * 6.7)` to `gold`.
 
 ```js
-assert.match(defeatMonster.toString(), /gold\s*\+=\s*Math\.floor\(\s*monsters\[fighting\]\.level\s*\*\s*6\.7\s*\)/);
+assert.match(defeatMonster.toString(), /gold\s*\+=\s*(Math\.floor\(\s*monsters\[fighting\]\.level\s*\*\s*6\.7\s*\))|(Math\.floor\(\s*6\.7\s*\*\s*monsters\[fighting\]\.level\s*\))/);
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

RPG Step 128 currently accepts:

```js
function defeatMonster() {
  gold += Math.floor(monsters[fighting].level * 6.7);
}
```

But not:

```js
function defeatMonster() {
  gold += Math.floor(6.7 * monsters[fighting].level);
}
```

This PR updates the regex to allow both variants.

Link to the challenge: https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures-v8/learn-basic-javascript-by-building-a-role-playing-game/step-129 (it's step 129 in production, but is 128 in `main`)

<!-- Feel free to add any additional description of changes below this line -->
