### PR TITLE
Improve instructions for steps 43, 53, 54, and 55

### DIFF
--- a/curriculum/challenges/_meta/learn-typography-by-building-a-nutrition-label/meta.json
+++ b/curriculum/challenges/_meta/learn-typography-by-building-a-nutrition-label/meta.json
@@ -181,11 +181,11 @@
       "title": "Step 43"
     },
     {
-      "id": "615f6cc778f7698258467596",
+      "id": "new-generated-id-44",
       "title": "Step 44"
     },
     {
-      "id": "615f6fddaac1e083502d3e6a",
+      "id": "615f6cc778f7698258467596",
       "title": "Step 45"
     },
     {


### PR DESCRIPTION


- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.


Closes  #51786

## Description
This PR addresses issues in the "Learn Typography by Building a Nutrition Label" section by:

1. Breaking step 43 into two steps for clarity.
2. Updating steps 53, 54, and 55 to better delineate the requirements.

### Changes Made
- Split step 43 into two steps: one for adding the span elements and another for wrapping them.
- Improved the clarity of instructions for steps 53, 54, and 55.
- Modified `filename.json` to reflect the updated instructions.

### Verification
- Verified that each step functions correctly and the instructions are clear.
- Updated tests to ensure they match the new step requirements.

Closes issue  #51786
