### PR TITLE
test: only use test dbs in testing

### DIFF
--- a/api/src/db/prisma.ts
+++ b/api/src/db/prisma.ts
@@ -1,9 +1,9 @@
-import { execSync } from 'node:child_process';
 import fp from 'fastify-plugin';
 import { FastifyPluginAsync } from 'fastify';
 import { PrismaClient } from '@prisma/client';
 
-import { FREECODECAMP_NODE_ENV, MONGOHQ_URL } from '../utils/env';
+// importing MONGOHQ_URL so we can mock it in testing.
+import { MONGOHQ_URL } from '../utils/env';
 
 declare module 'fastify' {
   interface FastifyInstance {
@@ -11,48 +11,20 @@ declare module 'fastify' {
   }
 }
 
-// Appends the dbId to the existing database name
-const createTestConnectionURL = (url: string, dbId: string) =>
-  url.replace(/(.*)(\?.*)/, `$1${dbId}$2`);
-
-const isTest = (workerId: string | undefined): workerId is string =>
-  !!workerId && FREECODECAMP_NODE_ENV === 'development';
-
 const prismaPlugin: FastifyPluginAsync = fp(async (server, _options) => {
-  if (isTest(process.env.JEST_WORKER_ID)) {
-    // push the schema to the test db to setup indexes, unique constraints, etc
-    execSync('pnpm prisma db push -- --skip-generate', {
-      env: {
-        ...process.env,
-        MONGOHQ_URL: createTestConnectionURL(
-          MONGOHQ_URL,
-          process.env.JEST_WORKER_ID
-        )
+  const prisma = new PrismaClient({
+    datasources: {
+      db: {
+        url: MONGOHQ_URL
       }
-    });
-  }
-
-  const prisma = isTest(process.env.JEST_WORKER_ID)
-    ? new PrismaClient({
-        datasources: {
-          db: {
-            url: createTestConnectionURL(
-              MONGOHQ_URL,
-              process.env.JEST_WORKER_ID
-            )
-          }
-        }
-      })
-    : new PrismaClient();
+    }
+  });
 
   await prisma.$connect();
 
   server.decorate('prisma', prisma);
 
   server.addHook('onClose', async server => {
-    if (isTest(process.env.JEST_WORKER_ID)) {
-      await server.prisma.$runCommandRaw({ dropDatabase: 1 });
-    }
     await server.prisma.$disconnect();
   });
 });


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

I thought this was already the case, but it was not: the session store was using the `freecodecamp` database, not the test databases (e.g. `freecodecamp1`, `freecodecamp2` and so on).

<!-- Feel free to add any additional description of changes below this line -->
