### PR TITLE
fix: test fail if # placed in beginning of line comment

### DIFF
--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-list-comprehension-by-building-a-case-converter-program/657f425dbab54e11993c80f0.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-list-comprehension-by-building-a-case-converter-program/657f425dbab54e11993c80f0.md
@@ -20,7 +20,7 @@ You should comment out all the 10 lines of code inside the `convert_to_snake_cas
 ```js
 ({
     test: () => {
-        const transformedCode = code.replace(/\r/g, "");
+        const transformedCode = code.replace(/\r/g, "").replace(/\n#/g, "\n #");
         const convert_to_snake_case = __helpers.python.getDef("\n" + transformedCode, "convert_to_snake_case");
         const { function_body } = convert_to_snake_case;
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [ x] My pull request targets the `main` branch of freeCodeCamp.
- [x ] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related to #53359

<!-- Feel free to add any additional description of changes below this line -->
Now, when # placed in the beginning of line it doesn't prevent the test from passing, the bug appears only in the lines that contain single quotes ``` '' ``` 
