### PR TITLE
fix(client): alignment issue in the title of step-based blocks

### DIFF
--- a/client/src/templates/Introduction/intro.css
+++ b/client/src/templates/Introduction/intro.css
@@ -423,12 +423,6 @@ a.map-grid-item.challenge-completed {
   padding: 25px;
 }
 
-/* this margin is used to center the element.
-ToDo: find out why, and remove the need for it */
-.block-grid .map-title > svg {
-  margin-bottom: 4px;
-}
-
 .title-wrapper {
   display: flex;
   flex-direction: row;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

## Issue

In the title of step-based blocks, the icons are not vertically aligned with the text (list-based blocks are not affected).

<img width="771" alt="Screenshot 2024-05-08 at 22 41 35" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/6f44c5f7-4edc-4111-a4d4-7d4d1cefb829">

The issue is because the icons have some bottom margin, which pushes them upwards. The margin was added via [#48327](https://github.com/freeCodeCamp/freeCodeCamp/pull/48327/files#r1019201682), and to achieve vertical alignment when the page language is set to Arabic. But I'm also seeing the issue in Arabic/right-to-left layout.

<img width="769" alt="Screenshot 2024-05-08 at 22 11 46" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/ded19b51-0ffa-438d-b0ef-ec790e717df1">

## Solution

I guess we changed the CSS at some point, and the bottom margin is now redundant. So the fix is just to remove it.

## Testing

Tested the change with the following language-page combinations:
- English - /learn/2022/responsive-web-design/ (grid-based)
- Arabic - /learn/2022/responsive-web-design/ (grid-based)
- English - /learn/front-end-development-libraries/#bootstrap (list-based)
- Arabic - /learn/front-end-development-libraries/#bootstrap (list-based)

## Screenshots

| Language | Before | After |
| --- | --- | --- |
| English | <img width="771" alt="Screenshot 2024-05-08 at 22 41 35" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/b7be0c9a-eb21-4ef6-ac15-d6fb2b5e4d02"> | <img width="782" alt="Screenshot 2024-05-08 at 22 36 00" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/454f45cb-c498-4046-bede-b392a2f0cc3f"> |
| Arabic | <img width="769" alt="Screenshot 2024-05-08 at 22 11 46" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/38d97714-2989-474a-b031-946350bd6208"> | <img width="793" alt="Screenshot 2024-05-08 at 21 57 17" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/b91c0d2e-daca-413f-bae9-1f3f657bdb11"> |

<!-- Feel free to add any additional description of changes below this line -->
