### PR TITLE
fix: use boolean value for acceptedPrivacyTerms

### DIFF
--- a/tools/scripts/seed/seed-demo-user.js
+++ b/tools/scripts/seed/seed-demo-user.js
@@ -87,7 +87,7 @@ const trophyChallenges = [
     user.yearsTopContributor = ['2017', '2018', '2019'];
   }
   if (args.includes('--unset-privacy-terms')) {
-    user.acceptedPrivacyTerms = null;
+    user.acceptedPrivacyTerms = false;
   }
   if (args.includes('--seed-trophy-challenges')) {
     user.completedChallenges = trophyChallenges;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

`acceptedPrivacyTerms` should be boolean. That's how it is the schema.

<!-- Feel free to add any additional description of changes below this line -->
