### PR TITLE
fix: explain null in calorie counter step 62

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-form-validation-by-building-a-calorie-counter/63c9bcc26219e7090da0f549.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-form-validation-by-building-a-calorie-counter/63c9bcc26219e7090da0f549.md
@@ -7,6 +7,8 @@ dashedName: step-62
 
 # --description--
 
+In programming, `null` is meant to represent the absence of a value. In this case, if the user enters an invalid input, you want to alert them and then return `null` to indicate that the function has failed.
+
 Still within your `if` block, set `isError` to `true` and return `null`.
 
 # --hints--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ x ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ x ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [ x ] My pull request targets the `main` branch of freeCodeCamp.
- [ x ] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->



<!-- Feel free to add any additional description of changes below this line -->
As mentioned in the original issue: "We have casually mentioned null in previous steps, but never really defined it.
So campers will no clue what null is. We should provide a short definition."

This will especially be the case for campers without any previous experience of JavaScript. As such, this change should provide some greater clarity about what `null` is and why it might be used in this kind of scenario.