### PR TITLE
fix: delete non-existing challenge from meta

### DIFF
--- a/curriculum/challenges/_meta/learn-data-structures-by-building-the-merge-sort-algorithm/meta.json
+++ b/curriculum/challenges/_meta/learn-data-structures-by-building-the-merge-sort-algorithm/meta.json
@@ -141,10 +141,6 @@
     {
       "id": "6569c2cbf6c993ea8cd85682",
       "title": "Step 33"
-    },
-    {
-      "id": "65817fcc829d9d176878c54a",
-      "title": "Step 34"
     }
   ],
   "helpCategory": "Python"


### PR DESCRIPTION
This challenge is in the meta, but there isn't a markdown file for it - it doesn't seem to exist.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
