### PR TITLE
fix(api): use challenge helper to update completed challenges

### DIFF
--- a/api/src/routes/challenge.test.ts
+++ b/api/src/routes/challenge.test.ts
@@ -1201,7 +1201,6 @@ describe('challengeRoutes', () => {
               completedDate
             });
 
-            // TODO: use a custom matcher for thisu
             expect(completedDate).toBeGreaterThan(now);
             expect(completedDate).toBeLessThan(now + 1000);
             expect(res.statusCode).toBe(200);

--- a/api/src/routes/challenge.test.ts
+++ b/api/src/routes/challenge.test.ts
@@ -550,7 +550,7 @@ describe('challengeRoutes', () => {
 
           // If a challenge has already been completed, it should return the
           // original completedDate
-          expect(resUpdate.body.completedDate).not.toBe(
+          expect(resUpdate.body.completedDate).toBe(
             resOriginal.body.completedDate
           );
           expect(resUpdate.statusCode).toBe(200);

--- a/api/src/routes/challenge.ts
+++ b/api/src/routes/challenge.ts
@@ -38,6 +38,17 @@ interface JwtPayload {
   userToken: string;
 }
 
+// TODO(Post-MVP): This could be narrowed down to only the fields needed by
+// specific endpoints, but that means complicating the update helper.
+const userChallengeSelect = {
+  id: true,
+  completedChallenges: true,
+  partiallyCompletedChallenges: true,
+  progressTimestamps: true,
+  needsModeration: true,
+  savedChallenges: true
+};
+
 /**
  * Plugin for the challenge submission endpoints.
  *
@@ -215,9 +226,8 @@ export const challengeRoutes: FastifyPluginCallbackTypebox = (
       }
 
       const user = await fastify.prisma.user.findUniqueOrThrow({
-        where: { id: userId }
-        // TODO: update updateUserChallengeData to handle the subset of user
-        // fields we want to select, rather than having to select all fields
+        where: { id: userId },
+        select: userChallengeSelect
       });
 
       if (
@@ -274,7 +284,9 @@ export const challengeRoutes: FastifyPluginCallbackTypebox = (
     },
     async req => {
       const user = await fastify.prisma.user.findUniqueOrThrow({
-        where: { id: req.user?.id }
+        where: { id: req.user?.id },
+
+        select: userChallengeSelect
       });
       const progressTimestamps = user.progressTimestamps as
         | ProgressTimestamp[]
@@ -318,7 +330,8 @@ export const challengeRoutes: FastifyPluginCallbackTypebox = (
       const { id, files, challengeType } = req.body;
 
       const user = await fastify.prisma.user.findUniqueOrThrow({
-        where: { id: req.user?.id }
+        where: { id: req.user?.id },
+        select: userChallengeSelect
       });
       const RawProgressTimestamp = user.progressTimestamps as
         | ProgressTimestamp[]
@@ -532,8 +545,8 @@ export const challengeRoutes: FastifyPluginCallbackTypebox = (
         }
 
         const user = await fastify.prisma.user.findUniqueOrThrow({
-          where: { id: req.user?.id }
-          // TODO: select only the fields we need
+          where: { id: req.user?.id },
+          select: userChallengeSelect
         });
 
         const progressTimestamps =

--- a/api/src/routes/helpers/challenge-helpers.ts
+++ b/api/src/routes/helpers/challenge-helpers.ts
@@ -1,7 +1,3 @@
-import type { Prisma } from '@prisma/client';
-
-import type { ProgressTimestamp } from '../../utils/progress';
-
 /**
  * Confirm that a user can submit a CodeRoad project.
  *
@@ -25,39 +21,6 @@ export const canSubmitCodeRoadCertProject = (
   if (completedChallenges.some(c => c.id === id)) return true;
   return false;
 };
-
-/**
- * Create the Prisma query to update a project.
- * @param id The id of the project.
- * @param newChallenge The challenge corresponding to the project.
- * @returns A Prisma query to update the project.
- */
-export const updateProject = (
-  id: string,
-  newChallenge: Prisma.CompletedChallengeUpdateInput
-) => ({
-  completedChallenges: {
-    updateMany: { where: { id }, data: newChallenge }
-  },
-  partiallyCompletedChallenges: { deleteMany: { where: { id } } }
-});
-
-/**
- * Create the Prisma query to create a project.
- * @param id The id of the project.
- * @param newChallenge The challenge corresponding to the project.
- * @param progressTimestamps The user's current progress timestamps.
- * @returns A Prisma query to update the project.
- */
-export const createProject = (
-  id: string,
-  newChallenge: Prisma.CompletedChallengeCreateInput,
-  progressTimestamps: ProgressTimestamp[]
-) => ({
-  completedChallenges: { push: newChallenge },
-  partiallyCompletedChallenges: { deleteMany: { where: { id } } },
-  progressTimestamps: [...progressTimestamps, newChallenge.completedDate]
-});
 
 type MSProfileError = {
   type: 'error';

--- a/api/src/utils/common-challenge-functions.ts
+++ b/api/src/utils/common-challenge-functions.ts
@@ -107,8 +107,7 @@ export function saveUserChallengeData(
 /**
  * Helper function to update a user's challenge data. Used in challenge
  * submission endpoints.
- *
- * @deprecated Create specific functions for each submission endpoint.
+ * TODO: Keep refactoring. This function does too much.
  * @param fastify The Fastify instance.
  * @param user The existing user record.
  * @param challengeId The id of the submitted challenge.
@@ -150,7 +149,6 @@ export async function updateUserChallengeData(
     completedChallenge = omit(_completedChallenge, ['files']);
   }
 
-  // Since these values are destuctured for easier updating, collectively update before returning
   const {
     timezone: userTimezone,
     completedChallenges = [],

--- a/api/src/utils/common-challenge-functions.ts
+++ b/api/src/utils/common-challenge-functions.ts
@@ -112,15 +112,21 @@ export function saveUserChallengeData(
  * @param user The existing user record.
  * @param challengeId The id of the submitted challenge.
  * @param _completedChallenge The challenge submission.
- * @param timezone The user's timezone.
  * @returns Information about the update.
  */
 export async function updateUserChallengeData(
   fastify: FastifyInstance,
-  user: user,
+  user: Pick<
+    user,
+    | 'id'
+    | 'completedChallenges'
+    | 'needsModeration'
+    | 'savedChallenges'
+    | 'progressTimestamps'
+    | 'partiallyCompletedChallenges'
+  >,
   challengeId: string,
-  _completedChallenge: CompletedChallenge,
-  timezone?: string // TODO: is this required as its not given as a arg anywhere
+  _completedChallenge: CompletedChallenge
 ) {
   const { files, completedDate: newProgressTimeStamp = Date.now() } =
     _completedChallenge;
@@ -150,7 +156,6 @@ export async function updateUserChallengeData(
   }
 
   const {
-    timezone: userTimezone,
     completedChallenges = [],
     needsModeration = false,
     savedChallenges = [],
@@ -204,20 +209,6 @@ export async function updateUserChallengeData(
   const userPartiallyCompletedChallenges = partiallyCompletedChallenges.filter(
     challenge => challenge.id !== challengeId
   );
-
-  if (
-    timezone &&
-    timezone !== 'UTC' &&
-    !userTimezone &&
-    userTimezone === 'UTC'
-  ) {
-    await fastify.prisma.user.update({
-      where: { id: user.id },
-      data: {
-        timezone: userTimezone
-      }
-    });
-  }
 
   if (needsModeration) {
     await fastify.prisma.user.update({

--- a/api/src/utils/common-challenge-functions.ts
+++ b/api/src/utils/common-challenge-functions.ts
@@ -163,7 +163,7 @@ export async function updateUserChallengeData(
 
   const userCompletedChallenges: CompletedChallenge[] = completedChallenges;
   const userSavedChallenges: SavedChallenge[] = savedChallenges;
-  const userProgressTimestamps = progressTimestamps;
+  let userProgressTimestamps = progressTimestamps;
   const userPartiallyCompletedChallenges = partiallyCompletedChallenges;
 
   const oldIndex = userCompletedChallenges.findIndex(
@@ -187,7 +187,10 @@ export async function updateUserChallengeData(
       ...completedChallenge
     };
     if (userProgressTimestamps && Array.isArray(userProgressTimestamps)) {
-      userProgressTimestamps.push(newProgressTimeStamp);
+      userProgressTimestamps = [
+        ...userProgressTimestamps,
+        newProgressTimeStamp
+      ];
     }
     userCompletedChallenges.push(finalChallenge);
   }


### PR DESCRIPTION
- **test: completedDate should not update**
- **fix: use helper in /project-completed**
- **refactor: use helper function for trophy route**
- **fix: stop mutating some argument properties**
- **refactor: simplify updateUserChallengeData**
- **fix: de-deprecate helper**

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Splitting this functionality into separate helpers was a mistake. It makes it more likely that we have inconsistent behaviour between the various submission endpoints.

Since I think we should keep using (some form of) the helper, I cleaned it up a little and fixed a bug caused by the fact it modified its input.

<!-- Feel free to add any additional description of changes below this line -->
