### PR TITLE
fix(curriculum): update regex to handle multiple valid solutions

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64faca774fd9fd74bc084cc9.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64faca774fd9fd74bc084cc9.md
@@ -16,7 +16,7 @@ To begin, within the `closeTaskFormBtn` event listener, create a `formInputsCont
 You should use `const` to create a variable `formInputsContainValues` with the value `titleInput.value || dateInput.value || descriptionInput.value;`
 
 ```js
-assert.match(code, /const\s+formInputsContainValues\s*=\s*titleInput\.value\s*\|\|\s*dateInput\.value\s*\|\|\s*descriptionInput\.value;?/)
+assert.match(code, /const\s+formInputsContainValues\s*=\s*(titleInput\.value\s*(\|\||!==\s*['"]?null['"]?)\s*|\s*dateInput\.value\s*(\|\||!==\s*['"]?null['"]?)\s*|\s*descriptionInput\.value\s*(\|\||!==\s*['"]?null['"]?)\s*)+;?/)
 ```
 
 # --seed--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64faca774fd9fd74bc084cc9.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64faca774fd9fd74bc084cc9.md
@@ -16,7 +16,7 @@ To begin, within the `closeTaskFormBtn` event listener, create a `formInputsCont
 You should use `const` to create a variable `formInputsContainValues` with the value `titleInput.value || dateInput.value || descriptionInput.value;`
 
 ```js
-assert.match(code, /const\s+formInputsContainValues\s*=\s*(titleInput\.value\s*(\|\||!==\s*['"]?null['"]?)\s*|\s*dateInput\.value\s*(\|\||!==\s*['"]?null['"]?)\s*|\s*descriptionInput\.value\s*(\|\||!==\s*['"]?null['"]?)\s*)+;?/)
+assert.match(code, /const\s+formInputsContainValues\s*=\s*(titleInput\.value\s*\|\|\s*dateInput\.value\s*\|\|\s*descriptionInput\.value|titleInput\.value\s*!==\s*null\s*\|\|\s*dateInput\.value\s*!==\s*null\s*\|\|\s*descriptionInput\.value\s*!==\s*null)\;?/)
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #53200 

<!-- Feel free to add any additional description of changes below this line -->
I have updated the regex and tested it locally now it is handling both the cases above and some other cases as well. For now this is the most flexible one I can come up with. Feel free to ping me if you need any update
