### PR TITLE
fix(curriculum): Build a Music Player is too sensitive to attribute order

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-string-and-array-methods-by-building-a-music-player/65672136535209761a5cf02b.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-string-and-array-methods-by-building-a-music-player/65672136535209761a5cf02b.md
@@ -13,10 +13,10 @@ Don't forget you need to interpolate with the dollar sign here.
 
 # --hints--
 
-You should add an `onclick` with the value `playSong(${song.id})` as the second attribute and value of the `button` element.
+You should add an `onclick` attribute with the value `playSong(${song.id})` to the `button` element.
 
 ```js
-assert.match(code, /<button\s+class\s*=\s*('|")playlist-song-info\1\s*onclick\s*=\s*('|")playSong\(\s*\$\{song\.id\}\s*\)\2\s*>\s*<span\s+class\s*=\s*('|")playlist-song-title\3\s*>\$\{song\.title\}<\/span>\s*<span\s+class\s*=\s*('|")playlist-song-artist\4\s*>\$\{song\.artist\}<\/span>\s*<span\s+class\s*=\s*('|")playlist-song-duration\5\s*>\$\{song\.duration\}<\/span>\s*<\/button>/)
+assert.match(code, /<button(?:\s+|\s+.*\s+)onclick\s*=\s*('|")playSong\(\s*\$\{song\.id\}\s*\)\1(?:\s+.*|)>/)
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes https://github.com/freeCodeCamp/freeCodeCamp/issues/52788

<!-- Feel free to add any additional description of changes below this line -->
Step 31 mentioned in the issue changed to step 36
![image](https://github.com/freeCodeCamp/freeCodeCamp/assets/23631165/16cc6b8a-407e-42e4-8418-c8b9b7a03426)