### PR TITLE
fix(client): forum search link for English challenges missing block name

### DIFF
--- a/client/src/templates/Challenges/components/help-modal.test.tsx
+++ b/client/src/templates/Challenges/components/help-modal.test.tsx
@@ -1,0 +1,36 @@
+import { generateSearchLink } from './help-modal';
+
+describe('generateSearchLink', () => {
+  it("should return a link with search query containing block name and challenge title if the title includes 'step'", () => {
+    const link = generateSearchLink(
+      'Step 10',
+      'learn-basic-javascript-by-building-a-role-playing-game'
+    );
+
+    expect(link).toBe(
+      'https://forum.freecodecamp.org/search?q=learn%20basic%20javascript%20by%20building%20a%20role%20playing%20game%20-%20Step%2010'
+    );
+  });
+
+  it("should return a link with search query containing block name and challenge title if the title includes 'task'", () => {
+    const link = generateSearchLink(
+      'Task 10',
+      'learn-greetings-in-your-first-day-at-the-office'
+    );
+
+    expect(link).toBe(
+      'https://forum.freecodecamp.org/search?q=learn%20greetings%20in%20your%20first%20day%20at%20the%20office%20-%20Task%2010'
+    );
+  });
+
+  it("should return a link with search query containing only challenge title if the title does not include 'step' or 'task'", () => {
+    const link = generateSearchLink(
+      'Perform Basic String Formatting in C#',
+      'write-your-first-code-using-c-sharp'
+    );
+
+    expect(link).toBe(
+      'https://forum.freecodecamp.org/search?q=Perform%20Basic%20String%20Formatting%20in%20C%23'
+    );
+  });
+});

--- a/client/src/templates/Challenges/components/help-modal.tsx
+++ b/client/src/templates/Challenges/components/help-modal.tsx
@@ -34,10 +34,10 @@ const mapDispatchToProps = (dispatch: Dispatch) =>
     dispatch
   );
 
-const generateSearchLink = (title: string, block: string) => {
+export const generateSearchLink = (title: string, block: string) => {
   const blockWithoutHyphens = block.replace(/-/g, ' ');
 
-  const query = /^step\s*\d*$/i.test(title)
+  const query = /^(step|task)\s*\d*$/i.test(title)
     ? encodeURIComponent(`${blockWithoutHyphens} - ${title}`)
     : encodeURIComponent(title);
   const search = `${forumLocation}/search?q=${query}`;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

When I was testing #54294 locally, I noticed that the forum search link for English challenges aren't containing block name. I think we forgot to update the function when we renamed English challenges from "Step" to "Task".

This PR fixes the issue, and also adds unit tests to prevent regression.

## Testing

- Go to /learn/a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/task-6
- Click the "Ask for Help" button
- Check the forum search link



<!-- Feel free to add any additional description of changes below this line -->
