### PR TITLE
test(e2e): skip redundant tests using isMacOS

### DIFF
--- a/e2e/completion-modal.spec.ts
+++ b/e2e/completion-modal.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import translations from '../client/i18n/locales/english/translations.json';
+import { isMacOS } from './utils/user-agent';
 
 const nextChallengeURL =
   '/learn/data-analysis-with-python/data-analysis-with-python-projects/demographic-data-analyzer';
@@ -98,8 +99,7 @@ test.describe('Challenge Completion Modal Tests (Signed In)', () => {
 
   test('should display the text of go to next challenge button accordingly based on device type', async ({
     page,
-    isMobile,
-    browserName
+    isMobile
   }) => {
     if (isMobile) {
       await expect(
@@ -108,7 +108,7 @@ test.describe('Challenge Completion Modal Tests (Signed In)', () => {
           exact: true
         })
       ).toBeVisible();
-    } else if (browserName === 'webkit') {
+    } else if (isMacOS) {
       await expect(
         page.getByRole('button', {
           name: 'Submit and go to next challenge (Command + Enter)'
@@ -135,6 +135,8 @@ test.describe('Challenge Completion Modal Tests (Signed In)', () => {
   test('should submit and go to the next challenge when the user presses Ctrl + Enter', async ({
     page
   }) => {
+    test.skip(isMacOS, 'the test is only relevant to non-MacOS devices');
+
     await page.keyboard.press('Control+Enter');
     await expect(page).toHaveURL(nextChallengeURL);
   });
@@ -142,6 +144,8 @@ test.describe('Challenge Completion Modal Tests (Signed In)', () => {
   test('should submit and go to the next challenge when the user presses Command + Enter', async ({
     page
   }) => {
+    test.skip(!isMacOS, 'the test is only relevant to MacOS devices');
+
     await page.keyboard.press('Meta+Enter');
     await expect(page).toHaveURL(nextChallengeURL);
   });

--- a/e2e/editor.spec.ts
+++ b/e2e/editor.spec.ts
@@ -20,14 +20,10 @@ const testPage =
   '/learn/2022/responsive-web-design/learn-html-by-building-a-cat-photo-app/step-3';
 
 test.describe('Editor Component', () => {
-  test('should allow the user to insert text', async ({
-    page,
-    isMobile,
-    browserName
-  }) => {
+  test('should allow the user to insert text', async ({ page, isMobile }) => {
     await page.goto(testPage);
 
-    await focusEditor({ page, isMobile, browserName });
+    await focusEditor({ page, isMobile });
     await page.keyboard.insertText('<h2>FreeCodeCamp</h2>');
     const text = page.getByText('<h2>FreeCodeCamp</h2>');
     await expect(text).toBeVisible();

--- a/e2e/lower-jaw.spec.ts
+++ b/e2e/lower-jaw.spec.ts
@@ -87,7 +87,7 @@ test('Focuses on the submit button after tests passed', async ({
   const submitButton = page.getByRole('button', {
     name: 'Submit and go to next challenge'
   });
-  await focusEditor({ page, browserName, isMobile });
+  await focusEditor({ page, isMobile });
   await clearEditor({ page, browserName });
 
   await editor.fill(

--- a/e2e/progress-bar.spec.ts
+++ b/e2e/progress-bar.spec.ts
@@ -42,7 +42,7 @@ test.describe('Progress bar component', () => {
     await page.goto(
       '/learn/javascript-algorithms-and-data-structures/basic-javascript/declare-javascript-variables'
     );
-    await focusEditor({ page, isMobile, browserName });
+    await focusEditor({ page, isMobile });
     await clearEditor({ page, browserName });
 
     await page.keyboard.insertText('var myName;');


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

In `completion-modal.spec.ts`, we have two test cases for submit keyboard shortcut: `Ctrl+Enter` and `Command+Enter`, and the two tests run on all devices.

This PR updates the tests to only run on relevant devices using the `isMacOS` check. The change shaves ~5 seconds off the test completion time.

<!-- Feel free to add any additional description of changes below this line -->
