### PR TITLE
fix(curriculum): Clarified language around printing result

### DIFF
--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-the-bisection-method-by-finding-the-square-root-of-a-number/65ef1eac497754cafa12a26c.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-the-bisection-method-by-finding-the-square-root-of-a-number/65ef1eac497754cafa12a26c.md
@@ -7,7 +7,7 @@ dashedName: step-21
 
 # --description--
 
-Call the `square_root_bisection` function with the `N` variable as the argument. This will print the result to the console. 
+Call the `square_root_bisection` function with the `N` variable as the argument. This will print the result to the console.
 
 Experiment with larger values.
 

--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-the-bisection-method-by-finding-the-square-root-of-a-number/65ef1eac497754cafa12a26c.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-the-bisection-method-by-finding-the-square-root-of-a-number/65ef1eac497754cafa12a26c.md
@@ -7,7 +7,7 @@ dashedName: step-21
 
 # --description--
 
-Call the `square_root_bisection` function with the `N` variable as the argument and print the result.
+Call the `square_root_bisection` function with the `N` variable as the argument. This will print the result to the console. 
 
 Experiment with larger values.
 
@@ -15,7 +15,7 @@ With this, you have successfully implemented the bisection method to find the sq
  
 # --hints--
 
-You should call the `square_root_bisection` function with the `N` variable as the argument and print the result.
+You should call the `square_root_bisection` function with the variable `N` as the argument.
 
 ```js
 ({ 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Closes #55039 

<!-- Feel free to add any additional description of changes below this line -->
Previously, the instructions implied that printing the result was a separate action from calling the `square_root_bisection` function. The function itself actually prints the result, so updated the language to avoid this ambiguity. Also updated similar language in the hint. 