### PR TITLE
fix(client): hide breadcrumbs for mobile views

### DIFF
--- a/client/src/templates/Challenges/classic/classic.css
+++ b/client/src/templates/Challenges/classic/classic.css
@@ -190,7 +190,6 @@
 
 #mobile-layout .portal-button-wrap {
   position: absolute;
-  top: calc(var(--header-height) + var(--breadcrumbs-height));
   right: 0;
   height: 2rem;
   border-bottom: 1px solid var(--quaternary-color);

--- a/client/src/templates/Challenges/classic/editor.css
+++ b/client/src/templates/Challenges/classic/editor.css
@@ -33,6 +33,12 @@ textarea.inputarea {
   height: var(--breadcrumbs-height);
 }
 
+@media only screen and (max-width: 768px) {
+  .breadcrumbs-demo {
+    display: none;
+  }
+}
+
 .editor-upper-jaw,
 .editor-lower-jaw {
   padding-inline: 0 15px;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Addresses #49054

This PR was opened to reduce the space taken up by the fixed contents above the editor (breadcrumb), partially addressing the original issue as a first step.

When the viewport height is 768px or less, the breadcrumb is removed from view to allow for more space in working and interacting with the editor.

<!-- Feel free to add any additional description of changes below this line -->
- Images
![Original Version](https://github.com/freeCodeCamp/freeCodeCamp/assets/91735098/68211a70-f496-4188-a257-2b2670ba2c73)
![Changes Made](https://github.com/freeCodeCamp/freeCodeCamp/assets/91735098/a4a4abaf-83b4-4148-bd4e-f398864f09e7)
