### PR TITLE
fix(api): narrow serializers for update-my-email

### DIFF
--- a/api/src/schemas/settings/update-my-email.ts
+++ b/api/src/schemas/settings/update-my-email.ts
@@ -11,9 +11,13 @@ export const updateMyEmail = {
       ),
       type: Type.Literal('info')
     }),
-    '4xx': Type.Object({
+    400: Type.Object({
       message: Type.String(),
       type: Type.Union([Type.Literal('danger'), Type.Literal('info')])
+    }),
+    429: Type.Object({
+      message: Type.String(),
+      type: Type.Literal('info')
     }),
     500: Type.Object({
       message: Type.Literal('flash.wrong-updating'),


### PR DESCRIPTION
4xx meant that it would try to serialize CSRF errors, which would fail
and generate a serialization error.

Serializing CSRF errors does make sense, but I'll look into that separately.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
