### PR TITLE
chore(curriculum): remove pyodide from Luhn algorithm project

### DIFF
--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-how-to-work-with-numbers-and-strings-by-implementing-the-luhn-algorithm/6565a536ba1f9f25bd30e88b.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-how-to-work-with-numbers-and-strings-by-implementing-the-luhn-algorithm/6565a536ba1f9f25bd30e88b.md
@@ -22,7 +22,7 @@ You should have `def main():` in your code.
 ```js
 ({
     test: () => {
-        assert(__pyodide.runPython(`
+        assert(runPython(`
         import inspect
         a = __locals.get("main")
         inspect.isfunction(a)

--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-how-to-work-with-numbers-and-strings-by-implementing-the-luhn-algorithm/65687f47f9001dd35bdcd5ab.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-how-to-work-with-numbers-and-strings-by-implementing-the-luhn-algorithm/65687f47f9001dd35bdcd5ab.md
@@ -17,7 +17,7 @@ You could have `card_number = '4111-1111-4555-1141'` within the main function.
 ({
   test: () => {
     const spyCode = "a = ''\ndef printSpy(*x):\n    global a\n    a += str(x)\n" + code.replaceAll("print(", "printSpy(") + "\na";
-    const out = __pyodide.runPython(spyCode);
+    const out = runPython(spyCode);
     assert.include(out, "INVALID!");
   }
 })

--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-how-to-work-with-numbers-and-strings-by-implementing-the-luhn-algorithm/656880227dab4bd8fbc02d41.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-how-to-work-with-numbers-and-strings-by-implementing-the-luhn-algorithm/656880227dab4bd8fbc02d41.md
@@ -33,7 +33,7 @@ You should change `card_number` back to something valid.
 ({
     test: () => {
         const spyCode = "a = ''\ndef printSpy(*x):\n    global a\n    a = str(x)\n" + code.replaceAll("print(", "printSpy(") + "\na";
-        const out = __pyodide.runPython(spyCode);
+        const out = runPython(spyCode);
         assert.notInclude(out, "INVALID!");
         assert.include(out, "VALID!");
     }

--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-how-to-work-with-numbers-and-strings-by-implementing-the-luhn-algorithm/656b47dc2cf39e37025dc033.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-how-to-work-with-numbers-and-strings-by-implementing-the-luhn-algorithm/656b47dc2cf39e37025dc033.md
@@ -27,7 +27,7 @@ ${function_body.match(/ +/)[0]}return card_number_reversed
 
 verify_card_number(card_number)
 `;
-        const out = __pyodide.runPython(pyCode, {});
+        const out = runPython(pyCode, {});
         assert.equal(out, "2411");
     }
 })


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Following this comment I have removed `__pyodide` from the Luhn algorithm tests and replaced with comparable functions
https://github.com/freeCodeCamp/freeCodeCamp/blob/08f63a0b974c5ca17aa2b27b3ce5151fd0b2eea6/tools/client-plugins/browser-scripts/python-test-evaluator.ts#L122-L123

<!-- Feel free to add any additional description of changes below this line -->
