### PR TITLE
fix(UI): prevent blank cutoffs

### DIFF
--- a/client/src/templates/Challenges/fill-in-the-blank/show.css
+++ b/client/src/templates/Challenges/fill-in-the-blank/show.css
@@ -11,7 +11,7 @@
 
 .fill-in-the-blank-wrap > p {
   margin: 0;
-  font-size: 1.25em;
+  font-size: 1.25rem;
 }
 
 .fill-in-the-blank-input {
@@ -20,7 +20,7 @@
   background-color: var(--primary-background);
   border-radius: 0;
   overflow-wrap: anywhere;
-  line-height: 1.5rem;
+  line-height: 1.5;
   z-index: 1;
   position: relative;
   border-left: none;
@@ -28,6 +28,10 @@
   border-top: none;
   border-bottom-width: 4px;
   border-bottom-color: var(--gray-45) !important;
+}
+
+.fill-in-the-blank-input:focus {
+  z-index: 2;
 }
 
 .code-tag code {

--- a/client/src/templates/Challenges/fill-in-the-blank/show.css
+++ b/client/src/templates/Challenges/fill-in-the-blank/show.css
@@ -12,6 +12,7 @@
 .fill-in-the-blank-wrap > p {
   margin: 0;
   font-size: 1.25rem;
+  line-height: 1.5;
 }
 
 .fill-in-the-blank-input {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #55212

<!-- Feel free to add any additional description of changes below this line -->
I had updated the units for the font-size and line-height to match what was discussed. While nothing was accomplished with the units, I increased the z index of the active blank input. Putting it on a higher layer fixed the issue. 