### PR TITLE
refactor(client): migrate donation modal

### DIFF
--- a/client/src/components/Donation/donation-modal-body.tsx
+++ b/client/src/components/Donation/donation-modal-body.tsx
@@ -1,8 +1,8 @@
-import { Modal } from '@freecodecamp/react-bootstrap';
-import { Col, Row } from '@freecodecamp/ui';
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useFeature } from '@growthbook/growthbook-react';
+import { Col, Row, Modal } from '@freecodecamp/ui';
+
 import BearProgressModal from '../../assets/images/components/bear-progress-modal';
 import BearBlockCompletion from '../../assets/images/components/bear-block-completion-modal';
 import { closeDonationModal } from '../../redux/actions';
@@ -61,6 +61,7 @@ function ModalHeader({
   donationAnimationFlag: boolean;
 }) {
   const { t } = useTranslation();
+
   if (!showHeaderAndFooter || donationAttempted) {
     return null;
   } else if (!donationAnimationFlag) {
@@ -76,7 +77,9 @@ function ModalHeader({
               })}
             </b>
           )}
-          <h2>{t('donate.help-us-develop')}</h2>
+          <Modal.Header showCloseButton={false} borderless>
+            {t('donate.help-us-develop')}
+          </Modal.Header>
         </Col>
       </Row>
     );
