### PR TITLE
fix: never flush logs after executing tests

### DIFF
--- a/client/src/templates/Challenges/redux/execute-challenge-saga.js
+++ b/client/src/templates/Challenges/redux/execute-challenge-saga.js
@@ -241,24 +241,24 @@ function* executeTests(testRunner, tests, testTimeout = 5000) {
 // updates preview frame and the fcc console.
 export function* previewChallengeSaga(action) {
   const flushLogs = action?.type !== actionTypes.previewMounted;
-  yield delay(700);
-
   const isBuildEnabled = yield select(isBuildEnabledSelector);
   if (!isBuildEnabled) {
     return;
   }
 
+  const isExecuting = yield select(isExecutingSelector);
+  // executeChallengeSaga flushes the logs, so there's no need to if that's
+  // just happened.
+  if (flushLogs && !isExecuting) {
+    yield put(initLogs());
+    yield put(initConsole(''));
+  }
+  yield delay(700);
+
   const logProxy = yield channel();
   const proxyLogger = args => logProxy.put(args);
 
   try {
-    const isExecuting = yield select(isExecutingSelector);
-    // executeChallengeSaga flushes the logs, so there's no need to if that's
-    // just happened.
-    if (flushLogs && !isExecuting) {
-      yield put(initLogs());
-      yield put(initConsole(''));
-    }
     yield fork(takeEveryConsole, logProxy);
 
     const challengeData = yield select(challengeDataSelector);


### PR DESCRIPTION
The delay(700) meant that a previewChallengeSaga could be queued up
before executeCancellableChallengeSaga and still resolve after it.

In practice, this meant that users who made code edits and
immediately ran tests would see the console show the running tests and
then reset

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->

This should stop the tests randomly failing, too: https://github.com/freeCodeCamp/freeCodeCamp/actions/runs/8620112740/job/23626566971?pr=54336#step:14:89

Example of the failure:
![editor console returns to default after tests finish](https://github.com/freeCodeCamp/freeCodeCamp/assets/15801806/4ce58ca1-f294-4a59-9697-b1430a119d8e)

To reproduce press space then immediately `ctrl + enter` while the editor is focused. It should not be possible with these changes. 