### PR TITLE
fix(a11y): hide GreenPass icon of donation modal from a11y tree

### DIFF
--- a/client/src/components/Donation/donation-text-components.tsx
+++ b/client/src/components/Donation/donation-text-components.tsx
@@ -324,15 +324,15 @@ export const ModalBenefitList = () => {
   return (
     <ul>
       <li>
-        <GreenPass aria-disabled={true} />
+        <GreenPass aria-hidden={true} />
         {t('donate.help-us-more-certifications')}
       </li>
       <li>
-        <GreenPass aria-disabled={true} />
+        <GreenPass aria-hidden={true} />
         {t('donate.remove-donation-popups')}
       </li>
       <li>
-        <GreenPass aria-disabled={true} />
+        <GreenPass aria-hidden={true} />
         {t('donate.help-millions-learn')}
       </li>
     </ul>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

The donation modal uses the `GreenPass` icon in its content:

<img width="316" alt="Screenshot 2024-03-28 at 12 24 33" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/02f13c81-5c14-4198-96b8-2820b2f659e2">

It seems to me the icon is used only for decorative purposes, so it should be removed from the accessibility tree to reduce noise. The icon label is "Passed", so having it announced to the users could also confuse them.

<!-- Feel free to add any additional description of changes below this line -->
