### PR TITLE
fix(curriculum): improved instructions for better clarity between argument and paramenter name

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a8b3cc436db8139cc5fc09.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a8b3cc436db8139cc5fc09.md
@@ -7,7 +7,7 @@ dashedName: step-61
 
 # --description--
 
-You now need to pass the `location` argument into the `update` call. You pass arguments by including them within the parentheses of the function call. For example, calling `myFunction` with an `arg` argument would look like:
+You now need to pass the `locations` array as an argument into the `location` parameter of `update` function call. You pass arguments by including them within the parentheses of the function call. For example, calling `myFunction` with an `arg` argument would look like:
 
 ```js
 myFunction(arg)


### PR DESCRIPTION
Made the instruction for STEP 61 more clear, for better understanding between `locations` as an argument and `location` as an parameter.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #54219 

<!-- Feel free to add any additional description of changes below this line -->

The issue:

Step 61 states that you need to pass `location` argument to the update() function, some users might make a mistake as `location is the name of parameter in update(), `locations` is the argument name.

So they might use: 

function goTown() {
  update(location);
}

Solution: 
Current => You now need to pass the `location` argument into the `update` call. You pass arguments by including them within the parentheses of the function call.

Change=> You now need to pass the `locations` array as an argument into the `location` parameter of `update` function call. You pass arguments by including them within the parentheses of the function call. 

