### PR TITLE
chore: restrict container action to a single test

### DIFF
--- a/.github/workflows/temporary-container-checks.yml
+++ b/.github/workflows/temporary-container-checks.yml
@@ -167,4 +167,5 @@ jobs:
           wait-on-timeout: 1200
           config: baseUrl=http://localhost:8000
           browser: ${{ matrix.browsers }}
-          spec: ${{ matrix.spec }}
+          # Only run one test to keep the run time down.
+          spec: 'cypress/e2e/default/learn/challenges/backend.ts'


### PR DESCRIPTION
It should be enough to catch the kinds of failures we're interested in:
namely is it possible to build the application.

This should also save a significant chunk of time.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->
