### PR TITLE
feat(api): add multifile python projects to new api

### DIFF
--- a/api/src/routes/challenge.test.ts
+++ b/api/src/routes/challenge.test.ts
@@ -775,7 +775,7 @@ describe('challengeRoutes', () => {
                 challengeType: multiFileCertProjectBody.challengeType,
                 files: testFiles,
                 completedDate: expect.any(Number),
-                isManuallyApproved: true
+                isManuallyApproved: false
               }
             ],
             savedChallenges: [
@@ -839,7 +839,7 @@ describe('challengeRoutes', () => {
                 challengeType: updatedMultiFileCertProjectBody.challengeType,
                 files: testFiles,
                 completedDate: expect.any(Number),
-                isManuallyApproved: true
+                isManuallyApproved: false
               },
               {
                 id: HtmlChallengeId,

--- a/api/src/routes/challenge.ts
+++ b/api/src/routes/challenge.ts
@@ -352,7 +352,7 @@ export const challengeRoutes: FastifyPluginCallbackTypebox = (
           challengeType === challengeTypes.multifileCertProject ||
           challengeType === challengeTypes.multifilePythonCertProject
         ) {
-          completedChallenge.isManuallyApproved = true;
+          completedChallenge.isManuallyApproved = false;
           user.needsModeration = true;
         }
 

--- a/api/src/routes/challenge.ts
+++ b/api/src/routes/challenge.ts
@@ -8,6 +8,7 @@ import { schemas } from '../schemas';
 import {
   jsCertProjectIds,
   multifileCertProjectIds,
+  multifilePythonCertProjectIds,
   updateUserChallengeData,
   type CompletedChallenge,
   saveUserChallengeData,
@@ -347,14 +348,18 @@ export const challengeRoutes: FastifyPluginCallbackTypebox = (
           completedDate: Date.now()
         };
 
-        if (challengeType === challengeTypes.multifileCertProject) {
+        if (
+          challengeType === challengeTypes.multifileCertProject ||
+          challengeType === challengeTypes.multifilePythonCertProject
+        ) {
           completedChallenge.isManuallyApproved = true;
           user.needsModeration = true;
         }
 
         if (
           jsCertProjectIds.includes(id) ||
-          multifileCertProjectIds.includes(id)
+          multifileCertProjectIds.includes(id) ||
+          multifilePythonCertProjectIds.includes(id)
         ) {
           completedChallenge.challengeType = challengeType;
         }
@@ -404,7 +409,10 @@ export const challengeRoutes: FastifyPluginCallbackTypebox = (
           files
         };
 
-        if (!multifileCertProjectIds.includes(challengeId)) {
+        if (
+          !multifileCertProjectIds.includes(challengeId) &&
+          !multifilePythonCertProjectIds.includes(challengeId)
+        ) {
           void reply.code(403);
           return 'That challenge type is not saveable.';
         }

--- a/api/src/routes/challenge.ts
+++ b/api/src/routes/challenge.ts
@@ -348,10 +348,7 @@ export const challengeRoutes: FastifyPluginCallbackTypebox = (
           completedDate: Date.now()
         };
 
-        if (
-          challengeType === challengeTypes.multifileCertProject ||
-          challengeType === challengeTypes.multifilePythonCertProject
-        ) {
+        if (challengeType === challengeTypes.multifileCertProject) {
           completedChallenge.isManuallyApproved = false;
           user.needsModeration = true;
         }

--- a/api/src/utils/common-challenge-functions.ts
+++ b/api/src/utils/common-challenge-functions.ts
@@ -16,6 +16,10 @@ export const multifileCertProjectIds = getChallenges()
   .filter(c => c.challengeType === challengeTypes.multifileCertProject)
   .map(c => c.id);
 
+export const multifilePythonCertProjectIds = getChallenges()
+  .filter(c => c.challengeType === challengeTypes.multifilePythonCertProject)
+  .map(c => c.id);
+
 export const msTrophyChallenges = getChallenges()
   .filter(challenge => challenge.challengeType === challengeTypes.msTrophy)
   .map(({ id, msTrophyId }) => ({ id, msTrophyId }));
@@ -124,7 +128,8 @@ export async function updateUserChallengeData(
 
   if (
     jsCertProjectIds.includes(challengeId) ||
-    multifileCertProjectIds.includes(challengeId)
+    multifileCertProjectIds.includes(challengeId) ||
+    multifilePythonCertProjectIds.includes(challengeId)
   ) {
     completedChallenge = {
       ..._completedChallenge,
@@ -186,7 +191,10 @@ export async function updateUserChallengeData(
     userCompletedChallenges.push(finalChallenge);
   }
 
-  if (multifileCertProjectIds.includes(challengeId)) {
+  if (
+    multifileCertProjectIds.includes(challengeId) ||
+    multifilePythonCertProjectIds.includes(challengeId)
+  ) {
     const challengeToSave: SavedChallenge = {
       id: challengeId,
       lastSavedDate: newProgressTimeStamp,


### PR DESCRIPTION
✔️ Saving python cert project saves to/updates savedChallenges
✔️ Submitting python cert project saves to completedChallenges and saves to/updates savedChallenges

To test, `POST` to `save-challenge` or `modern-challenge-completed` with this body (or other python project/content):

```
{"id":"5e44412c903586ffb414c94c","files":[{"contents":"abcde","ext":"py","history":["main.py"],"key":"mainpy","name":"main"}],"challengeType":23}
```

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #53930

<!-- Feel free to add any additional description of changes below this line -->
