### PR TITLE
test: improve shortcuts modal spec

### DIFF
--- a/e2e/shortcuts-modal.spec.ts
+++ b/e2e/shortcuts-modal.spec.ts
@@ -1,4 +1,4 @@
-import { APIRequestContext, expect, test } from '@playwright/test';
+import { APIRequestContext, Page, expect, test } from '@playwright/test';
 
 import translations from '../client/i18n/locales/english/translations.json';
 
@@ -17,6 +17,13 @@ const enableKeyboardShortcuts = async (request: APIRequestContext) =>
     }
   );
 
+const openModal = async (page: Page) => {
+  // The editor pane is focused by default, so we need to escape or it will
+  // capture the keyboard shortcuts
+  await page.getByLabel(editorPaneLabel).press('Escape');
+  await page.keyboard.press('Shift+?');
+};
+
 test.beforeEach(async ({ page, isMobile, request }) => {
   test.skip(
     isMobile,
@@ -30,11 +37,7 @@ test.beforeEach(async ({ page, isMobile, request }) => {
 test('the modal can be opened with SHIFT + ? and closed with ESC', async ({
   page
 }) => {
-  // The editor pane is focused by default, so we need to escape or it will
-  // capture the keyboard shortcuts
-  await page.getByLabel(editorPaneLabel).press('Escape');
-  await page.keyboard.press('Shift+?');
-
+  await openModal(page);
   const dialog = page.getByRole('dialog', {
     name: translations.shortcuts.title
   });
@@ -67,6 +70,7 @@ test('the modal can be opened with SHIFT + ? and closed with ESC', async ({
 test('has a button to disable or enable keyboard shortcuts', async ({
   page
 }) => {
+  await openModal(page);
   const dialog = page.getByRole('dialog', {
     name: translations.shortcuts.title
   });

--- a/e2e/shortcuts-modal.spec.ts
+++ b/e2e/shortcuts-modal.spec.ts
@@ -1,4 +1,4 @@
-import { Page, expect, test } from '@playwright/test';
+import { APIRequestContext, expect, test } from '@playwright/test';
 
 import translations from '../client/i18n/locales/english/translations.json';
 
@@ -9,24 +9,21 @@ const editorPaneLabel =
 
 test.use({ storageState: 'playwright/.auth/certified-user.json' });
 
-// Enable keyboard shortcuts
-const enableKeyboardShortcuts = async (page: Page) => {
-  await page.goto('/settings');
-  const keyboardShortcutGroup = page.getByRole('group', {
-    name: translations.settings.labels['keyboard-shortcuts']
-  });
-  await keyboardShortcutGroup
-    .getByRole('button', { name: translations.buttons.on, exact: true })
-    .click();
-};
+const enableKeyboardShortcuts = async (request: APIRequestContext) =>
+  await request.put(
+    process.env.API_LOCATION + '/update-my-keyboard-shortcuts',
+    {
+      data: { keyboardShortcuts: true }
+    }
+  );
 
-test.beforeEach(async ({ page,  isMobile }) => {
+test.beforeEach(async ({ page, isMobile, request }) => {
   test.skip(
-     isMobile,
+    isMobile,
     'Skipping on mobile as it does not have a physical keyboard'
   );
 
-  await enableKeyboardShortcuts(page);
+  await enableKeyboardShortcuts(request);
   await page.goto(course);
 });
 

--- a/e2e/shortcuts-modal.spec.ts
+++ b/e2e/shortcuts-modal.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { Page, expect, test } from '@playwright/test';
 
 import translations from '../client/i18n/locales/english/translations.json';
 
@@ -9,13 +9,8 @@ const editorPaneLabel =
 
 test.use({ storageState: 'playwright/.auth/certified-user.json' });
 
-test.beforeEach(async ({ page, isMobile }) => {
-  test.skip(
-    isMobile,
-    'Skipping on mobile as it does not have a physical keyboard'
-  );
-
-  // Enable keyboard shortcuts
+// Enable keyboard shortcuts
+const enableKeyboardShortcuts = async (page: Page) => {
   await page.goto('/settings');
   const keyboardShortcutGroup = page.getByRole('group', {
     name: translations.settings.labels['keyboard-shortcuts']
@@ -23,25 +18,30 @@ test.beforeEach(async ({ page, isMobile }) => {
   await keyboardShortcutGroup
     .getByRole('button', { name: translations.buttons.on, exact: true })
     .click();
+};
 
-  // Open shortcuts modal
-  await page.goto(course);
-  await page.getByLabel(editorPaneLabel).press('Escape');
-  await page.keyboard.press('Shift+?');
-});
-
-test('User can see list of shortcuts  by pressing SHIFT + ?', async ({
-  page,
-  isMobile
-}) => {
+test.beforeEach(async ({ page,  isMobile }) => {
   test.skip(
-    isMobile,
-    'Skipping on mobile as it does not have a physical keyboard.'
+     isMobile,
+    'Skipping on mobile as it does not have a physical keyboard'
   );
 
-  await expect(
-    page.getByRole('dialog', { name: translations.shortcuts.title })
-  ).toBeVisible();
+  await enableKeyboardShortcuts(page);
+  await page.goto(course);
+});
+
+test('the modal can be opened with SHIFT + ? and closed with ESC', async ({
+  page
+}) => {
+  // The editor pane is focused by default, so we need to escape or it will
+  // capture the keyboard shortcuts
+  await page.getByLabel(editorPaneLabel).press('Escape');
+  await page.keyboard.press('Shift+?');
+
+  const dialog = page.getByRole('dialog', {
+    name: translations.shortcuts.title
+  });
+  await expect(dialog).toBeVisible();
 
   for (const shortcut of Object.values(translations.shortcuts)) {
     if (shortcut === translations.shortcuts.title) continue;
@@ -61,31 +61,15 @@ test('User can see list of shortcuts  by pressing SHIFT + ?', async ({
   await expect(
     page.getByRole('button', { name: translations.buttons.close })
   ).toBeVisible();
-});
-
-test('User can close the modal by pressing ESC', async ({ page, isMobile }) => {
-  test.skip(
-    isMobile,
-    'Skipping on mobile as it does not have a physical keyboard.'
-  );
-
-  const dialog = page.getByRole('dialog', {
-    name: translations.shortcuts.title
-  });
-
-  await expect(dialog).toBeVisible();
 
   await page.keyboard.press('Escape');
 
   await expect(dialog).not.toBeVisible();
 });
 
-test('User can disable keyboard shortcuts', async ({ page, isMobile }) => {
-  test.skip(
-    isMobile,
-    'Skipping on mobile as it does not have a physical keyboard.'
-  );
-
+test('has a button to disable or enable keyboard shortcuts', async ({
+  page
+}) => {
   const dialog = page.getByRole('dialog', {
     name: translations.shortcuts.title
   });


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

I noticed on https://github.com/freeCodeCamp/freeCodeCamp/pull/54518 that this spec is flaky https://github.com/freeCodeCamp/freeCodeCamp/actions/runs/8845803793/job/24290758729 

I'm not 100% confident this fixes that, but it is considerably faster and a bit tidier.

In general, we should be able to make the tests more performant if we only test the UI _once_ in the spec that's concerned with that portion of the UI. When a spec needs the db to be in a particular state before starting, we should set that up via db calls or, preferably, api calls.

<!-- Feel free to add any additional description of changes below this line -->
