### PR TITLE
fix(client): privacy settings message on profile page

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -293,7 +293,6 @@
     }
   },
   "profile": {
-    "username-not-public": "{{username}} has not made their portfolio public.",
     "you-change-privacy": "You need to change your privacy setting in order for your portfolio to be seen by others. This is a preview of how your portfolio will look when made public.",
     "username-change-privacy": "{{username}} needs to change their privacy setting in order for you to view their portfolio.",
     "supporter": "Supporter",

--- a/client/src/components/profile/profile.tsx
+++ b/client/src/components/profile/profile.tsx
@@ -38,12 +38,9 @@ const VisitorMessage = ({
 }: Omit<MessageProps, 'isSessionUser'>) => {
   return (
     <FullWidthRow>
-      <h2 className='text-center' style={{ overflowWrap: 'break-word' }}>
-        {t('profile.username-not-public', { username: username })}
-      </h2>
-      <p className='alert alert-info'>
-        {t('profile.username-change-privacy', { username: username })}
-      </p>
+      <Alert variant='info'>
+        {t('profile.username-change-privacy', { username })}
+      </Alert>
       <Spacer size='medium' />
     </FullWidthRow>
   );


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR:
- Removes the "{{username}} has not made their portfolio public." heading on the profile page, as it is redundant
- Uses the `Alert` component for the privacy settings message
- Is similar to #54779 but for a visitor user (I should have included this change in that PR, but I missed it)

| Before | After |
| --- | -- |
| <img width="802" alt="Screenshot 2024-05-15 at 00 00 07" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/8cb5b9e2-5626-445a-9544-473de8bb2f9f"> | <img width="792" alt="Screenshot 2024-05-14 at 23 58 54" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/b56b7ae4-becf-4a3e-a10a-2291feed13cb"> |

<!-- Feel free to add any additional description of changes below this line -->
