### PR TITLE
fix(ui): update CloseButton styles to match /learn

### DIFF
--- a/client/src/components/Flash/index.tsx
+++ b/client/src/components/Flash/index.tsx
@@ -35,11 +35,7 @@ function Flash({ flashMessage, removeFlashMessage }: FlashProps): JSX.Element {
           data-playwright-test-label='flash-message'
         >
           {t(message, variables)}
-          <CloseButton
-            onClick={handleClose}
-            label={t('buttons.close')}
-            className='close'
-          />
+          <CloseButton onClick={handleClose} label={t('buttons.close')} />
         </Alert>
       </CSSTransition>
     </TransitionGroup>

--- a/client/src/components/Flash/index.tsx
+++ b/client/src/components/Flash/index.tsx
@@ -35,7 +35,11 @@ function Flash({ flashMessage, removeFlashMessage }: FlashProps): JSX.Element {
           data-playwright-test-label='flash-message'
         >
           {t(message, variables)}
-          <CloseButton onClick={handleClose} label={t('buttons.close')} />
+          <CloseButton
+            onClick={handleClose}
+            label={t('buttons.close')}
+            className='close'
+          />
         </Alert>
       </CSSTransition>
     </TransitionGroup>

--- a/cypress/e2e/default/learn/challenges/multifile-cert-project.ts
+++ b/cypress/e2e/default/learn/challenges/multifile-cert-project.ts
@@ -4,8 +4,7 @@ const save2text = 'save 2';
 const editorElements = {
   container: '.vertical .reflex-container',
   editor: '.react-monaco-editor-container',
-  saveCodeBtn: '[data-cy="save-code-to-database-btn"]',
-  closeFlash: '.close'
+  saveCodeBtn: '[data-cy="save-code-to-database-btn"]'
 };
 
 describe('multifileCertProjects', function () {
@@ -43,7 +42,8 @@ describe('multifileCertProjects', function () {
     cy.focused().clear().click().type(`${save2text}{ctrl+s}`);
     cy.get(editorElements.editor).contains(save2text);
     cy.contains('Your code was saved to the database.');
-    cy.get(editorElements.closeFlash).click();
+    // close flash message
+    cy.get('button:contains("Close")').click();
     // load saved code when navigating site (no hard refresh)'
     cy.contains('Tribute Page').click();
     cy.get(editorElements.container)

--- a/tools/ui-components/src/close-button/close-button.tsx
+++ b/tools/ui-components/src/close-button/close-button.tsx
@@ -22,19 +22,16 @@ export function CloseButton({
     'text-lg',
     'font-bold',
     'text-foreground-primary',
-    // Active state
-    'active:before:w-full',
-    'active:before:h-full',
-    'active:before:absolute',
-    'active:before:inset-0',
-    'active:before:border-3',
-    'active:before:border-transparent',
-    'active:before:bg-gray-900',
-    'active:before:opacity-20',
+
     // Focus state
     'focus:outline-none', // Hide the default browser outline
     'focus-visible:ring',
     'focus-visible:ring-focus-outline-color',
+    // Hover and focus styles for opacity and color
+    'hover:opacity-100',
+    'focus:opacity-100',
+    'hover:text-opacity-100',
+    'focus:text-opacity-100',
     // Content positioning
     'flex',
     'justify-center',

--- a/tools/ui-components/src/close-button/close-button.tsx
+++ b/tools/ui-components/src/close-button/close-button.tsx
@@ -22,16 +22,15 @@ export function CloseButton({
     'text-lg',
     'font-bold',
     'text-foreground-primary',
-
     // Focus state
+    'focus:opacity-100',
+    'focus:text-opacity-100',
     'focus:outline-none', // Hide the default browser outline
     'focus-visible:ring',
     'focus-visible:ring-focus-outline-color',
-    // Hover and focus styles for opacity and color
+    // Hover state
     'hover:opacity-100',
-    'focus:opacity-100',
     'hover:text-opacity-100',
-    'focus:text-opacity-100',
     // Content positioning
     'flex',
     'justify-center',


### PR DESCRIPTION
Summary of Changes:

In this pull request, I've updated the CloseButton component in the ui-components 
to match the styles used in the /learn section. Specifically, I've added hover and focus styles 
to ensure consistency and improve the user experience across the application.

Details of Changes:

Modified the CloseButton component in close-button.tsx to include hover and focus styles.
Updated the CSS classes within the CloseButton component to reflect the styles
 used in the /learn section.
Removed the close class from the CloseButton component in the Flash component 
to avoid conflicts and maintain visual consistency.

Updated Cypress test selectors to query elements by their semantic role 
Replaced the '.close' selector with button:contains("Close") to target the CloseButton component using its semantic role as a button.

Testing:
I have tested these changes locally to ensure they function as intended. Specifically, I've verified the appearance and behavior of the CloseButton component in various contexts, including modals, alerts

https://github.com/freeCodeCamp/freeCodeCamp/assets/91702503/58b35f2d-eb46-452a-93a7-7929d2314ccc


Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [ x] My pull request targets the `main` branch of freeCodeCamp.
- [ x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

closes #54011 
<!-- Feel free to add any additional description of changes below this line -->
