### PR TITLE
fix: sign-out-modal playwright test

### DIFF
--- a/e2e/signout-modal.spec.ts
+++ b/e2e/signout-modal.spec.ts
@@ -14,6 +14,9 @@ test.describe('Signout Modal component', () => {
       .getByRole('button', { name: translations.buttons['sign-out'] })
       .click();
 
+    const dialogs = await page.getByRole('dialog').all();
+    expect(dialogs).toHaveLength(2);
+
     await expect(page.getByText(translations.signout.heading)).toBeVisible();
     await expect(page.getByText(translations.signout.p1)).toBeVisible();
     await expect(page.getByText(translations.signout.p2)).toBeVisible();
@@ -36,11 +39,16 @@ test.describe('Signout Modal component', () => {
     await page
       .getByRole('button', { name: translations.buttons['sign-out'] })
       .click();
+    const dialogs = await page.getByRole('dialog').all();
+    expect(dialogs).toHaveLength(2);
 
     await page
       .getByRole('button', { name: translations.signout.certain })
       .click();
 
+    for (const dialog of dialogs) {
+      await expect(dialog).not.toBeVisible();
+    }
     await expect(page).toHaveURL(/.*\/learn\/?$/);
   });
 
@@ -50,10 +58,16 @@ test.describe('Signout Modal component', () => {
       .getByRole('button', { name: translations.buttons['sign-out'] })
       .click();
 
+    const dialogs = await page.getByRole('dialog').all();
+    expect(dialogs).toHaveLength(2);
+
     await page
       .getByRole('button', { name: translations.signout.nevermind })
       .click();
 
+    for (const dialog of dialogs) {
+      await expect(dialog).not.toBeVisible();
+    }
     await expect(page).toHaveURL('/');
     await expect(
       page.getByText(translations.signout.heading)

--- a/e2e/signout-modal.spec.ts
+++ b/e2e/signout-modal.spec.ts
@@ -14,8 +14,8 @@ test.describe('Signout Modal component', () => {
       .getByRole('button', { name: translations.buttons['sign-out'] })
       .click();
 
-    const dialogs = await page.getByRole('dialog').all();
-    expect(dialogs).toHaveLength(2);
+    const dialogs = page.getByRole('dialog');
+    await expect(dialogs).toHaveCount(2);
 
     await expect(page.getByText(translations.signout.heading)).toBeVisible();
     await expect(page.getByText(translations.signout.p1)).toBeVisible();
@@ -39,14 +39,15 @@ test.describe('Signout Modal component', () => {
     await page
       .getByRole('button', { name: translations.buttons['sign-out'] })
       .click();
-    const dialogs = await page.getByRole('dialog').all();
-    expect(dialogs).toHaveLength(2);
+
+    const dialogs = page.getByRole('dialog');
+    await expect(dialogs).toHaveCount(2);
 
     await page
       .getByRole('button', { name: translations.signout.certain })
       .click();
 
-    for (const dialog of dialogs) {
+    for (const dialog of await dialogs.all()) {
       await expect(dialog).not.toBeVisible();
     }
     await expect(page).toHaveURL(/.*\/learn\/?$/);
@@ -58,14 +59,14 @@ test.describe('Signout Modal component', () => {
       .getByRole('button', { name: translations.buttons['sign-out'] })
       .click();
 
-    const dialogs = await page.getByRole('dialog').all();
-    expect(dialogs).toHaveLength(2);
+    const dialogs = page.getByRole('dialog');
+    await expect(dialogs).toHaveCount(2);
 
     await page
       .getByRole('button', { name: translations.signout.nevermind })
       .click();
 
-    for (const dialog of dialogs) {
+    for (const dialog of await dialogs.all()) {
       await expect(dialog).not.toBeVisible();
     }
     await expect(page).toHaveURL('/');


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related to #53895

<!-- Feel free to add any additional description of changes below this line -->
The test previously didn't check for the existence of two dialogs upon opening and closing the modal.
