### PR TITLE
feat(api): port /confirm-email to new api

### DIFF
--- a/api/jest.utils.ts
+++ b/api/jest.utils.ts
@@ -46,16 +46,21 @@ export function superRequest(
   config: {
     method: 'GET' | 'POST' | 'PUT' | 'DELETE';
     setCookies?: string[];
+    headers?: { referer: string };
   },
   options?: Options
 ): request.Test {
-  const { method, setCookies } = config;
+  const { method, setCookies, headers } = config;
   const { sendCSRFToken = true } = options ?? {};
 
   const req = requests[method](resource).set('Origin', ORIGIN);
 
   if (setCookies) {
     void req.set('Cookie', getCookies(setCookies));
+  }
+
+  if (headers) {
+    void req.set('Referer', headers.referer);
   }
 
   const csrfToken = (setCookies && getCsrfToken(setCookies)) ?? '';

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -180,6 +180,8 @@ export const build = async (
     fastify.log.info(`Swagger UI available at ${API_LOCATION}/documentation`);
   }
 
+  // redirectWithMessage must be registered before codeFlowAuth
+  void fastify.register(redirectWithMessage);
   void fastify.register(codeFlowAuth);
   void fastify.register(prismaPlugin);
   void fastify.register(mobileAuth0Routes);
@@ -199,7 +201,6 @@ export const build = async (
   void fastify.register(deprecatedEndpoints);
   void fastify.register(statusRoute);
   void fastify.register(unsubscribeDeprecated);
-  void fastify.register(redirectWithMessage);
 
   return fastify;
 };

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -36,7 +36,7 @@ import { deprecatedEndpoints } from './routes/deprecated-endpoints';
 import { unsubscribeDeprecated } from './routes/deprecated-unsubscribe';
 import { donateRoutes } from './routes/donate';
 import { emailSubscribtionRoutes } from './routes/email-subscription';
-import { settingRoutes } from './routes/settings';
+import { settingRoutes, settingRedirectRoutes } from './routes/settings';
 import { statusRoute } from './routes/status';
 import { userGetRoutes, userRoutes, userPublicGetRoutes } from './routes/user';
 import {
@@ -188,6 +188,7 @@ export const build = async (
   }
   void fastify.register(challengeRoutes);
   void fastify.register(settingRoutes);
+  void fastify.register(settingRedirectRoutes);
   void fastify.register(donateRoutes);
   void fastify.register(emailSubscribtionRoutes);
   void fastify.register(userRoutes);

--- a/api/src/plugins/code-flow-auth.test.ts
+++ b/api/src/plugins/code-flow-auth.test.ts
@@ -203,4 +203,131 @@ describe('auth', () => {
       expect(res.json()).toEqual({ ok: true });
     });
   });
