### PR TITLE
fix(ui): fix upperjaw inline code string spacing

### DIFF
--- a/client/src/templates/Challenges/classic/editor.css
+++ b/client/src/templates/Challenges/classic/editor.css
@@ -37,7 +37,6 @@ textarea.inputarea {
 .editor-lower-jaw {
   padding-inline: 0 15px;
   padding-block: 15px;
-  white-space: pre-wrap;
 }
 
 .editor-upper-jaw {

--- a/client/src/templates/Challenges/classic/editor.css
+++ b/client/src/templates/Challenges/classic/editor.css
@@ -37,6 +37,7 @@ textarea.inputarea {
 .editor-lower-jaw {
   padding-inline: 0 15px;
   padding-block: 15px;
+  white-space: pre-wrap;
 }
 
 .editor-upper-jaw {

--- a/client/src/templates/Challenges/classic/editor.css
+++ b/client/src/templates/Challenges/classic/editor.css
@@ -43,6 +43,10 @@ textarea.inputarea {
   max-width: unset !important;
 }
 
+code {
+  white-space: pre-wrap;
+}
+
 .action-row-container,
 .description-container {
   background-color: var(--secondary-background);
@@ -51,10 +55,6 @@ textarea.inputarea {
   /* the max-width is set to keep the characters in a line at below ~70 to help
   with readability */
   max-width: 600px;
-}
-
-.description-container {
-  white-space: pre-wrap;
 }
 
 .challenge-description-header {

--- a/client/src/templates/Challenges/classic/editor.css
+++ b/client/src/templates/Challenges/classic/editor.css
@@ -41,7 +41,6 @@ textarea.inputarea {
 
 .editor-upper-jaw {
   max-width: unset !important;
-  white-space: pre-wrap;
 }
 
 .action-row-container,
@@ -52,6 +51,10 @@ textarea.inputarea {
   /* the max-width is set to keep the characters in a line at below ~70 to help
   with readability */
   max-width: 600px;
+}
+
+.description-container {
+  white-space: pre-wrap;
 }
 
 .challenge-description-header {

--- a/client/src/templates/Challenges/classic/editor.css
+++ b/client/src/templates/Challenges/classic/editor.css
@@ -44,7 +44,7 @@ textarea.inputarea {
 }
 
 code {
-  white-space: pre-wrap;
+  white-space: pre;
 }
 
 .action-row-container,

--- a/client/src/templates/Challenges/classic/editor.css
+++ b/client/src/templates/Challenges/classic/editor.css
@@ -37,11 +37,11 @@ textarea.inputarea {
 .editor-lower-jaw {
   padding-inline: 0 15px;
   padding-block: 15px;
-  white-space: pre-wrap;
 }
 
 .editor-upper-jaw {
   max-width: unset !important;
+  white-space: pre-wrap;
 }
 
 .action-row-container,


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Closes #52498

We fixed the code string spacing issue and passed all github action tests by changing the white-space property on the code blocks. 
<img width="662" alt="Screenshot 2024-04-27 at 23 34 56" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/92952291/6804e705-bc57-4919-b3e0-1d79b81c54d1">
