### PR TITLE
fix(curriculum): replace rows[2] with rows[rows.length - 1] in step 20 of JS building a pyramid generator project

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f09a2694b59c3a10ee304.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f09a2694b59c3a10ee304.md
@@ -7,7 +7,7 @@ dashedName: step-20
 
 # --description--
 
-For now, remove your first console log and your `rows[2]` assignment. Leave the second `rows` log statement for later.
+For now, remove your first console log and your `rows[rows.length - 1]` assignment. Leave the second `rows` log statement for later.
 
 # --hints--
 
@@ -17,10 +17,10 @@ You should remove your `console.log(rows[0])` statement.
 assert.notMatch(code, /console\.log\(\s*rows\[\s*0\s*\]\s*\)/);
 ```
 
-You should remove your `rows[2]` reassignment.
+You should remove your `rows[rows.length - 1]` reassignment.
 
 ```js
-assert.notMatch(code, /rows\[2\]/);
+assert.notMatch(code, /rows\[\s*rows\.length\s*-\s*1\s*\]/);
 ```
 
 You should not remove your `console.log(rows)` statement.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #54741

<!-- Feel free to add any additional description of changes below this line -->

Screenshot
![localhost_8000_learn_javascript-algorithms-and-data-structures-v8_learn-introductory-javascript-by-building-a-pyramid-generator_step-20](https://github.com/freeCodeCamp/freeCodeCamp/assets/41056890/b4ac138a-a2d9-41dd-8078-6c31eb3a6558)

