### PR TITLE
fix(client): space between years being top contributor

### DIFF
--- a/client/src/components/profile/components/camper.tsx
+++ b/client/src/components/profile/components/camper.tsx
@@ -82,7 +82,7 @@ function Camper({
                   <h3>{t('profile.contributor')}</h3>
                   <p>
                     {t('profile.contributor-prolific', {
-                      year: yearsTopContributor
+                      year: yearsTopContributor.join(', ')
                     })}
                   </p>
                 </div>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Adds a space between the comma and the top contributor year.

| Before | After |
| --- | --- |
| <img width="332" alt="Screenshot 2024-05-20 at 14 38 37" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/234eb1c9-fd77-4267-9773-fcdf31ae4bab"> | <img width="326" alt="Screenshot 2024-05-20 at 14 39 20" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/d2504ec3-7122-4179-9b15-2222745354d5"> |

<!-- Feel free to add any additional description of changes below this line -->
