### PR TITLE
fix(curriculum): fix class names in cat painting project

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-intermediate-css-by-building-a-cat-painting/646ce9d790d2a44de5f99e04.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-intermediate-css-by-building-a-cat-painting/646ce9d790d2a44de5f99e04.md
@@ -11,13 +11,13 @@ Create two `div` elements, the first inside the `.cat-left-ear` element with a c
 
 # --hints--
 
-You should not change the existing `div` element with the class `cat-left-inner-ear`.
+You should not change the existing `div` element with the class `cat-left-ear`.
 
 ```js
 assert(document.querySelectorAll('div.cat-left-ear').length === 1);
 ```
 
-You should not change the existing `div` element with the class `cat-right-inner-ear`.
+You should not change the existing `div` element with the class `cat-right-ear`.
 
 ```js
 assert(document.querySelectorAll('div.cat-right-ear').length === 1);

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-intermediate-css-by-building-a-cat-painting/646ddd3f9f97a0667b964bdb.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-intermediate-css-by-building-a-cat-painting/646ddd3f9f97a0667b964bdb.md
@@ -17,7 +17,7 @@ You should not change the existing `div` element with the class `cat-left-eye`.
 assert(document.querySelectorAll('div.cat-left-eye').length === 1);
 ```
 
-You should not change the existing `div` element with the class `.cat-right-eye`.
+You should not change the existing `div` element with the class `cat-right-eye`.
 
 ```js
 assert(document.querySelectorAll('div.cat-right-eye').length === 1);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

- Step 21: Correct the class names of the existing elements
- Step 40: Remove unnecessary dot since it is referring to the class name itself here, not the element selected by `.cat-right-eye` selector
