### PR TITLE
fix(ui): hide the help icon from the screen reader

### DIFF
--- a/client/src/assets/icons/help.tsx
+++ b/client/src/assets/icons/help.tsx
@@ -18,7 +18,7 @@ function Help(
   props: JSX.IntrinsicAttributes & React.SVGProps<SVGSVGElement>
 ): JSX.Element {
   return (
-    <div style={wrapper}>
+    <div style={wrapper} aria-hidden='true'>
       <svg
         xmlns='http://www.w3.org/2000/svg'
         viewBox='0 0 512 512'

--- a/e2e/help-button.spec.ts
+++ b/e2e/help-button.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import translations from '../client/i18n/locales/english/translations.json';
 
 test.describe('help-button tests for a page with three links (hint, help and video)', () => {
   test('should render the button, menu and the three links when video is available', async ({
@@ -38,5 +39,43 @@ test.describe('help-button tests for a page with two links when video is not ava
     await expect(page.getByTestId('ask-for-help')).toBeVisible();
     //The video link is hidden
     await expect(page.getByTestId('watch-a-video')).toBeHidden();
+  });
+});
+
+test.describe('help-button tests for a page with a reset and help button', () => {
+  test('should not be present before the user checks their code three times', async ({
+    page
+  }) => {
+    await page.goto(
+      'learn/2022/responsive-web-design/learn-html-by-building-a-cat-photo-app/step-8'
+    );
+    await expect(page.getByTestId('get-help-button')).toBeHidden();
+  });
+
+  test('should be present after the user checks their code three times', async ({
+    page
+  }) => {
+    await page.goto(
+      'learn/2022/responsive-web-design/learn-html-by-building-a-cat-photo-app/step-8'
+    );
+    const checkButton = page.getByTestId('lowerJaw-check-button');
+    await checkButton.click();
+    await checkButton.click();
+    await checkButton.click();
+    await expect(page.getByText(translations.buttons.help)).toBeVisible();
+  });
+  test('icon should be invisible to screen-reader', async ({ page }) => {
+    await page.goto(
+      'learn/2022/responsive-web-design/learn-html-by-building-a-cat-photo-app/step-8'
+    );
+    const checkButton = page.getByTestId('lowerJaw-check-button');
+    await checkButton.click();
+    await checkButton.click();
+    await checkButton.click();
+    const helpButton = page.getByText(translations.buttons.help);
+    const helpIconGroup = helpButton.getByRole('group', {
+      includeHidden: false
+    });
+    await expect(helpIconGroup).toBeHidden();
   });
 });

--- a/e2e/help-button.spec.ts
+++ b/e2e/help-button.spec.ts
@@ -62,7 +62,7 @@ test.describe('help-button tests for a page with a reset and help button', () =>
     await checkButton.click();
     await checkButton.click();
     await checkButton.click();
-    await expect(page.getByText(translations.buttons.help)).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Help' })).toBeVisible();
   });
   test('icon should be invisible to screen-reader', async ({ page }) => {
     await page.goto(

--- a/e2e/help-button.spec.ts
+++ b/e2e/help-button.spec.ts
@@ -1,5 +1,4 @@
 import { test, expect } from '@playwright/test';
-import translations from '../client/i18n/locales/english/translations.json';
 
 test.describe('help-button tests for a page with three links (hint, help and video)', () => {
   test('should render the button, menu and the three links when video is available', async ({
@@ -62,17 +61,8 @@ test.describe('help-button tests for a page with a reset and help button', () =>
     await checkButton.click();
     await checkButton.click();
     await checkButton.click();
-    await expect(page.getByRole('button', { name: 'Help' })).toBeVisible();
-  });
-  test('icon should be invisible to screen-reader', async ({ page }) => {
-    await page.goto(
-      'learn/2022/responsive-web-design/learn-html-by-building-a-cat-photo-app/step-8'
-    );
-    const checkButton = page.getByTestId('lowerJaw-check-button');
-    await checkButton.click();
-    await checkButton.click();
-    await checkButton.click();
-    const helpButton = page.getByText(translations.buttons.help);
+    const helpButton = page.getByRole('button', { name: 'Help' });
+    await expect(helpButton).toBeVisible();
     const helpIconGroup = helpButton.getByRole('group', {
       includeHidden: false
     });

--- a/e2e/help-button.spec.ts
+++ b/e2e/help-button.spec.ts
@@ -49,7 +49,7 @@ test.describe('help-button tests for a page with a reset and help button', () =>
     await page.goto(
       'learn/2022/responsive-web-design/learn-html-by-building-a-cat-photo-app/step-8'
     );
-    await expect(page.getByTestId('get-help-button')).toBeHidden();
+    await expect(page.getByRole('button', { name: 'Help' })).toBeHidden();
   });
 
   test('should be present after the user checks their code three times', async ({


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #54803

<!-- Feel free to add any additional description of changes below this line -->
I had tested with NVDA. While I had not properly discovered this error, I still went ahead and the icon. I had even added a test to ensure it is properly hidden to screenreaders. 

While in the file, I couldn't find any tests pertaining the help button not being visible; so I added them as well. If there are already relevant tests in a different file, I will happily remove the ones I added. 