### PR TITLE
fix(api-server): fallback to username for cert

### DIFF
--- a/api-server/src/server/boot/certificate.js
+++ b/api-server/src/server/boot/certificate.js
@@ -469,7 +469,9 @@ function createShowCert(app) {
         });
       }
 
-      if (!user.name) {
+      // If the user does not have a name, and have set their name to public,
+      // warn them. Otherwise, fallback to username
+      if (!user.name && user.showName) {
         return res.json({
           messages: [
             {


### PR DESCRIPTION
Allow fallback to username, if no name is set AND name is private

The reasoning for this as opposed to ALWAYS falling back to the username is there is an assumption when Campers set their name to public, they expect it on their certifications.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #41040 