### PR TITLE
fix: arithmetic formatter tests

### DIFF
--- a/curriculum/challenges/english/07-scientific-computing-with-python/scientific-computing-with-python-projects/arithmetic-formatter.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/scientific-computing-with-python-projects/arithmetic-formatter.md
@@ -75,33 +75,10 @@ The function will return the correct conversion if the supplied problems are pro
 ```js
 ({
   test: () => {
-    pyodide.FS.writeFile('/home/pyodide/arithmetic_arranger.py', code);
-    pyodide.FS.writeFile('/home/pyodide/test_module.py', 
-    `
-from arithmetic_arranger import arithmetic_arranger
-import pytest
-test_cases = [
-  pytest.param(
-    [['3801 - 2', '123 + 49']],
-        '  3801      123\\n'
-        '-    2    +  49\\n'
-        '------    -----',
-        'Expected different output when calling "arithmetic_arranger()" with ["3801 - 2", "123 + 49"]',
-        id='test_two_problems_arrangement1'
-    )
-]
+    runPython(`
+from unittest import TestCase
 
-@pytest.mark.parametrize('arguments,expected_output,fail_message', test_cases)
-def test_template(arguments, expected_output, fail_message):
-    actual = arithmetic_arranger(*arguments)
-    assert actual == expected_output, fail_message
-`);
-    const testCode = `
-from pytest import main
-main(['-vv', '/home/pyodide/test_module.py'])
-`;
-    const out = __pyodide.runPython(testCode);
-    assert.equal(out, 0);
+TestCase().assertEqual(arithmetic_arranger(["3801 - 2", "123 + 49"]), '  3801      123\\n-    2    +  49\\n------    -----')`);
   }
 })
 ```
@@ -111,32 +88,10 @@ main(['-vv', '/home/pyodide/test_module.py'])
 ```js
 ({
   test: () => {
-    pyodide.FS.writeFile('/home/pyodide/arithmetic_arranger.py', code);
-    pyodide.FS.writeFile('/home/pyodide/test_module.py', 
-    `
-from arithmetic_arranger import arithmetic_arranger
-import pytest
-test_cases = [
-    pytest.param(
-        [['1 + 2', '1 - 9380']],
-        '  1         1\\n'
-        '+ 2    - 9380\\n'
-        '---    ------',
-        'Expected different output when calling "arithmetic_arranger()" with ["1 + 2", "1 - 9380"]',
-        id='test_two_problems_arrangement2')
-]
+    runPython(`
+from unittest import TestCase
 
-@pytest.mark.parametrize('arguments,expected_output,fail_message', test_cases)
-def test_template(arguments, expected_output, fail_message):
-    actual = arithmetic_arranger(*arguments)
-    assert actual == expected_output, fail_message
-`);
-    const testCode = `
-from pytest import main
-main(['-vv', '/home/pyodide/test_module.py'])
-`;
-    const out = __pyodide.runPython(testCode);
-    assert.equal(out, 0);
+TestCase().assertEqual(arithmetic_arranger(["1 + 2", "1 - 9380"]), '  1         1\\n+ 2    - 9380\\n---    ------')`);
   }
 })
 ```
@@ -146,32 +101,10 @@ main(['-vv', '/home/pyodide/test_module.py'])
 ```js
 ({
   test: () => {
-    pyodide.FS.writeFile('/home/pyodide/arithmetic_arranger.py', code);
-    pyodide.FS.writeFile('/home/pyodide/test_module.py', 
-    `
-from arithmetic_arranger import arithmetic_arranger
-import pytest
-test_cases = [
-    pytest.param(
-        [['3 + 855', '3801 - 2', '45 + 43', '123 + 49']],
-        '    3      3801      45      123\\n'
-        '+ 855    -    2    + 43    +  49\\n'
-        '-----    ------    ----    -----',
-        'Expected different output when calling "arithmetic_arranger()" with ["3 + 855", "3801 - 2", "45 + 43", "123 + 49"]',
-        id='test_four_problems_arrangement')
-]
+    runPython(`
+from unittest import TestCase
 
-@pytest.mark.parametrize('arguments,expected_output,fail_message', test_cases)
-def test_template(arguments, expected_output, fail_message):
-    actual = arithmetic_arranger(*arguments)
-    assert actual == expected_output, fail_message
-`);
-    const testCode = `
-from pytest import main
-main(['-vv', '/home/pyodide/test_module.py'])
-`;
-    const out = __pyodide.runPython(testCode);
-    assert.equal(out, 0);
+TestCase().assertEqual(arithmetic_arranger(["3 + 855", "3801 - 2", "45 + 43", "123 + 49"]), '    3      3801      45      123\\n+ 855    -    2    + 43    +  49\\n-----    ------    ----    -----')`);
   }
 })
 ```
