### PR TITLE
fix(curriculum): provide stress mark (é) in tasks

### DIFF
--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-a-typical-workday-and-tasks/657e2c02a685f4ec9ec951ff.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-a-typical-workday-and-tasks/657e2c02a685f4ec9ec951ff.md
@@ -54,7 +54,7 @@ A verb meaning to take something with you. This word should be capitalized.
 
 ### --feedback--
 
-Places where you can buy and eat food. Don't forget the stress mark.
+Places where you can buy and eat food. Don't forget the stress mark (`é`).
 
 # --scene--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-a-typical-workday-and-tasks/657e3228f9f24007a7d59779.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-a-typical-workday-and-tasks/657e3228f9f24007a7d59779.md
@@ -65,7 +65,7 @@ Midday or 12 PM.
 
 ### --feedback--
 
-Places to eat or drink. Don't forget the stress mark.
+Places to eat or drink. Don't forget the stress mark (`é`).
 
 ---
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Closes #53771
