### PR TITLE
feat(curriculum): altered step 92 of Cipher project to additionally introduce python string quotation rules

### DIFF
--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-string-manipulation-by-building-a-cipher/6555e43e783ed31a0532b1b2.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-string-manipulation-by-building-a-cipher/6555e43e783ed31a0532b1b2.md
@@ -7,16 +7,34 @@ dashedName: step-92
 
 # --description--
 
-The newline character `\n` is a special sequence used to represent a new line. You can write a backslash `\` followed by an `n` as a normal sequence of characters in a string and it will be replaced by a new line in the output when the program runs.
+In programming, escaping characters within a string lets us include special characters that would otherwise have a different meaning in the language syntax. For Python, the escape character is a backslash `\`. Combining the escape character with an `n`, gives us the new line character, `\n`. When Python sees `\n` in a string, it will be replaced by a new line in the output when the program runs.
 
-Put a newline character at the beginning of your first `print` call and see the output.
+If you need to add quotes (`"` or `'`) within a string, you can use `\` to escape them (`\"` or `\'`). However, consider picking single or double quotes for the string and use the opposite for quotes inside to avoid escaping them. 
+
+For example, if you need double quotes inside, surround your string with single quotes (e.x. `"This is a valid 'string'"`).
+
+Add a newline at the start of your first print statement, and display the encrypted text in double quotes. Avoid escaping double quotes by choosing your string delimiters wisely.
+
+Example output: For the encrypted text `abcde`, the output should read: 
+
+```shell
+>>> 
+Encrypted text: "abcde"
+>>> Key: python
+```
 
 # --hints--
 
-You should modify your first print call into `print(f'\nEncrypted text: {text}')`.
+To include a newline character at the beginning of the output, prepend `\n` to your string inside the print function.
 
 ```js
-({ test: () => assert.match(code, /^print\s*\(\s*f("|')\\nEncrypted\stext:\s\{\s*text\s*\}\1\s*\)/m) })
+({ test: () => assert.match(code, /^print\s*\(\s*f("|')\\nEncrypted\stext:/m) })
+```
+
+Since you need to include double quotes around the encrypted text in the output, use single quotes to delimit your string. This way, you avoid needing to escape the double quotes.
+
+```js
+({ test: () => assert.match(code, /^print\s*\(\s*f'\\nEncrypted\stext:\s"\{\s*text\s*\}"'\s*\)/m) })
 ```
 
 # --seed--
@@ -61,4 +79,11 @@ print(f'Key: {custom_key}')
 --fcc-editable-region--
 #decryption = decrypt(encryption, custom_key)
 #print(decryption)
