### PR TITLE
add ads.txt

### DIFF
--- a/client/static/ads.txt
+++ b/client/static/ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-9482786369113753, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
ads.txt needs to be served from freecodecamp.org instead of freecodecamp.org/news to verify the domain for adsense.

The current ads.txt is served here: https://www.freecodecamp.org/news/ads.txt

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
