### PR TITLE
test: check for navigation, not text

### DIFF
--- a/cypress/e2e/default/learn/challenges/projects.ts
+++ b/cypress/e2e/default/learn/challenges/projects.ts
@@ -112,11 +112,14 @@ describe('project submission', () => {
             return challenges.find(({ title }) => title === projectTitle);
           }) as Challenge[];
 
-          // We need to wait for everything to finish loading and hydrating, so we
-          // use this text as a proxy for that.
-          const textInNextPage = projectTitles.slice(1);
-          // The following text exists on the donation modal
-          textInNextPage.push('Nicely done');
+          const expectedPaths = projectsInOrder
+            .slice(1)
+            .map(({ block, superBlock, dashedName }) => {
+              return `/learn/${superBlock}/${block}/${dashedName}`;
+            });
+          expectedPaths.push(
+            `/learn/javascript-algorithms-and-data-structures/`
+          );
 
           projectsInOrder.forEach(
             ({ block, superBlock, dashedName, solutions }, i) => {
@@ -139,7 +142,7 @@ describe('project submission', () => {
                   cy.contains('Submit and go to next challenge', {
                     timeout: 16000
                   }).click();
-                  cy.contains(textInNextPage[i]);
+                  cy.url().should('include', expectedPaths[i]);
                 });
               });
             }


### PR DESCRIPTION
This test is still doing too much, but this change makes it more
focused. It doesn't matter (for this test) what text is in the page,
just that it's navigated to the right page.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->
