### PR TITLE
fix: throw error when unable to create challenge

### DIFF
--- a/tools/challenge-helper-scripts/create-next-challenge.ts
+++ b/tools/challenge-helper-scripts/create-next-challenge.ts
@@ -1,5 +1,5 @@
 import ObjectID from 'bson-objectid';
-import { challengeTypeToTemplate } from './helpers/get-challenge-template';
+import { getTemplate } from './helpers/get-challenge-template';
 import { newChallengePrompts } from './helpers/new-challenge-prompts';
 import { getProjectPath } from './helpers/get-project-info';
 import { getMetaData, updateMetaData } from './helpers/project-metadata';
@@ -9,13 +9,12 @@ const createNextChallenge = async () => {
   const path = getProjectPath();
 
   const options = await newChallengePrompts();
-  const templateGenerator = challengeTypeToTemplate[options.challengeType];
-  if (!templateGenerator) {
-    return;
-  }
+  const template = getTemplate(options.challengeType);
+
   const challengeId = new ObjectID();
-  const template = templateGenerator({ ...options, challengeId });
-  createChallengeFile(options.dashedName, template, path);
+  const challengeText = template({ ...options, challengeId });
+
+  createChallengeFile(options.dashedName, challengeText, path);
 
   const meta = getMetaData();
   meta.challengeOrder.push({

--- a/tools/challenge-helper-scripts/helpers/get-challenge-template.ts
+++ b/tools/challenge-helper-scripts/helpers/get-challenge-template.ts
@@ -251,6 +251,18 @@ ${options.title} description.
 ${options.title} assignment!
 `;
 
+type Template = (opts: ChallengeOptions) => string;
+
+export const getTemplate = (challengeType: string): Template => {
+  const template = challengeTypeToTemplate[challengeType];
+  if (!template) {
+    throw Error(`Challenge type ${challengeType} has no template.
+To create one, please add a new function to this file and include it in the challengeTypeToTemplate map.
+`);
+  }
+  return template;
+};
+
 /**
  * This should be kept in parity with the challengeTypes in the
  * client.
@@ -258,8 +270,9 @@ ${options.title} assignment!
  * Keys are explicitly marked null so we know the challenge type itself
  * exists, and can expand this to use the correct template later on.
  */
-export const challengeTypeToTemplate: {
-  [key: string]: null | ((opts: ChallengeOptions) => string);
+
+const challengeTypeToTemplate: {
+  [key: string]: null | Template;
 } = {
   0: getLegacyChallengeTemplate,
   1: getLegacyChallengeTemplate,

--- a/tools/challenge-helper-scripts/insert-challenge.ts
+++ b/tools/challenge-helper-scripts/insert-challenge.ts
@@ -1,6 +1,6 @@
 import ObjectID from 'bson-objectid';
 import { prompt } from 'inquirer';
-import { challengeTypeToTemplate } from './helpers/get-challenge-template';
+import { getTemplate } from './helpers/get-challenge-template';
 import { newChallengePrompts } from './helpers/new-challenge-prompts';
 import { getProjectPath } from './helpers/get-project-info';
 import { getMetaData, updateMetaData } from './helpers/project-metadata';
@@ -27,13 +27,10 @@ const insertChallenge = async () => {
     ({ id }) => id === challengeAfter.id
   );
 
-  const templateGenerator = challengeTypeToTemplate[options.challengeType];
-  if (!templateGenerator) {
-    return;
-  }
+  const template = getTemplate(options.challengeType);
   const challengeId = new ObjectID();
-  const template = templateGenerator({ ...options, challengeId });
-  createChallengeFile(options.dashedName, template, path);
+  const challengeText = template({ ...options, challengeId });
+  createChallengeFile(options.dashedName, challengeText, path);
 
   const meta = getMetaData();
   meta.challengeOrder.splice(indexToInsert, 0, {


### PR DESCRIPTION
When the challenge helpers fail they now tell you why and how to fix it.

I also simplified the verbiage slightly by using "template" to refer the function that generates the challenge file's text. It's not the only choice, but it's concise and should make us consistent in how we use it.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->
