### PR TITLE
fix(curriculum): accessibility question labels in accessibility quiz project

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6145f14f019a4b0adb94b051.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6145f14f019a4b0adb94b051.md
@@ -163,7 +163,7 @@ assert.isTrue(document.querySelector('div.answer > select')?.required);
           <h2 id="css-questions">CSS</h2>
           <div class="formrow">
             <div class="question-block">
-              <label>Are you a frontend developer?</label>
+              <label>Can the CSS margin property accept negative values?</label>
             </div>
 --fcc-editable-region--
             <div class="answer">

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6145f3a5cd9be60b9459cdd6.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6145f3a5cd9be60b9459cdd6.md
@@ -132,7 +132,7 @@ assert.notEmpty(document.querySelector('.answer > select')?.name);
           <div class="formrow">
 --fcc-editable-region--
             <div class="question-block">
-              <label>Are you a frontend developer?</label>
+              <label>Can the CSS margin property accept negative values?</label>
             </div>
             <div class="answer">
               <select required>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6145f47393fbe70c4d885f9c.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6145f47393fbe70c4d885f9c.md
@@ -137,10 +137,10 @@ assert.notEmpty(document.querySelectorAll('div.answer')?.[1]?.querySelector('tex
           <h2 id="css-questions">CSS</h2>
           <div class="formrow">
             <div class="question-block">
-              <label for="customer">Are you a frontend developer?</label>
+              <label for="selector">Can the CSS margin property accept negative values?</label>
             </div>
             <div class="answer">
-              <select name="customer" id="customer" required>
+              <select name="selector" id="selector" required>
                 <option value="">Select an option</option>
                 <option value="yes">Yes</option>
                 <option value="no">No</option>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6145f59029474c0d3dc1c8b8.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6145f59029474c0d3dc1c8b8.md
@@ -144,10 +144,10 @@ assert.match(document.querySelectorAll('.answer')?.[1]?.querySelector('textarea'
           <h2 id="css-questions">CSS</h2>
           <div class="formrow">
             <div class="question-block">
-              <label for="customer">Are you a frontend developer?</label>
+              <label for="selector">Can the CSS margin property accept negative values?</label>
             </div>
             <div class="answer">
-              <select name="customer" id="customer" required>
+              <select name="selector" id="selector" required>
                 <option value="">Select an option</option>
                 <option value="yes">Yes</option>
                 <option value="no">No</option>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6145f685797bd30df9784e8c.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6145f685797bd30df9784e8c.md
@@ -138,10 +138,10 @@ assert.equal(document.querySelector('button[type="submit"]')?.textContent ?? doc
           <h2 id="css-questions">CSS</h2>
           <div class="formrow">
             <div class="question-block">
-              <label for="customer">Are you a frontend developer?</label>
+              <label for="selector">Can the CSS margin property accept negative values?</label>
             </div>
             <div class="answer">
-              <select name="customer" id="customer" required>
+              <select name="selector" id="selector" required>
                 <option value="">Select an option</option>
                 <option value="yes">Yes</option>
                 <option value="no">No</option>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6145f829ac6a920ebf5797d7.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6145f829ac6a920ebf5797d7.md
@@ -121,10 +121,10 @@ assert.exists(document.querySelector('footer > address'));
           <h2 id="css-questions">CSS</h2>
           <div class="formrow">
             <div class="question-block">
-              <label for="customer">Are you a frontend developer?</label>
+              <label for="selector">Can the CSS margin property accept negative values?</label>
             </div>
             <div class="answer">
-              <select name="customer" id="customer" required>
+              <select name="selector" id="selector" required>
                 <option value="">Select an option</option>
                 <option value="yes">Yes</option>
                 <option value="no">No</option>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6145f8f8bcd4370f6509078e.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6145f8f8bcd4370f6509078e.md
@@ -122,10 +122,10 @@ assert.equal(document.querySelector('address')?.innerText, 'freeCodeCamp\nSan Fr
           <h2 id="css-questions">CSS</h2>
           <div class="formrow">
             <div class="question-block">
-              <label for="customer">Are you a frontend developer?</label>
+              <label for="selector">Can the CSS margin property accept negative values?</label>
             </div>
             <div class="answer">
-              <select name="customer" id="customer" required>
+              <select name="selector" id="selector" required>
                 <option value="">Select an option</option>
                 <option value="yes">Yes</option>
                 <option value="no">No</option>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6145fb5018cb5b100cb2a88c.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6145fb5018cb5b100cb2a88c.md
@@ -128,10 +128,10 @@ assert.equal(document.querySelector('address')?.innerHTML?.match(/freeCodeCamp/g
           <h2 id="css-questions">CSS</h2>
           <div class="formrow">
             <div class="question-block">
-              <label for="customer">Are you a frontend developer?</label>
+              <label for="selector">Can the CSS margin property accept negative values?</label>
             </div>
             <div class="answer">
-              <select name="customer" id="customer" required>
+              <select name="selector" id="selector" required>
                 <option value="">Select an option</option>
                 <option value="yes">Yes</option>
                 <option value="no">No</option>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6145fc3707fc3310c277f5c8.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6145fc3707fc3310c277f5c8.md
@@ -153,10 +153,10 @@ assert.equal(display, 'block');
           <h2 id="css-questions">CSS</h2>
           <div class="formrow">
             <div class="question-block">
-              <label for="customer">Are you a frontend developer?</label>
+              <label for="selector">Can the CSS margin property accept negative values?</label>
             </div>
             <div class="answer">
-              <select name="customer" id="customer" required>
+              <select name="selector" id="selector" required>
                 <option value="">Select an option</option>
                 <option value="yes">Yes</option>
                 <option value="no">No</option>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/614796cb8086be482d60e0ac.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/614796cb8086be482d60e0ac.md
@@ -150,10 +150,10 @@ for (let elem of document.querySelectorAll('li > a')) {
           <h2 id="css-questions">CSS</h2>
           <div class="formrow">
             <div class="question-block">
-              <label for="customer">Are you a frontend developer?</label>
+              <label for="selector">Can the CSS margin property accept negative values?</label>
             </div>
             <div class="answer">
-              <select name="customer" id="customer" required>
+              <select name="selector" id="selector" required>
                 <option value="">Select an option</option>
                 <option value="yes">Yes</option>
                 <option value="no">No</option>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6147a14ef5668b5881ef2297.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6147a14ef5668b5881ef2297.md
@@ -146,10 +146,10 @@ assert.equal(cursor, 'pointer');
           <h2 id="css-questions">CSS</h2>
           <div class="formrow">
             <div class="question-block">
-              <label for="customer">Are you a frontend developer?</label>
+              <label for="selector">Can the CSS margin property accept negative values?</label>
             </div>
             <div class="answer">
-              <select name="customer" id="customer" required>
+              <select name="selector" id="selector" required>
                 <option value="">Select an option</option>
                 <option value="yes">Yes</option>
                 <option value="no">No</option>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/614878f7a412310647873015.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/614878f7a412310647873015.md
@@ -133,10 +133,10 @@ assert.equal(new __helpers.CSSHelp(document).getStyle('header')?.top, '0px');
           <h2 id="css-questions">CSS</h2>
           <div class="formrow">
             <div class="question-block">
-              <label for="customer">Are you a frontend developer?</label>
+              <label for="selector">Can the CSS margin property accept negative values?</label>
             </div>
             <div class="answer">
-              <select name="customer" id="customer" required>
+              <select name="selector" id="selector" required>
                 <option value="">Select an option</option>
                 <option value="yes">Yes</option>
                 <option value="no">No</option>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/61487b77d4a37707073a64e5.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/61487b77d4a37707073a64e5.md
@@ -135,10 +135,10 @@ assert.isEmpty(new __helpers.CSSHelp(document).getStyle('main')?.paddingRight);
           <h2 id="css-questions">CSS</h2>
           <div class="formrow">
             <div class="question-block">
-              <label for="customer">Are you a frontend developer?</label>
+              <label for="selector">Can the CSS margin property accept negative values?</label>
             </div>
             <div class="answer">
-              <select name="customer" id="customer" required>
+              <select name="selector" id="selector" required>
                 <option value="">Select an option</option>
                 <option value="yes">Yes</option>
                 <option value="no">No</option>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/61487da611a65307e78d2c20.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/61487da611a65307e78d2c20.md
@@ -146,10 +146,10 @@ assert.equal(new __helpers.CSSHelp(document).getStyle('nav > ul')?.height, '100%
           <h2 id="css-questions">CSS</h2>
           <div class="formrow">
             <div class="question-block">
-              <label for="customer">Are you a frontend developer?</label>
+              <label for="selector">Can the CSS margin property accept negative values?</label>
             </div>
             <div class="answer">
-              <select name="customer" id="customer" required>
+              <select name="selector" id="selector" required>
                 <option value="">Select an option</option>
                 <option value="yes">Yes</option>
                 <option value="no">No</option>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/61487f703571b60899055cf9.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/61487f703571b60899055cf9.md
@@ -151,10 +151,10 @@ assert.equal(new __helpers.CSSHelp(document).getStyle('section')?.maxWidth, '600
           <h2 id="css-questions">CSS</h2>
           <div class="formrow">
             <div class="question-block">
-              <label for="customer">Are you a frontend developer?</label>
+              <label for="selector">Can the CSS margin property accept negative values?</label>
             </div>
             <div class="answer">
-              <select name="customer" id="customer" required>
+              <select name="selector" id="selector" required>
                 <option value="">Select an option</option>
                 <option value="yes">Yes</option>
                 <option value="no">No</option>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/614880dc16070e093e29bc56.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/614880dc16070e093e29bc56.md
@@ -119,10 +119,10 @@ assert.equal(new __helpers.CSSHelp(document).getStyle('h2')?.paddingTop, '60px')
           <h2 id="css-questions">CSS</h2>
           <div class="formrow">
             <div class="question-block">
-              <label for="customer">Are you a frontend developer?</label>
+              <label for="selector">Can the CSS margin property accept negative values?</label>
             </div>
             <div class="answer">
-              <select name="customer" id="customer" required>
+              <select name="selector" id="selector" required>
                 <option value="">Select an option</option>
                 <option value="yes">Yes</option>
                 <option value="no">No</option>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/614883b6fa720e09fb167de9.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/614883b6fa720e09fb167de9.md
@@ -137,10 +137,10 @@ assert.isAtLeast(Number(new __helpers.CSSHelp(document).getStyle('.info')?.paddi
           <h2 id="css-questions">CSS</h2>
           <div class="formrow">
             <div class="question-block">
-              <label for="customer">Are you a frontend developer?</label>
+              <label for="selector">Can the CSS margin property accept negative values?</label>
             </div>
             <div class="answer">
-              <select name="customer" id="customer" required>
+              <select name="selector" id="selector" required>
                 <option value="">Select an option</option>
                 <option value="yes">Yes</option>
                 <option value="no">No</option>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/614884c1f5d6f30ab3d78cde.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/614884c1f5d6f30ab3d78cde.md
@@ -217,10 +217,10 @@ assert.isAtLeast(valInPx, 13);
           <h2 id="css-questions">CSS</h2>
           <div class="formrow">
             <div class="question-block">
-              <label for="customer">Are you a frontend developer?</label>
+              <label for="selector">Can the CSS margin property accept negative values?</label>
             </div>
             <div class="answer">
-              <select name="customer" id="customer" required>
+              <select name="selector" id="selector" required>
                 <option value="">Select an option</option>
                 <option value="yes">Yes</option>
                 <option value="no">No</option>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/61488ecfd05e290b5712e6da.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/61488ecfd05e290b5712e6da.md
@@ -130,10 +130,10 @@ assert.equal(textAlign, 'left');
           <h2 id="css-questions">CSS</h2>
           <div class="formrow">
             <div class="question-block">
-              <label for="customer">Are you a frontend developer?</label>
+              <label for="selector">Can the CSS margin property accept negative values?</label>
             </div>
             <div class="answer">
-              <select name="customer" id="customer" required>
+              <select name="selector" id="selector" required>
                 <option value="">Select an option</option>
                 <option value="yes">Yes</option>
                 <option value="no">No</option>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6148d99cdc7acd0c519862cb.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6148d99cdc7acd0c519862cb.md
@@ -130,10 +130,10 @@ assert.equal(minWidth, '55px');
           <h2 id="css-questions">CSS</h2>
           <div class="formrow">
             <div class="question-block">
-              <label for="customer">Are you a frontend developer?</label>
+              <label for="selector">Can the CSS margin property accept negative values?</label>
             </div>
             <div class="answer">
-              <select name="customer" id="customer" required>
+              <select name="selector" id="selector" required>
                 <option value="">Select an option</option>
                 <option value="yes">Yes</option>
                 <option value="no">No</option>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6148da157cc0bd0d06df5c0a.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6148da157cc0bd0d06df5c0a.md
@@ -134,10 +134,10 @@ document.querySelectorAll('.info label').forEach(el => {
           <h2 id="css-questions">CSS</h2>
           <div class="formrow">
             <div class="question-block">
-              <label for="customer">Are you a frontend developer?</label>
+              <label for="selector">Can the CSS margin property accept negative values?</label>
             </div>
             <div class="answer">
-              <select name="customer" id="customer" required>
+              <select name="selector" id="selector" required>
                 <option value="">Select an option</option>
                 <option value="yes">Yes</option>
                 <option value="no">No</option>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6148dc095264000dce348bf5.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6148dc095264000dce348bf5.md
@@ -151,10 +151,10 @@ assert.equal(new __helpers.CSSHelp(document).getStyle('.question-block')?.textAl
           <h2 id="css-questions">CSS</h2>
           <div class="formrow">
             <div class="question-block">
-              <label for="customer">Are you a frontend developer?</label>
+              <label for="selector">Can the CSS margin property accept negative values?</label>
             </div>
             <div class="answer">
-              <select name="customer" id="customer" required>
+              <select name="selector" id="selector" required>
                 <option value="">Select an option</option>
                 <option value="yes">Yes</option>
                 <option value="no">No</option>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6148dcaaf2e8750e6cb4501a.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6148dcaaf2e8750e6cb4501a.md
@@ -137,10 +137,10 @@ assert.equal(new __helpers.CSSHelp(document).getStyle('p')?.fontSize, '20px');
           <h2 id="css-questions">CSS</h2>
           <div class="formrow">
             <div class="question-block">
-              <label for="customer">Are you a frontend developer?</label>
+              <label for="selector">Can the CSS margin property accept negative values?</label>
             </div>
             <div class="answer">
-              <select name="customer" id="customer" required>
+              <select name="selector" id="selector" required>
                 <option value="">Select an option</option>
                 <option value="yes">Yes</option>
                 <option value="no">No</option>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6148dd31d210990f0fb140f8.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6148dd31d210990f0fb140f8.md
@@ -127,10 +127,10 @@ assert.equal(new __helpers.CSSHelp(document).getStyle('.question')?.paddingBotto
           <h2 id="css-questions">CSS</h2>
           <div class="formrow">
             <div class="question-block">
-              <label for="customer">Are you a frontend developer?</label>
+              <label for="selector">Can the CSS margin property accept negative values?</label>
             </div>
             <div class="answer">
-              <select name="customer" id="customer" required>
+              <select name="selector" id="selector" required>
                 <option value="">Select an option</option>
                 <option value="yes">Yes</option>
                 <option value="no">No</option>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6148defa9c01520fb9d178a0.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6148defa9c01520fb9d178a0.md
@@ -133,10 +133,10 @@ assert.equal(new __helpers.CSSHelp(document).getStyle('.answers-list')?.padding,
           <h2 id="css-questions">CSS</h2>
           <div class="formrow">
             <div class="question-block">
-              <label for="customer">Are you a frontend developer?</label>
+              <label for="selector">Can the CSS margin property accept negative values?</label>
             </div>
             <div class="answer">
-              <select name="customer" id="customer" required>
+              <select name="selector" id="selector" required>
                 <option value="">Select an option</option>
                 <option value="yes">Yes</option>
                 <option value="no">No</option>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6148dfab9b54c110577de165.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6148dfab9b54c110577de165.md
@@ -165,10 +165,10 @@ assert.equal(new __helpers.CSSHelp(document).getStyle('button')?.border, '3px so
           <h2 id="css-questions">CSS</h2>
           <div class="formrow">
             <div class="question-block">
-              <label for="customer">Are you a frontend developer?</label>
+              <label for="selector">Can the CSS margin property accept negative values?</label>
             </div>
             <div class="answer">
-              <select name="customer" id="customer" required>
+              <select name="selector" id="selector" required>
                 <option value="">Select an option</option>
                 <option value="yes">Yes</option>
                 <option value="no">No</option>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6148e0bcc13efd10f7d7a6a9.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6148e0bcc13efd10f7d7a6a9.md
@@ -131,10 +131,10 @@ assert.equal(new __helpers.CSSHelp(document).getStyle('footer')?.justifyContent,
           <h2 id="css-questions">CSS</h2>
           <div class="formrow">
             <div class="question-block">
-              <label for="customer">Are you a frontend developer?</label>
+              <label for="selector">Can the CSS margin property accept negative values?</label>
             </div>
             <div class="answer">
-              <select name="customer" id="customer" required>
+              <select name="selector" id="selector" required>
                 <option value="">Select an option</option>
                 <option value="yes">Yes</option>
                 <option value="no">No</option>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6148e161ecec9511941f8833.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6148e161ecec9511941f8833.md
@@ -145,10 +145,10 @@ assert.isAtLeast(contrast(backgroundColour, aColour), 7);
           <h2 id="css-questions">CSS</h2>
           <div class="formrow">
             <div class="question-block">
-              <label for="customer">Are you a frontend developer?</label>
+              <label for="selector">Can the CSS margin property accept negative values?</label>
             </div>
             <div class="answer">
-              <select name="customer" id="customer" required>
+              <select name="selector" id="selector" required>
                 <option value="">Select an option</option>
                 <option value="yes">Yes</option>
                 <option value="no">No</option>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6148e28706b34912340fd042.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6148e28706b34912340fd042.md
@@ -143,10 +143,10 @@ assert.isAtLeast(Number(window.getComputedStyle(document.querySelector('address'
           <h2 id="css-questions">CSS</h2>
           <div class="formrow">
             <div class="question-block">
-              <label for="customer">Are you a frontend developer?</label>
+              <label for="selector">Can the CSS margin property accept negative values?</label>
             </div>
             <div class="answer">
-              <select name="customer" id="customer" required>
+              <select name="selector" id="selector" required>
                 <option value="">Select an option</option>
                 <option value="yes">Yes</option>
                 <option value="no">No</option>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6148e335c1edd512d00e4691.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6148e335c1edd512d00e4691.md
@@ -121,10 +121,10 @@ assert.equal(new __helpers.CSSHelp(document).getStyle('*')?.scrollBehavior, 'smo
           <h2 id="css-questions">CSS</h2>
           <div class="formrow">
             <div class="question-block">
-              <label for="customer">Are you a frontend developer?</label>
+              <label for="selector">Can the CSS margin property accept negative values?</label>
             </div>
             <div class="answer">
-              <select name="customer" id="customer" required>
+              <select name="selector" id="selector" required>
                 <option value="">Select an option</option>
                 <option value="yes">Yes</option>
                 <option value="no">No</option>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6148e41c728f65138addf9cc.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6148e41c728f65138addf9cc.md
@@ -137,10 +137,10 @@ assert.notExists(new __helpers.CSSHelp(document).getStyle('*'));
           <h2 id="css-questions">CSS</h2>
           <div class="formrow">
             <div class="question-block">
-              <label for="customer">Are you a frontend developer?</label>
+              <label for="selector">Can the CSS margin property accept negative values?</label>
             </div>
             <div class="answer">
-              <select name="customer" id="customer" required>
+              <select name="selector" id="selector" required>
                 <option value="">Select an option</option>
                 <option value="yes">Yes</option>
                 <option value="no">No</option>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6148e5aeb102e3142de026a2.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6148e5aeb102e3142de026a2.md
@@ -458,7 +458,7 @@ address {
         <h2 id="css-questions">CSS</h2>
         <div class="formrow">
           <div class="question-block">
-            <label for="customer">Are you an frontend developer?</label>
+            <label for="selector">Can the CSS margin property accept negative values?</label>
           </div>
           <div class="answer">
             <select name="selector" id="selector" required>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6148e5aeb102e3142de026a2.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6148e5aeb102e3142de026a2.md
@@ -139,10 +139,10 @@ assert.equal(document.querySelectorAll('a')?.[2]?.getAttribute('accesskey')?.len
           <h2 id="css-questions">CSS</h2>
           <div class="formrow">
             <div class="question-block">
-              <label for="customer">Are you a frontend developer?</label>
+              <label for="selector">Can the CSS margin property accept negative values?</label>
             </div>
             <div class="answer">
-              <select name="customer" id="customer" required>
+              <select name="selector" id="selector" required>
                 <option value="">Select an option</option>
                 <option value="yes">Yes</option>
                 <option value="no">No</option>
@@ -461,7 +461,7 @@ address {
             <label for="customer">Are you an frontend developer?</label>
           </div>
           <div class="answer">
-            <select name="customer" id="customer" required>
+            <select name="selector" id="selector" required>
               <option value="">Select an option</option>
               <option value="yes">Yes</option>
               <option value="no">No</option>


### PR DESCRIPTION
## Summary 
This PR updates the label for the `css-questions` section to use an actual css question instead of an unrelated question that exists now. 
More context in the issue. 

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #53236

<!-- Feel free to add any additional description of changes below this line -->
