### PR TITLE
fix(api): ms validation new api

### DIFF
--- a/api/src/routes/challenge.test.ts
+++ b/api/src/routes/challenge.test.ts
@@ -1032,7 +1032,7 @@ describe('challengeRoutes', () => {
         // Create and Run Simple C# Console Applications's id:
         const trophyChallengeId2 = '647f87dc07d29547b3bee1bf';
         const nonTrophyChallengeId = 'bd7123c8c441eddfaeb5bdef';
-        const solutionUrl = `https://learn.microsoft.com/api/gamestatus/${msUserId}`;
+        const solutionUrl = `https://learn.microsoft.com/api/achievements/user/${msUserId}`;
 
         const idIsMissingOrInvalid = {
           type: 'error',
@@ -1149,7 +1149,7 @@ describe('challengeRoutes', () => {
             mockVerifyTrophyWithMicrosoft.mockImplementationOnce(() =>
               Promise.resolve({
                 type: 'success',
-                msGameStatusApiUrl: solutionUrl
+                msUserAchievementsApiUrl: solutionUrl
               })
             );
             const msUsername = 'ANRandom';
@@ -1192,7 +1192,7 @@ describe('challengeRoutes', () => {
             mockVerifyTrophyWithMicrosoft.mockImplementationOnce(() =>
               Promise.resolve({
                 type: 'success',
-                msGameStatusApiUrl: solutionUrl
+                msUserAchievementsApiUrl: solutionUrl
               })
             );
             const msUsername = 'ANRandom';
@@ -1205,7 +1205,7 @@ describe('challengeRoutes', () => {
             mockVerifyTrophyWithMicrosoft.mockImplementationOnce(() =>
               Promise.resolve({
                 type: 'success',
-                msGameStatusApiUrl: solutionUrl
+                msUserAchievementsApiUrl: solutionUrl
               })
             );
             const resTwo = await superPost(
@@ -1217,7 +1217,7 @@ describe('challengeRoutes', () => {
             mockVerifyTrophyWithMicrosoft.mockImplementationOnce(() =>
               Promise.resolve({
                 type: 'success',
-                msGameStatusApiUrl: solutionUrl
+                msUserAchievementsApiUrl: solutionUrl
               })
             );
             const resUpdate = await superPost(

--- a/api/src/routes/challenge.ts
+++ b/api/src/routes/challenge.ts
@@ -588,7 +588,7 @@ export const challengeRoutes: FastifyPluginCallbackTypebox = (
           const newChallenge = {
             id: challengeId,
             completedDate,
-            solution: msTrophyStatus.msGameStatusApiUrl
+            solution: msTrophyStatus.msUserAchievementsApiUrl
           };
           await fastify.prisma.user.update({
             where: { id: req.session.user.id },

--- a/api/src/routes/helpers/challenge-helpers.test.ts
+++ b/api/src/routes/helpers/challenge-helpers.test.ts
@@ -151,7 +151,7 @@ describe('Challenge Helpers', () => {
       });
     });
 
-    test('returns msAchievementsApiUrl on success', async () => {
+    test('returns msUserAchievementsApiUrl on success', async () => {
       const fetchProfile = createFetchMock({ body: { userId } });
       const fetchAchievements = createFetchMock({
         body: { achievements: [{ typeId: msTrophyId }] }

--- a/api/src/routes/helpers/challenge-helpers.test.ts
+++ b/api/src/routes/helpers/challenge-helpers.test.ts
@@ -79,7 +79,7 @@ describe('Challenge Helpers', () => {
     const msUsername = 'ANRandom';
     const msTrophyId = 'learn.wwl.get-started-c-sharp-part-3.trophy';
     const verifyData = { msUsername, msTrophyId };
-    const gamestatusUrl = `https://learn.microsoft.com/api/gamestatus/${userId}`;
+    const achievementsUrl = `https://learn.microsoft.com/api/achievements/user/${userId}`;
 
     afterEach(() => jest.clearAllMocks());
 
@@ -98,13 +98,13 @@ describe('Challenge Helpers', () => {
       });
     });
 
-    test("handles failure to reach Microsoft's gamestatus api", async () => {
+    test("handles failure to reach Microsoft's achievements api", async () => {
       const fetchProfile = createFetchMock({ body: { userId } });
-      const fetchGameStatus = createFetchMock({ ok: false });
+      const fetchAchievements = createFetchMock({ ok: false });
       jest
         .spyOn(globalThis, 'fetch')
         .mockImplementationOnce(fetchProfile)
-        .mockImplementationOnce(fetchGameStatus);
+        .mockImplementationOnce(fetchAchievements);
 
       const verification = await verifyTrophyWithMicrosoft(verifyData);
 
@@ -116,11 +116,11 @@ describe('Challenge Helpers', () => {
 
     test('handles the case where the user has no achievements', async () => {
       const fetchProfile = createFetchMock({ body: { userId } });
-      const fetchGameStatus = createFetchMock({ body: { achievements: [] } });
+      const fetchAchievements = createFetchMock({ body: { achievements: [] } });
       jest
         .spyOn(globalThis, 'fetch')
         .mockImplementationOnce(fetchProfile)
-        .mockImplementationOnce(fetchGameStatus);
+        .mockImplementationOnce(fetchAchievements);
 
       const verification = await verifyTrophyWithMicrosoft(verifyData);
 
@@ -132,13 +132,13 @@ describe('Challenge Helpers', () => {
 
     test("handles failure to find the trophy in the user's achievements", async () => {
       const fetchProfile = createFetchMock({ body: { userId } });
-      const fetchGameStatus = createFetchMock({
-        body: { achievements: [{ awardUid: 'fake-id' }] }
+      const fetchAchievements = createFetchMock({
+        body: { achievements: [{ typeId: 'fake-id' }] }
       });
       jest
         .spyOn(globalThis, 'fetch')
         .mockImplementationOnce(fetchProfile)
-        .mockImplementationOnce(fetchGameStatus);
+        .mockImplementationOnce(fetchAchievements);
 
       const verification = await verifyTrophyWithMicrosoft(verifyData);
 
@@ -151,21 +151,21 @@ describe('Challenge Helpers', () => {
       });
     });
 
-    test('returns msGameStatusApiUrl on success', async () => {
+    test('returns msAchievementsApiUrl on success', async () => {
       const fetchProfile = createFetchMock({ body: { userId } });
-      const fetchGameStatus = createFetchMock({
-        body: { achievements: [{ awardUid: msTrophyId }] }
+      const fetchAchievements = createFetchMock({
+        body: { achievements: [{ typeId: msTrophyId }] }
       });
       jest
         .spyOn(globalThis, 'fetch')
         .mockImplementationOnce(fetchProfile)
-        .mockImplementationOnce(fetchGameStatus);
+        .mockImplementationOnce(fetchAchievements);
 
       const verification = await verifyTrophyWithMicrosoft(verifyData);
 
       expect(verification).toEqual({
         type: 'success',
-        msGameStatusApiUrl: gamestatusUrl
+        msUserAchievementsApiUrl: achievementsUrl
       });
     });
   });

--- a/api/src/routes/helpers/challenge-helpers.ts
+++ b/api/src/routes/helpers/challenge-helpers.ts
@@ -99,18 +99,18 @@ export async function verifyTrophyWithMicrosoft({
 
   if (msProfile.type === 'error') return msProfile;
 
-  const msGameStatusApiUrl = `https://learn.microsoft.com/api/gamestatus/${msProfile.userId}`;
-  const msGameStatusApiRes = await fetch(msGameStatusApiUrl);
+  const msUserAchievementsApiUrl = `https://learn.microsoft.com/api/achievements/user/${msProfile.userId}`;
+  const msUserAchievementsApiRes = await fetch(msUserAchievementsApiUrl);
 
-  if (!msGameStatusApiRes.ok) {
+  if (!msUserAchievementsApiRes.ok) {
     return {
       type: 'error',
       message: 'flash.ms.trophy.err-3'
     } as const;
   }
 
-  const { achievements } = (await msGameStatusApiRes.json()) as {
-    achievements?: { awardUid: string }[];
+  const { achievements } = (await msUserAchievementsApiRes.json()) as {
+    achievements?: { typeId: string }[];
   };
 
   if (!achievements?.length)
@@ -119,12 +119,16 @@ export async function verifyTrophyWithMicrosoft({
       message: 'flash.ms.trophy.err-6'
     } as const;
 
-  const earnedTrophy = achievements?.some(a => a.awardUid === msTrophyId);
+  // TODO: handle the case where there are achievements, but the `typeId` is not
+  // a property of the achievements. This suggests that Microsoft has changed
+  // their API and, to aid debugging, we should report a different error
+  // message.
+  const earnedTrophy = achievements?.some(a => a.typeId === msTrophyId);
 
   if (earnedTrophy) {
     return {
       type: 'success',
-      msGameStatusApiUrl
+      msUserAchievementsApiUrl
     } as const;
   } else {
     return {


### PR DESCRIPTION
- fix: update new api to use new MS api endpoint
- refactor: clean up types with aliases

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Ports https://github.com/freeCodeCamp/freeCodeCamp/pull/53978 to the new api

I also added some type aliases to make it easier to understand `verifyTrophyWithMicrosoft` without digging through the implemenation.
 
<!-- Feel free to add any additional description of changes below this line -->
