### PR TITLE
fix(curriculum): use python syntax for >= & <=

### DIFF
--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-string-manipulation-by-building-a-cipher/655a2a7210094920069b117c.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-string-manipulation-by-building-a-cipher/655a2a7210094920069b117c.md
@@ -37,11 +37,11 @@ Python has the following comparison operators:
       <td>Less than</td>
     </tr>
     <tr>
-      <td>&ge;</td>
+      <td>>=</td>
       <td>Greater than or equal to</td>
     </tr>
     <tr>
-      <td>&le;</td>
+      <td><=</td>
       <td>Less than or equal to</td>
     </tr>
   </tbody>

--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-string-manipulation-by-building-a-cipher/655a2a7210094920069b117c.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-string-manipulation-by-building-a-cipher/655a2a7210094920069b117c.md
@@ -37,7 +37,7 @@ Python has the following comparison operators:
       <td>Less than</td>
     </tr>
     <tr>
-      <td>>=</td>
+      <td>&gt;=</td>
       <td>Greater than or equal to</td>
     </tr>
     <tr>

--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-string-manipulation-by-building-a-cipher/655a2a7210094920069b117c.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-string-manipulation-by-building-a-cipher/655a2a7210094920069b117c.md
@@ -41,7 +41,7 @@ Python has the following comparison operators:
       <td>Greater than or equal to</td>
     </tr>
     <tr>
-      <td><=</td>
+      <td>&lt;=</td>
       <td>Less than or equal to</td>
     </tr>
   </tbody>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

This pull request changes the symbols for "greater than or equal to" and "less than or equal to" from normal mathematical symbols into their python syntax. The python syntax is used for "equal to" and "not equal to" earlier in the table, and I think it makes sense to be consistent here. Note this is my first pull-request ever, so I'd appreciate coaching if I've made any errors with it. Thanks!