### PR TITLE
fix(ui): restore python reset button

### DIFF
--- a/client/src/templates/Challenges/components/tool-panel.tsx
+++ b/client/src/templates/Challenges/components/tool-panel.tsx
@@ -92,14 +92,12 @@ function ToolPanel({
             </Button>
           </>
         )}
-      {challengeType !== challengeTypes.multifilePythonCertProject && (
-        <>
-          <Spacer size='xxSmall' />
-          <Button block={true} variant='primary' onClick={openResetModal}>
-            {isMobile ? t('buttons.reset') : t('buttons.reset-lesson')}
-          </Button>
-        </>
-      )}
+      <>
+        <Spacer size='xxSmall' />
+        <Button block={true} variant='primary' onClick={openResetModal}>
+          {isMobile ? t('buttons.reset') : t('buttons.reset-lesson')}
+        </Button>
+      </>
       <Spacer size='xxSmall' />
       <Dropdown dropup>
         <Dropdown.Toggle


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #54360

<!-- Feel free to add any additional description of changes below this line -->
This should completely restore the reset button. There aren't any conditions where it won't show up anymore. 