### PR TITLE
fix(client): handle reset after saving learner code

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -9,3 +9,4 @@ shared/config/donation-settings.js
 shared/config/superblocks.js
 docs/**/*.md
 playwright*.config.ts
+playwright/**

--- a/client/src/redux/save-challenge-saga.js
+++ b/client/src/redux/save-challenge-saga.js
@@ -7,6 +7,7 @@ import {
   challengeDataSelector,
   challengeMetaSelector
 } from '../templates/Challenges/redux/selectors';
+import { createFiles } from '../templates/Challenges/redux/actions';
 import { mapFilesToChallengeFiles, postSaveChallenge } from '../utils/ajax';
 import {
   bodySizeFits,
@@ -56,6 +57,7 @@ function* saveChallengeSaga() {
         if (data?.message) {
           yield put(createFlashMessage(data));
         } else if (data?.savedChallenges) {
+          yield put(createFiles(challengeFiles));
           yield put(
             saveChallengeComplete(
               mapFilesToChallengeFiles(data.savedChallenges)

--- a/client/src/templates/Challenges/redux/actions.js
+++ b/client/src/templates/Challenges/redux/actions.js
@@ -14,7 +14,7 @@ export const createFiles = createAction(
         challengeFile.editableRegionBoundaries
       ),
       seedEditableRegionBoundaries:
-        challengeFile.editableRegionBoundaries?.slice()
+        challengeFile.editableRegionBoundaries?.slice() ?? []
     }))
 );
 

--- a/e2e/challenge-reset-modal.spec.ts
+++ b/e2e/challenge-reset-modal.spec.ts
@@ -158,10 +158,22 @@ test('should close when the user clicks the close button', async ({ page }) => {
   ).toBeHidden();
 });
 
-test('User can reset on a multi-file project', async ({ page }) => {
+test('User can reset on a multi-file project', async ({
+  page,
+  isMobile,
+  browserName
+}) => {
+  const sampleText = 'function palindrome() { return true; }';
+
   await page.goto(
     '/learn/javascript-algorithms-and-data-structures-v8/build-a-palindrome-checker-project/build-a-palindrome-checker'
   );
+
+  await focusEditor({ page, isMobile });
+  await clearEditor({ page, browserName });
+  await getEditors(page).fill(sampleText);
+  await expect(page.getByText(sampleText)).toBeVisible();
+
   await page.getByRole('button', { name: translations.buttons.reset }).click();
 
   await expectToRenderResetModal(page);
@@ -171,4 +183,6 @@ test('User can reset on a multi-file project', async ({ page }) => {
       name: translations.buttons['reset-lesson']
     })
     .click();
+
+  await expect(page.getByText(sampleText)).not.toBeVisible();
 });

--- a/e2e/challenge-reset-modal.spec.ts
+++ b/e2e/challenge-reset-modal.spec.ts
@@ -239,4 +239,42 @@ test.describe('Signed in user', () => {
     await expect(page.getByText(updatedText)).not.toBeVisible();
     await expect(page.getByText(savedText)).toBeVisible();
   });
+
+  test('User can reset on a multi-file project without reloading', async ({
+    page,
+    isMobile,
+    browserName
+  }) => {
+    test.setTimeout(60000);
+    const savedText = 'function palindrome() { return true; }';
+    const updatedText = 'function palindrome() { return false; }';
+
+    await page.goto(
+      '/learn/javascript-algorithms-and-data-structures-v8/build-a-palindrome-checker-project/build-a-palindrome-checker'
+    );
+
+    // This first edit should reappear after the reset
+    await focusEditor({ page, isMobile });
+    await clearEditor({ page, browserName });
+    await getEditors(page).fill(savedText);
+    await page.keyboard.press('Control+S');
+
+    // This second edit should be reset
+    await focusEditor({ page, isMobile });
+    await clearEditor({ page, browserName });
+    await getEditors(page).fill(updatedText);
+
+    await page
+      .getByRole('button', { name: translations.buttons.reset })
+      .click();
+
+    await page
+      .getByRole('button', {
+        name: translations.buttons['reset-lesson']
+      })
+      .click();
+
+    await expect(page.getByText(updatedText)).not.toBeVisible();
+    await expect(page.getByText(savedText)).toBeVisible();
+  });
 });

--- a/e2e/challenge-reset-modal.spec.ts
+++ b/e2e/challenge-reset-modal.spec.ts
@@ -1,15 +1,9 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 
 import translations from '../client/i18n/locales/english/translations.json';
 import { clearEditor, focusEditor, getEditors } from './utils/editor';
 
-test('should render the modal content correctly', async ({ page }) => {
-  await page.goto(
-    '/learn/2022/responsive-web-design/learn-html-by-building-a-cat-photo-app/step-3'
-  );
-
-  await page.getByRole('button', { name: translations.buttons.reset }).click();
-
+const expectToRenderResetModal = async (page: Page) => {
   await expect(
     page.getByRole('dialog', { name: translations.learn.reset })
   ).toBeVisible();
@@ -35,6 +29,16 @@ test('should render the modal content correctly', async ({ page }) => {
       name: translations.buttons['reset-lesson']
     })
   ).toBeVisible();
+};
+
+test('should render the modal content correctly', async ({ page }) => {
+  await page.goto(
+    '/learn/2022/responsive-web-design/learn-html-by-building-a-cat-photo-app/step-3'
+  );
+
+  await page.getByRole('button', { name: translations.buttons.reset }).click();
+
+  await expectToRenderResetModal(page);
 });
 
 test('User can reset challenge', async ({ page, isMobile, browserName }) => {
@@ -155,40 +159,16 @@ test('should close when the user clicks the close button', async ({ page }) => {
 });
 
 test('User can reset on a multi-file project', async ({ page }) => {
-  {
-    await page.goto(
-      '/learn/javascript-algorithms-and-data-structures-v8/build-a-palindrome-checker-project/build-a-palindrome-checker'
-    );
-    await page
-      .getByRole('button', { name: translations.buttons.reset })
-      .click();
+  await page.goto(
+    '/learn/javascript-algorithms-and-data-structures-v8/build-a-palindrome-checker-project/build-a-palindrome-checker'
+  );
+  await page.getByRole('button', { name: translations.buttons.reset }).click();
 
-    await expect(
-      page.getByRole('dialog', { name: translations.learn.reset })
-    ).toBeVisible();
+  await expectToRenderResetModal(page);
 
-    await expect(
-      page.getByRole('button', {
-        name: translations.buttons.close
-      })
-    ).toBeVisible();
-    await expect(
-      page.getByRole('heading', {
-        name: translations.learn.reset
-      })
-    ).toBeVisible();
-
-    await expect(
-      page.getByText(translations.learn['reset-warn'])
-    ).toBeVisible();
-    await expect(
-      page.getByText(translations.learn['reset-warn-2'])
-    ).toBeVisible();
-
-    await expect(
-      page.getByRole('button', {
-        name: translations.buttons['reset-lesson']
-      })
-    ).toBeVisible();
-  }
+  await page
+    .getByRole('button', {
+      name: translations.buttons['reset-lesson']
+    })
+    .click();
 });


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes: https://github.com/freeCodeCamp/freeCodeCamp/issues/55100

Now the behaviour is the same if you save -> reload -> reset or just save -> reset. In both cases the code will be reset to whatever you last saved.

<!-- Feel free to add any additional description of changes below this line -->