@@ -181,32 +114,10 @@ main(['-vv', '/home/pyodide/test_module.py'])
 ```js
 ({
   test: () => {
-    pyodide.FS.writeFile('/home/pyodide/arithmetic_arranger.py', code);
-    pyodide.FS.writeFile('/home/pyodide/test_module.py', 
-    `
-from arithmetic_arranger import arithmetic_arranger
-import pytest
-test_cases = [
-    pytest.param(
-        [['11 + 4', '3801 - 2999', '1 + 2', '123 + 49', '1 - 9380']],
-        '  11      3801      1      123         1\\n'
-        '+  4    - 2999    + 2    +  49    - 9380\\n'
-        '----    ------    ---    -----    ------',
-        'Expected different output when calling "arithmetic_arranger()" with ["11 + 4", "3801 - 2999", "1 + 2", "123 + 49", "1 - 9380"]',
-        id='test_five_problems_arrangement')
-]
+    runPython(`
+from unittest import TestCase
 
-@pytest.mark.parametrize('arguments,expected_output,fail_message', test_cases)
-def test_template(arguments, expected_output, fail_message):
-    actual = arithmetic_arranger(*arguments)
-    assert actual == expected_output, fail_message
-`);
-    const testCode = `
-from pytest import main
-main(['-vv', '/home/pyodide/test_module.py'])
-`;
-    const out = __pyodide.runPython(testCode);
-    assert.equal(out, 0);
+TestCase().assertEqual(arithmetic_arranger(["11 + 4", "3801 - 2999", "1 + 2", "123 + 49", "1 - 9380"]), '  11      3801      1      123         1\\n+  4    - 2999    + 2    +  49    - 9380\\n----    ------    ---    -----    ------')`);
   }
 })
 ```
@@ -216,31 +127,10 @@ main(['-vv', '/home/pyodide/test_module.py'])
 ```js
 ({
   test: () => {
-    pyodide.FS.writeFile('/home/pyodide/arithmetic_arranger.py', code);
-    pyodide.FS.writeFile('/home/pyodide/test_module.py', 
-    `
-from arithmetic_arranger import arithmetic_arranger
-import pytest
-test_cases = [
-    pytest.param(
-        [['44 + 815', '909 - 2', '45 + 43', '123 + 49',
-          '888 + 40', '653 + 87']],
-        'Error: Too many problems.',
-        'Expected calling "arithmetic_arranger()" with more than five problems to return "Error: Too many problems."',
-        id='test_too_many_problems')
-]
+    runPython(`
+from unittest import TestCase
 
-@pytest.mark.parametrize('arguments,expected_output,fail_message', test_cases)
-def test_template(arguments, expected_output, fail_message):
-    actual = arithmetic_arranger(*arguments)
-    assert actual == expected_output, fail_message
-`);
-    const testCode = `
-from pytest import main
-main(['-vv', '/home/pyodide/test_module.py'])
-`;
-    const out = __pyodide.runPython(testCode);
-    assert.equal(out, 0);
+TestCase().assertEqual(arithmetic_arranger(["44 + 815", "909 - 2", "45 + 43", "123 + 49", "888 + 40", "653 + 87"]), 'Error: Too many problems.')`);
   }
 })
 ```
