### PR TITLE
feat: add Korean translation for curriculum

### DIFF
--- a/.github/workflows/crowdin-download.client-ui.yml
+++ b/.github/workflows/crowdin-download.client-ui.yml
@@ -262,6 +262,30 @@ jobs:
           # Uncomment below to debug
           # dryrun_action: true
 
+      ##### Download Korean #####
+      - name: Crowdin Download Korean Translations
+        uses: crowdin/github-action@master
+        # options: https://github.com/crowdin/github-action/blob/master/action.yml
+        with:
+          # uploads
+          upload_sources: false
+          upload_translations: false
+          auto_approve_imported: false
+          import_eq_suggestions: false
+          # downloads
+          download_translations: true
+          download_language: ko
+          skip_untranslated_files: false
+          export_only_approved: true
+          push_translations: false
+          # pull-request
+          create_pull_request: false
+          # global options
+          config: './crowdin-config.yml'
+          base_url: ${{ secrets.CROWDIN_BASE_URL_FCC }}
+          # Uncomment below to debug
+          # dryrun_action: true
+
       ###### Format JSON #####
       # Crowdin gives the files read-only permissions, so we first have to allow
       # writes.

--- a/.github/workflows/crowdin-download.curriculum.yml
+++ b/.github/workflows/crowdin-download.curriculum.yml
@@ -274,6 +274,31 @@ jobs:
           # Uncomment below to debug
           # dryrun_action: true
 
+      ##### Download Korean #####
+      - name: Crowdin Download Korean Translations
+        uses: crowdin/github-action@master
+        # options: https://github.com/crowdin/github-action/blob/master/action.yml
+        with:
+          # uploads
+          upload_sources: false
+          upload_translations: false
+          auto_approve_imported: false
+          import_eq_suggestions: false
+          # downloads
+          download_translations: true
+          download_language: ko
+          skip_untranslated_strings: false
+          skip_untranslated_files: false
+          export_only_approved: true
+          push_translations: false
+          # pull-request
+          create_pull_request: false
+          # global options
+          config: './crowdin-config.yml'
+          base_url: ${{ secrets.CROWDIN_BASE_URL_FCC }}
+          # Uncomment below to debug
+          # dryrun_action: true
+
       # Validate the Download #
       # All languages should go ABOVE this. #
       - name: Setup pnpm


### PR DESCRIPTION
This is the first PR(based on the [doc](https://contribute.freecodecamp.org/#/how-to-enable-new-languages?id=deploying-new-languages-on-learn)) to add Korean curriculum translation for Responsive Web Development certification.
