### PR TITLE
fix: english audio again

### DIFF
--- a/client/src/templates/Challenges/components/scene/scene.tsx
+++ b/client/src/templates/Challenges/components/scene/scene.tsx
@@ -13,6 +13,10 @@ const sToMs = (n: number) => {
   return n * 1000;
 };
 
+const loadImage = (src: string | null) => {
+  if (src) new Image().src = src;
+};
+
 export function Scene({
   scene,
   isPlaying,
@@ -25,27 +29,20 @@ export function Scene({
   const { t } = useTranslation();
   const { setup, commands } = scene;
   const { audio, alwaysShowDialogue } = setup;
-  const { startTimestamp, finishTimestamp } = audio;
+  const { startTimestamp = null, finishTimestamp = null } = audio;
 
-  const audioTimestamp =
-    startTimestamp !== null && finishTimestamp !== null
-      ? `#t=${startTimestamp}`
-      : '';
-
-  const hasTimestamps = startTimestamp && finishTimestamp;
-  // if there are timestamps, we use the difference between them as the duration
-  // if not, we assume we're playing the whole audio file.
-  const duration = hasTimestamps
-    ? sToMs(finishTimestamp - startTimestamp)
-    : Infinity;
+  const hasTimestamps = startTimestamp !== null && finishTimestamp !== null;
+  const audioTimestamp = hasTimestamps ? `#t=${startTimestamp}` : '';
 
   const audioRef = useRef<HTMLAudioElement>(
     new Audio(`${sounds}/${audio.filename}${audioTimestamp}`)
   );
 
-  const loadImage = (src: string | null) => {
-    if (src) new Image().src = src;
-  };
+  // if there are timestamps, we use the difference between them as the duration
+  // if not, we assume we're playing the whole audio file.
+  const duration = hasTimestamps
+    ? sToMs(finishTimestamp - startTimestamp)
+    : Infinity;
 
   // on mount
   useEffect(() => {


### PR DESCRIPTION
The main change here is the `hasTimestamps` variable. Many of the `startTimestamp` values are `0`, which resulted in `hasTimestamps = 0` - therefore the duration was getting set to `Infinity`, and the scenes which had `startTimestamp = 0` would play until the audio got stopped in the finishScene function (after the last command played, not when it was supposed to stop).

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
