### PR TITLE
fix: playwright installation command

### DIFF
--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -136,9 +136,7 @@ jobs:
         run: npm i -g pm2
 
       - name: Install playwright dependencies
-        run: |
-          npx playwright install
-          npx playwright install-deps
+        run: npx playwright install --with-deps
 
       - name: Run playwright tests
         run: |

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "lint:prettier": "prettier --list-different .",
     "reload:server": "pm2 reload api-server/ecosystem.config.js",
     "preseed": "npm-run-all create:shared",
-    "playwright:install-build-tools": "cd ./e2e && npm i && npx playwright install && npx playwright install-deps",
+    "playwright:install-build-tools": "npx playwright install --with-deps",
     "playwright:install-build-tools-linux": "sh ./playwright-install.sh",
     "rename-challenges": "ts-node tools/challenge-helper-scripts/rename-challenge-files.ts",
     "seed": "pnpm seed:surveys && pnpm seed:exams && cross-env DEBUG=fcc:* node ./tools/scripts/seed/seed-demo-user",


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

After #53884, Playwright tests are now run from the root.

This PR updates the `playwright:install-build-tools` command to also run in the root rather than the `e2e` directory. Without this change, the command results the following error:

<img width="817" alt="Screenshot 2024-02-28 at 14 15 42" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/1bb88679-89b8-4bc0-b353-d4360411d447">

<!-- Feel free to add any additional description of changes below this line -->
