### PR TITLE
fix (curriculum): remove code block for translation purpose

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fefebad99209211ec30537.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fefebad99209211ec30537.md
@@ -7,7 +7,7 @@ dashedName: step-55
 
 # --description--
 
-If you check the `Application` tab of your browser console, you'll notice a series of `[object Object]`. This is because everything you save in `localStorage` needs to be in string format.
+If you check the "Application" tab of your browser console, you'll notice a series of `[object Object]`. This is because everything you save in `localStorage` needs to be in string format.
 
 To resolve the issue, wrap the data you're saving in the `JSON.stringify()` method. Then, check local storage again to observe the results.
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

I am translating this content into Chinese and noticed that the word "Application" is wrapped in a code block, so it cannot be translated (or Crowdin will throw an error that I changed the code block). However, browsers will show the word "Application" in local languages, so this word should also be translated.

This PR fixes the issue by replacing the code block with a quotation mark, so it can be translated.
