### PR TITLE
fix(curriculum): typo in bisection method step 4

### DIFF
--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-the-bisection-method-by-finding-the-square-root-of-a-number/65ef198fde24dfb7ff675b42.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-the-bisection-method-by-finding-the-square-root-of-a-number/65ef198fde24dfb7ff675b42.md
@@ -7,7 +7,7 @@ dashedName: step-4
 
 # --description--
 
-The `raise` statement allows you to force a specific exception to occur. It constists of the `raise` keyword followed by the exception type, and enables you to provide a custom error message:
+The `raise` statement allows you to force a specific exception to occur. It consists of the `raise` keyword followed by the exception type, and enables you to provide a custom error message:
 
 ```py
 raise ValueError("Invalid value")


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->

Corrected a typo in the Scientific Computing with Python course, Bisection Method project, step 4.
                                                                                
Changed:

- `constists` to `consists`