### PR TITLE
fix : multiple test issues with the pass keyword in the case converter project

### DIFF
--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-list-comprehension-by-building-a-case-converter-program/657e928716b77b2277980276.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-list-comprehension-by-building-a-case-converter-program/657e928716b77b2277980276.md
@@ -11,7 +11,7 @@ In this project, you are going to learn about list comprehensions in Python by b
 
 List comprehensions in Python are a concise way to construct a list without using loops or the `.append()` method. Apart from being briefer, list comprehensions often run faster.
 
-Start defining a new function named `convert_to_snake_case()` that accepts a string named `pascal_or_camel_cased_string` as input.
+Start defining a new function named `convert_to_snake_case()` that accepts a string named `pascal_or_camel_cased_string` as input. For now, add a `pass` statement inside the function.
 
 # --hints--
 

--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-list-comprehension-by-building-a-case-converter-program/657ed53c19461d4b95c4757a.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-list-comprehension-by-building-a-case-converter-program/657ed53c19461d4b95c4757a.md
@@ -21,7 +21,7 @@ You should replace `pass` with an empty list named `snake_cased_char_list` withi
         const transformedCode = code.replace(/\r/g, "");
         const convert_to_snake_case = __helpers.python.getDef("\n" + transformedCode, "convert_to_snake_case");
         const { function_body } = convert_to_snake_case;
-
+        assert.notMatch(function_body, /\bpass\b/);
         assert.match(function_body, / +snake_cased_char_list\s*=\s*\[\s*\]\s*/);
     }
 })

--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-list-comprehension-by-building-a-case-converter-program/657ee28cefc4945568287673.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-list-comprehension-by-building-a-case-converter-program/657ee28cefc4945568287673.md
@@ -9,7 +9,7 @@ dashedName: step-3
 
 Now that you have an empty list in place, you can start iterating through the input string and start converting each character to snake case.
 
-Use a `for` loop to iterate through the `pascal_or_camel_cased_string`. Make sure to name the target variable `char` which is short for character.
+Use a `for` loop to iterate through the `pascal_or_camel_cased_string`. Make sure to name the target variable `char` which is short for character. For now, add a `pass` statement in the loop body.
 
 # --hints--
 

--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-list-comprehension-by-building-a-case-converter-program/657ee28cefc4945568287673.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-list-comprehension-by-building-a-case-converter-program/657ee28cefc4945568287673.md
@@ -22,7 +22,7 @@ You should write a new `for` loop with the target variable named `char`. Don't f
         const convert_to_snake_case = __helpers.python.getDef("\n" + transformedCode, "convert_to_snake_case");
         const { function_body } = convert_to_snake_case;
 
-        assert.match(function_body, / +for\s+char\s+in\s+pascal_or_camel_cased_string\s*:/);
+        assert.match(function_body, / +for\s+char\s+in\s+pascal_or_camel_cased_string\s*:\s*pass[\s]*$/);
     }
 })
 ```

--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-list-comprehension-by-building-a-case-converter-program/657ef2a86d4e545cec9a85fb.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-list-comprehension-by-building-a-case-converter-program/657ef2a86d4e545cec9a85fb.md
@@ -9,7 +9,9 @@ dashedName: step-4
 
 Uppercase characters in camel case or pascal case indicate the start of new words.
 
-Inside the loop body, use an `if` statement in conjunction with the `.isupper()` string method to check for uppercase characters and move `pass` inside the new `if` statement.
+Inside the loop body, replace the `pass` statement with an `if` statement in conjunction with the `.isupper()` string method to check for uppercase characters.
+
+For now, add a `pass` statement in the if statement body.
 
 # --hints--
 

--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-list-comprehension-by-building-a-case-converter-program/657ef2a86d4e545cec9a85fb.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-list-comprehension-by-building-a-case-converter-program/657ef2a86d4e545cec9a85fb.md
@@ -29,6 +29,21 @@ You should write a new `if` statement with `char.isupper()` as the condition. Do
 })
 ```
 
+You should replace the `pass` statement in the loop body with the `if` statement.
+
+```js
+({
+    test: () => {
+        const transformedCode = code.replace(/\r/g, "");
+        const convert_to_snake_case = __helpers.python.getDef("\n" + transformedCode, "convert_to_snake_case");
+        const { function_body } = convert_to_snake_case;
+
+        assert.notMatch(function_body, / +for\s+char\s+in\s+pascal_or_camel_cased_string\s*:\s*pass[\s]*/);
+
+    }
+})
+```
+
 # --seed--
 
 ## --seed-contents--

