### PR TITLE
fix(curriculum): Update tests for step 91 to accept substring method

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-functional-programming-by-building-a-spreadsheet/646d47c8f58107d10f1e5106.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-functional-programming-by-building-a-spreadsheet/646d47c8f58107d10f1e5106.md
@@ -20,13 +20,13 @@ assert.match(code, /const\s+update\s*=\s*\(?\s*event\s*\)?\s*=>\s*\{\s*const\s+e
 You should call the `.slice()` method on the `value` argument.
 
 ```js
-assert.match(code, /const\s+update\s*=\s*\(?\s*event\s*\)?\s*=>\s*\{\s*const\s+element\s*=\s*event\.target;?\s*const\s+value\s*=\s*element\.value\.replace\(\s*\/\\s\/g\s*,\s*('|"|`)\1\s*\);?\s*if\s*\(\s*(!value\.includes\(\s*element\.id\s*\)\s*&&\s*(?:value\s*\[\s*0\s*\]\s*===\s*('|"|`)=\3|value\.charAt\(0\)\s*===\s*('|"|`)=\4|value\.startsWith\(('|"|`)=\5\))|(?:value\s*\[\s*0\s*\]\s*===\s*('|"|`)=\6|value\.charAt\(0\)\s*===\s*('|"|`)=\7|value\.startsWith\(('|"|`)=\8\))\s*\|\|\s*!value\.includes\(\s*element\.id\s*\))\s*\)\s*\{\s*element\.value\s*=\s*evalFormula\(\s*value\.slice\(/);
+assert.match(code, /const\s+update\s*=\s*\(?\s*event\s*\)?\s*=>\s*\{\s*const\s+element\s*=\s*event\.target;?\s*const\s+value\s*=\s*element\.value\.replace\(\s*\/\\s\/g\s*,\s*('|"|`)\1\s*\);?\s*if\s*\(\s*(!value\.includes\(\s*element\.id\s*\)\s*&&\s*(?:value\s*\[\s*0\s*\]\s*===\s*('|"|`)=\3|value\.charAt\(0\)\s*===\s*('|"|`)=\4|value\.startsWith\(('|"|`)=\5\))|(?:value\s*\[\s*0\s*\]\s*===\s*('|"|`)=\6|value\.charAt\(0\)\s*===\s*('|"|`)=\7|value\.startsWith\(('|"|`)=\8\))\s*\|\|\s*!value\.includes\(\s*element\.id\s*\))\s*\)\s*\{\s*element\.value\s*=\s*evalFormula\(\s*value\.(?:slice|substring)\(/);
 ```
 
 You should pass the number `1` as the argument to your `.slice()` call.
 
 ```js
-assert.match(code, /const\s+update\s*=\s*\(?\s*event\s*\)?\s*=>\s*\{\s*const\s+element\s*=\s*event\.target;?\s*const\s+value\s*=\s*element\.value\.replace\(\s*\/\\s\/g\s*,\s*('|"|`)\1\s*\);?\s*if\s*\(\s*(!value\.includes\(\s*element\.id\s*\)\s*&&\s*(?:value\s*\[\s*0\s*\]\s*===\s*('|"|`)=\3|value\.charAt\(0\)\s*===\s*('|"|`)=\4|value\.startsWith\(('|"|`)=\5\))|(?:value\s*\[\s*0\s*\]\s*===\s*('|"|`)=\6|value\.charAt\(0\)\s*===\s*('|"|`)=\7|value\.startsWith\(('|"|`)=\8\))\s*\|\|\s*!value\.includes\(\s*element\.id\s*\))\s*\)\s*\{\s*element\.value\s*=\s*evalFormula\(\s*value\.slice\(\s*1\s*\)\s*\);?/);
+assert.match(code, /const\s+update\s*=\s*\(?\s*event\s*\)?\s*=>\s*\{\s*const\s+element\s*=\s*event\.target;?\s*const\s+value\s*=\s*element\.value\.replace\(\s*\/\\s\/g\s*,\s*('|"|`)\1\s*\);?\s*if\s*\(\s*(!value\.includes\(\s*element\.id\s*\)\s*&&\s*(?:value\s*\[\s*0\s*\]\s*===\s*('|"|`)=\3|value\.charAt\(0\)\s*===\s*('|"|`)=\4|value\.startsWith\(('|"|`)=\5\))|(?:value\s*\[\s*0\s*\]\s*===\s*('|"|`)=\6|value\.charAt\(0\)\s*===\s*('|"|`)=\7|value\.startsWith\(('|"|`)=\8\))\s*\|\|\s*!value\.includes\(\s*element\.id\s*\))\s*\)\s*\{\s*element\.value\s*=\s*evalFormula\(\s*value\.(?:slice|substring)\(\s*1\s*\)\s*\);?/);
 ```
 
 # --seed--


### PR DESCRIPTION
Updated the assertions regex to accept both the methods `slice()` and `substring()` as they are both a valid solution to the problem.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #53225

<!-- Feel free to add any additional description of changes below this line -->
