### PR TITLE
fix(api): allow "" for social, not undefined

### DIFF
--- a/api/src/routes/settings.test.ts
+++ b/api/src/routes/settings.test.ts
@@ -530,11 +530,26 @@ Please wait 5 minutes to resend an authentication link.`
         expect(response.statusCode).toEqual(200);
       });
 
+      test('PUT accepts empty strings for socials', async () => {
+        const response = await superPut('/update-my-socials').send({
+          website: 'https://www.freecodecamp.org/',
+          twitter: '',
+          linkedin: '',
+          githubProfile: ''
+        });
+
+        expect(response.body).toEqual({
+          message: 'flash.updated-socials',
+          type: 'success'
+        });
+        expect(response.statusCode).toEqual(200);
+      });
+
       test('PUT returns 400 status code with invalid socials setting', async () => {
         const response = await superPut('/update-my-socials').send({
           website: 'invalid',
-          twitter: 'invalid',
-          linkedin: 'invalid',
+          twitter: '',
+          linkedin: '',
           githubProfile: 'invalid'
         });
 

--- a/api/src/schemas/settings/update-my-socials.ts
+++ b/api/src/schemas/settings/update-my-socials.ts
@@ -1,13 +1,16 @@
 import { Type } from '@fastify/type-provider-typebox';
 
+const urlOrEmptyString = Type.Union([
+  Type.Literal(''),
+  Type.String({ format: 'uri', maxLength: 1024 })
+]);
+
 export const updateMySocials = {
   body: Type.Object({
-    website: Type.Optional(Type.String({ format: 'url', maxLength: 1024 })),
-    twitter: Type.Optional(Type.String({ format: 'url', maxLength: 1024 })),
-    githubProfile: Type.Optional(
-      Type.String({ format: 'url', maxLength: 1024 })
-    ),
-    linkedin: Type.Optional(Type.String({ format: 'url', maxLength: 1024 }))
+    website: urlOrEmptyString,
+    twitter: urlOrEmptyString,
+    githubProfile: urlOrEmptyString,
+    linkedin: urlOrEmptyString
   }),
   response: {
     200: Type.Object({


### PR DESCRIPTION
The client always sends something, the value can either be an empty string or a url. This means the api should allow those kinds of payloads.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->
