### PR TITLE
fix(api): use generic error handler with Sentry

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -114,10 +114,7 @@ export const build = async (
     errorResponse: (error, _request, reply) => {
       if (reply.statusCode === 500) {
         void reply.send({
-          // TODO: use flash message: 'flash.went-wrong' after checking the
-          // client always understands it.
-          message:
-            'Oops! Something went wrong. Please try again in a moment or contact support@freecodecamp.org if the error persists.',
+          message: 'flash.generic-error',
           type: 'danger'
         });
       } else {

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -111,14 +111,18 @@ export const build = async (
     // No need to initialize if DSN is not provided (e.g. in development and
     // test environments)
     skipInit: !!SENTRY_DSN,
-    errorResponse: (_error, _request, reply) => {
-      void reply.code(500).send({
-        // TODO: use flash message: 'flash.went-wrong' after checking the
-        // client always understands it.
-        message:
-          'Oops! Something went wrong. Please try again in a moment or contact support@freecodecamp.org if the error persists.',
-        type: 'danger'
-      });
+    errorResponse: (error, _request, reply) => {
+      if (reply.statusCode === 500) {
+        void reply.send({
+          // TODO: use flash message: 'flash.went-wrong' after checking the
+          // client always understands it.
+          message:
+            'Oops! Something went wrong. Please try again in a moment or contact support@freecodecamp.org if the error persists.',
+          type: 'danger'
+        });
+      } else {
+        void reply.send(error);
+      }
     }
   });
 

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -106,7 +106,18 @@ export const build = async (
   // NOTE: Awaited to ensure `.use` is registered on `fastify`
   await fastify.register(express);
   if (SENTRY_DSN) {
-    await fastify.register(fastifySentry, { dsn: SENTRY_DSN });
+    await fastify.register(fastifySentry, {
+      dsn: SENTRY_DSN,
+      errorResponse: (_error, _request, reply) => {
+        void reply.code(500).send({
+          // TODO: use flash message: 'flash.went-wrong' after checking the
+          // client always understands it.
+          message:
+            'Oops! Something went wrong. Please try again in a moment or contact support@freecodecamp.org if the error persists.',
+          type: 'danger'
+        });
+      }
+    });
   }
 
   await fastify.register(cors);

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -105,20 +105,22 @@ export const build = async (
   });
   // NOTE: Awaited to ensure `.use` is registered on `fastify`
   await fastify.register(express);
-  if (SENTRY_DSN) {
-    await fastify.register(fastifySentry, {
-      dsn: SENTRY_DSN,
-      errorResponse: (_error, _request, reply) => {
-        void reply.code(500).send({
-          // TODO: use flash message: 'flash.went-wrong' after checking the
-          // client always understands it.
-          message:
-            'Oops! Something went wrong. Please try again in a moment or contact support@freecodecamp.org if the error persists.',
-          type: 'danger'
-        });
-      }
-    });
-  }
+
+  await fastify.register(fastifySentry, {
+    dsn: SENTRY_DSN,
+    // No need to initialize if DSN is not provided (e.g. in development and
+    // test environments)
+    skipInit: !!SENTRY_DSN,
+    errorResponse: (_error, _request, reply) => {
+      void reply.code(500).send({
+        // TODO: use flash message: 'flash.went-wrong' after checking the
+        // client always understands it.
+        message:
+          'Oops! Something went wrong. Please try again in a moment or contact support@freecodecamp.org if the error persists.',
+        type: 'danger'
+      });
+    }
+  });
 
   await fastify.register(cors);
   await fastify.register(cookies);

--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -749,7 +749,7 @@
   "flash": {
     "honest-first": "To claim a certification, you must first agree to our academic honesty policy",
     "really-weird": "Something really weird happened, if it happens again, please consider raising an issue on https://github.com/freeCodeCamp/freeCodeCamp/issues/new",
-    "not-right": "Something is not quite right. A report has been generated and the freeCodeCamp.org team have been notified",
+    "generic-error": "Something went wrong. Please try again in a moment or contact support@freecodecamp.org if the error persists.",
     "went-wrong": "Something went wrong, please check and try again",
     "account-deleted": "Your account has been successfully deleted",
     "progress-reset": "Your progress has been reset",

--- a/client/src/components/Flash/redux/flash-messages.ts
+++ b/client/src/components/Flash/redux/flash-messages.ts
@@ -39,7 +39,7 @@ export enum FlashMessages {
   None = '',
   NotEligible = 'flash.not-eligible',
   NotHonest = 'flash.not-honest',
-  NotRight = 'flash.not-right',
+  GenericError = 'flash.generic-error',
   ProfilePrivate = 'flash.profile-private',
   ProgressReset = 'flash.progress-reset',
   ProvideUsername = 'flash.provide-username',

--- a/client/src/utils/error-messages.ts
+++ b/client/src/utils/error-messages.ts
@@ -12,7 +12,7 @@ export const reallyWeirdErrorMessage = {
 
 export const reportedErrorMessage = {
   type: 'danger',
-  message: FlashMessages.NotRight
+  message: FlashMessages.GenericError
 };
 
 export const certificateMissingErrorMessage = {

--- a/client/src/utils/tone/index.ts
+++ b/client/src/utils/tone/index.ts
@@ -54,7 +54,7 @@ const toneUrls = {
   // [FlashMessages.None]: '',
   [FlashMessages.NotEligible]: TRY_AGAIN,
   [FlashMessages.NotHonest]: TRY_AGAIN,
-  [FlashMessages.NotRight]: TRY_AGAIN,
+  [FlashMessages.GenericError]: TRY_AGAIN,
   [FlashMessages.ProfilePrivate]: TRY_AGAIN,
   [FlashMessages.ProgressReset]: TRY_AGAIN,
   [FlashMessages.ProvideUsername]: TRY_AGAIN,


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This creates a standard, generic error that the client understands and the api can send if something unexpected happens. The client won't use it yet, but this makes it available for translation.

I'll update some routes to use this error in a followup PR.

<!-- Feel free to add any additional description of changes below this line -->
