### PR TITLE
test(e2e): allow testing of multiple users

### DIFF
--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,9 +1,31 @@
+import { execSync } from 'child_process';
+
 import { test as setup } from '@playwright/test';
 
-setup('Login', async ({ page }) => {
-  await page.goto('/');
-  await page.getByRole('link', { name: 'Sign in' }).click();
-  await page
-    .context()
-    .storageState({ path: 'playwright/.auth/certified-user.json' });
+setup.describe('certifieduser', () => {
+  setup('can sign in', async ({ request }) => {
+    await request.get(process.env.API_LOCATION + '/signin');
+    await request.storageState({
+      path: 'playwright/.auth/certified-user.json'
+    });
+  });
+});
+
+setup.describe('developmentuser', () => {
+  // We can only sign in as a single user (one with email: 'foo@bar.com'), so
+  // changing users means changing the record with that email in the database.
+  setup.beforeAll(() => {
+    execSync('node ./tools/scripts/seed/seed-demo-user');
+  });
+
+  setup.afterAll(() => {
+    execSync('node ./tools/scripts/seed/seed-demo-user certified-user');
+  });
+
+  setup('can sign in', async ({ request }) => {
+    await request.get(process.env.API_LOCATION + '/signin');
+    await request.storageState({
+      path: 'playwright/.auth/development-user.json'
+    });
+  });
 });

--- a/e2e/signin.spec.ts
+++ b/e2e/signin.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('signing in', () => {
+  test('welcomes the user', async ({ page }) => {
+    const welcomeText = 'Welcome back, Full Stack User.';
+    await page.goto('/');
+    await expect(page.getByText(welcomeText)).not.toBeVisible();
+
+    await page.getByRole('link', { name: 'Sign in' }).click();
+
+    await expect(page.getByText(welcomeText)).toBeVisible();
+  });
+});


### PR DESCRIPTION
- **test(e2e): setup two user's storageStates**
- **test(e2e): test signing in via the ui**

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This allows tests to switch users by seeding the user they want and `test.use`ing the `storageState` of that user.

There is an alternative approach that I didn't go with, but we could consider. Using the same `_id` for whichever user is signed in. i.e. when seeding the db, the `foo@bar.com` user would always have the same `_id`, regardless of the rest of the document. I don't like this because it's not so clear what's going on, but it would mean we could use the same `storageState` for all users and only need to change the db to change who is signed in.

However, neither approach will work for https://github.com/freeCodeCamp/freeCodeCamp/issues/54751 so I went with the (hopefully) less confusing one for now.

<!-- Feel free to add any additional description of changes below this line -->