+
+  describe('authorizeOrRedirect', () => {
+    beforeEach(() => {
+      fastify.addHook('onRequest', fastify.authorizeOrRedirect);
+      fastify.get('/test', () => {
+        return { message: 'ok' };
+      });
+    });
+    it('should redirect to the origin if the access token is missing', async () => {
+      const res = await fastify.inject({
+        method: 'GET',
+        url: '/test'
+      });
+
+      expect(res.headers.location).toBe('http://localhost:8000');
+      expect(res.statusCode).toBe(302);
+    });
+
+    it('should reject if the access token is missing', async () => {
+      const res = await fastify.inject({
+        method: 'GET',
+        url: '/test'
+      });
+
+      expect(res.headers.location).toBe('http://localhost:8000');
+      expect(res.statusCode).toBe(302);
+    });
+
+    it('should reject if the access token is not signed', async () => {
+      const token = jwt.sign(
+        { accessToken: createAccessToken('123') },
+        JWT_SECRET
+      );
+      const res = await fastify.inject({
+        method: 'GET',
+        url: '/test',
+        cookies: {
+          jwt_access_token: token
+        }
+      });
+
+      expect(res.headers.location).toBe('http://localhost:8000');
+      expect(res.statusCode).toBe(302);
+    });
+
+    it('should reject if the access token is invalid', async () => {
+      const token = jwt.sign(
+        { accessToken: createAccessToken('123') },
+        'invalid-secret'
+      );
+
+      const res = await fastify.inject({
+        method: 'GET',
+        url: '/test',
+        cookies: {
+          jwt_access_token: signCookie(token)
+        }
+      });
+
+      expect(res.headers.location).toBe('http://localhost:8000');
+      expect(res.statusCode).toBe(302);
+    });
+
+    it('should reject if the access token has expired', async () => {
+      const token = jwt.sign(
+        { accessToken: createAccessToken('123', -1) },
+        JWT_SECRET
+      );
+
+      const res = await fastify.inject({
+        method: 'GET',
+        url: '/test',
+        cookies: {
+          jwt_access_token: signCookie(token)
+        }
+      });
+
+      expect(res.headers.location).toBe('http://localhost:8000');
+      expect(res.statusCode).toBe(302);
+    });
+
+    it('should reject if the user is not found', async () => {
+      // @ts-expect-error prisma isn't defined, since we're not building the
+      // full application here.
+      fastify.prisma = { user: { findUnique: () => null } };
+      const token = jwt.sign(
+        { accessToken: createAccessToken('123') },
+        JWT_SECRET
+      );
+
+      const res = await fastify.inject({
+        method: 'GET',
+        url: '/test',
+        cookies: {
+          jwt_access_token: signCookie(token)
+        }
+      });
+
+      expect(res.headers.location).toBe('http://localhost:8000');
+      expect(res.statusCode).toBe(302);
+    });
+
+    it('should populate the request with the user if the token is valid', async () => {
+      const fakeUser = { id: '123', username: 'test-user' };
+      // @ts-expect-error prisma isn't defined, since we're not building the
+      // full application here.
+      fastify.prisma = { user: { findUnique: () => fakeUser } };
+      fastify.get('/test-user', req => {
+        expect(req.user).toEqual(fakeUser);
+        return { ok: true };
+      });
+
+      const token = jwt.sign(
+        { accessToken: createAccessToken('123') },
+        JWT_SECRET
+      );
+      const res = await fastify.inject({
+        method: 'GET',
+        url: '/test-user',
+        cookies: {
+          jwt_access_token: signCookie(token)
+        }
+      });
+
+      expect(res.json()).toEqual({ ok: true });
+    });
+  });
 });

--- a/api/src/plugins/code-flow-auth.test.ts
+++ b/api/src/plugins/code-flow-auth.test.ts
@@ -5,6 +5,7 @@ import { COOKIE_DOMAIN, JWT_SECRET } from '../utils/env';
 import { type Token, createAccessToken } from '../utils/tokens';
 import cookies, { sign as signCookie, unsign as unsignCookie } from './cookies';
 import codeFlowAuth from './code-flow-auth';
