### PR TITLE
fix(client): use block instead of fields: blockName in graphql query

### DIFF
--- a/client/src/templates/Challenges/codeally/show.tsx
+++ b/client/src/templates/Challenges/codeally/show.tsx
@@ -214,9 +214,9 @@ class ShowCodeAlly extends Component<ShowCodeAllyProps> {
       data: {
         challengeNode: {
           challenge: {
+            block,
             challengeType,
             description,
-            fields: { blockName },
             id: challengeId,
             instructions,
             notes,
@@ -237,7 +237,7 @@ class ShowCodeAlly extends Component<ShowCodeAllyProps> {
     } = this.props;
 
     const blockNameTitle = `${t(
-      `intro:${superBlock}.blocks.${blockName}.title`
+      `intro:${superBlock}.blocks.${block}.title`
     )}: ${title}`;
     const windowTitle = `${blockNameTitle} | freeCodeCamp.org`;
 
@@ -397,7 +397,7 @@ class ShowCodeAlly extends Component<ShowCodeAllyProps> {
                 <Spacer size='medium' />
               </Col>
               <CompletionModal />
-              <HelpModal challengeTitle={title} challengeBlock={blockName} />
+              <HelpModal challengeTitle={title} challengeBlock={block} />
             </Row>
           </Container>
         </LearnLayout>
@@ -418,11 +418,9 @@ export const query = graphql`
   query CodeAllyChallenge($slug: String!) {
     challengeNode(challenge: { fields: { slug: { eq: $slug } } }) {
       challenge {
+        block
         challengeType
         description
-        fields {
-          blockName
-        }
         helpCategory
         id
         instructions


### PR DESCRIPTION
We are trying to not add the fields info to the CAP database. This helps make that easier. 

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
