### PR TITLE
fix(cypress): rollback firefox

### DIFF
--- a/.github/workflows/e2e-web.yml
+++ b/.github/workflows/e2e-web.yml
@@ -112,6 +112,14 @@ jobs:
           tar -xf client-artifact.tar
           rm client-artifact.tar
 
+      - name: Downgrade Firefox
+        run: |
+          curl https://ftp.mozilla.org/pub/firefox/releases/123.0/linux-x86_64/en-US/firefox-123.0.tar.bz2 --output firefox-123.0.tar.bz2
+          tar -xjf firefox-123.0.tar.bz2
+          sudo mv firefox /opt/
+          sudo mv /usr/bin/firefox /usr/bin/firefox_old
+          sudo ln -s /opt/firefox/firefox /usr/bin/firefox
+
       - name: Setup pnpm
         uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d #v3.0.0
         with:


### PR DESCRIPTION
The firefox cypress test is failing on many recent PR's. It seems to be on all runs that use firefox 124. I couldn't find any that used v124 and passed. So I don't think it's just flakiness.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
