### PR TITLE
fix(client): handle pure js challenges in multifile editor

### DIFF
--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -239,13 +239,13 @@ function ShowClassic({
   // TODO: show preview should NOT be computed like this. That determination is
   // made during the build (at least twice!). It should be either a prop or
   // computed from challengeType
-  const showPreview =
-    challengeType === challengeTypes.html ||
-    challengeType === challengeTypes.modern ||
-    challengeType === challengeTypes.multifileCertProject ||
-    challengeType === challengeTypes.multifilePythonCertProject ||
-    challengeType === challengeTypes.python;
-
+  const showPreview = [
+    challengeTypes.html,
+    challengeTypes.modern,
+    challengeTypes.multifileCertProject,
+    challengeTypes.multifilePythonCertProject,
+    challengeTypes.python
+  ].includes(challengeType);
   const getLayoutState = () => {
     const reflexLayout = store.get(REFLEX_LAYOUT) as ReflexLayout;
 

--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -240,12 +240,11 @@ function ShowClassic({
   // made during the build (at least twice!). It should be either a prop or
   // computed from challengeType
   const showPreview =
-    (challengeType === challengeTypes.html ||
-      challengeType === challengeTypes.modern ||
-      challengeType === challengeTypes.multifileCertProject ||
-      challengeType === challengeTypes.multifilePythonCertProject ||
-      challengeType === challengeTypes.python) &&
-    !showConsole;
+    challengeType === challengeTypes.html ||
+    challengeType === challengeTypes.modern ||
+    challengeType === challengeTypes.multifileCertProject ||
+    challengeType === challengeTypes.multifilePythonCertProject ||
+    challengeType === challengeTypes.python;
 
   const getLayoutState = () => {
     const reflexLayout = store.get(REFLEX_LAYOUT) as ReflexLayout;

--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -234,8 +234,7 @@ function ShowClassic({
     `intro:${superBlock}.blocks.${block}.title`
   )}: ${title}`;
   const windowTitle = `${blockNameTitle} | freeCodeCamp.org`;
-  const showConsole =
-    block === 'learn-introductory-javascript-by-building-a-pyramid-generator';
+  const showConsole = challengeType === challengeTypes.js;
   // TODO: show preview should NOT be computed like this. That determination is
   // made during the build (at least twice!). It should be either a prop or
   // computed from challengeType

--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -512,7 +512,7 @@ function ShowClassic({
         <HelpModal challengeTitle={title} challengeBlock={blockName} />
         <VideoModal videoUrl={videoUrl} />
         <ResetModal />
-        {showPreview && (
+        {showProjectPreview && (
           <ProjectPreviewModal
             challengeData={challengeData}
             closeText={t('buttons.start-coding')}

--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -512,14 +512,12 @@ function ShowClassic({
         <HelpModal challengeTitle={title} challengeBlock={blockName} />
         <VideoModal videoUrl={videoUrl} />
         <ResetModal />
-        {showProjectPreview && (
-          <ProjectPreviewModal
-            challengeData={challengeData}
-            closeText={t('buttons.start-coding')}
-            previewTitle={t('learn.project-preview-title')}
-            showProjectPreview={showProjectPreview}
-          />
-        )}
+        <ProjectPreviewModal
+          challengeData={challengeData}
+          closeText={t('buttons.start-coding')}
+          previewTitle={t('learn.project-preview-title')}
+          showProjectPreview={showProjectPreview}
+        />
         <ShortcutsModal />
       </LearnLayout>
     </Hotkeys>

--- a/client/utils/gatsby/challenge-page-creator.js
+++ b/client/utils/gatsby/challenge-page-creator.js
@@ -169,10 +169,13 @@ function getProjectPreviewConfig(challenge, allChallengeEdges) {
     showProjectPreview:
       challengeOrder === 0 &&
       usesMultifileEditor &&
+      // TODO: handle the special cases better. Create a meta property for
+      // showProjectPreview, maybe? Then we can remove all the following cases
       challengeType !== challengeTypes.multifileCertProject &&
       challengeType !== challengeTypes.multifilePythonCertProject &&
       // TODO: revert this to enable project previews for python challenges
-      challengeType !== challengeTypes.python,
+      challengeType !== challengeTypes.python &&
+      block !== 'learn-introductory-javascript-by-building-a-pyramid-generator',
     challengeData: {
       challengeType: lastChallenge.challengeType,
       challengeFiles: projectPreviewChallengeFiles

--- a/client/utils/gatsby/challenge-page-creator.js
+++ b/client/utils/gatsby/challenge-page-creator.js
@@ -174,8 +174,7 @@ function getProjectPreviewConfig(challenge, allChallengeEdges) {
       challengeType !== challengeTypes.multifileCertProject &&
       challengeType !== challengeTypes.multifilePythonCertProject &&
       // TODO: revert this to enable project previews for python challenges
-      challengeType !== challengeTypes.python &&
-      block !== 'learn-introductory-javascript-by-building-a-pyramid-generator',
+      challengeType !== challengeTypes.python,
     challengeData: {
       challengeType: lastChallenge.challengeType,
       challengeFiles: projectPreviewChallengeFiles

--- a/client/utils/gatsby/challenge-page-creator.js
+++ b/client/utils/gatsby/challenge-page-creator.js
@@ -173,8 +173,8 @@ function getProjectPreviewConfig(challenge, allChallengeEdges) {
       // showProjectPreview, maybe? Then we can remove all the following cases
       challengeType !== challengeTypes.multifileCertProject &&
       challengeType !== challengeTypes.multifilePythonCertProject &&
-      // TODO: revert this to enable project previews for python challenges
-      challengeType !== challengeTypes.python,
+      challengeType !== challengeTypes.python &&
+      challengeType !== challengeTypes.js,
     challengeData: {
       challengeType: lastChallenge.challengeType,
       challengeFiles: projectPreviewChallengeFiles

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660ee6e3a242da6bd579de69.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660ee6e3a242da6bd579de69.md
@@ -1,7 +1,7 @@
 ---
 id: 660ee6e3a242da6bd579de69
 title: Step 1
-challengeType: 0
+challengeType: 1
 dashedName: step-1
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660eebd83100d37862268781.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660eebd83100d37862268781.md
@@ -1,7 +1,7 @@
 ---
 id: 660eebd83100d37862268781
 title: Step 2
-challengeType: 0
+challengeType: 1
 dashedName: step-2
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660ef0f7c4b8e68ccd1f0786.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660ef0f7c4b8e68ccd1f0786.md
@@ -1,7 +1,7 @@
 ---
 id: 660ef0f7c4b8e68ccd1f0786
 title: Step 3
-challengeType: 0
+challengeType: 1
 dashedName: step-3
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660ef19b95d3308e7dd31bb6.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660ef19b95d3308e7dd31bb6.md
@@ -1,7 +1,7 @@
 ---
 id: 660ef19b95d3308e7dd31bb6
 title: Step 4
-challengeType: 0
+challengeType: 1
 dashedName: step-4
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660ef31a5be625914a0102cd.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660ef31a5be625914a0102cd.md
@@ -1,7 +1,7 @@
 ---
 id: 660ef31a5be625914a0102cd
 title: Step 5
-challengeType: 0
+challengeType: 1
 dashedName: step-5
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660ef5105b8ba095307a0e50.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660ef5105b8ba095307a0e50.md
@@ -1,7 +1,7 @@
 ---
 id: 660ef5105b8ba095307a0e50
 title: Step 6
-challengeType: 0
+challengeType: 1
 dashedName: step-6
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660ef55dd468079679ee0092.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660ef55dd468079679ee0092.md
@@ -1,7 +1,7 @@
 ---
 id: 660ef55dd468079679ee0092
 title: Step 11
-challengeType: 0
+challengeType: 1
 dashedName: step-11
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660ef5c1904955978a986a5c.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660ef5c1904955978a986a5c.md
@@ -1,7 +1,7 @@
 ---
 id: 660ef5c1904955978a986a5c
 title: Step 12
-challengeType: 0
+challengeType: 1
 dashedName: step-12
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660ef6355e8f5a9e67fe5f46.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660ef6355e8f5a9e67fe5f46.md
@@ -1,7 +1,7 @@
 ---
 id: 660ef6355e8f5a9e67fe5f46
 title: Step 13
-challengeType: 0
+challengeType: 1
 dashedName: step-13
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660ef857f2806aa626d29d17.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660ef857f2806aa626d29d17.md
@@ -1,7 +1,7 @@
 ---
 id: 660ef857f2806aa626d29d17
 title: Step 14
-challengeType: 0
+challengeType: 1
 dashedName: step-14
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f033cf051ebb50ea3bf48.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f033cf051ebb50ea3bf48.md
@@ -1,7 +1,7 @@
 ---
 id: 660f033cf051ebb50ea3bf48
 title: Step 15
-challengeType: 0
+challengeType: 1
 dashedName: step-15
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f039ff313dbb696b007ca.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f039ff313dbb696b007ca.md
@@ -1,7 +1,7 @@
 ---
 id: 660f039ff313dbb696b007ca
 title: Step 16
-challengeType: 0
+challengeType: 1
 dashedName: step-16
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f061d259bbebc37461080.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f061d259bbebc37461080.md
@@ -1,7 +1,7 @@
 ---
 id: 660f061d259bbebc37461080
 title: Step 17
-challengeType: 0
+challengeType: 1
 dashedName: step-17
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f07d231941bc11719f664.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f07d231941bc11719f664.md
@@ -1,7 +1,7 @@
 ---
 id: 660f07d231941bc11719f664
 title: Step 18
-challengeType: 0
+challengeType: 1
 dashedName: step-18
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f09a2694b59c3a10ee304.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f09a2694b59c3a10ee304.md
@@ -1,7 +1,7 @@
 ---
 id: 660f09a2694b59c3a10ee304
 title: Step 20
-challengeType: 0
+challengeType: 1
 dashedName: step-20
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f0a55847d6cc485f29ba5.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f0a55847d6cc485f29ba5.md
@@ -1,7 +1,7 @@
 ---
 id: 660f0a55847d6cc485f29ba5
 title: Step 21
-challengeType: 0
+challengeType: 1
 dashedName: step-21
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f0c34aad72dc712b97624.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f0c34aad72dc712b97624.md
@@ -1,7 +1,7 @@
 ---
 id: 660f0c34aad72dc712b97624
 title: Step 22
-challengeType: 0
+challengeType: 1
 dashedName: step-22
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f0da9bf1035c9097af20a.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f0da9bf1035c9097af20a.md
@@ -1,7 +1,7 @@
 ---
 id: 660f0da9bf1035c9097af20a
 title: Step 23
-challengeType: 0
+challengeType: 1
 dashedName: step-23
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f0ee51d7460ce88cd248d.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f0ee51d7460ce88cd248d.md
@@ -1,7 +1,7 @@
 ---
 id: 660f0ee51d7460ce88cd248d
 title: Step 24
-challengeType: 0
+challengeType: 1
 dashedName: step-24
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f0f980e98e8cf77f1ce31.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f0f980e98e8cf77f1ce31.md
@@ -1,7 +1,7 @@
 ---
 id: 660f0f980e98e8cf77f1ce31
 title: Step 25
-challengeType: 0
+challengeType: 1
 dashedName: step-25
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f165270622fd4ec0da3f7.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f165270622fd4ec0da3f7.md
@@ -1,7 +1,7 @@
 ---
 id: 660f165270622fd4ec0da3f7
 title: Step 26
-challengeType: 0
+challengeType: 1
 dashedName: step-26
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f17294346b7d69e79db3d.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f17294346b7d69e79db3d.md
@@ -1,7 +1,7 @@
 ---
 id: 660f17294346b7d69e79db3d
 title: Step 27
-challengeType: 0
+challengeType: 1
 dashedName: step-27
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f17d4e9f227d86e834abd.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f17d4e9f227d86e834abd.md
@@ -1,7 +1,7 @@
 ---
 id: 660f17d4e9f227d86e834abd
 title: Step 28
-challengeType: 0
+challengeType: 1
 dashedName: step-28
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f18f059fe0fda192ce394.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f18f059fe0fda192ce394.md
@@ -1,7 +1,7 @@
 ---
 id: 660f18f059fe0fda192ce394
 title: Step 29
-challengeType: 0
+challengeType: 1
 dashedName: step-29
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f1a00ac619ddc1e259a66.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f1a00ac619ddc1e259a66.md
@@ -1,7 +1,7 @@
 ---
 id: 660f1a00ac619ddc1e259a66
 title: Step 30
-challengeType: 0
+challengeType: 1
 dashedName: step-30
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f1b6e60bd9edf902c81fd.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f1b6e60bd9edf902c81fd.md
@@ -1,7 +1,7 @@
 ---
 id: 660f1b6e60bd9edf902c81fd
 title: Step 31
-challengeType: 0
+challengeType: 1
 dashedName: step-31
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f1bf673487ae0bb25b900.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f1bf673487ae0bb25b900.md
@@ -1,7 +1,7 @@
 ---
 id: 660f1bf673487ae0bb25b900
 title: Step 32
-challengeType: 0
+challengeType: 1
 dashedName: step-32
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f1cedf3676fe26122ebf6.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f1cedf3676fe26122ebf6.md
@@ -1,7 +1,7 @@
 ---
 id: 660f1cedf3676fe26122ebf6
 title: Step 33
-challengeType: 0
+challengeType: 1
 dashedName: step-33
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f1e3f047bf4e403268713.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f1e3f047bf4e403268713.md
@@ -1,7 +1,7 @@
 ---
 id: 660f1e3f047bf4e403268713
 title: Step 34
-challengeType: 0
+challengeType: 1
 dashedName: step-34
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f20473aef47e9b8c9afc6.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f20473aef47e9b8c9afc6.md
@@ -1,7 +1,7 @@
 ---
 id: 660f20473aef47e9b8c9afc6
 title: Step 35
-challengeType: 0
+challengeType: 1
 dashedName: step-35
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f207334fabaeac3269c38.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f207334fabaeac3269c38.md
@@ -1,7 +1,7 @@
 ---
 id: 660f207334fabaeac3269c38
 title: Step 36
-challengeType: 0
+challengeType: 1
 dashedName: step-36
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f229d2dbe09ef2954a4a1.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f229d2dbe09ef2954a4a1.md
@@ -1,7 +1,7 @@
 ---
 id: 660f229d2dbe09ef2954a4a1
 title: Step 37
-challengeType: 0
+challengeType: 1
 dashedName: step-37
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f23b53db70af0f2620e78.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f23b53db70af0f2620e78.md
@@ -1,7 +1,7 @@
 ---
 id: 660f23b53db70af0f2620e78
 title: Step 38
-challengeType: 0
+challengeType: 1
 dashedName: step-38
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f255022991ef34ed0ee88.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f255022991ef34ed0ee88.md
@@ -1,7 +1,7 @@
 ---
 id: 660f255022991ef34ed0ee88
 title: Step 39
-challengeType: 0
+challengeType: 1
 dashedName: step-39
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f280dda5040f707c76b4a.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f280dda5040f707c76b4a.md
@@ -1,7 +1,7 @@
 ---
 id: 660f280dda5040f707c76b4a
 title: Step 40
-challengeType: 0
+challengeType: 1
 dashedName: step-40
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f2a70ad6225fa503e71c3.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f2a70ad6225fa503e71c3.md
@@ -1,7 +1,7 @@
 ---
 id: 660f2a70ad6225fa503e71c3
 title: Step 41
-challengeType: 0
+challengeType: 1
 dashedName: step-41
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f2b6fd54ac1fc142804dd.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f2b6fd54ac1fc142804dd.md
@@ -1,7 +1,7 @@
 ---
 id: 660f2b6fd54ac1fc142804dd
 title: Step 42
-challengeType: 0
+challengeType: 1
 dashedName: step-42
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f2eccfe3f820304af1b39.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f2eccfe3f820304af1b39.md
@@ -1,7 +1,7 @@
 ---
 id: 660f2eccfe3f820304af1b39
 title: Step 57
-challengeType: 0
+challengeType: 1
 dashedName: step-57
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f2fbd45b520046cac68e8.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f2fbd45b520046cac68e8.md
@@ -1,7 +1,7 @@
 ---
 id: 660f2fbd45b520046cac68e8
 title: Step 58
-challengeType: 0
+challengeType: 1
 dashedName: step-58
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f34626216270c682e2f7b.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f34626216270c682e2f7b.md
@@ -1,7 +1,7 @@
 ---
 id: 660f34626216270c682e2f7b
 title: Step 59
-challengeType: 0
+challengeType: 1
 dashedName: step-59
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f34e99571070d56d2f231.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f34e99571070d56d2f231.md
@@ -1,7 +1,7 @@
 ---
 id: 660f34e99571070d56d2f231
 title: Step 60
-challengeType: 0
+challengeType: 1
 dashedName: step-60
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f359af3e32e0f1a6880b7.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f359af3e32e0f1a6880b7.md
@@ -1,7 +1,7 @@
 ---
 id: 660f359af3e32e0f1a6880b7
 title: Step 61
-challengeType: 0
+challengeType: 1
 dashedName: step-61
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f374d532dc41189cc9cc2.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f374d532dc41189cc9cc2.md
@@ -1,7 +1,7 @@
 ---
 id: 660f374d532dc41189cc9cc2
 title: Step 62
-challengeType: 0
+challengeType: 1
 dashedName: step-62
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f383d4c772c12ff59904b.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f383d4c772c12ff59904b.md
@@ -1,7 +1,7 @@
 ---
 id: 660f383d4c772c12ff59904b
 title: Step 63
-challengeType: 0
+challengeType: 1
 dashedName: step-63
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f38c34a4de6141c0c369f.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f38c34a4de6141c0c369f.md
@@ -1,7 +1,7 @@
 ---
 id: 660f38c34a4de6141c0c369f
 title: Step 64
-challengeType: 0
+challengeType: 1
 dashedName: step-64
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f3915b41a441537ec9f5e.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f3915b41a441537ec9f5e.md
@@ -1,7 +1,7 @@
 ---
 id: 660f3915b41a441537ec9f5e
 title: Step 65
-challengeType: 0
+challengeType: 1
 dashedName: step-65
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f39b444fd6f16d1e49c1f.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f39b444fd6f16d1e49c1f.md
@@ -1,7 +1,7 @@
 ---
 id: 660f39b444fd6f16d1e49c1f
 title: Step 66
-challengeType: 0
+challengeType: 1
 dashedName: step-66
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f3b664421471aa595170f.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f3b664421471aa595170f.md
@@ -1,7 +1,7 @@
 ---
 id: 660f3b664421471aa595170f
 title: Step 67
-challengeType: 0
+challengeType: 1
 dashedName: step-67
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f3ba3cceef11b6ba08b59.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f3ba3cceef11b6ba08b59.md
@@ -1,7 +1,7 @@
 ---
 id: 660f3ba3cceef11b6ba08b59
 title: Step 68
-challengeType: 0
+challengeType: 1
 dashedName: step-68
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f3ce51f70571e1c5227c8.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f3ce51f70571e1c5227c8.md
@@ -1,7 +1,7 @@
 ---
 id: 660f3ce51f70571e1c5227c8
 title: Step 69
-challengeType: 0
+challengeType: 1
 dashedName: step-69
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f3ce51f70571e1c5227c8.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f3ce51f70571e1c5227c8.md
@@ -3,6 +3,7 @@ id: 660f3ce51f70571e1c5227c8
 title: Step 69
 challengeType: 1
 dashedName: step-69
+removeComments: false
 ---
 
 # --description--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f3dd626be3a1ffe27e5d1.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f3dd626be3a1ffe27e5d1.md
@@ -3,6 +3,7 @@ id: 660f3dd626be3a1ffe27e5d1
 title: Step 70
 challengeType: 1
 dashedName: step-70
+removeComments: false
 ---
 
 # --description--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f3dd626be3a1ffe27e5d1.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f3dd626be3a1ffe27e5d1.md
@@ -1,7 +1,7 @@
 ---
 id: 660f3dd626be3a1ffe27e5d1
 title: Step 70
-challengeType: 0
+challengeType: 1
 dashedName: step-70
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f415b76859a2736771607.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f415b76859a2736771607.md
@@ -1,7 +1,7 @@
 ---
 id: 660f415b76859a2736771607
 title: Step 71
-challengeType: 0
+challengeType: 1
 dashedName: step-71
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f4377a359972c521d3f4b.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f4377a359972c521d3f4b.md
@@ -1,7 +1,7 @@
 ---
 id: 660f4377a359972c521d3f4b
 title: Step 72
-challengeType: 0
+challengeType: 1
 dashedName: step-72
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f4455f457ef2e3ec6920f.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f4455f457ef2e3ec6920f.md
@@ -1,7 +1,7 @@
 ---
 id: 660f4455f457ef2e3ec6920f
 title: Step 73
-challengeType: 0
+challengeType: 1
 dashedName: step-73
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f447efc0e722f016c1be0.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f447efc0e722f016c1be0.md
@@ -1,7 +1,7 @@
 ---
 id: 660f447efc0e722f016c1be0
 title: Step 74
-challengeType: 0
+challengeType: 1
 dashedName: step-74
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f44f10ea40f300b896a5e.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f44f10ea40f300b896a5e.md
@@ -1,7 +1,7 @@
 ---
 id: 660f44f10ea40f300b896a5e
 title: Step 75
-challengeType: 0
+challengeType: 1
 dashedName: step-75
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f455b044d3230ed971e98.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f455b044d3230ed971e98.md
@@ -1,7 +1,7 @@
 ---
 id: 660f455b044d3230ed971e98
 title: Step 76
-challengeType: 0
+challengeType: 1
 dashedName: step-76
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f45ccf4ca5c31f253005a.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f45ccf4ca5c31f253005a.md
@@ -1,7 +1,7 @@
 ---
 id: 660f45ccf4ca5c31f253005a
 title: Step 77
-challengeType: 0
+challengeType: 1
 dashedName: step-77
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f46460f9c36330ebc07d8.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f46460f9c36330ebc07d8.md
@@ -1,7 +1,7 @@
 ---
 id: 660f46460f9c36330ebc07d8
 title: Step 79
-challengeType: 0
+challengeType: 1
 dashedName: step-79
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f46b9c417a8341729a3ab.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f46b9c417a8341729a3ab.md
@@ -1,7 +1,7 @@
 ---
 id: 660f46b9c417a8341729a3ab
 title: Step 80
-challengeType: 0
+challengeType: 1
 dashedName: step-80
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f4774e3e0df35a68bb5f2.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f4774e3e0df35a68bb5f2.md
@@ -1,7 +1,7 @@
 ---
 id: 660f4774e3e0df35a68bb5f2
 title: Step 81
-challengeType: 0
+challengeType: 1
 dashedName: step-81
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f47afe4c98536715d5fa4.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f47afe4c98536715d5fa4.md
@@ -1,7 +1,7 @@
 ---
 id: 660f47afe4c98536715d5fa4
 title: Step 82
-challengeType: 0
+challengeType: 1
 dashedName: step-82
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f487dc0c8fa38084f9754.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f487dc0c8fa38084f9754.md
@@ -1,7 +1,7 @@
 ---
 id: 660f487dc0c8fa38084f9754
 title: Step 83
-challengeType: 0
+challengeType: 1
 dashedName: step-83
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f48a419b40238e2b8b4d5.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f48a419b40238e2b8b4d5.md
@@ -1,7 +1,7 @@
 ---
 id: 660f48a419b40238e2b8b4d5
 title: Step 84
-challengeType: 0
+challengeType: 1
 dashedName: step-84
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f48e1d3682f39e81843c4.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f48e1d3682f39e81843c4.md
@@ -1,7 +1,7 @@
 ---
 id: 660f48e1d3682f39e81843c4
 title: Step 85
-challengeType: 0
+challengeType: 1
 dashedName: step-85
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f4934fb48f63abd5ae371.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f4934fb48f63abd5ae371.md
@@ -1,7 +1,7 @@
 ---
 id: 660f4934fb48f63abd5ae371
 title: Step 86
-challengeType: 0
+challengeType: 1
 dashedName: step-86
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f4990b1caa03b9dc97a43.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f4990b1caa03b9dc97a43.md
@@ -1,7 +1,7 @@
 ---
 id: 660f4990b1caa03b9dc97a43
 title: Step 88
-challengeType: 0
+challengeType: 1
 dashedName: step-88
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f49e32001983c90b75850.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f49e32001983c90b75850.md
@@ -1,7 +1,7 @@
 ---
 id: 660f49e32001983c90b75850
 title: Step 89
-challengeType: 0
+challengeType: 1
 dashedName: step-89
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f4a1472f8e63d76162ce5.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f4a1472f8e63d76162ce5.md
@@ -1,7 +1,7 @@
 ---
 id: 660f4a1472f8e63d76162ce5
 title: Step 90
-challengeType: 0
+challengeType: 1
 dashedName: step-90
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f4a83373de83ea101685f.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f4a83373de83ea101685f.md
@@ -1,7 +1,7 @@
 ---
 id: 660f4a83373de83ea101685f
 title: Step 91
-challengeType: 0
+challengeType: 1
 dashedName: step-91
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f4ae5b3924c3fc3373973.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f4ae5b3924c3fc3373973.md
@@ -1,7 +1,7 @@
 ---
 id: 660f4ae5b3924c3fc3373973
 title: Step 92
-challengeType: 0
+challengeType: 1
 dashedName: step-92
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f4b33e2a3364094ecb540.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f4b33e2a3364094ecb540.md
@@ -1,7 +1,7 @@
 ---
 id: 660f4b33e2a3364094ecb540
 title: Step 93
-challengeType: 0
+challengeType: 1
 dashedName: step-93
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f4b641290da41b2cf0dd9.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f4b641290da41b2cf0dd9.md
@@ -1,7 +1,7 @@
 ---
 id: 660f4b641290da41b2cf0dd9
 title: Step 94
-challengeType: 0
+challengeType: 1
 dashedName: step-94
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f4c3b01c44743719c99e4.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f4c3b01c44743719c99e4.md
@@ -1,7 +1,7 @@
 ---
 id: 660f4c3b01c44743719c99e4
 title: Step 95
-challengeType: 0
+challengeType: 1
 dashedName: step-95
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f4cde8dd305450514a1cb.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f4cde8dd305450514a1cb.md
@@ -1,7 +1,7 @@
 ---
 id: 660f4cde8dd305450514a1cb
 title: Step 96
-challengeType: 0
+challengeType: 1
 dashedName: step-96
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f4cffb1459d45e34902d1.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f4cffb1459d45e34902d1.md
@@ -1,7 +1,7 @@
 ---
 id: 660f4cffb1459d45e34902d1
 title: Step 97
-challengeType: 0
+challengeType: 1
 dashedName: step-97
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f4de78f775e480ba2e451.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f4de78f775e480ba2e451.md
@@ -1,7 +1,7 @@
 ---
 id: 660f4de78f775e480ba2e451
 title: Step 98
-challengeType: 0
+challengeType: 1
 dashedName: step-98
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f4e74f7fd3f4a99ac2e50.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f4e74f7fd3f4a99ac2e50.md
@@ -1,7 +1,7 @@
 ---
 id: 660f4e74f7fd3f4a99ac2e50
 title: Step 99
-challengeType: 0
+challengeType: 1
 dashedName: step-99
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f4efcb8068e4cb470dca1.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f4efcb8068e4cb470dca1.md
@@ -1,7 +1,7 @@
 ---
 id: 660f4efcb8068e4cb470dca1
 title: Step 100
-challengeType: 0
+challengeType: 1
 dashedName: step-100
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f4f79e2a82a4e92290f44.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f4f79e2a82a4e92290f44.md
@@ -1,7 +1,7 @@
 ---
 id: 660f4f79e2a82a4e92290f44
 title: Step 101
-challengeType: 0
+challengeType: 1
 dashedName: step-101
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f4f79e2a82a4e92290f44.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f4f79e2a82a4e92290f44.md
@@ -3,6 +3,7 @@ id: 660f4f79e2a82a4e92290f44
 title: Step 101
 challengeType: 1
 dashedName: step-101
+removeComments: false
 ---
 
 # --description--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f505d02b2bd513a1c3468.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f505d02b2bd513a1c3468.md
@@ -1,7 +1,7 @@
 ---
 id: 660f505d02b2bd513a1c3468
 title: Step 102
-challengeType: 0
+challengeType: 1
 dashedName: step-102
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f50a21fe7645252804f2b.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f50a21fe7645252804f2b.md
@@ -1,7 +1,7 @@
 ---
 id: 660f50a21fe7645252804f2b
 title: Step 103
-challengeType: 0
+challengeType: 1
 dashedName: step-103
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f5179b3b0ca558f6b4d4f.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f5179b3b0ca558f6b4d4f.md
@@ -1,7 +1,7 @@
 ---
 id: 660f5179b3b0ca558f6b4d4f
 title: Step 104
-challengeType: 0
+challengeType: 1
 dashedName: step-104
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f51f1df0a8757934a5796.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f51f1df0a8757934a5796.md
@@ -1,7 +1,7 @@
 ---
 id: 660f51f1df0a8757934a5796
 title: Step 105
-challengeType: 0
+challengeType: 1
 dashedName: step-105
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f530d6e33d159e1bf4947.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f530d6e33d159e1bf4947.md
@@ -1,7 +1,7 @@
 ---
 id: 660f530d6e33d159e1bf4947
 title: Step 106
-challengeType: 0
+challengeType: 1
 dashedName: step-106
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f535ec33a285b33af3774.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f535ec33a285b33af3774.md
@@ -1,7 +1,7 @@
 ---
 id: 660f535ec33a285b33af3774
 title: Step 107
-challengeType: 0
+challengeType: 1
 dashedName: step-107
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f53ad3d39175c5d4335ac.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f53ad3d39175c5d4335ac.md
@@ -1,7 +1,7 @@
 ---
 id: 660f53ad3d39175c5d4335ac
 title: Step 108
-challengeType: 0
+challengeType: 1
 dashedName: step-108
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f53ad3d39175c5d4335ac.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f53ad3d39175c5d4335ac.md
@@ -3,6 +3,7 @@ id: 660f53ad3d39175c5d4335ac
 title: Step 108
 challengeType: 1
 dashedName: step-108
+removeComments: false
 ---
 
 # --description--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f540c2176ea5dec01306d.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f540c2176ea5dec01306d.md
@@ -1,7 +1,7 @@
 ---
 id: 660f540c2176ea5dec01306d
 title: Step 109
-challengeType: 0
+challengeType: 1
 dashedName: step-109
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/6610b741b54b90f0c0fb3d58.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/6610b741b54b90f0c0fb3d58.md
@@ -1,7 +1,7 @@
 ---
 id: 6610b741b54b90f0c0fb3d58
 title: Step 7
-challengeType: 0
+challengeType: 1
 dashedName: step-7
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/6610b8017d1671f2814e8c77.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/6610b8017d1671f2814e8c77.md
@@ -1,7 +1,7 @@
 ---
 id: 6610b8017d1671f2814e8c77
 title: Step 8
-challengeType: 0
+challengeType: 1
 dashedName: step-8
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/6610b8f6a98d25f4d485a94d.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/6610b8f6a98d25f4d485a94d.md
@@ -1,7 +1,7 @@
 ---
 id: 6610b8f6a98d25f4d485a94d
 title: Step 9
-challengeType: 0
+challengeType: 1
 dashedName: step-9
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/6610b9f7619764fad5fd516d.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/6610b9f7619764fad5fd516d.md
@@ -1,7 +1,7 @@
 ---
 id: 6610b9f7619764fad5fd516d
 title: Step 10
-challengeType: 0
+challengeType: 1
 dashedName: step-10
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/6610bbed59bc2a0194d85533.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/6610bbed59bc2a0194d85533.md
@@ -1,7 +1,7 @@
 ---
 id: 6610bbed59bc2a0194d85533
 title: Step 19
-challengeType: 0
+challengeType: 1
 dashedName: step-19
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/6610bf6fa14d700beed1b109.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/6610bf6fa14d700beed1b109.md
@@ -1,7 +1,7 @@
 ---
 id: 6610bf6fa14d700beed1b109
 title: Step 78
-challengeType: 0
+challengeType: 1
 dashedName: step-78
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/6610c105bbdacc114d6cdc44.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/6610c105bbdacc114d6cdc44.md
@@ -1,7 +1,7 @@
 ---
 id: 6610c105bbdacc114d6cdc44
 title: Step 43
-challengeType: 0
+challengeType: 1
 dashedName: step-43
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/6610c16c4fa0df12c0e30675.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/6610c16c4fa0df12c0e30675.md
@@ -1,7 +1,7 @@
 ---
 id: 6610c16c4fa0df12c0e30675
 title: Step 44
-challengeType: 0
+challengeType: 1
 dashedName: step-44
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/6610c1d97b1671140f95cfbb.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/6610c1d97b1671140f95cfbb.md
@@ -1,7 +1,7 @@
 ---
 id: 6610c1d97b1671140f95cfbb
 title: Step 45
-challengeType: 0
+challengeType: 1
 dashedName: step-45
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/6610c21b3ef82015573ffbbe.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/6610c21b3ef82015573ffbbe.md
@@ -1,7 +1,7 @@
 ---
 id: 6610c21b3ef82015573ffbbe
 title: Step 46
-challengeType: 0
+challengeType: 1
 dashedName: step-46
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/6610c2d8d67563174fcf96dc.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/6610c2d8d67563174fcf96dc.md
@@ -1,7 +1,7 @@
 ---
 id: 6610c2d8d67563174fcf96dc
 title: Step 47
-challengeType: 0
+challengeType: 1
 dashedName: step-47
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/6610c424b7119919b62932f4.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/6610c424b7119919b62932f4.md
@@ -1,7 +1,7 @@
 ---
 id: 6610c424b7119919b62932f4
 title: Step 48
-challengeType: 0
+challengeType: 1
 dashedName: step-48
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/6610c48c4ea0891afa7c4696.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/6610c48c4ea0891afa7c4696.md
@@ -1,7 +1,7 @@
 ---
 id: 6610c48c4ea0891afa7c4696
 title: Step 49
-challengeType: 0
+challengeType: 1
 dashedName: step-49
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/6610c538372aa61cc0f5b122.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/6610c538372aa61cc0f5b122.md
@@ -1,7 +1,7 @@
 ---
 id: 6610c538372aa61cc0f5b122
 title: Step 50
-challengeType: 0
+challengeType: 1
 dashedName: step-50
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/6610c6541c82551f95e765ab.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/6610c6541c82551f95e765ab.md
@@ -1,7 +1,7 @@
 ---
 id: 6610c6541c82551f95e765ab
 title: Step 51
-challengeType: 0
+challengeType: 1
 dashedName: step-51
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/6610c71600966a2191d3a64a.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/6610c71600966a2191d3a64a.md
@@ -1,7 +1,7 @@
 ---
 id: 6610c71600966a2191d3a64a
 title: Step 52
-challengeType: 0
+challengeType: 1
 dashedName: step-52
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/6610c77d50636722e5b6be17.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/6610c77d50636722e5b6be17.md
@@ -1,7 +1,7 @@
 ---
 id: 6610c77d50636722e5b6be17
 title: Step 53
-challengeType: 0
+challengeType: 1
 dashedName: step-53
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/6610c83b52583e245a079217.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/6610c83b52583e245a079217.md
@@ -1,7 +1,7 @@
 ---
 id: 6610c83b52583e245a079217
 title: Step 54
-challengeType: 0
+challengeType: 1
 dashedName: step-54
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/6610c87eac0f0b256d7b037e.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/6610c87eac0f0b256d7b037e.md
@@ -1,7 +1,7 @@
 ---
 id: 6610c87eac0f0b256d7b037e
 title: Step 55
-challengeType: 0
+challengeType: 1
 dashedName: step-55
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/6610c8cfe4cf4d278e35c156.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/6610c8cfe4cf4d278e35c156.md
@@ -1,7 +1,7 @@
 ---
 id: 6610c8cfe4cf4d278e35c156
 title: Step 56
-challengeType: 0
+challengeType: 1
 dashedName: step-56
 ---
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/661483051820c3c1ab4595e0.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/661483051820c3c1ab4595e0.md
@@ -1,7 +1,7 @@
 ---
 id: 661483051820c3c1ab4595e0
 title: Step 87
-challengeType: 0
+challengeType: 1
 dashedName: step-87
 ---
 


### PR DESCRIPTION
- **fix: only show project preview on step 1**
- **refactor: remove conditional**

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

https://github.com/freeCodeCamp/freeCodeCamp/pull/54416 introduced a weird bug by using `showPreview` to control if the _project_ preview was shown.  

If you went to step one of Learn Introductory JavaScript by Building a Pyramid Generator and then went to any other challenge which has previews, you'd see an empty project preview modal.

This addresses this problem by 1) preventing project previews for challengeType 1 (i.e. `js`) and 2) using that challenge type for all of these lessons. Since the client already understands how to run code without a preview frame when given a `js` challenge, there's no need to handle the `learn-introductory-javascript-by-building-a-pyramid-generator` block separately.

<!-- Feel free to add any additional description of changes below this line -->
