### PR TITLE
fix: memoize completedPercentageSelector

### DIFF
--- a/client/src/templates/Challenges/redux/completion-epic.test.js
+++ b/client/src/templates/Challenges/redux/completion-epic.test.js
@@ -17,7 +17,10 @@ describe('completionEpic', () => {
       const state$ = {
         value: {
           challenge: { challengeMeta: { challengeType: 0 } },
-          app: { user: { username: 'test' } }
+          app: {
+            user: { username: 'test' },
+            allChallengesInfo: { challengeEdges: [], certificateNodes: [] }
+          }
         }
       };
 

--- a/client/src/templates/Challenges/redux/selectors.js
+++ b/client/src/templates/Challenges/redux/selectors.js
@@ -1,3 +1,4 @@
+import { createSelector } from 'reselect';
 import { challengeTypes } from '../../../../../shared/config/challenge-types';
 import {
   completedChallengesSelector,
@@ -103,17 +104,20 @@ export const challengeDataSelector = state => {
   return challengeData;
 };
 
-export const currentBlockIdsSelector = state => {
-  const { block, certification, challengeType } = challengeMetaSelector(state);
-  const allChallengesInfo = allChallengesInfoSelector(state);
+export const currentBlockIdsSelector = createSelector(
+  challengeMetaSelector,
+  allChallengesInfoSelector,
+  (challengeMeta, allChallengesInfo) => {
+    const { block, certification, challengeType } = challengeMeta;
 
-  return getCurrentBlockIds(
-    allChallengesInfo,
-    block,
-    certification,
-    challengeType
-  );
-};
+    return getCurrentBlockIds(
+      allChallengesInfo,
+      block,
+      certification,
+      challengeType
+    );
+  }
+);
 
 export const completedChallengesInBlockSelector = state => {
   const completedChallengesIds = completedChallengesIdsSelector(state);
@@ -127,20 +131,22 @@ export const completedChallengesInBlockSelector = state => {
   );
 };
 
-export const completedPercentageSelector = state => {
-  const isSignedIn = isSignedInSelector(state);
-  if (isSignedIn) {
-    const completedChallengesIds = completedChallengesIdsSelector(state);
-    const { id } = challengeMetaSelector(state);
-    const currentBlockIds = currentBlockIdsSelector(state);
-    const completedPercentage = getCompletedPercentage(
-      completedChallengesIds,
-      currentBlockIds,
-      id
-    );
-    return completedPercentage;
-  } else return 0;
-};
+export const completedPercentageSelector = createSelector(
+  isSignedInSelector,
+  completedChallengesSelector,
+  challengeMetaSelector,
+  currentBlockIdsSelector,
+  (isSignedIn, completedChallenges, { id }, currentBlockIds) => {
+    if (isSignedIn) {
+      const completedPercentage = getCompletedPercentage(
+        completedChallenges.map(node => node.id),
+        currentBlockIds,
+        id
+      );
+      return completedPercentage;
+    } else return 0;
+  }
+);
 
 export const isBlockNewlyCompletedSelector = state => {
   const completedPercentage = completedPercentageSelector(state);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Memoises completedPercentageSelector to prevent the (relatively) expensive calculation in getCompletedPercentage.

Potentially closes https://github.com/freeCodeCamp/freeCodeCamp/issues/54736

<!-- Feel free to add any additional description of changes below this line -->
