### PR TITLE
chore: fix challenge titles

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -956,7 +956,7 @@
     "note": "",
     "blocks": {
       "tensorflow": {
-        "title": "Tensorflow",
+        "title": "TensorFlow",
         "intro": [
           "TensorFlow is an open source framework that makes machine learning and neural networking easier to use.",
           "The following video course was created by Tim Ruscica, also known as “Tech With Tim”. It will help you to understand TensorFlow and some of its powerful capabilities."
@@ -1480,7 +1480,7 @@
         "intro": ["", ""]
       },
       "learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects": {
-        "title": "Learn How to Talk About Updates and Plans for Tasks and Projects",
+        "title": "Learn How to Talk about Updates and Plans for Tasks and Projects",
         "intro": ["", ""]
       },
       "learn-how-to-express-agreement-or-disagreement": {

--- a/curriculum/challenges/_meta/basic-javascript/meta.json
+++ b/curriculum/challenges/_meta/basic-javascript/meta.json
@@ -183,19 +183,19 @@
     },
     {
       "id": "56bbb991ad1ed5201cd392cb",
-      "title": "Manipulate Arrays With push()"
+      "title": "Manipulate Arrays With push Method"
     },
     {
       "id": "56bbb991ad1ed5201cd392cc",
-      "title": "Manipulate Arrays With pop()"
+      "title": "Manipulate Arrays With pop Method"
     },
     {
       "id": "56bbb991ad1ed5201cd392cd",
-      "title": "Manipulate Arrays With shift()"
+      "title": "Manipulate Arrays With shift Method"
     },
     {
       "id": "56bbb991ad1ed5201cd392ce",
-      "title": "Manipulate Arrays With unshift()"
+      "title": "Manipulate Arrays With unshift Method"
     },
     {
       "id": "56533eb9ac21ba0edf2244bc",

--- a/curriculum/challenges/_meta/build-a-celestial-bodies-database-project/meta.json
+++ b/curriculum/challenges/_meta/build-a-celestial-bodies-database-project/meta.json
@@ -1,5 +1,5 @@
 {
-  "name": "Build a Celestial Bodies Database Project",
+  "name": "Celestial Bodies Database",
   "isUpcomingChange": false,
   "dashedName": "build-a-celestial-bodies-database-project",
   "order": 2,

--- a/curriculum/challenges/_meta/build-a-data-graph-explorer-project/meta.json
+++ b/curriculum/challenges/_meta/build-a-data-graph-explorer-project/meta.json
@@ -1,5 +1,5 @@
 {
-  "name": "Build a Data Graph Explorer Project",
+  "name": "Data Graph Explorer",
   "isUpcomingChange": false,
   "dashedName": "build-a-data-graph-explorer-project",
   "order": 19,

--- a/curriculum/challenges/_meta/build-a-financial-calculator-project/meta.json
+++ b/curriculum/challenges/_meta/build-a-financial-calculator-project/meta.json
@@ -1,5 +1,5 @@
 {
-  "name": "Build a Financial Calculator Project",
+  "name": "Financial Calculator",
   "isUpcomingChange": false,
   "dashedName": "build-a-financial-calculator-project",
   "order": 17,

--- a/curriculum/challenges/_meta/build-a-graphing-calculator-project/meta.json
+++ b/curriculum/challenges/_meta/build-a-graphing-calculator-project/meta.json
@@ -1,5 +1,5 @@
 {
-  "name": "Build a Graphing Calculator Project",
+  "name": "Graphing Calculator",
   "isUpcomingChange": false,
   "dashedName": "build-a-graphing-calculator-project",
   "order": 11,

--- a/curriculum/challenges/_meta/build-a-multi-function-calculator-project/meta.json
+++ b/curriculum/challenges/_meta/build-a-multi-function-calculator-project/meta.json
@@ -1,5 +1,5 @@
 {
-  "name": "Build a Multi-Function Calculator Project",
+  "name": "Multi-Function Calculator",
   "isUpcomingChange": false,
   "dashedName": "build-a-multi-function-calculator-project",
   "order": 6,

--- a/curriculum/challenges/_meta/build-a-number-guessing-game-project/meta.json
+++ b/curriculum/challenges/_meta/build-a-number-guessing-game-project/meta.json
@@ -1,5 +1,5 @@
 {
-  "name": "Build a Number Guessing Game Project",
+  "name": "Number Guessing Game",
   "isUpcomingChange": false,
   "dashedName": "build-a-number-guessing-game-project",
   "order": 13,

--- a/curriculum/challenges/_meta/build-a-periodic-table-database-project/meta.json
+++ b/curriculum/challenges/_meta/build-a-periodic-table-database-project/meta.json
@@ -1,5 +1,5 @@
 {
-  "name": "Build a Periodic Table Database Project",
+  "name": "Periodic Table Database",
   "isUpcomingChange": false,
   "dashedName": "build-a-periodic-table-database-project",
   "order": 12,

--- a/curriculum/challenges/_meta/build-a-personal-portfolio-webpage-project/meta.json
+++ b/curriculum/challenges/_meta/build-a-personal-portfolio-webpage-project/meta.json
@@ -1,5 +1,5 @@
 {
-  "name": "Build a Personal Portfolio Webpage Project",
+  "name": "Personal Portfolio Webpage",
   "isUpcomingChange": false,
   "dashedName": "build-a-personal-portfolio-webpage-project",
   "usesMultifileEditor": true,

--- a/curriculum/challenges/_meta/build-a-product-landing-page-project/meta.json
+++ b/curriculum/challenges/_meta/build-a-product-landing-page-project/meta.json
@@ -1,5 +1,5 @@
 {
-  "name": "Build a Product Landing Page Project",
+  "name": "Product Landing Page",
   "isUpcomingChange": false,
   "dashedName": "build-a-product-landing-page-project",
   "usesMultifileEditor": true,

--- a/curriculum/challenges/_meta/build-a-salon-appointment-scheduler-project/meta.json
+++ b/curriculum/challenges/_meta/build-a-salon-appointment-scheduler-project/meta.json
@@ -1,5 +1,5 @@
 {
-  "name": "Build a Salon Appointment Scheduler Project",
+  "name": "Salon Appointment Scheduler",
   "isUpcomingChange": false,
   "dashedName": "build-a-salon-appointment-scheduler-project",
   "order": 9,

--- a/curriculum/challenges/_meta/build-a-survey-form-project/meta.json
+++ b/curriculum/challenges/_meta/build-a-survey-form-project/meta.json
@@ -1,5 +1,5 @@
 {
-  "name": "Build a Survey Form Project",
+  "name": "Survey Form",
   "isUpcomingChange": false,
   "dashedName": "build-a-survey-form-project",
   "usesMultifileEditor": true,

--- a/curriculum/challenges/_meta/build-a-technical-documentation-page-project/meta.json
+++ b/curriculum/challenges/_meta/build-a-technical-documentation-page-project/meta.json
@@ -1,5 +1,5 @@
 {
-  "name": "Build a Technical Documentation Page Project",
+  "name": "Technical Documentation Page",
   "isUpcomingChange": false,
   "dashedName": "build-a-technical-documentation-page-project",
   "usesMultifileEditor": true,

--- a/curriculum/challenges/_meta/build-a-tribute-page-project/meta.json
+++ b/curriculum/challenges/_meta/build-a-tribute-page-project/meta.json
@@ -1,5 +1,5 @@
 {
-  "name": "Build a Tribute Page Project",
+  "name": "Tribute Page",
   "isUpcomingChange": false,
   "dashedName": "build-a-tribute-page-project",
   "usesMultifileEditor": true,

--- a/curriculum/challenges/_meta/build-a-world-cup-database-project/meta.json
+++ b/curriculum/challenges/_meta/build-a-world-cup-database-project/meta.json
@@ -1,5 +1,5 @@
 {
-  "name": "Build a World Cup Database Project",
+  "name": "World Cup Database",
   "isUpcomingChange": false,
   "dashedName": "build-a-world-cup-database-project",
   "helpCategory": "Backend Development",

--- a/curriculum/challenges/_meta/build-three-math-games-project/meta.json
+++ b/curriculum/challenges/_meta/build-three-math-games-project/meta.json
@@ -1,5 +1,5 @@
 {
-  "name": "Build Three Math Games Project",
+  "name": "Three Math Games",
   "isUpcomingChange": false,
   "dashedName": "build-three-math-games-project",
   "helpCategory": "Python",

--- a/curriculum/challenges/_meta/d3-dashboard/meta.json
+++ b/curriculum/challenges/_meta/d3-dashboard/meta.json
@@ -2,7 +2,6 @@
   "name": "D3 Dashboard",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
-  "hasEditableBoundaries": true,
   "dashedName": "d3-dashboard",
   "helpCategory": "JavaScript",
   "order": 3,

--- a/curriculum/challenges/_meta/data-analysis-with-python-course/meta.json
+++ b/curriculum/challenges/_meta/data-analysis-with-python-course/meta.json
@@ -1,5 +1,5 @@
 {
-  "name": "Data Analysis with Python Course",
+  "name": "Data Analysis with Python",
   "isUpcomingChange": false,
   "dashedName": "data-analysis-with-python-course",
   "helpCategory": "Python",

--- a/curriculum/challenges/_meta/es6/meta.json
+++ b/curriculum/challenges/_meta/es6/meta.json
@@ -59,7 +59,7 @@
     },
     {
       "id": "587d7b8a367417b2b2512b4c",
-      "title": "Use Destructuring Assignment with the Rest Parameter to Reassign Array Elements"
+      "title": "Destructuring via rest elements"
     },
     {
       "id": "587d7b8a367417b2b2512b4d",

--- a/curriculum/challenges/_meta/learn-basic-javascript-by-building-a-role-playing-game/meta.json
+++ b/curriculum/challenges/_meta/learn-basic-javascript-by-building-a-role-playing-game/meta.json
@@ -1,5 +1,5 @@
 {
-  "name": "Learn Basic JavaScript By Building a Role Playing Game",
+  "name": "Learn Basic JavaScript by Building a Role Playing Game",
   "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,

--- a/curriculum/challenges/_meta/learn-form-validation-by-building-a-calorie-counter/meta.json
+++ b/curriculum/challenges/_meta/learn-form-validation-by-building-a-calorie-counter/meta.json
@@ -1,5 +1,5 @@
 {
-  "name": "Learn Form Validation By Building a Calorie Counter",
+  "name": "Learn Form Validation by Building a Calorie Counter",
   "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,

--- a/curriculum/challenges/_meta/learn-how-to-describe-your-current-project/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-describe-your-current-project/meta.json
@@ -102,7 +102,7 @@
     },
     {
       "id": "655c9a549835a8601764bd0b",
-      "title": "Dialogue 3: Maria And Mark Talk about Their Project"
+      "title": "Dialogue 3: Maria and Mark Talk about Their Project"
     },
     {
       "id": "655c9a89818e18606c18ca4b",

--- a/curriculum/challenges/_meta/learn-how-to-discuss-roles-and-responsibilies/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-discuss-roles-and-responsibilies/meta.json
@@ -10,7 +10,7 @@
   "challengeOrder": [
     {
       "id": "65b0dd4e70e9dcf7c402eb8e",
-      "title": "Dialogue 1: Describing other people and what they do"
+      "title": "Dialogue 1: Describing Other People and What They Do"
     },
     {
       "id": "65b0dde5120c33f904f47a62",
@@ -330,7 +330,7 @@
     },
     {
       "id": "65d88b76573df039d43f29bc",
-      "title": "Dialogue 4: Sophie asks Bob about his responsibilities"
+      "title": "Dialogue 4: Sophie Asks Bob about His Responsibilities"
     },
     {
       "id": "65d892ad7262d64a5db56906",

--- a/curriculum/challenges/_meta/learn-how-to-discuss-your-morning-or-evening-routine/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-discuss-your-morning-or-evening-routine/meta.json
@@ -10,7 +10,7 @@
   "challengeOrder": [
     {
       "id": "655699a46134fa74acaf6204",
-      "title": "Dialogue 1: Learn How to Discuss Your Morning or Evening Routine"
+      "title": "Dialogue 1: Learn How to Discuss your Morning or Evening Routine"
     },
     {
       "id": "65569ebbc9ef9f7b5b99827b",
@@ -58,7 +58,7 @@
     },
     {
       "id": "65578ed1a4ae65a8fbc341f5",
-      "title": "task 12"
+      "title": "Task 12"
     },
     {
       "id": "655792631f21afaa40c611e1",
@@ -262,7 +262,7 @@
     },
     {
       "id": "655a591ad34faa18c8338f9b",
-      "title": "Dialogue 3: Evening Routine With Kids"
+      "title": "Dialogue 3: Evening Routine with Kids"
     },
     {
       "id": "655a5bfadf47e1199f9b65eb",
@@ -330,7 +330,7 @@
     },
     {
       "id": "655a9f8d6d3af8538a178166",
-      "title": "Dialogue 4: Brian and Maria talk about eventful evenings"
+      "title": "Dialogue 4: Brian and Maria Talk about Eventful Evenings"
     },
     {
       "id": "655aa098bb38a05474a3f5b4",
@@ -386,7 +386,7 @@
     },
     {
       "id": "655b34a4b45a76689cb429c6",
-      "title": "Dialogue 5: Sophie and Brian Talk About The Weekend"
+      "title": "Dialogue 5: Sophie and Brian Talk about the Weekend"
     },
     {
       "id": "655b34e53bf2cb6908042c98",

--- a/curriculum/challenges/_meta/learn-how-to-have-a-conversation-about-preferences-and-motivations/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-have-a-conversation-about-preferences-and-motivations/meta.json
@@ -286,7 +286,7 @@
     },
     {
       "id": "65a351bd69b0b72d7ed24eb5",
-      "title": "Dialogue 3: Talking About Motivations to Pursue a career"
+      "title": "Dialogue 3: Talking about Motivations to Pursue a Career"
     },
     {
       "id": "65a3524b7cfbc82f51667b0a",

--- a/curriculum/challenges/_meta/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/meta.json
@@ -10,7 +10,7 @@
   "challengeOrder": [
     {
       "id": "6613cf7cb0b2704934764852",
-      "title": "Dialogue 1: Debating Plans for the Next Project"
+      "title": "Dialogue 1: Discussing Plans for the Next Project"
     },
     {
       "id": "6613d00727a7a64a5e010243",

--- a/curriculum/challenges/_meta/learn-intermediate-oop-by-building-a-platformer-game/meta.json
+++ b/curriculum/challenges/_meta/learn-intermediate-oop-by-building-a-platformer-game/meta.json
@@ -1,5 +1,5 @@
 {
-  "name": "learn-intermediate-oop-by-building-a-platformer-game",
+  "name": "Learn Intermediate OOP by Building a Platformer Game",
   "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,

--- a/curriculum/challenges/_meta/learn-introductions-in-an-online-team-meeting/meta.json
+++ b/curriculum/challenges/_meta/learn-introductions-in-an-online-team-meeting/meta.json
@@ -102,7 +102,7 @@
     },
     {
       "id": "657c836198f77668f5cfd122",
-      "title": "Dialogue 2: Introducing The New Junior Developer"
+      "title": "Dialogue 2: Introducing the New Junior Developer"
     },
     {
       "id": "657c9900c2df3b6ffdd86129",

--- a/curriculum/challenges/_meta/learn-python-by-building-a-blackjack-game/meta.json
+++ b/curriculum/challenges/_meta/learn-python-by-building-a-blackjack-game/meta.json
@@ -1,5 +1,5 @@
 {
-  "name": "Learn Python By Building a Blackjack Game",
+  "name": "Learn Python by Building a Blackjack Game",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,

--- a/curriculum/challenges/_meta/managing-packages-with-npm/meta.json
+++ b/curriculum/challenges/_meta/managing-packages-with-npm/meta.json
@@ -1,5 +1,5 @@
 {
-  "name": "Managing Packages with npm",
+  "name": "Managing Packages with NPM",
   "isUpcomingChange": false,
   "dashedName": "managing-packages-with-npm",
   "helpCategory": "JavaScript",

--- a/curriculum/challenges/_meta/project-euler-problems-1-to-100/meta.json
+++ b/curriculum/challenges/_meta/project-euler-problems-1-to-100/meta.json
@@ -1,5 +1,5 @@
 {
-  "name": "project euler problems 1 to 100",
+  "name": "Project Euler Problems 1 to 100",
   "isUpcomingChange": false,
   "dashedName": "project-euler-problems-1-to-100",
   "helpCategory": "Euler",

--- a/curriculum/challenges/_meta/project-euler-problems-101-to-200/meta.json
+++ b/curriculum/challenges/_meta/project-euler-problems-101-to-200/meta.json
@@ -1,5 +1,5 @@
 {
-  "name": "project euler problems 101 to 200",
+  "name": "Project Euler Problems 101 to 200",
   "isUpcomingChange": false,
   "dashedName": "project-euler-problems-101-to-200",
   "helpCategory": "Euler",

--- a/curriculum/challenges/_meta/project-euler-problems-201-to-300/meta.json
+++ b/curriculum/challenges/_meta/project-euler-problems-201-to-300/meta.json
@@ -1,5 +1,5 @@
 {
-  "name": "project euler problems 201 to 300",
+  "name": "Project Euler Problems 201 to 300",
   "isUpcomingChange": false,
   "dashedName": "project-euler-problems-201-to-300",
   "helpCategory": "Euler",

--- a/curriculum/challenges/_meta/project-euler-problems-301-to-400/meta.json
+++ b/curriculum/challenges/_meta/project-euler-problems-301-to-400/meta.json
@@ -1,5 +1,5 @@
 {
-  "name": "project euler problems 301 to 400",
+  "name": "Project Euler Problems 301 to 400",
   "isUpcomingChange": false,
   "dashedName": "project-euler-problems-301-to-400",
   "helpCategory": "Euler",

--- a/curriculum/challenges/_meta/project-euler-problems-401-to-480/meta.json
+++ b/curriculum/challenges/_meta/project-euler-problems-401-to-480/meta.json
@@ -1,5 +1,5 @@
 {
-  "name": "project euler problems 401 to 480",
+  "name": "Project Euler Problems 401 to 480",
   "isUpcomingChange": false,
   "dashedName": "project-euler-problems-401-to-480",
   "helpCategory": "Euler",
@@ -92,7 +92,7 @@
     },
     {
       "id": "5900f5131000cf542c510024",
-      "title": "Problem 421: Prime factors of n15+1"
+      "title": "Problem 421: Prime factors of n^15+1"
     },
     {
       "id": "5900f5131000cf542c510025",

--- a/curriculum/challenges/_meta/sass/meta.json
+++ b/curriculum/challenges/_meta/sass/meta.json
@@ -1,5 +1,5 @@
 {
-  "name": "Sass",
+  "name": "SASS",
   "isUpcomingChange": false,
   "dashedName": "sass",
   "helpCategory": "HTML-CSS",

--- a/curriculum/challenges/_meta/top-basic-function-projects/meta.json
+++ b/curriculum/challenges/_meta/top-basic-function-projects/meta.json
@@ -1,5 +1,5 @@
 {
-  "name": "TOP Basic Function Projects",
+  "name": "Basic Function Projects",
   "isUpcomingChange": true,
   "dashedName": "top-basic-function-projects",
   "helpCategory": "Odin",

--- a/curriculum/challenges/_meta/top-build-a-recipe-project/meta.json
+++ b/curriculum/challenges/_meta/top-build-a-recipe-project/meta.json
@@ -1,5 +1,5 @@
 {
-  "name": "TOP build a recipe project",
+  "name": "Learn HTML Foundations by Building a Recipe Page",
   "isUpcomingChange": false,
   "dashedName": "top-build-a-recipe-project",
   "helpCategory": "Odin",

--- a/curriculum/challenges/_meta/top-introduction-to-flexbox/meta.json
+++ b/curriculum/challenges/_meta/top-introduction-to-flexbox/meta.json
@@ -1,5 +1,5 @@
 {
-  "name": "TOP Introudction to Flexbox",
+  "name": "Introduction to Flexbox",
   "isUpcomingChange": false,
   "dashedName": "top-introduction-to-flexbox",
   "helpCategory": "Odin",

--- a/curriculum/challenges/_meta/top-learn-block-and-inline/meta.json
+++ b/curriculum/challenges/_meta/top-learn-block-and-inline/meta.json
@@ -1,5 +1,5 @@
 {
-  "name": "TOP Learn Block and Inline",
+  "name": "Learn the difference between Block and Inline",
   "isUpcomingChange": false,
   "dashedName": "top-learn-block-and-inline",
   "helpCategory": "Odin",

--- a/curriculum/challenges/_meta/top-learn-css-foundations-projects/meta.json
+++ b/curriculum/challenges/_meta/top-learn-css-foundations-projects/meta.json
@@ -1,5 +1,5 @@
 {
-  "name": "TOP Learn CSS Foundations Projects",
+  "name": "Learn CSS Foundations Projects",
   "isUpcomingChange": false,
   "dashedName": "top-learn-css-foundations-projects",
   "helpCategory": "Odin",

--- a/curriculum/challenges/_meta/top-learn-css-foundations/meta.json
+++ b/curriculum/challenges/_meta/top-learn-css-foundations/meta.json
@@ -1,5 +1,5 @@
 {
-  "name": "TOP Learn CSS Foundations",
+  "name": "Learn CSS Foundations",
   "isUpcomingChange": false,
   "dashedName": "top-learn-css-foundations",
   "helpCategory": "Odin",

--- a/curriculum/challenges/_meta/top-learn-css-specificity/meta.json
+++ b/curriculum/challenges/_meta/top-learn-css-specificity/meta.json
@@ -1,5 +1,5 @@
 {
-  "name": "TOP Learn CSS Specificity",
+  "name": "Learn CSS Specificity",
   "dashedName": "top-learn-css-specificity",
   "isUpcomingChange": false,
   "helpCategory": "Odin",

--- a/curriculum/challenges/_meta/top-learn-data-types-and-conditionals/meta.json
+++ b/curriculum/challenges/_meta/top-learn-data-types-and-conditionals/meta.json
@@ -1,5 +1,5 @@
 {
-  "name": "TOP Learn Data Types and Conditionals",
+  "name": "Learn Data Types and Conditionals",
   "isUpcomingChange": true,
   "dashedName": "top-learn-data-types-and-conditionals",
   "helpCategory": "Odin",

--- a/curriculum/challenges/_meta/top-learn-function-basics/meta.json
+++ b/curriculum/challenges/_meta/top-learn-function-basics/meta.json
@@ -1,5 +1,5 @@
 {
-  "name": "TOP Learn function basics",
+  "name": "Learn Function Basics",
   "isUpcomingChange": true,
   "dashedName": "top-learn-function-basics",
   "helpCategory": "Odin",

--- a/curriculum/challenges/_meta/top-learn-html-foundations/meta.json
+++ b/curriculum/challenges/_meta/top-learn-html-foundations/meta.json
@@ -1,5 +1,5 @@
 {
-  "name": "TOP Learn HTML Foundations",
+  "name": "Learn HTML Foundations",
   "isUpcomingChange": false,
   "dashedName": "top-learn-html-foundations",
   "helpCategory": "Odin",

--- a/curriculum/challenges/_meta/top-learn-variables-and-operators/meta.json
+++ b/curriculum/challenges/_meta/top-learn-variables-and-operators/meta.json
@@ -1,5 +1,5 @@
 {
-  "name": "TOP Learn Variables and Operators",
+  "name": "Learn Variables and Operators",
   "isUpcomingChange": true,
   "dashedName": "top-learn-variables-and-operators",
   "helpCategory": "Odin",

--- a/curriculum/challenges/_meta/top-links-and-images/meta.json
+++ b/curriculum/challenges/_meta/top-links-and-images/meta.json
@@ -1,5 +1,5 @@
 {
-    "name": "TOP Links and Images",
+    "name": "Links and Images",
     "isUpcomingChange": false,
     "dashedName": "top-links-and-images",
     "helpCategory": "Odin",

--- a/curriculum/challenges/_meta/top-the-box-model/meta.json
+++ b/curriculum/challenges/_meta/top-the-box-model/meta.json
@@ -1,5 +1,5 @@
 {
-    "name": "TOP Learn Box Model",
+    "name": "Learn the Box Model",
     "isUpcomingChange": false,
     "dashedName": "top-the-box-model",
     "helpCategory": "Odin",

--- a/curriculum/challenges/_meta/top-working-with-text/meta.json
+++ b/curriculum/challenges/_meta/top-working-with-text/meta.json
@@ -1,5 +1,5 @@
 {
-    "name": "TOP Working with Text",
+    "name": "Working with Text",
     "isUpcomingChange": false,
     "dashedName": "top-working-with-text",
     "helpCategory": "Odin",

--- a/curriculum/challenges/_meta/upcoming-python-project/meta.json
+++ b/curriculum/challenges/_meta/upcoming-python-project/meta.json
@@ -2,6 +2,7 @@
   "name": "Upcoming Python Project",
   "isUpcomingChange": true,
   "dashedName": "upcoming-python-project",
+  "hasEditableBoundaries": true,
   "helpCategory": "Python",
   "order": 1,
   "time": "2 hours",

--- a/curriculum/challenges/english/16-the-odin-project/top-working-with-text/working-with-text-question-h.md
+++ b/curriculum/challenges/english/16-the-odin-project/top-working-with-text/working-with-text-question-h.md
@@ -1,7 +1,7 @@
 ---
 id: 637f4e3e72c65bc8e73dfe24
 videoId: kcHKFZBVtf4
-title: Working with Text Question H
+title: Working With Text Question H
 challengeType: 15
 dashedName: working-with-text-question-h
 ---

--- a/curriculum/challenges/english/16-the-odin-project/top-working-with-text/working-with-text-question-i.md
+++ b/curriculum/challenges/english/16-the-odin-project/top-working-with-text/working-with-text-question-i.md
@@ -1,6 +1,6 @@
 ---
 id: 637f4e4672c65bc8e73dfe25
-title: Working with Text Question I
+title: Working With Text Question I
 challengeType: 15
 dashedName: working-with-text-question-i
 ---

--- a/curriculum/challenges/english/16-the-odin-project/top-working-with-text/working-with-text-question-j.md
+++ b/curriculum/challenges/english/16-the-odin-project/top-working-with-text/working-with-text-question-j.md
@@ -1,6 +1,6 @@
 ---
 id: 637f4e5172c65bc8e73dfe26
-title: Working with Text Question J
+title: Working With Text Question J
 challengeType: 15
 dashedName: working-with-text-question-j
 ---

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a2a7b05241026c429e3f0.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a2a7b05241026c429e3f0.md
@@ -1,6 +1,6 @@
 ---
 id: 656a2a7b05241026c429e3f0
-title: "Dialogue 2: Tom Meets the Coworker Next To Him"
+title: "Dialogue 2: Tom Meets the Coworker Next to Him"
 challengeType: 21
 dashedName: dialogue-2-tom-meets-the-coworker-next-to-him
 ---

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/655c9a549835a8601764bd0b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/655c9a549835a8601764bd0b.md
@@ -1,6 +1,6 @@
 ---
 id: 655c9a549835a8601764bd0b
-title: "Dialogue 3: Maria And Mark Talk about Their Projects"
+title: "Dialogue 3: Maria and Mark Talk about Their Projects"
 challengeType: 21
 dashedName: dialogue-maria-and-mark-talk-about-their-projects
 ---

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65b0dd4e70e9dcf7c402eb8e.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65b0dd4e70e9dcf7c402eb8e.md
@@ -1,6 +1,6 @@
 ---
 id: 65b0dd4e70e9dcf7c402eb8e
-title: "Dialogue 1: Describing Other People And What They Do"
+title: "Dialogue 1: Describing Other People and What They Do"
 challengeType: 21
 dashedName: dialogue-1-describing-other-people-and-what-they-do
 ---

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655699a46134fa74acaf6204.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655699a46134fa74acaf6204.md
@@ -1,6 +1,6 @@
 ---
 id: 655699a46134fa74acaf6204
-title: "Dialogue 1: Learn How to Discuss Your Morning or Evening Routine"
+title: "Dialogue 1: Learn How to Discuss your Morning or Evening Routine"
 challengeType: 21
 dashedName: learn-how-to-discuss-your-morning-or-evening-routine
 ---

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655a9f8d6d3af8538a178166.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655a9f8d6d3af8538a178166.md
@@ -1,6 +1,6 @@
 ---
 id: 655a9f8d6d3af8538a178166
-title: "Dialogue 4: Brian and Maria Talk About Eventful Evenings"
+title: "Dialogue 4: Brian and Maria Talk about Eventful Evenings"
 challengeType: 21
 dashedName: dialogue-brian-and-maria-talk-about-eventful-evenings
 ---

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655b34a4b45a76689cb429c6.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655b34a4b45a76689cb429c6.md
@@ -1,6 +1,6 @@
 ---
 id: 655b34a4b45a76689cb429c6
-title: "Dialogue 5: Sophie and Brian Talk About the Weekend"
+title: "Dialogue 5: Sophie and Brian Talk about the Weekend"
 challengeType: 21
 dashedName: dialogue-sophie-and-brian-talk-about-the-weekend
 ---

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a351bd69b0b72d7ed24eb5.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a351bd69b0b72d7ed24eb5.md
@@ -1,6 +1,6 @@
 ---
 id: 65a351bd69b0b72d7ed24eb5
-title: "Dialogue 3: Talking About Motivations to Pursue a Career"
+title: "Dialogue 3: Talking about Motivations to Pursue a Career"
 challengeType: 21
 dashedName: dialogue-3-talking-about-motivations-to-pursue-a-career
 ---

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6614abad2657585c6229fb4a.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6614abad2657585c6229fb4a.md
@@ -1,6 +1,6 @@
 ---
 id: 6614abad2657585c6229fb4a
-title: "Dialogue 2: Discussing Strategies for the Release of A Product at a Conference Call"
+title: "Dialogue 2: Discussing Strategies for the Release of a Product at a Conference Call"
 challengeType: 21
 dashedName: dialogue-2-discussing-strategies-for-the-release-of-a-product-at-a-conference-call
 ---


### PR DESCRIPTION
The CAP Database doesn't have a lot of information from certain areas of the curriculum, like the meta.json files. We just added the block titles from the intro.json file, and the used challenge titles from the challenge markdown files. So when trying to recreate the curriculum.json file from the CAP DB/API, we use those - and those don't match what's in the curriculum.json file cause there's differences in the titles, for instance, in the markdown and the meta.json. This PR aligns the titles with what is in the markdown, and the block names with what's in the intro.json - there's a few other minor changes as well.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
