### PR TITLE
fix(curriculum): remove leftover `console.log` from hints

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-advanced-array-methods-by-building-a-statistics-calculator/63507ebb0c50ce3b9d669cd9.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-advanced-array-methods-by-building-a-statistics-calculator/63507ebb0c50ce3b9d669cd9.md
@@ -28,7 +28,6 @@ assert.notMatch(calculate.toString(), /filtered/);
 You should chain your `.filter()` call to your `.map()` call.
 
 ```js
-console.log(calculate.toString());
 assert.match(calculate.toString(), /array\.map\(.*\)\.filter\(/s);
 ```
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-advanced-array-methods-by-building-a-statistics-calculator/6352e96d2604f813c656750b.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-advanced-array-methods-by-building-a-statistics-calculator/6352e96d2604f813c656750b.md
@@ -22,7 +22,6 @@ assert.match(getMode.toString(), /array\.forEach\(/);
 Your `.forEach()` method should have a callback function which takes an `el` parameter.
 
 ```js
-console.log(getMode.toString());
 assert.match(getMode.toString(), /(array\.forEach\(\(?\s*el\s*\)?\s*=>|array\.forEach\(function\s*\(?el\)?\s*\{)/);
 ```
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-advanced-array-methods-by-building-a-statistics-calculator/6352fcb156834128001ea945.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-advanced-array-methods-by-building-a-statistics-calculator/6352fcb156834128001ea945.md
@@ -34,7 +34,6 @@ assert.match(getVariance.toString(), /sumSquaredDifferences\s*=\s*squaredDiffere
 Your `reduce` callback should return the sum of `acc` and `el`.
 
 ```js
-console.log(getVariance.toString());
 assert.match(getVariance.toString(), /sumSquaredDifferences\s*=\s*squaredDifferences\.reduce\(function\s*\(?\s*acc\s*,\s*el\s*\)?\s*\{\s*return\s*acc\s*\+\s*el\s*\;\s*\},\s*0\s*\)/);
 ```
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a8c2bbbd8aa82052f47c53.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a8c2bbbd8aa82052f47c53.md
@@ -16,7 +16,6 @@ Set `name` to `cave`. Set `button text` to an array with the strings `Fight slim
 You should have three values in your `locations` array.
 
 ```js
-console.log(locations);
 assert.lengthOf(locations, 3);
 ```
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a8e142f7f0bd4fed898de3.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a8e142f7f0bd4fed898de3.md
@@ -14,7 +14,6 @@ Add a new object to the end of the `locations` array, following the same propert
 Your `locations` array should have 4 values in it.
 
 ```js
-console.log(locations);
 assert.lengthOf(locations, 4);
 ```
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62aa226207f33d3ad4c6f546.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62aa226207f33d3ad4c6f546.md
@@ -33,7 +33,6 @@ assert.match(attack.toString(), /text\.innerText\s*\+=\s*('|")\sYour\s\1/);
 You should add the return value of `inventory.pop()` to the ` Your ` string.
 
 ```js
-console.log(attack.toString());
 assert.match(attack.toString(), /text\.innerText\s*\+=\s*('|")\sYour\s\1\s*\+\s*inventory\.pop\(\)/);
 ```
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62aa28fb651bf14efa2dbb16.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62aa28fb651bf14efa2dbb16.md
@@ -32,7 +32,6 @@ assert.match(pick.toString(), /text\.innerText\s*\+=\s*numbers\s*\[\s*i\s*\]/);
 You should add a new-line character after the `numbers[i]` value. Remember that you can do this with `\n`.
 
 ```js
-console.log(pick.toString());
 assert.match(pick.toString(), /text\.innerText\s*\+=\s*numbers\s*\[\s*i\s*\]\s*\+\s*('|")\\n\1/);
 ```
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-oop-by-building-a-shopping-cart/63f02bdeb9b428208b97eb6b.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-oop-by-building-a-shopping-cart/63f02bdeb9b428208b97eb6b.md
@@ -37,7 +37,6 @@ assert.match(afterCalculateTaxes, /amount\s*\*\s*\(\s*this\s*\.\s*taxRate\s*\/\s
 Your `calculateTaxes` method should return the value of the `taxRate` (divided by 100, to convert it to a percent) multiplied by the `amount` parameter.
 
 ```js
-console.log(cart.calculateTaxes(10), (cart.taxRate / 100) * 10);
 assert.equal(cart.calculateTaxes(10), (cart.taxRate / 100) * 10);
 ```
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-recursion-by-building-a-decimal-to-binary-converter/645b6dad50514e69df601df6.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-recursion-by-building-a-decimal-to-binary-converter/645b6dad50514e69df601df6.md
@@ -24,7 +24,6 @@ Use the `.reverse()` method to reverse the order of the `remainders` array, and 
 You should use the `.reverse()` method on the `remainders` array.
 
 ```js
-console.log(String(decimalToBinary))
 assert.match(String(decimalToBinary), /remainders\.reverse\(\s*\)/);
 ```
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

- - -
- Forgotten `console.log` calls in hints.