### PR TITLE
fix(a11y): make the focus outline not be cut off

### DIFF
--- a/client/src/templates/Challenges/components/tool-panel.css
+++ b/client/src/templates/Challenges/components/tool-panel.css
@@ -18,32 +18,20 @@
   bottom: 0;
 }
 
-.tool-panel-group-mobile > .btn-block {
-  margin: 0 2px 0 0;
-  padding: 5px 0;
-}
-
-.tool-panel-group .btn-group {
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-}
-
-.tool-panel-group-mobile .btn-group {
-  display: block;
-  width: 100%;
-  margin: 0 2px;
-}
-
-.tool-panel-group-mobile .btn {
-  margin: 0 !important;
-}
-
 .tool-panel-group-mobile #get-help-dropdown {
   height: 37px;
 }
 
-.tool-panel-group-mobile *:focus-visible {
+.tool-panel-group-mobile > button {
+  margin-block-start: 0px;
+}
+
+.tool-panel-group-mobile > button:focus-visible {
+  border: 0;
+  margin: 3px;
+}
+
+.tool-panel-group-mobile button:focus-visible {
   outline-offset: -3px;
 }
 

--- a/client/src/templates/Challenges/components/tool-panel.css
+++ b/client/src/templates/Challenges/components/tool-panel.css
@@ -19,11 +19,7 @@
 }
 
 .tool-panel-group-mobile #get-help-dropdown {
-  height: 37px;
-}
-
-.tool-panel-group-mobile > button {
-  margin-block-start: 0px;
+  height: 36.5px;
 }
 
 .tool-panel-group-mobile button:focus-visible {

--- a/client/src/templates/Challenges/components/tool-panel.css
+++ b/client/src/templates/Challenges/components/tool-panel.css
@@ -26,13 +26,11 @@
   margin-block-start: 0px;
 }
 
-.tool-panel-group-mobile > button:focus-visible {
-  border: 0;
-  margin: 3px;
-}
-
 .tool-panel-group-mobile button:focus-visible {
   outline-offset: -3px;
+  border-color: var(--focus-outline-color);
+  outline: none;
+  box-shadow: none;
 }
 
 @media screen and (max-width: 450px) {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

Related issue was repoted at bottom part of the [#50465 comment](https://github.com/freeCodeCamp/freeCodeCamp/pull/50465#issuecomment-1593481069). 

<!-- Feel free to add any additional description of changes below this line -->
This PR was opened to make the focus outline of tool panel buttons not be cut off in mobile layout.
Also, the css code which is not used was removed.
|before|after|
|---|---|
|![focus_outlint_is_cut_off](https://github.com/freeCodeCamp/freeCodeCamp/assets/44451585/4544c93d-264e-40e3-a80b-0822960cfe0b)|![made_focus_outline_not_be_cut_off](https://github.com/freeCodeCamp/freeCodeCamp/assets/44451585/fe3ef26a-39f1-4dc1-bbe7-800c619e49ca)|

By using gitpod, the code was tested with following environment.

1. Windows 11 Home PC using Chrome, Firefox, Edge, and Brave browser, or, webkit within the Playwright.
1. Android Studio's emulator(Pixel 6 Pro with Android API 34 system image) using Chrome.
1. iPhone SE (iOS 15.7.8) using Chrome and Firefox browser.