### PR TITLE
chore: replace deprecated jest matchers

### DIFF
--- a/api/src/routes/user.test.ts
+++ b/api/src/routes/user.test.ts
@@ -659,8 +659,8 @@ describe('userRoutes', () => {
             '<script>const breath = "loud"</script>Luke, I am your father'
         });
 
-        expect(sendEmailSpy).toBeCalledTimes(1);
-        expect(sendEmailSpy).toBeCalledWith(
+        expect(sendEmailSpy).toHaveBeenCalledTimes(1);
+        expect(sendEmailSpy).toHaveBeenCalledWith(
           expect.objectContaining({
             text: expect.stringContaining(
               'Report Details:\n\nLuke, I am your father'
@@ -680,8 +680,8 @@ describe('userRoutes', () => {
           reportDescription: 'Luke, I am your father'
         });
 
-        expect(sendEmailSpy).toBeCalledTimes(1);
-        expect(sendEmailSpy).toBeCalledWith({
+        expect(sendEmailSpy).toHaveBeenCalledTimes(1);
+        expect(sendEmailSpy).toHaveBeenCalledWith({
           from: 'team@freecodecamp.org',
           to: 'support@freecodecamp.org',
           cc: 'foo@bar.com',

--- a/client/src/templates/Challenges/utils/worker-executor.test.js
+++ b/client/src/templates/Challenges/utils/worker-executor.test.js
@@ -44,14 +44,14 @@ it('Worker executor should successfully execute one task', async () => {
 
   await expect(task.done).resolves.toBe('test processed');
 
-  expect(handler).toBeCalledTimes(1);
-  expect(handler).toBeCalledWith('test processed');
+  expect(handler).toHaveBeenCalledTimes(1);
+  expect(handler).toHaveBeenCalledWith('test processed');
 
-  expect(errorHandler).not.toBeCalled();
-  expect(terminateHandler).not.toBeCalled();
+  expect(errorHandler).not.toHaveBeenCalled();
+  expect(terminateHandler).not.toHaveBeenCalled();
 
-  expect(global.Worker).toBeCalledTimes(1);
-  expect(global.Worker).toBeCalledWith('/js/test.js');
+  expect(global.Worker).toHaveBeenCalledTimes(1);
+  expect(global.Worker).toHaveBeenCalledWith('/js/test.js');
 });
 
 it('Worker executor should successfully execute two tasks in parallel', async () => {
@@ -76,16 +76,16 @@ it('Worker executor should successfully execute two tasks in parallel', async ()
     'test2 processed'
   ]);
 
-  expect(handler1).toBeCalledTimes(1);
-  expect(handler1).toBeCalledWith('test1 processed');
-  expect(errorHandler1).not.toBeCalled();
+  expect(handler1).toHaveBeenCalledTimes(1);
+  expect(handler1).toHaveBeenCalledWith('test1 processed');
+  expect(errorHandler1).not.toHaveBeenCalled();
 
-  expect(handler2).toBeCalledTimes(1);
-  expect(handler2).toBeCalledWith('test2 processed');
-  expect(errorHandler2).not.toBeCalled();
-  expect(terminateHandler).not.toBeCalled();
+  expect(handler2).toHaveBeenCalledTimes(1);
+  expect(handler2).toHaveBeenCalledWith('test2 processed');
+  expect(errorHandler2).not.toHaveBeenCalled();
+  expect(terminateHandler).not.toHaveBeenCalled();
 
-  expect(global.Worker).toBeCalledTimes(2);
+  expect(global.Worker).toHaveBeenCalledTimes(2);
 });
 
 it('Worker executor should successfully execute 3 tasks in parallel and use two workers', async () => {
@@ -99,7 +99,7 @@ it('Worker executor should successfully execute 3 tasks in parallel and use two 
     Promise.all([task1.done, task2.done, task3.done])
   ).resolves.toEqual(['test1 processed', 'test2 processed', 'test3 processed']);
 
-  expect(global.Worker).toBeCalledTimes(2);
+  expect(global.Worker).toHaveBeenCalledTimes(2);
 });
 
 it('Worker executor should successfully execute 3 tasks, use 3 workers and terminate each worker', async () => {
@@ -114,8 +114,8 @@ it('Worker executor should successfully execute 3 tasks, use 3 workers and termi
     Promise.all([task1.done, task2.done, task3.done])
   ).resolves.toEqual(['test1 processed', 'test2 processed', 'test3 processed']);
 
-  expect(terminateHandler).toBeCalledTimes(3);
-  expect(global.Worker).toBeCalledTimes(3);
+  expect(terminateHandler).toHaveBeenCalledTimes(3);
+  expect(global.Worker).toHaveBeenCalledTimes(3);
 });
 
 it('Worker executor should successfully execute 3 tasks in parallel and use 3 workers', async () => {
@@ -129,7 +129,7 @@ it('Worker executor should successfully execute 3 tasks in parallel and use 3 wo
     Promise.all([task1.done, task2.done, task3.done])
   ).resolves.toEqual(['test1 processed', 'test2 processed', 'test3 processed']);
 
-  expect(global.Worker).toBeCalledTimes(3);
+  expect(global.Worker).toHaveBeenCalledTimes(3);
 });
 
 it('Worker executor should successfully execute 3 tasks and use 1 worker', async () => {
@@ -143,7 +143,7 @@ it('Worker executor should successfully execute 3 tasks and use 1 worker', async
     Promise.all([task1.done, task2.done, task3.done])
   ).resolves.toEqual(['test1 processed', 'test2 processed', 'test3 processed']);
 
-  expect(global.Worker).toBeCalledTimes(1);
+  expect(global.Worker).toHaveBeenCalledTimes(1);
 });
 
 it('Worker executor should reject task', async () => {
@@ -160,8 +160,8 @@ it('Worker executor should reject task', async () => {
   task.on('error', errorHandler);
   await expect(task.done).rejects.toBe(error.message);
 
-  expect(errorHandler).toBeCalledTimes(1);
-  expect(errorHandler).toBeCalledWith(error);
+  expect(errorHandler).toHaveBeenCalledTimes(1);
+  expect(errorHandler).toHaveBeenCalledWith(error);
 });
 
 it('Worker executor should emit LOG events', async () => {
@@ -193,11 +193,11 @@ it('Worker executor should emit LOG events', async () => {
 
   await expect(task.done).resolves.toBe('test processed');
 
-  expect(handler).toBeCalledTimes(1);
-  expect(handler).toBeCalledWith('test processed');
-  expect(errorHandler).not.toBeCalled();
+  expect(handler).toHaveBeenCalledTimes(1);
+  expect(handler).toHaveBeenCalledWith('test processed');
+  expect(errorHandler).not.toHaveBeenCalled();
 
-  expect(logHandler).toBeCalledTimes(3);
+  expect(logHandler).toHaveBeenCalledTimes(3);
   for (let i = 0; i < 3; i++) {
     expect(logHandler.mock.calls[i][0]).toBe(i);
   }
@@ -216,10 +216,10 @@ it('Worker executor should reject task on timeout', async () => {
   task.on('error', errorHandler);
   await expect(task.done).rejects.toBe('timeout');
 
-  expect(errorHandler).toBeCalledTimes(1);
+  expect(errorHandler).toHaveBeenCalledTimes(1);
   expect(errorHandler.mock.calls[0][0]).toEqual({ message: 'timeout' });
 
-  expect(terminateHandler).toBeCalledTimes(1);
+  expect(terminateHandler).toHaveBeenCalledTimes(1);
 });
 
 it('Worker executor should get worker from specified location', async () => {
@@ -231,8 +231,8 @@ it('Worker executor should get worker from specified location', async () => {
   const task = testWorker.execute('test');
   await expect(task.done).resolves.toBe('test processed');
 
-  expect(global.Worker).toBeCalledTimes(1);
-  expect(global.Worker).toBeCalledWith('/other/location/test.js');
+  expect(global.Worker).toHaveBeenCalledTimes(1);
+  expect(global.Worker).toHaveBeenCalledWith('/other/location/test.js');
 });
 
 it('Task should only emit handler once', () => {
@@ -244,5 +244,5 @@ it('Task should only emit handler once', () => {
 
   task.emit('testOnce', handler);
   task.emit('testOnce', handler);
-  expect(handler).toBeCalledTimes(1);
+  expect(handler).toHaveBeenCalledTimes(1);
 });

--- a/tools/ui-components/src/button/button.test.tsx
+++ b/tools/ui-components/src/button/button.test.tsx
@@ -69,7 +69,7 @@ describe('<Button />', () => {
 
     userEvent.click(button);
 
-    expect(onClick).not.toBeCalled();
+    expect(onClick).not.toHaveBeenCalled();
   });
 
   it('should render an anchor element if the `href` prop is defined', () => {

--- a/tools/ui-components/src/drop-down/drop-down.test.tsx
+++ b/tools/ui-components/src/drop-down/drop-down.test.tsx
@@ -122,7 +122,7 @@ describe('<DropDownButton>', () => {
     const Item = within(unorderedList).getByText('Hello world');
     userEvent.click(Item);
 
-    expect(onClick).not.toBeCalled();
+    expect(onClick).not.toHaveBeenCalled();
   });
 
   it('should render an anchor element if the `href` prop is defined', () => {

--- a/tools/ui-components/src/toggle-button/toggle-button.test.tsx
+++ b/tools/ui-components/src/toggle-button/toggle-button.test.tsx
@@ -17,7 +17,7 @@ describe('<ToggleButton />', () => {
 
     userEvent.click(screen.getByRole('button', { name: /on/i }));
 
-    expect(onChange).toBeCalledTimes(1);
+    expect(onChange).toHaveBeenCalledTimes(1);
   });
 
   it('should be checked if checked prop is true', () => {
@@ -59,7 +59,7 @@ describe('<ToggleButton />', () => {
 
     userEvent.click(screen.getByRole('button', { name: /on/i }));
 
-    expect(onChange).not.toBeCalled();
+    expect(onChange).not.toHaveBeenCalled();
   });
 
   it('should have value property if radio', () => {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

I noticed a deprecation warning in the code editor, and found that some Jest matchers will be removed in the next major version (https://github.com/jestjs/jest/issues/13164).

<img width="785" alt="Screenshot 2024-02-16 at 11 32 26" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/40bba328-517c-4dda-9332-4ae15a6d3383">

This PR replaces the deprecated matchers with their recommended counterparts. The replacement is as follows:

| From | To |
| --- | --- |
| `toBeCalled()` | `toHaveBeenCalled()` |
| `toBeCalledTimes()` | `toHaveBeenCalledTimes()` |
| `toBeCalledWith()` | `toHaveBeenCalledWith()` |

<!-- Feel free to add any additional description of changes below this line -->
