### PR TITLE
fix: campfire volume slider colors

### DIFF
--- a/client/src/components/settings/sound.css
+++ b/client/src/components/settings/sound.css
@@ -2,33 +2,34 @@
   margin: 1em 0 2em;
   width: 100%;
   height: 25px;
-  background: var(--gray-45);
+  background: var(--quaternary-background);
 }
 
 input[type='range'] {
   appearance: none;
   overflow: hidden;
-  border: 1px solid var(--secondary-color);
+  border: 2px solid var(--secondary-color);
 }
 
 /* Special styling for WebKit/Blink */
 input[type='range']::-webkit-slider-thumb {
-  box-shadow: -2000px 0 0 2000px var(--gray-90);
+  box-shadow: -2000px 0 0 2000px var(--gray-45);
   -webkit-appearance: none;
-  border-left: 2px solid var(--secondary-color);
+  border: 2px solid var(--primary-color);
   height: 25px;
   width: 16px;
-  background: var(--quaternary-background);
+  background: var(--primary-background);
   cursor: pointer;
 }
 
 /* All the same stuff for Firefox */
 input[type='range']::-moz-range-thumb {
-  border: 2px solid var(--secondary-color);
+  box-shadow: -2000px 0 0 2000px var(--gray-45);
+  border: 2px solid var(--primary-color);
   border-radius: 0;
   height: 25px;
   width: 16px;
-  background: var(--gray-90);
+  background: var(--primary-background);
   cursor: pointer;
 }
 

--- a/client/src/components/settings/sound.css
+++ b/client/src/components/settings/sound.css
@@ -6,18 +6,16 @@
 }
 
 input[type='range'] {
-  -webkit-appearance: none;
+  appearance: none;
   overflow: hidden;
+  border: 1px solid var(--secondary-color);
 }
 
-input[type='range']:focus {
-  outline-color: transparent;
-}
 /* Special styling for WebKit/Blink */
 input[type='range']::-webkit-slider-thumb {
   box-shadow: -2000px 0 0 2000px var(--gray-90);
   -webkit-appearance: none;
-  border: 2px solid var(--secondary-color);
+  border-left: 2px solid var(--secondary-color);
   height: 25px;
   width: 16px;
   background: var(--quaternary-background);
@@ -30,7 +28,7 @@ input[type='range']::-moz-range-thumb {
   border-radius: 0;
   height: 25px;
   width: 16px;
-  background: var(--quaternary-background);
+  background: var(--gray-90);
   cursor: pointer;
 }
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->
<img width="773" alt="image" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/46919888/a9f658f8-cabe-4150-8cd7-88c2d37f72bc">

<img width="773" alt="image" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/46919888/7929daf2-250a-41e5-9177-1ca700a75e96">


Closes #52730

<!-- Feel free to add any additional description of changes below this line -->
