### PR TITLE
feat: prevent dialogs appearing when users run tests

### DIFF
--- a/client/src/templates/Challenges/utils/frame.ts
+++ b/client/src/templates/Challenges/utils/frame.ts
@@ -389,43 +389,54 @@ export const createMainPreviewFramer = (
   frameTitle: string,
   frameReady?: () => void
 ): ((args: Context) => void) =>
-  createFramer(
+  createFramer({
     document,
-    mainPreviewId,
-    initMainFrame,
+    id: mainPreviewId,
+    init: initMainFrame,
     proxyLogger,
     frameReady,
     frameTitle
-  );
+  });
 
 export const createProjectPreviewFramer = (
   document: Document,
   frameTitle: string
 ): ((args: Context) => void) =>
-  createFramer(
+  createFramer({
     document,
-    projectPreviewId,
-    initPreviewFrame,
-    undefined,
-    undefined,
+    id: projectPreviewId,
+    init: initPreviewFrame,
     frameTitle
-  );
+  });
 
 export const createTestFramer = (
   document: Document,
   proxyLogger: ProxyLogger,
   frameReady: () => void
 ): ((args: Context) => void) =>
-  createFramer(document, testId, initTestFrame, proxyLogger, frameReady);
+  createFramer({
+    document,
+    id: testId,
+    init: initTestFrame,
+    proxyLogger,
+    frameReady
+  });
 
-const createFramer = (
-  document: Document,
-  id: string,
-  init: InitFrame,
-  proxyLogger?: ProxyLogger,
-  frameReady?: () => void,
-  frameTitle?: string
-) =>
+const createFramer = ({
+  document,
+  id,
+  init,
+  proxyLogger,
+  frameReady,
+  frameTitle
+}: {
+  document: Document;
+  id: string;
+  init: InitFrame;
+  proxyLogger?: ProxyLogger;
+  frameReady?: () => void;
+  frameTitle?: string;
+}) =>
   flow(
     createFrame(document, id, frameTitle),
     mountFrame(document, id),

--- a/client/src/templates/Challenges/utils/frame.ts
+++ b/client/src/templates/Challenges/utils/frame.ts
@@ -332,21 +332,6 @@ function handleDocumentNotFound(err: string) {
 
 const initPreviewFrame = () => (frameContext: Context) => frameContext;
 
-// TODO: reimplement when ready to preview python challenges
-// const initPreviewFrame = () => (frameContext: Context) => {
-//   waitForFrame(frameContext)
-//     .then(() => {
-//       if (
-//         frameContext.document &&
-//         '__initPythonFrame' in frameContext.document
-//       ) {
-//         void frameContext.document?.__initPythonFrame();
-//       }
-//     })
-//     .catch(handleDocumentNotFound);
-//   return frameContext;
-// };
-
 const waitForFrame = (frameContext: Context) => {
   return new Promise((resolve, reject) => {
     if (!frameContext.document) {

--- a/client/src/templates/Challenges/utils/frame.ts
+++ b/client/src/templates/Challenges/utils/frame.ts
@@ -259,7 +259,7 @@ const updateProxyConsole =
     return frameContext;
   };
 
-const updateWindowI18next = () => (frameContext: Context) => {
+const updateWindowI18next = (frameContext: Context) => {
   // window does not exist if the preview is hidden, so we have to check.
   if (frameContext?.window) {
     frameContext.window.i18nContent = i18next;
@@ -441,7 +441,7 @@ const createFramer = ({
     createFrame(document, id, frameTitle),
     mountFrame(document, id),
     updateProxyConsole(proxyLogger),
-    updateWindowI18next(),
+    updateWindowI18next,
     writeContentToFrame,
     init(frameReady, proxyLogger)
   ) as (args: Context) => void;


### PR DESCRIPTION
- **refactor: call createFramer with object**
- **refactor: simplify function call**
- **refactor: drop comment**
- **feat: stop showing dialogs in challenge tests**

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Having dialogs pop up when testing is quite annoying. The user just wants to see if their code is correct. This overrides the three common functions that create dialogs, so the tests can run quietly.

Challenge authors can still override them again in the tests if they want to include spys or mocks.

Note for QA: only the last commit should change any behaviour.

<!-- Feel free to add any additional description of changes below this line -->
