### PR TITLE
fix(client): Removed margin from completion indicators

### DIFF
--- a/client/src/components/profile/components/camper.css
+++ b/client/src/components/profile/components/camper.css
@@ -86,7 +86,7 @@
   margin-left: 1rem;
 }
 
-.badge {
+.camper-badge {
   margin-right: 1em;
 }
 @media (max-width: 768px) {

--- a/client/src/components/profile/components/camper.tsx
+++ b/client/src/components/profile/components/camper.tsx
@@ -64,7 +64,7 @@ function Camper({
           <div className='badge-card-container'>
             {isDonating && (
               <div className='badge-card'>
-                <div className='badge'>
+                <div className='camper-badge'>
                   <SupporterBadgeEmblem />
                 </div>
                 <div className='badge-card-description'>
@@ -75,7 +75,7 @@ function Camper({
             )}
             {isTopContributor && (
               <div className='badge-card'>
-                <div className='badge'>
+                <div className='camper-badge'>
                   <TopContibutorBadgeEmblem />
                 </div>
                 <div className='badge-card-description'>

--- a/client/src/templates/Introduction/components/challenges.tsx
+++ b/client/src/templates/Introduction/components/challenges.tsx
@@ -32,7 +32,7 @@ const Challenge = ({
   challenge: ChallengeWithCompletedNode;
 }) => (
   <Link to={challenge.fields.slug}>
-    <span className='badge map-badge'>
+    <span className='map-badge'>
       <CheckMark isCompleted={challenge.isCompleted} />
     </span>
     {challenge.title}
@@ -42,7 +42,7 @@ const Challenge = ({
 const Project = ({ challenge }: { challenge: ChallengeWithCompletedNode }) => (
   <Link to={challenge.fields.slug}>
     {challenge.title}
-    <span className=' badge map-badge map-project-checkmark'>
+    <span className='map-badge map-project-checkmark'>
       <CheckMark isCompleted={challenge.isCompleted} />
     </span>
   </Link>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #55047

<!-- Feel free to add any additional description of changes below this line -->

- Removed `badge` class from `challenges.tsx`
- Renamed the `badge` class in `camper.tsx` to `camper-badge` to avoid future collision
- Renamed the `badge` class in `camper.css` to `camper-badge` accordingly with the new class name in camper.tsx

I tested the changes on GitPod:
<img width="1672" alt="Screenshot of the fCC website that shows the side margin removed" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/126105563/aa7b7ba5-d29f-4645-94f7-0f15791be467">
