### PR TITLE
feat(api): send errors to Sentry

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -110,7 +110,7 @@ export const build = async (
     dsn: SENTRY_DSN,
     // No need to initialize if DSN is not provided (e.g. in development and
     // test environments)
-    skipInit: !!SENTRY_DSN,
+    skipInit: !SENTRY_DSN,
     errorResponse: (error, _request, reply) => {
       if (reply.statusCode === 500) {
         void reply.send({

--- a/api/src/routes/certificate.test.ts
+++ b/api/src/routes/certificate.test.ts
@@ -229,7 +229,7 @@ describe('certificate routes', () => {
         });
 
         expect(response.body).toStrictEqual({
-          message: 'flash.went-wrong',
+          message: 'flash.generic-error',
           type: 'danger'
         });
         expect(response.status).toBe(500);

--- a/api/src/routes/certificate.ts
+++ b/api/src/routes/certificate.ts
@@ -107,6 +107,8 @@ export const protectedCertificateRoutes: FastifyPluginCallbackTypebox = (
 
       if (!user) {
         void reply.code(500);
+        fastify.log.error('User not found');
+        fastify.Sentry.captureException(Error('User not found'));
         return {
           type: 'danger',
           // message: 'User not found'

--- a/api/src/routes/certificate.ts
+++ b/api/src/routes/certificate.ts
@@ -101,170 +101,160 @@ export const protectedCertificateRoutes: FastifyPluginCallbackTypebox = (
       const certType = certSlugTypeMap[certSlug];
       const certName = certTypeTitleMap[certType];
 
-      try {
-        const user = await fastify.prisma.user.findUnique({
-          where: { id: req.user?.id }
-        });
+      const user = await fastify.prisma.user.findUnique({
+        where: { id: req.user?.id }
+      });
 
-        if (!user) {
-          void reply.code(500);
-          return {
-            type: 'danger',
-            // message: 'User not found'
-            message: 'flash.went-wrong'
-          } as const;
-        }
-        const { completedChallenges } = user;
-        const isCertMap = getUserIsCertMap(removeNulls(user));
-
-        // TODO: Discuss if this is a requirement still
-        if (!user.name) {
-          void reply.code(400);
-          return {
-            response: {
-              type: 'info',
-              message: 'flash.name-needed'
-            },
-            isCertMap,
-            completedChallenges: normalizeChallenges(completedChallenges)
-          } as const;
-        }
-
-        if (user[certType]) {
-          void reply.code(200);
-          return {
-            response: {
-              type: 'info',
-              message: 'flash.already-claimed',
-              variables: {
-                name: certName
-              }
-            },
-            isCertMap,
-            completedChallenges: normalizeChallenges(completedChallenges)
-          } as const;
-        }
-
-        const { id, tests, challengeType } = certTypeIds[certType];
-        const hasCompletedTestRequirements = hasCompletedTests(
-          tests,
-          user.completedChallenges
-        );
-
-        if (!hasCompletedTestRequirements) {
-          void reply.code(400);
-          return {
-            response: {
-              type: 'info',
-              message: 'flash.incomplete-steps',
-              variables: {
-                name: certName
-              }
-            },
-            isCertMap,
-            completedChallenges: normalizeChallenges(completedChallenges)
-          } as const;
-        }
-
-        const updatedUser = await fastify.prisma.user.update({
-          where: { id: user.id },
-          data: {
-            [certType]: true,
-            completedChallenges: {
-              push: {
-                id,
-                completedDate: Date.now(),
-                challengeType
-              }
-            }
-          },
-          select: {
-            username: true,
-            email: true,
-            name: true,
-            completedChallenges: true,
-            is2018DataVisCert: true,
-            is2018FullStackCert: true,
-            isApisMicroservicesCert: true,
-            isBackEndCert: true,
-            isDataVisCert: true,
-            isCollegeAlgebraPyCertV8: true,
-            isDataAnalysisPyCertV7: true,
-            isFoundationalCSharpCertV8: true,
-            isFrontEndCert: true,
-            isFrontEndLibsCert: true,
-            isFullStackCert: true,
-            isInfosecCertV7: true,
-            isInfosecQaCert: true,
-            isJsAlgoDataStructCert: true,
-            isJsAlgoDataStructCertV8: true,
-            isMachineLearningPyCertV7: true,
-            isQaCertV7: true,
-            isRelationalDatabaseCertV8: true,
-            isRespWebDesignCert: true,
-            isSciCompPyCertV7: true,
-            isUpcomingPythonCertV8: true
-          }
-        });
-
-        const updatedUserSansNull = removeNulls(updatedUser);
-
-        const updatedIsCertMap = getUserIsCertMap(updatedUserSansNull);
-
-        // TODO(POST-MVP): Consider sending email based on `user.isEmailVerified` as well
-        const hasCompletedAllCerts = currentCertifications
-          .map(x => certSlugTypeMap[x])
-          .every(certType => updatedIsCertMap[certType]);
-        const shouldSendCertifiedEmailToCamper =
-          isEmail(updatedUser.email) && hasCompletedAllCerts;
-
-        if (shouldSendCertifiedEmailToCamper) {
-          const notifyUser = {
-            to: updatedUser.email,
-            from: 'quincy@freecodecamp.org',
-            subject:
-              'Congratulations on completing all of the freeCodeCamp certifications!',
-            text: renderCertifiedEmail({
-              username: updatedUser.username,
-              // Safety: `user.name` is required to exist earlier. TODO: Assert
-              name: updatedUser.name as string
-            })
-          };
-
-          // Failed email should not prevent successful response.
-          try {
-            // TODO(POST-MVP): Ensure Camper knows they **have** claimed the cert, but the email failed to send.
-            await fastify.sendEmail(notifyUser);
-          } catch (e) {
-            fastify.log.error(e);
-            // TODO: Log to Sentry
-          }
-        }
-
-        void reply.code(200);
-        return {
-          response: {
-            type: 'success',
-            message: 'flash.cert-claim-success',
-            variables: {
-              username: updatedUser.username,
-              name: certName
-            }
-          },
-          isCertMap: updatedIsCertMap,
-          completedChallenges: normalizeChallenges(
-            updatedUserSansNull.completedChallenges
-          )
-        } as const;
-      } catch (e) {
-        fastify.log.error(e);
+      if (!user) {
         void reply.code(500);
-        throw {
+        return {
           type: 'danger',
-          // message: 'Oops! Something went wrong. Please try again in a moment or contact
+          // message: 'User not found'
           message: 'flash.went-wrong'
         } as const;
       }
+      const { completedChallenges } = user;
+      const isCertMap = getUserIsCertMap(removeNulls(user));
+
+      // TODO: Discuss if this is a requirement still
+      if (!user.name) {
+        void reply.code(400);
+        return {
+          response: {
+            type: 'info',
+            message: 'flash.name-needed'
+          },
+          isCertMap,
+          completedChallenges: normalizeChallenges(completedChallenges)
+        } as const;
+      }
+
+      if (user[certType]) {
+        void reply.code(200);
+        return {
+          response: {
+            type: 'info',
+            message: 'flash.already-claimed',
+            variables: {
+              name: certName
+            }
+          },
+          isCertMap,
+          completedChallenges: normalizeChallenges(completedChallenges)
+        } as const;
+      }
+
+      const { id, tests, challengeType } = certTypeIds[certType];
+      const hasCompletedTestRequirements = hasCompletedTests(
+        tests,
+        user.completedChallenges
+      );
+
+      if (!hasCompletedTestRequirements) {
+        void reply.code(400);
+        return {
+          response: {
+            type: 'info',
+            message: 'flash.incomplete-steps',
+            variables: {
+              name: certName
+            }
+          },
+          isCertMap,
+          completedChallenges: normalizeChallenges(completedChallenges)
+        } as const;
+      }
+
+      const updatedUser = await fastify.prisma.user.update({
+        where: { id: user.id },
+        data: {
+          [certType]: true,
+          completedChallenges: {
+            push: {
+              id,
+              completedDate: Date.now(),
+              challengeType
+            }
+          }
+        },
+        select: {
+          username: true,
+          email: true,
+          name: true,
+          completedChallenges: true,
+          is2018DataVisCert: true,
+          is2018FullStackCert: true,
+          isApisMicroservicesCert: true,
+          isBackEndCert: true,
+          isDataVisCert: true,
+          isCollegeAlgebraPyCertV8: true,
+          isDataAnalysisPyCertV7: true,
+          isFoundationalCSharpCertV8: true,
+          isFrontEndCert: true,
+          isFrontEndLibsCert: true,
+          isFullStackCert: true,
+          isInfosecCertV7: true,
+          isInfosecQaCert: true,
+          isJsAlgoDataStructCert: true,
+          isJsAlgoDataStructCertV8: true,
+          isMachineLearningPyCertV7: true,
+          isQaCertV7: true,
+          isRelationalDatabaseCertV8: true,
+          isRespWebDesignCert: true,
+          isSciCompPyCertV7: true,
+          isUpcomingPythonCertV8: true
+        }
+      });
+
+      const updatedUserSansNull = removeNulls(updatedUser);
+
+      const updatedIsCertMap = getUserIsCertMap(updatedUserSansNull);
+
+      // TODO(POST-MVP): Consider sending email based on `user.isEmailVerified` as well
+      const hasCompletedAllCerts = currentCertifications
+        .map(x => certSlugTypeMap[x])
+        .every(certType => updatedIsCertMap[certType]);
+      const shouldSendCertifiedEmailToCamper =
+        isEmail(updatedUser.email) && hasCompletedAllCerts;
+
+      if (shouldSendCertifiedEmailToCamper) {
+        const notifyUser = {
+          to: updatedUser.email,
+          from: 'quincy@freecodecamp.org',
+          subject:
+            'Congratulations on completing all of the freeCodeCamp certifications!',
+          text: renderCertifiedEmail({
+            username: updatedUser.username,
+            // Safety: `user.name` is required to exist earlier. TODO: Assert
+            name: updatedUser.name as string
+          })
+        };
+
+        // Failed email should not prevent successful response.
+        try {
+          // TODO(POST-MVP): Ensure Camper knows they **have** claimed the cert, but the email failed to send.
+          await fastify.sendEmail(notifyUser);
+        } catch (e) {
+          fastify.log.error(e);
+          // TODO: Log to Sentry
+        }
+      }
+
+      void reply.code(200);
+      return {
+        response: {
+          type: 'success',
+          message: 'flash.cert-claim-success',
+          variables: {
+            username: updatedUser.username,
+            name: certName
+          }
+        },
+        isCertMap: updatedIsCertMap,
+        completedChallenges: normalizeChallenges(
+          updatedUserSansNull.completedChallenges
+        )
+      } as const;
     }
   );
 
@@ -289,215 +279,205 @@ export const unprotectedCertificateRoutes: FastifyPluginCallbackTypebox = (
       schema: schemas.certSlug
     },
     async (req, reply) => {
-      try {
-        const username = req.params.username.toLowerCase();
-        const certSlug = req.params.certSlug;
+      const username = req.params.username.toLowerCase();
+      const certSlug = req.params.certSlug;
 
-        fastify.log.info(`certSlug: ${certSlug}`);
+      fastify.log.info(`certSlug: ${certSlug}`);
 
-        if (!isKnownCertSlug(certSlug)) {
-          void reply.code(404);
-          return reply.send({
-            messages: [
-              {
-                type: 'info',
-                message: 'flash.cert-not-found',
-                variables: { certSlug }
-              }
-            ]
-          });
-        }
-
-        const certType = certSlugTypeMap[certSlug];
-        const certId = certTypeIdMap[certType];
-        const certTitle = certTypeTitleMap[certType];
-        const completionTime = completionHours[certType] || 300;
-        const user = await fastify.prisma.user.findFirst({
-          where: { username },
-          select: {
-            isBanned: true,
-            isCheater: true,
-            isFrontEndCert: true,
-            isBackEndCert: true,
-            isFullStackCert: true,
-            isRespWebDesignCert: true,
-            isFrontEndLibsCert: true,
-            isJsAlgoDataStructCert: true,
-            isJsAlgoDataStructCertV8: true,
-            isDataVisCert: true,
-            is2018DataVisCert: true,
-            isApisMicroservicesCert: true,
-            isInfosecQaCert: true,
-            isQaCertV7: true,
-            isInfosecCertV7: true,
-            isSciCompPyCertV7: true,
-            isDataAnalysisPyCertV7: true,
-            isMachineLearningPyCertV7: true,
-            isRelationalDatabaseCertV8: true,
-            isCollegeAlgebraPyCertV8: true,
-            isFoundationalCSharpCertV8: true,
-            isUpcomingPythonCertV8: true,
-            isHonest: true,
-            username: true,
-            name: true,
-            completedChallenges: true,
-            profileUI: true
-          }
+      if (!isKnownCertSlug(certSlug)) {
+        void reply.code(404);
+        return reply.send({
+          messages: [
+            {
+              type: 'info',
+              message: 'flash.cert-not-found',
+              variables: { certSlug }
+            }
+          ]
         });
+      }
 
-        if (user === null) {
-          return reply.send({
-            messages: [
-              {
-                type: 'info',
-                message: 'flash.username-not-found',
-                variables: { username }
-              }
-            ]
-          });
+      const certType = certSlugTypeMap[certSlug];
+      const certId = certTypeIdMap[certType];
+      const certTitle = certTypeTitleMap[certType];
+      const completionTime = completionHours[certType] || 300;
+      const user = await fastify.prisma.user.findFirst({
+        where: { username },
+        select: {
+          isBanned: true,
+          isCheater: true,
+          isFrontEndCert: true,
+          isBackEndCert: true,
+          isFullStackCert: true,
+          isRespWebDesignCert: true,
+          isFrontEndLibsCert: true,
+          isJsAlgoDataStructCert: true,
+          isJsAlgoDataStructCertV8: true,
+          isDataVisCert: true,
+          is2018DataVisCert: true,
+          isApisMicroservicesCert: true,
+          isInfosecQaCert: true,
+          isQaCertV7: true,
+          isInfosecCertV7: true,
+          isSciCompPyCertV7: true,
+          isDataAnalysisPyCertV7: true,
+          isMachineLearningPyCertV7: true,
+          isRelationalDatabaseCertV8: true,
+          isCollegeAlgebraPyCertV8: true,
+          isFoundationalCSharpCertV8: true,
+          isUpcomingPythonCertV8: true,
+          isHonest: true,
+          username: true,
+          name: true,
+          completedChallenges: true,
+          profileUI: true
         }
+      });
 
-        if (user.isCheater || user.isBanned) {
-          return reply.send({
-            messages: [
-              {
-                type: 'info',
-                message: 'flash.not-eligible'
-              }
-            ]
-          });
-        }
+      if (user === null) {
+        return reply.send({
+          messages: [
+            {
+              type: 'info',
+              message: 'flash.username-not-found',
+              variables: { username }
+            }
+          ]
+        });
+      }
 
-        if (!user.isHonest) {
-          return reply.send({
-            messages: [
-              {
-                type: 'info',
-                message: 'flash.not-honest',
-                variables: { username }
-              }
-            ]
-          });
-        }
+      if (user.isCheater || user.isBanned) {
+        return reply.send({
+          messages: [
+            {
+              type: 'info',
+              message: 'flash.not-eligible'
+            }
+          ]
+        });
+      }
 
-        if (user.profileUI?.isLocked) {
-          return reply.send({
-            messages: [
-              {
-                type: 'info',
-                message: 'flash.profile-private',
-                variables: { username }
-              }
-            ]
-          });
-        }
+      if (!user.isHonest) {
+        return reply.send({
+          messages: [
+            {
+              type: 'info',
+              message: 'flash.not-honest',
+              variables: { username }
+            }
+          ]
+        });
+      }
 
-        if (!user.name) {
-          return reply.send({
-            messages: [
-              {
-                type: 'info',
-                message: 'flash.add-name'
-              }
-            ]
-          });
-        }
+      if (user.profileUI?.isLocked) {
+        return reply.send({
+          messages: [
+            {
+              type: 'info',
+              message: 'flash.profile-private',
+              variables: { username }
+            }
+          ]
+        });
+      }
 
-        if (!user.profileUI?.showCerts) {
-          return reply.send({
-            messages: [
-              {
-                type: 'info',
-                message: 'flash.certs-private',
-                variables: { username }
-              }
-            ]
-          });
-        }
+      if (!user.name) {
+        return reply.send({
+          messages: [
+            {
+              type: 'info',
+              message: 'flash.add-name'
+            }
+          ]
+        });
+      }
 
-        if (!user.profileUI?.showTimeLine) {
-          return reply.send({
-            messages: [
-              {
-                type: 'info',
-                message: 'flash.timeline-private',
-                variables: { username }
-              }
-            ]
-          });
-        }
+      if (!user.profileUI?.showCerts) {
+        return reply.send({
+          messages: [
+            {
+              type: 'info',
+              message: 'flash.certs-private',
+              variables: { username }
+            }
+          ]
+        });
+      }
 
-        if (!user[certType]) {
-          return reply.send({
-            messages: [
-              {
-                type: 'info',
-                message: 'flash.user-not-certified',
-                variables: { username, cert: certTypeTitleMap[certType] }
-              }
-            ]
-          });
-        }
+      if (!user.profileUI?.showTimeLine) {
+        return reply.send({
+          messages: [
+            {
+              type: 'info',
+              message: 'flash.timeline-private',
+              variables: { username }
+            }
+          ]
+        });
+      }
 
-        const { completedChallenges } = user;
-        const certChallenge = find(
+      if (!user[certType]) {
+        return reply.send({
+          messages: [
+            {
+              type: 'info',
+              message: 'flash.user-not-certified',
+              variables: { username, cert: certTypeTitleMap[certType] }
+            }
+          ]
+        });
+      }
+
+      const { completedChallenges } = user;
+      const certChallenge = find(
+        completedChallenges,
+        ({ id }) => certId === id
+      );
+
+      let { completedDate = Date.now() } = certChallenge || {};
+
+      // the challenge id has been rotated for isDataVisCert
+      if (certType === 'isDataVisCert' && !certChallenge) {
+        const oldDataVisIdChall = find(
           completedChallenges,
-          ({ id }) => certId === id
+          ({ id }) => oldDataVizId === id
         );
 
-        let { completedDate = Date.now() } = certChallenge || {};
-
-        // the challenge id has been rotated for isDataVisCert
-        if (certType === 'isDataVisCert' && !certChallenge) {
-          const oldDataVisIdChall = find(
-            completedChallenges,
-            ({ id }) => oldDataVizId === id
-          );
-
-          if (oldDataVisIdChall) {
-            completedDate = oldDataVisIdChall.completedDate || completedDate;
-          }
+        if (oldDataVisIdChall) {
+          completedDate = oldDataVisIdChall.completedDate || completedDate;
         }
+      }
 
-        // if fullcert is not found, return the latest completedDate
-        if (certType === 'isFullStackCert' && !certChallenge) {
-          completedDate = getFallbackFullStackDate(
-            completedChallenges,
-            completedDate
-          );
-        }
+      // if fullcert is not found, return the latest completedDate
+      if (certType === 'isFullStackCert' && !certChallenge) {
+        completedDate = getFallbackFullStackDate(
+          completedChallenges,
+          completedDate
+        );
+      }
 
-        const { name } = user;
+      const { name } = user;
 
-        if (!user.profileUI.showName) {
-          void reply.code(200);
-          return reply.send({
-            certSlug,
-            certTitle,
-            username,
-            date: completedDate,
-            completionTime
-          });
-        }
-
+      if (!user.profileUI.showName) {
         void reply.code(200);
         return reply.send({
           certSlug,
           certTitle,
           username,
-          name,
           date: completedDate,
           completionTime
         });
-      } catch (err) {
-        fastify.log.error(err);
-        void reply.code(500);
-        return reply.send({
-          message:
-            'Oops! Something went wrong. Please try again in a moment or contact support@freecodecamp.org if the error persists.',
-          type: 'danger'
-        });
       }
+
+      void reply.code(200);
+      return reply.send({
+        certSlug,
+        certTitle,
+        username,
+        name,
+        date: completedDate,
+        completionTime
+      });
     }
   );
 

--- a/api/src/routes/challenge.ts
+++ b/api/src/routes/challenge.ts
@@ -166,6 +166,7 @@ export const challengeRoutes: FastifyPluginCallbackTypebox = (
           });
         }
       } catch {
+        // TODO(Post-MVP): don't catch, just let Sentry handle this.
         void reply.code(400);
         return {
           type: 'error',
@@ -483,7 +484,9 @@ export const challengeRoutes: FastifyPluginCallbackTypebox = (
         numberOfQuestionsInExam
       );
 
-      if ('error' in validGeneratedExamSchema) {
+      if (validGeneratedExamSchema.error) {
+        fastify.log.error(validGeneratedExamSchema.error);
+        fastify.Sentry.captureException(validGeneratedExamSchema.error);
         void reply.code(500);
         return { error: 'An error occurred trying to randomize the exam.' };
       }
@@ -584,6 +587,7 @@ export const challengeRoutes: FastifyPluginCallbackTypebox = (
         };
       } catch (error) {
         fastify.log.error(error);
+        fastify.Sentry.captureException(error);
         void reply.code(500);
         return {
           type: 'error',
@@ -780,6 +784,7 @@ export const challengeRoutes: FastifyPluginCallbackTypebox = (
         };
       } catch (error) {
         fastify.log.error(error);
+        fastify.Sentry.captureException(error);
         void reply.code(500);
         return {
           error: 'An error occurred trying to submit your exam.'

--- a/api/src/routes/email-subscription.ts
+++ b/api/src/routes/email-subscription.ts
@@ -68,6 +68,7 @@ export const emailSubscribtionRoutes: FastifyPluginCallbackTypebox = (
         );
       } catch (error) {
         fastify.log.error(error);
+        fastify.Sentry.captureException(error);
         void reply.code(302);
         return reply.redirectWithMessage(origin, {
           type: 'danger',
@@ -125,6 +126,7 @@ export const emailSubscribtionRoutes: FastifyPluginCallbackTypebox = (
         });
       } catch (error) {
         fastify.log.error(error);
+        fastify.Sentry.captureException(error);
         void reply.code(302);
         return reply.redirectWithMessage(origin, {
           type: 'danger',

--- a/api/src/routes/settings.ts
+++ b/api/src/routes/settings.ts
@@ -147,8 +147,8 @@ export const settingRoutes: FastifyPluginCallbackTypebox = (
           type: 'success'
         } as const;
       } catch (err) {
-        // TODO: send to Sentry
         fastify.log.error(err);
+        fastify.Sentry.captureException(err);
         void reply.code(500);
         return { message: 'flash.wrong-updating', type: 'danger' } as const;
       }
@@ -288,6 +288,7 @@ ${isLinkSentWithinLimitTTL}`
         });
       } catch (err) {
         fastify.log.error(err);
+        fastify.Sentry.captureException(err);
         void reply.code(500);
         await reply.send({ message: 'flash.wrong-updating', type: 'danger' });
       }
@@ -315,6 +316,7 @@ ${isLinkSentWithinLimitTTL}`
         } as const;
       } catch (err) {
         fastify.log.error(err);
+        fastify.Sentry.captureException(err);
         void reply.code(500);
         return { message: 'flash.wrong-updating', type: 'danger' } as const;
       }
@@ -345,6 +347,7 @@ ${isLinkSentWithinLimitTTL}`
         } as const;
       } catch (err) {
         fastify.log.error(err);
+        fastify.Sentry.captureException(err);
         void reply.code(500);
         return { message: 'flash.wrong-updating', type: 'danger' } as const;
       }
@@ -430,6 +433,7 @@ ${isLinkSentWithinLimitTTL}`
         });
       } catch (err) {
         fastify.log.error(err);
+        fastify.Sentry.captureException(err);
         void reply.code(500);
         await reply.send({ message: 'flash.wrong-updating', type: 'danger' });
       }
@@ -460,6 +464,7 @@ ${isLinkSentWithinLimitTTL}`
         } as const;
       } catch (err) {
         fastify.log.error(err);
+        fastify.Sentry.captureException(err);
         void reply.code(500);
         return { message: 'flash.wrong-updating', type: 'danger' } as const;
       }
@@ -487,6 +492,7 @@ ${isLinkSentWithinLimitTTL}`
         } as const;
       } catch (err) {
         fastify.log.error(err);
+        fastify.Sentry.captureException(err);
         void reply.code(500);
         return { message: 'flash.wrong-updating', type: 'danger' } as const;
       }
@@ -514,6 +520,7 @@ ${isLinkSentWithinLimitTTL}`
         } as const;
       } catch (err) {
         fastify.log.error(err);
+        fastify.Sentry.captureException(err);
         void reply.code(500);
         return { message: 'flash.wrong-updating', type: 'danger' } as const;
       }
@@ -541,6 +548,7 @@ ${isLinkSentWithinLimitTTL}`
         } as const;
       } catch (err) {
         fastify.log.error(err);
+        fastify.Sentry.captureException(err);
         void reply.code(500);
         return { message: 'flash.wrong-updating', type: 'danger' } as const;
       }
@@ -569,6 +577,7 @@ ${isLinkSentWithinLimitTTL}`
         } as const;
       } catch (err) {
         fastify.log.error(err);
+        fastify.Sentry.captureException(err);
         void reply.code(500);
         return { message: 'flash.wrong-updating', type: 'danger' } as const;
       }
@@ -607,6 +616,7 @@ ${isLinkSentWithinLimitTTL}`
         } as const;
       } catch (err) {
         fastify.log.error(err);
+        fastify.Sentry.captureException(err);
         void reply.code(500);
         return { message: 'flash.wrong-updating', type: 'danger' } as const;
       }
@@ -643,6 +653,7 @@ ${isLinkSentWithinLimitTTL}`
         } as const;
       } catch (err) {
         fastify.log.error(err);
+        fastify.Sentry.captureException(err);
         void reply.code(403);
         return { message: 'flash.wrong-updating', type: 'danger' } as const;
       }

--- a/api/src/routes/user.ts
+++ b/api/src/routes/user.ts
@@ -246,6 +246,7 @@ export const userRoutes: FastifyPluginCallbackTypebox = (
         return { msUsername: null };
       } catch (err) {
         fastify.log.error(err);
+        fastify.Sentry.captureException(err);
         void reply.code(500);
         void reply.send({
           message: 'flash.ms.transcript.unlink-err',
@@ -333,6 +334,7 @@ export const userRoutes: FastifyPluginCallbackTypebox = (
         return { msUsername: userName };
       } catch (err) {
         fastify.log.error(err);
+        fastify.Sentry.captureException(err);
         return reply.code(500).send({
           type: 'error',
           message: 'flash.ms.transcript.link-err-6'
@@ -393,6 +395,7 @@ export const userRoutes: FastifyPluginCallbackTypebox = (
         } as const;
       } catch (err) {
         fastify.log.error(err);
+        fastify.Sentry.captureException(err);
         void reply.code(500);
         return {
           type: 'error',
@@ -564,6 +567,7 @@ export const userGetRoutes: FastifyPluginCallbackTypebox = (
         });
       } catch (err) {
         fastify.log.error(err);
+        fastify.Sentry.captureException(err);
         void res.code(500);
         return { user: {}, result: '' };
       }

--- a/api/src/routes/user.ts
+++ b/api/src/routes/user.ts
@@ -107,32 +107,22 @@ export const userRoutes: FastifyPluginCallbackTypebox = (
       schema: schemas.deleteMyAccount
     },
     async (req, reply) => {
-      try {
-        await fastify.prisma.userToken.deleteMany({
-          where: { userId: req.user!.id }
-        });
-        await fastify.prisma.msUsername.deleteMany({
-          where: { userId: req.user!.id }
-        });
-        await fastify.prisma.survey.deleteMany({
-          where: { userId: req.user!.id }
-        });
-        await fastify.prisma.user.delete({
-          where: { id: req.user!.id }
-        });
-        await req.session.destroy();
-        void reply.clearCookie('sessionId');
+      await fastify.prisma.userToken.deleteMany({
+        where: { userId: req.user!.id }
+      });
+      await fastify.prisma.msUsername.deleteMany({
+        where: { userId: req.user!.id }
+      });
+      await fastify.prisma.survey.deleteMany({
+        where: { userId: req.user!.id }
+      });
+      await fastify.prisma.user.delete({
+        where: { id: req.user!.id }
+      });
+      await req.session.destroy();
+      void reply.clearCookie('sessionId');
 
-        return {};
-      } catch (err) {
-        fastify.log.error(err);
-        void reply.code(500);
-        return {
-          message:
-            'Oops! Something went wrong. Please try again in a moment or contact support@freecodecamp.org if the error persists.',
-          type: 'danger'
-        };
-      }
+      return {};
     }
   );
 
@@ -141,32 +131,22 @@ export const userRoutes: FastifyPluginCallbackTypebox = (
     {
       schema: schemas.resetMyProgress
     },
-    async (req, reply) => {
-      try {
-        await fastify.prisma.userToken.deleteMany({
-          where: { userId: req.user!.id }
-        });
-        await fastify.prisma.msUsername.deleteMany({
-          where: { userId: req.user!.id }
-        });
-        await fastify.prisma.survey.deleteMany({
-          where: { userId: req.user!.id }
-        });
-        await fastify.prisma.user.update({
-          where: { id: req.user!.id },
-          data: createResetProperties()
-        });
+    async req => {
+      await fastify.prisma.userToken.deleteMany({
+        where: { userId: req.user!.id }
+      });
+      await fastify.prisma.msUsername.deleteMany({
+        where: { userId: req.user!.id }
+      });
+      await fastify.prisma.survey.deleteMany({
+        where: { userId: req.user!.id }
+      });
+      await fastify.prisma.user.update({
+        where: { id: req.user!.id },
+        data: createResetProperties()
+      });
 
-        return {};
-      } catch (err) {
-        fastify.log.error(err);
-        void reply.code(500);
-        return {
-          message:
-            'Oops! Something went wrong. Please try again in a moment or contact support@freecodecamp.org if the error persists.',
-          type: 'danger'
-        };
-      }
+      return {};
     }
   );
   // TODO(Post-MVP): POST -> PUT
@@ -196,28 +176,18 @@ export const userRoutes: FastifyPluginCallbackTypebox = (
       schema: schemas.deleteUserToken
     },
     async (req, reply) => {
-      try {
-        const { count } = await fastify.prisma.userToken.deleteMany({
-          where: { userId: req.user?.id }
-        });
+      const { count } = await fastify.prisma.userToken.deleteMany({
+        where: { userId: req.user?.id }
+      });
 
-        if (count === 0) {
-          void reply.code(404);
-          return {
-            message: 'userToken not found',
-            type: 'info'
-          } as const;
-        }
-        return { userToken: null };
-      } catch (err) {
-        fastify.log.error(err);
-        void reply.code(500);
+      if (count === 0) {
+        void reply.code(404);
         return {
-          type: 'danger',
-          message:
-            'Oops! Something went wrong. Please try again in a moment or contact support@freecodecamp.org if the error persists.'
+          message: 'userToken not found',
+          type: 'info'
         } as const;
       }
+      return { userToken: null };
     }
   );
 
@@ -231,44 +201,33 @@ export const userRoutes: FastifyPluginCallbackTypebox = (
       }
     },
     async (req, reply) => {
-      try {
-        const user = await fastify.prisma.user.findUniqueOrThrow({
-          where: { id: req.user?.id }
-        });
-        const { username, reportDescription: report } = req.body;
+      const user = await fastify.prisma.user.findUniqueOrThrow({
+        where: { id: req.user?.id }
+      });
+      const { username, reportDescription: report } = req.body;
 
-        if (!username || !report || report === '') {
-          // NOTE: Do we want to log these instances?
-          void reply.code(400);
-          return {
-            type: 'danger',
-            message: 'flash.provide-username'
-          } as const;
-        }
-
-        await fastify.sendEmail({
-          from: 'team@freecodecamp.org',
-          to: 'support@freecodecamp.org',
-          cc: user.email,
-          subject: `Abuse Report : Reporting ${username}'s profile.`,
-          text: generateReportEmail(user, username, report)
-        });
-
-        return {
-          type: 'info',
-          message: 'flash.report-sent',
-          variables: { email: user.email }
-        } as const;
-      } catch (err) {
-        fastify.log.error(err);
-        // TODO: redirect to the reported user's profile if there's an error
-        void reply.code(500);
+      if (!username || !report || report === '') {
+        // NOTE: Do we want to log these instances?
+        void reply.code(400);
         return {
           type: 'danger',
-          message:
-            'Oops! Something went wrong. Please try again in a moment or contact support@freecodecamp.org if the error persists.'
+          message: 'flash.provide-username'
         } as const;
       }
+
+      await fastify.sendEmail({
+        from: 'team@freecodecamp.org',
+        to: 'support@freecodecamp.org',
+        cc: user.email,
+        subject: `Abuse Report : Reporting ${username}'s profile.`,
+        text: generateReportEmail(user, username, report)
+      });
+
+      return {
+        type: 'info',
+        message: 'flash.report-sent',
+        variables: { email: user.email }
+      } as const;
     }
   );
 

--- a/api/src/routes/user.ts
+++ b/api/src/routes/user.ts
@@ -206,7 +206,7 @@ export const userRoutes: FastifyPluginCallbackTypebox = (
       });
       const { username, reportDescription: report } = req.body;
 
-      if (!username || !report || report === '') {
+      if (!username || !report) {
         // NOTE: Do we want to log these instances?
         void reply.code(400);
         return {

--- a/api/src/schemas/certificate/cert-slug.ts
+++ b/api/src/schemas/certificate/cert-slug.ts
@@ -1,5 +1,6 @@
 import { Type } from '@fastify/type-provider-typebox';
 import { Certification } from '../../../../shared/config/certification-settings';
+import { generic500 } from '../types';
 
 export const certSlug = {
   params: Type.Object({
@@ -119,11 +120,6 @@ export const certSlug = {
         })
       )
     }),
-    500: Type.Object({
-      type: Type.Literal('danger'),
-      message: Type.Literal(
-        'Oops! Something went wrong. Please try again in a moment or contact support@freecodecamp.org if the error persists.'
-      )
-    })
+    500: generic500
   }
 };

--- a/api/src/schemas/certificate/certificate-verify.ts
+++ b/api/src/schemas/certificate/certificate-verify.ts
@@ -121,14 +121,12 @@ export const certificateVerify = {
         )
       })
     ]),
