### PR TITLE
test(e2e): refactor search.spec.ts

### DIFF
--- a/e2e/search-bar-optimized.spec.ts
+++ b/e2e/search-bar-optimized.spec.ts
@@ -19,7 +19,7 @@ const getSearchInput = async ({
   return page.getByLabel('Search');
 };
 
-test.describe('Search', () => {
+test.describe('Search bar optimized', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/');
   });

--- a/e2e/search-bar-optimized.spec.ts
+++ b/e2e/search-bar-optimized.spec.ts
@@ -30,7 +30,7 @@ test.describe('Search bar optimized', () => {
     await expect(searchInput).toBeVisible();
     await expect(searchInput).toHaveAttribute(
       'placeholder',
-      'Search 10,700+ tutorials'
+      translations.search.placeholder
     );
   });
 

--- a/e2e/search.spec.ts
+++ b/e2e/search.spec.ts
@@ -1,5 +1,23 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 import translations from '../client/i18n/locales/english/translations.json';
+
+const getSearchInput = async ({
+  page,
+  isMobile
+}: {
+  page: Page;
+  isMobile: boolean;
+}) => {
+  if (isMobile) {
+    const menuButton = page.getByRole('button', {
+      name: translations.buttons.menu
+    });
+    await expect(menuButton).toBeVisible();
+    await menuButton.click();
+  }
+
+  return page.getByLabel('Search');
+};
 
 test.describe('Search', () => {
   test.beforeEach(async ({ page }) => {
@@ -7,29 +25,13 @@ test.describe('Search', () => {
   });
 
   test('should display correct placeholder', async ({ page, isMobile }) => {
-    if (isMobile) {
-      const menuButton = page.getByRole('button', {
-        name: translations.buttons.menu
-      });
-      await expect(menuButton).toBeVisible();
-      await menuButton.click();
+    const searchInput = await getSearchInput({ page, isMobile });
 
-      const searchInput = page.getByLabel(translations.search.label);
-
-      await expect(searchInput).toBeVisible();
-      await expect(searchInput).toHaveAttribute(
-        'placeholder',
-        'Search 9,000+ tutorials'
-      );
-    } else {
-      const searchInput = page.getByLabel(translations.search.label);
-
-      await expect(searchInput).toBeVisible();
-      await expect(searchInput).toHaveAttribute(
-        'placeholder',
-        'Search 10,700+ tutorials'
-      );
-    }
+    await expect(searchInput).toBeVisible();
+    await expect(searchInput).toHaveAttribute(
+      'placeholder',
+      'Search 10,700+ tutorials'
+    );
   });
 
   test('should return the search results when the user presses Enter', async ({
@@ -37,40 +39,19 @@ test.describe('Search', () => {
     page,
     isMobile
   }) => {
-    if (isMobile) {
-      const menuButton = page.getByRole('button', {
-        name: translations.buttons.menu
-      });
-      await menuButton.click();
+    const searchInput = await getSearchInput({ page, isMobile });
+    await expect(searchInput).toBeVisible();
 
-      const searchInput = page.getByLabel(translations.search.label);
-      await expect(searchInput).toBeVisible();
+    await searchInput.fill('test');
+    await page.keyboard.press('Enter');
 
-      await searchInput.fill('test');
-      await page.keyboard.press('Enter');
+    // Wait for the new page to load.
+    const newPage = await context.waitForEvent('page');
+    await newPage.waitForLoadState();
 
-      // Wait for the new page to load.
-      const newPage = await context.waitForEvent('page');
-      await newPage.waitForLoadState();
-
-      expect(newPage.url()).toBe(
-        'https://www.freecodecamp.org/news/search/?query=test'
-      );
-    } else {
-      const searchInput = page.getByLabel(translations.search.label);
-      await expect(searchInput).toBeVisible();
-
-      await searchInput.fill('test');
-      await page.keyboard.press('Enter');
-
-      // Wait for the new page to load.
-      const newPage = await context.waitForEvent('page');
-      await newPage.waitForLoadState();
-
-      expect(newPage.url()).toBe(
-        'https://www.freecodecamp.org/news/search/?query=test'
-      );
-    }
+    expect(newPage.url()).toBe(
+      'https://www.freecodecamp.org/news/search/?query=test'
+    );
   });
 
   test('should return the search results when the user clicks the search button', async ({
@@ -78,75 +59,35 @@ test.describe('Search', () => {
     page,
     isMobile
   }) => {
-    if (isMobile) {
-      const menuButton = page.getByRole('button', {
-        name: translations.buttons.menu
-      });
-      await menuButton.click();
+    const searchInput = await getSearchInput({ page, isMobile });
+    await expect(searchInput).toBeVisible();
 
-      const searchInput = page.getByLabel(translations.search.label);
-      await expect(searchInput).toBeVisible();
+    await searchInput.fill('test');
+    await page
+      .getByRole('button', { name: translations.icons.magnifier })
+      .click();
 
-      await searchInput.fill('test');
-      await page
-        .getByRole('button', { name: translations.icons.magnifier })
-        .click();
+    // Wait for the new page to load.
+    const newPage = await context.waitForEvent('page');
+    await newPage.waitForLoadState();
 
-      // Wait for the new page to load.
-      const newPage = await context.waitForEvent('page');
-      await newPage.waitForLoadState();
-
-      expect(newPage.url()).toBe(
-        'https://www.freecodecamp.org/news/search/?query=test'
-      );
-    } else {
-      const searchInput = page.getByLabel(translations.search.label);
-      await expect(searchInput).toBeVisible();
-
-      await searchInput.fill('test');
-      await page
-        .getByRole('button', { name: translations.icons.magnifier })
-        .click();
-
-      // Wait for the new page to load.
-      const newPage = await context.waitForEvent('page');
-      await newPage.waitForLoadState();
-
-      expect(newPage.url()).toBe(
-        'https://www.freecodecamp.org/news/search/?query=test'
-      );
-    }
+    expect(newPage.url()).toBe(
+      'https://www.freecodecamp.org/news/search/?query=test'
+    );
   });
 
   test('should clear the search input when the user clicks the clear button', async ({
     page,
     isMobile
   }) => {
-    if (isMobile) {
-      const menuButton = page.getByRole('button', {
-        name: translations.buttons.menu
-      });
-      await menuButton.click();
+    const searchInput = await getSearchInput({ page, isMobile });
+    await expect(searchInput).toBeVisible();
 
-      const searchInput = page.getByLabel(translations.search.label);
-      await expect(searchInput).toBeVisible();
+    await searchInput.fill('test');
+    await page
+      .getByRole('button', { name: translations.icons['input-reset'] })
+      .click();
 
-      await searchInput.fill('test');
-      await page
-        .getByRole('button', { name: translations.icons['input-reset'] })
-        .click();
-
-      await expect(searchInput).toHaveValue('');
-    } else {
-      const searchInput = page.getByLabel(translations.search.label);
-      await expect(searchInput).toBeVisible();
-
-      await searchInput.fill('test');
-      await page
-        .getByRole('button', { name: translations.icons['input-reset'] })
-        .click();
-
-      await expect(searchInput).toHaveValue('');
-    }
+    await expect(searchInput).toHaveValue('');
   });
 });


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR:
- Improves the readability of `search.spec.ts` by moving the search input query to a separate function
- Renames `search.spec.ts` to `search-bar-optimized.spec.ts`
  - We have two search bar components: `SearchBar` and `SearchBarOptimized`. The one `search.spec.ts` is testing is `SearchBarOptimized`
- Is to aid #52905 

Note: Reviewing by commit is recommended.

<!-- Feel free to add any additional description of changes below this line -->
