### PR TITLE
feat(client, i18n): move help translate CTA to superblock intro

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -412,7 +412,7 @@
       "tab-trapped": "Pressing tab will now insert the tab character",
       "tab-free": "Pressing tab will now move focus to the next focusable element"
     },
-    "help-translate": "We are still translating the following certifications.",
+    "help-translate": "We are still translating this certification.",
     "help-translate-link": "Help us translate.",
     "project-preview-title": "Here's a preview of what you will build",
     "github-required": "<0>Create a GitHub</0> account if you don't have one. You'll need it when you create the virtual Linux server machine. This process may take a few minutes.",

--- a/client/src/components/Map/index.tsx
+++ b/client/src/components/Map/index.tsx
@@ -1,22 +1,16 @@
-import i18next from 'i18next';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
 import {
   SuperBlockStages,
   SuperBlocks,
-  getFirstNotAuditedSuperBlock,
   superBlockOrder
 } from '../../../../shared/config/superblocks';
 import { SuperBlockIcon } from '../../assets/icons/superblock-icon';
 import LinkButton from '../../assets/icons/link-button';
 import { Link, Spacer } from '../helpers';
 import { getSuperBlockTitleForMap } from '../../utils/superblock-map-titles';
-import {
-  curriculumLocale,
-  showUpcomingChanges,
-  showNewCurriculum
-} from '../../../config/env.json';
+import { showUpcomingChanges } from '../../../config/env.json';
 
 import './map.css';
 
@@ -30,12 +24,6 @@ const linkSpacingStyle = {
   alignItems: 'center',
   gap: '15px'
 };
