### PR TITLE
fix(curriculum): typo on step 61

### DIFF
--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-classes-and-objects-by-building-a-sudoku-solver/6569e481e67f123ad25c5d20.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-classes-and-objects-by-building-a-sudoku-solver/6569e481e67f123ad25c5d20.md
@@ -11,7 +11,7 @@ Place the condition in an `if` statement and check if it is `None`.
 
 # --hints--
 
-You should have `if (next_empty := self.find_empty_cell()) is None:` withing `solver`.
+You should have `if (next_empty := self.find_empty_cell()) is None:` within `solver`.
 
 ```js
 const tCode = code.replace(/\r/g, '');


### PR DESCRIPTION
Typo on Step 61 of Sudoku Solver project

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #54250

<!-- Feel free to add any additional description of changes below this line -->
