### PR TITLE
test: try to make reset-modal.spec reliable

### DIFF
--- a/e2e/reset-modal.spec.ts
+++ b/e2e/reset-modal.spec.ts
@@ -44,21 +44,33 @@ test('should render the modal content correctly', async ({ page }) => {
 });
 
 test('User can reset challenge', async ({ page }) => {
+  const initialText = 'CatPhotoApp';
+  const initialFrame = page
+    .frameLocator('iframe[title="challenge preview"]')
+    .getByText(initialText);
+
+  const updatedText = 'Only Dogs';
+  const updatedFrame = page
+    .frameLocator('iframe[title="challenge preview"]')
+    .getByText(updatedText);
+
   await page.goto(
     '/learn/2022/responsive-web-design/learn-html-by-building-a-cat-photo-app/step-2'
   );
 
+  await expect(initialFrame).toBeVisible();
+
   const editorPaneLabel =
     'Editor content;Press Alt+F1 for Accessibility Options.';
-  const challengeSolution = '<h2>Cat Photos</h2>';
 
-  await page.getByLabel(editorPaneLabel).fill(challengeSolution);
-  await expect(
-    page
-      .frameLocator('iframe[title="challenge preview"]')
-      .getByRole('heading', { name: 'Cat Photos' })
-  ).toBeVisible();
+  // Modify the text in the editor pane, clearing first, otherwise the existing
+  // text will be selected before typing
+  await page.getByLabel(editorPaneLabel).fill('');
+  await page.getByLabel(editorPaneLabel).fill(updatedText);
+  await expect(updatedFrame).toBeVisible();
 
+  // Run the tests so the lower jaw updates (later we confirm that the update
+  // are reset)
   await page
     .getByRole('button', {
       name: translations.buttons['check-code']
@@ -69,16 +81,14 @@ test('User can reset challenge', async ({ page }) => {
     page.getByText(translations.learn['sorry-keep-trying'])
   ).toBeVisible();
 
+  // Reset the challenge
   await page.getByTestId('lowerJaw-reset-button').click();
   await page
     .getByRole('button', { name: translations.buttons['reset-lesson'] })
     .click();
 
-  await expect(
-    page
-      .frameLocator('iframe[title="challenge preview"]')
-      .getByRole('heading', { name: 'Cat Photos' })
-  ).not.toBeVisible();
+  // Check it's back to the initial state
+  await expect(initialFrame).toBeVisible();
   await expect(
     page.getByText(translations.learn['sorry-keep-trying'])
   ).not.toBeVisible();

--- a/e2e/reset-modal.spec.ts
+++ b/e2e/reset-modal.spec.ts
@@ -68,7 +68,7 @@ test('User can reset challenge', async ({ page }) => {
   // text will be selected before typing
   await page.getByLabel(editorPaneLabel).fill('');
   await page.getByLabel(editorPaneLabel).fill(updatedText);
-  await expect(updatedFrame).toBeVisible({ timeout: 10000});
+  await expect(updatedFrame).toBeVisible({ timeout: 10000 });
 
   // Run the tests so the lower jaw updates (later we confirm that the update
   // are reset)

--- a/e2e/reset-modal.spec.ts
+++ b/e2e/reset-modal.spec.ts
@@ -68,7 +68,7 @@ test('User can reset challenge', async ({ page }) => {
   // text will be selected before typing
   await page.getByLabel(editorPaneLabel).fill('');
   await page.getByLabel(editorPaneLabel).fill(updatedText);
-  await expect(updatedFrame).toBeVisible();
+  await expect(updatedFrame).toBeVisible({ timeout: 10000});
 
   // Run the tests so the lower jaw updates (later we confirm that the update
   // are reset)
@@ -89,7 +89,7 @@ test('User can reset challenge', async ({ page }) => {
     .click();
 
   // Check it's back to the initial state
-  await expect(initialFrame).toBeVisible();
+  await expect(initialFrame).toBeVisible({ timeout: 10000 });
   await expect(
     page.getByText(translations.learn['sorry-keep-trying'])
   ).not.toBeVisible();

--- a/e2e/reset-modal.spec.ts
+++ b/e2e/reset-modal.spec.ts
@@ -58,7 +58,8 @@ test('User can reset challenge', async ({ page }) => {
     '/learn/2022/responsive-web-design/learn-html-by-building-a-cat-photo-app/step-2'
   );
 
-  await expect(initialFrame).toBeVisible();
+  // Building the preview can take a while
+  await expect(initialFrame).toBeVisible({ timeout: 10000 });
 
   const editorPaneLabel =
     'Editor content;Press Alt+F1 for Accessibility Options.';


### PR DESCRIPTION
- **test: clear before typing + improve readability**
- **test: increase wait in case preview is slow**

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This is mostly a refactor, but there are two real changes: 1) clear the editor before typing 2) wait longer for the preview to first appear.

<!-- Feel free to add any additional description of changes below this line -->
