### PR TITLE
fix(curriculum): unclear messages in step 54 of statistics calculator

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-advanced-array-methods-by-building-a-statistics-calculator/6353004b235d7a2e0b913f2b.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-advanced-array-methods-by-building-a-statistics-calculator/6353004b235d7a2e0b913f2b.md
@@ -7,7 +7,7 @@ dashedName: step-54
 
 # --description--
 
-To calculate a root exponent such as $\sqrt[n]{x}$, you can use an inverted exponent $x^{1/n}$. JavaScript has a built-in `Math.pow()` function can be used to calculate exponents.
+To calculate a root exponent such as $\sqrt[n]{x}$, you can use an inverted exponent $x^{1/n}$. JavaScript has a built-in `Math.pow()` function that can be used to calculate exponents.
 
 Here is the basic syntax for the `Math.pow()` function:
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-advanced-array-methods-by-building-a-statistics-calculator/6353004b235d7a2e0b913f2b.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-advanced-array-methods-by-building-a-statistics-calculator/6353004b235d7a2e0b913f2b.md
@@ -7,7 +7,22 @@ dashedName: step-54
 
 # --description--
 
-To calculate a root exponent, such as $\sqrt[n]{x}$, you can use an inverted exponent $x^{1/n}$.
+To calculate a root exponent such as $\sqrt[n]{x}$, you can use an inverted exponent $x^{1/n}$. JavaScript has a built-in `Math.pow()` function can be used to calculate exponents.
+
+Here is the basic syntax for the `Math.pow()` function:
+
+```js
+Math.pow(base, exponent)
+```
+
+Here is an example of how to calculate the square root of `4`:
+
+```js
+const base = 4;
+const exponent = 0.5;
+// returns 2
+Math.pow(base, exponent);
+```
 
 Declare a `standardDeviation` variable, and use the `Math.pow()` function to assign it the value of $variance^{1/2}$.
 
@@ -25,13 +40,7 @@ Your `standardDeviation` variable should use the `Math.pow()` function.
 assert.match(getStandardDeviation.toString(), /standardDeviation\s*=\s*Math\.pow\(/);
 ```
 
-Your `standardDeviation` variable should use the `variance` variable.
-
-```js
-assert.match(getStandardDeviation.toString(), /standardDeviation\s*=\s*Math\.pow\(\s*variance\s*,/);
-```
-
-Your `standardDeviation` variable should use the `1/2` exponent.
+Your `Math.pow()` function should have a base of `variance` and an exponent of `1/2`.
 
 ```js
 assert.match(getStandardDeviation.toString(), /standardDeviation\s*=\s*Math\.pow\(\s*variance\s*,\s*1\s*\/\s*2\s*\)/);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #54427 

<!-- Feel free to add any additional description of changes below this line -->

Updated description for Step 54 (taken from comment https://github.com/freeCodeCamp/freeCodeCamp/issues/54427#issuecomment-2062467716 ), and merged two tests into one individual test for clarity.

![image](https://github.com/freeCodeCamp/freeCodeCamp/assets/58159084/bdc3b652-1c82-4839-aeeb-1649f4f593de)
![image](https://github.com/freeCodeCamp/freeCodeCamp/assets/58159084/a61f5a3e-583b-4ecf-ad3b-78d39b9abd4b)
