### PR TITLE
fix(ui-components): apply theme classes to Storybook preview body

### DIFF
--- a/tools/ui-components/.storybook/preview.js
+++ b/tools/ui-components/.storybook/preview.js
@@ -41,9 +41,13 @@ function renderTheme(Story, context) {
   // Use the value of the default background to prevent "undefined" className
   const className = selectedBackgroundName || parameters.backgrounds.default;
 
-  return (
-    <div className={className}>
-      <Story />
-    </div>
-  );
+  if (className === 'light-palette') {
+    document.body.classList.remove('dark-palette');
+    document.body.classList.add('light-palette');
+  } else {
+    document.body.classList.remove('light-palette');
+    document.body.classList.add('dark-palette');
+  }
+
+  return <Story />;
 }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR updates the config of Storybook's preview frame to assign the theme classes (`light-palette` and `dark-palette`) directly to the `<body>`, rather than adding a `<div>` with those classes to the frame.

This means Storybook's preview pane would now have the following DOM:

```html
<iframe>
  <body class="light-theme">
    <div id="storybook-root">
      // our components
    </div>
  </body>
</iframe>
```

Instead of:

```html
<iframe>
  <body>
    <div id="storybook-root">
      <div class="light-theme">
        // our components
      </div>
    </div>
  </body>
</iframe>
```

---

## Context

#51070 is currently having a display issue, in which the Modal and anything inside it don't have CSS styles applied properly. The issue is because the Modal is rendered with React Portal, and it was added outside of the `<div class="light-theme">`, which is responsible for theming.

And here is how the Modal currently looks like in Storybook (notice the modal and the button don't have any background color applied):

<img width="1680" alt="Screenshot 2024-03-05 at 02 39 15" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/6f942b8f-90b3-469c-91d9-d3d81c643323">

The library that Modal is built upon (`radix-ui`) does allow changing the portal's root node, so that it can be rendered under a different DOM node/tree. I've tried moving Modal under the wrapper div (`<div class="light-theme">`), but didn't achieve the desired result.

## Approaches
1. Add an ID to the wrapper div (in [preview.js](https://github.com/freeCodeCamp/freeCodeCamp/blob/967e813327ad6b306f4b6dc7fa76dee86347c863/tools/ui-components/.storybook/preview.js#L45)), then render the Modal under the div.
    `preview.js` (pseudo code): 
    ```tsx
    const renderTheme = () => (
      <div id="theme-container" className={selectedTheme}>
        <Story />
      </div>
    )
    ``` 
    `modal.tsx` (pseudo code):
    ```tsx
    const modalContainer = document.getElementById('theme-container')

    const Modal = () => (
      <Portal container={modalContainer}>
        // modal content
      </Portal>
    )
    ``` 
2. Create a `preview-body.html` file and add the wrapper div in there, following https://storybook.js.org/docs/configure/story-rendering#adding-to-body
    `preview-body.html`    
    ```html
    <div id="theme-container" class="light-palette"></div>
    ``` 
    `modal.tsx` (pseudo code):
    ```tsx
    const modalContainer = document.getElementById('theme-container')

    const Modal = () => (
      <Portal container={modalContainer}>
        // modal content
      </Portal>
    )
    ``` 
3. Skip the wrapper div and add the CSS classes directly to the `body`, similar to https://github.com/storybookjs/storybook/discussions/16176

**Results**:
- (1) doesn't work as the Modal doesn't seem to find the div (and thus it can't mount and can't be rendered)
- (2) works, in that the `light-palette` styles are applied to the Modal, but within `preview-body.html` we don't have access to the selected theme, and can't programmatically switch to `dark-palette`
- (3) works as the Modal is rendered under `body` by default, and inherits all the CSS that `body` has. This is the solution that I chose to go with.

## Screenshots

<details>
  <summary>Modal now can receive CSS styles</summary>

  | Before | After |
  | --- | --- |
  | <img width="1680" alt="Screenshot 2024-03-05 at 02 39 15" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/17674e12-976d-4c5e-a6c8-5d17291302b2"> | <img width="1680" alt="Screenshot 2024-03-05 at 02 38 18" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/134b8b3c-d14a-4db1-8b89-c9a580762b32"> |

</details>

<details>
  <summary>Other components are displayed as expected</summary>

  | Light | Dark |
  | --- | --- |
  | <img width="663" alt="Screenshot 2024-03-05 at 02 34 36" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/d9cb0b0f-a0f5-4bc1-b27d-ce2d52a6ad3c"> | <img width="661" alt="Screenshot 2024-03-05 at 02 34 24" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/816a2d08-85dc-4a66-9cbb-379bb6e6d442"> |

</details>

<!-- Feel free to add any additional description of changes below this line -->
