### PR TITLE
feat(client, i18n): add note about exam being available only in English

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -1455,6 +1455,7 @@
     "go-back-to-learn": "Go back to the stable version of the curriculum.",
     "read-database-cert-article": "Please read this forum post before proceeding.",
     "enable-cookies": "You must enable third-party cookies before starting.",
-    "english-only": "The courses in this section are only available in English. We are only able to translate the titles and introductions at the moment, not the lessons themselves."
+    "english-only": "The courses in this section are only available in English. We are only able to translate the titles and introductions at the moment, not the lessons themselves.",
+    "exam-english-only": "Please note that the certification exam is currently available only in English. The rest of the courses are available in some languages."
   }
 }

--- a/client/src/templates/Introduction/components/legacy-links.tsx
+++ b/client/src/templates/Introduction/components/legacy-links.tsx
@@ -46,15 +46,11 @@ function LegacyLinks({ superBlock }: LegacyLinksProps): JSX.Element {
         )}
       </>
     );
-  } else if (isExamCert(superBlock)) {
+  } else if (isExamCert(superBlock) && clientLocale != 'english') {
     return (
-      <>
-        {clientLocale != 'english' && (
-          <Alert variant='info'>
-            <p>{t('intro:misc-text.exam-english-only')}</p>
-          </Alert>
-        )}
-      </>
+      <Alert variant='info'>
+        <p>{t('intro:misc-text.exam-english-only')}</p>
+      </Alert>
     );
   } else {
     return (

--- a/client/src/templates/Introduction/components/legacy-links.tsx
+++ b/client/src/templates/Introduction/components/legacy-links.tsx
@@ -2,7 +2,11 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Alert } from '@freecodecamp/ui';
 import { SuperBlocks } from '../../../../../shared/config/superblocks';
-import { isOldRespCert, isRelationalDbCert } from '../../../utils/is-a-cert';
+import {
+  isOldRespCert,
+  isRelationalDbCert,
+  isExamCert
+} from '../../../utils/is-a-cert';
 import { Link } from '../../../components/helpers';
 import { CodeAllyDown } from '../../../components/growth-book/codeally-down';
 
@@ -38,6 +42,16 @@ function LegacyLinks({ superBlock }: LegacyLinksProps): JSX.Element {
         {clientLocale != 'english' && (
           <Alert variant='info'>
             <p>{t('intro:misc-text.english-only')}</p>
+          </Alert>
+        )}
+      </>
+    );
+  } else if (isExamCert(superBlock)) {
+    return (
+      <>
+        {clientLocale != 'english' && (
+          <Alert variant='info'>
+            <p>{t('intro:misc-text.exam-english-only')}</p>
           </Alert>
         )}
       </>

--- a/client/src/utils/is-a-cert.ts
+++ b/client/src/utils/is-a-cert.ts
@@ -7,3 +7,7 @@ export function isOldRespCert(superBlock: string): boolean {
 export function isRelationalDbCert(superBlock: string): boolean {
   return superBlock === String(SuperBlocks.RelationalDb);
 }
+
+export function isExamCert(superBlock: string): boolean {
+  return superBlock === String(SuperBlocks.FoundationalCSharp);
+}


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #53670

<!-- Feel free to add any additional description of changes below this line -->
After looking into the current code, I found we have a similar note for RDB certification. So I added a note at the top of the superblock intro page, using the same component.