### PR TITLE
fix: replace other messages with any build error

### DIFF
--- a/client/src/templates/Challenges/redux/execute-challenge-saga.js
+++ b/client/src/templates/Challenges/redux/execute-challenge-saga.js
@@ -298,14 +298,15 @@ export function* previewChallengeSaga(action) {
       }
     }
   } catch (err) {
-    console.log('previewChallengeSaga error', err);
     if (err[0] === 'timeout') {
       // TODO: translate the error
       // eslint-disable-next-line no-ex-assign
       err[0] = `The code you have written is taking longer than the ${previewTimeout}ms our challenges allow. You may have created an infinite loop or need to write a more efficient algorithm`;
     }
-    console.log(err);
-    yield put(updateConsole(escape(err)));
+    // If the preview fails, the most useful thing to do is to show the learner
+    // what the error is. As such, we replace whatever is in the console with
+    // the error message.
+    yield put(initConsole(escape(err)));
   }
 }
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This works around a race condition that seems to occur most often when the page is first loaded.  What seems to be happening is that when two `previewMounted` requests are fired off simultaneously, then they can both flush the logs before either one tries to build the user's code. Finally if the build throws an error then both errors will appear in the console. See, for example: https://github.com/freeCodeCamp/freeCodeCamp/actions/runs/8799321108/job/24148444879

The fix then, is to replace the console contents entirely when there's an error.

<!-- Feel free to add any additional description of changes below this line -->
