### PR TITLE
chore(curriculum): add quotes to strings in JS number sorter

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/64061a98f704a014b44afdb2.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/64061a98f704a014b44afdb2.md
@@ -9,7 +9,7 @@ dashedName: step-1
 
 In this project, you will be building a number sorter. The HTML and CSS have been provided for you. Feel free to explore them.
 
-When you are ready, declare a `sortButton` variable and assign it the value of `.getElementById()` with the argument `sort`.
+When you are ready, declare a `sortButton` variable and assign it the value of `.getElementById()` with the argument `"sort"`.
 
 # --hints--
 
@@ -19,7 +19,7 @@ You should declare a `sortButton` variable with `const`.
 assert.match(code, /const\s+sortButton\s*=/);
 ```
 
-You should call `document.getElementById()` with the argument `sort`.
+You should call `document.getElementById()` with the argument `"sort"`.
 
 ```js
 assert.match(code, /document\.getElementById\(\s*('|"|`)sort\1\s*\)/);

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6406a9945fa5d23c225d31cc.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6406a9945fa5d23c225d31cc.md
@@ -7,7 +7,7 @@ dashedName: step-4
 
 # --description--
 
-To test your code as you write it, mount an event listener to your `sortButton` element. It should listen for the `click` event, and take `sortInputArray` as the callback.
+To test your code as you write it, mount an event listener to your `sortButton` element. It should listen for the `"click"` event, and take `sortInputArray` as the callback.
 
 # --hints--
 
@@ -17,7 +17,7 @@ You should call the `.addEventListener()` method on your `sortButton` element.
 assert.match(code, /sortButton\s*\.\s*addEventListener\s*\(/);
 ```
 
-Your `.addEventListener()` method should listen for the `click` event.
+Your `.addEventListener()` method should listen for the `"click"` event.
 
 ```js
 assert.match(code, /sortButton\s*\.\s*addEventListener\s*\(\s*('|"|`)click\1\s*,/);

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6406adbca6b41d3d7cef85ab.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6406adbca6b41d3d7cef85ab.md
@@ -9,11 +9,11 @@ dashedName: step-5
 
 Back in your `sortInputArray` function, you need to get the values from your `select` elements. Since they all have the class `values-dropdown`, you can query them all at once.
 
-Use `document.getElementsByClassName()` to get all the elements with the class `values-dropdown`. Assign that to an `inputValues` variable.
+Use `document.getElementsByClassName()` to get all the elements with this class by passing in the argument `"values-dropdown"`. Assign that to an `inputValues` variable with `const`.
 
 # --hints--
 
-You should use `document.getElementsByClassName()` to get all the elements with the class `values-dropdown`.
+You should use `document.getElementsByClassName()` to get all the elements with the class `"values-dropdown"`.
 
 ```js
 assert.match(sortInputArray.toString(), /document\.getElementsByClassName\(\s*('|"|`)values-dropdown\1\s*\)/);

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6410fcd1f731fd17cdb101a7.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6410fcd1f731fd17cdb101a7.md
@@ -9,7 +9,7 @@ dashedName: step-26
 
 Inside your nested `for` loop, add a `console.log()` call to check the values of `array`, `array[j]`, and `array[minIndex]` at each iteration. You can click the `Sort` button to see how your algorithm is traversing the array.
 
-Then write an `if` statement that checks if the value at `j` is smaller than the value at `minIndex`. If it is, set `minIndex` to `j`.
+Then write an `if` statement that checks if the value at `array[j]` is smaller than the value at `array[minIndex]`. If it is, set `minIndex` to `j`.
 
 # --hints--
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6411024727181d190ef03166.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6411024727181d190ef03166.md
@@ -9,7 +9,7 @@ dashedName: step-27
 
 After your nested `for` loop, you've found the smallest value. You need to swap it with your current value.
 
-Like you did in your bubble sort, use a `temp` variable to extract the value at `i`, then swap the values at `i` and `minIndex`.
+Like you did in your bubble sort, use a `temp` variable to extract the value at `array[i]`, then swap the values at `array[i]` and `array[minIndex]`.
 
 # --hints--
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6411108bc8b9c324f66aab4c.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/6411108bc8b9c324f66aab4c.md
@@ -7,7 +7,7 @@ dashedName: step-33
 
 # --description--
 
-Declare a `currValue` variable and assign it the value at `i`. Then, declare a `j` variable and assign it `i - 1`. Your `j` variable should be re-assignable.
+Declare a `currValue` variable and assign it the value at `array[i]`. Then, declare a `j` variable and assign it `i - 1`. Your `j` variable should be re-assignable.
 
 # --hints--
 
@@ -17,7 +17,7 @@ You should declare a `currValue` variable with `const`.
 assert.match(code, /const\s+insertionSort\s*=\s*(\(\s*array\s*\)|array)\s*=>\s*{\s*for\s*\(\s*let\s+i\s*=\s*1\s*;\s*i\s*<\s*array\.length\s*;\s*i\s*\+\+\s*\)\s*{\s*const\s+currValue\s*=/);
 ```
 
-You should assign `currValue` the value at `i`.
+You should assign `currValue` the value at `array[i]`.
 
 ```js
 assert.match(code, /const\s+insertionSort\s*=\s*(\(\s*array\s*\)|array)\s*=>\s*{\s*for\s*\(\s*let\s+i\s*=\s*1\s*;\s*i\s*<\s*array\.length\s*;\s*i\s*\+\+\s*\)\s*{\s*const\s+currValue\s*=\s*array\s*\[\s*i\s*\]\s*;?/);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

This PR relates to issue #51036
Specifically, it relates to the "JavaScript Algorithms and Data Structures (Beta) --> Learn Basic Algorithmic Thinking by Building a Number Sorter" curriculum

This PR makes changes to the following steps: 1, 4, 5, 26, 27, 33

- Steps 1, 4, 5: quotation marks added to clarify for campers that these are strings
- Steps 26, 27, 33: instructions slightly modified to clarify for campers that what is being referred to are the values stored at certain array positions (e.g. `array[i]`, `array[j]`, etc.), rather than the values stored in variables (e.g. `i`, `j`, etc.) that are being used to keep track of array indexes for the given sorting algorithm.