+import redirectWithMessage, { formatMessage } from './redirect-with-message';
 
 describe('auth', () => {
   let fastify: FastifyInstance;
@@ -12,6 +13,7 @@ describe('auth', () => {
   beforeEach(async () => {
     fastify = Fastify();
     await fastify.register(cookies);
+    await fastify.register(redirectWithMessage);
     await fastify.register(codeFlowAuth);
   });
 
@@ -205,33 +207,26 @@ describe('auth', () => {
   });
 
   describe('authorizeOrRedirect', () => {
+    const redirectLocation = `http://localhost:8000?${formatMessage({ type: 'info', content: 'Only authenticated users can access this route. Please sign in and try again.' })}`;
+
     beforeEach(() => {
       fastify.addHook('onRequest', fastify.authorizeOrRedirect);
       fastify.get('/test', () => {
         return { message: 'ok' };
       });
     });
+
     it('should redirect to the origin if the access token is missing', async () => {
       const res = await fastify.inject({
         method: 'GET',
         url: '/test'
       });
 
-      expect(res.headers.location).toBe('http://localhost:8000');
+      expect(res.headers.location).toBe(redirectLocation);
       expect(res.statusCode).toBe(302);
     });
 
-    it('should reject if the access token is missing', async () => {
-      const res = await fastify.inject({
-        method: 'GET',
-        url: '/test'
-      });
-
-      expect(res.headers.location).toBe('http://localhost:8000');
-      expect(res.statusCode).toBe(302);
-    });
-
-    it('should reject if the access token is not signed', async () => {
+    it('should redirect to the origin if the access token is not signed', async () => {
       const token = jwt.sign(
         { accessToken: createAccessToken('123') },
         JWT_SECRET
@@ -244,11 +239,11 @@ describe('auth', () => {
         }
       });
 
-      expect(res.headers.location).toBe('http://localhost:8000');
+      expect(res.headers.location).toBe(redirectLocation);
       expect(res.statusCode).toBe(302);
     });
 
-    it('should reject if the access token is invalid', async () => {
+    it('should redirect to the origin if the access token is invalid', async () => {
       const token = jwt.sign(
         { accessToken: createAccessToken('123') },
         'invalid-secret'
@@ -262,11 +257,11 @@ describe('auth', () => {
         }
       });
 
-      expect(res.headers.location).toBe('http://localhost:8000');
+      expect(res.headers.location).toBe(redirectLocation);
       expect(res.statusCode).toBe(302);
     });
 
-    it('should reject if the access token has expired', async () => {
+    it('should redirect to the origin if the access token has expired', async () => {
       const token = jwt.sign(
         { accessToken: createAccessToken('123', -1) },
         JWT_SECRET
@@ -280,11 +275,11 @@ describe('auth', () => {
         }
       });
 
-      expect(res.headers.location).toBe('http://localhost:8000');
+      expect(res.headers.location).toBe(redirectLocation);
       expect(res.statusCode).toBe(302);
     });
 
-    it('should reject if the user is not found', async () => {
+    it('should redirect to the origin if the user is not found', async () => {
       // @ts-expect-error prisma isn't defined, since we're not building the
       // full application here.
       fastify.prisma = { user: { findUnique: () => null } };
@@ -301,7 +296,7 @@ describe('auth', () => {
         }
       });
 
-      expect(res.headers.location).toBe('http://localhost:8000');
+      expect(res.headers.location).toBe(redirectLocation);
       expect(res.statusCode).toBe(302);
     });
 

--- a/api/src/plugins/code-flow-auth.ts
+++ b/api/src/plugins/code-flow-auth.ts
@@ -56,9 +56,12 @@ const codeFlowAuth: FastifyPluginCallback = (fastify, _options, done) => {
     _ignored: string
   ) => {
     const { origin } = getRedirectParams(req);
-    // TODO: (Post-MVP) redirect with a message telling the user that they need
-    // to logsin to use the route.
-    void reply.status(302).redirect(origin);
+
+    void reply.redirectWithMessage(origin, {
+      type: 'info',
+      content:
+        'Only authenticated users can access this route. Please sign in and try again.'
+    });
   };
 
   const handleAuth =
@@ -104,4 +107,4 @@ const codeFlowAuth: FastifyPluginCallback = (fastify, _options, done) => {
   done();
 };
 
-export default fp(codeFlowAuth);
+export default fp(codeFlowAuth, { dependencies: ['redirect-with-message'] });

--- a/api/src/plugins/redirect-with-message.ts
+++ b/api/src/plugins/redirect-with-message.ts
@@ -32,15 +32,22 @@ function redirectWithMessage(
   url: string,
   message: Message
 ) {
-  return this.redirect(
-    `${url}?${qs.stringify(
-      {
-        messages: qs.stringify(prepareMessage(message), {
-          arrayFormat: 'index'
-        })
-      },
-      { arrayFormat: 'index' }
-    )}`
+  return this.redirect(`${url}?${formatMessage(message)}`);
+}
+
+/**
+ * Formats the message into a querystring.
+ * @param message The message to format.
+ * @returns The formatted message string.
+ */
+export function formatMessage(message: Message): string {
+  return qs.stringify(
+    {
+      messages: qs.stringify(prepareMessage(message), {
+        arrayFormat: 'index'
+      })
+    },
+    { arrayFormat: 'index' }
   );
 }
 

--- a/api/src/plugins/redirect-with-message.ts
+++ b/api/src/plugins/redirect-with-message.ts
@@ -57,4 +57,4 @@ const plugin: FastifyPluginCallback = (fastify, _options, done) => {
   done();
 };
 
-export default fp(plugin);
+export default fp(plugin, { name: 'redirect-with-message' });

--- a/api/src/routes/settings.test.ts
+++ b/api/src/routes/settings.test.ts
@@ -10,7 +10,7 @@ import {
 } from '../../jest.utils';
 import { formatMessage } from '../plugins/redirect-with-message';
 import { createUserInput } from '../utils/create-user';
-import { API_LOCATION } from '../utils/env';
+import { API_LOCATION, HOME_LOCATION } from '../utils/env';
 import { isPictureWithProtocol, getWaitMessage } from './settings';
 
 const baseProfileUI = {
@@ -209,7 +209,7 @@ describe('settingRoutes', () => {
         const resNoParams = await superGet('/confirm-email');
 
         expect(resNoParams.headers.location).toBe(
-          'http://localhost:8000?' + formatMessage(defaultErrorMessage)
+          `${HOME_LOCATION}?` + formatMessage(defaultErrorMessage)
         );
         expect(resNoParams.status).toBe(302);
       });
@@ -221,7 +221,7 @@ describe('settingRoutes', () => {
         );
 
         expect(res.headers.location).toBe(
-          'http://localhost:8000?' + formatMessage(defaultErrorMessage)
+          `${HOME_LOCATION}?` + formatMessage(defaultErrorMessage)
         );
         expect(res.status).toBe(302);
       });
@@ -232,7 +232,7 @@ describe('settingRoutes', () => {
         );
 
         expect(res.headers.location).toBe(
-          'http://localhost:8000?' + formatMessage(defaultErrorMessage)
+          `${HOME_LOCATION}?` + formatMessage(defaultErrorMessage)
         );
         expect(res.status).toBe(302);
       });
@@ -243,7 +243,7 @@ describe('settingRoutes', () => {
         );
 
         expect(res.headers.location).toBe(
-          'http://localhost:8000?' + formatMessage(defaultErrorMessage)
+          `${HOME_LOCATION}?` + formatMessage(defaultErrorMessage)
         );
         expect(res.status).toBe(302);
       });
@@ -254,7 +254,7 @@ describe('settingRoutes', () => {
         );
 
         expect(res.headers.location).toBe(
-          'http://localhost:8000?' + formatMessage(defaultErrorMessage)
+          `${HOME_LOCATION}?` + formatMessage(defaultErrorMessage)
         );
         expect(res.status).toBe(302);
       });
@@ -276,7 +276,7 @@ describe('settingRoutes', () => {
         );
 
         expect(res.headers.location).toBe(
-          'http://localhost:8000?' + formatMessage(defaultErrorMessage)
+          `${HOME_LOCATION}?` + formatMessage(defaultErrorMessage)
         );
         expect(res.status).toBe(302);
       });
@@ -287,7 +287,7 @@ describe('settingRoutes', () => {
         );
 
         expect(res.headers.location).toBe(
-          'http://localhost:8000?' +
+          `${HOME_LOCATION}?` +
             formatMessage({
               content:
                 'The link to confirm your new email address has expired. Please try again.',
@@ -306,7 +306,7 @@ describe('settingRoutes', () => {
         });
 
         expect(res.headers.location).toBe(
-          'http://localhost:8000?' + formatMessage(successMessage)
+          `${HOME_LOCATION}?` + formatMessage(successMessage)
         );
         expect(user.email).toBe(newEmail);
       });

--- a/api/src/routes/settings.test.ts
+++ b/api/src/routes/settings.test.ts
@@ -199,21 +199,12 @@ describe('settingRoutes', () => {
         await fastifyTestInstance.prisma.authToken.deleteMany({
           where: { id: { in: tokens } }
         });
-
-        // TODO: remove any other changes to the dev user.
         await fastifyTestInstance.prisma.user.update({
           where: { id: defaultUserId },
           data: { newEmail: null, email: defaultUserEmail, emailVerified: true }
         });
       });
 
-      // I think all requests, including bad ones, should be sent back to the origin. Can we check multiple origins or is it enough to check
-      // that the standard redirect logic is used?
-
-      // TODO(mention) The old api cannot handle this.
-      // TODO(mention) Old api redirects to /signin on the LEARN client (which doesn't exist), new
-      // TODO(mention) informative error messages or just 'contact support'?
-      // api just redirects to the homepage.
       it('should reject requests without params', async () => {
         const resNoParams = await superGet('/confirm-email');
 
@@ -1047,9 +1038,7 @@ Happy coding!
 
         expect(res.status).toBe(302);
         expect(res.headers).toMatchObject({
-          // TODO(mention): this is a fix. The old api doesn't send a message.
-          location:
-            'http://localhost:8000?messages=info%5B0%5D%3DOnly%2520authenticated%2520users%2520can%2520access%2520this%2520route.%2520Please%2520sign%2520in%2520and%2520try%2520again.'
+          location: `http://localhost:8000?${formatMessage({ type: 'info', content: 'Only authenticated users can access this route. Please sign in and try again.' })}`
         });
       });
     });

--- a/api/src/routes/settings.test.ts
+++ b/api/src/routes/settings.test.ts
@@ -343,7 +343,6 @@ describe('settingRoutes', () => {
         });
 
         expect(user.newEmail).toBeNull();
-        expect(user.newEmail).toBeNull();
         expect(user.emailVerified).toBe(true);
         expect(user.emailVerifyTTL).toBeNull();
         expect(user.emailAuthLinkTTL).toBeNull();

--- a/api/src/routes/settings.test.ts
+++ b/api/src/routes/settings.test.ts
@@ -141,6 +141,7 @@ describe('settingRoutes', () => {
 
       const validToken =
         '4kZFEVHChxzY7kX1XSzB4uhh8fcUwcqAGWV9hv25hsI6nviVlwzXCv2YE9lENYGy';
+      // This is a valid id for a token, but it doesn't exist in the database
       const validButMissingToken =
         '4kZFEVHChxzY7kX1XSzB4uhh8fcUwcqAGWV9hv25hsI6nviVlwzXCv2YE9lENYGY';
       const tokenWithMissingUser =

--- a/api/src/routes/settings.test.ts
+++ b/api/src/routes/settings.test.ts
@@ -1042,7 +1042,6 @@ Happy coding!
       it('redirects to the HOME_LOCATION with flash message', async () => {
         const res = await superRequest('/confirm-email', {
           method: 'GET',
-          setCookies,
           headers: { referer: 'https://who.knows/' }
         });
 

--- a/api/src/routes/settings.test.ts
+++ b/api/src/routes/settings.test.ts
@@ -799,37 +799,37 @@ Happy coding!
         expect(user?.isClassroomAccount).toEqual(false);
       });
     });
+  });
 
-    describe('Unauthenticated User', () => {
-      let setCookies: string[];
+  describe('Unauthenticated User', () => {
+    let setCookies: string[];
 
-      // Get the CSRF cookies from an unprotected route
-      beforeAll(async () => {
-        const res = await superRequest('/status/ping', { method: 'GET' });
-        setCookies = res.get('Set-Cookie');
-      });
+    // Get the CSRF cookies from an unprotected route
+    beforeAll(async () => {
+      const res = await superRequest('/status/ping', { method: 'GET' });
+      setCookies = res.get('Set-Cookie');
+    });
 
-      const endpoints: { path: string; method: 'PUT' }[] = [
-        { path: '/update-my-profileui', method: 'PUT' },
-        { path: '/update-my-theme', method: 'PUT' },
-        { path: '/update-my-username', method: 'PUT' },
-        { path: '/update-my-keyboard-shortcuts', method: 'PUT' },
-        { path: '/update-my-socials', method: 'PUT' },
-        { path: '/update-my-quincy-email', method: 'PUT' },
-        { path: '/update-my-about', method: 'PUT' },
-        { path: '/update-my-honesty', method: 'PUT' },
-        { path: '/update-privacy-terms', method: 'PUT' },
-        { path: '/update-my-portfolio', method: 'PUT' }
-      ];
+    const endpoints: { path: string; method: 'PUT' }[] = [
+      { path: '/update-my-profileui', method: 'PUT' },
+      { path: '/update-my-theme', method: 'PUT' },
+      { path: '/update-my-username', method: 'PUT' },
+      { path: '/update-my-keyboard-shortcuts', method: 'PUT' },
+      { path: '/update-my-socials', method: 'PUT' },
+      { path: '/update-my-quincy-email', method: 'PUT' },
+      { path: '/update-my-about', method: 'PUT' },
+      { path: '/update-my-honesty', method: 'PUT' },
+      { path: '/update-privacy-terms', method: 'PUT' },
+      { path: '/update-my-portfolio', method: 'PUT' }
+    ];
 
-      endpoints.forEach(({ path, method }) => {
-        test(`${method} ${path} returns 401 status code with error message`, async () => {
-          const response = await superRequest(path, {
-            method,
-            setCookies
-          });
-          expect(response.statusCode).toBe(401);
+    endpoints.forEach(({ path, method }) => {
+      test(`${method} ${path} returns 401 status code with error message`, async () => {
+        const response = await superRequest(path, {
+          method,
+          setCookies
         });
+        expect(response.statusCode).toBe(401);
       });
     });
   });

--- a/api/src/routes/settings.ts
+++ b/api/src/routes/settings.ts
@@ -754,6 +754,7 @@ export const settingRedirectRoutes: FastifyPluginCallbackTypebox = (
         return reply.redirectWithMessage(origin, redirectMessage);
       }
 
+      // TODO(Post-MVP): clean up expired auth tokens.
       if (isExpired(authToken)) {
         return reply.redirectWithMessage(origin, expirationMessage);
       }
@@ -768,6 +769,8 @@ export const settingRedirectRoutes: FastifyPluginCallbackTypebox = (
         return reply.redirectWithMessage(origin, redirectMessage);
       }
 
+      // TODO(Post-MVP): clean up any other auth tokens for this user once
+      // the email is confirmed.
       await Promise.all([
         updateEmail(fastify, { id: targetUser.id, email }),
         deleteAuthToken(fastify, { id: authToken.id })

--- a/api/src/routes/settings.ts
+++ b/api/src/routes/settings.ts
@@ -13,12 +13,12 @@ import type {
   RouteGenericInterface
 } from 'fastify';
 import { ResolveFastifyReplyType } from 'fastify/types/type-provider';
-import { differenceInMinutes, addMilliseconds, isAfter } from 'date-fns';
+import { differenceInMinutes } from 'date-fns';
 import validator from 'validator';
 
 import { isValidUsername } from '../../../shared/utils/validate';
 import * as schemas from '../schemas';
-import { createAuthToken } from '../utils/tokens';
+import { createAuthToken, isExpired } from '../utils/tokens';
 import { API_LOCATION } from '../utils/env';
 import { getRedirectParams } from '../utils/redirection';
 import { isRestricted } from './helpers/is-restricted';
@@ -726,18 +726,10 @@ export const settingRedirectRoutes: FastifyPluginCallbackTypebox = (
       });
 
       if (!authToken) {
-        // TODO
         return reply.redirectWithMessage(origin, redirectMessage);
       }
 
-      const tokenExpirationDate = addMilliseconds(
-        authToken.created,
-        authToken.ttl
-      );
-
-      // TODO: refactor token validation to a helper function in tokens.ts and use it in
-      // code-flow-auth
-      if (isAfter(new Date(), tokenExpirationDate)) {
+      if (isExpired(authToken)) {
         return reply.redirectWithMessage(origin, expirationMessage);
       }
 

--- a/api/src/routes/settings.ts
+++ b/api/src/routes/settings.ts
@@ -439,6 +439,7 @@ ${isLinkSentWithinLimitTTL}`
       }
     }
   );
+
   fastify.put(
     '/update-my-about',
     {
@@ -658,6 +659,14 @@ ${isLinkSentWithinLimitTTL}`
         return { message: 'flash.wrong-updating', type: 'danger' } as const;
       }
     }
+  );
+
+  fastify.get(
+    '/confirm-email',
+    {
+      schema: schemas.confirmEmail
+    },
+    async (_req, _reply) => {}
   );
 
   done();

--- a/api/src/schemas.ts
+++ b/api/src/schemas.ts
@@ -15,6 +15,7 @@ export { chargeStripeCard } from './schemas/donate/charge-stripe-card';
 export { resubscribe } from './schemas/email-subscription/resubscribe';
 export { unsubscribe } from './schemas/email-subscription/unsubscribe';
 export { updateMyAbout } from './schemas/settings/update-my-about';
+export { confirmEmail } from './schemas/settings/confirm-email';
 export { updateMyClassroomMode } from './schemas/settings/update-my-classroom-mode';
 export { updateMyEmail } from './schemas/settings/update-my-email';
 export { updateMyHonesty } from './schemas/settings/update-my-honesty';

--- a/api/src/schemas/settings/confirm-email.ts
+++ b/api/src/schemas/settings/confirm-email.ts
@@ -1,0 +1,8 @@
+import { Type } from '@fastify/type-provider-typebox';
+
+export const confirmEmail = {
+  querystring: Type.Object({
+    email: Type.String({ maxLength: 1000 }),
+    token: Type.String({ minLength: 64, maxLength: 64 })
+  })
+};

--- a/api/src/utils/tokens.test.ts
+++ b/api/src/utils/tokens.test.ts
@@ -1,5 +1,7 @@
+jest.useFakeTimers();
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import { createAccessToken, createAuthToken } from './tokens';
+import { createAccessToken, createAuthToken, isExpired } from './tokens';
+
 
 describe('createAccessToken', () => {
   it('creates an object with id, ttl, created and userId', () => {
@@ -50,5 +52,27 @@ describe('createAuthToken', () => {
 
     expect(actual.ttl).toBe(ttl);
     expect(createAuthToken(userId).ttl).toBe(900000);
+  })
+});
+
+describe('isExpired', () => {
+  it('returns true if the token expiry date is in the past', () => {
+    const token = createAccessToken('abc', 1000);
+    expect(isExpired(token)).toBe(false);
+    jest.advanceTimersByTime(500);
+    expect(isExpired(token)).toBe(false);
+    jest.advanceTimersByTime(500);
+    expect(isExpired(token)).toBe(false);
+    jest.advanceTimersByTime(1);
+    expect(isExpired(token)).toBe(true);
+  });
+
+  it('handles tokens with Date values for created', () => {
+    const token = { ...createAccessToken('abc', 2000), created: new Date() };
+    expect(isExpired(token)).toBe(false);
+    jest.advanceTimersByTime(2000);
+    expect(isExpired(token)).toBe(false);
+    jest.advanceTimersByTime(1);
+    expect(isExpired(token)).toBe(true);
   });
 });

--- a/api/src/utils/tokens.test.ts
+++ b/api/src/utils/tokens.test.ts
@@ -2,7 +2,6 @@ jest.useFakeTimers();
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { createAccessToken, createAuthToken, isExpired } from './tokens';
 
-
 describe('createAccessToken', () => {
   it('creates an object with id, ttl, created and userId', () => {
     const userId = 'abc';
@@ -52,7 +51,7 @@ describe('createAuthToken', () => {
 
     expect(actual.ttl).toBe(ttl);
     expect(createAuthToken(userId).ttl).toBe(900000);
-  })
+  });
 });
 
 describe('isExpired', () => {

--- a/api/src/utils/tokens.ts
+++ b/api/src/utils/tokens.ts
@@ -20,6 +20,13 @@ export type Token = {
   created: string;
 };
 
+type DbToken = {
+  userId: string;
+  id: string;
+  ttl: number;
+  created: Date;
+};
+
 /**
  * Creates an access token.
  * @param userId The user ID as a string (yes, it's an ObjectID, but it will be serialized to a string anyway).
@@ -48,4 +55,14 @@ export const createAuthToken = (userId: string, ttl?: number): Token => {
     ttl: ttl ?? 900000,
     created: new Date().toISOString()
   };
+};
+
+/**
+ * Check if an access token has expired.
+ * @param token The access token to check.
+ * @returns True if the token has expired, false otherwise.
+ */
+export const isExpired = (token: Token | DbToken): boolean => {
+  const created = new Date(token.created);
+  return Date.now() > created.getTime() + token.ttl;
 };


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This endpoint did not handle errors very well, but this version should handle all failure states (missing params and so on). Instead of redirecting to www.freecodecamp.org/signin (which doesn't exist) on failure, it sends you back to www.freecodecamp.org with a query param explaining that something went wrong.

The error messages are a little generic (and only English), so there's room for improvement there, but I wanted to keep things simple for now.

Closes: https://github.com/freeCodeCamp/freeCodeCamp/issues/54922

<!-- Feel free to add any additional description of changes below this line -->
