### PR TITLE
refactor(api): more, smaller tests

### DIFF
--- a/api/__mocks__/exam.ts
+++ b/api/__mocks__/exam.ts
@@ -72,8 +72,20 @@ export const completedTrophyChallenges = [
   }
 ];
 
+export type ExamSubmission = {
+  userExamQuestions: {
+    id: string;
+    question: string;
+    answer: {
+      id: string;
+      answer: string;
+    };
+  }[];
+  examTimeInSeconds: number;
+};
+
 // failed: 0 correct
-export const examWithZeroCorrect = {
+export const examWithZeroCorrect: ExamSubmission = {
   userExamQuestions: [
     {
       id: '3bbl2mx2mq',
@@ -95,7 +107,7 @@ export const examWithZeroCorrect = {
 };
 
 // passed: 1 correct
-export const examWithOneCorrect = {
+export const examWithOneCorrect: ExamSubmission = {
   userExamQuestions: [
     {
       id: '3bbl2mx2mq',
@@ -117,7 +129,7 @@ export const examWithOneCorrect = {
 };
 
 // passed: 2 correct
-export const examWithTwoCorrect = {
+export const examWithTwoCorrect: ExamSubmission = {
   userExamQuestions: [
     {
       id: '3bbl2mx2mq',
@@ -139,7 +151,7 @@ export const examWithTwoCorrect = {
 };
 
 // passed: 3 correct
-export const examWithAllCorrect = {
+export const examWithAllCorrect: ExamSubmission = {
   userExamQuestions: [
     {
       id: '3bbl2mx2mq',

--- a/api/__mocks__/exam.ts
+++ b/api/__mocks__/exam.ts
@@ -210,25 +210,27 @@ export const mockResultsAllCorrect = {
 
 const completedExamChallenge = {
   id: examChallengeId,
-  challengeType: 17
+  challengeType: 17,
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  completedDate: expect.any(Number)
 };
 
-export const completedExamChallenge1 = {
+export const completedExamChallengeZeroCorrect = {
   ...completedExamChallenge,
   examResults: mockResultsZeroCorrect
 };
 
-export const completedExamChallenge2 = {
+export const completedExamChallengeOneCorrect = {
   ...completedExamChallenge,
   examResults: mockResultsOneCorrect
 };
 
-export const completedExamChallenge3 = {
+export const completedExamChallengeTwoCorrect = {
   ...completedExamChallenge,
   examResults: mockResultsTwoCorrect
 };
 
-export const completedExamChallenge4 = {
+export const completedExamChallengeAllCorrect = {
   ...completedExamChallenge,
   examResults: mockResultsAllCorrect
 };

--- a/api/__mocks__/exam.ts
+++ b/api/__mocks__/exam.ts
@@ -73,7 +73,7 @@ export const completedTrophyChallenges = [
 ];
 
 // failed: 0 correct
-export const userExam1 = {
+export const examWithZeroCorrect = {
   userExamQuestions: [
     {
       id: '3bbl2mx2mq',
@@ -95,7 +95,7 @@ export const userExam1 = {
 };
 
 // passed: 1 correct
-export const userExam2 = {
+export const examWithOneCorrect = {
   userExamQuestions: [
     {
       id: '3bbl2mx2mq',
@@ -117,7 +117,7 @@ export const userExam2 = {
 };
 
 // passed: 2 correct
-export const userExam3 = {
+export const examWithTwoCorrect = {
   userExamQuestions: [
     {
       id: '3bbl2mx2mq',
@@ -139,7 +139,7 @@ export const userExam3 = {
 };
 
 // passed: 3 correct
-export const userExam4 = {
+export const examWithAllCorrect = {
   userExamQuestions: [
     {
       id: '3bbl2mx2mq',

--- a/api/__mocks__/exam.ts
+++ b/api/__mocks__/exam.ts
@@ -172,7 +172,7 @@ export const examWithAllCorrect: ExamSubmission = {
   examTimeInSeconds: 20
 };
 
-export const mockResults1 = {
+export const mockResultsZeroCorrect = {
   numberOfCorrectAnswers: 0,
   numberOfQuestionsInExam: 3,
   percentCorrect: 0,
@@ -181,7 +181,7 @@ export const mockResults1 = {
   examTimeInSeconds: 20
 };
 
-export const mockResults2 = {
+export const mockResultsOneCorrect = {
   numberOfCorrectAnswers: 1,
   numberOfQuestionsInExam: 3,
   percentCorrect: 33.3,
@@ -190,7 +190,7 @@ export const mockResults2 = {
   examTimeInSeconds: 20
 };
 
-export const mockResults3 = {
+export const mockResultsTwoCorrect = {
   numberOfCorrectAnswers: 2,
   numberOfQuestionsInExam: 3,
   percentCorrect: 66.7,
@@ -199,7 +199,7 @@ export const mockResults3 = {
   examTimeInSeconds: 20
 };
 
-export const mockResults4 = {
+export const mockResultsAllCorrect = {
   numberOfCorrectAnswers: 3,
   numberOfQuestionsInExam: 3,
   percentCorrect: 100,
@@ -215,20 +215,20 @@ const completedExamChallenge = {
 
 export const completedExamChallenge1 = {
   ...completedExamChallenge,
-  examResults: mockResults1
+  examResults: mockResultsZeroCorrect
 };
 
 export const completedExamChallenge2 = {
   ...completedExamChallenge,
-  examResults: mockResults2
+  examResults: mockResultsOneCorrect
 };
 
 export const completedExamChallenge3 = {
   ...completedExamChallenge,
-  examResults: mockResults3
+  examResults: mockResultsTwoCorrect
 };
 
 export const completedExamChallenge4 = {
   ...completedExamChallenge,
-  examResults: mockResults4
+  examResults: mockResultsAllCorrect
 };

--- a/api/__mocks__/exam.ts
+++ b/api/__mocks__/exam.ts
@@ -67,7 +67,8 @@ export const completedTrophyChallenges = [
   {
     id: '647f85d407d29547b3bee1bb',
     solution: 'challenge-solution',
-    completedDate: 1695064765244
+    completedDate: 1695064765244,
+    files: []
   }
 ];
 

--- a/api/jest.utils.ts
+++ b/api/jest.utils.ts
@@ -175,6 +175,7 @@ If you are seeing this error, the root cause is likely an error thrown in the be
 
 export const defaultUserId = '64c7810107dd4782d32baee7';
 export const defaultUserEmail = 'foo@bar.com';
+export const defaultUsername = 'fcc-test-user';
 
 export async function devLogin(): Promise<string[]> {
   await fastifyTestInstance.prisma.user.deleteMany({
@@ -184,7 +185,8 @@ export async function devLogin(): Promise<string[]> {
   await fastifyTestInstance.prisma.user.create({
     data: {
       ...createUserInput(defaultUserEmail),
-      id: defaultUserId
+      id: defaultUserId,
+      username: defaultUsername
     }
   });
   const res = await superRequest('/signin', { method: 'GET' });

--- a/api/src/routes/challenge.test.ts
+++ b/api/src/routes/challenge.test.ts
@@ -23,10 +23,10 @@ import {
   completedExamChallenge4,
   completedTrophyChallenges,
   examChallengeId,
-  mockResults1,
-  mockResults2,
-  mockResults3,
-  mockResults4,
+  mockResultsZeroCorrect,
+  mockResultsOneCorrect,
+  mockResultsTwoCorrect,
+  mockResultsAllCorrect,
   examWithZeroCorrect,
   examWithOneCorrect,
   examWithTwoCorrect,
@@ -1534,14 +1534,14 @@ describe('challengeRoutes', () => {
             id: '647e22d18acb466c97ccbef8',
             challengeType: 17,
             completedDate: expect.any(Number),
-            examResults: mockResults1
+            examResults: mockResultsZeroCorrect
           });
 
           expect(completedExams[0]?.completedDate).toBeGreaterThan(now);
           expect(response.body).toMatchObject({
             points: 0,
             alreadyCompleted: false,
-            examResults: mockResults1
+            examResults: mockResultsZeroCorrect
           });
           expect(response.statusCode).toBe(200);
         });
@@ -1578,7 +1578,7 @@ describe('challengeRoutes', () => {
           expect(responseA.body).toMatchObject({
             points: 1,
             alreadyCompleted: false,
-            examResults: mockResults3
+            examResults: mockResultsTwoCorrect
           });
           expect(responseA.statusCode).toBe(200);
 
@@ -1614,7 +1614,7 @@ describe('challengeRoutes', () => {
           expect(response2.body).toMatchObject({
             points: 1,
             alreadyCompleted: true,
-            examResults: mockResults2
+            examResults: mockResultsOneCorrect
           });
           expect(response2.statusCode).toBe(200);
 
@@ -1648,7 +1648,7 @@ describe('challengeRoutes', () => {
           expect(response3.body).toMatchObject({
             points: 1,
             alreadyCompleted: true,
-            examResults: mockResults4
+            examResults: mockResultsAllCorrect
           });
           expect(response3.statusCode).toBe(200);
         });

--- a/api/src/routes/challenge.test.ts
+++ b/api/src/routes/challenge.test.ts
@@ -27,10 +27,10 @@ import {
   mockResults2,
   mockResults3,
   mockResults4,
-  userExam1,
-  userExam2,
-  userExam3,
-  userExam4
+  examWithZeroCorrect,
+  examWithOneCorrect,
+  examWithTwoCorrect,
+  examWithAllCorrect
 } from '../../__mocks__/exam';
 import { Answer } from '../utils/exam-types';
 import type { getSessionUser } from '../schemas/user/get-session-user';
@@ -1506,7 +1506,7 @@ describe('challengeRoutes', () => {
           }).send({
             id: examChallengeId,
             challengeType: 17,
-            userCompletedExam: userExam1
+            userCompletedExam: examWithZeroCorrect
           });
 
           type GetSessionUserResponseBody = Static<
@@ -1550,7 +1550,7 @@ describe('challengeRoutes', () => {
           }).send({
             id: examChallengeId,
             challengeType: 17,
-            userCompletedExam: userExam3
+            userCompletedExam: examWithTwoCorrect
           });
 
           const userA = await fastifyTestInstance.prisma.user.findFirst({
@@ -1592,7 +1592,7 @@ describe('challengeRoutes', () => {
           }).send({
             id: examChallengeId,
             challengeType: 17,
-            userCompletedExam: userExam2
+            userCompletedExam: examWithOneCorrect
           });
 
           const user2 = await fastifyTestInstance.prisma.user.findFirst({
@@ -1635,7 +1635,7 @@ describe('challengeRoutes', () => {
           }).send({
             id: examChallengeId,
             challengeType: 17,
-            userCompletedExam: userExam4
+            userCompletedExam: examWithAllCorrect
           });
 
           const user3 = await fastifyTestInstance.prisma.user.findFirst({

--- a/api/src/routes/challenge.test.ts
+++ b/api/src/routes/challenge.test.ts
@@ -30,7 +30,8 @@ import {
   examWithZeroCorrect,
   examWithOneCorrect,
   examWithTwoCorrect,
-  examWithAllCorrect
+  examWithAllCorrect,
+  type ExamSubmission
 } from '../../__mocks__/exam';
 import { Answer } from '../utils/exam-types';
 import type { getSessionUser } from '../schemas/user/get-session-user';
@@ -1496,18 +1497,22 @@ describe('challengeRoutes', () => {
           });
         });
 
-        test('POST handles submitting a failing exam', async () => {
-          const now = Date.now();
-
-          // Submit exam with 0 correct answers
-          const response = await superRequest('/exam-challenge-completed', {
+        const submitExam = async (exam: ExamSubmission) => {
+          return superRequest('/exam-challenge-completed', {
             method: 'POST',
             setCookies
           }).send({
             id: examChallengeId,
             challengeType: 17,
-            userCompletedExam: examWithZeroCorrect
+            userCompletedExam: exam
           });
+        };
+
+        test('POST handles submitting a failing exam', async () => {
+          const now = Date.now();
+
+          // Submit exam with 0 correct answers
+          const response = await submitExam(examWithZeroCorrect);
 
           type GetSessionUserResponseBody = Static<
             (typeof getSessionUser)['response']['200']
@@ -1544,14 +1549,7 @@ describe('challengeRoutes', () => {
         test('POST handles submitting multiple passing exams', async () => {
           // Submit exam with 2/3 correct answers
           const nowA = Date.now();
-          const responseA = await superRequest('/exam-challenge-completed', {
-            method: 'POST',
-            setCookies
-          }).send({
-            id: examChallengeId,
-            challengeType: 17,
-            userCompletedExam: examWithTwoCorrect
-          });
+          const responseA = await submitExam(examWithTwoCorrect);
 
           const userA = await fastifyTestInstance.prisma.user.findFirst({
             where: { id: defaultUserId }
@@ -1586,14 +1584,7 @@ describe('challengeRoutes', () => {
 
           // Submit exam with 1/3 correct answers (worse exam than already submitted)
           const now2 = Date.now();
-          const response2 = await superRequest('/exam-challenge-completed', {
-            method: 'POST',
-            setCookies
-          }).send({
-            id: examChallengeId,
-            challengeType: 17,
-            userCompletedExam: examWithOneCorrect
-          });
+          const response2 = await submitExam(examWithOneCorrect);
 
           const user2 = await fastifyTestInstance.prisma.user.findFirst({
             where: { id: defaultUserId }
@@ -1629,14 +1620,7 @@ describe('challengeRoutes', () => {
 
           // Submit exam with 3/3 correct answers (better exam than already submitted)
           const now3 = Date.now();
-          const response3 = await superRequest('/exam-challenge-completed', {
-            method: 'POST',
-            setCookies
-          }).send({
-            id: examChallengeId,
-            challengeType: 17,
-            userCompletedExam: examWithAllCorrect
-          });
+          const response3 = await submitExam(examWithAllCorrect);
 
           const user3 = await fastifyTestInstance.prisma.user.findFirst({
             where: { email: 'foo@bar.com' }

--- a/api/src/utils/exam.test.ts
+++ b/api/src/utils/exam.test.ts
@@ -1,10 +1,10 @@
 import { Exam, Question } from '@prisma/client';
 import {
   examJson,
-  userExam1,
-  userExam2,
-  userExam3,
-  userExam4,
+  examWithZeroCorrect,
+  examWithOneCorrect,
+  examWithTwoCorrect,
+  examWithAllCorrect,
   mockResults1,
   mockResults2,
   mockResults3,
@@ -45,10 +45,22 @@ describe('Exam helpers', () => {
   });
 
   describe('createExamResults()', () => {
-    const examResults1 = createExamResults(userExam1, examJson as Exam);
-    const examResults2 = createExamResults(userExam2, examJson as Exam);
-    const examResults3 = createExamResults(userExam3, examJson as Exam);
-    const examResults4 = createExamResults(userExam4, examJson as Exam);
+    const examResults1 = createExamResults(
+      examWithZeroCorrect,
+      examJson as Exam
+    );
+    const examResults2 = createExamResults(
+      examWithOneCorrect,
+      examJson as Exam
+    );
+    const examResults3 = createExamResults(
+      examWithTwoCorrect,
+      examJson as Exam
+    );
+    const examResults4 = createExamResults(
+      examWithAllCorrect,
+      examJson as Exam
+    );
 
     it('failing exam should return correct results', () => {
       expect(examResults1).toEqual(mockResults1);

--- a/api/src/utils/exam.test.ts
+++ b/api/src/utils/exam.test.ts
@@ -5,10 +5,10 @@ import {
   examWithOneCorrect,
   examWithTwoCorrect,
   examWithAllCorrect,
-  mockResults1,
-  mockResults2,
-  mockResults3,
-  mockResults4
+  mockResultsZeroCorrect,
+  mockResultsOneCorrect,
+  mockResultsTwoCorrect,
+  mockResultsAllCorrect
 } from '../../__mocks__/exam';
 import { generateRandomExam, createExamResults } from './exam';
 import { GeneratedExam } from './exam-types';
@@ -63,13 +63,13 @@ describe('Exam helpers', () => {
     );
 
     it('failing exam should return correct results', () => {
-      expect(examResults1).toEqual(mockResults1);
+      expect(examResults1).toEqual(mockResultsZeroCorrect);
     });
 
     it('passing exam should return correct results', () => {
-      expect(examResults2).toEqual(mockResults2);
-      expect(examResults3).toEqual(mockResults3);
-      expect(examResults4).toEqual(mockResults4);
+      expect(examResults2).toEqual(mockResultsOneCorrect);
+      expect(examResults3).toEqual(mockResultsTwoCorrect);
+      expect(examResults4).toEqual(mockResultsAllCorrect);
     });
   });
 });


### PR DESCRIPTION
- **test: check get-session-user rather than db**
- **refactor: rename fixtures**
- **refactor: create submitExam helper function**
- **refactor: rename results**
- **refactor: more, smaller tests**

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

I was a little unsure about what the `/exam-challenge-completed` endpoint was expected to do, so I split the tests up. The is a little more boilerplate as a result, but each test is now more focused. It should be clear which behaviour they're asserting.

I also moved one of the tests from checking the db directly, to using `get-session-user`. The reason for this is simply it's more useful to know how an update modifies the api's behaviour (i.e. how subsequent requests will play out) than how it modifies the internals. I'll extend this to the other tests in a followup PR, since that requires updating `get-session-user`'s behaviour and I wanted to limit this to being a refactor.

<!-- Feel free to add any additional description of changes below this line -->