+```
+
+# --solutions--
+
+```py
+text = ''
+print(f'\nEncrypted text: "{text}"')
 ```

--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-string-manipulation-by-building-a-cipher/6555e547c18a2b1a7b795bd8.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-string-manipulation-by-building-a-cipher/6555e547c18a2b1a7b795bd8.md
@@ -59,7 +59,7 @@ def encrypt(message, key):
 def decrypt(message, key):
     return vigenere(message, key, -1)
 --fcc-editable-region--
-print(f'\nEncrypted text: {text}')
+print(f'\nEncrypted text: "{text}"')
 print(f'Key: {custom_key}')
 decryption = decrypt(text, custom_key)
 #print(decryption)

--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-string-manipulation-by-building-a-cipher/6555e5991af57d1ae0e35f0a.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-string-manipulation-by-building-a-cipher/6555e5991af57d1ae0e35f0a.md
@@ -63,7 +63,7 @@ def encrypt(message, key):
 def decrypt(message, key):
     return vigenere(message, key, -1)
 
-print(f'\nEncrypted text: {text}')
+print(f'\nEncrypted text: "{text}"')
 print(f'Key: {custom_key}')
 decryption = decrypt(text, custom_key)
 print(f'\nDecrypted text: {decryption}\n')
@@ -105,7 +105,7 @@ def encrypt(message, key):
 def decrypt(message, key):
     return vigenere(message, key, -1)
 
-print(f'\nEncrypted text: {text}')
+print(f'\nEncrypted text: "{text}"')
 print(f'Key: {custom_key}')
 decryption = decrypt(text, custom_key)
 print(f'\nDecrypted text: {decryption}\n')

--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-string-manipulation-by-building-a-cipher/65a51c9e000b660122b8b29e.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-string-manipulation-by-building-a-cipher/65a51c9e000b660122b8b29e.md
@@ -54,7 +54,7 @@ def encrypt(message, key):
 def decrypt(message, key):
     return vigenere(message, key, -1)
 --fcc-editable-region--
-print(f'\nEncrypted text: {text}')
+print(f'\nEncrypted text: "{text}"')
 print(f'Key: {custom_key}')
 #decryption = decrypt(encryption, custom_key)
 --fcc-editable-region--


### PR DESCRIPTION
feat(curriculum): altered step 92 of Cipher project to additionally introduce python string quotation rules

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #53542

<!-- Feel free to add any additional description of changes below this line -->

### Affected Pages
- https://www.freecodecamp.org/learn/scientific-computing-with-python/learn-string-manipulation-by-building-a-cipher/step-92
- https://www.freecodecamp.org/learn/scientific-computing-with-python/learn-string-manipulation-by-building-a-cipher/step-93
- https://www.freecodecamp.org/learn/scientific-computing-with-python/learn-string-manipulation-by-building-a-cipher/step-94
- https://www.freecodecamp.org/learn/scientific-computing-with-python/learn-string-manipulation-by-building-a-cipher/step-95

## Reason for PR
As mentioned in #53542, it would be a good idea to introduce the concept of combining single and/or double quotes in a string without escape characters in Python to campers.
This concept is important since, as stated in the issue report, the [PEP-8 style guide](https://peps.python.org/pep-0008/#string-quotes), advises against escaping quotations.
Consensus seems to be that [Step 92](https://www.freecodecamp.org/learn/scientific-computing-with-python/learn-string-manipulation-by-building-a-cipher/step-92) of the Cipher project, which introduces escaping but only with the newline character `\n`, would be a good place to introduce the concept.

## PR Description
As the issue remains open, I came up with a pull request that revises [Step 92](https://www.freecodecamp.org/learn/scientific-computing-with-python/learn-string-manipulation-by-building-a-cipher/step-92) to include:
- the concept of using quotes within strings without escape characters 
- an additional criteria to the step which asks the camper to surround text within an fstring with double quotes. 

I have revised mainly this step including the description, hints, tests, and solution, although Steps [93](https://www.freecodecamp.org/learn/scientific-computing-with-python/learn-string-manipulation-by-building-a-cipher/step-93), [94](https://www.freecodecamp.org/learn/scientific-computing-with-python/learn-string-manipulation-by-building-a-cipher/step-94), and [95](https://www.freecodecamp.org/learn/scientific-computing-with-python/learn-string-manipulation-by-building-a-cipher/step-95) I have also briefly edited to account for the new solution of the question.

## Testing
I tested locally at the challenge, block, and superblock level with:
- `FCC_CHALLENGE_ID=6555e43e783ed31a0532b1b2 pnpm run test:curriculum`
- `FCC_BLOCK='Learn String Manipulation by Building a Cipher' pnpm run test:curriculum`
- `FCC_SUPERBLOCK='scientific-computing-with-python' pnpm run test:curriculum`

All tests passed.

### System
Device: Macbook Pro
OS: Ventura 13.1
Browser: Chrome
Version: 122.0.6261.111 (Official Build) (x86_64)

If this pull request is not what freeCodeCamp is looking for, I am still interested in this issue and would be more than happy to adjust my PR as needed or start working in a different direction. I will continue to monitor [#53542](https://github.com/freeCodeCamp/freeCodeCamp/issues/53542) and this PR closely. Feedback is greatly appreciated on the content and wording of my PR code and description!
