### PR TITLE
fix(curriculum): feedback heading in english challenge

### DIFF
--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657b05367b59300bcb5f18ef.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657b05367b59300bcb5f18ef.md
@@ -31,7 +31,7 @@ Listen to the audio to complete the sentence below.
 
 `Are`
 
-## --feedback--
+### --feedback--
 
 You use this form of `to be` when asking about more than one person or directly to someone as `you`.
 


### PR DESCRIPTION
Enter the wrong answer in [this challenge,](https://www.freecodecamp.org/learn/a2-english-for-developers/learn-conversation-starters-in-the-break-room/task-1) and you will get the default feedback: "Sorry, that's not the right answer. Give it another try?"

This fixes that, and gives the feedback provided when you enter the wrong answer.

I did a search and didn't find any others with headings like this.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
