### PR TITLE
fix(curriculum): add dispatchevent to trigger onchange after value change in tests

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/build-a-cash-register-project/build-a-cash-register.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/build-a-cash-register-project/build-a-cash-register.md
@@ -85,6 +85,7 @@ window.alert = (message) => alertMessage = message; // Override alert and store 
 price = 20;
 cashInput.value = '10';
 
+cashInput.dispatchEvent(new Event('change'));
 purchaseBtn.click();
 assert.strictEqual(alertMessage.trim().replace(/[.,?!]+$/g, '').toLowerCase(), 'customer does not have enough money to purchase the item');
 ```
@@ -99,6 +100,7 @@ const changeDueDiv = document.getElementById('change-due');
 price = 11.95;
 cashInput.value = '11.95';
 
+cashInput.dispatchEvent(new Event('change'));
 purchaseBtn.click();
 assert.strictEqual(changeDueDiv.innerText.trim().replace(/[.,?!]+$/g, '').toLowerCase(), 'no change due - customer paid with exact cash');
 ```
@@ -115,6 +117,7 @@ cashInput.value = 20;
 cid = [['PENNY', 1.01], ['NICKEL', 2.05], ['DIME', 3.1], ['QUARTER', 4.25], ['ONE', 90], ['FIVE', 55], ['TEN', 20], ['TWENTY', 60], ['ONE HUNDRED', 100]];
 
 const expected = ['Status: OPEN', 'QUARTER: $0.5'];
+cashInput.dispatchEvent(new Event('change'));
 purchaseBtn.click();
 assert.isTrue(expected.every(str => changeDueDiv.innerText.trim().toLowerCase().includes(str.toLowerCase())));
 ```
@@ -131,6 +134,7 @@ cashInput.value = 100;
 cid = [['PENNY', 1.01], ['NICKEL', 2.05], ['DIME', 3.1], ['QUARTER', 4.25], ['ONE', 90], ['FIVE', 55], ['TEN', 20], ['TWENTY', 60], ['ONE HUNDRED', 100]];
 
 const expected = ['Status: OPEN', 'TWENTY: $60', 'TEN: $20', 'FIVE: $15', 'ONE: $1', 'QUARTER: $0.5', 'DIME: $0.2', 'PENNY: $0.04'];
+cashInput.dispatchEvent(new Event('change'));
 purchaseBtn.click();
 assert.isTrue(expected.every(str => changeDueDiv.innerText.trim().toLowerCase().includes(str.toLowerCase())));
 ```
@@ -146,6 +150,7 @@ price = 19.5;
 cashInput.value = 20;
 cid = [['PENNY', 0.01], ['NICKEL', 0], ['DIME', 0], ['QUARTER', 0], ['ONE', 0], ['FIVE', 0], ['TEN', 0], ['TWENTY', 0], ['ONE HUNDRED', 0]];
 
+cashInput.dispatchEvent(new Event('change'));
 purchaseBtn.click();
 assert.strictEqual(changeDueDiv.innerText.trim().toLowerCase(), 'status: insufficient_funds');
 ```
@@ -161,6 +166,7 @@ price = 19.5;
 cashInput.value = 20;
 cid = [['PENNY', 0.01], ['NICKEL', 0], ['DIME', 0], ['QUARTER', 0], ['ONE', 1], ['FIVE', 0], ['TEN', 0], ['TWENTY', 0], ['ONE HUNDRED', 0]];
 
+cashInput.dispatchEvent(new Event('change'));
 purchaseBtn.click();
 assert.strictEqual(changeDueDiv.innerText.trim().toLowerCase(), 'status: insufficient_funds');
 ```
@@ -177,6 +183,7 @@ cashInput.value = 20;
 cid = [['PENNY', 0.5], ['NICKEL', 0], ['DIME', 0], ['QUARTER', 0], ['ONE', 0], ['FIVE', 0], ['TEN', 0], ['TWENTY', 0], ['ONE HUNDRED', 0]];
 
 const expected = ['Status: CLOSED', 'PENNY: $0.5'];