-
-const firstNotAuditedSuperBlock = getFirstNotAuditedSuperBlock({
-  language: curriculumLocale,
-  showNewCurriculum,
-  showUpcomingChanges
-});
 
 const coreCurriculum = [
   ...superBlockOrder[SuperBlockStages.FrontEnd],
@@ -52,25 +40,6 @@ function MapLi({
 }) {
   return (
     <>
-      {firstNotAuditedSuperBlock === superBlock && (
-        <>
-          <hr />
-          <div style={{ textAlign: 'center' }}>
-            <p style={{ marginBottom: 0 }}>
-              {i18next.t('learn.help-translate')}{' '}
-            </p>
-            <Link
-              external={true}
-              sameTab={false}
-              to={i18next.t('links:help-translate-link-url')}
-            >
-              {i18next.t('learn.help-translate-link')}
-            </Link>
-            <Spacer size='medium' />
-          </div>
-        </>
-      )}
-
       <li
         data-test-label='curriculum-map-button'
         data-playwright-test-label='curriculum-map-button'

--- a/client/src/templates/Introduction/components/help-translate.tsx
+++ b/client/src/templates/Introduction/components/help-translate.tsx
@@ -15,10 +15,12 @@ interface HelpTranslateProps {
 function HelpTranslate({ superBlock }: HelpTranslateProps): JSX.Element | null {
   const { t } = useTranslation();
 
-  if (isAuditedSuperBlock(clientLocale, superBlock, {
-    showNewCurriculum,
-    showUpcomingChanges
-  })) {
+  if (
+    isAuditedSuperBlock(clientLocale, superBlock, {
+      showNewCurriculum,
+      showUpcomingChanges
+    })
+  ) {
     return null;
   }
 
@@ -32,10 +34,9 @@ function HelpTranslate({ superBlock }: HelpTranslateProps): JSX.Element | null {
         to={t('links:help-translate-link-url')}
       >
         {t('learn.help-translate-link')}
-      Link>
+      </Link>
     </div>
   );
 }
-
 
 export default HelpTranslate;

--- a/client/src/templates/Introduction/components/help-translate.tsx
+++ b/client/src/templates/Introduction/components/help-translate.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { SuperBlocks } from '../../../../../shared/config/superblocks';
+import { isAuditedSuperBlock } from '../../../../../shared/utils/is-audited';
+import { Link, Spacer } from '../../../components/helpers';
+
+import envData from '../../../../config/env.json';
+
+const { clientLocale, showUpcomingChanges, showNewCurriculum } = envData;
+
+interface HelpTranslateProps {
+  superBlock: SuperBlocks;
+}
+
+function HelpTranslate({ superBlock }: HelpTranslateProps): JSX.Element | null {
+  const { t } = useTranslation();
+
+  if (
+    !isAuditedSuperBlock(clientLocale, superBlock, {
+      showNewCurriculum,
+      showUpcomingChanges
+    })
+  ) {
+    return (
+      <>
+        <div style={{ textAlign: 'center' }}>
+          <Spacer size='medium' />
+          <p style={{ marginBottom: 0 }}>{t('learn.help-translate')} </p>
+          <Link
+            external={true}
+            sameTab={false}
+            to={t('links:help-translate-link-url')}
+          >
+            {t('learn.help-translate-link')}
+          </Link>
+        </div>
+      </>
+    );
+  } else {
+    return null;
+  }
+}
+
+export default HelpTranslate;

--- a/client/src/templates/Introduction/components/help-translate.tsx
+++ b/client/src/templates/Introduction/components/help-translate.tsx
@@ -15,30 +15,27 @@ interface HelpTranslateProps {
 function HelpTranslate({ superBlock }: HelpTranslateProps): JSX.Element | null {
   const { t } = useTranslation();
 
-  if (
-    !isAuditedSuperBlock(clientLocale, superBlock, {
-      showNewCurriculum,
-      showUpcomingChanges
-    })
-  ) {
-    return (
-      <>
-        <div style={{ textAlign: 'center' }}>
-          <Spacer size='medium' />
-          <p style={{ marginBottom: 0 }}>{t('learn.help-translate')} </p>
-          <Link
-            external={true}
-            sameTab={false}
-            to={t('links:help-translate-link-url')}
-          >
-            {t('learn.help-translate-link')}
-          </Link>
-        </div>
-      </>
-    );
-  } else {
+  if (isAuditedSuperBlock(clientLocale, superBlock, {
+    showNewCurriculum,
+    showUpcomingChanges
+  })) {
     return null;
   }
+
+  return (
+    <div style={{ textAlign: 'center' }}>
+      <Spacer size='medium' />
+      <p style={{ marginBottom: 0 }}>{t('learn.help-translate')} </p>
+      <Link
+        external={true}
+        sameTab={false}
+        to={t('links:help-translate-link-url')}
+      >
+        {t('learn.help-translate-link')}
+      Link>
+    </div>
+  );
 }
+
 
 export default HelpTranslate;

--- a/client/src/templates/Introduction/super-block-intro.tsx
+++ b/client/src/templates/Introduction/super-block-intro.tsx
@@ -29,6 +29,7 @@ import { defaultDonation } from '../../../../shared/config/donation-settings';
 import Block from './components/block';
 import CertChallenge from './components/cert-challenge';
 import LegacyLinks from './components/legacy-links';
+import HelpTranslate from './components/help-translate';
 import SuperBlockIntro from './components/super-block-intro';
 import { resetExpansion, toggleBlock } from './redux';
 
@@ -220,6 +221,7 @@ const SuperBlockIntroductionPage = (props: SuperBlockProp) => {
                 }
                 isDonating={user.isDonating}
               />
+              <HelpTranslate superBlock={superBlock} />
               <Spacer size='large' />
               <h2 className='text-center big-subheading'>
                 {t(`intro:misc-text.courses`)}

--- a/shared/config/superblocks.test.ts
+++ b/shared/config/superblocks.test.ts
@@ -6,8 +6,7 @@ import {
   notAuditedSuperBlocks,
   createSuperBlockMap,
   createFlatSuperBlockMap,
-  getAuditedSuperBlocks,
-  getFirstNotAuditedSuperBlock
+  getAuditedSuperBlocks
 } from './superblocks';
 
 describe('superBlockOrder', () => {
@@ -63,26 +62,6 @@ describe('createFlatSuperBlockMap', () => {
     tempSuperBlockMap[SuperBlockStages.New] = [];
     tempSuperBlockMap[SuperBlockStages.Upcoming] = [];
     expect(result).toHaveLength(Object.values(tempSuperBlockMap).flat().length);
-  });
-});
-
-describe('firstNotAuditedSuperBlock', () => {
-  it("should return 'null' when language is 'english'", () => {
-    const result = getFirstNotAuditedSuperBlock({
-      language: Languages.English,
-      showNewCurriculum: false,
-      showUpcomingChanges: false
-    });
-    expect(result).toBeNull();
-  });
-
-  it.skip("should return a SuperBlock when language is 'chinese'", () => {
-    const result = getFirstNotAuditedSuperBlock({
-      language: Languages.Chinese,
-      showNewCurriculum: false,
-      showUpcomingChanges: false
-    });
-    expect(result).toEqual(SuperBlocks.JsAlgoDataStructNew);
   });
 });
 

--- a/shared/config/superblocks.ts
+++ b/shared/config/superblocks.ts
@@ -289,24 +289,6 @@ export function createFlatSuperBlockMap({
   return Object.values(superBlockMap).flat();
 }
 
-// this is so we know where to display the "help us translate" section
-export function getFirstNotAuditedSuperBlock({
-  language,
-  showNewCurriculum,
-  showUpcomingChanges
-}: LanguagesConfig): SuperBlocks | null {
-  const flatSuperBlockMap = createFlatSuperBlockMap({
-    showNewCurriculum,
-    showUpcomingChanges
-  });
-  for (const superBlock of flatSuperBlockMap) {
-    if (notAuditedSuperBlocks[language as Languages].includes(superBlock)) {
-      return superBlock;
-    }
-  }
-  return null;
-}
-
 export function getAuditedSuperBlocks({
   language = 'english',
   showNewCurriculum,


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #52656 

<!-- Feel free to add any additional description of changes below this line -->

I'm not sure if it looks better to put it in a blue information box. I thought so at first, but it may look a little cluttered when there are many of those boxes. So I didn't change how the message looks.

Here is how it looks:
![new-js-ja](https://github.com/freeCodeCamp/freeCodeCamp/assets/25644062/ef89c12f-2db4-4a65-8fb0-ecfa5ed270e3)

![odin-ja](https://github.com/freeCodeCamp/freeCodeCamp/assets/25644062/2fae28b6-a5fa-4112-853a-8739c69867a1)