### PR TITLE
fix(api): consistent responses from certificate/showCert

### DIFF
--- a/api/src/routes/certificate.test.ts
+++ b/api/src/routes/certificate.test.ts
@@ -627,6 +627,25 @@ describe('certificate routes', () => {
         });
         expect(response.status).toBe(200);
       });
+
+      test('should return cert-not-found if there is no cert with that slug', async () => {
+        const response = await superRequest(
+          '/certificate/showCert/foobar/not-a-valid-cert-slug',
+          {
+            method: 'GET'
+          }
+        );
+        expect(response.body).toEqual({
+          messages: [
+            {
+              type: 'info',
+              message: 'flash.cert-not-found',
+              variables: { certSlug: 'not-a-valid-cert-slug' }
+            }
+          ]
+        });
+        expect(response.status).toBe(404);
+      });
     });
   });
 });

--- a/api/src/routes/certificate.ts
+++ b/api/src/routes/certificate.ts
@@ -307,9 +307,13 @@ export const unprotectedCertificateRoutes: FastifyPluginCallbackTypebox = (
         if (!isKnownCertSlug(certSlug)) {
           void reply.code(404);
           return reply.send({
-            type: 'info',
-            message: 'flash.cert-not-found',
-            variables: { certSlug }
+            messages: [
+              {
+                type: 'info',
+                message: 'flash.cert-not-found',
+                variables: { certSlug }
+              }
+            ]
           });
         }
 

--- a/api/src/routes/certificate.ts
+++ b/api/src/routes/certificate.ts
@@ -19,7 +19,6 @@ import {
 } from '../../../shared/config/certification-settings';
 import { normalizeChallenges, removeNulls } from '../utils/normalize';
 import { SHOW_UPCOMING_CHANGES } from '../utils/env';
-import { formatCertificationValidation } from '../utils/error-formatting';
 
 const {
   legacyFrontEndChallengeId,
@@ -287,15 +286,7 @@ export const unprotectedCertificateRoutes: FastifyPluginCallbackTypebox = (
   fastify.get(
     '/certificate/showCert/:username/:certSlug',
     {
-      schema: schemas.certSlug,
-      errorHandler(error, request, reply) {
-        if (error.validation) {
-          void reply.code(400);
-          return formatCertificationValidation(error.validation);
-        } else {
-          fastify.errorHandler(error, request, reply);
-        }
-      }
+      schema: schemas.certSlug
     },
     async (req, reply) => {
       try {

--- a/api/src/schemas/certificate/cert-slug.ts
+++ b/api/src/schemas/certificate/cert-slug.ts
@@ -113,11 +113,15 @@ export const certSlug = {
       message: Type.String()
     }),
     404: Type.Object({
-      message: Type.Literal('flash.cert-not-found'),
-      type: Type.Literal('info'),
-      variables: Type.Object({
-        certSlug: Type.String()
-      })
+      messages: Type.Array(
+        Type.Object({
+          message: Type.Literal('flash.cert-not-found'),
+          type: Type.Literal('info'),
+          variables: Type.Object({
+            certSlug: Type.String()
+          })
+        })
+      )
     }),
     500: Type.Object({
       type: Type.Literal('danger'),

--- a/api/src/schemas/certificate/cert-slug.ts
+++ b/api/src/schemas/certificate/cert-slug.ts
@@ -108,10 +108,6 @@ export const certSlug = {
         )
       })
     ]),
-    400: Type.Object({
-      type: Type.Literal('error'),
-      message: Type.String()
-    }),
     404: Type.Object({
       messages: Type.Array(
         Type.Object({

--- a/api/src/utils/error-formatting.ts
+++ b/api/src/utils/error-formatting.ts
@@ -1,7 +1,4 @@
 import { ErrorObject } from 'ajv';
-import { certTypes } from '../../../shared/config/certification-settings';
-
-type CertLogs = (typeof certTypes)[keyof typeof certTypes];
 
 type FormattedError = {
   type: 'error';
@@ -48,30 +45,6 @@ export const formatProjectCompletedValidation = (
         type: 'error',
         message: 'That does not appear to be a valid challenge submission.'
       };
-};
-
-/**
- * Format validation errors for /project-completed.
- *
- * @param errors An array of validation errors.
- * @returns Formatted errors that can be used in the response.
- */
-export const formatCertificationValidation = (
-  errors: ErrorObject[]
-): FormattedError => {
-  const error = getError(errors);
-
-  return error.instancePath === '' &&
-    Object.values(certTypes).includes(error.params.missingProperty as CertLogs)
-    ? ({
-        type: 'error',
-        message:
-          'You have not provided the valid param for us to display the certification.'
-      } as const)
-    : ({
-        type: 'error',
-        message: 'That does not appear to be a valid certification request.'
-      } as const);
 };
 
 /**


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Since https://github.com/freeCodeCamp/freeCodeCamp/pull/50515/ introduced `flash.cert-not-found` to the translations, the client can already handle the new response, so I fixed it, rather than removed it.

The parameter validation is a little odd, because normally if the request validation failed it would be because the client made a bad request. In this case it would happen if we had made a mistake in the definition of the route. For example:

```ts
fastify.get('/certificate/showCert/:bad/:wrong', ...
```

would create a validation error. However, we don't need to create a response for this, because it won't happen in practice. It could, in principle, but every test would fail if we tried.


<!-- Feel free to add any additional description of changes below this line -->
