### PR TITLE
fix: padding on dialogue challenge link

### DIFF
--- a/client/src/templates/Introduction/intro.css
+++ b/client/src/templates/Introduction/intro.css
@@ -277,7 +277,7 @@ button.map-title {
 .map-dialogue-wrap a {
   align-items: center;
   min-height: 50px;
-  padding: 0;
+  padding: 10px 15px;
 }
 
 .block-description {


### PR DESCRIPTION
There wasn't any padding in front of the links to the dialogue challenges...

Before:

<img width="418" alt="Screenshot 2024-06-17 at 7 01 26 PM" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/20648924/3417e705-447d-428f-b37b-e3eea8d01ed4">

^ notice no padding on the left of the highlighted challenge, next to the checkbox.

After:

<img width="463" alt="Screenshot 2024-06-17 at 7 00 14 PM" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/20648924/3a712d59-054c-4acb-90c6-fa95f528af88">

^ Same padding as all the other challenges that are displayed like this.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
