### PR TITLE
fix(curriculum): semantic/grammatical issue

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-advanced-array-methods-by-building-a-statistics-calculator/65c4dc57418fd6bfc710d61d.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-advanced-array-methods-by-building-a-statistics-calculator/65c4dc57418fd6bfc710d61d.md
@@ -7,7 +7,7 @@ dashedName: step-32
 
 # --description--
 
-Inside your `getMode` function, on the empty line above your return call `forEach` on `array`. Your `.forEach()` method should have an empty callback function that takes an `el` parameter.
+Inside your `getMode` function, on the empty line above your `return` statement, call `forEach` on `array`. Your `.forEach()` method should have an empty callback function that takes an `el` parameter.
 
 In the next few steps, you will use this loop to count the frequency of occurrences of each number in the array.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

-  [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #55105 

@Lebussy pointed out a grammatical mistake in the description in #55105, and @Dario-DC suggested a way to fix it.

From:
"Inside your `getMode` function, on the empty line above your return call `forEach` on `array`" 

To:
Inside your `getMode` function, on the empty line above your `return` statement, call `forEach` on `array`.

<!-- Feel free to add any additional description of changes below this line -->