-    500: Type.Union(
-      [
-        Type.Object({
-          type: Type.Literal('danger'),
-          message: Type.Literal('flash.went-wrong')
-        })
-      ],
+    500: Type.Union([
+      Type.Object({
+        type: Type.Literal('danger'),
+        message: Type.Literal('flash.went-wrong')
+      }),
       generic500
-    )
+    ])
   }
 };

--- a/api/src/schemas/certificate/certificate-verify.ts
+++ b/api/src/schemas/certificate/certificate-verify.ts
@@ -1,5 +1,5 @@
 import { Type } from '@fastify/type-provider-typebox';
-import { isCertMap } from '../types';
+import { generic500, isCertMap } from '../types';
 
 export const certificateVerify = {
   // TODO(POST_MVP): Remove partial validation from route for schema validation
@@ -121,9 +121,14 @@ export const certificateVerify = {
         )
       })
     ]),
-    500: Type.Object({
-      type: Type.Literal('danger'),
-      message: Type.Literal('flash.went-wrong')
-    })
+    500: Type.Union(
+      [
+        Type.Object({
+          type: Type.Literal('danger'),
+          message: Type.Literal('flash.went-wrong')
+        })
+      ],
+      generic500
+    )
   }
 };

--- a/api/src/schemas/challenge/backend-challenge-completed.ts
+++ b/api/src/schemas/challenge/backend-challenge-completed.ts
@@ -1,4 +1,5 @@
 import { Type } from '@fastify/type-provider-typebox';
