### PR TITLE
fix(curriculums): Changed wording in description and hints for clarity

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f359af3e32e0f1a6880b7.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f359af3e32e0f1a6880b7.md
@@ -19,7 +19,7 @@ Remember that you can use the `+` operator to concatenate strings like this:
 
 # --hints--
 
-You should concatenate an single space to the beginning of your returned value.
+You should concatenate a single space to the beginning of your returned value.
 
 ```js
 assert.match(padRow(1, 1), /^\s/);

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f359af3e32e0f1a6880b7.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f359af3e32e0f1a6880b7.md
@@ -9,7 +9,7 @@ dashedName: step-65
 
 You should now see the same bunch of characters in your console. Your `padRow` function is doing the exact same thing you were doing earlier, but now it's in a reusable section of its own.
 
-Use the addition operator to concatenate a blank space `" "` to the beginning and end of your repeated `character` string.
+Use the addition operator to concatenate a single space `" "` to the beginning and end of your repeated `character` string.
 
 Remember that you can use the `+` operator to concatenate strings like this:
 
@@ -19,13 +19,13 @@ Remember that you can use the `+` operator to concatenate strings like this:
 
 # --hints--
 
-You should concatenate an empty space to the beginning of your returned value.
+You should concatenate an single space to the beginning of your returned value.
 
 ```js
 assert.match(padRow(1, 1), /^\s/);
 ```
 
-You should concatenate an empty space to the end of your returned value.
+You should concatenate a single space to the end of your returned value.
 
 ```js
 assert.match(padRow(1, 1), /\s$/);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #55118

JeremyIt pointed out confusion in the wording used to describe: `" "`.  The terms "blank space", "empty space", and "single space" can be unclear. 

Changes were made so that all of the listed words were changed to "single space".

<!-- Feel free to add any additional description of changes below this line -->
