### PR TITLE
fix(client): don't display `act` error in fcc console

### DIFF
--- a/client/src/templates/Challenges/utils/frame.ts
+++ b/client/src/templates/Challenges/utils/frame.ts
@@ -209,6 +209,8 @@ const mountFrame =
     };
   };
 
+const actRE = new RegExp(/act\(\.\.\.\) is not supported in production builds/);
+
 const updateProxyConsole =
   (proxyLogger?: ProxyLogger) => (frameContext: Context) => {
     // window does not exist if the preview is hidden, so we have to check.
@@ -248,7 +250,9 @@ const updateProxyConsole =
       frameContext.window.console.error = function proxyWarn(
         ...args: string[]
       ) {
-        proxyLogger(args.map((arg: string) => utilsFormat(arg)).join(' '));
+        if (args.every(arg => !actRE.test(arg))) {
+          proxyLogger(args.map((arg: string) => utilsFormat(arg)).join(' '));
+        }
         return oldError(...(args as []));
       };
     }


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Closes #50725

- - -
- Hides _act(...) is not supported in production builds of React, and might not behave as expected._ error from fcc console.
- It is still displayed in browser console.
- To test (and observe initial issue) production client build is required:
  - `pnpm run build:client`
  - `pnpm run serve:client`
- Another place that I found where filtering it out was possible was `templates/Challenges/redux/execute-challenge-saga.js`, but that's further along the execution. All the `yield`s in that file are also a bit intimidating. https://github.com/freeCodeCamp/freeCodeCamp/blob/c8f5bfab76ba96231d42476f923060431693521d/client/src/templates/Challenges/redux/execute-challenge-saga.js#L167-L173