### PR TITLE
fix(curriculum): update tests to close img element

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5dc24073f86c76b9248c6ebb.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5dc24073f86c76b9248c6ebb.md
@@ -45,6 +45,12 @@ Although you have set the `img` element's `src` to the correct URL, it is recomm
 assert(!/\<img\s+src\s*=\s*https:\/\/cdn\.freecodecamp\.org\/curriculum\/cat-photo-app\/relaxing-cat\.jpg/.test(code));
 ```
 
+Close your `img` element with either `>` or `/>`.
+
+```js
+assert.match(code, /\<img\s+src\s*=\s*('|"|`)https:\/\/cdn\.freecodecamp\.org\/curriculum\/cat-photo-app\/relaxing-cat\.jpg\1\s*(?:(\s*\>|\s*\/\s*\>))/);
+```
+
 # --seed--
 
 ## --seed-contents--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #54642

<!-- Feel free to add any additional description of changes below this line -->

Hint message when `img` element is not closed.
![image](https://github.com/freeCodeCamp/freeCodeCamp/assets/153783117/f465cc2a-5e77-4ed1-9d5d-29d984790ca4)

Success message when `img` element is closed (1)
![image](https://github.com/freeCodeCamp/freeCodeCamp/assets/153783117/02195e45-4bf3-44f4-92f1-63e293970bd6)

Success message when `img` element is closed (2)
![image](https://github.com/freeCodeCamp/freeCodeCamp/assets/153783117/0623866a-5d3d-4bea-a3c3-4bf434d620af)
