### PR TITLE
chore(curriculum): add quotes to strings in OOP shopping cart

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-oop-by-building-a-shopping-cart/63ec20a06fff670d37befbd9.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-oop-by-building-a-shopping-cart/63ec20a06fff670d37befbd9.md
@@ -9,7 +9,7 @@ dashedName: step-6
 
 You now need to start adding products. Before you do that, you need to consider the structure of your product data. A product will need a unique identifier to distinguish it from other products, a price so people know how much it costs, and a name so people know what they are buying. You should also add a category to each product.
 
-Add an object to your `products` array. Give this object an `id` property set to the number `1`, a `name` property set to `Vanilla Cupcakes (6 Pack)`, a `price` property set to the number `12.99`, and a `category` property set to `Cupcake`.
+Add an object to your `products` array. Give this object an `id` property set to the number `1`, a `name` property set to the string `"Vanilla Cupcakes (6 Pack)"`, a `price` property set to the number `12.99`, and a `category` property set to the string `"Cupcake"`.
 
 # --hints--
 
@@ -31,7 +31,7 @@ Your products array should have an object with an `id` property set to the numbe
 assert.equal(products[0].id, 1);
 ```
 
-Your products array should have an object with a `name` property set to `Vanilla Cupcakes (6 Pack)`.
+Your products array should have an object with a `name` property set to the string `"Vanilla Cupcakes (6 Pack)"`.
 
 ```js
 assert.equal(products[0].name, 'Vanilla Cupcakes (6 Pack)');
@@ -43,7 +43,7 @@ Your products array should have an object with a `price` property set to the num
 assert.equal(products[0].price, 12.99);
 ```
 
-Your products array should have an object with a `category` property set to `Cupcake`.
+Your products array should have an object with a `category` property set to the string `"Cupcake"`.
 
 ```js
 assert.equal(products[0].category, 'Cupcake');

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-oop-by-building-a-shopping-cart/63ee5d8f9e7168076e932fe2.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-oop-by-building-a-shopping-cart/63ee5d8f9e7168076e932fe2.md
@@ -7,7 +7,7 @@ dashedName: step-12
 
 # --description--
 
-After your `h2` element, create two `p` elements. Give the first a `class` of `dessert-price`, and the text of the `price` variable with a dollar sign in front of it. Give the second a `class` of `product-category`, and the text `Category: ` followed by the value of the `category` variable.
+After your `h2` element, create two `p` elements. Give the first a `class` of `dessert-price`, and the text of the `price` variable with a dollar sign in front of it. Give the second a `class` of `product-category`, and the text `"Category: "` followed by the value of the `category` variable.
 
 # --hints--
 
@@ -44,7 +44,7 @@ Your second `p` element should have a `class` of `product-category`.
 assert.equal(document.querySelector('.dessert-card')?.children[2].className, 'product-category');
 ```
 
-Your second `p` element should have the text `Category: ` followed by the value of the `category` variable.
+Your second `p` element should have the text `"Category: "` followed by the value of the `category` variable.
 
 ```js
 assert.equal(document.querySelector('.dessert-card')?.children[2].textContent, 'Category: Cupcake');

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-oop-by-building-a-shopping-cart/63ee5e0f08e82208364c4128.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-oop-by-building-a-shopping-cart/63ee5e0f08e82208364c4128.md
@@ -7,7 +7,7 @@ dashedName: step-13
 
 # --description--
 
-Finally, after your `p` elements, create a `button` element. Give it an `id` set to the value of the `id` variable, a `class` of `btn add-to-cart-btn`, and use `Add to cart` for the text.
+Finally, after your `p` elements, create a `button` element. Give it an `id` set to the value of the `id` variable, a `class` of `btn add-to-cart-btn`, and use `"Add to cart"` for the text.
 
 # --hints--
 
@@ -37,7 +37,7 @@ assert.include(document.querySelector('.dessert-card button')?.className, 'btn')
 assert.include(document.querySelector('.dessert-card button')?.className, 'add-to-cart-btn');
 ```
 
-Your `button` element should have the text `Add to cart`.
+Your `button` element should have the text `"Add to cart"`.
 
 ```js
 assert.equal(document.querySelector('.dessert-card button')?.textContent?.trim(), 'Add to cart');

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-oop-by-building-a-shopping-cart/63f0224ceb16dc196d2c860a.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-oop-by-building-a-shopping-cart/63f0224ceb16dc196d2c860a.md
@@ -7,7 +7,7 @@ dashedName: step-33
 
 # --description--
 
-You need to get all of the `Add to cart` buttons that you added to the DOM earlier. Declare an `addToCartBtns` variable, and assign it the value of calling the `getElementsByClassName()` method on the `document` object, passing in the string `add-to-cart-btn`.
+You need to get all of the `Add to cart` buttons that you added to the DOM earlier. Declare an `addToCartBtns` variable, and assign it the value of calling the `getElementsByClassName()` method on the `document` object, passing in the string `"add-to-cart-btn"`.
 
 # --hints--
 
