### PR TITLE
feat: add legacyCertsSelector to Map component

### DIFF
--- a/client/src/components/Map/index.tsx
+++ b/client/src/components/Map/index.tsx
@@ -18,7 +18,8 @@ import './map.css';
 
 import {
   isSignedInSelector,
-  currentCertsSelector
+  currentCertsSelector,
+  legacyCertsSelector
 } from '../../redux/selectors';
 
 import { RibbonIcon, Arrow } from '../../assets/icons/completion-ribbon';
@@ -38,6 +39,7 @@ interface MapProps {
   forLanding?: boolean;
   isSignedIn: boolean;
   currentCerts: CurrentCert[];
+  legacyCerts: CurrentCert[];
   claimedCertifications?: ClaimedCertifications;
   completedChallengeIds: string[];
 }
@@ -58,10 +60,17 @@ const coreCurriculum = [
 const mapStateToProps = createSelector(
   isSignedInSelector,
   currentCertsSelector,
+  legacyCertsSelector,
   completedChallengesIdsSelector,
-  (isSignedIn: boolean, currentCerts, completedChallengeIds: string[]) => ({
+  (
+    isSignedIn: boolean,
+    currentCerts: CurrentCert[],
+    legacyCerts: CurrentCert[],
+    completedChallengeIds: string[]
+  ) => ({
     isSignedIn,
     currentCerts,
+    legacyCerts,
     completedChallengeIds
   })
 );
@@ -87,6 +96,7 @@ function MapLi({
 }) {
   return (
     <>
+      <div>{superBlock.toString()}</div>
       <li
         data-test-label='curriculum-map-button'
         data-playwright-test-label='curriculum-map-button'
@@ -121,6 +131,7 @@ function Map({
   forLanding = false,
   isSignedIn,
   currentCerts,
+  legacyCerts,
   completedChallengeIds
 }: MapProps): React.ReactElement {
   const {
@@ -160,7 +171,7 @@ function Map({
   const isClaimed = (stage: SuperBlocks) => {
     return isSignedIn
       ? Boolean(
-          currentCerts?.find(
+          [...currentCerts, ...legacyCerts]?.find(
             (cert: { certSlug: string }) =>
               (certSlugTypeMap as { [key: string]: string })[cert.certSlug] ===
               (superBlockCertTypeMap as { [key: string]: string })[stage]

--- a/client/src/components/Map/index.tsx
+++ b/client/src/components/Map/index.tsx
@@ -96,7 +96,6 @@ function MapLi({
 }) {
   return (
     <>
-      <div>{superBlock.toString()}</div>
       <li
         data-test-label='curriculum-map-button'
         data-playwright-test-label='curriculum-map-button'

--- a/client/src/redux/selectors.js
+++ b/client/src/redux/selectors.js
@@ -100,6 +100,9 @@ export const userByNameSelector = username => state => {
 export const currentCertsSelector = state =>
   certificatesByNameSelector(state[MainApp]?.appUsername)(state)?.currentCerts;
 
+export const legacyCertsSelector = state =>
+  certificatesByNameSelector(state[MainApp]?.appUsername)(state)?.legacyCerts;
+
 export const certificatesByNameSelector = username => state => {
   const {
     isRespWebDesignCert,


### PR DESCRIPTION
This adds a `legacyCertsSelector` to tell if a legacy cert is claimed on the superblock ribbons.

Before:
<img width="748" alt="image" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/46919888/30a2e47a-02cc-4a0a-b55b-7d0f3855f45c">

After:
<img width="764" alt="image" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/46919888/0dcc2f7e-8a4e-4aac-bba9-a9abc5d68920">

The python certification isn't  marked as a legacy cert yet, but is already being placed in the map as a legacy cert. Nor does it have a ribbon.

The `Legacy responsive web design` icon was already showing up as filled (with ribbon) as we use the same `Certification` enum for the new one. Which led to it being already filled.
