### PR TITLE
Fix(Client): Clarify Progress Reset Modal

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -264,7 +264,16 @@
       "reset-p1": "This will really delete all of your progress, points, completed challenges, our records of your projects, any certifications you have, everything.",
       "reset-p2": "We won't be able to recover any of it for you later, even if you change your mind.",
       "nevermind-2": "Nevermind, I don't want to delete all of my progress",
-      "reset-confirm": "Reset everything. I want to start from the beginning"
+      "reset-confirm": "Reset everything. I want to start from the beginning",
+      "new-reset-dialog": {
+        "reset-warning": "WARNING!",
+        "reset-action-explanation": "By clicking below you'll RESET everything:",
+        "reset-challenges-and-progress-desc": "Your completed challenges and progress",
+        "reset-code-and-certifications-desc": "Any saved code, including certifications",
+        "reset-certifications-desc": "All completed certifications",
+        "reset-consequence-warning": "This action is irreversible and will take you back to day one.",
+        "reset-recovery-warning": "No recovery is possible, so be sure before proceeding."
+      }
     },
     "email": {
       "missing": "You do not have an email associated with this account.",

--- a/client/src/components/settings/danger-zone.tsx
+++ b/client/src/components/settings/danger-zone.tsx
@@ -5,11 +5,10 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import type { Dispatch } from 'redux';
 import { Panel, Button } from '@freecodecamp/ui';
-
 import { deleteAccount, resetProgress } from '../../redux/settings/actions';
 import { FullWidthRow, Spacer } from '../helpers';
 import DeleteModal from './delete-modal';
-import ResetModal from './reset-modal';
+import ResetModalRenderer from './reset-modal-renderer';
 
 interface DangerZoneProps {
   deleteAccount: () => void;
@@ -69,8 +68,7 @@ function DangerZone({ deleteAccount, resetProgress, t }: DangerZoneProps) {
           <Spacer size='medium' />
         </FullWidthRow>
       </Panel>
-
-      <ResetModal
+      <ResetModalRenderer
         onHide={toggleResetModal}
         reset={resetProgress}
         show={reset}

--- a/client/src/components/settings/new-reset-modal.tsx
+++ b/client/src/components/settings/new-reset-modal.tsx
@@ -1,0 +1,104 @@
+import { Modal } from '@freecodecamp/react-bootstrap';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Button } from '@freecodecamp/ui';
+
+import { Spacer } from '../helpers';
+
+type ResetModalProps = {
+  onHide: () => void;
+  reset: () => void;
+  show: boolean;
+};
+
+function NewResetModal(props: ResetModalProps): JSX.Element {
+  const { t } = useTranslation();
+  const { show, onHide } = props;
+
+  return (
+    <Modal
+      aria-labelledby='modal-title'
+      backdrop={true}
+      bsSize='lg'
+      className='text-center'
+      keyboard={true}
+      onHide={onHide}
+      show={show}
+    >
+      <Modal.Header closeButton={true}>
+        <Modal.Title id='modal-title'>
+          {t('settings.danger.reset-heading')}
+        </Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <p
+          style={{
+            color: '#ff0000',
+            fontWeight: 'bold',
+            fontSize: '1.5em',
+            marginTop: '0.5em'
+          }}
+        >
+          {t('settings.danger.new-reset-dialog.reset-warning')}
+        </p>
+        <p>{t('settings.danger.new-reset-dialog.reset-action-explanation')}</p>
+        <ul
+          style={{
+            maxWidth: '50%',
+            marginLeft: 'auto',
+            marginRight: 'auto',
+            paddingLeft: '3em',
+            listStylePosition: 'inside',
+            textAlign: 'left'
+          }}
+        >
+          <li>
+            {t(
+              'settings.danger.new-reset-dialog.reset-challenges-and-progress-desc'
+            )}
+          </li>
+          <li>
+            {t(
+              'settings.danger.new-reset-dialog.reset-code-and-certifications-desc'
+            )}
+          </li>
+          <li>
+            {t('settings.danger.new-reset-dialog.reset-certifications-desc')}
+          </li>
+        </ul>
+        <p>
+          {t('settings.danger.new-reset-dialog.reset-consequence-warning')}
+          <br />
+          {t('settings.danger.new-reset-dialog.reset-recovery-warning')}
+        </p>
+        <hr />
+        <Button
+          block={true}
+          size='large'
+          variant='primary'
+          onClick={props.onHide}
+          type='button'
+        >
+          {t('settings.danger.nevermind-2')}
+        </Button>
+        <Spacer size='small' />
+        <Button
+          block={true}
+          size='large'
+          variant='danger'
+          onClick={props.reset}
+          type='button'
+        >
+          {t('settings.danger.reset-confirm')}
+        </Button>
+      </Modal.Body>
+      <Modal.Footer>
+        <Button onClick={props.onHide}>{t('buttons.close')}</Button>
+      </Modal.Footer>
+    </Modal>
+  );
+}
+
+NewResetModal.displayName = 'ResetModal';
+
+export default NewResetModal;

--- a/client/src/components/settings/old-reset-modal.tsx
+++ b/client/src/components/settings/old-reset-modal.tsx
@@ -2,7 +2,6 @@ import { Modal } from '@freecodecamp/react-bootstrap';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@freecodecamp/ui';
-
 import { Spacer } from '../helpers';
 
 type ResetModalProps = {
@@ -11,7 +10,7 @@ type ResetModalProps = {
   show: boolean;
 };
 
-function ResetModal(props: ResetModalProps): JSX.Element {
+function OldResetModal(props: ResetModalProps): JSX.Element {
   const { t } = useTranslation();
   const { show, onHide } = props;
 
@@ -61,6 +60,6 @@ function ResetModal(props: ResetModalProps): JSX.Element {
   );
 }
 
-ResetModal.displayName = 'ResetModal';
+OldResetModal.displayName = 'OldResetModal';
 
-export default ResetModal;
+export default OldResetModal;

--- a/client/src/components/settings/reset-modal-renderer.tsx
+++ b/client/src/components/settings/reset-modal-renderer.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import i18n from 'i18next';
+import NewResetModal from './new-reset-modal';
+import OldResetModal from './old-reset-modal';
+
+type ResetModalProps = {
+  onHide: () => void;
+  reset: () => void;
+  show: boolean;
+};
+
+function ResetModalRenderer(props: ResetModalProps): JSX.Element {
+  const isNewModalAvailable = i18n.exists('settings.danger.new-reset-version');
+
+  return (
+    <>
+      {isNewModalAvailable ? (
+        <NewResetModal {...props} />
+      ) : (
+        <OldResetModal {...props} />
+      )}
+    </>
+  );
+}
+
+ResetModalRenderer.displayName = 'ResetModalRenderer';
+
+export default ResetModalRenderer;

--- a/client/src/components/settings/reset-modal-renderer.tsx
+++ b/client/src/components/settings/reset-modal-renderer.tsx
@@ -10,7 +10,7 @@ type ResetModalProps = {
 };
 
 function ResetModalRenderer(props: ResetModalProps): JSX.Element {
-  const isNewModalAvailable = i18n.exists('settings.danger.new-reset-version');
+  const isNewModalAvailable = i18n.exists('settings.danger.new-reset-dialog');
 
   return (
     <>


### PR DESCRIPTION
Checklist:
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

## Overview

This pull request closes [Issue #53959](https://github.com/freeCodeCamp/freeCodeCamp/issues/53959) through the implementation of a new reset modal as discussed, including a mechanism for backward compatibility for languages yet to receive updates for the new modal translations.

## Changes

- **Translations**: New key-value pairs have been added to `translations.json` for enhanced clarity in the modal's messaging.
- **Component Architecture**: `NewResetModal` and `OldResetModal` components have been created, segregating the new modal's functionality from the existing one.
- **Rendering Logic**: A `ResetModalRenderer` component is implemented to selectively render modals based on translation availability.

## Backward Compatibility

- **Translation Existence Check**: `ResetModalRenderer` utilizes i18n keys to verify the presence of new modal translations.
- **Fallback to Legacy Modal**: In the absence of new translations, the old modal is rendered, preserving the user experience.
- **Progressive Translation Updates**: This dual-modal system enables incremental translation updates without disrupting user functionality.

## Updated Reset Modal Interface
![image](https://github.com/freeCodeCamp/freeCodeCamp/assets/88036623/6fe8b0f3-c49a-4647-aff5-8333a5e696a5)
- Here's how the new reset modal looks in the local development environment, reflecting the latest UI updates as discussed in the issue.




