### PR TITLE
feat(curriculum) - set all the tests for step 47 to use matches

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fb1c4dc0feb219149a7c7d.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fb1c4dc0feb219149a7c7d.md
@@ -33,7 +33,7 @@ assert.match(code, regex);
 Your `formInputValuesUpdated` variable should check if `titleInput.value` is not equal to `currentTask.title`, `dateInput.value` is not equal to `currentTask.date`, or `descriptionInput.value` is not equal to `currentTask.description`.
 
 ```js
-const regex = /const\s+formInputValuesUpdated\s*=\s*titleInput\.value\s*!==\s*currentTask\.title\s*\|\|\s*dateInput\.value\s*!==\s*currentTask\.date\s*\|\|\s*descriptionInput\.value\s*!==\s*currentTask\.description\s*;?/
+const regex = /const\s+formInputValuesUpdated\s*=\s*titleInput\.value\s*(!==|!=)\s*currentTask\.title\s*\|\|\s*dateInput\.value\s*(!==|!=)\s*currentTask\.date\s*\|\|\s*descriptionInput\.value\s*(!==|!=)\s*currentTask\.description\s*;?/
 
 assert.match(code, regex);
 ```


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related to (https://github.com/freeCodeCamp/freeCodeCamp/pull/53606) 

<!-- Feel free to add any additional description of changes below this line -->
This fixes the final test so that campers don't have to use strictly equal in order to pass the challenge. All three tests need to be the same. 
