### PR TITLE
fix(api): ms trophy validation

### DIFF
--- a/api-server/src/server/boot/challenge.js
+++ b/api-server/src/server/boot/challenge.js
@@ -766,26 +766,26 @@ function createMsTrophyChallengeCompleted(app) {
 
       const { userId } = msProfileJson;
 
-      const msGameStatusApi = `https://learn.microsoft.com/api/gamestatus/${userId}`;
-      const msGameStatusApiRes = await fetch(msGameStatusApi);
-      const msGameStatusJson = await msGameStatusApiRes.json();
+      const msUserAchievementsApi = `https://learn.microsoft.com/api/achievements/user/${userId}`;
+      const msUserAchievementsApiRes = await fetch(msUserAchievementsApi);
+      const msUserAchievementsJson = await msUserAchievementsApiRes.json();
 
-      if (!msGameStatusApiRes.ok) {
+      if (!msUserAchievementsApiRes.ok) {
         return res.status(403).json({
           type: 'error',
           message: 'flash.ms.trophy.err-3'
         });
       }
 
-      if (msGameStatusJson.achievements?.length === 0) {
+      if (msUserAchievementsJson.achievements?.length === 0) {
         return res.status(403).json({
           type: 'error',
           message: 'flash.ms.trophy.err-6'
         });
       }
 
-      const hasEarnedTrophy = msGameStatusJson.achievements?.some(
-        a => a.awardUid === msTrophyId
+      const hasEarnedTrophy = msUserAchievementsJson.achievements?.some(
+        a => a.typeId === msTrophyId
       );
 
       if (!hasEarnedTrophy) {
@@ -800,7 +800,7 @@ function createMsTrophyChallengeCompleted(app) {
 
       const completedChallenge = pick(body, ['id']);
 
-      completedChallenge.solution = msGameStatusApi;
+      completedChallenge.solution = msUserAchievementsApi;
       completedChallenge.completedDate = Date.now();
 
       try {


### PR DESCRIPTION
The MS API has changed, breaking trophy validation in the C# courses. We formerly verified trophies with information from  https://learn.microsoft.com/api/gamestatus/60fd13c3-1c9d-4149-940e-7c2a4450ca45 - that has changed to https://learn.microsoft.com/api/achievements/user/60fd13c3-1c9d-4149-940e-7c2a4450ca45

To test: you should be able to link my account locally with https://learn.microsoft.com/en-us/users/mot01/transcript/vmp2ycy0kkwjpqk and verify the trophies.

TODO: Add this to new API

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
