### PR TITLE
test(playwright): shortcuts-modal improvements

### DIFF
--- a/e2e/shortcuts-modal.spec.ts
+++ b/e2e/shortcuts-modal.spec.ts
@@ -39,6 +39,9 @@ test('User can see list of shortcuts  by pressing SHIFT + ?', async ({
     'Skipping on mobile as it does not have a physical keyboard.'
   );
 
+  const dialogs = page.getByRole('dialog');
+  await expect(dialogs).toHaveCount(2);
+
   await expect(
     page.getByRole('heading', { name: translations.shortcuts.title })
   ).toBeVisible();
@@ -69,12 +72,16 @@ test('User can close the modal by pressing ESC', async ({ page, isMobile }) => {
     isMobile,
     'Skipping on mobile as it does not have a physical keyboard.'
   );
-
+  const dialogs = page.getByRole('dialog');
+  await expect(dialogs).toHaveCount(2);
   await expect(
     page.getByRole('heading', { name: translations.shortcuts.title })
   ).toBeVisible();
 
   await page.keyboard.press('Escape');
+  for (const dialog of await dialogs.all()) {
+    await expect(dialog).not.toBeVisible();
+  }
   await expect(
     page.getByRole('heading', { name: translations.shortcuts.title })
   ).not.toBeVisible();
@@ -85,13 +92,17 @@ test('User can disable keyboard shortcuts', async ({ page, isMobile }) => {
     isMobile,
     'Skipping on mobile as it does not have a physical keyboard.'
   );
-
+  const dialogs = page.getByRole('dialog');
+  await expect(dialogs).toHaveCount(2);
   await expect(
     page.getByRole('heading', { name: translations.shortcuts.title })
   ).toBeVisible();
 
   await page.getByRole('button', { name: translations.buttons.off }).click();
   await page.getByRole('button', { name: translations.buttons.close }).click();
+  for (const dialog of await dialogs.all()) {
+    await expect(dialog).not.toBeVisible();
+  }
   await expect(
     page.getByRole('heading', { name: translations.shortcuts.title })
   ).not.toBeVisible();


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related to #53895

<!-- Feel free to add any additional description of changes below this line -->
Added check for two dialogs on modal,  removed ```.all()``` method checking the count of dialogs using ```.toHaveCount()```
