### PR TITLE
fix(curriculums): Updated an Instruction that was misleading 

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660ef0f7c4b8e68ccd1f0786.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660ef0f7c4b8e68ccd1f0786.md
@@ -9,7 +9,7 @@ dashedName: step-3
 
 JavaScript has seven primitive data types, with `String` being one of them. In JavaScript, a <dfn>string</dfn> represents a sequence of characters and can be enclosed in either single (`'`) or double (`"`) quotes.
 
-Note that strings are <dfn>immutable</dfn>, which means once they are created, they cannot be changed.
+Note that strings are <dfn>immutable</dfn>, which means once they are created, they cannot be changed. The variable can still be reassigned another value.
 
 Change your `"Hello"` string to use single quotes.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #55093

NilsGke noted that new learners might misunderstand and think that the word `immutable` could be used to describe a `variable` in this context.

With Naomi and others' suggestions, we rewrote the instructions 
From: 
> Note that strings are immutable, which means once they are created, they cannot be changed.

To:
>Note that strings are immutable, which means once they are created, they cannot be changed. The variable can still be reassigned another value.




<!-- Feel free to add any additional description of changes below this line -->
