### PR TITLE
feat(i18n): enable korean downloads for client and curriculum

### DIFF
--- a/.github/workflows/crowdin-download.client-ui.yml
+++ b/.github/workflows/crowdin-download.client-ui.yml
@@ -291,6 +291,35 @@ jobs:
           # Uncomment below to debug
           # dryrun_action: true
 
+      ##### Download Korean #####
+      - name: Crowdin Download Korean Translations
+        uses: crowdin/github-action@master
+        # options: https://github.com/crowdin/github-action/blob/master/action.yml
+        with:
+          # uploads
+          upload_sources: false
+          upload_translations: false
+          auto_approve_imported: false
+          import_eq_suggestions: false
+
+          # downloads
+          download_translations: true
+          download_language: ko
+          skip_untranslated_files: false
+          export_only_approved: true
+
+          push_translations: false
+
+          # pull-request
+          create_pull_request: false
+
+          # global options
+          config: './crowdin-config.yml'
+          base_url: ${{ secrets.CROWDIN_BASE_URL_FCC }}
+
+          # Uncomment below to debug
+          # dryrun_action: true
+
       ###### Format JSON #####
       # Crowdin gives the files read-only permissions, so we first have to allow
       # writes.

--- a/.github/workflows/crowdin-download.curriculum.yml
+++ b/.github/workflows/crowdin-download.curriculum.yml
@@ -304,6 +304,37 @@ jobs:
           # Uncomment below to debug
           # dryrun_action: true
 
+
+      ##### Download Korean #####
+      - name: Crowdin Download Korean Translations
+        uses: crowdin/github-action@master
+        # options: https://github.com/crowdin/github-action/blob/master/action.yml
+        with:
+          # uploads
+          upload_sources: false
+          upload_translations: false
+          auto_approve_imported: false
+          import_eq_suggestions: false
+
+          # downloads
+          download_translations: true
+          download_language: ko
+          skip_untranslated_strings: false
+          skip_untranslated_files: false
+          export_only_approved: true
+
+          push_translations: false
+
+          # pull-request
+          create_pull_request: false
+
+          # global options
+          config: './crowdin-config.yml'
+          base_url: ${{ secrets.CROWDIN_BASE_URL_FCC }}
+
+          # Uncomment below to debug
+          # dryrun_action: true
+
       # Validate the Download #
       # All languages should go ABOVE this. #
       - name: Setup pnpm

--- a/.github/workflows/crowdin-download.curriculum.yml
+++ b/.github/workflows/crowdin-download.curriculum.yml
@@ -304,7 +304,6 @@ jobs:
           # Uncomment below to debug
           # dryrun_action: true
 
-
       ##### Download Korean #####
       - name: Crowdin Download Korean Translations
         uses: crowdin/github-action@master


### PR DESCRIPTION

Add Korean translation for the main freeCodeCamp curriculum.
Currently, Responsive Web Design certification course's Korean translation/proofreading work is done in Crowdin.


Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->
