### PR TITLE
chore(curriculum) add quotes to strings in Build a Platformer Game

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/649a6b393a10a4357087b3f7.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/649a6b393a10a4357087b3f7.md
@@ -9,7 +9,7 @@ dashedName: step-19
 
 Now, you need to set the color for your player.
 
-Inside the `draw()` method, assign the string `#99c9ff` to `ctx.fillStyle`.
+Inside the `draw()` method, assign the string `"#99c9ff"` to `ctx.fillStyle`.
 
 # --hints--
 
@@ -20,7 +20,7 @@ const player = new Player();
 assert.match(player.draw.toString(), /ctx\.fillStyle\s*/);
 ```
 
-You should assign the string `#99c9ff` to `ctx.fillStyle`.
+You should assign the string `"#99c9ff"` to `ctx.fillStyle`.
 
 ```js
 const player = new Player();

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/649a75a844f2ea3a0060d807.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/649a75a844f2ea3a0060d807.md
@@ -13,7 +13,7 @@ Below your `ctx.fillStyle`, you need to create the player's shape by calling the
 fillRect(x, y, width, height)
 ```
 
-Inside the `fillRect()`  method add the `this.position.x`, `this.position.y`, `this.width` and `this.height` values.
+Inside the `fillRect()` method add the `this.position.x`, `this.position.y`, `this.width` and `this.height` values.
 
 
 # --hints--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/649a75a844f2ea3a0060d807.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/649a75a844f2ea3a0060d807.md
@@ -7,7 +7,7 @@ dashedName: step-20
 
 # --description--
 
-Below your `ctx.fillStyle`, you need to create the player's shape by using the `fillRect()` method. 
+Below your `ctx.fillStyle`, you need to create the player's shape by calling the `fillRect()` method on the ctx object which you instantiated earlier. 
 
 ```js
 fillRect(x, y, width, height)

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64aaf83d46b16a7b20a27051.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64aaf83d46b16a7b20a27051.md
@@ -9,9 +9,9 @@ dashedName: step-37
 
 Inside your `startGame` function, you will need to display the `canvas` element and hide the `startScreen` container.
 
-Use `canvas.style.display` to change the display value to `block`. 
+Use `canvas.style.display` to change the display value to `"block"`. 
 
-Below that, use `startScreen.style.display` to change the display value to `none`.
+Below that, use `startScreen.style.display` to change the display value to `"none"`.
 
 # --hints--
 
@@ -27,7 +27,7 @@ You should use dot notation to access the `display` property of the `style` prop
 assert.match(startGame.toString(), /canvas\.style\.display/);
 ```
 
-You should set the `canvas` `display` property to `block`.
+You should set the `canvas` `display` property to `"block"`.
 
 ```js
 assert.match(startGame.toString(), /canvas\.style\.display\s*=\s*('|")block\1/);
@@ -45,7 +45,7 @@ You should use dot notation to access the `display` property of the `style` prop
 assert.match(startGame.toString(), /startScreen\.style\.display/);
 ```
 
-You should set the `startScreen` `display` property to `none`.
+You should set the `startScreen` `display` property to `"none"`.
 
 ```js
 assert.match(startGame.toString(), /startScreen\.style\.display\s*=\s*('|")none\1/);

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64ab06a9cc033b7d4a8bad2a.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64ab06a9cc033b7d4a8bad2a.md
@@ -27,10 +27,10 @@ You should pass `click` as the first argument to the `.addEventListener()` metho
 assert.match(code, /startBtn\.addEventListener\(\s*('|")click\1\s*/);
 ```
 
-You should pass `startGame` as the second argument to the `.addEventListener()` method.
+You should pass a reference to `startGame` as the second argument to the `.addEventListener()` method. Do not invoke `startGame()`.
 
 ```js
-assert.match(code, /startBtn\.addEventListener\(\s*('|")click\1\s*,\s*startGame\s*/);
+assert.match(code, /startBtn\.addEventListener\(\s*('|")click\1\s*,\s*startGame(?!\s*\()\s*/);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64ab06a9cc033b7d4a8bad2a.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64ab06a9cc033b7d4a8bad2a.md
@@ -27,7 +27,7 @@ You should pass `click` as the first argument to the `.addEventListener()` metho
 assert.match(code, /startBtn\.addEventListener\(\s*('|")click\1\s*/);
 ```
 
