### PR TITLE
fix(client): add padding to the user token section

### DIFF
--- a/client/src/components/settings/user-token.tsx
+++ b/client/src/components/settings/user-token.tsx
@@ -27,14 +27,11 @@ class UserToken extends Component<UserTokenProps> {
     const { t } = this.props;
 
     return (
-      <div
-        data-playwright-test-label='user-token'
-        className='user-token text-center'
-      >
-        <FullWidthRow>
-          <Panel variant='info'>
-            <Panel.Heading>{t('user-token.title')}</Panel.Heading>
-            <Spacer size='medium' />
+      <FullWidthRow>
+        <Panel variant='info' className='text-center'>
+          <Panel.Heading>{t('user-token.title')}</Panel.Heading>
+          <Spacer size='medium' />
+          <Panel.Body>
             <p>{t('user-token.delete-p1')}</p>
             <FullWidthRow>
               <Spacer size='small' />
@@ -49,9 +46,9 @@ class UserToken extends Component<UserTokenProps> {
               </Button>
               <Spacer size='medium' />
             </FullWidthRow>
-          </Panel>
-        </FullWidthRow>
-      </div>
+          </Panel.Body>
+        </Panel>
+      </FullWidthRow>
     );
   }
 }

--- a/e2e/user-token.spec.ts
+++ b/e2e/user-token.spec.ts
@@ -13,7 +13,9 @@ test.afterAll(() => {
 test.describe('Initially', () => {
   test('should not render', async ({ page }) => {
     await page.goto('/settings');
-    await expect(page.getByTestId('user-token')).not.toBeVisible();
+    await expect(
+      page.getByText('User Token', { exact: true })
+    ).not.toBeVisible();
   });
 });
 
@@ -25,11 +27,20 @@ test.describe('After creating token', () => {
     await page.getByRole('button', { name: 'Start the course' }).click();
 
     await page.goto('/settings');
-    await expect(page.getByTestId('user-token')).toBeVisible();
+    // Set `exact` to `true` to only match the panel heading
+    await expect(page.getByText('User Token', { exact: true })).toBeVisible();
+    await expect(
+      page.getByText(
+        'Your user token is used to save your progress on curriculum sections that use a virtual machine. If you suspect it has been compromised, you can delete it without losing any progress. A new one will be created automatically the next time you open a project.'
+      )
+    ).toBeVisible();
     await page.getByRole('button', { name: 'Delete my user token' }).click();
-    await expect(page.getByTestId('flash-message')).toContainText(
+
+    await expect(page.getByRole('alert')).toContainText(
       /Your user token has been deleted./
     );
-    await expect(page.getByTestId('user-token')).not.toBeVisible();
+    await expect(
+      page.getByText('User Token', { exact: true })
+    ).not.toBeVisible();
   });
 });


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR:
- Moves the content of the User Token section to `Panel.Body`, so that the content is properly padded
- Updates `user-token.spec-ts` to query the element without using test ID

## Screenshot

| Before | After |
| --- | --- |
| <img width="777" alt="Screenshot 2024-06-06 at 13 44 13" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/1b267220-ece0-4130-8e83-704537eef2d2"> | <img width="784" alt="Screenshot 2024-06-06 at 13 58 22" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/dd70aa46-2242-4462-b9a6-b4d5002de65c"> |

<!-- Feel free to add any additional description of changes below this line -->
