### PR TITLE
ci: run e2e tests against new and old apis

### DIFF
--- a/.github/workflows/e2e-with-new-api.yml
+++ b/.github/workflows/e2e-with-new-api.yml
@@ -115,7 +115,7 @@ jobs:
   playwright-run:
     name: Run Playwright Tests (with new Api)
     runs-on: ubuntu-22.04
-    needs: [build-client, build-api]
+    needs: [build-client, build-new-api]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/e2e-with-new-api.yml
+++ b/.github/workflows/e2e-with-new-api.yml
@@ -158,7 +158,9 @@ jobs:
         run: pnpm install
 
       - name: Set freeCodeCamp Environment Variables (needed by api)
-        run: cp sample.env .env
+        run: |
+          cp sample.env .env
+          echo 'HOST=0.0.0.0' >> .env
 
       - name: Install playwright dependencies
         run: npx playwright install --with-deps

--- a/.github/workflows/e2e-with-new-api.yml
+++ b/.github/workflows/e2e-with-new-api.yml
@@ -1,0 +1,189 @@
+name: CI - E2E - Containers
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: ['CI - Node.js']
+    types:
+      - completed
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+    branches:
+      - 'main'
+      - 'next-**'
+      - 'e2e-**'
+
+jobs:
+  build-client:
+    name: Build Client
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        node-version: [20.x]
+
+    steps:
+      - name: Checkout Source Files
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Checkout client-config
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          repository: freeCodeCamp/client-config
+          path: client-config
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d #v3.0.0
+        with:
+          version: 9
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: pnpm
+
+      - name: Set freeCodeCamp Environment Variables
+        run: cp sample.env .env
+
+      - name: Install and Build
+        run: |
+          pnpm install
+          pnpm run build
+
+      - name: Move serve.json to Public Folder
+        run: cp client-config/serve.json client/public/serve.json
+
+      # We tar them for performance reasons - uploading a lot of files is slow.
+      - name: Tar Files
+        run: tar -cf client-artifact.tar client/public
+
+      - name: Upload Client Artifact
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+        with:
+          name: client-artifact
+          path: client-artifact.tar
+
+      - name: Upload Webpack Stats
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+        with:
+          name: webpack-stats
+          path: client/public/stats.json
+
+  build-api:
+    name: Build Api (Container)
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        node-version: [20.x]
+
+    steps:
+      - name: Checkout Source Files
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Create Image
+        run: |
+          docker build \
+            -t fcc-api \
+            -f docker/api/Dockerfile .
+
+      - name: Save Image
+        run: docker save fcc-api > api-artifact.tar
+
+  build-new-api:
+    name: Build New Api (Container)
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        node-version: [20.x]
+
+    steps:
+      - name: Checkout Source Files
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Create Image
+        run: |
+          docker build \
+            -t fcc-new-api \
+            -f docker/new-api/Dockerfile .
+
+      - name: Upload Api Artifact
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+        with:
+          name: api-artifact
+          path: api-artifact.tar
+
+  playwright-run:
+    name: Run Playwright Tests (with new Api)
+    runs-on: ubuntu-22.04
+    needs: [build-client, build-api]
+    strategy:
+      fail-fast: false
+      matrix:
+        # Extend this to include firefox and webkit once chromium is working.
+        browsers: [chromium]
+        node-version: [20.x]
+
+    steps:
+      - name: Set Action Environment Variables
+        run: |
+          echo "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV
+
+      - name: Checkout Source Files
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
+
+      - name: Unpack Client Artifact
+        run: |
+          tar -xf client-artifact/client-artifact.tar
+          rm client-artifact/client-artifact.tar
+
+      - name: Load Api Image
+        run: |
+          docker load < api-artifact/api-artifact.tar
+          rm api-artifact/api-artifact.tar
+
+      # Cypress calls some pnpm scripts, so we need to install pnpm.
+      - name: Setup pnpm
+        uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d #v3.0.0
+        with:
+          version: 8
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install Dependencies
+        run: pnpm install
+
+      - name: Set freeCodeCamp Environment Variables (needed by api)
+        run: cp sample.env .env
+
+      - name: Install playwright dependencies
+        run: npx playwright install --with-deps
+
+      - name: Install and Build
+        run: |
+          pnpm install
+          pnpm run create:shared
+          pnpm run build:curriculum
+
+      - name: Start apps
+        run: |
+          docker compose up -d
+          pnpm run serve:client-ci &
+          sleep 10
+
+      - name: Seed Database with Certified User
+        run: pnpm run seed:certified-user
+
+      - name: Run playwright tests
+        run: npx playwright test --project=${{ matrix.browsers }} --grep-invert 'third-party-donation.spec.ts'
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report-${{ matrix.browsers }}
+          path: playwright/reporter
+          retention-days: 30

