### PR TITLE
refactor(api): sensible default cookie config

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -136,8 +136,6 @@ export const build = async (
 
     if (!isSignout) {
       const token = reply.generateCsrf();
-      // Path is necessary to ensure that only one cookie is set and it is valid
-      // for all routes.
       void reply.setCookie('csrf_token', token, {
         sameSite: 'strict',
         signed: false

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -44,7 +44,6 @@ import {
   EMAIL_PROVIDER,
   FCC_ENABLE_DEV_LOGIN_MODE,
   FCC_ENABLE_SWAGGER_UI,
-  FREECODECAMP_NODE_ENV,
   SENTRY_DSN
 } from './utils/env';
 import { isObjectID } from './utils/validation';

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -41,7 +41,6 @@ import { statusRoute } from './routes/status';
 import { userGetRoutes, userRoutes, userPublicGetRoutes } from './routes/user';
 import {
   API_LOCATION,
-  COOKIE_DOMAIN,
   EMAIL_PROVIDER,
   FCC_ENABLE_DEV_LOGIN_MODE,
   FCC_ENABLE_SWAGGER_UI,
@@ -127,7 +126,8 @@ export const build = async (
 
     ///Ignore all other possible sources of CSRF
     // tokens since we know we can provide this one
-    getToken: req => req.headers['csrf-token'] as string
+    getToken: req => req.headers['csrf-token'] as string,
+    cookieOpts: { signed: false, sameSite: 'strict' }
   });
 
   // All routes except signout should add a CSRF token to the response
@@ -139,10 +139,8 @@ export const build = async (
       // Path is necessary to ensure that only one cookie is set and it is valid
       // for all routes.
       void reply.setCookie('csrf_token', token, {
-        path: '/',
         sameSite: 'strict',
-        domain: COOKIE_DOMAIN,
-        secure: FREECODECAMP_NODE_ENV === 'production'
+        signed: false
       });
     }
     done();

--- a/api/src/plugins/code-flow-auth.ts
+++ b/api/src/plugins/code-flow-auth.ts
@@ -3,7 +3,7 @@ import fp from 'fastify-plugin';
 import jwt from 'jsonwebtoken';
 import { type user } from '@prisma/client';
 
-import { COOKIE_DOMAIN, JWT_SECRET } from '../utils/env';
+import { JWT_SECRET } from '../utils/env';
 import { type Token, isExpired } from '../utils/tokens';
 import { getRedirectParams } from '../utils/redirection';
 
@@ -27,12 +27,8 @@ const codeFlowAuth: FastifyPluginCallback = (fastify, _options, done) => {
   fastify.decorateReply('setAccessTokenCookie', function (accessToken: Token) {
     const signedToken = jwt.sign({ accessToken }, JWT_SECRET);
     void this.setCookie('jwt_access_token', signedToken, {
-      path: '/',
       httpOnly: false,
       secure: false,
-      sameSite: 'lax',
-      domain: COOKIE_DOMAIN,
-      signed: true,
       maxAge: accessToken.ttl
     });
   });

--- a/api/src/plugins/cookies.ts
+++ b/api/src/plugins/cookies.ts
@@ -2,7 +2,7 @@ import fastifyCookie from '@fastify/cookie';
 import { FastifyPluginCallback } from 'fastify';
 import fp from 'fastify-plugin';
 
-import { COOKIE_SECRET } from '../utils/env';
+import { COOKIE_DOMAIN, COOKIE_SECRET } from '../utils/env';
 
 /**
  * Signs a cookie value by prefixing it with "s:" and using the COOKIE_SECRET.
@@ -41,6 +41,14 @@ const cookies: FastifyPluginCallback = (fastify, _options, done) => {
     secret: {
       sign,
       unsign
+    },
+    parseOptions: {
+      domain: COOKIE_DOMAIN,
+      httpOnly: true,
+      path: '/',
+      sameSite: 'lax',
+      secure: true,
+      signed: true
     }
   });
 

--- a/api/src/plugins/cookies.ts
+++ b/api/src/plugins/cookies.ts
@@ -45,6 +45,8 @@ const cookies: FastifyPluginCallback = (fastify, _options, done) => {
     parseOptions: {
       domain: COOKIE_DOMAIN,
       httpOnly: true,
+      // Path is necessary to ensure that only one cookie is set and it is valid
+      // for all routes.
       path: '/',
       sameSite: 'lax',
       secure: true,

--- a/api/src/routes/auth-dev.test.ts
+++ b/api/src/routes/auth-dev.test.ts
@@ -181,13 +181,13 @@ describe('dev login', () => {
       expect(setCookie).toEqual(
         expect.arrayContaining([
           expect.stringMatching(
-            /jwt_access_token=; Path=\/; Expires=Thu, 01 Jan 1970 00:00:00 GMT/
+            /^jwt_access_token=; Path=\/; Expires=Thu, 01 Jan 1970 00:00:00 GMT/
           ),
           expect.stringMatching(
-            /csrf_token=; Path=\/; Expires=Thu, 01 Jan 1970 00:00:00 GMT/
+            /^csrf_token=; Path=\/; Expires=Thu, 01 Jan 1970 00:00:00 GMT/
           ),
           expect.stringMatching(
-            /_csrf=; Path=\/; Expires=Thu, 01 Jan 1970 00:00:00 GMT/
+            /^_csrf=; Path=\/; Expires=Thu, 01 Jan 1970 00:00:00 GMT/
           )
         ])
       );

--- a/api/src/routes/auth-dev.test.ts
+++ b/api/src/routes/auth-dev.test.ts
@@ -180,9 +180,15 @@ describe('dev login', () => {
       const setCookie = res.headers['set-cookie'];
       expect(setCookie).toEqual(
         expect.arrayContaining([
-          'jwt_access_token=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT',
-          '_csrf=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT',
-          'csrf_token=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT'
+          expect.stringMatching(
+            /jwt_access_token=; Path=\/; Expires=Thu, 01 Jan 1970 00:00:00 GMT/
+          ),
+          expect.stringMatching(
+            /csrf_token=; Path=\/; Expires=Thu, 01 Jan 1970 00:00:00 GMT/
+          ),
+          expect.stringMatching(
+            /_csrf=; Path=\/; Expires=Thu, 01 Jan 1970 00:00:00 GMT/
+          )
         ])
       );
       expect(setCookie).toHaveLength(3);

--- a/api/src/routes/user.test.ts
+++ b/api/src/routes/user.test.ts
@@ -369,9 +369,9 @@ describe('userRoutes', () => {
         const setCookie = res.headers['set-cookie'];
         expect(setCookie).toEqual(
           expect.arrayContaining([
-            'jwt_access_token=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT',
-            '_csrf=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT',
-            'csrf_token=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT'
+            'jwt_access_token=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; Secure; SameSite=Lax',
+            '_csrf=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; Secure; SameSite=Lax',
+            'csrf_token=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; Secure; SameSite=Lax'
           ])
         );
         expect(setCookie).toHaveLength(3);

--- a/api/src/routes/user.test.ts
+++ b/api/src/routes/user.test.ts
@@ -369,9 +369,15 @@ describe('userRoutes', () => {
         const setCookie = res.headers['set-cookie'];
         expect(setCookie).toEqual(
           expect.arrayContaining([
-            'jwt_access_token=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; Secure; SameSite=Lax',
-            '_csrf=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; Secure; SameSite=Lax',
-            'csrf_token=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; Secure; SameSite=Lax'
+            expect.stringMatching(
+              /^jwt_access_token=; Path=\/; Expires=Thu, 01 Jan 1970 00:00:00 GMT/
+            ),
+            expect.stringMatching(
+              /^csrf_token=; Path=\/; Expires=Thu, 01 Jan 1970 00:00:00 GMT/
+            ),
+            expect.stringMatching(
+              /^_csrf=; Path=\/; Expires=Thu, 01 Jan 1970 00:00:00 GMT/
+            )
           ])
         );
         expect(setCookie).toHaveLength(3);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

We can always overwrite the cookie config on a per-plugin or even per-setCookie basis, but I think these are good defaults.

<!-- Feel free to add any additional description of changes below this line -->
