### PR TITLE
feat(api): finish update-my-email endpoint

### DIFF
--- a/api/src/plugins/code-flow-auth.test.ts
+++ b/api/src/plugins/code-flow-auth.test.ts
@@ -2,7 +2,7 @@ import Fastify, { FastifyInstance } from 'fastify';
 import jwt from 'jsonwebtoken';
 
 import { COOKIE_DOMAIN, JWT_SECRET } from '../utils/env';
-import { AccessToken, createAccessToken } from '../utils/tokens';
+import { type Token, createAccessToken } from '../utils/tokens';
 import cookies, { sign as signCookie, unsign as unsignCookie } from './cookies';
 import codeFlowAuth from './code-flow-auth';
 
@@ -38,7 +38,7 @@ describe('auth', () => {
       const { value, ...rest } = res.cookies[0]!;
       const unsignedOnce = unsignCookie(value);
       const unsignedTwice = jwt.verify(unsignedOnce.value!, JWT_SECRET) as {
-        accessToken: AccessToken;
+        accessToken: Token;
       };
       expect(unsignedTwice.accessToken).toEqual(token);
       expect(rest).toEqual({

--- a/api/src/plugins/code-flow-auth.ts
+++ b/api/src/plugins/code-flow-auth.ts
@@ -5,14 +5,11 @@ import { isBefore } from 'date-fns';
 import { type user } from '@prisma/client';
 
 import { COOKIE_DOMAIN, JWT_SECRET } from '../utils/env';
-import { AccessToken } from '../utils/tokens';
+import { type Token } from '../utils/tokens';
 
 declare module 'fastify' {
   interface FastifyReply {
-    setAccessTokenCookie: (
-      this: FastifyReply,
-      accessToken: AccessToken
-    ) => void;
+    setAccessTokenCookie: (this: FastifyReply, accessToken: Token) => void;
   }
 
   interface FastifyRequest {
@@ -26,21 +23,18 @@ declare module 'fastify' {
 }
 
 const codeFlowAuth: FastifyPluginCallback = (fastify, _options, done) => {
-  fastify.decorateReply(
-    'setAccessTokenCookie',
-    function (accessToken: AccessToken) {
-      const signedToken = jwt.sign({ accessToken }, JWT_SECRET);
-      void this.setCookie('jwt_access_token', signedToken, {
-        path: '/',
-        httpOnly: false,
-        secure: false,
-        sameSite: 'lax',
-        domain: COOKIE_DOMAIN,
-        signed: true,
-        maxAge: accessToken.ttl
-      });
-    }
-  );
+  fastify.decorateReply('setAccessTokenCookie', function (accessToken: Token) {
+    const signedToken = jwt.sign({ accessToken }, JWT_SECRET);
+    void this.setCookie('jwt_access_token', signedToken, {
+      path: '/',
+      httpOnly: false,
+      secure: false,
+      sameSite: 'lax',
+      domain: COOKIE_DOMAIN,
+      signed: true,
+      maxAge: accessToken.ttl
+    });
+  });
 
   const TOKEN_REQUIRED = 'Access token is required for this request';
   const TOKEN_INVALID = 'Your access token is invalid';
@@ -68,7 +62,7 @@ const codeFlowAuth: FastifyPluginCallback = (fastify, _options, done) => {
 
       const {
         accessToken: { created, ttl, userId }
-      } = jwt.decode(jwtAccessToken!) as { accessToken: AccessToken };
+      } = jwt.decode(jwtAccessToken!) as { accessToken: Token };
       const valid = isBefore(Date.now(), Date.parse(created) + ttl);
       if (!valid) return send401(reply, TOKEN_EXPIRED);
 

--- a/api/src/routes/settings.test.ts
+++ b/api/src/routes/settings.test.ts
@@ -7,7 +7,7 @@ import {
   defaultUserId
 } from '../../jest.utils';
 import { createUserInput } from '../utils/create-user';
-
+import { API_LOCATION } from '../utils/env';
 import { isPictureWithProtocol, getWaitMessage } from './settings';
 
 const baseProfileUI = {
@@ -344,7 +344,7 @@ Please wait 5 minutes to resend an authentication link.`
           email: unusedEmailOne
         });
 
-        const expectedLink = `http://localhost:3000/confirm-email?email=${Buffer.from(unusedEmailOne).toString('base64')}&token=123&emailChange=true`;
+        const expectedLink = `${API_LOCATION}/confirm-email?email=${Buffer.from(unusedEmailOne).toString('base64')}&token=123&emailChange=true`;
         expect(sendEmailSpy).toHaveBeenCalledWith({
           from: 'team@freecodecamp.org',
           to: unusedEmailOne,

--- a/api/src/routes/settings.test.ts
+++ b/api/src/routes/settings.test.ts
@@ -187,11 +187,11 @@ describe('settingRoutes', () => {
           email: 'foo@foo.com'
         });
 
-        expect(response?.body).toEqual({
+        expect(response.body).toEqual({
           message: 'flash.email-valid',
           type: 'success'
         });
-        expect(response?.statusCode).toEqual(200);
+        expect(response.statusCode).toEqual(200);
       });
 
       test("PUT updates the user's record in preparation for receiving auth email", async () => {
@@ -211,7 +211,7 @@ describe('settingRoutes', () => {
           throw new Error('emailVerifyTTL is not defined');
         }
 
-        expect(response?.statusCode).toEqual(200);
+        expect(response.statusCode).toEqual(200);
 
         // expect the emailVerifyTTL to be within 10 seconds of the current time
         const tenSeconds = 10 * 1000;
@@ -231,11 +231,11 @@ describe('settingRoutes', () => {
 
         // We cannot use fastify's default validation failure response here
         // because the client consumes the response and displays it to the user.
-        expect(response?.body).toEqual({
+        expect(response.body).toEqual({
           type: 'danger',
           message: 'Email format is invalid'
         });
-        expect(response?.statusCode).toEqual(400);
+        expect(response.statusCode).toEqual(400);
       });
 
       test('PUT accepts requests to update to the current email address (ignoring case) if it is not verified', async () => {
@@ -247,8 +247,8 @@ describe('settingRoutes', () => {
           email: developerUserEmail.toUpperCase()
         });
 
-        expect(response?.statusCode).toEqual(200);
-        expect(response?.body).toEqual({
+        expect(response.statusCode).toEqual(200);
+        expect(response.body).toEqual({
           message: 'flash.email-valid',
           type: 'success'
         });
@@ -259,12 +259,12 @@ describe('settingRoutes', () => {
           email: developerUserEmail.toUpperCase()
         });
 
-        expect(response?.body).toEqual({
+        expect(response.body).toEqual({
           type: 'info',
           message: `${developerUserEmail} is already associated with this account.
 You can update a new email address instead.`
         });
-        expect(response?.statusCode).toEqual(400);
+        expect(response.statusCode).toEqual(400);
       });
 
       test('PUT rejects a request to update to the same email (ignoring case) twice', async () => {
@@ -272,7 +272,7 @@ You can update a new email address instead.`
           email: unusedEmailOne
         });
 
-        expect(successResponse?.statusCode).toEqual(200);
+        expect(successResponse.statusCode).toEqual(200);
 
         const failResponse = await superPut('/update-my-email').send({
           email: unusedEmailOne.toUpperCase()
@@ -291,11 +291,11 @@ Please wait 5 minutes to resend an authentication link.`
           email: otherDeveloperUserEmail
         });
 
-        expect(response?.body).toEqual({
+        expect(response.body).toEqual({
           type: 'info',
           message: `${otherDeveloperUserEmail} is already associated with another account.`
         });
-        expect(response?.statusCode).toEqual(400);
+        expect(response.statusCode).toEqual(400);
       });
 
       test('PUT rejects the second request if is immediately after the first', async () => {
@@ -303,7 +303,7 @@ Please wait 5 minutes to resend an authentication link.`
           email: unusedEmailOne
         });
 
-        expect(successResponse?.statusCode).toEqual(200);
+        expect(successResponse.statusCode).toEqual(200);
 
         const failResponse = await superPut('/update-my-email').send({
           email: unusedEmailTwo

--- a/api/src/routes/settings.test.ts
+++ b/api/src/routes/settings.test.ts
@@ -261,8 +261,9 @@ describe('settingRoutes', () => {
 
         expect(response.statusCode).toEqual(200);
         expect(response.body).toEqual({
-          message: 'flash.email-valid',
-          type: 'success'
+          message:
+            'Check your email and click the link we sent you to confirm your new email address.',
+          type: 'info'
         });
       });
 

--- a/api/src/routes/settings.ts
+++ b/api/src/routes/settings.ts
@@ -183,11 +183,11 @@ export const settingRoutes: FastifyPluginCallbackTypebox = (
       const isOwnEmail = newEmail === currentEmailFormatted;
       if (isOwnEmail && isVerifiedEmail) {
         void reply.code(400);
-        return {
+        return reply.send({
           type: 'info',
           message: `${newEmail} is already associated with this account.
 You can update a new email address instead.`
-        } as const;
+        });
       }
 
       const isResendUpdateToSameEmail =
@@ -198,11 +198,11 @@ You can update a new email address instead.`
 
       if (isResendUpdateToSameEmail && isLinkSentWithinLimitTTL) {
         void reply.code(429);
-        return {
+        return reply.send({
           type: 'info',
           message: `We have already sent an email confirmation request to ${newEmail}.
 ${isLinkSentWithinLimitTTL}`
-        } as const;
+        });
       }
 
       const isEmailAlreadyTaken =
@@ -210,10 +210,10 @@ ${isLinkSentWithinLimitTTL}`
 
       if (isEmailAlreadyTaken && !isOwnEmail) {
         void reply.code(400);
-        return {
+        return reply.send({
           type: 'info',
           message: `${newEmail} is already associated with another account.`
-        } as const;
+        });
       }
 
       // ToDo(MVP): email the new email and wait user to confirm it, before we update the user schema.
@@ -237,10 +237,10 @@ ${isLinkSentWithinLimitTTL}`
 
         if (tooManyRequestsMessage) {
           void reply.code(429);
-          return {
+          return reply.send({
             type: 'info',
             message: tooManyRequestsMessage
-          } as const;
+          });
         }
 
         await fastify.prisma.user.update({
@@ -250,11 +250,11 @@ ${isLinkSentWithinLimitTTL}`
           }
         });
 
-        return { message: 'flash.email-valid', type: 'success' } as const;
+        await reply.send({ message: 'flash.email-valid', type: 'success' });
       } catch (err) {
         fastify.log.error(err);
         void reply.code(500);
-        return { message: 'flash.wrong-updating', type: 'danger' } as const;
+        await reply.send({ message: 'flash.wrong-updating', type: 'danger' });
       }
     }
   );

--- a/api/src/schemas/settings/update-my-email.ts
+++ b/api/src/schemas/settings/update-my-email.ts
@@ -6,8 +6,10 @@ export const updateMyEmail = {
   }),
   response: {
     200: Type.Object({
-      message: Type.Literal('flash.email-valid'),
-      type: Type.Literal('success')
+      message: Type.Literal(
+        'Check your email and click the link we sent you to confirm your new email address.'
+      ),
+      type: Type.Literal('info')
     }),
     '4xx': Type.Object({
       message: Type.String(),

--- a/api/src/utils/tokens.test.ts
+++ b/api/src/utils/tokens.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import { createAccessToken } from './tokens';
+import { createAccessToken, createAuthToken } from './tokens';
 
 describe('createAccessToken', () => {
   it('creates an object with id, ttl, created and userId', () => {
@@ -24,5 +24,31 @@ describe('createAccessToken', () => {
 
     expect(actual.ttl).toBe(ttl);
     expect(createAccessToken(userId).ttl).toBe(77760000000);
+  });
+});
+
+describe('createAuthToken', () => {
+  it('creates an object with id, ttl, created and userId', () => {
+    const userId = 'abc';
+
+    const actual = createAuthToken(userId);
+
+    expect(actual).toStrictEqual({
+      id: expect.stringMatching(/[a-zA-Z0-9]{64}/),
+      ttl: 900000,
+      created: expect.stringMatching(
+        /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z/
+      ),
+      userId
+    });
+  });
+
+  it('sets the ttl, defaulting to 900000 ms', () => {
+    const userId = 'abc';
+    const ttl = 123;
+    const actual = createAuthToken(userId, ttl);
+
+    expect(actual.ttl).toBe(ttl);
+    expect(createAuthToken(userId).ttl).toBe(900000);
   });
 });

--- a/api/src/utils/tokens.ts
+++ b/api/src/utils/tokens.ts
@@ -13,7 +13,7 @@ export function encodeUserToken(userToken: string): string {
   return jwt.sign({ userToken }, JWT_SECRET);
 }
 
-export type AccessToken = {
+export type Token = {
   userId: string;
   id: string;
   ttl: number;
@@ -26,14 +26,26 @@ export type AccessToken = {
  * @param ttl The time to live for the token in milliseconds (default: 77760000000).
  * @returns The access token.
  */
-export const createAccessToken = (
-  userId: string,
-  ttl?: number
-): AccessToken => {
+export const createAccessToken = (userId: string, ttl?: number): Token => {
   return {
     userId,
     id: customNanoid(),
     ttl: ttl ?? 77760000000,
+    created: new Date().toISOString()
+  };
+};
+
+/**
+ * Creates an auth token.
+ * @param userId The user ID as a string (yes, it's an ObjectID, but it will be serialized to a string anyway).
+ * @param ttl The time to live for the token in milliseconds (default: 900000 aka 15 minutes).
+ * @returns The access token.
+ */
+export const createAuthToken = (userId: string, ttl?: number): Token => {
+  return {
+    userId,
+    id: customNanoid(),
+    ttl: ttl ?? 900000,
     created: new Date().toISOString()
   };
 };


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

When this endpoint was first migrated, we had not implemented the email service. That now exists, so I could finish endpoint.

Next job is to create the /confirm-email endpoint, without which this doesn't do a lot!

<!-- Feel free to add any additional description of changes below this line -->
