### PR TITLE
fix(curriculum): last assertion for review DOM project step 5

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/review-dom-manipulation-by-building-a-rock-paper-scissors-game/663d5697d80fef0eea026672.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/review-dom-manipulation-by-building-a-rock-paper-scissors-game/663d5697d80fef0eea026672.md
@@ -41,6 +41,7 @@ You should hide the `optionsContainer` and if the player or computer has reached
 playerScore = 3;
 showResults("Scissors");
 assert.equal(optionsContainer.style.display, "none");
+
 ```
 
 You should show the `resetGameBtn` button if the player or computer has reached three points.
@@ -48,7 +49,8 @@ You should show the `resetGameBtn` button if the player or computer has reached 
 ```js
 computerScore = 3;
 showResults("Rock");
-assert.notEqual(resetGameBtn.style.display, "none");
+const computedStyle = window.getComputedStyle(resetGameBtn).display;
+assert.notEqual(computedStyle, "none");
 ```
 
 # --seed--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/review-dom-manipulation-by-building-a-rock-paper-scissors-game/663d5697d80fef0eea026672.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/review-dom-manipulation-by-building-a-rock-paper-scissors-game/663d5697d80fef0eea026672.md
@@ -41,7 +41,6 @@ You should hide the `optionsContainer` and if the player or computer has reached
 playerScore = 3;
 showResults("Scissors");
 assert.equal(optionsContainer.style.display, "none");
-
 ```
 
 You should show the `resetGameBtn` button if the player or computer has reached three points.


### PR DESCRIPTION
## Summary
Currently the test passes without changing the display to block as mentioned in this forum post here
https://forum.freecodecamp.org/t/review-dom-manipulation-by-building-a-rock-paper-scissors-game-step-5/690574

The update the last assertion fixes that
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
