### PR TITLE
fix(client): remove side margin of completion indicator

### DIFF
--- a/client/src/components/profile/components/camper.css
+++ b/client/src/components/profile/components/camper.css
@@ -86,7 +86,7 @@
   margin-left: 1rem;
 }
 
-.badge {
+.camper-badge {
   margin-right: 1em;
 }
 @media (max-width: 768px) {

--- a/client/src/templates/Introduction/components/challenges.tsx
+++ b/client/src/templates/Introduction/components/challenges.tsx
@@ -32,7 +32,7 @@ const Challenge = ({
   challenge: ChallengeWithCompletedNode;
 }) => (
   <Link to={challenge.fields.slug}>
-    <span className='badge map-badge'>
+    <span className='map-badge'>
       <CheckMark isCompleted={challenge.isCompleted} />
     </span>
     {challenge.title}
@@ -42,7 +42,7 @@ const Challenge = ({
 const Project = ({ challenge }: { challenge: ChallengeWithCompletedNode }) => (
   <Link to={challenge.fields.slug}>
     {challenge.title}
-    <span className=' badge map-badge map-project-checkmark'>
+    <span className='map-badge map-project-checkmark'>
       <CheckMark isCompleted={challenge.isCompleted} />
     </span>
   </Link>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Removed `badge` from `challenges.tsx` and renamed '.badge' to `.camper-badge` in `camper.css`

Tested on local machine.

<img width="959" alt="Screenshot 2024-05-31 at 5 13 24 PM" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/71681684/8447fa10-1a8e-4664-8e34-4c54516fd858">

Closes #55047 

<!-- Feel free to add any additional description of changes below this line -->