@@ -250,30 +140,10 @@ main(['-vv', '/home/pyodide/test_module.py'])
 ```js
 ({
   test: () => {
-    pyodide.FS.writeFile('/home/pyodide/arithmetic_arranger.py', code);
-    pyodide.FS.writeFile('/home/pyodide/test_module.py', 
-    `
-from arithmetic_arranger import arithmetic_arranger
-import pytest
-test_cases = [
-    pytest.param(
-        [['3 / 855', '3801 - 2', '45 + 43', '123 + 49']],
-        "Error: Operator must be '+' or '-'.",
-        '''Expected calling "arithmetic_arranger()" with a problem that uses the "/" operator to return "Error: Operator must be '+' or '-'."''',
-        id='test_incorrect_operator')
-]
+    runPython(`
+from unittest import TestCase
 
-@pytest.mark.parametrize('arguments,expected_output,fail_message', test_cases)
-def test_template(arguments, expected_output, fail_message):
-    actual = arithmetic_arranger(*arguments)
-    assert actual == expected_output, fail_message
-`);
-    const testCode = `
-from pytest import main
-main(['-vv', '/home/pyodide/test_module.py'])
-`;
-    const out = __pyodide.runPython(testCode);
-    assert.equal(out, 0);
+TestCase().assertEqual(arithmetic_arranger(["3 / 855", "3801 - 2", "45 + 43", "123 + 49"]), "Error: Operator must be '+' or '-'.")`);
   }
 })
 ```
@@ -283,30 +153,10 @@ main(['-vv', '/home/pyodide/test_module.py'])
 ```js
 ({
   test: () => {
-    pyodide.FS.writeFile('/home/pyodide/arithmetic_arranger.py', code);
-    pyodide.FS.writeFile('/home/pyodide/test_module.py', 
-    `
-from arithmetic_arranger import arithmetic_arranger
-import pytest
-test_cases = [
-    pytest.param(
-        [['24 + 85215', '3801 - 2', '45 + 43', '123 + 49']],
-        'Error: Numbers cannot be more than four digits.',
-        'Expected calling "arithmetic_arranger()" with a problem that has a number over 4 digits long to return "Error: Numbers cannot be more than four digits."',
-        id='test_too_many_digits')
-]
+    runPython(`
+from unittest import TestCase
 
-@pytest.mark.parametrize('arguments,expected_output,fail_message', test_cases)
-def test_template(arguments, expected_output, fail_message):
-    actual = arithmetic_arranger(*arguments)
-    assert actual == expected_output, fail_message
-`);
-    const testCode = `
-from pytest import main
-main(['-vv', '/home/pyodide/test_module.py'])
-`;
-    const out = __pyodide.runPython(testCode);
-    assert.equal(out, 0);
+TestCase().assertEqual(arithmetic_arranger(["24 + 85215", "3801 - 2", "45 + 43", "123 + 49"]), "Error: Numbers cannot be more than four digits.")`);
   }
 })
 ```
@@ -316,30 +166,10 @@ main(['-vv', '/home/pyodide/test_module.py'])
 ```js
 ({
   test: () => {
-    pyodide.FS.writeFile('/home/pyodide/arithmetic_arranger.py', code);
-    pyodide.FS.writeFile('/home/pyodide/test_module.py', 
-    `
-from arithmetic_arranger import arithmetic_arranger
-import pytest
-test_cases = [
-    pytest.param(
-        [['98 + 3g5', '3801 - 2', '45 + 43', '123 + 49']],
-        'Error: Numbers must only contain digits.',
-        'Expected calling "arithmetic_arranger()" with a problem that contains a letter character in the number to return "Error: Numbers must only contain digits."',
-        id='test_only_digits')
-]
+    runPython(`
+from unittest import TestCase
 
-@pytest.mark.parametrize('arguments,expected_output,fail_message', test_cases)
-def test_template(arguments, expected_output, fail_message):
-    actual = arithmetic_arranger(*arguments)
-    assert actual == expected_output, fail_message
-`);
-    const testCode = `
-from pytest import main
-main(['-vv', '/home/pyodide/test_module.py'])
-`;
-    const out = __pyodide.runPython(testCode);
-    assert.equal(out, 0);
+TestCase().assertEqual(arithmetic_arranger(["98 + 3g5", "3801 - 2", "45 + 43", "123 + 49"]), "Error: Numbers must only contain digits.")`);
   }
 })
 ```
