### PR TITLE
fix(client): clear timeout when lower jaw unmounts

### DIFF
--- a/client/src/templates/Challenges/classic/lower-jaw.tsx
+++ b/client/src/templates/Challenges/classic/lower-jaw.tsx
@@ -221,6 +221,8 @@ const LowerJaw = ({
     challengeIsCompleted && completedPercent === isBlockCompleted;
 
   useEffect(() => {
+    let timeoutId: ReturnType<typeof setTimeout>;
+
     // prevent unnecessary updates:
     if (attempts === currentAttempts) return;
     // Attempts should only be zero when the step is reset, so we should reset
@@ -242,14 +244,18 @@ const LowerJaw = ({
       hintRef.current = hint;
 
       //display the test feedback contents.
-      setTimeout(() => {
+      timeoutId = setTimeout(() => {
         setRunningTests(false);
         setIsFeedbackHidden(false);
       }, 300);
     }
+
+    return () => clearTimeout(timeoutId);
   }, [attempts, hint, currentAttempts]);
 
   useEffect(() => {
+    let timeoutId: ReturnType<typeof setTimeout>;
+
     if (challengeIsCompleted) {
       // If Ctrl + Enter was used then we don't need to worry about setting
       // focus, just leave it where it is. In NVDA, Ctrl + Enter will trigger
@@ -262,11 +268,13 @@ const LowerJaw = ({
       // Delay focusing Submit button so that screen reader will announce
       // it after the test results.
       setQuote(randomCompliment());
-      setTimeout(() => {
+      timeoutId = setTimeout(() => {
         submitButtonRef.current?.focus();
         setFocusManagementCompleted(true);
       }, 500);
     }
+
+    return () => clearTimeout(timeoutId);
   }, [challengeIsCompleted]);
 
   // ToDo: turn it into a grid to remove the need for useEffect.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

I went through the `lower-jaw.tsx` file as I was investigating #54736, and noticed that the `useEffect` hooks in the component don't handle timeouts clearing. If the component unmounts before a timeout expires, we could potentially have memory leaks.

This PR adds a cleanup function to the `useEffect` hook and clears all timeouts when the component unmounts. (I don't think this change would make a dent, but at least there is one less thing to worry about).

<!-- Feel free to add any additional description of changes below this line -->
