### PR TITLE
fix(api): only import types from ts-reset

### DIFF
--- a/api/src/reset.d.ts
+++ b/api/src/reset.d.ts
@@ -1,0 +1,1 @@
+import '@total-typescript/ts-reset';

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -1,6 +1,8 @@
-// We import these declaration files here, in the entry point of our application, so
-// that they're available throughout.
-import '@total-typescript/ts-reset';
+// We need to use the triple-slash directive to ensure that ts-node uses the
+// reset.d.ts file. It's not possible to import the file directly because it
+// is not included in the build (it's a dev dependency).
+// eslint-disable-next-line @typescript-eslint/triple-slash-reference
+/// <reference path="./reset.d.ts" />
 import { build } from './app';
 import { FREECODECAMP_NODE_ENV, PORT } from './utils/env';
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

import type '@total-typescript/ts-reset'; isn't legal typescript and
import '@total-typescript/ts-reset'; leaves a require in the compiled js

Since this is a dev dependency, it cannot be required. The triple slash
directive works around this because TS will use it to find the
types, but JS will ignore it.

<!-- Feel free to add any additional description of changes below this line -->