@@ -349,33 +179,10 @@ main(['-vv', '/home/pyodide/test_module.py'])
 ```js
 ({
   test: () => {
-    pyodide.FS.writeFile('/home/pyodide/arithmetic_arranger.py', code);
-    pyodide.FS.writeFile('/home/pyodide/test_module.py', 
-    `
-from arithmetic_arranger import arithmetic_arranger
-import pytest
-test_cases = [
-    pytest.param(
-        [['3 + 855', '988 + 40'], True],
-        '    3      988\\n'
-        '+ 855    +  40\\n'
-        '-----    -----\\n'
-        '  858     1028',
-        'Expected solutions to be correctly displayed in output when calling "arithmetic_arranger()" with ["3 + 855", "988 + 40"] and a second argument of \`True\`.',
-        id='test_two_problems_with_solutions')
-]
+    runPython(`
+from unittest import TestCase
 
-@pytest.mark.parametrize('arguments,expected_output,fail_message', test_cases)
-def test_template(arguments, expected_output, fail_message):
-    actual = arithmetic_arranger(*arguments)
-    assert actual == expected_output, fail_message
-`);
-    const testCode = `
-from pytest import main
-main(['-vv', '/home/pyodide/test_module.py'])
-`;
-    const out = __pyodide.runPython(testCode);
-    assert.equal(out, 0);
+TestCase().assertEqual(arithmetic_arranger(["3 + 855", "988 + 40"], True), "    3      988\\n+ 855    +  40\\n-----    -----\\n  858     1028")`);
   }
 })
 ```
@@ -385,33 +192,10 @@ main(['-vv', '/home/pyodide/test_module.py'])
 ```js
 ({
   test: () => {
-    pyodide.FS.writeFile('/home/pyodide/arithmetic_arranger.py', code);
-    pyodide.FS.writeFile('/home/pyodide/test_module.py', 
-    `
-from arithmetic_arranger import arithmetic_arranger
-import pytest
-test_cases = [
-    pytest.param(
-        [['32 - 698', '1 - 3801', '45 + 43', '123 + 49', '988 + 40'], True],
-        '   32         1      45      123      988\\n'
-        '- 698    - 3801    + 43    +  49    +  40\\n'
-        '-----    ------    ----    -----    -----\\n'
-        ' -666     -3800      88      172     1028',
-        'Expected solutions to be correctly displayed in output when calling "arithmetic_arranger()" with five arithmetic problems and a second argument of \`True\`.'
-    )
-]
+    runPython(`
+from unittest import TestCase
 
-@pytest.mark.parametrize('arguments,expected_output,fail_message', test_cases)
-def test_template(arguments, expected_output, fail_message):
-    actual = arithmetic_arranger(*arguments)
-    assert actual == expected_output, fail_message
-`);
-    const testCode = `
-from pytest import main
-main(['-vv', '/home/pyodide/test_module.py'])
-`;
-    const out = __pyodide.runPython(testCode);
-    assert.equal(out, 0);
+TestCase().assertEqual(arithmetic_arranger(["32 - 698", "1 - 3801", "45 + 43", "123 + 49", "988 + 40"], True), "   32         1      45      123      988\\n- 698    - 3801    + 43    +  49    +  40\\n-----    ------    ----    -----    -----\\n -666     -3800      88      172     1028")`);
   }
 })
 ```

--- a/tools/client-plugins/browser-scripts/python-test-evaluator.ts
+++ b/tools/client-plugins/browser-scripts/python-test-evaluator.ts
@@ -41,8 +41,6 @@ async function setupPyodide() {
     indexURL: `https://cdn.jsdelivr.net/pyodide/v${pkg.version}/full/`
   });
 
-  await pyodide.loadPackage('pytest');
-
   // We freeze this to prevent learners from getting the worker into a
   // weird state. NOTE: this has to come after pyodide is loaded, because
   // pyodide modifies self while loading.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

We didn't really need pytest for these tests, so, rather than figuring out how to get it working, I removed it. This makes the code a lot cleaner and, because the assertion is no longer handled, we get readable errors to help with debugging.

<!-- Feel free to add any additional description of changes below this line -->
