### PR TITLE
fix(playwright): run tests with an authenticated user by default

### DIFF
--- a/e2e/certification.spec.ts
+++ b/e2e/certification.spec.ts
@@ -1,8 +1,6 @@
 import { test, expect, Page } from '@playwright/test';
 import translations from '../client/i18n/locales/english/translations.json';
 
-test.use({ storageState: 'playwright/.auth/certified-user.json' });
-
 test.describe('Certification page - Non Microsoft', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/certification/certifieduser/responsive-web-design');
@@ -148,7 +146,6 @@ test.describe('Invalid certification page', () => {
     }
   };
   test.describe('for authenticated user', () => {
-    test.use({ storageState: 'playwright/.auth/certified-user.json' });
     test(
       'it should redirect to / and display an error message',
       testInvalidCertification

--- a/e2e/challenge-title.spec.ts
+++ b/e2e/challenge-title.spec.ts
@@ -74,8 +74,6 @@ test.describe('Challenge Title Component (signed out)', () => {
 });
 
 test.describe('Challenge Title Component (signed in)', () => {
-  test.use({ storageState: 'playwright/.auth/certified-user.json' });
-
   test('should display GreenPass after challenge completion', async ({
     page
   }) => {

--- a/e2e/completion-modal.spec.ts
+++ b/e2e/completion-modal.spec.ts
@@ -15,6 +15,8 @@ test.beforeEach(async ({ page }) => {
 });
 
 test.describe('Challenge Completion Modal Tests (Signed Out)', () => {
+  test.use({ storageState: { cookies: [], origins: [] } });
+
   test('should render the modal correctly', async ({ page }) => {
     await expect(page.getByRole('heading')).toBeVisible();
     await expect(page.getByRole('button', { name: 'close' })).toBeVisible();

--- a/e2e/completion-modal.spec.ts
+++ b/e2e/completion-modal.spec.ts
@@ -49,8 +49,6 @@ test.describe('Challenge Completion Modal Tests (Signed Out)', () => {
 });
 
 test.describe('Challenge Completion Modal Tests (Signed In)', () => {
-  test.use({ storageState: 'playwright/.auth/certified-user.json' });
-
   test('should render the modal correctly', async ({ page }) => {
     await expect(page.getByRole('heading')).toBeVisible();
     await expect(page.getByRole('button', { name: 'close' })).toBeVisible();

--- a/e2e/delete-modal.spec.ts
+++ b/e2e/delete-modal.spec.ts
@@ -7,8 +7,6 @@ import translations from '../client/i18n/locales/english/translations.json';
 
 const execP = promisify(exec);
 
-test.use({ storageState: 'playwright/.auth/certified-user.json' });
-
 test.beforeEach(async ({ page }) => {
   await page.goto('/settings');
 });

--- a/e2e/desktop-layout.spec.ts
+++ b/e2e/desktop-layout.spec.ts
@@ -1,7 +1,5 @@
 import { test, expect } from '@playwright/test';
 
-test.use({ storageState: 'playwright/.auth/certified-user.json' });
-
 test.describe('Classic challenge - 3 pane desktop layout component', () => {
   test.skip(
     ({ isMobile }) => isMobile === true,

--- a/e2e/donate-page-default.spec.ts
+++ b/e2e/donate-page-default.spec.ts
@@ -1,8 +1,6 @@
 import { test, expect, type Page } from '@playwright/test';
 import translations from '../client/i18n/locales/english/translations.json';
 
-test.use({ storageState: 'playwright/.auth/certified-user.json' });
-
 const pageElements = {
   mainHeading: 'main-head',
   donateText1: 'donate-text-1',

--- a/e2e/email-settings.spec.ts
+++ b/e2e/email-settings.spec.ts
@@ -7,8 +7,6 @@ const settingsPageElement = {
   flashMessageAlert: 'flash-message'
 } as const;
 
-test.use({ storageState: 'playwright/.auth/certified-user.json' });
-
 test.beforeEach(async ({ page }) => {
   await page.goto('/settings');
 });

--- a/e2e/email-sign-up.spec.ts
+++ b/e2e/email-sign-up.spec.ts
@@ -92,8 +92,6 @@ test.describe('Email sign-up page when user is not signed in', () => {
 });
 
 test.describe('Email sign-up page when user is signed in', () => {
-  test.use({ storageState: 'playwright/.auth/certified-user.json' });
-
   test.beforeEach(async ({ page }) => {
     // It's necessary to seed with a user that has not accepted the privacy
     // terms, otherwise the user will be redirected away from the email sign-up

--- a/e2e/exam-results-modal.spec.ts
+++ b/e2e/exam-results-modal.spec.ts
@@ -1,7 +1,5 @@
 import { test, expect } from '@playwright/test';
 
-test.use({ storageState: 'playwright/.auth/certified-user.json' });
-
 test.describe('Exam results modal', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/settings');

--- a/e2e/exam-results.spec.ts
+++ b/e2e/exam-results.spec.ts
@@ -3,8 +3,6 @@ import { test, expect } from '@playwright/test';
 import translations from '../client/i18n/locales/english/translations.json';
 import intro from '../client/i18n/locales/english/intro.json';
 
-test.use({ storageState: 'playwright/.auth/certified-user.json' });
-
 const examUrl =
   '/learn/foundational-c-sharp-with-microsoft/foundational-c-sharp-with-microsoft-certification-exam/foundational-c-sharp-with-microsoft-certification-exam';
 

--- a/e2e/exam-show-non-qualified.spec.ts
+++ b/e2e/exam-show-non-qualified.spec.ts
@@ -9,7 +9,9 @@ test.beforeEach(async ({ page }) => {
   await page.goto(examUrl);
 });
 
-test.describe('Exam Show E2E Test Suite for non-qualified user', () => {
+test.describe('Exam Show E2E Test Suite for unauthenticated user', () => {
+  test.use({ storageState: { cookies: [], origins: [] } });
+
   test('The page renders with correct title', async ({ page }) => {
     await expect(page).toHaveTitle(
       'Foundational C# with Microsoft Certification Exam: Foundational C# with Microsoft Certification Exam | freeCodeCamp.org'

--- a/e2e/exam-show-qualified.spec.ts
+++ b/e2e/exam-show-qualified.spec.ts
@@ -2,8 +2,6 @@ import { test, expect } from '@playwright/test';
 import intro from '../client/i18n/locales/english/intro.json';
 import translations from '../client/i18n/locales/english/translations.json';
 
-test.use({ storageState: 'playwright/.auth/certified-user.json' });
-
 const examUrl =
   '/learn/foundational-c-sharp-with-microsoft/foundational-c-sharp-with-microsoft-certification-exam/foundational-c-sharp-with-microsoft-certification-exam';
 

--- a/e2e/exam-started-show.spec.ts
+++ b/e2e/exam-started-show.spec.ts
@@ -2,8 +2,6 @@ import { test, expect } from '@playwright/test';
 import translations from '../client/i18n/locales/english/translations.json';
 import intro from '../client/i18n/locales/english/intro.json';
 
-test.use({ storageState: 'playwright/.auth/certified-user.json' });
-
 const examUrl =
   '/learn/foundational-c-sharp-with-microsoft/foundational-c-sharp-with-microsoft-certification-exam/foundational-c-sharp-with-microsoft-certification-exam';
 

--- a/e2e/exit-exam-modal.spec.ts
+++ b/e2e/exit-exam-modal.spec.ts
@@ -1,8 +1,6 @@
 import { test, expect } from '@playwright/test';
 import translations from '../client/i18n/locales/english/translations.json';
 
-test.use({ storageState: 'playwright/.auth/certified-user.json' });
-
 const examUrl =
   '/learn/foundational-c-sharp-with-microsoft/foundational-c-sharp-with-microsoft-certification-exam/foundational-c-sharp-with-microsoft-certification-exam';
 const cancelExamUrl =

--- a/e2e/finish-exam-modal.spec.ts
+++ b/e2e/finish-exam-modal.spec.ts
@@ -1,8 +1,6 @@
 import { test, expect } from '@playwright/test';
 import translations from '../client/i18n/locales/english/translations.json';
 
-test.use({ storageState: 'playwright/.auth/certified-user.json' });
-
 const examUrl =
   '/learn/foundational-c-sharp-with-microsoft/foundational-c-sharp-with-microsoft-certification-exam/foundational-c-sharp-with-microsoft-certification-exam';
 const QUESTION_COUNT = 5;

--- a/e2e/flash.spec.ts
+++ b/e2e/flash.spec.ts
@@ -1,7 +1,6 @@
 import { test, expect, type Page } from '@playwright/test';
 import translations from '../client/i18n/locales/english/translations.json';
 
-test.use({ storageState: 'playwright/.auth/certified-user.json' });
 test.beforeEach(async ({ page }) => {
   await page.goto('/settings');
 });

--- a/e2e/form-helper.spec.ts
+++ b/e2e/form-helper.spec.ts
@@ -1,8 +1,6 @@
 import { test, expect } from '@playwright/test';
 import translations from '../client/i18n/locales/english/translations.json';
 
-test.use({ storageState: 'playwright/.auth/certified-user.json' });
-
 test.describe('Test form with only solution link', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto(

--- a/e2e/header.spec.ts
+++ b/e2e/header.spec.ts
@@ -20,8 +20,6 @@ const headerComponentElements = {
 const examUrl =
   '/learn/foundational-c-sharp-with-microsoft/foundational-c-sharp-with-microsoft-certification-exam/foundational-c-sharp-with-microsoft-certification-exam';
 
-test.use({ storageState: 'playwright/.auth/certified-user.json' });
-
 test.beforeEach(async ({ page }) => {
   await page.goto('/');
 });

--- a/e2e/help-modal.spec.ts
+++ b/e2e/help-modal.spec.ts
@@ -1,8 +1,6 @@
 import { test, expect } from '@playwright/test';
 import translations from '../client/i18n/locales/english/translations.json';
 
-test.use({ storageState: 'playwright/.auth/certified-user.json' });
-
 test.beforeEach(async ({ page }) => {
   await page.goto(
     '/learn/foundational-c-sharp-with-microsoft/write-your-first-code-using-c-sharp/write-your-first-c-sharp-code'

--- a/e2e/hotkeys.spec.ts
+++ b/e2e/hotkeys.spec.ts
@@ -7,8 +7,6 @@ const course =
 const editorPaneLabel =
   'Editor content;Press Alt+F1 for Accessibility Options.';
 
-test.use({ storageState: 'playwright/.auth/certified-user.json' });
-
 test('User can interact with the app using the keyboard', async ({ page }) => {
   // Enable keyboard shortcuts
   await page.goto('/settings');

--- a/e2e/image-picture-check.spec.ts
+++ b/e2e/image-picture-check.spec.ts
@@ -1,8 +1,6 @@
 import { test, expect } from '@playwright/test';
 
 test.describe('Picture input field', () => {
-  test.use({ storageState: 'playwright/.auth/certified-user.json' });
-
   test.beforeEach(async ({ page }) => {
     await page.goto('/settings');
   });

--- a/e2e/internet-presence-settings.spec.ts
+++ b/e2e/internet-presence-settings.spec.ts
@@ -11,8 +11,6 @@ const settingsPageElement = {
   internetPresenceForm: 'internet-presence'
 } as const;
 
-test.use({ storageState: 'playwright/.auth/certified-user.json' });
-
 test.beforeEach(async ({ page }) => {
   await page.goto('/settings');
 });

--- a/e2e/intro.spec.ts
+++ b/e2e/intro.spec.ts
@@ -58,6 +58,8 @@ test.describe('Intro Component E2E Test Suite with Signed In User', () => {
 });
 
 test.describe('Intro Component E2E Test Suite with Signed Out User', () => {
+  test.use({ storageState: { cookies: [], origins: [] } });
+
   test('Verifies the Correct Intro component heading', async ({ page }) => {
     await expect(page.getByText(translations.learn.heading)).toBeVisible();
   });

--- a/e2e/intro.spec.ts
+++ b/e2e/intro.spec.ts
@@ -38,7 +38,6 @@ const IntroDescription = [
 ];
 
 test.describe('Intro Component E2E Test Suite with Signed In User', () => {
-  test.use({ storageState: 'playwright/.auth/certified-user.json' });
   test('Verifies the Correct Intro component heading', async ({ page }) => {
     await expect(
       page.getByText(

--- a/e2e/learn.spec.ts
+++ b/e2e/learn.spec.ts
@@ -1,5 +1,4 @@
 import { test, expect } from '@playwright/test';
-import translations from '../client/i18n/locales/english/translations.json';
 import words from '../client/i18n/locales/english/motivation.json';
 
 const superBlocks = [
@@ -22,49 +21,69 @@ const superBlocks = [
   'Project Euler',
   'Rosetta Code',
   'Legacy Responsive Web Design Challenges',
-  'JavaScript Algorithms and Data Structures',
+  'Legacy JavaScript Algorithms and Data Structures',
   'Legacy Python for Everybody'
 ];
 
-test('the page should render correctly', async ({ page }) => {
-  await page.goto('/learn');
-  await expect(page).toHaveTitle(
-    'Learn to Code — For Free — Coding Courses for Busy People'
-  );
+test.describe('Learn page (unauthenticated user)', () => {
+  test.use({ storageState: { cookies: [], origins: [] } });
 
-  const header = page.getByTestId('learn-heading');
-  await expect(header).toBeVisible();
-  await expect(header).toContainText(translations.learn.heading);
+  test('the page should render correctly', async ({ page }) => {
+    await page.goto('/learn');
+    await expect(page).toHaveTitle(
+      'Learn to Code — For Free — Coding Courses for Busy People'
+    );
 
-  // Advice for new learners
-  const learnReadThisSection = page.getByTestId('learn-read-this-section');
-  await expect(learnReadThisSection).toBeVisible();
+    await expect(
+      page.getByRole('heading', {
+        level: 1,
+        name: "Welcome to freeCodeCamp's curriculum."
+      })
+    ).toBeVisible();
 
-  const learnReadThisSectionHeading = page.getByTestId(
-    'learn-read-this-heading'
-  );
-  await expect(learnReadThisSectionHeading).toBeVisible();
+    // Advice for new learners
+    const learnReadThisSection = page.getByTestId('learn-read-this-section');
+    await expect(learnReadThisSection).toBeVisible();
 
-  const learnReadThisSectionParagraphs = page.getByTestId('learn-read-this-p');
-  await expect(learnReadThisSectionParagraphs).toHaveCount(10);
+    const learnReadThisSectionHeading = page.getByTestId(
+      'learn-read-this-heading'
+    );
+    await expect(learnReadThisSectionHeading).toBeVisible();
 
-  for (const paragraph of await learnReadThisSectionParagraphs.all()) {
-    await expect(paragraph).toBeVisible();
-  }
-  // certifications
-  const curriculumBtns = page.getByTestId('curriculum-map-button');
-  await expect(curriculumBtns).toHaveCount(superBlocks.length);
-  for (let i = 0; i < superBlocks.length; i++) {
-    const btn = curriculumBtns.nth(i);
-    await expect(btn).toContainText(superBlocks[i]);
-  }
+    const learnReadThisSectionParagraphs =
+      page.getByTestId('learn-read-this-p');
+    await expect(learnReadThisSectionParagraphs).toHaveCount(10);
+
+    for (const paragraph of await learnReadThisSectionParagraphs.all()) {
+      await expect(paragraph).toBeVisible();
+    }
+
+    // certifications
+    const certifications = page.getByTestId('curriculum-map-button');
+    await expect(certifications).toHaveCount(superBlocks.length);
+
+    for (let i = 0; i < superBlocks.length; i++) {
+      const btn = certifications.nth(i);
+      await expect(btn).toContainText(superBlocks[i]);
+    }
+  });
 });
 
-test.describe('Learn (authenticated user)', () => {
-  test('the page shows a random quote for an authenticated user', async ({
-    page
-  }) => {
+test.describe('Learn page (authenticated user)', () => {
+  test('the page should render correctly', async ({ page }) => {
     await page.goto('/learn');
+    await expect(page).toHaveTitle(
+      'Learn to Code — For Free — Coding Courses for Busy People'
+    );
+
+    await expect(
+      page.getByRole('heading', {
+        level: 1,
+        name: 'Welcome back, Full Stack User.'
+      })
+    ).toBeVisible();
+
+    // Random quote
     const shownQuote = await page.getByTestId('random-quote').textContent();
 
     const shownAuthorText = await page
@@ -78,5 +97,14 @@ test.describe('Learn (authenticated user)', () => {
 
     expect(allMotivationalQuotes).toContain(shownQuote);
     expect(allAuthors).toContain(shownAuthor);
+
+    // Certifications
+    const certifications = page.getByTestId('curriculum-map-button');
+    await expect(certifications).toHaveCount(superBlocks.length);
+
+    for (let i = 0; i < superBlocks.length; i++) {
+      const btn = certifications.nth(i);
+      await expect(btn).toContainText(superBlocks[i]);
+    }
   });
 });

--- a/e2e/learn.spec.ts
+++ b/e2e/learn.spec.ts
@@ -61,8 +61,6 @@ test('the page should render correctly', async ({ page }) => {
 });
 
 test.describe('Learn (authenticated user)', () => {
-  test.use({ storageState: 'playwright/.auth/certified-user.json' });
-
   test('the page shows a random quote for an authenticated user', async ({
     page
   }) => {

--- a/e2e/link-ms-user.spec.ts
+++ b/e2e/link-ms-user.spec.ts
@@ -8,6 +8,8 @@ test.beforeEach(async ({ page }) => {
 });
 
 test.describe('Link MS user component (signed-out user)', () => {
+  test.use({ storageState: { cookies: [], origins: [] } });
+
   test('should display the page content with a signin CTA', async ({
     page
   }) => {

--- a/e2e/link-ms-user.spec.ts
+++ b/e2e/link-ms-user.spec.ts
@@ -38,8 +38,6 @@ test.describe('Link MS user component (signed-out user)', () => {
 });
 
 test.describe('Link MS user component (signed-in user)', () => {
-  test.use({ storageState: 'playwright/.auth/certified-user.json' });
-
   test("should recognize the user's MS account", async ({ page }) => {
     await expect(
       page.getByRole('heading', {

--- a/e2e/mobile-layout.spec.ts
+++ b/e2e/mobile-layout.spec.ts
@@ -2,8 +2,6 @@ import { test, expect } from '@playwright/test';
 
 import translations from '../client/i18n/locales/english/translations.json';
 
-test.use({ storageState: 'playwright/.auth/certified-user.json' });
-
 test.describe('Classic challenge - 5 tabs mobile layout component', () => {
   test.skip(
     ({ isMobile }) => isMobile === false,

--- a/e2e/ms-trophy-show.spec.ts
+++ b/e2e/ms-trophy-show.spec.ts
@@ -1,8 +1,4 @@
 import { test, expect } from '@playwright/test';
-import translations from '../client/i18n/locales/english/translations.json';
-
-const verifyTrophyButtonText = translations.buttons['verify-trophy'];
-const askForHelpButtonText = translations.buttons['ask-for-help'];
 
 test.beforeEach(async ({ page }) => {
   await page.goto(
@@ -10,41 +6,64 @@ test.beforeEach(async ({ page }) => {
   );
 });
 
-test('the page should render with correct title and description', async ({
-  page
-}) => {
-  await expect(page).toHaveTitle(
-    'Write Your First Code Using C# - Trophy - Write Your First Code Using C# | Learn | freeCodeCamp.org'
-  );
-  const title = page.getByTestId('challenge-title');
-  await expect(title).toBeVisible();
-  await expect(title).toContainText('Trophy - Write Your First Code Using C#');
+test.describe('MS Trophy page if the user is signed in', () => {
+  test('should render the content correctly', async ({ page }) => {
+    await expect(page).toHaveTitle(
+      'Write Your First Code Using C# - Trophy - Write Your First Code Using C# | Learn | freeCodeCamp.org'
+    );
+    await expect(
+      page.getByRole('heading', {
+        level: 1,
+        name: 'Trophy - Write Your First Code Using C#'
+      })
+    ).toBeVisible();
 
-  const description = page.getByTestId('challenge-description');
-  await expect(description).toBeVisible();
+    await expect(
+      page.getByText(
+        'Now that you\'ve completed all of the "Write Your First Code Using C#" challenges, you should have earned the trophy for it on the Microsoft Learn platform.'
+      )
+    ).toBeVisible();
+
+    await expect(page.getByRole('button', { name: 'Unlink' })).toBeVisible();
+    await expect(
+      page.getByRole('button', { name: 'Verify Trophy' })
+    ).toBeVisible();
+    await expect(
+      page.getByRole('button', { name: 'Ask for Help' })
+    ).toBeVisible();
+  });
 });
 
-test('Correct Verify Trophy button', async ({ page }) => {
-  const askHelpButton = page.getByRole('button', {
-    name: verifyTrophyButtonText
-  });
-  await expect(askHelpButton).toBeVisible();
-  await expect(askHelpButton).toHaveText(verifyTrophyButtonText);
-  await expect(askHelpButton).toBeDisabled();
-});
+test.describe('MS Trophy page if the user is not signed in', () => {
+  test.use({ storageState: { cookies: [], origins: [] } });
 
-test('Correct Ask for help button', async ({ page }) => {
-  const checkAnswerButton = page.getByRole('button', {
-    name: askForHelpButtonText
-  });
-  await expect(checkAnswerButton).toBeVisible();
-  await expect(checkAnswerButton).toContainText(askForHelpButtonText);
+  test('should render the content correctly', async ({ page }) => {
+    await expect(page).toHaveTitle(
+      'Write Your First Code Using C# - Trophy - Write Your First Code Using C# | Learn | freeCodeCamp.org'
+    );
+    await expect(
+      page.getByRole('heading', {
+        level: 1,
+        name: 'Trophy - Write Your First Code Using C#'
+      })
+    ).toBeVisible();
 
-  await checkAnswerButton.click();
-  await expect(
-    page.getByRole('heading', {
-      name: translations.buttons['ask-for-help'],
-      exact: true
-    })
-  ).toBeVisible();
+    await expect(
+      page.getByText(
+        'Now that you\'ve completed all of the "Write Your First Code Using C#" challenges, you should have earned the trophy for it on the Microsoft Learn platform.'
+      )
+    ).toBeVisible();
+
+    // There are two "Sign in" buttons on the page: one in the nav, and one in the page body
+    await expect(page.getByRole('link', { name: 'Sign in' })).toHaveCount(2);
+    await expect(
+      page.getByRole('button', { name: 'Verify Trophy' })
+    ).toBeVisible();
+    await expect(
+      page.getByRole('button', { name: 'Verify Trophy' })
+    ).toBeDisabled();
+    await expect(
+      page.getByRole('button', { name: 'Ask for Help' })
+    ).toBeVisible();
+  });
 });

--- a/e2e/profile.spec.ts
+++ b/e2e/profile.spec.ts
@@ -81,8 +81,6 @@ const legacyCerts = [
   { name: 'Legacy Full Stack', url: '/certification/certifieduser/full-stack' }
 ];
 
-test.use({ storageState: 'playwright/.auth/certified-user.json' });
-
 test.beforeEach(async ({ page }) => {
   await page.goto('/certifieduser');
 

--- a/e2e/reset-modal.spec.ts
+++ b/e2e/reset-modal.spec.ts
@@ -128,7 +128,7 @@ test('User can reset classic challenge', async ({ page, isMobile }) => {
   ).not.toBeVisible();
   await expect(
     page.getByLabel(translations.icons.passed).locator('circle')
-  ).not.toBeVisible();
+  ).toBeVisible();
   await expect(
     page.getByText(translations.learn['tests-completed'])
   ).not.toBeVisible();

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -1,6 +1,5 @@
 import { test, expect } from '@playwright/test';
 import translations from '../client/i18n/locales/english/translations.json';
-test.use({ storageState: 'playwright/.auth/certified-user.json' });
 
 const settingsTestIds = {
   settingsHeading: 'settings-heading',

--- a/e2e/shortcuts-modal.spec.ts
+++ b/e2e/shortcuts-modal.spec.ts
@@ -7,8 +7,6 @@ const course =
 const editorPaneLabel =
   'Editor content;Press Alt+F1 for Accessibility Options.';
 
-test.use({ storageState: 'playwright/.auth/certified-user.json' });
-
 const enableKeyboardShortcuts = async (
   page: Page,
   request: APIRequestContext

--- a/e2e/show-certificate-else.spec.ts
+++ b/e2e/show-certificate-else.spec.ts
@@ -1,14 +1,15 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect } from '@playwright/test';
 
 test.describe('Show certification else', () => {
-  let page: Page;
+  test.use({ storageState: { cookies: [], origins: [] } });
 
-  test.beforeAll(async ({ browser }) => {
-    page = await browser.newPage();
+  test.beforeEach(async ({ page }) => {
     await page.goto('/certification/certifieduser/responsive-web-design');
   });
 
-  test('while viewing someone else, should display the certificate information', async () => {
+  test('while viewing someone else, should display the certificate information', async ({
+    page
+  }) => {
     await expect(page.getByTestId('successful-completion')).toBeVisible();
     await expect(page.getByTestId('certification-title')).toBeVisible();
     await expect(page.getByTestId('issue-date')).toContainText(
@@ -16,7 +17,9 @@ test.describe('Show certification else', () => {
     );
   });
 
-  test('while viewing someone else, should not render a LinkedIn button and Twitter button', async () => {
+  test('while viewing someone else, should not render a LinkedIn button and Twitter button', async ({
+    page
+  }) => {
     await expect(page.getByTestId('linkedin-share-btn')).toBeHidden();
     await expect(page.getByTestId('twitter-share-btn')).toBeHidden();
   });

--- a/e2e/show-certificate-own.spec.ts
+++ b/e2e/show-certificate-own.spec.ts
@@ -1,7 +1,5 @@
 import { test, expect, type Page } from '@playwright/test';
 
-test.use({ storageState: 'playwright/.auth/certified-user.json' });
-
 test.describe('Show certification own', () => {
   let page: Page;
 

--- a/e2e/show.spec.ts
+++ b/e2e/show.spec.ts
@@ -40,8 +40,6 @@ test.describe('Odin challenges', () => {
   });
 
   test.describe('When the user is signed in', () => {
-    test.use({ storageState: 'playwright/.auth/certified-user.json' });
-
     test('should render the content correctly', async ({ page }) => {
       await expect(page).toHaveTitle(
         'Write Your First Code Using C# - Write Your First C# Code | Learn | freeCodeCamp.org'

--- a/e2e/signout-modal.spec.ts
+++ b/e2e/signout-modal.spec.ts
@@ -1,8 +1,6 @@
 import { test, expect } from '@playwright/test';
 import translations from '../client/i18n/locales/english/translations.json';
 
-test.use({ storageState: 'playwright/.auth/certified-user.json' });
-
 test.beforeEach(async ({ page }) => {
   await page.goto('/');
 });

--- a/e2e/solution-viewer.spec.ts
+++ b/e2e/solution-viewer.spec.ts
@@ -1,7 +1,5 @@
 import { test, expect } from '@playwright/test';
 
-test.use({ storageState: 'playwright/.auth/certified-user.json' });
-
 test.describe('Solution Viewer component', () => {
   test('renders the modal correctly', async ({ page }) => {
     await page.goto(

--- a/e2e/update-stripe-card-default.spec.ts
+++ b/e2e/update-stripe-card-default.spec.ts
@@ -2,7 +2,6 @@ import { test, expect } from '@playwright/test';
 import translations from '../client/i18n/locales/english/translations.json';
 
 test.describe('Update Card Page for Non-Donor Authenticated User', () => {
-  test.use({ storageState: 'playwright/.auth/certified-user.json' });
   test('should render correctly', async ({ page }) => {
     await page.goto('/update-stripe-card');
     await expect(page).toHaveTitle(

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -47,31 +47,46 @@ export default defineConfig({
 
     {
       name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: 'playwright/.auth/certified-user.json'
+      },
       dependencies: ['setup']
     },
 
     {
       name: 'firefox',
-      use: { ...devices['Desktop Firefox'] },
+      use: {
+        ...devices['Desktop Firefox'],
+        storageState: 'playwright/.auth/certified-user.json'
+      },
       dependencies: ['setup']
     },
 
     {
       name: 'webkit',
-      use: { ...devices['Desktop Safari'] },
+      use: {
+        ...devices['Desktop Safari'],
+        storageState: 'playwright/.auth/certified-user.json'
+      },
       dependencies: ['setup']
     },
 
     /* Test against mobile viewports. */
     {
       name: 'Mobile Chrome',
-      use: { ...devices['Pixel 5'] },
+      use: {
+        ...devices['Pixel 5'],
+        storageState: 'playwright/.auth/certified-user.json'
+      },
       dependencies: ['setup']
     },
     {
       name: 'Mobile Safari',
-      use: { ...devices['iPhone 12'] },
+      use: {
+        ...devices['iPhone 12'],
+        storageState: 'playwright/.auth/certified-user.json'
+      },
       dependencies: ['setup']
     }
     /* Uncomment the blocks out if you want to enable the mentioned features */


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Currently, if a test requires the user to be authenticated, we have to manually sign them in using:

```ts
test.use({ storageState: 'playwright/.auth/certified-user.json' });
```

This PR:
- Updates the config so that the user is signed in by default
- Closes #54609

Misc:
- Related discussion: https://github.com/freeCodeCamp/freeCodeCamp/pull/54481#discussion_r1581288800
- Playwright authentication guide: https://playwright.dev/docs/auth#basic-shared-account-in-all-tests

<!-- Feel free to add any additional description of changes below this line -->
