### PR TITLE
build: remove all node_modules when cleaning

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "clean:api": "cd api && pnpm clean",
     "clean:client": "cd ./client && pnpm run clean",
     "clean:curriculum": "rm -rf ./shared/config/curriculum.json",
-    "clean:packages": "rm -rf ./node_modules ./**/node_modules",
+    "clean:packages": "find . -name 'node_modules' -type d -prune -exec rm -rf '{}' +",
     "clean:server": "rm -rf ./api-server/lib",
     "create:shared": "tsc -p shared",
     "precypress": "node ./cypress-install.js",


### PR DESCRIPTION
The existing command was not reliably removing all node_modules folders
if they appeared deep in the tree. Using find ensures that rm -rf will
see every node_modules folder.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->
<!-- Feel free to add any additional description of changes below this line -->
