### PR TITLE
fix: show console on load for new js project

### DIFF
--- a/client/src/templates/Challenges/classic/desktop-layout.tsx
+++ b/client/src/templates/Challenges/classic/desktop-layout.tsx
@@ -52,6 +52,7 @@ interface DesktopLayoutProps {
   windowTitle: string;
   showPreviewPortal: boolean;
   showPreviewPane: boolean;
+  startWithConsoleShown: boolean;
   removePortalWindow: () => void;
   setShowPreviewPortal: (arg: boolean) => void;
   setShowPreviewPane: (arg: boolean) => void;
@@ -94,11 +95,12 @@ const DesktopLayout = (props: DesktopLayoutProps): JSX.Element => {
     removePortalWindow,
     setShowPreviewPane,
     setShowPreviewPortal,
-    portalWindow
+    portalWindow,
+    startWithConsoleShown
   } = props;
 
   const [showNotes, setShowNotes] = useState(false);
-  const [showConsole, setShowConsole] = useState(false);
+  const [showConsole, setShowConsole] = useState(startWithConsoleShown);
   const [showInstructions, setShowInstructions] = useState(true);
 
   const togglePane = (pane: string): void => {

--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -234,6 +234,8 @@ function ShowClassic({
     `intro:${superBlock}.blocks.${block}.title`
   )}: ${title}`;
   const windowTitle = `${blockNameTitle} | freeCodeCamp.org`;
+  const showConsole =
+    block === 'learn-introductory-javascript-by-building-a-pyramid-generator';
   // TODO: show preview should NOT be computed like this. That determination is
   // made during the build (at least twice!). It should be either a prop or
   // computed from challengeType
@@ -243,7 +245,7 @@ function ShowClassic({
       challengeType === challengeTypes.multifileCertProject ||
       challengeType === challengeTypes.multifilePythonCertProject ||
       challengeType === challengeTypes.python) &&
-    block !== 'learn-introductory-javascript-by-building-a-pyramid-generator';
+    !showConsole;
 
   const getLayoutState = () => {
     const reflexLayout = store.get(REFLEX_LAYOUT) as ReflexLayout;
@@ -503,6 +505,7 @@ function ShowClassic({
               <Output defaultOutput={defaultOutput} output={output} />
             }
             windowTitle={windowTitle}
+            startWithConsoleShown={showConsole}
           />
         )}
         <CompletionModal />


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

If the challenge does not have a preview, it will now default to showing the console instead.

<!-- Feel free to add any additional description of changes below this line -->