--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-list-comprehension-by-building-a-case-converter-program/657ef2a86d4e545cec9a85fb.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-list-comprehension-by-building-a-case-converter-program/657ef2a86d4e545cec9a85fb.md
@@ -44,6 +44,20 @@ You should replace the `pass` statement in the loop body with the `if` statement
 })
 ```
 
+You should add a `pass` statement in the `if` statement body.
+
+```js
+({
+    test: () => {
+        const transformedCode = code.replace(/\r/g, "");
+        const convert_to_snake_case = __helpers.python.getDef("\n" + transformedCode, "convert_to_snake_case");
+        const { function_body } = convert_to_snake_case;
+
+        assert.match(function_body, /\n* +if\s+char\.isupper\s*\(\s*\)\s*:\s*\n*\s*pass\s*\n*\s*$/);
+    }
+})
+```
+
 # --seed--
 
 ## --seed-contents--

--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-list-comprehension-by-building-a-case-converter-program/657efa642593c5746acc5c81.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-list-comprehension-by-building-a-case-converter-program/657efa642593c5746acc5c81.md
@@ -33,6 +33,20 @@ You should assign the modified character to a variable named `converted_characte
 })
 ```
 
+You should replace the pass statement with the expression.
+
+```js
+({
+    test: () => {
+        const transformedCode = code.replace(/\r/g, "");
+        const convert_to_snake_case = __helpers.python.getDef("\n" + transformedCode, "convert_to_snake_case");
+        const { function_body } = convert_to_snake_case;
+
+        assert.match(function_body, /\n* +if\s+char\.isupper\s*\(\s*\)\s*:\s*\n[\n\s]+converted_character\s*=\s*("|')_\1\s*\+\s*char\.lower\s*\(\s*\)/);
+    }
+})
+```
+
 # --seed--
 
 ## --seed-contents--

--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-list-comprehension-by-building-a-case-converter-program/657f025ec86c3d7c4177b6be.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-list-comprehension-by-building-a-case-converter-program/657f025ec86c3d7c4177b6be.md
@@ -9,6 +9,9 @@ dashedName: step-11
 
 Since the function is now complete, put it to use inside another function. Create a new function called `main()` on the same level as the `convert_to_snake_case()` function.
 
+Ensure the `main()` function includes the required placeholder, leaving it open for further development.
+
+
 # --hints--
 
 You should define a new function named `main()`. Don't forget the colon at the end and use `pass` to fill the function body.

--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-list-comprehension-by-building-a-case-converter-program/657f025ec86c3d7c4177b6be.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-list-comprehension-by-building-a-case-converter-program/657f025ec86c3d7c4177b6be.md
@@ -28,6 +28,21 @@ You should define a new function named `main()`. Don't forget the colon at the e
 })
 ```
 
+Fill the function body with a pass statement.
+
+```js
+({
+    test: () => {
+      const transformedCode = code.replace(/\r/g, "");
+      const main = __helpers.python.getDef("\n" + transformedCode, "main");
+      const { function_body } = main;
+      console.log(function_body);
+      assert.match(function_body, / +pass[\s\n]*$/);
+    }
+
+})
+```
+
 # --seed--
 
 ## --seed-contents--

--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-list-comprehension-by-building-a-case-converter-program/657f04ed0035f47ed04d0f1f.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-list-comprehension-by-building-a-case-converter-program/657f04ed0035f47ed04d0f1f.md
@@ -7,7 +7,9 @@ dashedName: step-13
 
 # --description--
 
-Before running the `main()` function, you need to make sure that the file is running as a script. Add an `if` statement on the same level as the two existing functions and check whether `__name__ == '__main__'` evaluates to `True` or not.
+Before running the `main()` function, you need to make sure that the file is running as a script. Add an `if` statement on the same level as the two existing functions and check whether `__name__ == '__main__'`.
+
+For now, provide the required placeholder so the `if` statement does nothing.
 
 # --hints--
 

--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-list-comprehension-by-building-a-case-converter-program/657f28a0482132aca51a9212.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-list-comprehension-by-building-a-case-converter-program/657f28a0482132aca51a9212.md
@@ -7,7 +7,7 @@ dashedName: step-14
 
 # --description--
 
-Replace pass with a call to the `main()` function inside the body of the `if` statement. You should see the given camel or pascal cased string converted to snake case upon execution.
+Replace `pass` with a call to the `main()` function inside the body of the `if` statement. You should see the given camel or pascal cased string converted to snake case upon execution.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #53392

<!-- Feel free to add any additional description of changes below this line -->
I updated and added test cases to rectify multiple issues where steps are able to succeed even if pass statement/s was erroneously present in the code when it shouldn't have been or vice versa. Also, I updated the instructions to explicitly mention adding a pass statement in the early steps and implicitly in the succeeding ones.