### PR TITLE
fix(curriculum): Typo in Step 8

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/613e275749ebd008e74bb62e.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/613e275749ebd008e74bb62e.md
@@ -17,7 +17,7 @@ img {
 }
 ```
 
-In this example, `img` elements will have a minimum width of `250px`. And as the viewport grows, the image will grow accordingly to be 25 percent of the viewport width. 
+In this example, `img` elements will have a maximum width of `250px`. And as the viewport grows, the image will grow accordingly to be 25 percent of the viewport width. 
 
 Scale the image using its `id` as a selector, and setting the `width` to be the maximum of `100px` or `18vw`. 
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!-- Feel free to add any additional description of changes below this line -->

Step 8 of the `responsive-web-design/learn-accessibility-by-building-a-quiz/` course had a typo which originally said:

> In the example `img {width: max(250px, 25vw);}` img elements will have a **minimum** width of 250px. 

I believe that it was meant to say that the **maximum** width would be set at 250px instead. If i'm incorrect please close the PR without merging - I'm still learning and may be totally misunderstanding the concepts! 

Thank you team! 