### PR TITLE
fix(UI): avoid overlapping the progression lines

### DIFF
--- a/client/src/components/Map/map.css
+++ b/client/src/components/Map/map.css
@@ -49,7 +49,7 @@
   content: '';
   display: block;
   width: 2px;
-  height: 39%;
+  height: calc(50% - 26px);
   background-color: var(--secondary-color);
   position: absolute;
   left: calc(36.5%);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
This PR was opened to avoid overlapping the progression lines of the curriculums in landing page and `/learn` page.

<details>
<summary>avoid overlapping the progression lines</summary>

|before|after|
|---|---|
|![progression_lines_overlapping](https://github.com/freeCodeCamp/freeCodeCamp/assets/44451585/0e24e25e-5c98-4c11-add0-8481c81d49ff)|![progression_lines_not_overlapping](https://github.com/freeCodeCamp/freeCodeCamp/assets/44451585/7078dff0-9271-4210-b428-c16e3caaa518)|
</details>


By using gitpod, the code was tested with following environment.

1. Windows 11 Home PC using Chrome, Firefox, Edge, and Brave browser, or, webkit within the Playwright.
1. Android Studio's emulator(Pixel 6 Pro with Android API 34 system image) using Chrome.
1. iPhone SE (iOS 15.7.8) using Chrome and Firefox browser.