### PR TITLE
Revert "feat: python error formatting"

### DIFF
--- a/e2e/editor.spec.ts
+++ b/e2e/editor.spec.ts
@@ -1,26 +1,10 @@
-import { expect, test, type Page } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
-async function focusEditor({
-  page,
-  isMobile,
-  browserName
-}: {
-  page: Page;
-  isMobile: boolean;
-  browserName: string;
-}) {
-  const monacoEditor = page.getByLabel('Editor content');
-
-  // The editor has an overlay div, which prevents the click event from bubbling up in iOS Safari.
-  // This is a quirk in this browser-OS combination, and the workaround here is to use `.focus()`
-  // in place of `.click()` to focus on the editor.
-  // Ref: https://www.quirksmode.org/blog/archives/2014/02/mouse_event_bub.html
-  if (isMobile && browserName === 'webkit') {
-    await monacoEditor.focus();
-  } else {
-    await monacoEditor.click();
-  }
-}
+test.beforeEach(async ({ page }) => {
+  await page.goto(
+    '/learn/2022/responsive-web-design/learn-html-by-building-a-cat-photo-app/step-3'
+  );
+});
 
 test.describe('Editor Component', () => {
   test('should allow the user to insert text', async ({
@@ -28,38 +12,19 @@ test.describe('Editor Component', () => {
     isMobile,
     browserName
   }) => {
-    await page.goto(
-      '/learn/2022/responsive-web-design/learn-html-by-building-a-cat-photo-app/step-3'
-    );
+    const monacoEditor = page.getByLabel('Editor content');
 
-    await focusEditor({ page, isMobile, browserName });
+    // The editor has an overlay div, which prevents the click event from bubbling up in iOS Safari.
+    // This is a quirk in this browser-OS combination, and the workaround here is to use `.focus()`
+    // in place of `.click()` to focus on the editor.
+    // Ref: https://www.quirksmode.org/blog/archives/2014/02/mouse_event_bub.html
+    if (isMobile && browserName === 'webkit') {
+      await monacoEditor.focus();
+    } else {
+      await monacoEditor.click();
+    }
     await page.keyboard.insertText('<h2>FreeCodeCamp</h2>');
     const text = page.getByText('<h2>FreeCodeCamp</h2>');
     await expect(text).toBeVisible();
-  });
-});
-
-test.describe('Python Terminal', () => {
-  test('should display error message when the user enters invalid code', async ({
-    page,
-    isMobile,
-    browserName
-  }) => {
-    await page.goto(
-      'learn/scientific-computing-with-python/learn-string-manipulation-by-building-a-cipher/step-2'
-    );
-
-    await focusEditor({ page, isMobile, browserName });
-    // First clear the editor
-    await page.keyboard.press('Control+a');
-    await page.keyboard.press('Backspace');
-    // Then enter invalid code
-    await page.keyboard.insertText('def');
-    const preview = page.getByTestId('preview-pane');
-
-    // While it's displayed on multiple lines, the string itself has no newlines, hence:
-    const error = `>>> Traceback (most recent call last):  File "main.py", line 1    def       ^SyntaxError: invalid syntax`;
-    // It shouldn't take this long, but the Python worker can be slow to respond.
-    await expect(preview).toContainText(error, { timeout: 15000 });
   });
 });

--- a/tools/client-plugins/browser-scripts/python-worker.ts
+++ b/tools/client-plugins/browser-scripts/python-worker.ts
@@ -3,7 +3,6 @@
 import { loadPyodide, type PyodideInterface } from 'pyodide/pyodide.js';
 import pkg from 'pyodide/package.json';
 import type { PyProxy, PythonError } from 'pyodide/ffi';
-import * as helpers from '@freecodecamp/curriculum-helpers';
 
 const ctx: Worker & typeof globalThis = self as unknown as Worker &
   typeof globalThis;
@@ -53,15 +52,6 @@ async function setupPyodide() {
   // weird state. NOTE: this has to come after pyodide is loaded, because
   // pyodide modifies self while loading.
   Object.freeze(self);
-
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-  pyodide.FS.writeFile(
-    '/home/pyodide/ast_helpers.py',
-    helpers.python.astHelpers,
-    {
-      encoding: 'utf8'
-    }
-  );
 
   ignoreRunMessages = true;
   postMessage({ type: 'stopped' });
@@ -144,19 +134,10 @@ function initRunPython() {
     else:
       return ""
   `);
-  runPython(`
-def print_exception():
-    from ast_helpers import format_exception
-    formatted = format_exception(exception=sys.last_value, traceback=sys.last_traceback, filename="<exec>", new_filename="main.py")
-    print(formatted)
-`);
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-  const printException = globals.get('print_exception') as PyProxy &
-    (() => string);
 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-call
   const getResetId = globals.get('__get_reset_id') as PyProxy & (() => string);
-  return { runPython, getResetId, globals, printException };
+  return { runPython, getResetId, globals };
 }
 
 ctx.onmessage = (e: PythonRunEvent | ListenRequestEvent | CancelEvent) => {
@@ -185,16 +166,13 @@ function handleRunRequest(data: PythonRunEvent['data']) {
   // TODO: use reset-terminal for clarity?
   postMessage({ type: 'reset' });
 
-  const { runPython, getResetId, globals, printException } = initRunPython();
+  const { runPython, getResetId, globals } = initRunPython();
   // use pyodide.runPythonAsync if we want top-level await
   try {
     runPython(code);
   } catch (e) {
     const err = e as PythonError;
-    // the formatted exception is printed to the terminal
-    printException();
-    // but the full error is logged to the console for debugging
-    console.error(err);
+    console.error(e);
     const resetId = getResetId();
     // TODO: if a user raises a KeyboardInterrupt with a custom message this
     // will be treated as a reset, the client will resend their code and this
@@ -209,7 +187,6 @@ function handleRunRequest(data: PythonRunEvent['data']) {
     }
   } finally {
     getResetId.destroy();
-    printException.destroy();
     globals.destroy();
   }
 }


### PR DESCRIPTION
This reverts commit 3e03fc87e73138f9b5a21edc558ed97213b75829.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Reverts #54185 

<!-- Feel free to add any additional description of changes below this line -->

I missed the comment about this one being blocked until the curriculum helpers were updated. 🤦🏻‍♀️ 