### PR TITLE
fix(a11y): aria label for /learn search

### DIFF
--- a/client/src/components/search/searchBar/search-bar.tsx
+++ b/client/src/components/search/searchBar/search-bar.tsx
@@ -212,7 +212,7 @@ export class SearchBar extends Component<SearchBarProps, SearchBarState> {
           <HotKeys handlers={this.keyHandlers} keyMap={this.keyMap}>
             <div className='fcc_search_wrapper'>
               <ObserveKeys except={['Space']}>
-                <div onFocus={this.handleFocus} role='textbox'>
+                <div onFocus={this.handleFocus}>
                   <label
                     className='sr-only'
                     htmlFor='unoptimized-SearchBox-input'
@@ -220,7 +220,7 @@ export class SearchBar extends Component<SearchBarProps, SearchBarState> {
                     {t('search.label')}
                   </label>
                   <SearchBox
-                    id='unoptimized-SearchBox-input'
+                    inputId='unoptimized-SearchBox-input'
                     data-playwright-test-label='header-search'
                     focusShortcuts={['83', '191']}
                     onChange={this.handleChange}

--- a/client/src/components/search/searchBar/search-bar.tsx
+++ b/client/src/components/search/searchBar/search-bar.tsx
@@ -213,7 +213,14 @@ export class SearchBar extends Component<SearchBarProps, SearchBarState> {
             <div className='fcc_search_wrapper'>
               <ObserveKeys except={['Space']}>
                 <div onFocus={this.handleFocus} role='textbox'>
+                  <label
+                    className='sr-only'
+                    htmlFor='unoptimized-SearchBox-input'
+                  >
+                    {t('search.label')}
+                  </label>
                   <SearchBox
+                    id='unoptimized-SearchBox-input'
                     data-playwright-test-label='header-search'
                     focusShortcuts={['83', '191']}
                     onChange={this.handleChange}


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Closes #54977

First pass on fixing this issue based on [mmatsumoto1026](https://github.com/mmatsumoto1026)'s findings in the GitHub issue. I know accessibility fixes can be complex, so publishing this draft for feedback and review.