@@ -84,7 +87,9 @@ function ModalHeader({
     return (
       <Row className='text-center block-modal-text'>
         <Col sm={10} smOffset={1} xs={12}>
-          <h2>{t('donate.modal-benefits-title')}</h2>
+          <Modal.Header showCloseButton={false} borderless>
+            {t('donate.modal-benefits-title')}
+          </Modal.Header>
         </Col>
       </Row>
     );
@@ -268,8 +273,8 @@ function DonationModalBody({
   }, []);
 
   return (
-    <Modal.Body>
-      <div aria-live={'polite'}>
+    <Modal.Body borderless alignment='start'>
+      <div aria-live='polite' className='donation-modal'>
         {donationAnimationFlag && isAnimationVisible ? (
           <AnimationContainer setIsAnimationVisible={setIsAnimationVisible} />
         ) : (

--- a/client/src/components/Donation/donation-modal.tsx
+++ b/client/src/components/Donation/donation-modal.tsx
@@ -1,10 +1,10 @@
-import { Modal } from '@freecodecamp/react-bootstrap';
 import { WindowLocation } from '@reach/router';
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import { goToAnchor } from 'react-scrollable-anchor';
 import { bindActionCreators, Dispatch, AnyAction } from 'redux';
 import { createSelector } from 'reselect';
+import { Modal } from '@freecodecamp/ui';
 
 import { closeDonationModal } from '../../redux/actions';
 import {
@@ -65,13 +65,7 @@ function DonateModal({
   };
 
   return (
-    <Modal
-      bsSize='lg'
-      className='donation-modal'
-      onExited={handleModalHide}
-      show={show}
-      data-cy='donation-modal'
-    >
+    <Modal size='large' onClose={handleModalHide} open={show}>
       <DonationModalBody
         closeDonationModal={closeDonationModal}
         recentlyClaimedBlock={recentlyClaimedBlock}

--- a/client/src/components/Donation/donation.css
+++ b/client/src/components/Donation/donation.css
@@ -259,10 +259,11 @@ li.disabled > a {
   }
 }
 
-.donation-modal .modal-title {
-  text-align: center;
-  font-weight: 600;
+.donation-modal h2 {
+  font-weight: 600 !important;
   font-size: 1.2rem;
+  /* TODO: Remove this rule once https://github.com/freeCodeCamp/freeCodeCamp/issues/54047 is resolved */
+  font-family: var(--font-family-sans-serif);
 }
 
 .donation-modal b {
@@ -325,11 +326,6 @@ li.disabled > a {
   text-decoration-line: none;
   background-color: var(--quaternary-background);
   color: var(--quaternary-color);
-}
-
-.donation-modal h2 {
-  font-family: var(--font-family-sans-serif);
-  font-size: 1.5rem;
 }
 
 @media (max-width: 500px) {
@@ -401,8 +397,8 @@ li.disabled > a {
     margin: 40px;
   }
 
-  .donation-modal .modal-title {
-    font-weight: 700;
+  .donation-modal h2 {
+    font-weight: 700 !important;
     font-size: 1.5rem;
   }
 }

--- a/cypress/e2e/default/learn/donate/donation-block-completion-modal.ts
+++ b/cypress/e2e/default/learn/donate/donation-block-completion-modal.ts
@@ -34,6 +34,10 @@ describe('Donate page', () => {
     projects.forEach(project => submitProject(project));
 
     // pop up modal
-    cy.get("[data-cy='donation-modal']");
+    cy.get("div[role='dialog']")
+      .contains(
+        'Help us develop free professional programming certifications for all.'
+      )
+      .should('be.visible');
   });
 });

--- a/tools/ui-components/src/modal/modal.tsx
+++ b/tools/ui-components/src/modal/modal.tsx
@@ -13,8 +13,7 @@ const TITLE_LEFT_PADDING = 24;
 const PANEL_DEFAULT_CLASSES =
   'flex flex-col border-solid border-1 border-foreground-secondary bg-background-secondary';
 
-const HEADER_DEFAULT_CLASSES =
-  'p-[15px] border-b-1 border-solid border-foreground-secondary';
+const HEADER_DEFAULT_CLASSES = 'p-[15px]';
 
 const ModalContext = createContext<Pick<ModalProps, 'onClose' | 'variant'>>({
   onClose: () => {},
@@ -24,7 +23,8 @@ const ModalContext = createContext<Pick<ModalProps, 'onClose' | 'variant'>>({
 const Header = ({
   children,
   showCloseButton = true,
-  closeButtonClassNames
+  closeButtonClassNames,
+  borderless
 }: HeaderProps) => {
   const { onClose, variant } = useContext(ModalContext);
 
@@ -32,6 +32,13 @@ const Header = ({
 
   if (variant === 'danger') {
     classes = classes.concat(' ', 'bg-foreground-danger');
+  }
+
+  if (!borderless) {
+    classes = classes.concat(
+      ' ',
+      'border-b-1 border-solid border-foreground-secondary'
+    );
   }
 
   if (showCloseButton) {
@@ -58,11 +65,13 @@ const Header = ({
   );
 };
 
-const Body = ({ children, alignment = 'center' }: BodyProps) => {
+const Body = ({ children, alignment = 'center', borderless }: BodyProps) => {
+  const borderClasses = borderless
+    ? ''
+    : 'border-b-1 border-solid border-foreground-secondary';
+
   return (
-    <div
-      className={`p-[15px] border-b-1 border-solid border-foreground-secondary text-${alignment}`}
-    >
+    <div className={`p-[15px] text-${alignment} ${borderClasses}`}>
       {children}
     </div>
   );

--- a/tools/ui-components/src/modal/types.ts
+++ b/tools/ui-components/src/modal/types.ts
@@ -21,6 +21,7 @@ export interface HeaderProps {
    * Tracking issue: https://github.com/freeCodeCamp/freeCodeCamp/issues/52715
    */
   closeButtonClassNames?: string;
+  borderless?: boolean;
 }
 
 export interface BodyProps {
@@ -31,6 +32,7 @@ export interface BodyProps {
    * Use `left` if the modal body contains code blocks.
    */
   alignment?: 'center' | 'left' | 'start';
+  borderless?: boolean;
 }
 
 export interface FooterProps {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR:
- Adds `borderless` prop to the Modal component, in order to display the donation modal properly
- Migrates the donation modal to `ui-components`
- Is related to #52759

## Screenshots

The PR includes some CSS cleanup, so I thought I should add some screenshots (to show that the display is unchanged).

| Desktop | Mobile |
| --- | --- |
| <img width="953" alt="Screenshot 2024-04-01 at 22 35 39" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/318614b4-17cf-49ec-96ef-6b8a19107877"> | <img width="441" alt="Screenshot 2024-04-01 at 22 36 54" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/996875f8-0d2c-4360-912c-248f867f18c5"> |

<!-- Feel free to add any additional description of changes below this line -->
