### PR TITLE
fix(curriculum): indicate strings using quote marks

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f039ff313dbb696b007ca.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f039ff313dbb696b007ca.md
@@ -13,7 +13,7 @@ When an array holds values, or <dfn>elements</dfn>, those values are separated b
 let array = ["first", "second"];
 ```
 
-Change your `rows` declaration to be an array with the strings `Naomi`, `Quincy,` and `CamperChan`. The order of values in an array is important, so follow that order. Remember that strings are case-sensitive.
+Change your `rows` declaration to be an array with the strings `"Naomi"`, `"Quincy"`, and `"CamperChan"`. The order of values in an array is important, so follow that order. Remember that strings are case-sensitive.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->



<!-- Feel free to add any additional description of changes below this line -->

![image](https://github.com/freeCodeCamp/freeCodeCamp/assets/153783117/434dfdbf-c2de-43a1-9758-6605d6e7d00d)

Previously used quote marks in Role Playing Game practice project to indicate a string.
![image](https://github.com/freeCodeCamp/freeCodeCamp/assets/153783117/a7fb0589-9a1d-4c70-8574-1e0f822d9c85)
