### PR TITLE
test: minor fix to how cookies are passed around

### DIFF
--- a/api/jest.utils.test.ts
+++ b/api/jest.utils.test.ts
@@ -1,4 +1,4 @@
-import { getCsrfToken } from './jest.utils';
+import { getCsrfToken, getCookies } from './jest.utils';
 
 const fakeCookies = [
   '_csrf=123; Path=/; HttpOnly; SameSite=Strict',
@@ -15,5 +15,20 @@ describe('getCsrfToken', () => {
     expect(
       getCsrfToken(['_csrf=123; Path=/; HttpOnly; SameSite=Strict'])
     ).toBeUndefined();
+  });
+});
+
+describe('setCookiesToCookies', () => {
+  test('returns a string of cookies', () => {
+    expect(getCookies(fakeCookies)).toEqual(
+      '_csrf=123; csrf_token=abc-123; sessionId=CV-abc.123'
+    );
+  });
+  test('handles bare cookies', () => {
+    expect(getCookies(['_csrf=123'])).toEqual('_csrf=123');
+  });
+
+  test('throws an error if the cookies are malformed', () => {
+    expect(() => getCookies(['_csrf'])).toThrow();
   });
 });

--- a/api/jest.utils.ts
+++ b/api/jest.utils.ts
@@ -34,6 +34,13 @@ export const getCsrfToken = (setCookies: string[]): string | undefined => {
 
 export const ORIGIN = 'https://www.freecodecamp.org';
 
+export const getCookies = (setCookies: string[]): string => {
+  for (const cookie of setCookies) {
+    expect(cookie).toMatch(/.*=.*/);
+  }
+  return setCookies.map(cookie => cookie.split(';')[0]).join('; ');
+};
+
 export function superRequest(
   resource: string,
   config: {
@@ -48,7 +55,7 @@ export function superRequest(
   const req = requests[method](resource).set('Origin', ORIGIN);
 
   if (setCookies) {
-    void req.set('Cookie', setCookies);
+    void req.set('Cookie', getCookies(setCookies));
   }
 
   const csrfToken = (setCookies && getCsrfToken(setCookies)) ?? '';


### PR DESCRIPTION
Nothing was broken by this, but since it was passing values like

_csrf=123; Path=/; HttpOnly; SameSite=Strict

in the cookie header, this would be interpreted as three cookies
(_csrf, Path and SameSite), which isn't the intention

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->
