### PR TITLE
fix(curriculum): All tests for the for...of loop in the Dice game should allow campers to use let or const

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-algorithmic-thinking-by-building-a-dice-game/657e0f2a6cb19c72b8760be5.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-algorithmic-thinking-by-building-a-dice-game/657e0f2a6cb19c72b8760be5.md
@@ -14,7 +14,7 @@ To count the occurrences for each number, use a `for...of` loop to iterate throu
 You should use a `for...of` loop to iterate through the `arr` array. 
 
 ```js
-assert.match(code, /const\s+detectFullHouse\s*=\s*(\(\s*arr\s*\)|arr)\s*=>\s*{.*\s*for\s*\(\s*const\s+num\s+of\s+arr\s*\)\s*{\s*.*}/s);
+assert.match(code, /const\s+detectFullHouse\s*=\s*(\(\s*arr\s*\)|arr)\s*=>\s*{.*\s*for\s*\(\s*(const|let|var)\s+num\s+of\s+arr\s*\)\s*{\s*.*}/s);
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #54065

<!-- Feel free to add any additional description of changes below this line -->
**I verified other for loops at step 35, 38 and 57. All these accepts the use of let or const or var.** 