### PR TITLE
fix(curriculum): formatting in Rosetta Code - Deal cards for FreeCell

### DIFF
--- a/curriculum/challenges/english/22-rosetta-code/rosetta-code-challenges/deal-cards-for-freecell.md
+++ b/curriculum/challenges/english/22-rosetta-code/rosetta-code-challenges/deal-cards-for-freecell.md
@@ -26,8 +26,8 @@ The algorithm follows:
   <li>Seed the RNG with the number of the deal.
   </li><li>Create an array of 52 cards: Ace of Clubs, Ace of Diamonds, Ace of Hearts, Ace of Spades, 2 of Clubs, 2 of Diamonds, and so on through the ranks: Ace, 2, 3, 4, 5, 6, 7, 8, 9, 10, Jack, Queen, King. The array indexes are 0 to 51, with Ace of Clubs at 0, and King of Spades at 51.</li>
   <li>Until the array is empty:</li>
-  <li>Choose a random card at index ≡ next random number (mod array length).</li>
     <ul>
+      <li>Choose a random card at <i>index</i> ≡ <i>next random number</i> (mod <i>array length</i>).</li>
       <li>Swap this random card with the last card of the array.</li>
       <li>Remove this random card from the array. (Array length goes down by 1.)</li>
       <li>Deal this random card.</li>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
Found this issue while working on proofreading the translation.

The formatting in the bullet list was incorrect compared to the original [Rosetta Code website](https://rosettacode.org/wiki/Deal_cards_for_FreeCell), making it difficult to understand the instructions.

Affected page: https://www.freecodecamp.org/learn/rosetta-code/rosetta-code-challenges/deal-cards-for-freecell

![image](https://github.com/freeCodeCamp/freeCodeCamp/assets/25644062/76e58c4b-e230-41be-8d88-d5f9a9951ed3)
