### PR TITLE
fix: no need to listen to shift

### DIFF
--- a/client/src/templates/Challenges/components/hotkeys.tsx
+++ b/client/src/templates/Challenges/components/hotkeys.tsx
@@ -167,7 +167,7 @@ function Hotkeys({
             }
           },
           showShortcuts: (keyEvent?: KeyboardEvent) => {
-            if (!canFocusEditor && keyEvent?.shiftKey && keyEvent.key === '?') {
+            if (!canFocusEditor && keyEvent?.key === '?') {
               openShortcutsModal();
             }
           }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Ref #53048

Either:
- The keyboard layout requires the use of `SHIFT` to trigger a `?` keypress, in which case checking for the shift key is redundant OR
- The keyboard layout does not require the use of shift, and checking for it makes the conditions impossible.

<!-- Feel free to add any additional description of changes below this line -->
