### PR TITLE
fix(client): fix fill-in-blank sentence style

### DIFF
--- a/client/src/templates/Challenges/fill-in-the-blank/show.css
+++ b/client/src/templates/Challenges/fill-in-the-blank/show.css
@@ -3,8 +3,10 @@
   padding: 20px;
   border: 4px solid var(--tertiary-background);
   display: flex;
-  align-items: center;
+  align-items: start;
   justify-content: center;
+  flex-direction: column;
+  gap: 1em;
 }
 
 .fill-in-the-blank-wrap > p {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

The problem is that paragraphs are stacked horizontally

![FillBefore](https://github.com/freeCodeCamp/freeCodeCamp/assets/15801806/50a9836c-ea00-41f3-89f4-b47dfa96c79b)

so this PR changes that:

![FillAfter](https://github.com/freeCodeCamp/freeCodeCamp/assets/15801806/677a186c-0eb0-4949-87ec-985215cd3aba)

I also changed the alignment, since it doesn't look good to center multiple sentences, so single sentences went from

![FillOneLineBefore](https://github.com/freeCodeCamp/freeCodeCamp/assets/15801806/f2b724aa-1b4c-4de2-8b75-447d831e17a5)

to

![FillOneLineAfter](https://github.com/freeCodeCamp/freeCodeCamp/assets/15801806/030fd8fc-3946-4c75-a2df-64a8b0b8a69d)

If people hate the new look, I think it's possible to center align if there's one sentence, but left align if there's more than one. It might be a bit hacky, though.

<!-- Feel free to add any additional description of changes below this line -->
