### PR TITLE
fix(curriculum): allow additional whitespace in tests

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641daae5e18eae4b562633e4.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641daae5e18eae4b562633e4.md
@@ -35,7 +35,7 @@ assert.match(code, /(`|"|')\s*<p\s+class\s*=\s*("|')error-msg\2>/)
 Your `p` element should have the text `There was an error loading the authors`.
 
 ```js
-assert.match(code, /(`|"|')\s*<p\s+class\s*=\s*("|')error-msg\2>There\s+was\s+an\s+error\s+loading\s+the\s+authors<\/p>\s*\1\;?/)
+assert.match(code, /(`|"|')<p\s+class\s*=\s*("|')error-msg\2>There\s+was\s+an\s+error\s+loading\s+the\s+authors<\/p>\s*\1\s*;?/)
 ```
 
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641daae5e18eae4b562633e4.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641daae5e18eae4b562633e4.md
@@ -23,19 +23,19 @@ You should access the `innerHTML` of `authorContainer` and set it to a `p` eleme
 
 
 ```js
-assert.match(code, /authorContainer\.innerHTML\s*=\s*(`|"|')<p.*>.*<\/p>\1/)
+assert.match(code, /authorContainer\.innerHTML\s*=\s*(`|"|')\s*<p.*>.*<\/p>\s*\1/)
 ```
 
 Your `p` element should have the class `error-msg`.
 
 ```js
-assert.match(code, /(`|"|')<p\s+class\s*=\s*("|')error-msg\2>/)
+assert.match(code, /(`|"|')\s*<p\s+class\s*=\s*("|')error-msg\2>/)
 ```
 
 Your `p` element should have the text `There was an error loading the authors`.
 
 ```js
-assert.match(code, /(`|"|')<p\s+class\s*=\s*("|')error-msg\2>There\s+was\s+an\s+error\s+loading\s+the\s+authors<\/p>\1\s*;?/)
+assert.match(code, /(`|"|')\s*<p\s+class\s*=\s*("|')error-msg\2>There\s+was\s+an\s+error\s+loading\s+the\s+authors<\/p>\s*\1\;?/)
 ```
 
 


### PR DESCRIPTION
Added an additional whitespace between template literals and the p element in affected tests.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #54654

<!-- Feel free to add any additional description of changes below this line -->
