### PR TITLE
fix(tools): make the editing steps tool keep the challenge type

### DIFF
--- a/tools/challenge-helper-scripts/commands.ts
+++ b/tools/challenge-helper-scripts/commands.ts
@@ -41,10 +41,12 @@ function insertStep(stepNum: number): void {
     throw `Step not inserted. New step number must be less than ${
       challengeOrder.length + 2
     }.`;
-  const challengeType =
-    (getMetaData().superBlock as SuperBlocks) === SuperBlocks.SciCompPy
-      ? challengeTypes.python
-      : challengeTypes.html;
+  const challengeType = [
+    SuperBlocks.SciCompPy,
+    SuperBlocks.UpcomingPython
+  ].includes(getMetaData().superBlock)
+    ? challengeTypes.python
+    : challengeTypes.html;
 
   const challengeSeeds =
     stepNum > 1
@@ -70,10 +72,12 @@ function createEmptySteps(num: number): void {
   }
 
   const nextStepNum = getMetaData().challengeOrder.length + 1;
-  const challengeType =
-    (getMetaData().superBlock as SuperBlocks) === SuperBlocks.SciCompPy
-      ? challengeTypes.python
-      : challengeTypes.html;
+  const challengeType = [
+    SuperBlocks.SciCompPy,
+    SuperBlocks.UpcomingPython
+  ].includes(getMetaData().superBlock)
+    ? challengeTypes.python
+    : challengeTypes.html;
 
   for (let stepNum = nextStepNum; stepNum < nextStepNum + num; stepNum++) {
     const stepId = createStepFile({ stepNum, challengeType });

--- a/tools/challenge-helper-scripts/commands.ts
+++ b/tools/challenge-helper-scripts/commands.ts
@@ -1,4 +1,6 @@
 import fs from 'fs';
+import { SuperBlocks } from '../../shared/config/superblocks';
+import { challengeTypes } from '../../shared/config/challenge-types';
 import { getProjectPath } from './helpers/get-project-info';
 import { getMetaData, updateMetaData } from './helpers/project-metadata';
 import { getChallengeOrderFromFileTree } from './helpers/get-challenge-order';
@@ -39,6 +41,10 @@ function insertStep(stepNum: number): void {
     throw `Step not inserted. New step number must be less than ${
       challengeOrder.length + 2
     }.`;
+  const challengeType =
+    (getMetaData().superBlock as SuperBlocks) === SuperBlocks.SciCompPy
+      ? challengeTypes.python
+      : challengeTypes.html;
 
   const challengeSeeds =
     stepNum > 1
@@ -49,6 +55,7 @@ function insertStep(stepNum: number): void {
 
   const stepId = createStepFile({
     stepNum,
+    challengeType,
     challengeSeeds
   });
 
@@ -63,9 +70,13 @@ function createEmptySteps(num: number): void {
   }
 
   const nextStepNum = getMetaData().challengeOrder.length + 1;
+  const challengeType =
+    (getMetaData().superBlock as SuperBlocks) === SuperBlocks.SciCompPy
+      ? challengeTypes.python
+      : challengeTypes.html;
 
   for (let stepNum = nextStepNum; stepNum < nextStepNum + num; stepNum++) {
-    const stepId = createStepFile({ stepNum });
+    const stepId = createStepFile({ stepNum, challengeType });
     insertStepIntoMeta({ stepNum, stepId });
   }
   console.log(`Successfully added ${num} steps`);

--- a/tools/challenge-helper-scripts/create-project.ts
+++ b/tools/challenge-helper-scripts/create-project.ts
@@ -164,6 +164,7 @@ async function createFirstChallenge(
   return createStepFile({
     projectPath: newChallengeDir + '/',
     stepNum: 1,
+    challengeType: 0,
     challengeSeeds
   });
 }

--- a/tools/challenge-helper-scripts/helpers/get-step-template.test.ts
+++ b/tools/challenge-helper-scripts/helpers/get-step-template.test.ts
@@ -48,7 +48,8 @@ Test 1
           tail: ''
         }
       },
-      stepNum: 5
+      stepNum: 5,
+      challengeType: 0
     };
 
     expect(getStepTemplate(props)).toEqual(baseOutput);

--- a/tools/challenge-helper-scripts/helpers/get-step-template.ts
+++ b/tools/challenge-helper-scripts/helpers/get-step-template.ts
@@ -24,6 +24,7 @@ type StepOptions = {
   challengeId: ObjectID;
   challengeSeeds: Record<string, ChallengeSeed>;
   stepNum: number;
+  challengeType: number;
 };
 
 export interface ChallengeSeed {
@@ -38,7 +39,8 @@ export interface ChallengeSeed {
 function getStepTemplate({
   challengeId,
   challengeSeeds,
-  stepNum
+  stepNum,
+  challengeType
 }: StepOptions): string {
   const seedTexts = Object.values(challengeSeeds)
     .map(({ contents, ext, editableRegionBoundaries }: ChallengeSeed) => {
@@ -69,7 +71,7 @@ function getStepTemplate({
     `---
 id: ${challengeId.toString()}
 title: Step ${stepNum}
-challengeType: 0
+challengeType: ${challengeType}
 dashedName: step-${stepNum}
 ---
 

--- a/tools/challenge-helper-scripts/utils.test.ts
+++ b/tools/challenge-helper-scripts/utils.test.ts
@@ -55,7 +55,8 @@ describe('Challenge utils helper scripts', () => {
       );
       process.env.CALLING_DIR = projectPath;
       const step = createStepFile({
-        stepNum: 3
+        stepNum: 3,
+        challengeType: 0
       });
 
       // eslint-disable-next-line @typescript-eslint/no-base-to-string

--- a/tools/challenge-helper-scripts/utils.ts
+++ b/tools/challenge-helper-scripts/utils.ts
@@ -13,12 +13,14 @@ import {
 
 interface Options {
   stepNum: number;
+  challengeType: number;
   projectPath?: string;
   challengeSeeds?: Record<string, ChallengeSeed>;
 }
 
 const createStepFile = ({
   stepNum,
+  challengeType,
   projectPath = getProjectPath(),
   challengeSeeds = {}
 }: Options): ObjectID => {
@@ -27,7 +29,8 @@ const createStepFile = ({
   const template = getStepTemplate({
     challengeId,
     challengeSeeds,
-    stepNum
+    stepNum,
+    challengeType
   });
 
   // eslint-disable-next-line @typescript-eslint/no-base-to-string


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #54296

<!-- Feel free to add any additional description of changes below this line -->
This PR was opened to make the editing steps tool keep the `challengeType` when the curriculum developers use the  "Create Next Step", "Create Empty Steps", or "Insert Step" button.

The code was tested locally, using Windows 11 Home PC with Chrome.