+cashInput.dispatchEvent(new Event('change'));
 purchaseBtn.click();
 assert.isTrue(expected.every(str => changeDueDiv.innerText.trim().toLowerCase().includes(str.toLowerCase())));
 ```

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/build-a-palindrome-checker-project/build-a-palindrome-checker.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/build-a-palindrome-checker-project/build-a-palindrome-checker.md
@@ -80,6 +80,7 @@ const checkBtn = document.getElementById('check-btn');
 const resultEl = document.getElementById('result');
 
 inputEl.value = 'A';
+inputEl.dispatchEvent(new Event('change'))
 checkBtn.click();
 assert.strictEqual(resultEl.innerText.trim().replace(/[.,?!]+$/g, '').toLowerCase(), 'a is a palindrome');
 ```
@@ -92,6 +93,7 @@ const checkBtn = document.getElementById('check-btn');
 const resultEl = document.getElementById('result');
 
 inputEl.value = 'eye';
+inputEl.dispatchEvent(new Event('change'))
 checkBtn.click();
 assert.strictEqual(resultEl.innerText.trim().replace(/[.,?!]+$/g, '').toLowerCase(), 'eye is a palindrome');
 ```
@@ -104,6 +106,7 @@ const checkBtn = document.getElementById('check-btn');
 const resultEl = document.getElementById('result');
 
 inputEl.value = '_eye';
+inputEl.dispatchEvent(new Event('change'))
 checkBtn.click();
 assert.strictEqual(resultEl.innerText.trim().replace(/[.,?!]+$/g, '').toLowerCase(), '_eye is a palindrome');
 ```
@@ -116,6 +119,7 @@ const checkBtn = document.getElementById('check-btn');
 const resultEl = document.getElementById('result');
 
 inputEl.value = 'race car';
+inputEl.dispatchEvent(new Event('change'))
 checkBtn.click();
 assert.strictEqual(resultEl.innerText.trim().replace(/[.,?!]+$/g, '').toLowerCase(), 'race car is a palindrome');
 ```
@@ -128,6 +132,7 @@ const checkBtn = document.getElementById('check-btn');
 const resultEl = document.getElementById('result');
 
 inputEl.value = 'not a palindrome';
+inputEl.dispatchEvent(new Event('change'))
 checkBtn.click();
 assert.strictEqual(resultEl.innerText.trim().replace(/[.,?!]+$/g, '').toLowerCase(), 'not a palindrome is not a palindrome');
 ```
@@ -140,6 +145,7 @@ const checkBtn = document.getElementById('check-btn');
 const resultEl = document.getElementById('result');
 
 inputEl.value = 'A man, a plan, a canal. Panama';
+inputEl.dispatchEvent(new Event('change'))
 checkBtn.click();
 assert.strictEqual(resultEl.innerText.trim().replace(/[.,?!]+$/g, '').toLowerCase(), 'a man, a plan, a canal. panama is a palindrome');
 ```
@@ -152,6 +158,7 @@ const checkBtn = document.getElementById('check-btn');
 const resultEl = document.getElementById('result');
 
 inputEl.value = 'never odd or even';
+inputEl.dispatchEvent(new Event('change'))
 checkBtn.click();
 assert.strictEqual(resultEl.innerText.trim().replace(/[.,?!]+$/g, '').toLowerCase(), 'never odd or even is a palindrome');
 ```
@@ -164,6 +171,7 @@ const checkBtn = document.getElementById('check-btn');
 const resultEl = document.getElementById('result');
 
 inputEl.value = 'nope';
+inputEl.dispatchEvent(new Event('change'))
 checkBtn.click();
 assert.strictEqual(resultEl.innerText.trim().replace(/[.,?!]+$/g, '').toLowerCase(), 'nope is not a palindrome');
 ```
@@ -176,6 +184,7 @@ const checkBtn = document.getElementById('check-btn');
 const resultEl = document.getElementById('result');
 
 inputEl.value = 'almostomla';
+inputEl.dispatchEvent(new Event('change'))
 checkBtn.click();
 assert.strictEqual(resultEl.innerText.trim().replace(/[.,?!]+$/g, '').toLowerCase(), 'almostomla is not a palindrome');
 ```
