### PR TITLE
fix(api): unsubscribe all subscribed emails

### DIFF
--- a/api/src/routes/email-subscription.test.ts
+++ b/api/src/routes/email-subscription.test.ts
@@ -17,11 +17,17 @@ const urlEncodedSuccessMessage2 =
 
 const unsubscribeId1 = 'abcde';
 const unsubscribeId2 = 'abcdef';
+const unsubscribeId3 = 'abcdefg';
 
 const testUserData1: Prisma.userCreateInput[] = [
   {
     ...createUserInput('user1@freecodecamp.org'),
     unsubscribeId: unsubscribeId1,
+    sendQuincyEmail: true
+  },
+  {
+    ...createUserInput('user1@freecodecamp.org'),
+    unsubscribeId: unsubscribeId2,
     sendQuincyEmail: true
   },
   {
@@ -31,7 +37,7 @@ const testUserData1: Prisma.userCreateInput[] = [
   },
   {
     ...createUserInput('user3@freecodecamp.org'),
-    unsubscribeId: unsubscribeId2,
+    unsubscribeId: unsubscribeId3,
     sendQuincyEmail: true
   }
 ];
@@ -57,7 +63,7 @@ const testUserData2: Prisma.userCreateInput[] = [
 describe('Email Subscription endpoints', () => {
   setupServer();
 
-  describe('GET /ue/unsubscribe/:unsubscribeId', () => {
+  describe('GET /ue/:unsubscribeId', () => {
     test('should 302 redirect with info message if no ID', async () => {
       const response = await superRequest('/ue/', { method: 'GET' });
       expect(response.headers.location).toStrictEqual(
@@ -74,7 +80,7 @@ describe('Email Subscription endpoints', () => {
       expect(response.status).toBe(302);
     });
 
-    test("should set 'sendQuincyEmail' to 'false' for user with matching ID and 302 redirect with success message", async () => {
+    test("1: should set 'sendQuincyEmail' to 'false' for users with matching email and 302 redirect with success message", async () => {
       await fastifyTestInstance.prisma.user.createMany({
         data: testUserData1
       });
@@ -87,14 +93,15 @@ describe('Email Subscription endpoints', () => {
         where: {
           OR: [
             { unsubscribeId: unsubscribeId1 },
-            { unsubscribeId: unsubscribeId2 }
+            { unsubscribeId: unsubscribeId2 },
+            { unsubscribeId: unsubscribeId3 }
           ]
         }
       });
 
-      expect(users).toHaveLength(3);
+      expect(users).toHaveLength(4);
       users.forEach(user => {
-        if (user.unsubscribeId === unsubscribeId1) {
+        if (['user1@freecodecamp.org'].includes(user.email)) {
           expect(user.sendQuincyEmail).toBe(false);
         } else {
           expect(user.sendQuincyEmail).toBe(true);
@@ -106,17 +113,19 @@ describe('Email Subscription endpoints', () => {
       );
 
       expect(response.status).toBe(302);
+      // TODO: If any assertions fail before this call, other tests will fail for no actual reason.
       await fastifyTestInstance.prisma.user.deleteMany({
         where: {
           OR: [
             { unsubscribeId: unsubscribeId1 },
-            { unsubscribeId: unsubscribeId2 }
+            { unsubscribeId: unsubscribeId2 },
+            { unsubscribeId: unsubscribeId3 }
           ]
         }
       });
     });
 
-    test("should set 'sendQuincyEmail' to 'false' for all users with matching ID and 302 redirect with success message", async () => {
+    test("2: should set 'sendQuincyEmail' to 'false' for all users with matching email and 302 redirect with success message", async () => {
       await fastifyTestInstance.prisma.user.createMany({
         data: testUserData1
       });
@@ -129,14 +138,19 @@ describe('Email Subscription endpoints', () => {
         where: {
           OR: [
             { unsubscribeId: unsubscribeId1 },
-            { unsubscribeId: unsubscribeId2 }
+            { unsubscribeId: unsubscribeId2 },
+            { unsubscribeId: unsubscribeId3 }
           ]
         }
       });
 
-      expect(users).toHaveLength(3);
+      expect(users).toHaveLength(4);
       users.forEach(user => {
-        if (user.unsubscribeId === unsubscribeId2) {
+        if (
+          ['user1@freecodecamp.org', 'user2@freecodecamp.org'].includes(
+            user.email
+          )
+        ) {
           expect(user.sendQuincyEmail).toBe(false);
         } else {
           expect(user.sendQuincyEmail).toBe(true);
@@ -148,11 +162,13 @@ describe('Email Subscription endpoints', () => {
       );
 
       expect(response.status).toBe(302);
+      // TODO: If any assertions fail before this call, other tests will fail for no actual reason.
       await fastifyTestInstance.prisma.user.deleteMany({
         where: {
           OR: [
             { unsubscribeId: unsubscribeId1 },
-            { unsubscribeId: unsubscribeId2 }
+            { unsubscribeId: unsubscribeId2 },
+            { unsubscribeId: unsubscribeId3 }
           ]
         }
       });

--- a/api/src/routes/email-subscription.ts
+++ b/api/src/routes/email-subscription.ts
@@ -36,11 +36,11 @@ export const emailSubscribtionRoutes: FastifyPluginCallbackTypebox = (
       try {
         const { origin } = getRedirectParams(req);
         const { unsubscribeId } = req.params;
-        const users = await fastify.prisma.user.findMany({
+        const unsubUsers = await fastify.prisma.user.findMany({
           where: { unsubscribeId }
         });
 
-        if (!users.length) {
+        if (!unsubUsers.length) {
           void reply.code(302);
           return reply.redirectWithMessage(origin, {
             type: 'info',
@@ -48,9 +48,9 @@ export const emailSubscribtionRoutes: FastifyPluginCallbackTypebox = (
           });
         }
 
-        const userUpdatePromises = users.map(user =>
-          fastify.prisma.user.update({
-            where: { id: user.id },
+        const userUpdatePromises = unsubUsers.map(user =>
+          fastify.prisma.user.updateMany({
+            where: { email: user.email },
             data: {
               sendQuincyEmail: false
             }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related #40773 (Only to be closed, once new api is deployed)

| Before | After |
| ------- | ------ |
| Unsubscribing accounts with the same email but different `unsubscribeId`s would result in emails still being sent | Unsubscribing accounts with the same email but different `unsubscribeId`s unsubscribes all accounts |
| All accounts with same `unsubscribeId` get unsubscribed | All accounts with same `unsubscribeId` get unsubscribed |

These changes could be backported to the old/current api. However, I find it unscrupulous.