### PR TITLE
chore(client): remove redundant `border-color` rule from donation.css

### DIFF
--- a/client/src/components/Donation/donation.css
+++ b/client/src/components/Donation/donation.css
@@ -445,7 +445,6 @@ button.confirm-donation-btn {
   align-content: center;
   border-radius: 5px;
   background-color: var(--yellow-light);
-  border-color: var(--yellow-light);
   color: black;
   font-weight: bold;
   width: 100%;


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.


Closes #55069

Solves issue #55069 

The donation button is not displaying any border due to the border-none style applied to it. This made the border-color: someColor style redundant and had to be removed.
