### PR TITLE
test(playwright): challenge reset-modal improvements

### DIFF
--- a/e2e/reset-modal.spec.ts
+++ b/e2e/reset-modal.spec.ts
@@ -16,15 +16,16 @@ test.describe('reset modal', () => {
     );
   });
   test('should render the modal content correctly', async ({ page }) => {
+    await page
+      .getByRole('button', { name: translations.buttons.reset })
+      .click();
 
-    await page.getByRole('button', { name: translations.buttons.reset }).click();
-  
     // There are two elements with the `dialog` role in the DOM.
     // This appears to be semantically incorrect and should be resolved
     // once we have migrated the component to use Dialog from the `ui-components` library.
     const dialogs = page.getByRole('dialog');
     await expect(dialogs).toHaveCount(2);
-  
+
     await expect(
       page.getByRole('button', {
         name: translations.buttons.close
@@ -35,42 +36,43 @@ test.describe('reset modal', () => {
         name: translations.learn.reset
       })
     ).toBeVisible();
-  
-    await expect(page.getByText(translations.learn['reset-warn'])).toBeVisible();
+
+    await expect(
+      page.getByText(translations.learn['reset-warn'])
+    ).toBeVisible();
     await expect(
       page.getByText(translations.learn['reset-warn-2'])
     ).toBeVisible();
-  
+
     await expect(
       page.getByRole('button', {
         name: translations.buttons['reset-lesson']
       })
     ).toBeVisible();
   });
-  
+
   test('User can reset challenge', async ({ page }) => {
-    
     const editorPaneLabel =
       'Editor content;Press Alt+F1 for Accessibility Options.';
     const challengeSolution = '<h2>Cat Photos</h2>';
-  
+
     await page.getByLabel(editorPaneLabel).fill(challengeSolution);
     await expect(
       page
         .frameLocator('iframe[title="challenge preview"]')
         .getByRole('heading', { name: 'Cat Photos' })
     ).toBeVisible();
-  
+
     await page
       .getByRole('button', {
         name: translations.buttons['check-code']
       })
       .click();
-  
+
     await expect(
       page.getByText(translations.learn['sorry-keep-trying'])
     ).toBeVisible();
-  
+
     await page.getByTestId('lowerJaw-reset-button').click();
     const dialogs = page.getByRole('dialog');
     await expect(dialogs).toHaveCount(2);
@@ -89,10 +91,13 @@ test.describe('reset modal', () => {
       page.getByText(translations.learn['sorry-keep-trying'])
     ).not.toBeVisible();
   });
-  
-  test('should close when the user clicks the close button', async ({ page }) => {
 
-    await page.getByRole('button', { name: translations.buttons.reset }).click();
+  test('should close when the user clicks the close button', async ({
+    page
+  }) => {
+    await page
+      .getByRole('button', { name: translations.buttons.reset })
+      .click();
 
     // There are two elements with the `dialog` role in the DOM.
     // This appears to be semantically incorrect and should be resolved
@@ -100,16 +105,15 @@ test.describe('reset modal', () => {
     const dialogs = page.getByRole('dialog');
     await expect(dialogs).toHaveCount(2);
     await page
-    .getByRole('button', {
-      name: translations.buttons.close
-    })
-    .click();
+      .getByRole('button', {
+        name: translations.buttons.close
+      })
+      .click();
     for (const dialog of await dialogs.all()) {
       await expect(dialog).not.toBeVisible();
     }
   });
 });
-
 
 test('User can reset classic challenge', async ({ page, isMobile }) => {
   await page.goto(

--- a/e2e/reset-modal.spec.ts
+++ b/e2e/reset-modal.spec.ts
@@ -9,82 +9,107 @@ test.beforeEach(({ browserName }) => {
   );
 });
 
-test('should render the modal content correctly', async ({ page }) => {
-  await page.goto(
-    '/learn/2022/responsive-web-design/learn-html-by-building-a-cat-photo-app/step-2'
-  );
+test.describe('reset modal', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(
+      '/learn/2022/responsive-web-design/learn-html-by-building-a-cat-photo-app/step-2'
+    );
+  });
+  test('should render the modal content correctly', async ({ page }) => {
 
-  await page.getByRole('button', { name: translations.buttons.reset }).click();
+    await page.getByRole('button', { name: translations.buttons.reset }).click();
+  
+    // There are two elements with the `dialog` role in the DOM.
+    // This appears to be semantically incorrect and should be resolved
+    // once we have migrated the component to use Dialog from the `ui-components` library.
+    const dialogs = page.getByRole('dialog');
+    await expect(dialogs).toHaveCount(2);
+  
+    await expect(
+      page.getByRole('button', {
+        name: translations.buttons.close
+      })
+    ).toBeVisible();
+    await expect(
+      page.getByRole('heading', {
+        name: translations.learn.reset
+      })
+    ).toBeVisible();
+  
+    await expect(page.getByText(translations.learn['reset-warn'])).toBeVisible();
+    await expect(
+      page.getByText(translations.learn['reset-warn-2'])
+    ).toBeVisible();
+  
+    await expect(
+      page.getByRole('button', {
+        name: translations.buttons['reset-lesson']
+      })
+    ).toBeVisible();
+  });
+  
+  test('User can reset challenge', async ({ page }) => {
+    
+    const editorPaneLabel =
+      'Editor content;Press Alt+F1 for Accessibility Options.';
+    const challengeSolution = '<h2>Cat Photos</h2>';
+  
+    await page.getByLabel(editorPaneLabel).fill(challengeSolution);
+    await expect(
+      page
+        .frameLocator('iframe[title="challenge preview"]')
+        .getByRole('heading', { name: 'Cat Photos' })
+    ).toBeVisible();
+  
+    await page
+      .getByRole('button', {
+        name: translations.buttons['check-code']
+      })
+      .click();
+  
+    await expect(
+      page.getByText(translations.learn['sorry-keep-trying'])
+    ).toBeVisible();
+  
+    await page.getByTestId('lowerJaw-reset-button').click();
+    const dialogs = page.getByRole('dialog');
+    await expect(dialogs).toHaveCount(2);
+    await page
+      .getByRole('button', { name: translations.buttons['reset-lesson'] })
+      .click();
+    for (const dialog of await dialogs.all()) {
+      await expect(dialog).not.toBeVisible();
+    }
+    await expect(
+      page
+        .frameLocator('iframe[title="challenge preview"]')
+        .getByRole('heading', { name: 'Cat Photos' })
+    ).not.toBeVisible();
+    await expect(
+      page.getByText(translations.learn['sorry-keep-trying'])
+    ).not.toBeVisible();
+  });
+  
+  test('should close when the user clicks the close button', async ({ page }) => {
 
-  // There are two elements with the `dialog` role in the DOM.
-  // This appears to be semantically incorrect and should be resolved
-  // once we have migrated the component to use Dialog from the `ui-components` library.
-  const dialogs = await page.getByRole('dialog').all();
-  expect(dialogs).toHaveLength(2);
+    await page.getByRole('button', { name: translations.buttons.reset }).click();
 
-  await expect(
-    page.getByRole('button', {
+    // There are two elements with the `dialog` role in the DOM.
+    // This appears to be semantically incorrect and should be resolved
+    // once we have migrated the component to use Dialog from the `ui-components` library.
+    const dialogs = page.getByRole('dialog');
+    await expect(dialogs).toHaveCount(2);
+    await page
+    .getByRole('button', {
       name: translations.buttons.close
     })
-  ).toBeVisible();
-  await expect(
-    page.getByRole('heading', {
-      name: translations.learn.reset
-    })
-  ).toBeVisible();
-
-  await expect(page.getByText(translations.learn['reset-warn'])).toBeVisible();
-  await expect(
-    page.getByText(translations.learn['reset-warn-2'])
-  ).toBeVisible();
-
-  await expect(
-    page.getByRole('button', {
-      name: translations.buttons['reset-lesson']
-    })
-  ).toBeVisible();
+    .click();
+    for (const dialog of await dialogs.all()) {
+      await expect(dialog).not.toBeVisible();
+    }
+  });
 });
 
-test('User can reset challenge', async ({ page }) => {
-  await page.goto(
-    '/learn/2022/responsive-web-design/learn-html-by-building-a-cat-photo-app/step-2'
-  );
-
-  const editorPaneLabel =
-    'Editor content;Press Alt+F1 for Accessibility Options.';
-  const challengeSolution = '<h2>Cat Photos</h2>';
-
-  await page.getByLabel(editorPaneLabel).fill(challengeSolution);
-  await expect(
-    page
-      .frameLocator('iframe[title="challenge preview"]')
-      .getByRole('heading', { name: 'Cat Photos' })
-  ).toBeVisible();
-
-  await page
-    .getByRole('button', {
-      name: translations.buttons['check-code']
-    })
-    .click();
-
-  await expect(
-    page.getByText(translations.learn['sorry-keep-trying'])
-  ).toBeVisible();
-
-  await page.getByTestId('lowerJaw-reset-button').click();
-  await page
-    .getByRole('button', { name: translations.buttons['reset-lesson'] })
-    .click();
-
-  await expect(
-    page
-      .frameLocator('iframe[title="challenge preview"]')
-      .getByRole('heading', { name: 'Cat Photos' })
-  ).not.toBeVisible();
-  await expect(
-    page.getByText(translations.learn['sorry-keep-trying'])
-  ).not.toBeVisible();
-});
 
 test('User can reset classic challenge', async ({ page, isMobile }) => {
   await page.goto(
@@ -118,7 +143,6 @@ test('User can reset classic challenge', async ({ page, isMobile }) => {
   await page
     .getByRole('button', { name: translations.buttons['reset-lesson'] })
     .click();
-
   await expect(
     page.locator('.view-lines').getByText(challengeSolution)
   ).not.toBeVisible();
@@ -129,26 +153,4 @@ test('User can reset classic challenge', async ({ page, isMobile }) => {
     page.getByText(translations.learn['tests-completed'])
   ).not.toBeVisible();
   await expect(page.getByText(translations.learn['test-output'])).toBeVisible();
-});
-
-test('should close when the user clicks the close button', async ({ page }) => {
-  await page.goto(
-    '/learn/2022/responsive-web-design/learn-html-by-building-a-cat-photo-app/step-2'
-  );
-
-  await page.getByRole('button', { name: translations.buttons.reset }).click();
-
-  // There are two elements with the `dialog` role in the DOM.
-  // This appears to be semantically incorrect and should be resolved
-  // once we have migrated the component to use Dialog from the `ui-components` library.
-  const dialogs = await page.getByRole('dialog').all();
-  expect(dialogs).toHaveLength(2);
-
-  await page
-    .getByRole('button', {
-      name: translations.buttons.close
-    })
-    .click();
-
-  await expect(page.getByRole('dialog')).toBeHidden();
 });


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related to #53895

<!-- Feel free to add any additional description of changes below this line -->

Minor refactoring, tests didn't check for modal dialogs to be invisible once closed, removed ```.all()``` method checking the count of dialogs using ```.toHaveCount()``` 

