### PR TITLE
fix(api): allow server to be run from any dir

### DIFF
--- a/api/src/utils/get-challenges.ts
+++ b/api/src/utils/get-challenges.ts
@@ -6,11 +6,11 @@
 import { readFileSync } from 'fs';
 import { join } from 'path';
 
-const CURRICULUM_PATH = '../shared/config/curriculum.json';
+const CURRICULUM_PATH = '../../../shared/config/curriculum.json';
 
 // Curriculum is read using fs, because it is too large for VSCode's LSP to handle type inference which causes anoying behaviour.
 const curriculum = JSON.parse(
-  readFileSync(join(process.cwd(), CURRICULUM_PATH), 'utf-8')
+  readFileSync(join(__dirname, CURRICULUM_PATH), 'utf-8')
 ) as Curriculum;
 
 interface Block {


### PR DESCRIPTION
Using process.cwd() means the scripts have to be called from the same
directory, __dirname removes this restriction.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
