### PR TITLE
refactor: handle Gatsby's dev page conditionally

### DIFF
--- a/e2e/profile.spec.ts
+++ b/e2e/profile.spec.ts
@@ -87,10 +87,12 @@ test.describe('Profile component', () => {
     test.beforeEach(async ({ page }) => {
       await page.goto('/certifieduser');
 
-      // The following line is required if you're running the test in local development
-      // await page
-      //   .getByRole('button', { name: 'Preview custom 404 page' })
-      //   .click();
+      // If you build the client locally, delete the button click below.
+      if (!process.env.CI) {
+        await page
+          .getByRole('button', { name: 'Preview custom 404 page' })
+          .click();
+      }
     });
 
     test('renders the camper profile correctly', async ({ page }) => {
@@ -193,10 +195,12 @@ test.describe('Profile component', () => {
     test.beforeEach(async ({ page }) => {
       await page.goto('/publicUser');
 
-      // The following line is required if you're running the test in local development
-      // await page
-      //   .getByRole('button', { name: 'Preview custom 404 page' })
-      //   .click();
+      // If you build the client locally, delete the button click below.
+      if (!process.env.CI) {
+        await page
+          .getByRole('button', { name: 'Preview custom 404 page' })
+          .click();
+      }
     });
 
     test.describe('while logged in', () => {


### PR DESCRIPTION
This assumes that most contributors do not build the client when testing
so (hopefully) fewer people need to make adjustments when working
locally.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
