### PR TITLE
fix: send CSRF-Token with GET requests

### DIFF
--- a/client/src/utils/ajax.ts
+++ b/client/src/utils/ajax.ts
@@ -36,7 +36,10 @@ export interface ResponseWithData<T> {
 // TODO: Might want to handle flash messages as close to the request as possible
 // to make use of the Response object (message, status, etc)
 async function get<T>(path: string): Promise<ResponseWithData<T>> {
-  const response = await fetch(`${base}${path}`, defaultOptions);
+  const response = await fetch(`${base}${path}`, {
+    ...defaultOptions,
+    headers: { 'CSRF-Token': getCSRFToken() }
+  });
 
   return combineDataWithResponse(response);
 }


### PR DESCRIPTION
The new api expects this header for more routes than the old api does. While we could make the new api ignore the header for all GET requests, it's easier to make the client provide it. The security benefits are small, but redundancy in security is a good thing.

These changes are included in https://github.com/freeCodeCamp/freeCodeCamp/pull/54546, so this PR is mostly for visibility.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
