### PR TITLE
feat(client): point claim cert links to corresponding sections on /settings

### DIFF
--- a/client/src/components/settings/certification.tsx
+++ b/client/src/components/settings/certification.tsx
@@ -334,26 +334,30 @@ function CertificationSettings(props: CertificationSettingsProps) {
   }) => {
     const { certSlug } = certsToProjects[certName][0];
     return (
-      <FullWidthRow>
-        <Spacer size='medium' />
-        <h3 className='text-center' id={`cert-${certSlug}`}>
-          {t(`certification.title.${certName}`, certName)}
-        </h3>
-        <Table>
-          <thead>
-            <tr>
-              <th>{t('settings.labels.project-name')}</th>
-              <th>{t('settings.labels.solution')}</th>
-            </tr>
-          </thead>
-          <tbody>
-            <ProjectsFor
-              certName={certName}
-              isCert={getUserIsCertMap()[certName]}
-            />
-          </tbody>
-        </Table>
-      </FullWidthRow>
+      <ScrollableAnchor id={`cert-${certSlug}`}>
+        <section>
+          <FullWidthRow>
+            <Spacer size='medium' />
+            <h3 className='text-center'>
+              {t(`certification.title.${certName}`, certName)}
+            </h3>
+            <Table>
+              <thead>
+                <tr>
+                  <th>{t('settings.labels.project-name')}</th>
+                  <th>{t('settings.labels.solution')}</th>
+                </tr>
+              </thead>
+              <tbody>
+                <ProjectsFor
+                  certName={certName}
+                  isCert={getUserIsCertMap()[certName]}
+                />
+              </tbody>
+            </Table>
+          </FullWidthRow>
+        </section>
+      </ScrollableAnchor>
     );
   };
 
@@ -413,43 +417,38 @@ function CertificationSettings(props: CertificationSettingsProps) {
   const { t } = props;
 
   return (
-    <ScrollableAnchor id='certification-settings'>
-      <section className='certification-settings'>
-        <SectionHeader>{t('settings.headings.certs')}</SectionHeader>
-        {currentCertTitles.map(title => (
+    <section className='certification-settings'>
+      <SectionHeader>{t('settings.headings.certs')}</SectionHeader>
+      {currentCertTitles.map(title => (
+        <Certification key={title} certName={title} t={t} />
+      ))}
+      <Spacer size='medium' />
+      <SectionHeader>{t('settings.headings.legacy-certs')}</SectionHeader>
+      <LegacyFullStack {...props} />
+      {legacyCertTitles.map(title => (
+        <Certification key={title} certName={title} t={t} />
+      ))}
+      {showUpcomingChanges &&
+        upcomingCertTitles.map(title => (
           <Certification key={title} certName={title} t={t} />
         ))}
-        <Spacer size='medium' />
-        <SectionHeader>{t('settings.headings.legacy-certs')}</SectionHeader>
-        <LegacyFullStack {...props} />
-        {legacyCertTitles.map(title => (
-          <Certification key={title} certName={title} t={t} />
-        ))}
-        {showUpcomingChanges &&
-          upcomingCertTitles.map(title => (
-            <Certification key={title} certName={title} t={t} />
-          ))}
-        <ProjectModal
-          {...{
-            projectTitle,
-            challengeFiles,
-            solution: solution ?? undefined,
-            isOpen
-          }}
-          handleSolutionModalHide={handleSolutionModalHide}
-        />
-        <ProjectPreviewModal
-          challengeData={challengeData}
-          previewTitle={projectTitle}
-          closeText={t('buttons.close')}
-          showProjectPreview={true}
-        />
-        <ExamResultsModal
-          projectTitle={projectTitle}
-          examResults={examResults}
-        />
-      </section>
-    </ScrollableAnchor>
+      <ProjectModal
+        {...{
+          projectTitle,
+          challengeFiles,
+          solution: solution ?? undefined,
+          isOpen
+        }}
+        handleSolutionModalHide={handleSolutionModalHide}
+      />
+      <ProjectPreviewModal
+        challengeData={challengeData}
+        previewTitle={projectTitle}
+        closeText={t('buttons.close')}
+        showProjectPreview={true}
+      />
+      <ExamResultsModal projectTitle={projectTitle} examResults={examResults} />
+    </section>
   );
 }
 

--- a/client/src/templates/Introduction/components/cert-challenge.tsx
+++ b/client/src/templates/Introduction/components/cert-challenge.tsx
@@ -129,7 +129,7 @@ const CertChallenge = ({
         <Button
           block={true}
           variant='primary'
-          href={isCertified ? certLocation : `/settings#certification-settings`}
+          href={isCertified ? certLocation : `/settings#cert-${certSlug}`}
           onClick={() => (isCertified ? createClickHandler(certSlug) : false)}
         >
           {isCertified && userLoaded

--- a/cypress/e2e/default/learn/responsive-web-design/show-cert-from-superblock.ts
+++ b/cypress/e2e/default/learn/responsive-web-design/show-cert-from-superblock.ts
@@ -34,9 +34,12 @@ describe('Front End Development Libraries Superblock', () => {
     cy.visit('/learn/front-end-development-libraries');
   });
   describe('Before submitting projects', () => {
-    it('should navigate to "/settings#certification-settings" when clicking the "Go to settings to claim your certification" anchor', () => {
+    it('should navigate to "/settings#cert-front-end-development-libraries" when clicking the "Go to settings to claim your certification" anchor', () => {
       cy.contains('Go to settings to claim your certification').click();
-      cy.url().should('match', /\/settings\/?#certification-settings/);
+      cy.url().should(
+        'match',
+        /\/settings\/?#cert-front-end-development-libraries/
+      );
     });
   });
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

On the superblock page, we have link that takes the user to the Certifications section of the Settings page (/settings#certification-settings). Since the Certifications section is quite long, I reckon it would be more convenient for the users if we just take them to the section corresponding to the superblock instead.

<details>
  <summary>Screen recording</summary> 

  https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/ef98a54c-004e-4544-8a86-5b578bfd1023

</details>

<!-- Feel free to add any additional description of changes below this line -->
