### PR TITLE
test(playwright): minor improvements to reset-modal.spec.ts

### DIFF
--- a/client/src/templates/Challenges/classic/lower-jaw.tsx
+++ b/client/src/templates/Challenges/classic/lower-jaw.tsx
@@ -95,7 +95,6 @@ const LowerButtonsPanel = ({
       <hr />
       <div className='utility-bar'>
         <button
-          data-playwright-test-label='lowerJaw-reset-button'
           className='btn fade-in'
           data-cy='reset-code-button'
           onClick={resetButtonEvent}

--- a/client/src/templates/Challenges/components/reset-modal.tsx
+++ b/client/src/templates/Challenges/components/reset-modal.tsx
@@ -51,7 +51,6 @@ function ResetModal({ reset, close, isOpen }: ResetModalProps): JSX.Element {
   }
   return (
     <Modal
-      data-playwright-test-label='reset-modal'
       animation={false}
       dialogClassName='reset-modal'
       keyboard={true}

--- a/e2e/lower-jaw.spec.ts
+++ b/e2e/lower-jaw.spec.ts
@@ -29,15 +29,6 @@ test('Click on the "check your code" button', async ({ page }) => {
   await expect(hint).toBeVisible();
 });
 
-test('Click on the "Reset" button', async ({ page }) => {
-  const resetButton = page.getByTestId('lowerJaw-reset-button');
-  await resetButton.click();
-
-  const resetModal = page.getByTestId('reset-modal');
-
-  await expect(resetModal).toBeVisible();
-});
-
 test('Should render UI correctly', async ({ page }) => {
   const codeCheckButton = page.getByRole('button', {
     name: 'Check Your Code'

--- a/e2e/reset-modal.spec.ts
+++ b/e2e/reset-modal.spec.ts
@@ -19,8 +19,8 @@ test('should render the modal content correctly', async ({ page }) => {
   // There are two elements with the `dialog` role in the DOM.
   // This appears to be semantically incorrect and should be resolved
   // once we have migrated the component to use Dialog from the `ui-components` library.
-  const dialogs = await page.getByRole('dialog').all();
-  expect(dialogs).toHaveLength(2);
+  const dialogs = page.getByRole('dialog');
+  await expect(dialogs).toHaveCount(2);
 
   await expect(
     page.getByRole('button', {
@@ -71,7 +71,14 @@ test('User can reset challenge', async ({ page }) => {
     page.getByText(translations.learn['sorry-keep-trying'])
   ).toBeVisible();
 
-  await page.getByTestId('lowerJaw-reset-button').click();
+  await page.getByRole('button', { name: translations.buttons.reset }).click();
+
+  // There are two elements with the `dialog` role in the DOM.
+  // This appears to be semantically incorrect and should be resolved
+  // once we have migrated the component to use Dialog from the `ui-components` library.
+  const dialogs = page.getByRole('dialog');
+  await expect(dialogs).toHaveCount(2);
+
   await page
     .getByRole('button', { name: translations.buttons['reset-lesson'] })
     .click();
@@ -115,6 +122,13 @@ test('User can reset classic challenge', async ({ page, isMobile }) => {
   await page
     .getByRole('button', { name: translations.buttons['reset-lesson'] })
     .click();
+
+  // There are two elements with the `dialog` role in the DOM.
+  // This appears to be semantically incorrect and should be resolved
+  // once we have migrated the component to use Dialog from the `ui-components` library.
+  const dialogs = page.getByRole('dialog');
+  await expect(dialogs).toHaveCount(2);
+
   await page
     .getByRole('button', { name: translations.buttons['reset-lesson'] })
     .click();
@@ -141,8 +155,8 @@ test('should close when the user clicks the close button', async ({ page }) => {
   // There are two elements with the `dialog` role in the DOM.
   // This appears to be semantically incorrect and should be resolved
   // once we have migrated the component to use Dialog from the `ui-components` library.
-  const dialogs = await page.getByRole('dialog').all();
-  expect(dialogs).toHaveLength(2);
+  const dialogs = page.getByRole('dialog');
+  await expect(dialogs).toHaveCount(2);
 
   await page
     .getByRole('button', {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR:
- Adds some minor improvements to `reset-modal.spec.ts`
- Is related to #53895 

---
Note: This test suite fails on mobile, and fixing it is out of the scope of this PR (the issue is tracked by #52198). 

I looked into it a bit, and found that the failure is because the Reset button isn't in the viewport on mobile, and I think Playwright doesn't auto-scroll to find it. I'll dig deeper when I'm done with the modal tests.

| Desktop | Mobile |
| --- | --- |
| <img width="1680" alt="Screenshot 2024-03-13 at 15 01 01" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/f7bf865f-c411-4c74-b8de-a0851d95f77c"> | <img width="789" alt="Screenshot 2024-03-13 at 15 01 43" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/f2e3cb98-9f9b-4b39-aa8c-d14aed003d8c"> |

<!-- Feel free to add any additional description of changes below this line -->
