### PR TITLE
fix(a11y): disabled button color contrast

### DIFF
--- a/client/src/components/layouts/global.css
+++ b/client/src/components/layouts/global.css
@@ -278,8 +278,9 @@ fieldset[disabled] .btn-primary:focus,
 fieldset[disabled] .btn-primary.focus {
   cursor: not-allowed;
   background-color: var(--quaternary-background);
-  border-color: var(--quaternary-color);
-  color: var(--quaternary-color);
+  border-color: var(--gray-45);
+  color: var(--secondary-color);
+  opacity: 0.8;
 }
 
 .btn-cta {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR updates the CSS of the buttons in disabled state. The changes are based on https://github.com/freeCodeCamp/ui/pull/65.

<!-- Feel free to add any additional description of changes below this line -->