@@ -188,6 +197,7 @@ const checkBtn = document.getElementById('check-btn');
 const resultEl = document.getElementById('result');
 
 inputEl.value = 'My age is 0, 0 si ega ym.';
+inputEl.dispatchEvent(new Event('change'))
 checkBtn.click();
 assert.strictEqual(resultEl.innerText.trim().replace(/[.,?!]+$/g, '').toLowerCase(), 'my age is 0, 0 si ega ym. is a palindrome');
 ```
@@ -200,6 +210,7 @@ const checkBtn = document.getElementById('check-btn');
 const resultEl = document.getElementById('result');
 
 inputEl.value = '1 eye for of 1 eye.';
+inputEl.dispatchEvent(new Event('change'))
 checkBtn.click();
 assert.strictEqual(resultEl.innerText.trim().replace(/[.,?!]+$/g, '').toLowerCase(), '1 eye for of 1 eye. is not a palindrome');
 ```
@@ -212,6 +223,7 @@ const checkBtn = document.getElementById('check-btn');
 const resultEl = document.getElementById('result');
 
 inputEl.value = '0_0 (: /-\ :) 0-0';
+inputEl.dispatchEvent(new Event('change'))
 checkBtn.click();
 assert.strictEqual(resultEl.innerText.trim().replace(/[.,?!]+$/g, '').toLowerCase(), '0_0 (: /-\ :) 0-0 is a palindrome');
 ```
@@ -224,6 +236,7 @@ const checkBtn = document.getElementById('check-btn');
 const resultEl = document.getElementById('result');
 
 inputEl.value = 'five|\_/|four';
+inputEl.dispatchEvent(new Event('change'))
 checkBtn.click();
 assert.strictEqual(resultEl.innerText.trim().replace(/[.,?!]+$/g, '').toLowerCase(), 'five|\_/|four is not a palindrome');
 ```

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/build-a-pokemon-search-app-project/build-a-pokemon-search-app.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/build-a-pokemon-search-app-project/build-a-pokemon-search-app.md
@@ -143,6 +143,7 @@ async () => {
     let alertMessage;
     window.alert = (message) => alertMessage = message; // Override alert and store message
     searchInput.value = 'Red';
+    searchInput.dispatchEvent(new Event('change'));
     searchButton.click();
 
     const res = await fetch('https://pokeapi-proxy.freecodecamp.rocks/api/pokemon/red'); // Fetch from proxy to simulate network delay
@@ -166,6 +167,7 @@ async () => {
     const searchInput = document.getElementById('search-input');
     const searchButton = document.getElementById('search-button');
     searchInput.value = 'Pikachu';
+    searchInput.dispatchEvent(new Event('change'));
     searchButton.click();
 
     const res = await fetch('https://pokeapi-proxy.freecodecamp.rocks/api/pokemon/pikachu'); // Fetch from proxy to simulate network delay
@@ -209,6 +211,7 @@ async () => {
     const searchInput = document.getElementById('search-input');
     const searchButton = document.getElementById('search-button');
     searchInput.value = 'Pikachu';
+    searchInput.dispatchEvent(new Event('change'));
     searchButton.click();
 
     const res = await fetch('https://pokeapi-proxy.freecodecamp.rocks/api/pokemon/pikachu'); // Fetch from proxy to simulate network delay
@@ -233,6 +236,7 @@ async () => {
     const searchInput = document.getElementById('search-input');
     const searchButton = document.getElementById('search-button');
     searchInput.value = 'Pikachu';
+    searchInput.dispatchEvent(new Event('change'));
     searchButton.click();
 
     const res = await fetch('https://pokeapi-proxy.freecodecamp.rocks/api/pokemon/pikachu'); // Fetch from proxy to simulate network delay
@@ -259,6 +263,7 @@ async () => {
     const searchInput = document.getElementById('search-input');
     const searchButton = document.getElementById('search-button');
     searchInput.value = '94';
+    searchInput.dispatchEvent(new Event('change'));
     searchButton.click();
 
     const res = await fetch('https://pokeapi-proxy.freecodecamp.rocks/api/pokemon/94'); // Fetch from proxy to simulate network delay
@@ -302,6 +307,7 @@ async () => {
     const searchInput = document.getElementById('search-input');
     const searchButton = document.getElementById('search-button');
     searchInput.value = '94';
+    searchInput.dispatchEvent(new Event('change'));
     searchButton.click();
 
     const res = await fetch('https://pokeapi-proxy.freecodecamp.rocks/api/pokemon/94'); // Fetch from proxy to simulate network delay
@@ -326,6 +332,7 @@ async () => {
     const searchInput = document.getElementById('search-input');
     const searchButton = document.getElementById('search-button');
     searchInput.value = '94';
+    searchInput.dispatchEvent(new Event('change'));
     searchButton.click();
 
     const res = await fetch('https://pokeapi-proxy.freecodecamp.rocks/api/pokemon/94'); // Fetch from proxy to simulate network delay

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/build-a-roman-numeral-converter-project/build-a-roman-numeral-converter.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/build-a-roman-numeral-converter-project/build-a-roman-numeral-converter.md
@@ -87,6 +87,7 @@ const convertBtnEl = document.getElementById('convert-btn');
 const outputEl = document.getElementById('output');
 
 numberInputEl.value = '-1';
+numberInputEl.dispatchEvent(new Event('change'));
 convertBtnEl.click();
 assert.strictEqual(outputEl.innerText.trim().replace(/[.,?!]+$/g, '').toLowerCase(), 'please enter a number greater than or equal to 1');
 ```
@@ -99,6 +100,7 @@ const convertBtnEl = document.getElementById('convert-btn');
 const outputEl = document.getElementById('output');
 
 numberInputEl.value = '4000';
+numberInputEl.dispatchEvent(new Event('change'));
 convertBtnEl.click();
 assert.strictEqual(outputEl.innerText.trim().replace(/[.,?!]+$/g, '').toLowerCase(), 'please enter a number less than or equal to 3999');
 ```
@@ -111,6 +113,7 @@ const convertBtnEl = document.getElementById('convert-btn');
 const outputEl = document.getElementById('output');
 
 numberInputEl.value = '9';
+numberInputEl.dispatchEvent(new Event('change'));
 convertBtnEl.click();
 assert.strictEqual(outputEl.innerText.trim(), 'IX');
 ```
@@ -123,6 +126,7 @@ const convertBtnEl = document.getElementById('convert-btn');
 const outputEl = document.getElementById('output');
 
 numberInputEl.value = '16';
+numberInputEl.dispatchEvent(new Event('change'));
 convertBtnEl.click();
 assert.strictEqual(outputEl.innerText.trim(), 'XVI');
 ```
@@ -135,6 +139,7 @@ const convertBtnEl = document.getElementById('convert-btn');
 const outputEl = document.getElementById('output');
 
 numberInputEl.value = '649';
+numberInputEl.dispatchEvent(new Event('change'));
 convertBtnEl.click();
 assert.strictEqual(outputEl.innerText.trim(), 'DCXLIX');
 ```
@@ -147,6 +152,7 @@ const convertBtnEl = document.getElementById('convert-btn');
 const outputEl = document.getElementById('output');
 
 numberInputEl.value = '1023';
+numberInputEl.dispatchEvent(new Event('change'));
 convertBtnEl.click();
 assert.strictEqual(outputEl.innerText.trim(), 'MXXIII');
 ```
@@ -159,6 +165,7 @@ const convertBtnEl = document.getElementById('convert-btn');
 const outputEl = document.getElementById('output');
 
 numberInputEl.value = '3999';
+numberInputEl.dispatchEvent(new Event('change'));
 convertBtnEl.click();
 assert.strictEqual(outputEl.innerText.trim(), 'MMMCMXCIX');
 ```

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/build-a-telephone-number-validator-project/build-a-telephone-number-validator.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/build-a-telephone-number-validator-project/build-a-telephone-number-validator.md
@@ -127,6 +127,7 @@ const resultsDiv = document.getElementById('results-div');
 
 resultsDiv.innerHTML = '';
 userInput.value = '1 555-555-5555';
+userInput.dispatchEvent(new Event('change'));
 checkBtn.click();
 assert.strictEqual(resultsDiv.innerText.trim().toLowerCase(), 'valid us number: 1 555-555-5555');
 ```
@@ -140,6 +141,7 @@ const resultsDiv = document.getElementById('results-div');
 
 resultsDiv.innerHTML = '';
 userInput.value = '1 (555) 555-5555';
+userInput.dispatchEvent(new Event('change'));
 checkBtn.click();
 assert.strictEqual(resultsDiv.innerText.trim().toLowerCase(), 'valid us number: 1 (555) 555-5555');
 ```
@@ -153,6 +155,7 @@ const resultsDiv = document.getElementById('results-div');
 
 resultsDiv.innerHTML = '';
 userInput.value = '5555555555';
+userInput.dispatchEvent(new Event('change'));
 checkBtn.click();
 assert.strictEqual(resultsDiv.innerText.trim().toLowerCase(), 'valid us number: 5555555555');
 ```
@@ -166,6 +169,7 @@ const resultsDiv = document.getElementById('results-div');
 
 resultsDiv.innerHTML = '';
 userInput.value = '555-555-5555';
+userInput.dispatchEvent(new Event('change'));
 checkBtn.click();
 assert.strictEqual(resultsDiv.innerText.trim().toLowerCase(), 'valid us number: 555-555-5555');
 ```
@@ -179,6 +183,7 @@ const resultsDiv = document.getElementById('results-div');
 
 resultsDiv.innerHTML = '';
 userInput.value = '(555)555-5555';
+userInput.dispatchEvent(new Event('change'));
 checkBtn.click();
 assert.strictEqual(resultsDiv.innerText.trim().toLowerCase(), 'valid us number: (555)555-5555');
 ```
@@ -192,6 +197,7 @@ const resultsDiv = document.getElementById('results-div');
 
 resultsDiv.innerHTML = '';
 userInput.value = '1(555)555-5555';
+userInput.dispatchEvent(new Event('change'));
 checkBtn.click();
 assert.strictEqual(resultsDiv.innerText.trim().toLowerCase(), 'valid us number: 1(555)555-5555');
 ```
@@ -205,6 +211,7 @@ const resultsDiv = document.getElementById('results-div');
 
 resultsDiv.innerHTML = '';
 userInput.value = '555-5555';
+userInput.dispatchEvent(new Event('change'));
 checkBtn.click();
 assert.strictEqual(resultsDiv.innerText.trim().toLowerCase(), 'invalid us number: 555-5555');
 ```
@@ -218,6 +225,7 @@ const resultsDiv = document.getElementById('results-div');
 
 resultsDiv.innerHTML = '';
 userInput.value = '5555555';
+userInput.dispatchEvent(new Event('change'));
 checkBtn.click();
 assert.strictEqual(resultsDiv.innerText.trim().toLowerCase(), 'invalid us number: 5555555');
 ```
@@ -231,6 +239,7 @@ const resultsDiv = document.getElementById('results-div');
 
 resultsDiv.innerHTML = '';
 userInput.value = '1 555)555-5555';
+userInput.dispatchEvent(new Event('change'));
 checkBtn.click();
 assert.strictEqual(resultsDiv.innerText.trim().toLowerCase(), 'invalid us number: 1 555)555-5555');
 ```
@@ -244,6 +253,7 @@ const resultsDiv = document.getElementById('results-div');
 
 resultsDiv.innerHTML = '';
 userInput.value = '1 555 555 5555';
+userInput.dispatchEvent(new Event('change'));
 checkBtn.click();
 assert.strictEqual(resultsDiv.innerText.trim().toLowerCase(), 'valid us number: 1 555 555 5555');
 ```
@@ -257,6 +267,7 @@ const resultsDiv = document.getElementById('results-div');
 
 resultsDiv.innerHTML = '';
 userInput.value = '1 456 789 4444';
+userInput.dispatchEvent(new Event('change'));
 checkBtn.click();
 assert.strictEqual(resultsDiv.innerText.trim().toLowerCase(), 'valid us number: 1 456 789 4444');
 ```
@@ -270,6 +281,7 @@ const resultsDiv = document.getElementById('results-div');
 
 resultsDiv.innerHTML = '';
 userInput.value = '123**&!!asdf#';
+userInput.dispatchEvent(new Event('change'));
 checkBtn.click();
 assert.strictEqual(resultsDiv.innerText.trim().toLowerCase(), 'invalid us number: 123**&!!asdf#');
 ```
@@ -283,6 +295,7 @@ const resultsDiv = document.getElementById('results-div');
 
 resultsDiv.innerHTML = '';
 userInput.value = '55555555';
+userInput.dispatchEvent(new Event('change'));
 checkBtn.click();
 assert.strictEqual(resultsDiv.innerText.trim().toLowerCase(), 'invalid us number: 55555555');
 ```
@@ -296,6 +309,7 @@ const resultsDiv = document.getElementById('results-div');
 
 resultsDiv.innerHTML = '';
 userInput.value = '(6054756961)';
+userInput.dispatchEvent(new Event('change'));
 checkBtn.click();
 assert.strictEqual(resultsDiv.innerText.trim().toLowerCase(), 'invalid us number: (6054756961)');
 ```
@@ -309,6 +323,7 @@ const resultsDiv = document.getElementById('results-div');
 
 resultsDiv.innerHTML = '';
 userInput.value = '2 (757) 622-7382';
+userInput.dispatchEvent(new Event('change'));
 checkBtn.click();
 assert.strictEqual(resultsDiv.innerText.trim().toLowerCase(), 'invalid us number: 2 (757) 622-7382');
 ```
@@ -322,6 +337,7 @@ const resultsDiv = document.getElementById('results-div');
 
 resultsDiv.innerHTML = '';
 userInput.value = '0 (757) 622-7382';
+userInput.dispatchEvent(new Event('change'));
 checkBtn.click();
 assert.strictEqual(resultsDiv.innerText.trim().toLowerCase(), 'invalid us number: 0 (757) 622-7382');
 ```
@@ -335,6 +351,7 @@ const resultsDiv = document.getElementById('results-div');
 
 resultsDiv.innerHTML = '';
 userInput.value = '-1 (757) 622-7382';
+userInput.dispatchEvent(new Event('change'));
 checkBtn.click();
 assert.strictEqual(resultsDiv.innerText.trim().toLowerCase(), 'invalid us number: -1 (757) 622-7382');
 ```
@@ -348,6 +365,7 @@ const resultsDiv = document.getElementById('results-div');
 
 resultsDiv.innerHTML = '';
 userInput.value = '2 757 622-7382';
+userInput.dispatchEvent(new Event('change'));
 checkBtn.click();
 assert.strictEqual(resultsDiv.innerText.trim().toLowerCase(), 'invalid us number: 2 757 622-7382');
 ```
@@ -361,6 +379,7 @@ const resultsDiv = document.getElementById('results-div');
 
 resultsDiv.innerHTML = '';
 userInput.value = '10 (757) 622-7382';
+userInput.dispatchEvent(new Event('change'));
 checkBtn.click();
 assert.strictEqual(resultsDiv.innerText.trim().toLowerCase(), 'invalid us number: 10 (757) 622-7382');
 ```
@@ -374,6 +393,7 @@ const resultsDiv = document.getElementById('results-div');
 
 resultsDiv.innerHTML = '';
 userInput.value = '27576227382';
+userInput.dispatchEvent(new Event('change'));
 checkBtn.click();
 assert.strictEqual(resultsDiv.innerText.trim().toLowerCase(), 'invalid us number: 27576227382');
 ```
@@ -387,6 +407,7 @@ const resultsDiv = document.getElementById('results-div');
 
 resultsDiv.innerHTML = '';
 userInput.value = '(275)76227382';
+userInput.dispatchEvent(new Event('change'));
 checkBtn.click();
 assert.strictEqual(resultsDiv.innerText.trim().toLowerCase(), 'invalid us number: (275)76227382');
 ```
@@ -400,6 +421,7 @@ const resultsDiv = document.getElementById('results-div');
 
 resultsDiv.innerHTML = '';
 userInput.value = '2(757)6227382';
+userInput.dispatchEvent(new Event('change'));
 checkBtn.click();
 assert.strictEqual(resultsDiv.innerText.trim().toLowerCase(), 'invalid us number: 2(757)6227382');
 ```
@@ -413,6 +435,7 @@ const resultsDiv = document.getElementById('results-div');
 
 resultsDiv.innerHTML = '';
 userInput.value = '2(757)622-7382';
+userInput.dispatchEvent(new Event('change'));
 checkBtn.click();
 assert.strictEqual(resultsDiv.innerText.trim().toLowerCase(), 'invalid us number: 2(757)622-7382');
 ```
@@ -426,6 +449,7 @@ const resultsDiv = document.getElementById('results-div');
 
 resultsDiv.innerHTML = '';
 userInput.value = '555)-555-5555';
+userInput.dispatchEvent(new Event('change'));
 checkBtn.click();
 assert.strictEqual(resultsDiv.innerText.trim().toLowerCase(), 'invalid us number: 555)-555-5555');
 ```
@@ -439,6 +463,7 @@ const resultsDiv = document.getElementById('results-div');
 
 resultsDiv.innerHTML = '';
 userInput.value = '(555-555-5555';
+userInput.dispatchEvent(new Event('change'));
 checkBtn.click();
 assert.strictEqual(resultsDiv.innerText.trim().toLowerCase(), 'invalid us number: (555-555-5555');
 ```
@@ -452,6 +477,7 @@ const resultsDiv = document.getElementById('results-div');
 
 resultsDiv.innerHTML = '';
 userInput.value = '(555)5(55?)-5555';
+userInput.dispatchEvent(new Event('change'));
 checkBtn.click();
 assert.strictEqual(resultsDiv.innerText.trim().toLowerCase(), 'invalid us number: (555)5(55?)-5555');
 ```
@@ -465,6 +491,7 @@ const resultsDiv = document.getElementById('results-div');
 
 resultsDiv.innerHTML = '';
 userInput.value = '55 55-55-555-5';
+userInput.dispatchEvent(new Event('change'));
 checkBtn.click();
 assert.strictEqual(resultsDiv.innerText.trim().toLowerCase(), 'invalid us number: 55 55-55-555-5');
 ```
@@ -478,6 +505,7 @@ const resultsDiv = document.getElementById('results-div');
 
 resultsDiv.innerHTML = '';
 userInput.value = '11 555-555-5555';
+userInput.dispatchEvent(new Event('change'));
 checkBtn.click();
 assert.strictEqual(resultsDiv.innerText.trim().toLowerCase(), 'invalid us number: 11 555-555-5555');
 ```


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Closes #53390

Dispatching change event after value change in the tests of the following certification projects:
- https://github.com/freeCodeCamp/freeCodeCamp/blob/main/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/build-a-cash-register-project/build-a-cash-register.md
- https://github.com/freeCodeCamp/freeCodeCamp/blob/main/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/build-a-palindrome-checker-project/build-a-palindrome-checker.md
- https://github.com/freeCodeCamp/freeCodeCamp/blob/main/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/build-a-pokemon-search-app-project/build-a-pokemon-search-app.md
- https://github.com/freeCodeCamp/freeCodeCamp/blob/main/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/build-a-roman-numeral-converter-project/build-a-roman-numeral-converter.md
- https://github.com/freeCodeCamp/freeCodeCamp/blob/main/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/build-a-telephone-number-validator-project/build-a-telephone-number-validator.md