### PR TITLE
fix(client): badge title alignment and privacy settings message

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -293,7 +293,6 @@
     }
   },
   "profile": {
-    "you-not-public": "You have not made your portfolio public.",
     "username-not-public": "{{username}} has not made their portfolio public.",
     "you-change-privacy": "You need to change your privacy setting in order for your portfolio to be seen by others. This is a preview of how your portfolio will look when made public.",
     "username-change-privacy": "{{username}} needs to change their privacy setting in order for you to view their portfolio.",

--- a/client/src/components/profile/components/camper.tsx
+++ b/client/src/components/profile/components/camper.tsx
@@ -60,7 +60,7 @@ function Camper({
       </div>
       {(isDonating || isTopContributor) && (
         <FullWidthRow>
-          <h2 className='text-center'>{t('profile.badges')}</h2>
+          <h2>{t('profile.badges')}</h2>
           <div className='badge-card-container'>
             {isDonating && (
               <div className='badge-card'>

--- a/client/src/components/profile/profile.tsx
+++ b/client/src/components/profile/profile.tsx
@@ -3,7 +3,7 @@ import Helmet from 'react-helmet';
 import type { TFunction } from 'i18next';
 import { useTranslation } from 'react-i18next';
 
-import { Container, Row } from '@freecodecamp/ui';
+import { Alert, Container, Row } from '@freecodecamp/ui';
 import { FullWidthRow, Link, Spacer } from '../helpers';
 import { User } from './../../redux/prop-types';
 import Timeline from './components/time-line';
@@ -26,8 +26,7 @@ interface MessageProps {
 const UserMessage = ({ t }: Pick<MessageProps, 't'>) => {
   return (
     <FullWidthRow>
-      <h2 className='text-center'>{t('profile.you-not-public')}</h2>
-      <p className='alert alert-info'>{t('profile.you-change-privacy')}</p>
+      <Alert variant='info'>{t('profile.you-change-privacy')}</Alert>
       <Spacer size='medium' />
     </FullWidthRow>
   );


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR:
- Removes the "You have not made your portfolio public." heading on the profile page, as it is redundant
- Uses the `Alert` component for the privacy settings message (so that we can remove some Bootstrap classes)
- Align the title of the Badges section to the left

## Screenshots

| Before | After |
| --- | --- |
| <img width="859" alt="Screenshot 2024-05-14 at 12 36 14" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/9ac1b7eb-65ba-4912-872b-b56f6eee4a38"> | <img width="903" alt="Screenshot 2024-05-14 at 12 30 15" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/35f8e0c3-2dc9-433d-b214-b2ab06527124"> |

<!-- Feel free to add any additional description of changes below this line -->
