### PR TITLE
feat(client): handle lessons with syntax errors

### DIFF
--- a/client/src/redux/prop-types.ts
+++ b/client/src/redux/prop-types.ts
@@ -422,7 +422,7 @@ export type ChallengeFile = {
   name: string;
   editableRegionBoundaries?: number[];
   usesMultifileEditor?: boolean;
-  error: null | string;
+  error?: unknown;
   head: string;
   tail: string;
   seed: string;

--- a/client/src/templates/Challenges/rechallenge/transformers.js
+++ b/client/src/templates/Challenges/rechallenge/transformers.js
@@ -1,10 +1,8 @@
 import protect from '@freecodecamp/loop-protect';
 import {
-  attempt,
   cond,
   flow,
   identity,
-  isError,
   matchesProperty,
   overSome,
   partial,
@@ -109,20 +107,6 @@ const replaceNBSP = cond([
   [stubTrue, identity]
 ]);
 
-function tryTransform(wrap = identity) {
-  return function transformWrappedPoly(source) {
-    const result = attempt(wrap, source);
-    if (isError(result)) {
-      // note(Bouncey): Error thrown here to collapse the build pipeline
-      // At the minute, it will not bubble up
-      // We collapse the pipeline so the app doesn't fall over trying
-      // parse bad code (syntax/type errors etc...)
-      throw result;
-    }
-    return result;
-  };
-}
-
 const babelTransformer = loopProtectOptions => {
   return cond([
     [
@@ -131,10 +115,10 @@ const babelTransformer = loopProtectOptions => {
         await loadBabel();
         await loadPresetEnv();
         const babelOptions = getBabelOptions(presetsJS, loopProtectOptions);
-        return partial(
-          transformHeadTailAndContents,
-          tryTransform(babelTransformCode(babelOptions))
-        )(code);
+        return transformHeadTailAndContents(
+          babelTransformCode(babelOptions),
+          code
+        );
       }
     ],
     [
@@ -146,7 +130,7 @@ const babelTransformer = loopProtectOptions => {
         return flow(
           partial(
             transformHeadTailAndContents,
-            tryTransform(babelTransformCode(babelOptions))
+            babelTransformCode(babelOptions)
           ),
           partial(setExt, 'js')
         )(code);
@@ -195,9 +179,9 @@ async function transformScript(documentElement) {
   await loadPresetEnv();
   const scriptTags = documentElement.querySelectorAll('script');
   scriptTags.forEach(script => {
-    script.innerHTML = tryTransform(
-      babelTransformCode(getBabelOptions(presetsJS))
-    )(script.innerHTML);
+    script.innerHTML = babelTransformCode(getBabelOptions(presetsJS))(
+      script.innerHTML
+    );
   });
 }
 

--- a/client/src/templates/Challenges/redux/execute-challenge-saga.js
+++ b/client/src/templates/Challenges/redux/execute-challenge-saga.js
@@ -117,6 +117,8 @@ export function* executeChallengeSaga({ payload }) {
 
     const challengeData = yield select(challengeDataSelector);
     const challengeMeta = yield select(challengeMetaSelector);
+    // The buildData is used even if there are build errors, so that lessons
+    // with syntax errors can be tested.
     const buildData = yield buildChallengeData(challengeData, {
       preview: false,
       disableLoopProtectTests: challengeMeta.disableLoopProtectTests,
@@ -270,6 +272,10 @@ export function* previewChallengeSaga(action) {
         disableLoopProtectTests: challengeMeta.disableLoopProtectTests,
         disableLoopProtectPreview: challengeMeta.disableLoopProtectPreview
       });
+      // If there's an error building the challenge then throwing it here will
+      // let the user know there's a problem.
+      if (buildData.error) throw buildData.error;
+
       // evaluate the user code in the preview frame or in the worker
       if (challengeHasPreview(challengeData)) {
         const document = yield getContext('document');

--- a/client/src/templates/Challenges/utils/build.ts
+++ b/client/src/templates/Challenges/utils/build.ts
@@ -33,7 +33,7 @@ interface ChallengeFile extends PropTypesChallengeFile {
 
 interface BuildChallengeData extends Context {
   challengeType: number;
-  challengeFiles: ChallengeFile[];
+  challengeFiles?: ChallengeFile[];
   required: { src: string }[];
   template: string;
   url: string;
@@ -275,7 +275,7 @@ export function buildDOMChallenge(
 }
 
 export function buildJSChallenge(
-  { challengeFiles }: { challengeFiles: ChallengeFile[] },
+  { challengeFiles }: { challengeFiles?: ChallengeFile[] },
   options: BuildOptions
 ): Promise<BuildResult> | undefined {
   const pipeLine = composeFunctions(...getTransformers(options));
@@ -314,7 +314,7 @@ export function buildPythonChallenge({
   challengeFiles
 }: BuildChallengeData): Promise<BuildResult> | undefined {
   const pipeLine = composeFunctions(...getPythonTransformers());
-  const finalFiles = challengeFiles.map(pipeLine);
+  const finalFiles = challengeFiles?.map(pipeLine);
 
   if (finalFiles) {
     return (

--- a/client/src/templates/Challenges/utils/build.ts
+++ b/client/src/templates/Challenges/utils/build.ts
@@ -31,11 +31,9 @@ interface ChallengeFile extends PropTypesChallengeFile {
   editableContents: string;
 }
 
-type ChallengeFiles = ChallengeFile[];
-
 interface BuildChallengeData extends Context {
   challengeType: number;
-  challengeFiles: ChallengeFiles;
+  challengeFiles: ChallengeFile[];
   required: { src: string }[];
   template: string;
   url: string;
@@ -84,7 +82,7 @@ const composeFunctions = (...fns: ApplyFunctionProps[]) =>
 
 // TODO: split this into at least two functions. One to create 'original' i.e.
 // the source and another to create the contents.
-function buildSourceMap(challengeFiles: ChallengeFiles): Source | undefined {
+function buildSourceMap(challengeFiles: ChallengeFile[]): Source | undefined {
   // TODO: rename sources.index to sources.contents.
   const source: Source | undefined = challengeFiles?.reduce(
     (sources, challengeFile) => {
@@ -103,7 +101,7 @@ function buildSourceMap(challengeFiles: ChallengeFiles): Source | undefined {
   return source;
 }
 
-function checkFilesErrors(challengeFiles: ChallengeFiles): ChallengeFiles {
+function checkFilesErrors(challengeFiles: ChallengeFile[]): ChallengeFile[] {
   const errors = challengeFiles
     .filter(({ error }) => error)
     .map(({ error }) => error);
@@ -257,8 +255,8 @@ export function buildDOMChallenge(
       .then(checkFilesErrors)
       .then(
         embedFilesInHtml as (
-          x: ChallengeFiles
-        ) => Promise<[ChallengeFiles, string]>
+          x: ChallengeFile[]
+        ) => Promise<[ChallengeFile[], string]>
       )
       .then(([challengeFiles, contents]) => ({
         // TODO: Stop overwriting challengeType with 'html'. Figure out why it's
@@ -277,7 +275,7 @@ export function buildDOMChallenge(
 }
 
 export function buildJSChallenge(
-  { challengeFiles }: { challengeFiles: ChallengeFiles },
+  { challengeFiles }: { challengeFiles: ChallengeFile[] },
   options: BuildOptions
 ): Promise<BuildResult> | undefined {
   const pipeLine = composeFunctions(...getTransformers(options));


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Syntax errors in learner code should still generate an error in the console, but now it should be possible to run tests against the code irrespective of whether or not it's syntactically valid.

To test this, the easiest thing to do is to modify a lesson so that it just tests `code` and then go that lesson, create a syntax error and run the tests.

Closes: https://github.com/freeCodeCamp/freeCodeCamp/issues/49018

<!-- Feel free to add any additional description of changes below this line -->
