### PR TITLE
fix(curriculum): typo in step 47 of binary converter project

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-recursion-by-building-a-decimal-to-binary-converter/645cbb5ab1296e49946adb6e.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-recursion-by-building-a-decimal-to-binary-converter/645cbb5ab1296e49946adb6e.md
@@ -9,7 +9,7 @@ dashedName: step-47
 
 In computer science, a <dfn>stack</dfn> is a data structure where items are stored in a <dfn>LIFO</dfn> (last-in-first-out) manner. If you imagine a stack of books, the last book you add to the stack is the first book you can take off the stack. Or an array where you can only `.push()` and `.pop()` elements.
 
-The <dfn>call stack</dfn> is a collection of function calls stored in a stack structure. When you call a function, it is added to the top or of the stack, and when it returns, it is removed from the top / end of the stack.
+The <dfn>call stack</dfn> is a collection of function calls stored in a stack structure. When you call a function, it is added to the top of the stack, and when it returns, it is removed from the top / end of the stack.
 
 You'll see this in action by creating mock call stack.
 


### PR DESCRIPTION
Requesting to remove a typo to clear potential confusion: 

At line 12:
Before removing "or":
"...When you call a function, it is added to the top or of the stack..."

After removing "or": 
"When you call a function, it is added to the top of the stack..."

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
