### PR TITLE
test: ensure shortcuts enabled before testing

### DIFF
--- a/e2e/hotkeys.spec.ts
+++ b/e2e/hotkeys.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test';
 
 import translations from '../client/i18n/locales/english/translations.json';
+import { authedRequest } from './utils/request';
 
 const course =
   '/learn/javascript-algorithms-and-data-structures/basic-javascript/comment-your-javascript-code';
@@ -8,6 +9,19 @@ const editorPaneLabel =
   'Editor content;Press Alt+F1 for Accessibility Options.';
 
 test.use({ storageState: 'playwright/.auth/certified-user.json' });
+
+test.beforeAll(async ({ request }) => {
+  await authedRequest(request, 'update-my-keyboard-shortcuts', {
+    keyboardShortcuts: false
+  });
+});
+
+test.afterEach(
+  async ({ request }) =>
+    await authedRequest(request, 'update-my-keyboard-shortcuts', {
+      keyboardShortcuts: false
+    })
+);
 
 test('User can interact with the app using the keyboard', async ({ page }) => {
   // Enable keyboard shortcuts
@@ -18,6 +32,12 @@ test('User can interact with the app using the keyboard', async ({ page }) => {
   await keyboardShortcutGroup
     .getByRole('button', { name: translations.buttons.on, exact: true })
     .click();
+  // TODO: getByRole('alert', name:
+  // translations.flash['keyboard-shortcut-updated']) did not find the alert.
+  // Should it a) be an alert and b) have a name?
+  await expect(
+    page.getByText(translations.flash['keyboard-shortcut-updated'])
+  ).toBeVisible();
 
   await page.goto(course);
 

--- a/e2e/hotkeys.spec.ts
+++ b/e2e/hotkeys.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 
 import translations from '../client/i18n/locales/english/translations.json';
-import { authedRequest } from './utils/request';
+import { authedPut } from './utils/request';
 
 const course =
   '/learn/javascript-algorithms-and-data-structures/basic-javascript/comment-your-javascript-code';
@@ -11,14 +11,14 @@ const editorPaneLabel =
 test.use({ storageState: 'playwright/.auth/certified-user.json' });
 
 test.beforeAll(async ({ request }) => {
-  await authedRequest(request, 'update-my-keyboard-shortcuts', {
+  await authedPut(request, 'update-my-keyboard-shortcuts', {
     keyboardShortcuts: false
   });
 });
 
 test.afterEach(
   async ({ request }) =>
-    await authedRequest(request, 'update-my-keyboard-shortcuts', {
+    await authedPut(request, 'update-my-keyboard-shortcuts', {
       keyboardShortcuts: false
     })
 );

--- a/e2e/shortcuts-modal.spec.ts
+++ b/e2e/shortcuts-modal.spec.ts
@@ -1,7 +1,7 @@
 import { APIRequestContext, Page, expect, test } from '@playwright/test';
 
 import translations from '../client/i18n/locales/english/translations.json';
-import { authedRequest } from './utils/request';
+import { authedPut } from './utils/request';
 
 const course =
   '/learn/javascript-algorithms-and-data-structures/basic-javascript/comment-your-javascript-code';
@@ -11,7 +11,7 @@ const editorPaneLabel =
 test.use({ storageState: 'playwright/.auth/certified-user.json' });
 
 const enableKeyboardShortcuts = async (request: APIRequestContext) => {
-  const res = await authedRequest(request, '/update-my-keyboard-shortcuts', {
+  const res = await authedPut(request, '/update-my-keyboard-shortcuts', {
     keyboardShortcuts: true
   });
   expect(await res.json()).toEqual({

--- a/e2e/shortcuts-modal.spec.ts
+++ b/e2e/shortcuts-modal.spec.ts
@@ -1,6 +1,7 @@
 import { APIRequestContext, Page, expect, test } from '@playwright/test';
 
 import translations from '../client/i18n/locales/english/translations.json';
+import { authedRequest } from './utils/request';
 
 const course =
   '/learn/javascript-algorithms-and-data-structures/basic-javascript/comment-your-javascript-code';
@@ -9,24 +10,10 @@ const editorPaneLabel =
 
 test.use({ storageState: 'playwright/.auth/certified-user.json' });
 
-const enableKeyboardShortcuts = async (
-  page: Page,
-  request: APIRequestContext
-) => {
-  const csrfToken = (await request.storageState()).cookies.find(
-    c => c.name === 'csrf_token'
-  )?.value;
-
-  expect(csrfToken).toBeTruthy();
-
-  const res = await request.put(
-    process.env.API_LOCATION + '/update-my-keyboard-shortcuts',
-    {
-      data: { keyboardShortcuts: true },
-      headers: { 'csrf-token': csrfToken! }
-    }
-  );
-  expect(res.status()).toBe(200);
+const enableKeyboardShortcuts = async (request: APIRequestContext) => {
+  const res = await authedRequest(request, '/update-my-keyboard-shortcuts', {
+    keyboardShortcuts: true
+  });
   expect(await res.json()).toEqual({
     message: 'flash.keyboard-shortcut-updated',
     type: 'success'
@@ -46,7 +33,7 @@ test.beforeEach(async ({ page, isMobile, request }) => {
     'Skipping on mobile as it does not have a physical keyboard'
   );
 
-  await enableKeyboardShortcuts(page, request);
+  await enableKeyboardShortcuts(request);
   await page.goto(course);
 });
 

--- a/e2e/utils/request.ts
+++ b/e2e/utils/request.ts
@@ -3,7 +3,7 @@ import { APIRequestContext, expect } from '@playwright/test';
 const ensureLeadingSlash = (endpoint: string) =>
   endpoint[0] === '/' ? endpoint : '/' + endpoint;
 
-export const authedRequest = async (
+export const authedPut = async (
   request: APIRequestContext,
   endpoint: string,
   data: Record<string, unknown>

--- a/e2e/utils/request.ts
+++ b/e2e/utils/request.ts
@@ -1,0 +1,26 @@
+import { APIRequestContext, expect } from '@playwright/test';
+
+const ensureLeadingSlash = (endpoint: string) =>
+  endpoint[0] === '/' ? endpoint : '/' + endpoint;
+
+export const authedRequest = async (
+  request: APIRequestContext,
+  endpoint: string,
+  data: Record<string, unknown>
+) => {
+  const csrfToken = (await request.storageState()).cookies.find(
+    c => c.name === 'csrf_token'
+  )?.value;
+
+  expect(csrfToken).toBeTruthy();
+
+  const res = await request.put(
+    process.env.API_LOCATION + ensureLeadingSlash(endpoint),
+    {
+      data,
+      headers: { 'csrf-token': csrfToken! }
+    }
+  );
+  expect(res.status()).toBe(200);
+  return res;
+};


### PR DESCRIPTION
- **refactor: create utility function for requests**
- **test: ensure shortcuts are enabled before testing**
- **refactor: rename utility function**

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

I'm not sure why hotkeys.spec.ts is flaky, but this should rule out one possibility. Namely that the hotkeys are not enabled at the point when Escape is first pressed.

<!-- Feel free to add any additional description of changes below this line -->
