### PR TITLE
fix: email authenication link messages

### DIFF
--- a/api/src/routes/settings.test.ts
+++ b/api/src/routes/settings.test.ts
@@ -6,7 +6,7 @@ import {
 } from '../../jest.utils';
 import { createUserInput } from '../utils/create-user';
 
-import { isPictureWithProtocol } from './settings';
+import { isPictureWithProtocol, getWaitMessage } from './settings';
 
 const baseProfileUI = {
   isLocked: false,
@@ -764,5 +764,51 @@ Please wait 5 minutes to resend an authentication link.`
       expect(isPictureWithProtocol('tp://www.example.com/')).toEqual(false);
       expect(isPictureWithProtocol('www.example.com/')).toEqual(false);
     });
+  });
+});
+
+describe('getWaitMessage', () => {
+  const sec = 1000;
+  const min = 60 * 1000;
+  it.each([
+    {
+      sentAt: new Date(0),
+      now: new Date(0),
+      expected: 'Please wait 5 minutes to resend an authentication link.'
+    },
+    {
+      sentAt: new Date(0),
+      now: new Date(59 * sec),
+      expected: 'Please wait 5 minutes to resend an authentication link.'
+    },
+    {
+      sentAt: new Date(0),
+      now: new Date(4 * min),
+      expected: 'Please wait 1 minute to resend an authentication link.'
+    },
+    {
+      sentAt: new Date(0),
+      now: new Date(4 * min + 59 * sec),
+      expected: 'Please wait 1 minute to resend an authentication link.'
+    },
+    {
+      sentAt: new Date(0),
+      now: new Date(5 * min),
+      expected: null
+    }
+  ])(
+    `returns "$expected" when sentAt is $sentAt and now is $now`,
+    ({ sentAt, now, expected }) => {
+      expect(getWaitMessage({ sentAt, now })).toEqual(expected);
+    }
+  );
+
+  it('returns null when sentAt is null', () => {
+    expect(getWaitMessage({ sentAt: null, now: new Date(0) })).toBeNull();
+  });
+  it('uses the current time when now is not provided', () => {
+    expect(getWaitMessage({ sentAt: new Date() })).toEqual(
+      'Please wait 5 minutes to resend an authentication link.'
+    );
   });
 });


### PR DESCRIPTION
Our tests were randomly failing because the wait period was calculated by comparing the sent minute to the current minute, rather than converting the difference into minutes. The tests were correct, so I updated the business logic.

The 'a few seconds' message was unreachable, so I removed it.

Ref: https://github.com/freeCodeCamp/freeCodeCamp/actions/runs/8189271486/job/22394190345

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->
