### PR TITLE
tests: remove mocks from delete account modal

### DIFF
--- a/e2e/delete-modal.spec.ts
+++ b/e2e/delete-modal.spec.ts
@@ -12,6 +12,7 @@ test.beforeEach(async ({ page }) => {
 
 test.afterAll(() => {
   execSync('node ./tools/scripts/seed/seed-demo-user certified-user');
+  execSync('node ./tools/scripts/seed/seed-surveys');
 });
 
 test.describe('Delete Modal component', () => {

--- a/e2e/delete-modal.spec.ts
+++ b/e2e/delete-modal.spec.ts
@@ -13,6 +13,7 @@ test.beforeEach(async ({ page }) => {
 test.afterAll(() => {
   execSync('node ./tools/scripts/seed/seed-demo-user certified-user');
   execSync('node ./tools/scripts/seed/seed-surveys');
+  execSync('node ./tools/scripts/seed/seed-ms-username');
 });
 
 test.describe('Delete Modal component', () => {

--- a/e2e/delete-modal.spec.ts
+++ b/e2e/delete-modal.spec.ts
@@ -1,8 +1,11 @@
-import { execSync } from 'child_process';
+import { exec } from 'child_process';
+import { promisify } from 'util';
 
 import { test, expect } from '@playwright/test';
 
 import translations from '../client/i18n/locales/english/translations.json';
+
+const execP = promisify(exec);
 
 test.use({ storageState: 'playwright/.auth/certified-user.json' });
 
@@ -10,11 +13,14 @@ test.beforeEach(async ({ page }) => {
   await page.goto('/settings');
 });
 
-test.afterAll(() => {
-  execSync('node ./tools/scripts/seed/seed-demo-user certified-user');
-  execSync('node ./tools/scripts/seed/seed-surveys');
-  execSync('node ./tools/scripts/seed/seed-ms-username');
-});
+test.afterAll(
+  async () =>
+    await Promise.all([
+      await execP('node ./tools/scripts/seed/seed-demo-user certified-user'),
+      await execP('node ./tools/scripts/seed/seed-surveys'),
+      await execP('node ./tools/scripts/seed/seed-ms-username')
+    ])
+);
 
 test.describe('Delete Modal component', () => {
   test('should render the modal correctly', async ({ page }) => {

--- a/e2e/delete-modal.spec.ts
+++ b/e2e/delete-modal.spec.ts
@@ -1,10 +1,17 @@
+import { execSync } from 'child_process';
+
 import { test, expect } from '@playwright/test';
+
 import translations from '../client/i18n/locales/english/translations.json';
 
 test.use({ storageState: 'playwright/.auth/certified-user.json' });
 
 test.beforeEach(async ({ page }) => {
   await page.goto('/settings');
+});
+
+test.afterAll(() => {
+  execSync('node ./tools/scripts/seed/seed-demo-user certified-user');
 });
 
 test.describe('Delete Modal component', () => {
@@ -75,13 +82,6 @@ test.describe('Delete Modal component', () => {
   test('should close the modal and redirect to /learn after the user clicks delete', async ({
     page
   }) => {
-    await page.route('*/**/account/delete', async route => {
-      // intercept the endpoint to prevent user account from being deleted
-      // as the deletion will cause subsequent tests to fail
-      const json = {};
-      await route.fulfill({ json });
-    });
-
     await page
       .getByRole('button', { name: translations.settings.danger.delete })
       .click();


### PR DESCRIPTION
- **test: use seed to recreate account after deletion**
- **test: delete notes.spec - it's not used**

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

And removes notes.spec, since it's mocking a feature we don't use.
<!-- Feel free to add any additional description of changes below this line -->
