### PR TITLE
feat(client): adjust solution-form for gitpod

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -365,6 +365,7 @@
     "question": "Question",
     "solution-link": "Solution Link",
     "github-link": "GitHub Link",
+    "source-code-link": "Source Code Link",
     "ms-link": "Microsoft Link",
     "submit-and-go": "Submit and go to my next challenge",
     "congratulations": "Congratulations, your code passes. Submit your code to continue.",

--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -364,7 +364,6 @@
     "assignments": "Assignments",
     "question": "Question",
     "solution-link": "Solution Link",
-    "github-link": "GitHub Link",
     "source-code-link": "Source Code Link",
     "ms-link": "Microsoft Link",
     "submit-and-go": "Submit and go to my next challenge",

--- a/client/src/components/formHelpers/form-validators.tsx
+++ b/client/src/components/formHelpers/form-validators.tsx
@@ -3,7 +3,6 @@ import { Trans } from 'react-i18next';
 
 // Matches editor links for: Replit, Glitch, CodeSandbox, GitHub. NOT Codespaces, and NOT Gitpod yet
 // Once safari allows negative lookbehinds, this can be used:
-// |(?<!https:\/\/\d+-[\w.-]+)\.gitpod\.io
 // |(?<!\.app)\.github\.dev
 const editorRegex =
   /repl\.?it(\.com)?\/(@|join\/)|glitch\.com\/edit\/#!|codesandbox\.io\/s\/|github\.com/;

--- a/client/src/components/formHelpers/form-validators.tsx
+++ b/client/src/components/formHelpers/form-validators.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { Trans } from 'react-i18next';
 
-// Matches editor links for: Replit, Glitch, CodeSandbox, GitHub, Codespaces, and NOT Gitpod
+// Matches editor links for: Replit, Glitch, CodeSandbox, GitHub. NOT Codespaces, and NOT Gitpod yet
 // Once safari allows negative lookbehinds, this can be used:
 // |(?<!https:\/\/\d+-[\w.-]+)\.gitpod\.io
+// |(?<!\.app)\.github\.dev
 const editorRegex =
-  /repl\.?it(\.com)?\/(@|join\/)|glitch\.com\/edit\/#!|codesandbox\.io\/s\/|github\.com|\.app\.github\.dev/;
+  /repl\.?it(\.com)?\/(@|join\/)|glitch\.com\/edit\/#!|codesandbox\.io\/s\/|github\.com/;
 const fCCRegex =
   /codepen\.io\/freecodecamp|freecodecamp\.rocks|github\.com\/freecodecamp|\.freecodecamp\.org/i;
 const localhostRegex = /localhost:/;

--- a/client/src/components/formHelpers/form-validators.tsx
+++ b/client/src/components/formHelpers/form-validators.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import { Trans } from 'react-i18next';
 
-// Matches editor links for: Replit, Glitch, CodeSandbox, GitHub
+// Matches editor links for: Replit, Glitch, CodeSandbox, GitHub, Codespaces, and NOT Gitpod
+// Once safari allows negative lookbehinds, this can be used:
+// |(?<!https:\/\/\d+-[\w.-]+)\.gitpod\.io
 const editorRegex =
-  /repl\.?it(\.com)?\/(@|join\/)|glitch\.com\/edit\/#!|codesandbox\.io\/s\/|github\.com/;
+  /repl\.?it(\.com)?\/(@|join\/)|glitch\.com\/edit\/#!|codesandbox\.io\/s\/|github\.com|\.app\.github\.dev/;
 const fCCRegex =
   /codepen\.io\/freecodecamp|freecodecamp\.rocks|github\.com\/freecodecamp|\.freecodecamp\.org/i;
 const localhostRegex = /localhost:/;

--- a/client/src/templates/Challenges/codeally/show.tsx
+++ b/client/src/templates/Challenges/codeally/show.tsx
@@ -234,7 +234,7 @@ class ShowCodeAlly extends Component<ShowCodeAllyProps> {
     const isCompleted = completedChallenges.some(
       challenge => challenge.id === challengeId
     );
-    const titleContext = t('learn.github-link');
+    const titleContext = t('learn.source-code-link');
     return showCodeAlly ? (
       <LearnLayout>
         <Helmet title={windowTitle} />

--- a/client/src/templates/Challenges/projects/solution-form.tsx
+++ b/client/src/templates/Challenges/projects/solution-form.tsx
@@ -51,7 +51,7 @@ export class SolutionForm extends Component<SolutionFormProps> {
     ];
     const backEndProjectFields = [
       { name: 'solution', label: t('learn.solution-link') },
-      { name: 'githubLink', label: t('learn.github-link') }
+      { name: 'githubLink', label: t('learn.source-code-link') }
     ];
 
     const buttonCopy = t('learn.i-completed');
@@ -80,12 +80,14 @@ export class SolutionForm extends Component<SolutionFormProps> {
       case challengeTypes.backend:
         formFields = solutionField;
         options.isLocalLinkAllowed = true;
-        solutionLink = solutionLink + 'https://project-name.camperbot.repl.co/';
+        solutionLink = solutionLink + 'https://3000-project-url.gitpod.io/';
         break;
 
       case challengeTypes.backEndProject:
         formFields = backEndProjectFields;
-        solutionLink = solutionLink + 'https://project-name.camperbot.repl.co/';
+        options.required.push('githubLink');
+        options.isLocalLinkAllowed = true;
+        solutionLink = solutionLink + 'https://3000-project-url.gitpod.io/';
         solutionFormID = 'back-end-form';
         break;
 
@@ -121,7 +123,7 @@ export class SolutionForm extends Component<SolutionFormProps> {
           ...options,
           placeholders: {
             solution: solutionLink,
-            githubLink: 'ex: https://github.com/camperbot/hello'
+            githubLink: 'ex: https://your-git-repo.url/files'
           }
         }}
         submit={this.handleSubmit}

--- a/e2e/form-helper.spec.ts
+++ b/e2e/form-helper.spec.ts
@@ -83,7 +83,7 @@ test.describe('Test form with solution link and github link', () => {
     );
     await expect(githubLinkInputLabel).toBeVisible();
     await expect(githubLinkInputLabel).toHaveText(
-      translations.learn['github-link']
+      translations.learn['source-code-link']
     );
 
     const githubLinkInput = solutionForm.getByTestId('githubLink-form-control');


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related to: https://github.com/freeCodeCamp/freeCodeCamp/issues/53470

**MERGE/DEPLOY BEFORE**: https://github.com/freeCodeCamp/freeCodeCamp/pull/53512

- This causes 7 `take-home-projects` to require source code links
  - Some of these projects are required for legacy certs. So, it is not a big deal.