### PR TITLE
fix(curriculum): Hide Ribbons for Legacy Curriculum Sections

### DIFF
--- a/client/src/components/Map/index.tsx
+++ b/client/src/components/Map/index.tsx
@@ -83,6 +83,11 @@ function MapLi({
   showNumbers?: boolean;
   index: number;
 }) {
+  const isLegacy = [
+    SuperBlocks.RespWebDesign,
+    SuperBlocks.PythonForEverybody,
+    SuperBlocks.JsAlgoDataStruct
+  ].includes(superBlock);
   return (
     <>
       <li
@@ -93,12 +98,14 @@ function MapLi({
           <div
             className={`progress-icon${showProgressionLines ? ' show-progression-lines' : ''}`}
           >
-            <RibbonIcon
-              value={index + 1}
-              showNumbers={showNumbers}
-              isCompleted={completed}
-              isClaimed={claimed}
-            />
+            {!isLegacy && (
+              <RibbonIcon
+                value={index + 1}
+                showNumbers={showNumbers}
+                isCompleted={completed}
+                isClaimed={claimed}
+              />
+            )}
           </div>
         </div>
 

--- a/client/src/components/Map/index.tsx
+++ b/client/src/components/Map/index.tsx
@@ -73,6 +73,7 @@ function MapLi({
   claimed,
   showProgressionLines = false,
   showNumbers = false,
+  showRibbonIcon = true,
   index
 }: {
   superBlock: SuperBlocks;
@@ -81,13 +82,15 @@ function MapLi({
   claimed: boolean;
   showProgressionLines?: boolean;
   showNumbers?: boolean;
+  showRibbonIcon?: boolean;
   index: number;
 }) {
-  const isLegacy = [
-    SuperBlocks.RespWebDesign,
-    SuperBlocks.PythonForEverybody,
-    SuperBlocks.JsAlgoDataStruct
-  ].includes(superBlock);
+  console.log(
+    'Rendering SuperBlock:',
+    superBlock,
+    'Show Ribbon:',
+    showRibbonIcon
+  );
   return (
     <>
       <li
@@ -98,7 +101,7 @@ function MapLi({
           <div
             className={`progress-icon${showProgressionLines ? ' show-progression-lines' : ''}`}
           >
-            {!isLegacy && (
+            {showRibbonIcon && (
               <RibbonIcon
                 value={index + 1}
                 showNumbers={showNumbers}
@@ -253,6 +256,7 @@ function Map({
             completed={allSuperblockChallengesCompleted(superBlock)}
             claimed={isClaimed(superBlock)}
             index={i}
+            showRibbonIcon={false}
           />
         ))}
       </ul>

--- a/client/src/components/Map/index.tsx
+++ b/client/src/components/Map/index.tsx
@@ -85,12 +85,6 @@ function MapLi({
   showRibbonIcon?: boolean;
   index: number;
 }) {
-  console.log(
-    'Rendering SuperBlock:',
-    superBlock,
-    'Show Ribbon:',
-    showRibbonIcon
-  );
   return (
     <>
       <li


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #54935

<!-- Feel free to add any additional description of changes below this line -->

This pull request introduces a UI adjustment to the curriculum map component. It specifically omits the completion ribbons for the legacy courses from the super blocks. 

Files Modified
index.tsx

Changes
The main change involves adding a check in the MapLi component to determine if a super block belongs to the legacy curriculum. If so, the completion ribbon is not rendered for that super block.

Here are the changes in action:
<img width="897" alt="Screenshot 2024-05-23 at 6 37 37 pm" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/99856161/09298d34-152a-4cf8-afe8-4dd323edc404">