-You should pass a reference to `startGame` as the second argument to the `.addEventListener()` method. Do not invoke `startGame()`.
+You should pass a reference to `startGame` as the second argument to the `.addEventListener()` method.
 
 ```js
 assert.match(code, /startBtn\.addEventListener\(\s*('|")click\1\s*,\s*startGame(?!\s*\()\s*/);

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64c70f78dbf5667a307a7d90.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64c70f78dbf5667a307a7d90.md
@@ -7,7 +7,7 @@ dashedName: step-51
 
 # --description--
 
-In the game, the player will interact with different checkpoints. If the `isCheckpointCollisionDetectionActive` is false, then you will need to stop the player's movements on the `x` and `y` axis.
+In the game, the player will interact with different checkpoints. If the `isCheckpointCollisionDetectionActive` is false, then you will need to stop the player's movements on the `x` and `y` axes.
 
 Start by creating an `if` statement where the condition checks if the `isCheckpointCollisionDetectionActive` is false.
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64c714ec1b844f7bc0723deb.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64c714ec1b844f7bc0723deb.md
@@ -9,11 +9,11 @@ dashedName: step-54
 
 The first case you will want to add is when the left arrow key is pressed.
 
-Inside the `switch` statement, add a new case called "ArrowLeft". 
+Inside the `switch` statement, add a new case called `"ArrowLeft"`. 
 
 # --hints--
 
-Your switch statement should have a case called "ArrowLeft".
+Your switch statement should have a case called `"ArrowLeft"`.
 
 ```js
 assert.match(code, /switch\s*\(\s*key\s*\)\s*{\s*case\s*('|")ArrowLeft\1\s*:\s*/);

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64c7173772c2497ce99b474c.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64c7173772c2497ce99b474c.md
@@ -9,7 +9,7 @@ dashedName: step-57
 
 The player can jump up by using the up arrow key or the spacebar. 
 
-Add three new cases for "ArrowUp", " ", and "Spacebar". Remember that you can group cases together when they share the same operation. 
+Add three new cases for `"ArrowUp"`, `" "`, and `"Spacebar"`. (Note that the `" "` here is a string with a single space character in it not an empty string.) Remember that you can group cases together when they share the same operation. 
 
 Inside those cases, use the subtraction assignment operator to subtract 8 from `player.velocity.y`.
 
@@ -17,19 +17,19 @@ To close out these cases, make sure to add a `break` statement.
 
 # --hints--
 
-You should add a new `case` clause for "ArrowUp" inside your `switch` statement.
+You should add a new `case` clause for `"ArrowUp"` inside your `switch` statement.
 
 ```js
 assert.match(code, /\s*case\s*('|"|`)\s*ArrowUp\s*\1\s*:\s*/)
 ```
 
-You should add a new `case` clause for " " inside your `switch` statement.
+You should add a new `case` clause for `" "` inside your `switch` statement.
 
 ```js
 assert.match(code, /\s*case\s*('|"|`)\s\1\s*:\s*/);
 ```
 
-You should add a new `case` clause for "Spacebar" inside your `switch` statement.
+You should add a new `case` clause for `"Spacebar"` inside your `switch` statement.
 
 ```js
 assert.match(code, /\s*case\s*('|"|`)\s*Spacebar\s*\1\s*:\s*/)

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64c7173772c2497ce99b474c.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64c7173772c2497ce99b474c.md
@@ -9,9 +9,9 @@ dashedName: step-57
 
 The player can jump up by using the up arrow key or the spacebar. 
 
-Add three new cases for `"ArrowUp"`, `" "`, and `"Spacebar"`. (Note that the `" "` here is a string with a single space character in it not an empty string.) Remember that you can group cases together when they share the same operation. 
+Add three new cases for `"ArrowUp"`, `" "`, and `"Spacebar"`. Remember that you can group cases together when they share the same operation. 
 
-Inside those cases, use the subtraction assignment operator to subtract 8 from `player.velocity.y`.
+Inside those cases, use the subtraction assignment operator to subtract `8` from `player.velocity.y`.
 
 To close out these cases, make sure to add a `break` statement.
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64c73367cce78a7fd65dd3be.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64c73367cce78a7fd65dd3be.md
@@ -7,7 +7,7 @@ dashedName: step-60
 
 # --description--
 
-Inside the arrow function, call the `movePlayer` function and pass in `key`, 8, and `true` as arguments.
+Inside the arrow function, call the `movePlayer` function and pass in `key`, `8`, and `true` as arguments.
 
 # --hints--
 
@@ -17,7 +17,7 @@ You should call the `movePlayer` function.
 assert.match(code, /movePlayer\s*\(.*\)/);
 ```
 
-You should pass in `key`, 8, and `true` as arguments to the `movePlayer` function.
+You should pass in `key`, `8`, and `true` as arguments to the `movePlayer` function.
 
 ```js
 assert.match(code, /movePlayer\s*\(\s*key\s*,\s*8\s*,\s*true\s*\)/);  

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64c7527100b19b09037ce5db.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64c7527100b19b09037ce5db.md
@@ -7,13 +7,13 @@ dashedName: step-70
 
 # --description--
 
-Inside the `draw` method, assign `#acd157` to the `ctx.fillStyle`.
+Inside the `draw` method, assign `"#acd157"` to the `ctx.fillStyle`.
 
 Below that, call the `ctx.fillRect` method and pass in the `x` and `y` coordinates, along with the `width` and `height` properties. Remember to include `this` before each property.
 
 # --hints--
 
-You should assign `#acd157` to the `ctx.fillStyle`.
+You should assign `"#acd157"` to the `ctx.fillStyle`.
 
 ```js
 assert.match(code, /ctx\.fillStyle\s*=\s*('|")#acd157\1\s*;?/);

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64cb2e5bdfb23a67272a07c7.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64cb2e5bdfb23a67272a07c7.md
@@ -9,7 +9,7 @@ dashedName: step-98
 
 Now you need to create a `draw` method for the `CheckPoint` class. 
 
-Inside the `draw` method, add a `fillStyle` property to the `ctx` object and set it to `#f1be32`. 
+Inside the `draw` method, add a `fillStyle` property to the `ctx` object and set it to `"#f1be32"`. 
 
 Below the `fillStyle` property, use the `fillRect` method on the `ctx` object and pass in the `x`, `y`, `width`, and `height` properties as arguments.
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64cb2e5bdfb23a67272a07c7.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64cb2e5bdfb23a67272a07c7.md
@@ -43,7 +43,7 @@ const splitter = code.split('#f1be32')
 assert.match(splitter[1], /ctx\.fillRect\(/);
 ```
 
-When invoking `ctx.fillRect` you should pass in the `x`, `y`, `width`, and `height` properties as arguments.
+When invoking `ctx.fillRect` you should pass in the `x`, `y`, `width`, and `height` properties as arguments. Don't forget the `this` keyword.
 
 ```js
 const splitter = code.split('#f1be32')

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64cb2e5bdfb23a67272a07c7.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64cb2e5bdfb23a67272a07c7.md
@@ -22,14 +22,28 @@ const splitter = code.split("ctx.fillRect(this.position.x, this.position.y, this
 assert.match(splitter[2], /draw\(\s*\)\s*\{/);
 ```
 
-Your `draw` method should have a `fillStyle` property.
+Your `draw` method should have a `fillStyle` property added to the `ctx` object.
+
+```js
+const splitter = code.split("ctx.fillRect(this.position.x, this.position.y, this.width, this.height)")
+assert.match(splitter[2], /draw\(\s*\)\s*\{\s*ctx\.fillStyle/);
+```
+
+You should assign `"#f1be32"` to the `ctx.fillStyle` property.
 
 ```js
 const splitter = code.split("ctx.fillRect(this.position.x, this.position.y, this.width, this.height)")
 assert.match(splitter[2], /draw\(\s*\)\s*\{\s*ctx\.fillStyle\s*=\s*('|")#f1be32\1\s*;?/);
 ```
 
-Your `draw` method should have a `fillRect` method.
+Your `draw` method should invoke the `fillRect` method on the `ctx` object.
+
+```js
+const splitter = code.split('#f1be32')
+assert.match(splitter[1], /ctx\.fillRect\(/);
+```
+
+When invoking `ctx.fillRect` you should pass in the `x`, `y`, `width`, and `height` properties as arguments.
 
 ```js
 const splitter = code.split('#f1be32')

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64cb4978631a4f6e3e1b964d.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64cb4978631a4f6e3e1b964d.md
@@ -7,11 +7,11 @@ dashedName: step-106
 
 # --description--
 
-Inside the `showCheckpointScreen` function, set the `checkpointScreen` `style` `display` property to `"block"`.
+Inside the `showCheckpointScreen` function, set the `checkpointScreen` `style.display` property to `"block"`.
 
 # --hints--
 
-You should set the `checkpointScreen` `style` `display` style property to `"block"`.
+You should set the `checkpointScreen` `style.display` property to `"block"`.
 
 ```js
 assert.match(code, /\s*checkpointScreen\s*\.\s*style\s*\.\s*display\s*=\s*('|")block\1\s*;?/);

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64cb4978631a4f6e3e1b964d.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64cb4978631a4f6e3e1b964d.md
@@ -7,11 +7,11 @@ dashedName: step-106
 
 # --description--
 
-Inside the `showCheckpointScreen` function, set the `checkpointScreen` `display` property to block.
+Inside the `showCheckpointScreen` function, set the `checkpointScreen` `style` `display` property to `"block"`.
 
 # --hints--
 
-You should set the `checkpointScreen` `display` style property to block.
+You should set the `checkpointScreen` `style` `display` style property to `"block"`.
 
 ```js
 assert.match(code, /\s*checkpointScreen\s*\.\s*style\s*\.\s*display\s*=\s*('|")block\1\s*;?/);

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64cb4ebdc75b3a73a43da5ec.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64cb4ebdc75b3a73a43da5ec.md
@@ -11,7 +11,7 @@ Create an `if` statement that checks if `isCheckpointCollisionDetectionActive` i
 
 Inside the `if` statement, add a `setTimeout()` that takes in a callback function and a delay of 2000 milliseconds.
 
-For the callback function, it should set the `checkpointScreen` `display` property to `none`.
+For the callback function, it should set the `checkpointScreen` `style` `display` property to `"none"`.
 
 # --hints--
 
@@ -39,7 +39,7 @@ Your `setTimeout()` function should have a delay of 2000 milliseconds as the sec
 assert.match(code, /\s*setTimeout\s*\(\s*\(\s*\)\s*=>[^,]*,\s*2000\s*\)/s);
 ```
 
-Your callback function should set the `checkpointScreen` `display` property to `none`.
+Your callback function should set the `checkpointScreen` `style` `display` property to `"none"`.
 
 ```js
 assert.match(code, /\s*if\s*\(\s*isCheckpointCollisionDetectionActive\s*\)\s*{\s*setTimeout\s*\(\s*\(\s*\)\s*=>\s*(\(\s*checkpointScreen\.style\.display\s*=\s*("|')none\2\s*\)|\{\s*checkpointScreen\.style\.display\s*=\s*("|')none\3\s*;?\s*\}|\s*checkpointScreen\.style\.display\s*=\s*("|')none\4\s*)\s*,\s*2000\s*\)\s*;?\s*}/s);

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64cb4ebdc75b3a73a43da5ec.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64cb4ebdc75b3a73a43da5ec.md
@@ -11,7 +11,7 @@ Create an `if` statement that checks if `isCheckpointCollisionDetectionActive` i
 
 Inside the `if` statement, add a `setTimeout()` that takes in a callback function and a delay of 2000 milliseconds.
 
-For the callback function, it should set the `checkpointScreen` `style` `display` property to `"none"`.
+For the callback function, it should set the `checkpointScreen` `style.display` property to `"none"`.
 
 # --hints--
 
@@ -39,7 +39,7 @@ Your `setTimeout()` function should have a delay of 2000 milliseconds as the sec
 assert.match(code, /\s*setTimeout\s*\(\s*\(\s*\)\s*=>[^,]*,\s*2000\s*\)/s);
 ```
 
-Your callback function should set the `checkpointScreen` `style` `display` property to `"none"`.
+Your callback function should set the `checkpointScreen` `style.display` property to `"none"`.
 
 ```js
 assert.match(code, /\s*if\s*\(\s*isCheckpointCollisionDetectionActive\s*\)\s*{\s*setTimeout\s*\(\s*\(\s*\)\s*=>\s*(\(\s*checkpointScreen\.style\.display\s*=\s*("|')none\2\s*\)|\{\s*checkpointScreen\.style\.display\s*=\s*("|')none\3\s*;?\s*\}|\s*checkpointScreen\.style\.display\s*=\s*("|')none\4\s*)\s*,\s*2000\s*\)\s*;?\s*}/s);

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/65afec8f02423144ef136a94.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/65afec8f02423144ef136a94.md
@@ -7,7 +7,7 @@ dashedName: step-11
 
 # --description--
 
-The `width` and the `height` of the main player, platforms and checkpoints will be proportional sized relative to the `innerHeight` of the the browser screen. The goal is to make the game responsive and visually consistent across different screen sizes.
+The `width` and the `height` of the main player, platforms and checkpoints will be proportional sized relative to the `innerHeight` of the browser screen. The goal is to make the game responsive and visually consistent across different screen sizes.
 
 Inside your `proportionalSize` function, you will need to return a ternary that checks if `innerHeight` is less than `500`. If so, return `Math.ceil((size / 500) * innerHeight)`, otherwise return `size`.
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/65b2bb4c279af3cd585ba777.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/65b2bb4c279af3cd585ba777.md
@@ -21,10 +21,10 @@ You should have a checkpoint detection rule that checks for the following: `play
 assert.match(code, /player\.position\.x\s*-\s*player\.width\s*<=\s*checkpoint\.position\.x\s*-\s*checkpoint\.width\s*\+\s*player\.width\s*\*\s*0\.9/i);
 ```
 
-You should have a checkpoint detection rule that checks for the following: `index === 0 || checkpoints[index - 1].claimed === true` or `index === 0 || checkpoints[index - 1].claimed`.
+You should have a checkpoint detection rule that checks for the following: `index === 0 || checkpoints[index - 1].claimed === true`.
 
 ```js
-assert.match(code, /index\s*===\s*0\s*\|\|\s*checkpoints\[index\s*-\s*1\]\.claimed(?!\s*===\s*false)/i);
+assert.match(code, /index\s*===\s*0\s*\|\|\s*checkpoints\[index\s*-\s*1\]\.claimed\s*===\s*true/i);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/65b2bb4c279af3cd585ba777.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/65b2bb4c279af3cd585ba777.md
@@ -21,10 +21,10 @@ You should have a checkpoint detection rule that checks for the following: `play
 assert.match(code, /player\.position\.x\s*-\s*player\.width\s*<=\s*checkpoint\.position\.x\s*-\s*checkpoint\.width\s*\+\s*player\.width\s*\*\s*0\.9/i);
 ```
 
-You should have a checkpoint detection rule that checks for the following: `index === 0 || checkpoints[index - 1].claimed === true`.
+You should have a checkpoint detection rule that checks for the following: `index === 0 || checkpoints[index - 1].claimed === true` or `index === 0 || checkpoints[index - 1].claimed`.
 
 ```js
-assert.match(code, /index\s*===\s*0\s*\|\|\s*checkpoints\[index\s*-\s*1\]\.claimed\s*===\s*true/i);
+assert.match(code, /index\s*===\s*0\s*\|\|\s*checkpoints\[index\s*-\s*1\]\.claimed/i);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/65b2bb4c279af3cd585ba777.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/65b2bb4c279af3cd585ba777.md
@@ -24,7 +24,7 @@ assert.match(code, /player\.position\.x\s*-\s*player\.width\s*<=\s*checkpoint\.p
 You should have a checkpoint detection rule that checks for the following: `index === 0 || checkpoints[index - 1].claimed === true` or `index === 0 || checkpoints[index - 1].claimed`.
 
 ```js
-assert.match(code, /index\s*===\s*0\s*\|\|\s*checkpoints\[index\s*-\s*1\]\.claimed/i);
+assert.match(code, /index\s*===\s*0\s*\|\|\s*checkpoints\[index\s*-\s*1\]\.claimed(?!\s*===\s*false)/i);
 ```
 
 # --seed--
@@ -368,7 +368,7 @@ const animate = () => {
       player.position.y >= checkpoint.position.y,
       player.position.y + player.height <=
         checkpoint.position.y + checkpoint.height,
-      isCheckpointCollisionDetectionActive
+      isCheckpointCollisionDetectionActive,
       --fcc-editable-region--
 
       --fcc-editable-region--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

**This PR relates to issue #51036**

The curriculum in question is: JavaScript Algorithms and Data Structures (Beta): Learn Intermediate OOP by Building a Platformer Game

I have made changes to the following steps: 11, 19, 20, 37, 39, 51, 54, 57, 60, 70, 98, 106, 108, 112

Step 11: There was a typo "the the browser screen"
Step 19: Quotation marks added around the hex color code
Step 20: Instructions changed slightly for clarity
Step 37: Quotation marks added around the word `"block"` and `"none"`
Step 39: Test altered slightly by adding a negative lookahead in the regex so as to accept a reference to the `startGame` function but to not accept `startGame` being invoked with parentheses. **I have tested this (and all the changes in this PR) in GitPod, but it would be worth reviewing this one closely to make sure the RegEx is ok.**
Step 51: Typo; the plural of 'axis' is 'axes'
Step 54: Added backticks around `"ArrowLeft"` so that it displays consistently with other steps
Step 57: Added clarification that `" "` has a space rather than being an empty string
Step 60: Added backticks around the number `8` to be consistent with Step 62 where the number `0` was already surrounded by backticks
Step 70: Added quotation marks around the hex color code
Step 98: Added quotation marks around the hex color code; updated the tests for this step to have more incremental hints
Step 106: Added quotation marks around `"block"` and made slight change to instructions for clarity
Step 108: Added quotation marks around `"none"`
Step 112: Added a comma in the 'seed' JS so that campers don't have to make changes to the code outside of the 'editable region'; updated the tests to accept either `"checkpoints[index - 1].claimed === true"` OR `"checkpoints[index - 1].claimed"` since `.claimed` references a boolean. **This may or may not be a desirable change. This should be looked at.**
