### PR TITLE
fix: gotta account for the slug too I guess?

### DIFF
--- a/tools/scripts/sync-i18n.ts
+++ b/tools/scripts/sync-i18n.ts
@@ -44,11 +44,18 @@ const syncChallenges = async () => {
         const langContent = await readFile(targetPath, 'utf-8');
         const engLines = englishContent.split('\n');
         const engId = engLines.find(l => l.startsWith('id'));
+        const engSlug = engLines.find(l => l.startsWith('dashedName'));
         const langLines = langContent.split('\n');
         const langId = langLines.find(l => l.startsWith('id'));
+        const langSlug = langLines.find(l => l.startsWith('dashedName'));
         if (engId && langId && engId !== langId) {
           langLines.splice(langLines.indexOf(langId), 1, engId);
           console.log(`Updating ID for ${targetPath}`);
+          await writeFile(targetPath, langLines.join('\n'), 'utf-8');
+        }
+        if (engSlug && langSlug && engSlug !== langSlug) {
+          langLines.splice(langLines.indexOf(langSlug), 1, engSlug);
+          console.log(`Updating dashed name for ${targetPath}`);
           await writeFile(targetPath, langLines.join('\n'), 'utf-8');
         }
       })

--- a/tools/scripts/sync-i18n.ts
+++ b/tools/scripts/sync-i18n.ts
@@ -48,12 +48,22 @@ const syncChallenges = async () => {
         const langLines = langContent.split('\n');
         const langId = langLines.find(l => l.startsWith('id'));
         const langSlug = langLines.find(l => l.startsWith('dashedName'));
-        if (engId && langId && engId !== langId) {
+        if (!langSlug) {
+          throw new Error(
+            `Missing dashedName for ${targetPath}. Please add it so that it matches the English version.`
+          );
+        }
+        if (!langId) {
+          throw new Error(
+            `Missing id for ${targetPath}. Please add it so that it matches the English version.`
+          );
+        }
+        if (engId && engId !== langId) {
           langLines.splice(langLines.indexOf(langId), 1, engId);
           console.log(`Updating ID for ${targetPath}`);
           await writeFile(targetPath, langLines.join('\n'), 'utf-8');
         }
-        if (engSlug && langSlug && engSlug !== langSlug) {
+        if (engSlug && engSlug !== langSlug) {
           langLines.splice(langLines.indexOf(langSlug), 1, engSlug);
           console.log(`Updating dashed name for ${targetPath}`);
           await writeFile(targetPath, langLines.join('\n'), 'utf-8');


### PR DESCRIPTION
One day I'll refactor this. Maybe.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Another pain point resolved - this time in #52884 

<!-- Feel free to add any additional description of changes below this line -->
