### PR TITLE
test: remove api mocks from link ms user spec

### DIFF
--- a/e2e/link-ms-user.spec.ts
+++ b/e2e/link-ms-user.spec.ts
@@ -1,3 +1,5 @@
+import { execSync } from 'child_process';
+
 import { test, expect } from '@playwright/test';
 import translations from '../client/i18n/locales/english/translations.json';
 
@@ -38,6 +40,9 @@ test.describe('Link MS user component (signed-out user)', () => {
 });
 
 test.describe('Link MS user component (signed-in user)', () => {
+  test.afterEach(() => {
+    execSync('node ./tools/scripts/seed/seed-ms-username');
+  });
   test.use({ storageState: 'playwright/.auth/certified-user.json' });
 
   test("should recognize the user's MS account", async ({ page }) => {
@@ -48,23 +53,14 @@ test.describe('Link MS user component (signed-in user)', () => {
       })
     ).toBeVisible();
 
-    await expect(
-      page.getByText(
-        'The Microsoft account with username "certifieduser" is currently linked to your freeCodeCamp account. If this is not your Microsoft username, remove the link.'
-      )
-    ).toBeVisible();
+    await expect(page.locator('main')).toHaveText(
+      /The Microsoft account with username "certifieduser" is currently linked to your freeCodeCamp account. If this is not your Microsoft username, remove the link./
+    );
   });
 
   test('should allow the user to unlink their MS account and display a form for re-link', async ({
     page
   }) => {
-    // Intercept the endpoint to prevent `msUsername` from being deleted
-    // as the deletion will cause subsequent tests to fail
-    await page.route('*/**/user/ms-username', async route => {
-      const json = { msUsername: null };
-      await route.fulfill({ json });
-    });
-
     const unlinkButton = page.getByRole('button', {
       name: translations.buttons['unlink-account']
     });

--- a/e2e/link-ms-user.spec.ts
+++ b/e2e/link-ms-user.spec.ts
@@ -54,7 +54,7 @@ test.describe('Link MS user component (signed-in user)', () => {
     ).toBeVisible();
 
     await expect(page.locator('main')).toHaveText(
-      /The Microsoft account with username "certifieduser" is currently linked to your freeCodeCamp account. If this is not your Microsoft username, remove the link./
+      /The Microsoft account with username "certifieduser" is currently linked to your freeCodeCamp account\. If this is not your Microsoft username, remove the link\./
     );
   });
 


### PR DESCRIPTION
- **test: seed the ms username to avoid mocking**

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Rather than mocking the server's response, this modifies the db so that the api responds correctly.

This makes the e2e tests actually e2e tests as well as making them more useful for the api migration. i.e. if the migration breaks one of the routes and that route was mocked we wouldn't know.

<!-- Feel free to add any additional description of changes below this line -->
