### PR TITLE
fix: modified tests for step 10 of building a spam filter

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-regular-expressions-by-building-a-spam-filter/641cf198ec366c33d6504854.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-regular-expressions-by-building-a-spam-filter/641cf198ec366c33d6504854.md
@@ -23,12 +23,14 @@ Your `helpRegex` should match the string `please help`.
 
 ```js
 assert.match('please help', helpRegex);
+assert.isTrue(helpRegex.toString().includes('please help'));
 ```
 
 Your `helpRegex` should match the string `assist me`.
 
 ```js
 assert.match('assist me', helpRegex);
+assert.isTrue(helpRegex.toString().includes('assist me'));
 ```
 
 # --seed--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-regular-expressions-by-building-a-spam-filter/641cf198ec366c33d6504854.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-regular-expressions-by-building-a-spam-filter/641cf198ec366c33d6504854.md
@@ -32,7 +32,7 @@ Your `helpRegex` should match the string `assist me`.
 ```js
 assert.match('assist me', helpRegex);
 const splitRegex = helpRegex.toString().split(/[\/|]/);
-assert.isTrue(splitRegex.indexOf('assist me') != -1);
+assert.include(splitRegex, 'assist me');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-regular-expressions-by-building-a-spam-filter/641cf198ec366c33d6504854.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-regular-expressions-by-building-a-spam-filter/641cf198ec366c33d6504854.md
@@ -24,7 +24,7 @@ Your `helpRegex` should match the string `please help`.
 ```js
 assert.match('please help', helpRegex);
 const splitRegex = helpRegex.toString().split(/[\/|]/);
-assert.isTrue(splitRegex.indexOf('please help') != -1);
+assert.include(splitRegex, 'please help');
 ```
 
 Your `helpRegex` should match the string `assist me`.

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-regular-expressions-by-building-a-spam-filter/641cf198ec366c33d6504854.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-regular-expressions-by-building-a-spam-filter/641cf198ec366c33d6504854.md
@@ -23,14 +23,16 @@ Your `helpRegex` should match the string `please help`.
 
 ```js
 assert.match('please help', helpRegex);
-assert.isTrue(helpRegex.toString().includes('please help'));
+const splitRegex = helpRegex.toString().split(/[\/|]/);
+assert.isTrue(splitRegex.indexOf('please help') != -1);
 ```
 
 Your `helpRegex` should match the string `assist me`.
 
 ```js
 assert.match('assist me', helpRegex);
-assert.isTrue(helpRegex.toString().includes('assist me'));
+const splitRegex = helpRegex.toString().split(/[\/|]/);
+assert.isTrue(splitRegex.indexOf('assist me') != -1);
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #54337 

<!-- Feel free to add any additional description of changes below this line -->

Added checks to prevent step 10 of building a spam filter from passing if left-hand or right-hand side of `|` is empty

<img width="1440" alt="Screen Shot 2024-04-11 at 5 07 25 PM" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/62906996/6147e8c5-92ca-403a-b70e-ddbe8577b0c2">


