### PR TITLE
fix: Added a Hint to JavaScript Challenges

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-oop-by-building-a-shopping-cart/63f03686c5ea863533ec71f4.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-oop-by-building-a-shopping-cart/63f03686c5ea863533ec71f4.md
@@ -11,14 +11,14 @@ Declare a variable `tax` and assign it the value of calling your new `.calculate
 
 # --hints--
 
-Use `const` to declare a variable named `tax`.
+Use `const` to declare a variable named `tax`. Remember to use the `this` keyword.
 
 ```js
 const afterCalculateTotal = code.split('calculateTotal')[1];
 assert.match(afterCalculateTotal, /const\s+tax\s*=/);
 ```
 
-Assign the value of calling your new `.calculateTaxes()` method, passing `subTotal` as the argument, to the `tax` variable.
+Assign the value of calling your new `.calculateTaxes()` method, passing `subTotal` as the argument, to the `tax` variable. 
 
 ```js
 const afterCalculateTotal = code.split('calculateTotal')[1];


### PR DESCRIPTION
Fixed the missing hint for the this keyword in the JavaScript challenges. The hint has been added to the [Learn Basic OOP by Building a Shopping Cart](https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures-v8/learn-basic-oop-by-building-a-shopping-cart/step-48) lesson.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #54602
<img width="1432" alt="Screenshot 2024-05-03 at 4 22 34 AM" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/97442923/8acff8b3-e083-41cf-af61-d04ae0825ee8">


<!-- Feel free to add any additional description of changes below this line -->
