### PR TITLE
fix: remove test case in execute-brain

### DIFF
--- a/curriculum/challenges/english/22-rosetta-code/rosetta-code-challenges/execute-brain.md
+++ b/curriculum/challenges/english/22-rosetta-code/rosetta-code-challenges/execute-brain.md
@@ -31,22 +31,16 @@ Any cell size is allowed, EOF (*E*nd-*O*-*F*ile) support is optional, as is whet
 
 # --hints--
 
-`brain(bye)` should return a string
+`brain(hello)` should return a string
 
 ```js
-assert(typeof brain(bye) === 'string');
+assert(typeof brain(hello) === 'string');
 ```
 
 `brain("++++++[>++++++++++<-]>+++++.")` should return "A"
 
 ```js
 assert.equal(brain('++++++[>++++++++++<-]>+++++.'), 'A');
-```
-
-`brain(bye)` should return `Goodbye, World!\r\n`
-
-```js
-assert.equal(brain(bye), 'Goodbye, World!\r\n');
 ```
 
 `brain(hello)` should return `Hello World!\n`
@@ -130,7 +124,6 @@ let fib=`+
 
 >-]>[<+>-]<<<-]`;
 let hello='++++++++[>++++[>++>+++>+++>+<<<<-]>+>+>->>+[<]<-]>>.>---.+++++++..+++.>>.<-.<.+++.------.--------.>>+.>++.'
-let bye='++++++++++[>+>+++>++++>+++++++>++++++++>+++++++++>++++++++++>+++++++++++>++++++++++++<<<<<<<<<-]>>>>+.>>>>+..<.<++++++++.>>>+.<<+.<<<<++++.<++.>>>+++++++.>>>.+++.<+++++++.--------.<<<<<+.<+++.---.';
 ```
 
 ## --seed-contents--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

The `let bye=` string is breaking Crowdin. I don't know why. It just doesn't appear, no matter what I try. My guess is something in the string just explodes the parser.

Given that Rosetta Code itself doesn't provide test cases, removing this is the path of least resistance. :3