### PR TITLE
fix(curriculum): prevent hardcoding pokemon

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/build-a-pokemon-search-app-project/build-a-pokemon-search-app.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/build-a-pokemon-search-app-project/build-a-pokemon-search-app.md
@@ -345,6 +345,83 @@ async () => {
 };
 ```
 
+When the `#search-input` element contains an invalid Pokemon name and the `#search-button` element is clicked, an alert should appear with the text `"Pokémon not found"`.
+
+```js
+async () => {
+  try {
+    const searchInput = document.getElementById('search-input');
+    const searchButton = document.getElementById('search-button');
+    let alertMessage;
+    window.alert = (message) => alertMessage = message; // Override alert and store message
+    const letters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'
+    const numbers = '0123456789';
+    const charactersLength = letters.length;
+    const numbersLength = numbers.length; 
+
+
+    const firstLetter = letters.charAt(Math.floor(Math.random() * charactersLength));
+    const secondLetter = letters.charAt(Math.floor(Math.random() * charactersLength));
+    const thirdLetter = letters.charAt(Math.floor(Math.random() * charactersLength));
+    const fourthLetter = letters.charAt(Math.floor(Math.random() * charactersLength));
+    const randomNumber1 = numbers.charAt(Math.floor(Math.random() * numbersLength));
+    const randomNumber2 = numbers.charAt(Math.floor(Math.random() * numbersLength));
+    
+    const badName = firstLetter + secondLetter + thirdLetter + fourthLetter + randomNumber1 + randomNumber2; 
+
+    const randomInvalidPokeId = badName; 
+    searchInput.value = randomInvalidPokeId;
+    searchButton.click();
+
+    const res = await fetch('https://pokeapi-proxy.freecodecamp.rocks/api/pokemon/' + randomInvalidPokeId.toString()); // Fetch from proxy to simulate network delay
+
+    if (!res.ok) {
+      await new Promise(resolve => setTimeout(resolve, 1000)); // Additional delay to allow the alert to trigger
+
+      assert.include(['pokémon not found', 'pokemon not found'], alertMessage.trim().replace(/[.,?!]+$/g, '').toLowerCase());
+    }
+  } catch (err) {
+    throw new Error(err);
+  }
+};
+```
+
+
+When the `#search-input` element contains an valid Pokemon id and the `#search-button` element is clicked, an alert should appear with the correct type.
+
+```js
+async () => {
+  try {
+    const searchInput = document.getElementById('search-input');
+    const searchButton = document.getElementById('search-button');
+    let alertMessage;
+    window.alert = (message) => alertMessage = message; // Override alert and store message
+
+    const randomValidPokeId = Math.floor(Math.random() * 1025) + 1; 
+    searchInput.value = randomValidPokeId;
+    searchButton.click();
+
+    const res = await fetch('https://pokeapi-proxy.freecodecamp.rocks/api/pokemon/' +  randomValidPokeId.toString()); // Fetch from proxy to simulate network delay
+
+    if (res.ok) {
+      await new Promise(resolve => setTimeout(resolve, 1000)); // Additional delay to allow UI to update
+     
+      const data = await res.json(); 
+
+      const typesEl = document.getElementById('types');      
+      
+      const actualTypes = data.types.map(typeSlot => typeSlot.type.name); 
+
+      assert.lengthOf(typesEl.children, actualTypes.length);
+
+      assert.sameMembers(actualTypes, [...typesEl.children].map(el => el.innerText.trim().toLowerCase()));
+    }
+  } catch (err) {
+    throw new Error(err);
+  }
+};
+```
+
 # --seed--
 
 ## --seed-contents--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/build-a-pokemon-search-app-project/build-a-pokemon-search-app.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/build-a-pokemon-search-app-project/build-a-pokemon-search-app.md
@@ -387,7 +387,7 @@ async () => {
 ```
 
 
-When the `#search-input` element contains an valid Pokemon id and the `#search-button` element is clicked, an alert should appear with the correct type.
+When the `#search-input` element contains a valid Pokemon id and the `#search-button` element is clicked, the UI should be filled with the correct data.
 
 ```js
 async () => {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Ref #54063

<!-- Feel free to add any additional description of changes below this line -->
Two tests were added. One randomly generates an invalid Pokemon name and tests for a Pokemon not found response. The other test randomly generates a valid Pokemon id and compares it to the types received from our Pokemon API and sees if they match. If I had just used a few regular names, we would have to continually add new options to our generic tests. It also makes test writing a lot smoother. 