### PR TITLE
fix(curriculum): ensure not additional change

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/build-a-cash-register-project/build-a-cash-register.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/build-a-cash-register-project/build-a-cash-register.md
@@ -119,7 +119,10 @@ cid = [['PENNY', 1.01], ['NICKEL', 2.05], ['DIME', 3.1], ['QUARTER', 4.25], ['ON
 const expected = ['Status: OPEN', 'QUARTER: $0.5'];
 cashInput.dispatchEvent(new Event('change'));
 purchaseBtn.click();
-assert.isTrue(expected.every(str => changeDueDiv.innerText.trim().toLowerCase().includes(str.toLowerCase())));
+const result = changeDueDiv.innerText.trim().toLowerCase();
+assert.isTrue(expected.every(str => result.includes(str.toLowerCase())));
+const notExpected = [/PENNY/, /NICKEL/, /DIME/, /ONE [^H]/, /FIVE/, /TEN/, /TWENTY/, /ONE HUNDRED/];
+assert.isTrue(!notExpected.some(regex => result.match(new RegExp(regex, 'i'))))
 ```
 
 When `price` is `3.26`, the value in the `#cash` element is `100`, `cid` is `[["PENNY", 1.01], ["NICKEL", 2.05], ["DIME", 3.1], ["QUARTER", 4.25], ["ONE", 90], ["FIVE", 55], ["TEN", 20], ["TWENTY", 60], ["ONE HUNDRED", 100]]`, and the `#purchase-btn` element is clicked, the value in the `#change-due` element should be `"Status: OPEN TWENTY: $60 TEN: $20 FIVE: $15 ONE: $1 QUARTER: $0.5 DIME: $0.2 PENNY: $0.04"`.
@@ -136,7 +139,10 @@ cid = [['PENNY', 1.01], ['NICKEL', 2.05], ['DIME', 3.1], ['QUARTER', 4.25], ['ON
 const expected = ['Status: OPEN', 'TWENTY: $60', 'TEN: $20', 'FIVE: $15', 'ONE: $1', 'QUARTER: $0.5', 'DIME: $0.2', 'PENNY: $0.04'];
 cashInput.dispatchEvent(new Event('change'));
 purchaseBtn.click();
-assert.isTrue(expected.every(str => changeDueDiv.innerText.trim().toLowerCase().includes(str.toLowerCase())));
+const result = changeDueDiv.innerText.trim().toLowerCase();
+assert.isTrue(expected.every(str => result.includes(str.toLowerCase())));
+const notExpected = [/NICKEL/];
+assert.isTrue(!notExpected.some(regex => result.match(new RegExp(regex, 'i'))))
 ```
 
 When `price` is `19.5`, the value in the `#cash` element is `20`, `cid` is `[["PENNY", 0.01], ["NICKEL", 0], ["DIME", 0], ["QUARTER", 0], ["ONE", 0], ["FIVE", 0], ["TEN", 0], ["TWENTY", 0], ["ONE HUNDRED", 0]]`, and the `#purchase-btn` element is clicked, the value in the `#change-due` element should be `"Status: INSUFFICIENT_FUNDS"`
@@ -185,7 +191,10 @@ cid = [['PENNY', 0.5], ['NICKEL', 0], ['DIME', 0], ['QUARTER', 0], ['ONE', 0], [
 const expected = ['Status: CLOSED', 'PENNY: $0.5'];
 cashInput.dispatchEvent(new Event('change'));
 purchaseBtn.click();
-assert.isTrue(expected.every(str => changeDueDiv.innerText.trim().toLowerCase().includes(str.toLowerCase())));
+const result = changeDueDiv.innerText.trim().toLowerCase();
+assert.isTrue(expected.every(str => result.includes(str.toLowerCase())));
+const notExpected = [/NICKEL/, /DIME/, /QUARTER/, /ONE [^H]/, /FIVE/, /TEN/, /TWENTY/, /ONE HUNDRED/];
+assert.isTrue(!notExpected.some(regex => result.match(new RegExp(regex, 'i'))))
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Ref #53836

- - -
- Adds checking for denominations that should NOT be present in result.
- This is a bit more complicated than needed specifically for these cases. But to make it fully correct, checking for `ONE` should not fail test, in case there's expected `ONE HUNDRED` denomination in result.