### PR TITLE
fix: reduce premature skipping of donation animation

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -100,7 +100,6 @@
     "update-card": "Update your card",
     "donate-now": "Donate Now",
     "confirm-amount": "Confirm amount",
-    "skip-advertisement": "Skip Advertisement",
     "play-scene": "Press Play"
   },
   "landing": {

--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -645,7 +645,7 @@
     "reach-goals-faster": "Reach your goals faster",
     "remove-distractions": "Remove distractions",
     "animation-description": "This is a 20 second animated advertisement to encourage campers to become supporters of freeCodeCamp. The animation starts with a teddy bear who becomes a supporter. As a result, distracting pop-ups disappear and the bear gets to complete all of its goals. Then, it graduates and becomes an education super hero helping people around the world.",
-    "animation-countdown": "This advertisement will close after {{secondsRemaining}} seconds."
+    "animation-countdown": "This modal will close after {{secondsRemaining}} seconds."
   },
   "report": {
     "sign-in": "You need to be signed in to report a user",

--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -645,7 +645,7 @@
     "reach-goals-faster": "Reach your goals faster",
     "remove-distractions": "Remove distractions",
     "animation-description": "This is a 20 second animated advertisement to encourage campers to become supporters of freeCodeCamp. The animation starts with a teddy bear who becomes a supporter. As a result, distracting pop-ups disappear and the bear gets to complete all of its goals. Then, it graduates and becomes an education super hero helping people around the world.",
-    "animation-countdown": "This modal will close after {{secondsRemaining}} seconds."
+    "animation-countdown": "This animation will stop after {{secondsRemaining}} seconds."
   },
   "report": {
     "sign-in": "You need to be signed in to report a user",

--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -645,7 +645,8 @@
     "help-millions-learn": "Help millions of people learn",
     "reach-goals-faster": "Reach your goals faster",
     "remove-distractions": "Remove distractions",
-    "animation-description": "This is a 20 second animated advertisement to encourage campers to become supporters of freeCodeCamp. The animation starts with a teddy bear who becomes a supporter. As a result, distracting pop-ups disappear and the bear gets to complete all of its goals. Then, it graduates and becomes an education super hero helping people around the world."
+    "animation-description": "This is a 20 second animated advertisement to encourage campers to become supporters of freeCodeCamp. The animation starts with a teddy bear who becomes a supporter. As a result, distracting pop-ups disappear and the bear gets to complete all of its goals. Then, it graduates and becomes an education super hero helping people around the world.",
+    "animation-countdown": "This advertisement will close after {{secondsRemaining}} seconds."
   },
   "report": {
     "sign-in": "You need to be signed in to report a user",

--- a/client/src/components/Donation/donation-modal-body.tsx
+++ b/client/src/components/Donation/donation-modal-body.tsx
@@ -154,6 +154,7 @@ const AnimationContainer = ({
           </p>
         </div>
         <img
+          key={Date.now()}
           alt=''
           src={donationAnimation}
           id={'donation-animation'}

--- a/client/src/components/Donation/donation-modal-body.tsx
+++ b/client/src/components/Donation/donation-modal-body.tsx
@@ -124,16 +124,20 @@ const Benefits = ({ setShowForm }: { setShowForm: (arg: boolean) => void }) => {
 };
 
 const AnimationContainer = ({
-  setIsAnimationVisible
+  secondsRemaining
 }: {
-  setIsAnimationVisible: (arg: boolean) => void;
+  secondsRemaining: number;
 }) => {
   const { t } = useTranslation();
   return (
     <>
-      <p style={{ opacity: 0, position: 'absolute' }}>
-        {t('donate.animation-description')}{' '}
-      </p>
+      <div style={{ opacity: 0, position: 'absolute' }}>
+        <p>{t('donate.animation-description')}</p>
+        <span aria-live='polite'>
+          {t('donate.animation-countdown', { secondsRemaining })}
+        </span>
+      </div>
+
       <div className='donation-animation-container' aria-hidden='true'>
         <div className='donation-animation-bullet-points'>
           <p className='donation-animation-bullet-1'>
@@ -156,13 +160,6 @@ const AnimationContainer = ({
           data-playwright-test-label='not-found-image'
         />
       </div>
-      <button
-        style={{ opacity: 0, position: 'absolute' }}
-        className={'sr-only'}
-        onClick={() => setIsAnimationVisible(false)}
-      >
-        {t('buttons.skip-advertisement')}
-      </button>
     </>
   );
 };
@@ -226,24 +223,33 @@ function DonationModalBody({
   const [showHeaderAndFooter, setShowHeaderAndFooter] = useState(true);
   const [isAnimationVisible, setIsAnimationVisible] = useState(true);
   const [showForm, setShowForm] = useState(false);
+  const [secondsRemaining, setSecondsRemaining] = useState(20);
+
   const handleProcessing = () => {
     setDonationAttempted(true);
   };
 
   useEffect(() => {
-    const timer = setTimeout(() => {
-      setIsAnimationVisible(false);
-    }, 20000); // 20000 milliseconds = 20 seconds
+    const interval = setInterval(() => {
+      setSecondsRemaining(prevSeconds => {
+        if (prevSeconds > 0) {
+          return prevSeconds - 1;
+        } else {
+          setIsAnimationVisible(false);
+          clearInterval(interval);
+          return 0;
+        }
+      });
+    }, 1000);
 
-    // Clear the timer if the component unmounts
-    return () => clearTimeout(timer);
+    return () => clearInterval(interval);
   }, []);
 
   return (
     <Modal.Body borderless alignment='start'>
       <div aria-live='polite' className='donation-modal'>
         {isAnimationVisible ? (
-          <AnimationContainer setIsAnimationVisible={setIsAnimationVisible} />
+          <AnimationContainer secondsRemaining={secondsRemaining} />
         ) : (
           <BecomeASupporterConfirmation
             recentlyClaimedBlock={recentlyClaimedBlock}

--- a/client/src/redux/donation-saga.js
+++ b/client/src/redux/donation-saga.js
@@ -43,10 +43,15 @@ const updateCardErrorMessage = i18next.t('donate.error-3');
 
 function* showDonateModalSaga() {
   let shouldRequestDonation = yield select(shouldRequestDonationSelector);
-  if (shouldRequestDonation) {
+  const MODAL_SHOWN_KEY = 'modalShownTimestamp';
+  const modalShownTimestamp = sessionStorage.getItem(MODAL_SHOWN_KEY);
+  const isModalRecentlyShown = Date.now() - modalShownTimestamp < 20000;
+
+  if (shouldRequestDonation || isModalRecentlyShown) {
     yield delay(200);
     const recentlyClaimedBlock = yield select(recentlyClaimedBlockSelector);
     yield put(openDonationModal());
+    sessionStorage.setItem(MODAL_SHOWN_KEY, Date.now());
     yield take(appTypes.closeDonationModal);
     if (recentlyClaimedBlock) {
       yield put(preventBlockDonationRequests());


### PR DESCRIPTION

This pr has two objectives.

1. Remove the skip button
2. Remove the ability to skip the animation on page refresh

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

