### PR TITLE
fix: Editor scroll bar issue

### DIFF
--- a/client/src/templates/Challenges/classic/editor.css
+++ b/client/src/templates/Challenges/classic/editor.css
@@ -210,7 +210,7 @@ textarea.inputarea {
 .vs .monaco-scrollable-element .scrollbar .arrow-background {
   height: var(--monaco-scrollbar-arrow-box-size) !important;
   background-color: #666;
-  z-index: 998;
+  z-index: 199;
 }
 
 /* arrow icons - includes both up and down */
@@ -221,7 +221,7 @@ textarea.inputarea {
   height: var(--monaco-scrollbar-arrow-icon-size) !important;
   font-size: var(--monaco-scrollbar-arrow-icon-font-size) !important;
   color: white;
-  z-index: 999;
+  z-index: 199;
 }
 
 /* down arrow icon only */


### PR DESCRIPTION
The arrow icon of the editor scroll bar was displayed in front of menu dropdown  and this pulll request solves the problem.


Fixes #53385
![Screenshot 2024-01-27 233632](https://github.com/freeCodeCamp/freeCodeCamp/assets/73016596/61b58538-4690-4af2-b371-3201dc1eadbf)


- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Closes #53385
