### PR TITLE
chore: remove audioPath

### DIFF
--- a/client/gatsby-node.js
+++ b/client/gatsby-node.js
@@ -74,7 +74,6 @@ exports.createPages = function createPages({ graphql, actions, reporter }) {
             edges {
               node {
                 challenge {
-                  audioPath
                   block
                   certification
                   challengeType
@@ -321,7 +320,6 @@ exports.createSchemaCustomization = ({ actions }) => {
       challenge: Challenge
     }
     type Challenge {
-      audioPath: String
       challengeFiles: [FileContents]
       notes: String
       url: String

--- a/client/src/redux/prop-types.ts
+++ b/client/src/redux/prop-types.ts
@@ -177,7 +177,6 @@ export type ChallengeWithCompletedNode = {
 
 export type ChallengeNode = {
   challenge: {
-    audioPath: string;
     block: string;
     certification: string;
     challengeOrder: number;

--- a/client/src/templates/Challenges/fill-in-the-blank/show.tsx
+++ b/client/src/templates/Challenges/fill-in-the-blank/show.tsx
@@ -275,7 +275,6 @@ class ShowFillInTheBlank extends Component<
             translationPending,
             fields: { blockName },
             fillInTheBlank: { sentence, blanks },
-            audioPath,
             scene
           }
         }
@@ -322,19 +321,6 @@ class ShowFillInTheBlank extends Component<
               <Col md={8} mdOffset={2} sm={10} smOffset={1} xs={12}>
                 <PrismFormatted text={description} />
                 <Spacer size='medium' />
-                {audioPath && (
-                  <>
-                    {/* TODO: Add tracks for audio elements */}
-                    {/* eslint-disable-next-line jsx-a11y/media-has-caption*/}
-                    <audio className='audio' controls>
-                      <source
-                        src={`https://cdn.freecodecamp.org/${audioPath}`}
-                        type='audio/mpeg'
-                      />
-                    </audio>
-                    <Spacer size='medium' />
-                  </>
-                )}
               </Col>
 
               {scene && (
@@ -510,7 +496,6 @@ export const query = graphql`
           }
         }
         translationPending
-        audioPath
       }
     }
   }

--- a/client/src/templates/Challenges/odin/show.tsx
+++ b/client/src/templates/Challenges/odin/show.tsx
@@ -238,7 +238,6 @@ class ShowOdin extends Component<ShowOdinProps, ShowOdinState> {
             fields: { blockName },
             question: { text, answers, solution },
             assignments,
-            audioPath,
             translationPending,
             scene
           }
@@ -308,19 +307,6 @@ class ShowOdin extends Component<ShowOdinProps, ShowOdinState> {
                 </ChallengeTitle>
                 <PrismFormatted className={'line-numbers'} text={description} />
                 <Spacer size='medium' />
-                {audioPath && (
-                  <>
-                    {/* TODO: Add tracks for audio elements */}
-                    {/* eslint-disable-next-line jsx-a11y/media-has-caption*/}
-                    <audio className='audio' controls>
-                      <source
-                        src={`https://cdn.freecodecamp.org/${audioPath}`}
-                        type='audio/mp3'
-                      />
-                    </audio>
-                    <Spacer size='medium' />
-                  </>
-                )}
               </Col>
 
               {scene && (
@@ -541,7 +527,6 @@ export const query = graphql`
         }
         translationPending
         assignments
-        audioPath
       }
     }
   }

--- a/curriculum/schema/__snapshots__/challenge-schema.test.js.snap
+++ b/curriculum/schema/__snapshots__/challenge-schema.test.js.snap
@@ -86,7 +86,6 @@ const commandJoi = Joi.object().keys({
 
 const schema = Joi.object()
   .keys({
-    audioPath: Joi.string(),
     block: Joi.string().regex(slugRE).required(),
     blockId: Joi.objectId(),
     challengeOrder: Joi.number(),

--- a/curriculum/schema/challenge-schema.js
+++ b/curriculum/schema/challenge-schema.js
@@ -83,7 +83,6 @@ const commandJoi = Joi.object().keys({
 
 const schema = Joi.object()
   .keys({
-    audioPath: Joi.string(),
     block: Joi.string().regex(slugRE).required(),
     blockId: Joi.objectId(),
     challengeOrder: Joi.number(),

--- a/tools/challenge-helper-scripts/create-this-challenge.ts
+++ b/tools/challenge-helper-scripts/create-this-challenge.ts
@@ -23,8 +23,6 @@ const challengeId = new ObjectID().toString();
  * NOTE: if the body of the challenge is not correctly formatted, see below for
  * examples of the correct format.
  *
- * Finally dialogs have different frontmatter. After running the script, replace
- * the audioPath with the videoId. Again, there is an example below.
  */
 
 const num = 1;
@@ -36,7 +34,6 @@ id: ${challengeId}
 title: ${title}
 challengeType: ${challengeType}
 dashedName: ${dashedName}
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 `;
@@ -127,7 +124,6 @@ The term `an issue` relates to the solution, not to the expression of understand
 id: 651dd3e06ffb500e3f2ce478
 title: "Dialogue 1: Maria Introduces Herself to Tom"
 challengeType: 21
-videoId: nLDychdBwUg
 dashedName: dialogue-1-maria-introduces-herself-to-tom
 ---
 


### PR DESCRIPTION
When prototyping the English challenges, we were considering playing an audio file in the challenges - and created an `audioPath` property in the challenge front matter and the ability to play the audio in the view components. We have since moved to the animations and don't use this anywhere anymore.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
