### PR TITLE
fix(client): keep editor tabs buttons visible

### DIFF
--- a/client/src/components/Header/components/universal-nav.css
+++ b/client/src/components/Header/components/universal-nav.css
@@ -423,10 +423,10 @@ li > button.nav-link-signout:not([aria-disabled='true']):is(:hover, :focus) {
 /**
  * Handle submenu containers collapsed and expanded states
  */
-button[aria-expanded='false'] + div {
+#universal-nav button[aria-expanded='false'] + div {
   display: none;
 }
 
-button[aria-expanded='true'] + div {
+#universal-nav button[aria-expanded='true'] + div {
   display: block;
 }

--- a/client/src/templates/Challenges/classic/classic.css
+++ b/client/src/templates/Challenges/classic/classic.css
@@ -23,20 +23,23 @@
 }
 
 .monaco-editor-tabs button[aria-expanded='true'],
-.panel-display-tabs button[aria-expanded='true'] {
+.panel-display-tabs button[aria-expanded='true'],
+.tabs-row button[aria-expanded='true'] {
   border-color: var(--primary-color);
   background-color: var(--primary-color);
   color: var(--secondary-background);
 }
 
 .monaco-editor-tabs button:hover,
-.panel-display-tabs button:hover {
+.panel-display-tabs button:hover,
+.tabs-row button:hover {
   color: var(--secondary-color);
   background-color: var(--primary-background);
 }
 
 .monaco-editor-tabs button[aria-expanded='true']:hover,
-.panel-display-tabs button[aria-expanded='true']:hover {
+.panel-display-tabs button[aria-expanded='true']:hover,
+.tabs-row button[aria-expanded='true']:hover {
   background-color: var(--quaternary-color);
   color: var(--secondary-background);
 }

--- a/client/src/templates/Challenges/classic/classic.css
+++ b/client/src/templates/Challenges/classic/classic.css
@@ -67,7 +67,7 @@
 }
 
 .monaco-editor-tabs {
-  display: flex !important;
+  display: flex;
   margin-inline-end: auto;
 }
 

--- a/client/src/templates/Challenges/classic/classic.css
+++ b/client/src/templates/Challenges/classic/classic.css
@@ -67,7 +67,7 @@
 }
 
 .monaco-editor-tabs {
-  display: flex;
+  display: flex !important;
   margin-inline-end: auto;
 }
 

--- a/e2e/action-row.spec.ts
+++ b/e2e/action-row.spec.ts
@@ -47,7 +47,7 @@ test('Action row buttons are visible', async ({ isMobile, page }) => {
   }
 });
 
-test('Clicking instructions button hides editor buttons', async ({
+test('Clicking instructions button hides instructions panel, but not editor buttons', async ({
   isMobile,
   page
 }) => {
@@ -62,7 +62,7 @@ test('Clicking instructions button hides editor buttons', async ({
 
     for (let i = 0; i < editorButtons.length; i++) {
       const btn = tabsRow.getByRole('button', { name: editorButtons[i] });
-      await expect(btn).toBeHidden();
+      await expect(btn).toBeVisible();
     }
 
     const instructionsPanelTitle = page.getByRole('heading', {


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Closes #52641

- - -
- Consistent styling for _Instructions_ button.
- Editor tabs buttons stops being hidden when _Instructions_ are not expanded.
- For somebody who knows very little of css, let's call this quite eventful. `.monaco-editor-tabs` div was being hidden by the style from the universal nav https://github.com/freeCodeCamp/freeCodeCamp/blob/987fe44b27f561dda6f3fec4778d7fa70e650a79/client/src/components/Header/components/universal-nav.css#L426-L428
- Now this makes me think, it might be better to make that one to apply only to `#universal-nav`.
