### PR TITLE
fix(curriculum) : allow a and b to be cast as numbers in step 41 of num sort

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/641130423e5f512d8972dae1.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/641130423e5f512d8972dae1.md
@@ -7,9 +7,11 @@ dashedName: step-40
 
 # --description--
 
-Notice how the `10` value is placed at the beginning of the array. This is because the default behavior of `.sort()` is to convert the values to strings, and sort them alphabetically. And `10` comes before `2` alphabetically.
+Notice how the number `10` is placed at the beginning of the array. This is because the default behavior of `.sort()` is to convert the numbers values to strings, and sort them alphabetically. And `10` comes before `2` alphabetically.
 
-To fix this, you can pass a callback function to the `.sort()` method. The callback function has two parameters - for yours, use `a` and `b`. Leave the function empty for now.
+To fix this, you can pass a callback function to the `.sort()` method. The callback function has two parameters - for yours, use `a` and `b`. The parameters of `a` and `b` represent the number values in the array that will be sorted.
+
+Leave the function empty for now.
 
 # --hints--
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/64113124efd2852edafaf25f.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-algorithmic-thinking-by-building-a-number-sorter/64113124efd2852edafaf25f.md
@@ -26,7 +26,7 @@ assert.match(code, /const\s+sortedValues\s*=\s*inputValues\s*\.\s*sort\s*\(\s*\(
 Your callback function should return `a - b`.
 
 ```js
-assert.match(code, /const\s+sortedValues\s*=\s*inputValues\s*\.\s*sort\s*\(\s*\(\s*a\s*,\s*b\s*\)\s*=>\s*{\s*return\s+a\s*-\s*b\s*;?\s*}\s*\)/);
+assert.match(code, /const\s+sortedValues\s*=\s*inputValues\s*\.\s*sort\s*\(\s*\(\s*a\s*,\s*b\s*\)\s*=>\s*{\s*return\s+(?:parseInt)?(?:Number)?\(?a\)?\s*-\s*(?:parseInt)?(?:Number)?\(?b\)?\s*;?\s*}\s*\)/);
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #54420

<!-- Feel free to add any additional description of changes below this line -->
In my opinion the following answers should be allowed. 

`a` and `b` both wrapped in parentheses. 

```
 const sortedValues = inputValues.sort((a, b) => {
    return (a - b);
  });
```


Our default solution. 

```
 const sortedValues = inputValues.sort((a, b) => {
    return a - b;
  });
```

`a` and `b` parsed as integers. 

```
 const sortedValues = inputValues.sort((a, b) => {
    return parseInt(a) - parseInt(b);
  });
```

`a` and `b` used as arguments in the Number function. 

```
 const sortedValues = inputValues.sort((a, b) => {
    return Number(a) - Number(b);
  });
```

This pull request covers all four test cases that should be expected to pass. 