+import { generic500 } from '../types';
 
 export const backendChallengeCompleted = {
   body: Type.Object({
@@ -16,11 +17,6 @@ export const backendChallengeCompleted = {
         'That does not appear to be a valid challenge submission.'
       )
     }),
-    500: Type.Object({
-      type: Type.Literal('danger'),
-      message: Type.Literal(
-        'Oops! Something went wrong. Please try again in a moment or contact support@freecodecamp.org if the error persists.'
-      )
-    })
+    500: generic500
   }
 };

--- a/api/src/schemas/challenge/coderoad-challenge-completed.ts
+++ b/api/src/schemas/challenge/coderoad-challenge-completed.ts
@@ -1,4 +1,5 @@
 import { Type } from '@fastify/type-provider-typebox';
+import { generic500 } from '../types';
 
 export const coderoadChallengeCompleted = {
   body: Type.Object({
@@ -14,9 +15,6 @@ export const coderoadChallengeCompleted = {
       type: Type.Literal('error'),
       msg: Type.String()
     }),
-    500: Type.Object({
-      type: Type.Literal('danger'),
-      msg: Type.String()
-    })
+    500: generic500
   }
 };

--- a/api/src/schemas/challenge/modern-challenge-completed.ts
+++ b/api/src/schemas/challenge/modern-challenge-completed.ts
@@ -1,5 +1,5 @@
 import { Type } from '@fastify/type-provider-typebox';
