### PR TITLE
fix(curriculum): correct pronoun gender

### DIFF
--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-a-typical-workday-and-tasks/657e06eca8147f561619be7d.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-a-typical-workday-and-tasks/657e06eca8147f561619be7d.md
@@ -11,7 +11,7 @@ Sophie: Hi Tom! Well, my day usually starts at 8:30. I check my emails and reply
 
 # --description--
 
-In this part of the dialogue, Sophie talks about his morning activities. 
+In this part of the dialogue, Sophie talks about her morning activities. 
 
 The use of time expressions like `usually` and specific times like `8:30` helps to give more details about the routine.
 


### PR DESCRIPTION
Describe the Issue

Sophie is misgendered in the first sentence of task5 of the 4th course

'In this part of the dialogue, Sophie talks about his morning activities.' changed to "In this part of the dialogue, Sophie talks about her morning activities"

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #53920

<!-- Feel free to add any additional description of changes below this line -->
