### PR TITLE
fix(UI): make the progression arrows be centered

### DIFF
--- a/client/src/components/Map/index.tsx
+++ b/client/src/components/Map/index.tsx
@@ -91,16 +91,18 @@ function MapLi({
         data-test-label='curriculum-map-button'
         data-playwright-test-label='curriculum-map-button'
       >
-        <div className='progress-icon'>
-          <RibbonIcon
-            value={index + 1}
-            showNumbers={showNumbers}
-            isCompleted={completed}
-            isClaimed={claimed}
-          />
-        </div>
-        <div className='progression-arrow'>
-          {!last && showArrows && <Arrow />}
+        <div className='progress-icon-wrapper'>
+          <div className='progress-icon'>
+            <RibbonIcon
+              value={index + 1}
+              showNumbers={showNumbers}
+              isCompleted={completed}
+              isClaimed={claimed}
+            />
+          </div>
+          <div className='progression-arrow'>
+            {!last && showArrows && <Arrow />}
+          </div>
         </div>
 
         <Link className='btn link-btn btn-lg' to={`/learn/${superBlock}/`}>

--- a/client/src/components/Map/map.css
+++ b/client/src/components/Map/map.css
@@ -9,23 +9,25 @@
 }
 
 .progress-icon-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
   position: relative;
 }
 
 .progression-arrow {
   position: absolute;
-  bottom: -31px;
-  left: 29px;
+  top: calc(78%);
+  left: 21px;
 }
 
 .map-ui ul .progress-icon {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  width: 4rem;
-  margin: 0 10px 10px 0;
   position: relative;
+  right: 7px;
+  width: 4rem;
+  display: flex;
+  justify-content: center;
 }
 
 .map-ui ul .progress-icon .cert-icon-outline {
@@ -47,8 +49,6 @@
 .map-ui ul li {
   display: flex;
   flex-direction: row;
-  align-items: center;
-  justify-content: space-between;
 }
 
 .map-ui ul li .arrow path {

--- a/client/src/components/Map/map.css
+++ b/client/src/components/Map/map.css
@@ -51,6 +51,10 @@
   flex-direction: row;
 }
 
+.map-ui ul li a > svg {
+  overflow: visible;
+}
+
 .map-ui ul li .arrow path {
   fill: var(--secondary-color);
 }

--- a/client/src/components/Map/map.css
+++ b/client/src/components/Map/map.css
@@ -8,10 +8,14 @@
   padding: 0;
 }
 
+.progress-icon-wrapper {
+  position: relative;
+}
+
 .progression-arrow {
   position: absolute;
-  bottom: -16px;
-  left: 25px;
+  bottom: -31px;
+  left: 29px;
 }
 
 .map-ui ul .progress-icon {
@@ -45,7 +49,6 @@
   flex-direction: row;
   align-items: center;
   justify-content: space-between;
-  position: relative;
 }
 
 .map-ui ul li .arrow path {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

Edit: related PR is #54576.

<!-- Feel free to add any additional description of changes below this line -->
This PR was opened to make the progression arrows be ~~vertically~~ horizontally centered on any viewport width including small mobile devices.

|before|after|
|---|---|
|![arrows_not_centered_in_mobile_device_1](https://github.com/freeCodeCamp/freeCodeCamp/assets/44451585/1e7eaa69-0381-4a1c-9c5f-3ee660fe9da6)|![arrows_centered_in_mobile_device_1](https://github.com/freeCodeCamp/freeCodeCamp/assets/44451585/9aedcb15-7090-4d3b-a836-a0d71b7ff001)|

By using gitpod, the code was tested with following environment.

1. Windows 11 Home PC using Chrome, Firefox, Edge, and Brave browser, or, webkit within the Playwright.
1. Android Studio's emulator(Pixel 6 Pro with Android API 34 system image) using Chrome.
1. iPhone SE (iOS 15.7.8) using Chrome and Firefox browser.