### PR TITLE
fix(playwright): video-modal test

### DIFF
--- a/e2e/video-modal.spec.ts
+++ b/e2e/video-modal.spec.ts
@@ -14,6 +14,8 @@ test.describe('Exit Video Modal E2E Test Suite', () => {
   test('Verifies the Correct Rendering of the Video Modal', async ({
     page
   }) => {
+    const dialogs = page.getByRole('dialog');
+    await expect(dialogs).toHaveCount(2);
     await expect(page.getByTestId('video-modal-title')).toBeVisible();
     await expect(
       page.getByTestId('video-modal-video-player-iframe')
@@ -29,9 +31,14 @@ test.describe('Exit Video Modal E2E Test Suite', () => {
   test('Closes the Video Modal When the User clicks on exit button', async ({
     page
   }) => {
+    const dialogs = page.getByRole('dialog');
+    await expect(dialogs).toHaveCount(2);
     await page
       .getByRole('button', { name: translations.buttons.close })
       .click();
+    for (const dialog of await dialogs.all()) {
+      await expect(dialog).not.toBeVisible();
+    }
     await expect(
       page.getByText(translations.buttons['watch-video'])
     ).not.toBeVisible();


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related to #53895

<!-- Feel free to add any additional description of changes below this line -->

Previously the test didn't properly check for the existence of two modal dialogs when rendering video-modal  
