### PR TITLE
fix(curriculum): fixed strict regex

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-algorithmic-thinking-by-building-a-dice-game/657c9f0af0e3d61abde1c005.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-algorithmic-thinking-by-building-a-dice-game/657c9f0af0e3d61abde1c005.md
@@ -34,13 +34,13 @@ assert.match(code, /const\s+randomDice\s*=\s*.*Math\.random\s*\(\s*\)\s*\*\s*6\s
 You should use `Math.floor()` to round the result down to the nearest whole number.
 
 ```js
-assert.match(code, /const\s+randomDice\s*=\s*Math\.floor\s*\(\s*Math\.random\s*\(\s*\)\s*\*\s*6\s*\)\s*/);
+assert.match(code, /const\s+randomDice\s*=\s*Math\.floor\s*\(\(?\s*Math\.random\s*\(\s*\)\s*\*\s*6\s*\)\s*/);
 ```
 
 You should add `1` to the end result of your `randomDice` variable.
 
 ```js
-assert.match(code, /const\s+randomDice\s*=\s*Math\.floor\s*\(\s*Math\.random\s*\(\s*\)\s*\*\s*6\s*\)\s*\+\s*1\s*/);
+assert.match(code, /const\s+randomDice\s*=\s*Math\.floor\s*\(\(?\s*Math\.random\s*\(\s*\)\s*\*\s*6\s*\)\s*\+\s*1\)?\s*/);
 ```
 
 # --seed--


### PR DESCRIPTION
fix(curriculum): fixed strict regex

fix(curriculum): fixed strict regex

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #54744

<!-- Feel free to add any additional description of changes below this line -->
This change allows for the 1 to be included inside the argument of Math.floor(), meaning the following code is now passes:

const randomDice = Math.floor((Math.random() * 6) + 1)

I added the optional parenthesis to line 37 as well because otherwise it was seen as required,  and would show the "You should use Math.floor()..." hint.