### PR TITLE
fix(curriculum): improve description and instructions of Step 78 of Platformer game

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64c9e90c433fde2e870285a3.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64c9e90c433fde2e870285a3.md
@@ -9,7 +9,7 @@ dashedName: step-78
 
 Inside the callback function, create a new `const` variable called `collisionDetectionRules` and assign it an empty array. 
 
-Inside that array, add a boolean expression that checks if the player's `y` position plus the player's height is less than or equal to the platform's `y` position.
+Inside that array, add a boolean expression that checks whether the player's `y` position plus the player's height is less than or equal to the platform's `y` position.
 
 # --hints--
 
@@ -19,7 +19,7 @@ You should have a `const` variable called `collisionDetectionRules` that is assi
 assert.match(code, /const\s+collisionDetectionRules\s*=\s*\[\s*(?:[^\]]*\s*)*\s*\]\s*;?/);
 ```
 
-You should have a boolean expression that checks if the player's `y` position plus the player's height is less than or equal to the platform's `y` position.
+You should have a boolean expression that checks whether the player's `y` position plus the player's height is less than or equal to the platform's `y` position.
 
 ```js
 assert.match(code, /const\s+collisionDetectionRules\s*=\s*\[\s*player\.position\.y\s*\+\s*player\.height\s*<=\s*platform\.position\.y\s*,?\s*]\s*;?/);


### PR DESCRIPTION
Updated the Instructions for step 78 of the platformer game as it was unclear for some learners. Instead of using the *if* statement in the line:

`Inside that array, add a boolean expression that checks if the player's y position plus the player's height is less than or equal to the platform's y position.`

and changed it to whether so, it's not confusing for learners that they have to use it if statement or not

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #53538 

<!-- Feel free to add any additional description of changes below this line -->
