### PR TITLE
fix(api): use port 27017

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -18,13 +18,6 @@ cd tools
 docker compose up -d
 ```
 
-Once that's running, update the connection string in the `.env` file to use port `27018`.
-
-```txt
-# Database
-MONGOHQ_URL=mongodb://127.0.0.1:27018/freecodecamp?directConnection=true
-```
-
 The new db will be empty, so you can run the seed script to populate it.
 
 ```bash

--- a/api/tools/docker-compose.yml
+++ b/api/tools/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     command: mongod --replSet rs0
     restart: unless-stopped
     ports:
-      - 27018:27017
+      - 27017:27017
     volumes:
       - db-data:/data
   setup:


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

There is no reason to use a different port. Using a non-default port:
- Requires specific config to use `mongosh`/compass
- Catches me off-guard every time I switch context between old api and new api.