### PR TITLE
fix: prevent false matches in step 10 spam

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-regular-expressions-by-building-a-spam-filter/641cf198ec366c33d6504854.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-regular-expressions-by-building-a-spam-filter/641cf198ec366c33d6504854.md
@@ -23,12 +23,20 @@ Your `helpRegex` should match the string `please help`.
 
 ```js
 assert.match('please help', helpRegex);
+assert.isTrue(helpRegex.toString().includes('please help'));
 ```
 
 Your `helpRegex` should match the string `assist me`.
 
 ```js
 assert.match('assist me', helpRegex);
+assert.isTrue(helpRegex.toString().includes('assist me'));
+```
+
+Your `helpRegex` should not match the string `question me`.
+
+```js
+assert.notMatch('question me', helpRegex);
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #54337

<!-- Feel free to add any additional description of changes below this line -->
I decided the best way to combat this type of unintentional behavior is to make sure that something doesn't actually match. Hence the new case. After that I had noticed I was only able to pass by matching "assist" and the problem is the question wants to the camper to match the whole thing. So I decided to make sure the regex actually included the whole phrase. 