### PR TITLE
[POC] chore(tools): disable testing-library/await-async-events ESLint rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -57,7 +57,8 @@
         "caughtErrorsIgnorePattern": "^_"
       }
     ],
-    "filenames-simple/naming-convention": ["warn"]
+    "filenames-simple/naming-convention": ["warn"],
+    "testing-library/await-async-events": "off"
   },
   "overrides": [
     {

--- a/tools/ui-components/src/button/button.test.tsx
+++ b/tools/ui-components/src/button/button.test.tsx
@@ -99,4 +99,16 @@ describe('<Button />', () => {
     // Ensure that a link element is not rendered
     expect(link).not.toBeInTheDocument();
   });
+
+  it('test - should trigger the onClick prop on click', () => {
+    const onClick = jest.fn();
+
+    render(<Button onClick={onClick}>Hello world</Button>);
+
+    const button = screen.getByRole('button', { name: /hello world/i });
+
+    userEvent.click(button);
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [ ] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This is a POC of #53758.

The PR adds a new test case to trigger a CodeFactor error. The new test case is identical to an existing test case, with only the test description being changed. 
- Test that was cloned from:
    https://github.com/freeCodeCamp/freeCodeCamp/blob/696348953da6f8b9d415f96c72d543adb2b8f12c/tools/ui-components/src/button/button.test.tsx#L36-L46

CodeFactor errored out on the new test (https://github.com/freeCodeCamp/freeCodeCamp/pull/53757/checks?check_run_id=21641461588), but passed after the ESLint rule was disabled (https://github.com/freeCodeCamp/freeCodeCamp/pull/53757/checks?check_run_id=21641486181).

<!-- Feel free to add any additional description of changes below this line -->
