### PR TITLE
fix(curriculum): typo "Yous" to "You" in hint text

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fac4d1773e7a719b1254de.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fac4d1773e7a719b1254de.md
@@ -11,7 +11,7 @@ Remove the existing code toggling the class of `hidden` on `taskForm` and call t
 
 # --hints--
 
-Yous should remove the code toggling the `hidden` class on `taskForm`.
+You should remove the code toggling the `hidden` class on `taskForm`.
 
 ```js
 const splitter = code.split('<button type="button" class="btn">Delete</button>')

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fac6a497811572b338e5e5.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fac6a497811572b338e5e5.md
@@ -11,7 +11,7 @@ Also, remove the existing code toggling the class `hidden` on `taskForm` inside 
 
 # --hints--
 
-Yous should remove the code toggling the class `hidden` on `taskForm`.
+You should remove the code toggling the class `hidden` on `taskForm`.
 
 ```js
 const splitter = code.split("confirmCloseDialog.close();")


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #53719

<!-- Feel free to add any additional description of changes below this line -->

As per the title, this fixes the typo "Yous" to "You". 
This has not been tested locally, as it is just a text change.
