### PR TITLE
feat(tools): run all curriculum tests on i18n pr

### DIFF
--- a/.github/workflows/curriculum-i18n.yml
+++ b/.github/workflows/curriculum-i18n.yml
@@ -1,0 +1,70 @@
+name: CI - Node.js
+env:
+  NODE_OPTIONS: '--max_old_space_size=6144'
+
+on:
+  # Run on push events, but only for the below branches
+  push:
+    branches:
+      - 'i18n-sync-curriculum'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test-curriculum:
+    name: Test Curriculum
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20.x]
+        # Exclude the languages that we currently run in the full CI suite.
+        locale:
+          [
+            'chinese',
+            'espanol',
+            'ukrainian',
+            'japanese',
+            'german',
+            'arabic',
+            'swahili'
+          ]
+    steps:
+      - name: Checkout Source Files
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: pnpm
+
+      - name: Set Environment variables
+        run: |
+          cp sample.env .env
+          cat .env
+
+      - name: Install node_modules
+        run: pnpm install
+
+      # DONT REMOVE THIS STEP.
+      # TODO: Refactor and use re-usable workflow and shared artifacts
+      - name: Build Client in ${{ matrix.locale }}
+        env:
+          CURRICULUM_LOCALE: ${{ matrix.locale }}
+          CLIENT_LOCALE: ${{ matrix.locale }}
+        run: |
+          pnpm run build
+
+      - name: Run Tests
+        env:
+          CURRICULUM_LOCALE: ${{ matrix.locale }}
+          CLIENT_LOCALE: ${{ matrix.locale }}
+        run: pnpm test:curriculum


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

The idea here is that we want to catch any potential translation issues that might cause builds to fail.

We *only* run the curriculum tests to save time on the runners - with 2 commits a week, this shouldn't be too painful for the pipeline?