### PR TITLE
test: stop mocking env vars in jest.utils

### DIFF
--- a/api/jest.utils.ts
+++ b/api/jest.utils.ts
@@ -7,23 +7,6 @@ import { createUserInput } from './src/utils/create-user';
 import { examJson } from './__mocks__/exam';
 import { MONGOHQ_URL } from './src/utils/env';
 
-jest.mock('./src/utils/env', () => {
-  const createTestConnectionURL = (url: string, dbId: string) =>
-    url.replace(/(.*)(\?.*)/, `$1${dbId}$2`);
-  // There are other properties, and this type is too narrow, but we're only
-  // interested in MONGOHQ_URL here.
-  const actual: {
-    MONGOHQ_URL: string;
-  } = jest.requireActual('./src/utils/env');
-  return {
-    ...actual,
-    MONGOHQ_URL: createTestConnectionURL(
-      actual.MONGOHQ_URL,
-      process.env.JEST_WORKER_ID!
-    )
-  };
-});
-
 type FastifyTestInstance = Awaited<ReturnType<typeof build>>;
 
 declare global {

--- a/api/src/server.test.ts
+++ b/api/src/server.test.ts
@@ -1,14 +1,6 @@
 import { setupServer, superRequest } from '../jest.utils';
 import { HOME_LOCATION, COOKIE_DOMAIN } from './utils/env';
 
-jest.mock('./utils/env', () => {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-  return {
-    ...jest.requireActual('./utils/env'),
-    COOKIE_DOMAIN: '.freecodecamp.org'
-  };
-});
-
 describe('server', () => {
   setupServer();
 


### PR DESCRIPTION
- fix: create test URLs in env.ts
- chore: stop mocking env.ts in jest.utils
- test: remove unnecessary env mock in server.test

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

On reflection mocking env.ts in jest.utils was a mock too far. It's not necessary and prevents tests from mocking env.ts (in the worst way: the second mock is simply ignored).

This did mean that env.ts is a little more complicated than I'd like, but it should be impossible to try and connect to the wrong db outside of testing :crossed_fingers:  

<!-- Feel free to add any additional description of changes below this line -->
