### PR TITLE
fix(curriculum): correct instructions, add quotes around value

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-asynchronous-programming-by-building-an-fcc-forum-leaderboard/645f7879ebbdb201892e55e1.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-asynchronous-programming-by-building-an-fcc-forum-leaderboard/645f7879ebbdb201892e55e1.md
@@ -9,11 +9,11 @@ dashedName: step-61
 
 Next, you will construct the `userAvatarUrl`.
 
-Start by creating a constant called `userAvatarUrl`. Then use a `ternary` operator to check if `avatar` starts with `/user_avatar/`. 
+Start by creating a constant called `userAvatarUrl`. Then use a `ternary` operator to check if `avatar` starts with `"/user_avatar/"`. 
 
-If so, use the `concat` method to concatenate `avatarUrl` to `avatar`. Otherwise return `avatar`.
+If so, use the `concat` method to concatenate `avatar` to `avatarUrl`. Otherwise return `avatar`.
 
-This will ensure the avatar URL is correctly formed whether it's a relative or absolute URL. 
+This will ensure the avatar URL is correctly formed whether it's a relative or absolute URL.
 
 # --hints--
 
@@ -23,7 +23,7 @@ You should have a constant named `userAvatarUrl`.
 assert(code.match(/const\s+userAvatarUrl\s*=/));
 ```
 
-You should assign a `ternary` operator to the `userAvatarUrl`. Your `ternary` should check if `avatar` starts with `/user_avatar/` and return `avatarUrl.concat(avatar)` or `avatar`.
+Your `ternary` should check if `avatar` starts with `"/user_avatar/"` and return `avatarUrl.concat(avatar)` or `avatar`.
 
 ```js
 assert(code.match(/const\s+userAvatarUrl\s*=\s*(?:avatar\.startsWith\(\s*('|")\/user_avatar\/\1\s*\)|\/\^\\\/user_avatar\\\/\/\.test\(\s*avatar\s*\))\s*\?\s*avatarUrl\.concat\(\s*avatar\s*\)\s*:\s*avatar/));


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

- Add quotes around the value to be used with `startsWith` in the instructions.
- Correct `concat` instructions, they are backward. The argument to `concat` is the string being concatenated to the string the method is called on.
- Removed part of the hint text as it was worded strangely and seemed unnecessary.