-import { savedChallenge } from '../types';
+import { generic500, savedChallenge } from '../types';
 
 export const modernChallengeCompleted = {
   body: Type.Object({
@@ -30,11 +30,6 @@ export const modernChallengeCompleted = {
         'That does not appear to be a valid challenge submission.'
       )
     }),
-    500: Type.Object({
-      type: Type.Literal('danger'),
-      message: Type.Literal(
-        'Oops! Something went wrong. Please try again in a moment or contact support@freecodecamp.org if the error persists.'
-      )
-    })
+    500: generic500
   }
 };

--- a/api/src/schemas/challenge/project-completed.ts
+++ b/api/src/schemas/challenge/project-completed.ts
@@ -1,4 +1,5 @@
 import { Type } from '@fastify/type-provider-typebox';
+import { generic500 } from '../types';
 
 export const projectCompleted = {
   body: Type.Object({
@@ -36,11 +37,6 @@ export const projectCompleted = {
         Type.Literal('That does not appear to be a valid challenge submission.')
       ])
     }),
-    500: Type.Object({
-      message: Type.Literal(
-        'Oops! Something went wrong. Please try again in a moment or contact support@freecodecamp.org if the error persists.'
-      ),
-      type: Type.Literal('danger')
-    })
+    500: generic500
   }
 };

