### PR TITLE
fix(api): reset all claimed certs during reset

### DIFF
--- a/api/src/routes/auth-dev.test.ts
+++ b/api/src/routes/auth-dev.test.ts
@@ -94,7 +94,7 @@ describe('dev login', () => {
           showPortfolio: false,
           showTimeLine: false
         },
-        progressTimestamps: [],
+        progressTimestamps: [expect.any(Number)],
         sendQuincyEmail: false,
         theme: 'default',
         username: expect.stringMatching(fccUuidRe),

--- a/api/src/routes/user.test.ts
+++ b/api/src/routes/user.test.ts
@@ -402,6 +402,8 @@ describe('userRoutes', () => {
         expect(userTokens).toHaveLength(1);
         expect(userTokens[0]?.userId).toBe(otherUserId);
       });
+
+      test.todo('POST resets the user to the default state');
     });
 
     describe('/user/user-token', () => {

--- a/api/src/routes/user.ts
+++ b/api/src/routes/user.ts
@@ -20,6 +20,7 @@ import {
 import { encodeUserToken } from '../utils/tokens';
 import { trimTags } from '../utils/validation';
 import { generateReportEmail } from '../utils/email-templates';
+import { createResetProperties } from '../utils/create-user';
 
 /**
  * Helper function to get the api url from the shared transcript link.
@@ -110,33 +111,7 @@ export const userRoutes: FastifyPluginCallbackTypebox = (
         });
         await fastify.prisma.user.update({
           where: { id: req.user!.id },
-          data: {
-            progressTimestamps: [Date.now()],
-            currentChallengeId: '',
-            isRespWebDesignCert: false,
-            is2018DataVisCert: false,
-            isFrontEndLibsCert: false,
-            isJsAlgoDataStructCert: false,
-            isApisMicroservicesCert: false,
-            isInfosecQaCert: false,
-            isQaCertV7: false,
-            isInfosecCertV7: false,
-            is2018FullStackCert: false,
-            isFrontEndCert: false,
-            isBackEndCert: false,
-            isDataVisCert: false,
-            isFullStackCert: false,
-            isSciCompPyCertV7: false,
-            isDataAnalysisPyCertV7: false,
-            isMachineLearningPyCertV7: false,
-            isRelationalDatabaseCertV8: false,
-            isCollegeAlgebraPyCertV8: false,
-            completedChallenges: [],
-            completedExams: [],
-            savedChallenges: [],
-            partiallyCompletedChallenges: [],
-            needsModeration: false
-          }
+          data: createResetProperties()
         });
 
         return {};

--- a/api/src/utils/create-user.ts
+++ b/api/src/utils/create-user.ts
@@ -8,6 +8,40 @@ export const nanoidCharSet =
 const nanoid = customAlphabet(nanoidCharSet, 21);
 
 /**
+ * Creates the necessary data to reset a user's properties.
+ * @returns Default data for resetting a user's properties.
+ */
+export const createResetProperties = () => ({
+  completedChallenges: [], // TODO(Post-MVP): Omit this from the document? (prisma will always return [])
+  completedExams: [], // TODO(Post-MVP): Omit this from the document? (prisma will always return [])
+  currentChallengeId: '',
+  is2018DataVisCert: false,
+  is2018FullStackCert: false,
+  isApisMicroservicesCert: false,
+  isBackEndCert: false,
+  isCollegeAlgebraPyCertV8: false,
+  isDataAnalysisPyCertV7: false,
+  isDataVisCert: false,
+  isFoundationalCSharpCertV8: false,
+  isFrontEndCert: false,
+  isFrontEndLibsCert: false,
+  isFullStackCert: false,
+  isInfosecCertV7: false,
+  isInfosecQaCert: false,
+  isJsAlgoDataStructCert: false,
+  isJsAlgoDataStructCertV8: false,
+  isMachineLearningPyCertV7: false,
+  isQaCertV7: false,
+  isRelationalDatabaseCertV8: false,
+  isRespWebDesignCert: false,
+  isSciCompPyCertV7: false,
+  needsModeration: false,
+  partiallyCompletedChallenges: [], // TODO(Post-MVP): Omit this from the document? (prisma will always return [])
+  progressTimestamps: [Date.now()], // TODO(Post-MVP): This may need normalising before we can omit it. Also, does it need to start with a timestamp?
+  savedChallenges: [] // TODO(Post-MVP): Omit this from the document? (prisma will always return [])
+});
+
+/**
  * Creates the necessary data to create a new user.
  * @param email The email address of the new user.
  * @returns Default data for a new user.
@@ -22,43 +56,19 @@ export function createUserInput(email: string): Prisma.userCreateInput {
   return {
     about: '',
     acceptedPrivacyTerms: false,
-    completedChallenges: [], // TODO(Post-MVP): Omit this from the document? (prisma will always return [])
-    completedExams: [], // TODO(Post-MVP): Omit this from the document? (prisma will always return [])
-    currentChallengeId: '',
     donationEmails: [], // TODO(Post-MVP): Omit this from the document? (prisma will always return [])
     email,
     emailVerified: true, // this should be true until a user changes their email address
     // TODO(Post-MVP): remove externalId?
     externalId,
-    is2018DataVisCert: false,
-    is2018FullStackCert: false,
-    isApisMicroservicesCert: false,
-    isBackEndCert: false,
     isBanned: false,
     isCheater: false,
-    isDataAnalysisPyCertV7: false,
-    isDataVisCert: false,
     isDonating: false,
-    isFoundationalCSharpCertV8: false,
-    isFrontEndCert: false,
-    isFrontEndLibsCert: false,
-    isFullStackCert: false,
     isHonest: false,
-    isInfosecCertV7: false,
-    isInfosecQaCert: false,
-    isJsAlgoDataStructCert: false,
-    isJsAlgoDataStructCertV8: false,
-    isMachineLearningPyCertV7: false,
-    isQaCertV7: false,
-    isRelationalDatabaseCertV8: false,
-    isCollegeAlgebraPyCertV8: false,
-    isRespWebDesignCert: false,
-    isSciCompPyCertV7: false,
     keyboardShortcuts: false,
     location: '',
     name: '',
     unsubscribeId: nanoid(),
-    partiallyCompletedChallenges: [], // TODO(Post-MVP): Omit this from the document? (prisma will always return [])
     picture: '',
     portfolio: [], // TODO(Post-MVP): Omit this from the document? (prisma will always return [])
     profileUI: {
@@ -73,12 +83,11 @@ export function createUserInput(email: string): Prisma.userCreateInput {
       showPortfolio: false,
       showTimeLine: false
     },
-    progressTimestamps: [], // TODO(Post-MVP): This may need normalising before we can omit it.
-    savedChallenges: [], // TODO(Post-MVP): Omit this from the document? (prisma will always return [])
     sendQuincyEmail: false,
     theme: 'default',
     username,
     usernameDisplay: username,
-    yearsTopContributor: [] // TODO: Omit this from the document? (prisma will always return [])
+    yearsTopContributor: [], // TODO: Omit this from the document? (prisma will always return []),
+    ...createResetProperties()
   };
 }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Changing this did not trip as many tests as it should have, since we're using more 'fuzzy' assertions like `expect.toMatchObject`. I plan to rework a few in a followup PR, but for this I fixed the issues: `isFoundationalCSharpCertV8` and `isJsAlgoDataStructCertV8` were not getting reset and new users were not getting the 'free progress timestamp'. i.e. setting `progressTimestamps = [Date.now()]` rather than `[]`.

We may want to _not_ give that, because it makes very little sense, but it's a post-MVP issue.

<!-- Feel free to add any additional description of changes below this line -->
