### PR TITLE
fix(curriculum): block pages still have replit instructions

### DIFF
--- a/client/src/pages/learn/quality-assurance/advanced-node-and-express/index.md
+++ b/client/src/pages/learn/quality-assurance/advanced-node-and-express/index.md
@@ -9,14 +9,3 @@ superBlock: quality-assurance
 _Authentication_ is the process or action of verifying the identity of a user or process. Up to this point you have not been able to create an app utilizing this key concept.
 
 The most common and easiest way to use authentication middleware for Node.js is [Passport](http://passportjs.org/). It is easy to learn, light-weight, and extremely flexible allowing for many _strategies_, which we will talk about in later challenges. In addition to authentication we will also look at template engines which allow for use of _Pug_ and web sockets which allow for real time communication between all your clients and your server.
-
-Working on these challenges involves writing code on Replit in our starter project.
-
-- Start by importing the project on Replit.
-- Next, you will see a <code>.replit</code> window.
-- Select <code>Use run command</code> and click the <code>Done</code> button.
-- Complete each challenge and copy the public Replit URL (to the homepage of your app) into the challenge screen to test it!
-
-Optionally, you may write your project on another platform, but it must be publicly visible for our testing.
-
-Start this project on Replit using [this link](https://replit.com/github/freeCodeCamp/boilerplate-advancednode) or clone [this repository](https://github.com/freeCodeCamp/boilerplate-advancednode/) on GitHub! If you use Replit, remember to save the link to your project somewhere safe.

--- a/client/src/pages/learn/quality-assurance/quality-assurance-and-testing-with-chai/index.md
+++ b/client/src/pages/learn/quality-assurance/quality-assurance-and-testing-with-chai/index.md
@@ -7,14 +7,3 @@ superBlock: quality-assurance
 ## Introduction to Quality Assurance with Chai Challenges
 
 As your programs become more complex, you need to test them often to make sure any new code you add doesn't break the program's original functionality. Chai is a JavaScript testing library that helps you check that your program still behaves the way you expect it to after you make changes. Using Chai, you can write tests that describe your program's requirements and see if your program meets them.
-
-Working on these challenges involves writing code on Replit in our starter project.
-
-- Start by importing the project on Replit.
-- Next, you will see a <code>.replit</code> window.
-- Select <code>Use run command</code> and click the <code>Done</code> button.
-- Complete each challenge and copy the public Replit URL (to the homepage of your app) into the challenge screen to test it!
-
-Optionally, you may write your project on another platform, but it must be publicly visible for our testing.
-
-Start this project on Replit using [this link](https://replit.com/github/freeCodeCamp/boilerplate-mochachai) or clone [this repository](https://github.com/freeCodeCamp/boilerplate-mochachai/) on GitHub! If you use Replit, remember to save the link to your project somewhere safe!


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #53936

<!-- Feel free to add any additional description of changes below this line -->
> The two options would be to remove instructions from the block pages entirely, which I think may be the best idea actually considering that they were forgotten.


This option will remove the replit instructions.