### PR TITLE
fix(ui-components): modal body alignment

### DIFF
--- a/tools/ui-components/src/modal/modal.stories.tsx
+++ b/tools/ui-components/src/modal/modal.stories.tsx
@@ -3,7 +3,10 @@ import { StoryObj, StoryFn, Meta } from '@storybook/react';
 
 import { Button } from '../button';
 import { Modal } from './modal';
-import { type ModalProps, type HeaderProps } from './types';
+import { type ModalProps, type HeaderProps, type BodyProps } from './types';
+
+type StoryProps = ModalProps & HeaderProps & BodyProps;
+type Story = StoryObj<StoryProps>;
 
 const story = {
   title: 'Example/Modal',
@@ -28,12 +31,11 @@ const story = {
   }
 } satisfies Meta<typeof Modal>;
 
-type Story = StoryObj<ModalProps & HeaderProps>;
-
 const Spacer = () => <div style={{ height: '5px', width: '100%' }} />;
 
-const DefaultTemplate: StoryFn<ModalProps & HeaderProps> = ({
+const DefaultTemplate: StoryFn<StoryProps> = ({
   showCloseButton,
+  alignment,
   ...modalProps
 }) => {
   const [open, setOpen] = useState(false);
@@ -47,7 +49,7 @@ const DefaultTemplate: StoryFn<ModalProps & HeaderProps> = ({
         <Modal.Header showCloseButton={showCloseButton}>
           Lorem ipsum
         </Modal.Header>
-        <Modal.Body>
+        <Modal.Body alignment={alignment}>
           <p>
             Laboriosam autem non et nisi. Ut voluptatem sit beatae assumenda
             amet aliquam corporis.
@@ -149,6 +151,20 @@ export const WithoutCloseButton: Story = {
   render: DefaultTemplate,
   args: {
     showCloseButton: false
+  }
+};
+
+export const LeftAlignedBody: Story = {
+  render: DefaultTemplate,
+  args: {
+    alignment: 'left'
+  }
+};
+
+export const StartAlignedBody: Story = {
+  render: DefaultTemplate,
+  args: {
+    alignment: 'start'
   }
 };
 

--- a/tools/ui-components/src/modal/modal.tsx
+++ b/tools/ui-components/src/modal/modal.tsx
@@ -7,7 +7,7 @@ import React, {
 import { Dialog, Transition } from '@headlessui/react';
 
 import { CloseButton } from '../close-button';
-import { type ModalProps, type HeaderProps } from './types';
+import { type ModalProps, type HeaderProps, BodyProps } from './types';
 
 // There is a close button on the right side of the modal title.
 // Some extra padding needs to be added to the left of the title text
@@ -59,9 +59,11 @@ const Header = ({ children, showCloseButton = true }: HeaderProps) => {
   );
 };
 
-const Body = ({ children }: { children: ReactNode }) => {
+const Body = ({ children, alignment = 'center' }: BodyProps) => {
   return (
-    <div className='p-[15px] border-b-1 border-solid border-foreground-secondary'>
+    <div
+      className={`p-[15px] border-b-1 border-solid border-foreground-secondary text-${alignment}`}
+    >
       {children}
     </div>
   );

--- a/tools/ui-components/src/modal/types.ts
+++ b/tools/ui-components/src/modal/types.ts
@@ -12,3 +12,13 @@ export interface HeaderProps {
   children: ReactNode;
   showCloseButton?: boolean;
 }
+
+export interface BodyProps {
+  children: ReactNode;
+
+  /**
+   * Use `start` for better right-to-left support.
+   * Use `left` if the modal body contains code blocks.
+   */
+  alignment?: 'center' | 'left' | 'start';
+}


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR adds `alignment` option to `Modal.Body`.

<details>
  <summary>Screenshots</summary>

  | Alignment | Screenshot | 
  | --- | --- |
  | `center` | <img width="1680" alt="Screenshot 2024-03-21 at 12 02 54" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/0aa33f21-b676-4af8-ab64-00cb14951a5c"> |
 | `left` | <img width="1680" alt="Screenshot 2024-03-21 at 12 03 15" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/54e11743-95ad-4a74-8ffb-161fb11482d6"> |
  | `start` | <img width="1680" alt="Screenshot 2024-03-21 at 12 13 27" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/467af173-c3f8-4366-89d3-50436c885f8e"> |
</details>
<!-- Feel free to add any additional description of changes below this line -->
