### PR TITLE
fix(client): english audio playback consistency

### DIFF
--- a/client/src/templates/Challenges/components/scene/scene.tsx
+++ b/client/src/templates/Challenges/components/scene/scene.tsx
@@ -102,6 +102,7 @@ export function Scene({
   }, [isPlaying]);
 
   const audioLoaded = () => {
+    console.log('scene is ready');
     setSceneIsReady(true);
   };
 
@@ -247,7 +248,7 @@ export function Scene({
           aspectRatio: '16 / 9'
         }}
       >
-        {sceneIsReady /*!audioLoaded || !imagesLoaded ? (*/ ? (
+        {!sceneIsReady ? (
           <Loader />
         ) : (
           <>

--- a/client/src/templates/Challenges/components/scene/scene.tsx
+++ b/client/src/templates/Challenges/components/scene/scene.tsx
@@ -41,10 +41,6 @@ export function Scene({
 
   // on mount
   useEffect(() => {
-    // preload audio
-    // audioRef.current.load();
-    // setAudioLoaded(true);
-
     audioRef.current.addEventListener('canplaythrough', audioLoaded);
 
     // preload images
@@ -60,8 +56,6 @@ export function Scene({
         background ? `${backgrounds}/${background}` : null
       )
       .forEach(loadImage);
-
-    // setImagesLoaded(true);
 
     // on unmount
     return () => {
@@ -84,8 +78,6 @@ export function Scene({
   });
 
   const [sceneIsReady, setSceneIsReady] = useState(false);
-  // const [audioLoaded, setAudioLoaded] = useState(false);
-  // const [imagesLoaded, setImagesLoaded] = useState(false);
   const [showDialogue, setShowDialogue] = useState(false);
   const [accessibilityOn, setAccessibilityOn] = useState(false);
   const [characters, setCharacters] = useState(initCharacters);
@@ -102,7 +94,6 @@ export function Scene({
   }, [isPlaying]);
 
   const audioLoaded = () => {
-    console.log('scene is ready');
     setSceneIsReady(true);
   };
 
@@ -118,15 +109,11 @@ export function Scene({
 
     // start audio after startTime has been reached
     if (runningTime >= sToMs(audio.startTime) && audioRef.current.paused) {
-      console.log('playing audio');
       void audioRef.current.play();
     }
 
     // stop audio if the duration has been reached
     if (runningTime >= duration) {
-      console.log('finishNow', finishNow);
-      console.log('duration ran', finishNow - startNow);
-      console.log('stopping audio');
       stopAudio = true;
       audioRef.current.pause();
     }
@@ -139,24 +126,18 @@ export function Scene({
   const playScene = () => {
     setShowDialogue(true);
 
-    console.log(audioRef.current);
-
     // the timestamps don't exist when we play the whole audio, so we only need
     // to use the playAudio function if they are set. Otherwise, we can just
     // play the whole clip
     if (audio.startTimestamp && audio.finishTimestamp) {
-      console.log('running playAudio');
       duration =
         sToMs(audio.finishTimestamp) -
         sToMs(audio.startTimestamp) +
         sToMs(audio.startTime);
-      console.log('duration', duration);
       startNow = Date.now();
-      console.log('startNow', startNow);
 
       playAudio();
     } else {
-      console.log('not running playAudio');
       setTimeout(function () {
         void audioRef.current.play();
       }, sToMs(audio.startTime));
@@ -226,7 +207,6 @@ export function Scene({
   };
 
   const finishScene = () => {
-    console.log(audioRef.current);
     audioRef.current.pause();
     audioRef.current.src = `${sounds}/${audio.filename}${audioTimestamp}`;
     audioRef.current.currentTime = audio.startTimestamp || 0;

--- a/client/src/templates/Challenges/components/scene/scene.tsx
+++ b/client/src/templates/Challenges/components/scene/scene.tsx
@@ -197,9 +197,9 @@ export function Scene({
           () => {
             setIsPlaying(false);
           },
+          // an extra 500ms at the end to let the characters fade out (CSS transition)
           command.finishTime
-            ? // an extra 500ms at the end to let the characters fade out (CSS transition)
-              sToMs(command.finishTime) + 500
+            ? sToMs(command.finishTime) + 500
             : sToMs(command.startTime) + 500
         );
       }


### PR DESCRIPTION
The audio playback in the English challenges across browsers was very inconsistent - the audio would often get cut off a little early or play a little long. Firefox and Chrome were pretty similar and both close to the intended timestamps, Safari was off by quite a bit more. You could test this PR by checking some of the challenges (not the "Dialogue" ones, since those play the whole audio and didn't have issues) on different browsers on production, and then again on this PR. The main thing is that they should be consistent. Some of the timestamp may be off a little in the challenge files because they were adjusted due to the inconsistencies. We will have to go back and adjust those later or as issues come in.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
