### PR TITLE
fix(curriculum): change of not indicated a elements fail tests

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/614796cb8086be482d60e0ac.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/614796cb8086be482d60e0ac.md
@@ -23,10 +23,10 @@ anchors.forEach(a => assert.exists(getComputedStyle(a)));
 You should give the `a` elements inside list items a `color` property.
 
 ```js
-const helper = new __helpers.CSSHelp(document)
+const helper = new __helpers.CSSHelp(document);
 
 const usedSelector = code.match(/^\s*?(.*?a)\s*?{/m)[1];
-assert.notEmpty(helper.getStyle(usedSelector)?.color)
+assert.notEmpty(helper.getStyle(usedSelector)?.color);
 ```
 
 You should only change the color of `a` elements inside list elements.

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/614796cb8086be482d60e0ac.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/614796cb8086be482d60e0ac.md
@@ -13,7 +13,7 @@ Change the font color of all the anchor elements within the list elements to som
 
 # --hints--
 
-Your selector should targer links inside list items.
+Your selector should target links inside list items.
 
 ```js
 const anchors = document.querySelectorAll('li > a');

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/614796cb8086be482d60e0ac.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/614796cb8086be482d60e0ac.md
@@ -27,7 +27,7 @@ const anchors = document.querySelectorAll('li > a');
 anchors.forEach(a => assert.notEmpty(getComputedStyle(a)?.color)); 
 ```
 
-You should not change the color of `a` elements that are not inside list elements.
+You should only change the color of `a` elements inside list elements.
 
 ```js
 const footerAnchor = document.querySelector('footer a');

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/614796cb8086be482d60e0ac.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/614796cb8086be482d60e0ac.md
@@ -27,6 +27,14 @@ const anchors = document.querySelectorAll('li > a');
 anchors.forEach(a => assert.notEmpty(getComputedStyle(a)?.color)); 
 ```
 
+You should not change the color of `a` elements that are not inside list elements.
+
+```js
+const footerAnchor = document.querySelector('footer a');
+const listAnchor = document.querySelector('list a');
+assert.isFalse(getComputedStyle(footerAnchor)?.color === getComputedStyle(listAnchor)?.color)
+```
+
 You should give the `color` property a contrast with the background of at least 7:1. _Hint: I would use `#dfdfe2`_
 
 ```js
@@ -54,7 +62,6 @@ for (let elem of document.querySelectorAll('li > a')) {
   assert.isAtLeast(contrast(backgroundColour, aColour), 7);
 }
 ```
-
 
 # --seed--
 

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/614796cb8086be482d60e0ac.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/614796cb8086be482d60e0ac.md
@@ -31,7 +31,7 @@ You should only change the color of `a` elements inside list elements.
 
 ```js
 const footerAnchor = document.querySelector('footer a');
-const listAnchors = document.querySelectorAll('list a');
+const listAnchors = document.querySelectorAll('li a');
 listAnchors.forEach(listAnchor => assert.isFalse(getComputedStyle(footerAnchor)?.color === getComputedStyle(listAnchor)?.color))
 ```
 

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/614796cb8086be482d60e0ac.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/614796cb8086be482d60e0ac.md
@@ -31,8 +31,8 @@ You should not change the color of `a` elements that are not inside list element
 
 ```js
 const footerAnchor = document.querySelector('footer a');
-const listAnchor = document.querySelector('list a');
-assert.isFalse(getComputedStyle(footerAnchor)?.color === getComputedStyle(listAnchor)?.color)
+const listAnchors = document.querySelectorAll('list a');
+listAnchors.forEach(listAnchor => assert.isFalse(getComputedStyle(footerAnchor)?.color === getComputedStyle(listAnchor)?.color))
 ```
 
 You should give the `color` property a contrast with the background of at least 7:1. _Hint: I would use `#dfdfe2`_

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/614796cb8086be482d60e0ac.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/614796cb8086be482d60e0ac.md
@@ -23,8 +23,10 @@ anchors.forEach(a => assert.exists(getComputedStyle(a)));
 You should give the `a` elements inside list items a `color` property.
 
 ```js
-const anchors = document.querySelectorAll('li > a');
-anchors.forEach(a => assert.notEmpty(getComputedStyle(a)?.color));
+const helper = new __helpers.CSSHelp(document)
+
+const usedSelector = code.match(/^\s*?(.*?a)\s*?{/m)[1];
+assert.notEmpty(helper.getStyle(usedSelector)?.color)
 ```
 
 You should only change the color of `a` elements inside list elements.

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/614796cb8086be482d60e0ac.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/614796cb8086be482d60e0ac.md
@@ -13,18 +13,18 @@ Change the font color of all the anchor elements within the list elements to som
 
 # --hints--
 
-You should use the `li > a` selector.
+Your selector should targer links inside list items.
 
 ```js
-const anchors = document.querySelectorAll('li > a'); 
-anchors.forEach(a => assert.exists(getComputedStyle(a))); 
+const anchors = document.querySelectorAll('li > a');
+anchors.forEach(a => assert.exists(getComputedStyle(a)));
 ```
 
-You should give the `a` element a `color` property.
+You should give the `a` elements inside list items a `color` property.
 
 ```js
-const anchors = document.querySelectorAll('li > a'); 
-anchors.forEach(a => assert.notEmpty(getComputedStyle(a)?.color)); 
+const anchors = document.querySelectorAll('li > a');
+anchors.forEach(a => assert.notEmpty(getComputedStyle(a)?.color));
 ```
 
 You should only change the color of `a` elements inside list elements.
@@ -32,7 +32,7 @@ You should only change the color of `a` elements inside list elements.
 ```js
 const footerAnchor = document.querySelector('footer a');
 const listAnchors = document.querySelectorAll('li a');
-listAnchors.forEach(listAnchor => assert.isFalse(getComputedStyle(footerAnchor)?.color === getComputedStyle(listAnchor)?.color))
+listAnchors.forEach(listAnchor => assert.isFalse(getComputedStyle(footerAnchor)?.color === getComputedStyle(listAnchor)?.color));
 ```
 
 You should give the `color` property a contrast with the background of at least 7:1. _Hint: I would use `#dfdfe2`_


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #54457

<!-- Feel free to add any additional description of changes below this line -->

A discussion on Discord helping a camper that passed the challenge with the code:
```
a {
  color: #dfdfe2;
}
```
passing the challenge like this caused lots of confusion to the camper. This new test make so that it is not possible to pass if the anchor in the footer has also the color changed.