--- a/.github/workflows/e2e-with-new-api.yml
+++ b/.github/workflows/e2e-with-new-api.yml
@@ -86,9 +86,6 @@ jobs:
             -t fcc-api \
             -f docker/api/Dockerfile .
 
-      - name: Save Image
-        run: docker save fcc-api > api-artifact.tar
-
   build-new-api:
     name: Build New Api (Container)
     runs-on: ubuntu-22.04
@@ -105,6 +102,9 @@ jobs:
           docker build \
             -t fcc-new-api \
             -f docker/new-api/Dockerfile .
+
+      - name: Save Image
+        run: docker save fcc-new-api > api-artifact.tar
 
       - name: Upload Api Artifact
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1

--- a/.github/workflows/e2e-with-new-api.yml
+++ b/.github/workflows/e2e-with-new-api.yml
@@ -147,7 +147,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d #v3.0.0
         with:
-          version: 8
+          version: 9
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,18 @@ services:
     image: mongo
     ports:
       - '27017:27017'
+  setup:
+    image: mongo
+    depends_on:
+      - mongo
+    restart: on-failure
+    entrypoint: [
+        'bash',
+        '-c',
+        # This will try to initiate the replica set, until it succeeds twice (i.e. until the replica set is already initialized)
+        'mongosh --host mongo:27017 --eval ''try {rs.initiate();} catch (err) { if(err.codeName !== "AlreadyInitialized") throw err };'''
+      ]
+
   mailhog:
     restart: unless-stopped
     image: mailhog/mailhog
@@ -13,7 +25,7 @@ services:
     depends_on:
       - mongo
       - mailhog
-    image: fcc-api
+    image: fcc-new-api
     env_file:
       - .env
     environment:
@@ -24,9 +36,4 @@ services:
     ports:
       # PORT is used by the new api, so we use the less generic API_PORT to
       # avoid conflicts.
-      - '${API_PORT:-3000}:3000'
-  client:
-    image: fcc-client
-    ports:
-      # Same principle as above (avoiding conflicts)
-      - '${CLIENT_PORT:-8000}:8000'
+      - '3000:3000'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
     image: mongo
     ports:
       - '27017:27017'
+    command: mongod --replSet rs0
   setup:
     image: mongo
     depends_on:
@@ -14,7 +15,6 @@ services:
         # This will try to initiate the replica set, until it succeeds twice (i.e. until the replica set is already initialized)
         'mongosh --host mongo:27017 --eval ''try {rs.initiate();} catch (err) { if(err.codeName !== "AlreadyInitialized") throw err };'''
       ]
-
   mailhog:
     restart: unless-stopped
     image: mailhog/mailhog
@@ -22,6 +22,7 @@ services:
       - '1025:1025'
       - '8025:8025'
   api:
+    restart: unless-stopped
     depends_on:
       - mongo
       - mailhog


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This extends the CI coverage to run the e2e tests against the new api as well as the old. Once we've completed the migration to the new api, we can delete the old.

<!-- Feel free to add any additional description of changes below this line -->
