### PR TITLE
fix: help-modal playwright test

### DIFF
--- a/e2e/help-modal.spec.ts
+++ b/e2e/help-modal.spec.ts
@@ -15,6 +15,9 @@ test.describe('Help Modal component', () => {
       .getByRole('button', { name: translations.buttons['ask-for-help'] })
       .click();
 
+    const dialogs = await page.getByRole('dialog').all();
+    expect(dialogs).toHaveLength(2);
+
     await expect(
       page.getByRole('heading', {
         name: translations.buttons['ask-for-help'],
@@ -50,7 +53,8 @@ test.describe('Help Modal component', () => {
     await page
       .getByRole('button', { name: translations.buttons['ask-for-help'] })
       .click();
-
+    const dialogs = await page.getByRole('dialog').all();
+    expect(dialogs).toHaveLength(2);
     const newPagePromise = context.waitForEvent('page');
 
     await page
@@ -68,7 +72,9 @@ test.describe('Help Modal component', () => {
 
     const newPage = await newPagePromise;
     await newPage.waitForLoadState();
-
+    for (const dialog of dialogs) {
+      await expect(dialog).not.toBeVisible();
+    }
     await expect(newPage).toHaveURL(/.*forum\.freecodecamp.org.*/);
   });
 
@@ -76,11 +82,14 @@ test.describe('Help Modal component', () => {
     await page
       .getByRole('button', { name: translations.buttons['ask-for-help'] })
       .click();
-
+    const dialogs = await page.getByRole('dialog').all();
+    expect(dialogs).toHaveLength(2);
     await page
       .getByRole('button', { name: translations.buttons.cancel })
       .click();
-
+    for (const dialog of dialogs) {
+      await expect(dialog).not.toBeVisible();
+    }
     await expect(
       page.getByRole('heading', {
         name: translations.buttons['ask-for-help'],
@@ -93,11 +102,14 @@ test.describe('Help Modal component', () => {
     await page
       .getByRole('button', { name: translations.buttons['ask-for-help'] })
       .click();
-
+    const dialogs = await page.getByRole('dialog').all();
+    expect(dialogs).toHaveLength(2);
     await page
       .getByRole('button', { name: translations.buttons.close })
       .click();
-
+    for (const dialog of dialogs) {
+      await expect(dialog).not.toBeVisible();
+    }
     await expect(
       page.getByRole('heading', {
         name: translations.buttons['ask-for-help'],
@@ -110,6 +122,8 @@ test.describe('Help Modal component', () => {
     await page
       .getByRole('button', { name: translations.buttons['ask-for-help'] })
       .click();
+    const dialogs = await page.getByRole('dialog').all();
+    expect(dialogs).toHaveLength(2);
     const link = page.getByRole('link', { name: 'Read-Search-Ask' });
     await expect(link).toHaveAttribute(
       'href',
@@ -123,6 +137,8 @@ test.describe('Help Modal component', () => {
     await page
       .getByRole('button', { name: translations.buttons['ask-for-help'] })
       .click();
+    const dialogs = await page.getByRole('dialog').all();
+    expect(dialogs).toHaveLength(2);
     const link = page.getByRole('link', {
       name: 'already been answered on the forum'
     });


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related to #53895

<!-- Feel free to add any additional description of changes below this line -->
The test didn't previously check for the existence of dialog elements upon opening and closing help-modal component