@@ -23,7 +23,7 @@ You should call the `getElementsByClassName()` method on the `document` object.
 assert.match(code, /document\s*\.\s*getElementsByClassName\s*\(/);
 ```
 
-You should pass the string `add-to-cart-btn` to the `getElementsByClassName()` method.
+You should pass the string `"add-to-cart-btn"` to the `getElementsByClassName()` method.
 
 ```js
 assert.match(code, /document\s*\.\s*getElementsByClassName\s*\(\s*('|"|`)add-to-cart-btn\1\s*\)/);

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-oop-by-building-a-shopping-cart/63f0348a54a177272071a595.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-oop-by-building-a-shopping-cart/63f0348a54a177272071a595.md
@@ -7,7 +7,7 @@ dashedName: step-39
 
 # --description--
 
-Now assign the `textContent` of the `showHideCartSpan` variable the result of a ternary expression which checks if `isCartShowing` is true. If it is, set the `textContent` to `Hide`, otherwise set it to `Show`.
+Now assign the `textContent` of the `showHideCartSpan` variable the result of a ternary expression which checks if `isCartShowing` is true. If it is, set the `textContent` to `"Hide"`, otherwise set it to `"Show"`.
 
 # --hints--
 
@@ -23,13 +23,13 @@ You should use ternary syntax to check if `isCartShowing` is true.
 assert.match(code, /showHideCartSpan\s*\.\s*textContent\s*=\s*isCartShowing\s*\?\s*/)
 ```
 
-You should set the `textContent` of the `showHideCartSpan` variable to `Hide` if `isCartShowing` is true.
+You should set the `textContent` of the `showHideCartSpan` variable to `"Hide"` if `isCartShowing` is true.
 
 ```js
 assert.match(code, /showHideCartSpan\s*\.\s*textContent\s*=\s*isCartShowing\s*\?\s*('|"|`)Hide\1\s*:\s*/)
 ```
 
-You should set the `textContent` of the `showHideCartSpan` variable to `Show` if `isCartShowing` is false.
+You should set the `textContent` of the `showHideCartSpan` variable to `"Show"` if `isCartShowing` is false.
 
 ```js
 assert.match(code, /showHideCartSpan\s*\.\s*textContent\s*=\s*isCartShowing\s*\?\s*('|"|`)Hide\1\s*:\s*('|"|`)Show\2/)

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-oop-by-building-a-shopping-cart/63f034d012f74627ce538d3a.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-oop-by-building-a-shopping-cart/63f034d012f74627ce538d3a.md
@@ -7,7 +7,7 @@ dashedName: step-40
 
 # --description--
 
-Finally, update the `display` property of the `style` object of the `cartContainer` variable to another ternary which checks if `isCartShowing` is true. If it is, set the `display` property to `block`, otherwise set it to `none`.
+Finally, update the `display` property of the `style` object of the `cartContainer` variable to another ternary which checks if `isCartShowing` is true. If it is, set the `display` property to `"block"`, otherwise set it to `"none"`.
 
 Now you should be able to see your cart and add items to it.
 
@@ -31,13 +31,13 @@ You should use ternary syntax to check if `isCartShowing` is true.
 assert.match(code, /cartContainer\s*\.\s*style\s*\.\s*display\s*=\s*isCartShowing\s*\?\s*/)
 ```
 
-You should set the `display` property of the `style` property of the `cartContainer` variable to `block` if `isCartShowing` is true.
+You should set the `display` property of the `style` property of the `cartContainer` variable to `"block"` if `isCartShowing` is true.
 
 ```js
 assert.match(code, /cartContainer\s*\.\s*style\s*\.\s*display\s*=\s*isCartShowing\s*\?\s*('|"|`)block\1\s*:\s*/)
 ```
 
-You should set the `display` property of the `style` property of the `cartContainer` variable to `none` if `isCartShowing` is false.
+You should set the `display` property of the `style` property of the `cartContainer` variable to `"none"` if `isCartShowing` is false.
 
 ```js
 assert.match(code, /cartContainer\s*\.\s*style\s*\.\s*display\s*=\s*isCartShowing\s*\?\s*('|"|`)block\1\s*:\s*('|"|`)none\2/)


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related to #51036

<!-- Feel free to add any additional description of changes below this line -->

I have looked through all of the stages in Learn Basic OOP by Building a Shopping Cart (part of JavaScript Algorithms and Data Structures (Beta)) and identified the following stages for updating: 6, 7, 12, 13, 33, 39, 40 This PR makes changes to all of those stages except for Stage 7 (more on that below).

The changes I've made to stages 6, 12, and 13 seem to me to be clearly in line with the original issue.

The changes I've made to stages 33, 39, 40 I think make sense, because it helps to add some clarity for campers. However, these may not line up exactly with the original intention of the issue. So, I'm happy to drop these changes if needed.

Finally, for Stage 7, there is a table with a number of items which could be wrapped in quotation marks. This would be consistent with Stage 6. However, I think that if campers have completed Stage 6 successfully, it should be sufficiently clear that they need to do more of the same. I have not made any changes to Stage 7 yet, but am happy to update Stage 7 as well, if that's requested.