### PR TITLE
fix(client): eyes not blinking in english animations

### DIFF
--- a/client/src/templates/Challenges/components/scene/scene.tsx
+++ b/client/src/templates/Challenges/components/scene/scene.tsx
@@ -3,7 +3,7 @@ import { Col } from '@freecodecamp/ui';
 import { FullScene } from '../../../../redux/prop-types';
 import { Loader } from '../../../../components/helpers';
 import ClosedCaptionsIcon from '../../../../assets/icons/closedcaptions';
-import { sounds, images, backgrounds } from './scene-assets';
+import { sounds, images, backgrounds, characterAssets } from './scene-assets';
 import Character from './character';
 
 import './scene.css';
@@ -21,10 +21,31 @@ export function Scene({ scene }: { scene: FullScene }): JSX.Element {
     new Audio(`${sounds}/${audio.filename}${audioTimestamp}`)
   );
 
+  const loadImage = (src: string) => {
+    const img = new Image();
+    img.src = src;
+  };
+
   // on mount
   useEffect(() => {
     const { current } = audioRef;
     current.addEventListener('canplaythrough', audioLoaded);
+
+    // preload images
+    loadImage(`${backgrounds}/${setup.background}`);
+
+    setup.characters.forEach(character => {
+      const characterImages = characterAssets[character.character];
+      Object.values(characterImages).forEach(src => {
+        if (src) {
+          loadImage(src);
+        }
+      });
+    });
+
+    commands.forEach(command => {
+      if (command.background) loadImage(`${backgrounds}/${command.background}`);
+    });
 
     // on unmount
     return () => {
@@ -34,7 +55,7 @@ export function Scene({ scene }: { scene: FullScene }): JSX.Element {
       current.currentTime = 0;
       current.removeEventListener('canplaythrough', audioLoaded);
     };
-  }, [audioRef]);
+  }, [audioRef, setup.background, setup.characters, commands]);
 
   const audioLoaded = () => {
     setSceneIsReady(true);

--- a/client/src/templates/Challenges/components/scene/scene.tsx
+++ b/client/src/templates/Challenges/components/scene/scene.tsx
@@ -22,7 +22,7 @@ export function Scene({ scene }: { scene: FullScene }): JSX.Element {
   );
 
   const loadImage = (src: string | null) => {
-    if (src) new Image().src;
+    if (src) new Image().src = src;
   };
 
   // on mount

--- a/client/src/templates/Challenges/components/scene/scene.tsx
+++ b/client/src/templates/Challenges/components/scene/scene.tsx
@@ -21,9 +21,8 @@ export function Scene({ scene }: { scene: FullScene }): JSX.Element {
     new Audio(`${sounds}/${audio.filename}${audioTimestamp}`)
   );
 
-  const loadImage = (src: string) => {
-    const img = new Image();
-    img.src = src;
+  const loadImage = (src: string | null) => {
+    if (src) new Image().src;
   };
 
   // on mount
@@ -34,18 +33,16 @@ export function Scene({ scene }: { scene: FullScene }): JSX.Element {
     // preload images
     loadImage(`${backgrounds}/${setup.background}`);
 
-    setup.characters.forEach(character => {
-      const characterImages = characterAssets[character.character];
-      Object.values(characterImages).forEach(src => {
-        if (src) {
-          loadImage(src);
-        }
-      });
-    });
+    setup.characters
+      .map(({ character }) => Object.values(characterAssets[character]))
+      .flat()
+      .forEach(loadImage);
 
-    commands.forEach(command => {
-      if (command.background) loadImage(`${backgrounds}/${command.background}`);
-    });
+    commands
+      .map(({ background }) =>
+        background ? `${backgrounds}/${background}` : null
+      )
+      .forEach(loadImage);
 
     // on unmount
     return () => {


### PR DESCRIPTION
The eyes in the English animations aren't blinking sometimes. I found that the browser is cancelling the requests to load the images:

<img width="1066" alt="Screenshot 2024-02-05 at 11 13 26 AM" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/20648924/8f37677a-09fe-4912-bcaa-81d450cc61cd">


Sometimes some of the images do seem to load. Perhaps some kind of issue with the blinking timeout in the component, causing the browser to cancel the request. The mouth images never seem to have this issue, which use a similar timeout. Not sure if this has always been an issue - pretty sure it used to work just fine. Anyway, this PR preloads all the images in the scene, which seems to fix the issue. If anyone has an idea for an alternative fix, feel free to share.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
