### PR TITLE
fix(cirriculum): tell campers to use leading space in rpg step 120

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a8e41e2f190c58404dd46e.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a8e41e2f190c58404dd46e.md
@@ -7,8 +7,7 @@ dashedName: step-119
 
 # --description--
 
-On a new line, add the string ` You attack it with your <weapon>.` to the `text` value, replacing `<weapon>` with the player's current weapon. Additionally, remember that this line of text starts
-with a space so it will properly display. 
+On a new line, add the string ` You attack it with your <weapon>.` to the `text` value, replacing `<weapon>` with the player's current weapon. Additionally, remember that this line of text starts with a space so it will properly display. 
 
 # --hints--
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a8e41e2f190c58404dd46e.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a8e41e2f190c58404dd46e.md
@@ -7,7 +7,8 @@ dashedName: step-119
 
 # --description--
 
-On a new line, add the string ` You attack it with your <weapon>.` to the `text` value, replacing `<weapon>` with the player's current weapon.
+On a new line, add the string ` You attack it with your <weapon>.` to the `text` value, replacing `<weapon>` with the player's current weapon. Additionally, remember that this line of text starts
+with a space so it will properly display. 
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #53198

<!-- Feel free to add any additional description of changes below this line -->
In the code base, this is actually step 120. All I did was add a line of text clarifying to the camper they should indeed add a leading space to the new line of text. Hopefully this is enough. If not, I'll be happy to see what else I could do. 