### PR TITLE
fix(UI): make the progression lines elastic

### DIFF
--- a/client/src/assets/icons/completion-ribbon.tsx
+++ b/client/src/assets/icons/completion-ribbon.tsx
@@ -7,18 +7,6 @@ interface RibbonProps {
   showNumbers?: boolean;
 }
 
-export const Arrow = () => (
-  <svg
-    width='14'
-    height='35'
-    viewBox='0 0 14 35'
-    fill='none'
-    xmlns='http://www.w3.org/2000/svg'
-  >
-    <path d='M7 0V30' stroke='var(--secondary-color)' strokeWidth='2' />
-  </svg>
-);
-
 export const RibbonIcon = ({
   value,
   isCompleted: completed,

--- a/client/src/components/Map/index.tsx
+++ b/client/src/components/Map/index.tsx
@@ -71,7 +71,7 @@ function MapLi({
   landing = false,
   completed,
   claimed,
-  showArrows = false,
+  showProgressionLines = false,
   showNumbers = false,
   index
 }: {
@@ -79,7 +79,7 @@ function MapLi({
   landing: boolean;
   completed: boolean;
   claimed: boolean;
-  showArrows?: boolean;
+  showProgressionLines?: boolean;
   showNumbers?: boolean;
   index: number;
 }) {
@@ -90,7 +90,9 @@ function MapLi({
         data-playwright-test-label='curriculum-map-button'
       >
         <div className='progress-icon-wrapper'>
-          <div className={`progress-icon${showArrows ? ' show-arrow' : ''}`}>
+          <div
+            className={`progress-icon${showProgressionLines ? ' show-progression-lines' : ''}`}
+          >
             <RibbonIcon
               value={index + 1}
               showNumbers={showNumbers}
@@ -177,7 +179,7 @@ function Map({
             landing={forLanding}
             index={i}
             claimed={isClaimed(superBlock)}
-            showArrows={true}
+            showProgressionLines={true}
             showNumbers={true}
             completed={allSuperblockChallengesCompleted(superBlock)}
           />

--- a/client/src/components/Map/index.tsx
+++ b/client/src/components/Map/index.tsx
@@ -21,7 +21,7 @@ import {
   currentCertsSelector
 } from '../../redux/selectors';
 
-import { RibbonIcon, Arrow } from '../../assets/icons/completion-ribbon';
+import { RibbonIcon } from '../../assets/icons/completion-ribbon';
 
 import {
   CurrentCert,
@@ -69,7 +69,6 @@ const mapStateToProps = createSelector(
 function MapLi({
   superBlock,
   landing = false,
-  last = false,
   completed,
   claimed,
   showArrows = false,
@@ -78,7 +77,6 @@ function MapLi({
 }: {
   superBlock: SuperBlocks;
   landing: boolean;
-  last?: boolean;
   completed: boolean;
   claimed: boolean;
   showArrows?: boolean;
@@ -92,16 +90,13 @@ function MapLi({
         data-playwright-test-label='curriculum-map-button'
       >
         <div className='progress-icon-wrapper'>
-          <div className='progress-icon'>
+          <div className={`progress-icon${showArrows ? ' show-arrow' : ''}`}>
             <RibbonIcon
               value={index + 1}
               showNumbers={showNumbers}
               isCompleted={completed}
               isClaimed={claimed}
             />
-          </div>
-          <div className='progression-arrow'>
-            {!last && showArrows && <Arrow />}
           </div>
         </div>
 
@@ -185,7 +180,6 @@ function Map({
             showArrows={true}
             showNumbers={true}
             completed={allSuperblockChallengesCompleted(superBlock)}
-            last={i + 1 == coreCurriculum.length}
           />
         ))}
       </ul>
@@ -202,7 +196,6 @@ function Map({
             completed={allSuperblockChallengesCompleted(superBlock)}
             claimed={isClaimed(superBlock)}
             index={i}
-            last={i + 1 == superBlockOrder[SuperBlockStages.English].length}
           />
         ))}
       </ul>
@@ -219,9 +212,6 @@ function Map({
             completed={allSuperblockChallengesCompleted(superBlock)}
             claimed={isClaimed(superBlock)}
             index={i}
-            last={
-              i + 1 == superBlockOrder[SuperBlockStages.Professional].length
-            }
           />
         ))}
       </ul>
@@ -238,7 +228,6 @@ function Map({
             completed={allSuperblockChallengesCompleted(superBlock)}
             claimed={isClaimed(superBlock)}
             index={i}
-            last={i + 1 == superBlockOrder[SuperBlockStages.Extra].length}
           />
         ))}
       </ul>
@@ -255,7 +244,6 @@ function Map({
             completed={allSuperblockChallengesCompleted(superBlock)}
             claimed={isClaimed(superBlock)}
             index={i}
-            last={i + 1 == superBlockOrder[SuperBlockStages.Legacy].length}
           />
         ))}
       </ul>
@@ -274,9 +262,6 @@ function Map({
                 completed={allSuperblockChallengesCompleted(superBlock)}
                 index={i}
                 claimed={isClaimed(superBlock)}
-                last={
-                  i + 1 == superBlockOrder[SuperBlockStages.Upcoming].length
-                }
               />
             ))}
           </ul>

--- a/client/src/components/Map/map.css
+++ b/client/src/components/Map/map.css
@@ -8,7 +8,12 @@
   padding: 0;
 }
 
-.progress-icon-wrapper {
+.map-ui ul li {
+  display: flex;
+  flex-direction: row;
+}
+
+.map-ui ul li .progress-icon-wrapper {
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -58,26 +63,8 @@
   top: calc(50% + 1.2rem);
 }
 
-.map-ui ul li {
-  display: flex;
-  flex-direction: row;
-}
-
 .map-ui ul li a > svg {
   overflow: visible;
-}
-
-.map-ui ul li .progress-number {
-  width: calc(42px - 0.1rem);
-  height: 4rem;
-  border-radius: 50%;
-  background-color: var(--quaternary-background);
-  color: var(--secondary-color);
-  border: 0.2rem solid var(--secondary-color);
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  font-weight: bold;
 }
 
 @media (max-width: 640px) {

--- a/client/src/components/Map/map.css
+++ b/client/src/components/Map/map.css
@@ -39,8 +39,8 @@
   width: auto;
 }
 
-.map-ui ul li:not(:first-child) .progress-icon.show-arrow:before,
-.map-ui ul li:not(:last-child) .progress-icon.show-arrow:after {
+.map-ui ul li:not(:first-child) .progress-icon.show-progression-lines:before,
+.map-ui ul li:not(:last-child) .progress-icon.show-progression-lines:after {
   content: '';
   display: block;
   width: 2px;
@@ -50,11 +50,11 @@
   left: calc(37%);
 }
 
-.map-ui ul li:not(:first-child) .progress-icon.show-arrow:before {
+.map-ui ul li:not(:first-child) .progress-icon.show-progression-lines:before {
   bottom: calc(50% + 1.7rem);
 }
 
-.map-ui ul li:not(:last-child) .progress-icon.show-arrow:after {
+.map-ui ul li:not(:last-child) .progress-icon.show-progression-lines:after {
   top: calc(50% + 1.2rem);
 }
 

--- a/client/src/components/Map/map.css
+++ b/client/src/components/Map/map.css
@@ -16,18 +16,11 @@
   position: relative;
 }
 
-.progression-arrow {
-  position: absolute;
-  top: calc(78%);
-  left: 21px;
-}
-
 .map-ui ul .progress-icon {
-  position: relative;
-  right: 7px;
   width: 4rem;
   display: flex;
   justify-content: center;
+  padding-inline-end: 0.9rem;
 }
 
 .map-ui ul .progress-icon .cert-icon-outline {
@@ -46,6 +39,25 @@
   width: auto;
 }
 
+.map-ui ul li:not(:first-child) .progress-icon.show-arrow:before,
+.map-ui ul li:not(:last-child) .progress-icon.show-arrow:after {
+  content: '';
+  display: block;
+  width: 2px;
+  height: 39%;
+  background-color: var(--secondary-color);
+  position: absolute;
+  left: calc(37%);
+}
+
+.map-ui ul li:not(:first-child) .progress-icon.show-arrow:before {
+  bottom: calc(50% + 1.7rem);
+}
+
+.map-ui ul li:not(:last-child) .progress-icon.show-arrow:after {
+  top: calc(50% + 1.2rem);
+}
+
 .map-ui ul li {
   display: flex;
   flex-direction: row;
@@ -53,10 +65,6 @@
 
 .map-ui ul li a > svg {
   overflow: visible;
-}
-
-.map-ui ul li .arrow path {
-  fill: var(--secondary-color);
 }
 
 .map-ui ul li .progress-number {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

Related PR is #54595.

<!-- Feel free to add any additional description of changes below this line -->

This PR was opened to make the progression lines on landing and `/learn` page elastic so the ones will be able to change to appropriate length depending on viewport width as shown in below.

<details>
<summary>Elastic progression lines on landing page</summary>

<img src="https://github.com/freeCodeCamp/freeCodeCamp/assets/44451585/bd948ad7-b127-40fd-8f31-a6f67d1501d4" width="240px">
</details>

By using gitpod, the code was tested with following environment.

1. Windows 11 Home PC using Chrome, Firefox, Edge, and Brave browser, or, webkit within the Playwright.
1. Android Studio's emulator(Pixel 6 Pro with Android API 34 system image) using Chrome.
1. iPhone SE (iOS 15.7.8) using Chrome and Firefox browser.
