### PR TITLE
fix(curriculum,i18n): use code tag in a hint text

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -376,7 +376,7 @@
     "tests-completed": "// tests completed",
     "console-output": "// console output",
     "syntax-error": "Your code raised an error before any tests could run. Please fix it and try again.",
-    "indentation-error": "Your code has an indentation error. You may need to add 'pass' on a new line to form a valid block of code.",
+    "indentation-error": "Your code has an indentation error. You may need to add <code>pass</code> on a new line to form a valid block of code.",
     "sign-in-save": "Sign in to save your progress",
     "download-solution": "Download my solution",
     "download-results": "Download my results",


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

The string was added in #53744. I was a bit confused when translating it because I wasn't aware that `pass` was a keyword in Python. Wrapping it in code tags should prevent confusion like that.

You can test this in Learn Tree Traversal by Building a Binary Search Tree Step 1:
![image](https://github.com/freeCodeCamp/freeCodeCamp/assets/25644062/a9fa670e-c7ec-476f-8f11-0c7190bbb458)