--- a/api/src/schemas/challenge/save-challenge.ts
+++ b/api/src/schemas/challenge/save-challenge.ts
@@ -1,5 +1,5 @@
 import { Type } from '@fastify/type-provider-typebox';
-import { file, savedChallenge } from '../types';
+import { file, generic500, savedChallenge } from '../types';
 
 export const saveChallenge = {
   body: Type.Object({
@@ -15,11 +15,6 @@ export const saveChallenge = {
       savedChallenges: Type.Array(savedChallenge)
     }),
     403: Type.Literal('That challenge type is not saveable.'),
-    500: Type.Object({
-      type: Type.Literal('danger'),
-      message: Type.Literal(
-        'Oops! Something went wrong. Please try again in a moment or contact support@freecodecamp.org if the error persists.'
-      )
-    })
+    500: generic500
   }
 };

--- a/api/src/schemas/types.ts
+++ b/api/src/schemas/types.ts
@@ -1,9 +1,7 @@
 import { Type } from '@fastify/type-provider-typebox';
 
 export const generic500 = Type.Object({
-  message: Type.Literal(
-    'Oops! Something went wrong. Please try again in a moment or contact support@freecodecamp.org if the error persists.'
-  ),
+  message: Type.Literal('flash.generic-error'),
   type: Type.Literal('danger')
 });
 

--- a/api/src/schemas/user/delete-user-token.ts
+++ b/api/src/schemas/user/delete-user-token.ts
@@ -1,4 +1,5 @@
 import { Type } from '@fastify/type-provider-typebox';
+import { generic500 } from '../types';
 
 export const deleteUserToken = {
   response: {
@@ -9,11 +10,6 @@ export const deleteUserToken = {
       message: Type.Literal('userToken not found'),
       type: Type.Literal('info')
     }),
-    500: Type.Object({
-      message: Type.Literal(
-        'Oops! Something went wrong. Please try again in a moment or contact support@freecodecamp.org if the error persists.'
-      ),
-      type: Type.Literal('danger')
-    })
+    500: generic500
   }
 };


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Key points:

- Sends errors when the DSN exists (oops)
- Uses the same response for all unhandled errors
- Doesn't mess with the weirder responses (I'm looking at you, donation and exams)

<!-- Feel free to add any additional description of changes below this line -->
