### PR TITLE
fix(api): use generic error message if CSRF error

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -107,7 +107,10 @@ export const build = async (
     // test environments)
     skipInit: !SENTRY_DSN,
     errorResponse: (error, _request, reply) => {
-      if (reply.statusCode === 500) {
+      const isCSRFError =
+        error.code === 'FST_CSRF_INVALID_TOKEN' ||
+        error.code === 'FST_CSRF_MISSING_SECRET';
+      if (reply.statusCode === 500 || isCSRFError) {
         void reply.send({
           message: 'flash.generic-error',
           type: 'danger'

--- a/api/src/routes/challenge.ts
+++ b/api/src/routes/challenge.ts
@@ -396,8 +396,7 @@ export const challengeRoutes: FastifyPluginCallbackTypebox = (
         !multifileCertProjectIds.includes(challengeId) &&
         !multifilePythonCertProjectIds.includes(challengeId)
       ) {
-        void reply.code(403);
-        return 'That challenge type is not saveable.';
+        void reply.code(403).send('That challenge type is not saveable.');
       }
 
       const userSavedChallenges = saveUserChallengeData(
@@ -413,7 +412,7 @@ export const challengeRoutes: FastifyPluginCallbackTypebox = (
         }
       });
 
-      return { savedChallenges: userSavedChallenges };
+      void reply.send({ savedChallenges: userSavedChallenges });
     }
   );
 

--- a/api/src/routes/settings.test.ts
+++ b/api/src/routes/settings.test.ts
@@ -59,10 +59,8 @@ describe('settingRoutes', () => {
       });
 
       expect(response.body).toEqual({
-        code: 'FST_CSRF_MISSING_SECRET',
-        error: 'Forbidden',
-        message: 'Missing csrf secret',
-        statusCode: 403
+        message: 'flash.generic-error',
+        type: 'danger'
       });
       expect(response.statusCode).toEqual(403);
     });
@@ -73,10 +71,8 @@ describe('settingRoutes', () => {
       }).set('Cookie', ['_csrf=foo', 'csrf-token=bar']);
 
       expect(response.body).toEqual({
-        code: 'FST_CSRF_INVALID_TOKEN',
-        error: 'Forbidden',
-        message: 'Invalid csrf token',
-        statusCode: 403
+        message: 'flash.generic-error',
+        type: 'danger'
       });
       expect(response.statusCode).toEqual(403);
     });

--- a/api/src/schemas/certificate/cert-slug.ts
+++ b/api/src/schemas/certificate/cert-slug.ts
@@ -120,6 +120,6 @@ export const certSlug = {
         })
       )
     }),
-    500: genericError
+    default: genericError
   }
 };

--- a/api/src/schemas/certificate/cert-slug.ts
+++ b/api/src/schemas/certificate/cert-slug.ts
@@ -1,6 +1,6 @@
 import { Type } from '@fastify/type-provider-typebox';
 import { Certification } from '../../../../shared/config/certification-settings';
-import { generic500 } from '../types';
+import { genericError } from '../types';
 
 export const certSlug = {
   params: Type.Object({
@@ -120,6 +120,6 @@ export const certSlug = {
         })
       )
     }),
-    500: generic500
+    500: genericError
   }
 };

--- a/api/src/schemas/certificate/certificate-verify.ts
+++ b/api/src/schemas/certificate/certificate-verify.ts
@@ -127,6 +127,7 @@ export const certificateVerify = {
         message: Type.Literal('flash.went-wrong')
       }),
       genericError
-    ])
+    ]),
+    default: genericError
   }
 };

--- a/api/src/schemas/certificate/certificate-verify.ts
+++ b/api/src/schemas/certificate/certificate-verify.ts
@@ -1,5 +1,5 @@
 import { Type } from '@fastify/type-provider-typebox';
-import { generic500, isCertMap } from '../types';
+import { genericError, isCertMap } from '../types';
 
 export const certificateVerify = {
   // TODO(POST_MVP): Remove partial validation from route for schema validation
@@ -126,7 +126,7 @@ export const certificateVerify = {
         type: Type.Literal('danger'),
         message: Type.Literal('flash.went-wrong')
       }),
-      generic500
+      genericError
     ])
   }
 };

--- a/api/src/schemas/challenge/backend-challenge-completed.ts
+++ b/api/src/schemas/challenge/backend-challenge-completed.ts
@@ -17,6 +17,6 @@ export const backendChallengeCompleted = {
         'That does not appear to be a valid challenge submission.'
       )
     }),
-    500: genericError
+    default: genericError
   }
 };

--- a/api/src/schemas/challenge/backend-challenge-completed.ts
+++ b/api/src/schemas/challenge/backend-challenge-completed.ts
@@ -1,5 +1,5 @@
 import { Type } from '@fastify/type-provider-typebox';
-import { generic500 } from '../types';
+import { genericError } from '../types';
 
 export const backendChallengeCompleted = {
   body: Type.Object({
@@ -17,6 +17,6 @@ export const backendChallengeCompleted = {
         'That does not appear to be a valid challenge submission.'
       )
     }),
-    500: generic500
+    500: genericError
   }
 };

--- a/api/src/schemas/challenge/coderoad-challenge-completed.ts
+++ b/api/src/schemas/challenge/coderoad-challenge-completed.ts
@@ -15,6 +15,6 @@ export const coderoadChallengeCompleted = {
       type: Type.Literal('error'),
       msg: Type.String()
     }),
-    500: genericError
+    default: genericError
   }
 };

--- a/api/src/schemas/challenge/coderoad-challenge-completed.ts
+++ b/api/src/schemas/challenge/coderoad-challenge-completed.ts
@@ -1,5 +1,5 @@
 import { Type } from '@fastify/type-provider-typebox';
-import { generic500 } from '../types';
+import { genericError } from '../types';
 
 export const coderoadChallengeCompleted = {
   body: Type.Object({
@@ -15,6 +15,6 @@ export const coderoadChallengeCompleted = {
       type: Type.Literal('error'),
       msg: Type.String()
     }),
-    500: generic500
+    500: genericError
   }
 };

--- a/api/src/schemas/challenge/exam-challenge-completed.ts
+++ b/api/src/schemas/challenge/exam-challenge-completed.ts
@@ -1,5 +1,5 @@
 import { Type } from '@fastify/type-provider-typebox';
-import { examResults } from '../types';
+import { examResults, genericError } from '../types';
 
 export const examChallengeCompleted = {
   body: Type.Object({
@@ -30,9 +30,12 @@ export const examChallengeCompleted = {
     400: Type.Object({
       error: Type.String()
     }),
-    403: Type.Object({
-      error: Type.String()
-    }),
+    403: Type.Union([
+      Type.Object({
+        error: Type.String()
+      }),
+      genericError
+    ]),
     500: Type.Object({
       error: Type.String()
     })

--- a/api/src/schemas/challenge/exam.ts
+++ b/api/src/schemas/challenge/exam.ts
@@ -1,4 +1,5 @@
 import { Type } from '@fastify/type-provider-typebox';
+import { genericError } from '../types';
 
 export const exam = {
   params: Type.Object({
@@ -27,9 +28,12 @@ export const exam = {
     400: Type.Object({
       error: Type.String()
     }),
-    403: Type.Object({
-      error: Type.String()
-    }),
+    403: Type.Union([
+      Type.Object({
+        error: Type.String()
+      }),
+      genericError
+    ]),
     500: Type.Object({
       error: Type.String()
     })

--- a/api/src/schemas/challenge/modern-challenge-completed.ts
+++ b/api/src/schemas/challenge/modern-challenge-completed.ts
@@ -1,5 +1,5 @@
 import { Type } from '@fastify/type-provider-typebox';
-import { generic500, savedChallenge } from '../types';
+import { genericError, savedChallenge } from '../types';
 
 export const modernChallengeCompleted = {
   body: Type.Object({
@@ -30,6 +30,6 @@ export const modernChallengeCompleted = {
         'That does not appear to be a valid challenge submission.'
       )
     }),
-    500: generic500
+    500: genericError
   }
 };

--- a/api/src/schemas/challenge/modern-challenge-completed.ts
+++ b/api/src/schemas/challenge/modern-challenge-completed.ts
@@ -30,6 +30,6 @@ export const modernChallengeCompleted = {
         'That does not appear to be a valid challenge submission.'
       )
     }),
-    500: genericError
+    default: genericError
   }
 };

--- a/api/src/schemas/challenge/project-completed.ts
+++ b/api/src/schemas/challenge/project-completed.ts
@@ -37,6 +37,6 @@ export const projectCompleted = {
         Type.Literal('That does not appear to be a valid challenge submission.')
       ])
     }),
-    500: genericError
+    default: genericError
   }
 };

--- a/api/src/schemas/challenge/project-completed.ts
+++ b/api/src/schemas/challenge/project-completed.ts
@@ -28,15 +28,20 @@ export const projectCompleted = {
         )
       ])
     }),
-    403: Type.Object({
-      type: Type.Literal('error'),
-      message: Type.Union([
-        Type.Literal(
-          'You have to complete the project before you can submit a URL.'
-        ),
-        Type.Literal('That does not appear to be a valid challenge submission.')
-      ])
-    }),
+    403: Type.Union([
+      Type.Object({
+        type: Type.Literal('error'),
+        message: Type.Union([
+          Type.Literal(
+            'You have to complete the project before you can submit a URL.'
+          ),
+          Type.Literal(
+            'That does not appear to be a valid challenge submission.'
+          )
+        ])
+      }),
+      genericError
+    ]),
     default: genericError
   }
 };

--- a/api/src/schemas/challenge/project-completed.ts
+++ b/api/src/schemas/challenge/project-completed.ts
@@ -1,5 +1,5 @@
 import { Type } from '@fastify/type-provider-typebox';
-import { generic500 } from '../types';
+import { genericError } from '../types';
 
 export const projectCompleted = {
   body: Type.Object({
@@ -37,6 +37,6 @@ export const projectCompleted = {
         Type.Literal('That does not appear to be a valid challenge submission.')
       ])
     }),
-    500: generic500
+    500: genericError
   }
 };

--- a/api/src/schemas/challenge/save-challenge.ts
+++ b/api/src/schemas/challenge/save-challenge.ts
@@ -1,5 +1,5 @@
 import { Type } from '@fastify/type-provider-typebox';
-import { file, generic500, savedChallenge } from '../types';
+import { file, genericError, savedChallenge } from '../types';
 
 export const saveChallenge = {
   body: Type.Object({
@@ -15,6 +15,6 @@ export const saveChallenge = {
       savedChallenges: Type.Array(savedChallenge)
     }),
     403: Type.Literal('That challenge type is not saveable.'),
-    500: generic500
+    500: genericError
   }
 };

--- a/api/src/schemas/challenge/save-challenge.ts
+++ b/api/src/schemas/challenge/save-challenge.ts
@@ -14,7 +14,16 @@ export const saveChallenge = {
     200: Type.Object({
       savedChallenges: Type.Array(savedChallenge)
     }),
-    403: Type.Literal('That challenge type is not saveable.'),
+    400: Type.Object({
+      message: Type.Literal(
+        'That does not appear to be a valid challenge submission.'
+      ),
+      type: Type.Literal('error')
+    }),
+    403: Type.Union([
+      Type.Literal('That challenge type is not saveable.'),
+      genericError
+    ]),
     default: genericError
   }
 };

--- a/api/src/schemas/challenge/save-challenge.ts
+++ b/api/src/schemas/challenge/save-challenge.ts
@@ -15,6 +15,6 @@ export const saveChallenge = {
       savedChallenges: Type.Array(savedChallenge)
     }),
     403: Type.Literal('That challenge type is not saveable.'),
-    500: genericError
+    default: genericError
   }
 };

--- a/api/src/schemas/settings/update-my-classroom-mode.ts
+++ b/api/src/schemas/settings/update-my-classroom-mode.ts
@@ -1,4 +1,5 @@
 import { Type } from '@fastify/type-provider-typebox';
+import { genericError } from '../types';
 
 export const updateMyClassroomMode = {
   body: Type.Object({
@@ -9,9 +10,12 @@ export const updateMyClassroomMode = {
       message: Type.Literal('flash.classroom-mode-updated'),
       type: Type.Literal('success')
     }),
-    403: Type.Object({
-      message: Type.Literal('flash.wrong-updating'),
-      type: Type.Literal('danger')
-    })
+    403: Type.Union([
+      Type.Object({
+        message: Type.Literal('flash.wrong-updating'),
+        type: Type.Literal('danger')
+      }),
+      genericError
+    ])
   }
 };

--- a/api/src/schemas/types.ts
+++ b/api/src/schemas/types.ts
@@ -1,6 +1,6 @@
 import { Type } from '@fastify/type-provider-typebox';
 
-export const generic500 = Type.Object({
+export const genericError = Type.Object({
   message: Type.Literal('flash.generic-error'),
   type: Type.Literal('danger')
 });

--- a/api/src/schemas/user/delete-my-account.ts
+++ b/api/src/schemas/user/delete-my-account.ts
@@ -4,6 +4,6 @@ import { genericError } from '../types';
 export const deleteMyAccount = {
   response: {
     200: Type.Object({}),
-    500: genericError
+    default: genericError
   }
 };

--- a/api/src/schemas/user/delete-my-account.ts
+++ b/api/src/schemas/user/delete-my-account.ts
@@ -1,9 +1,9 @@
 import { Type } from '@fastify/type-provider-typebox';
-import { generic500 } from '../types';
+import { genericError } from '../types';
 
 export const deleteMyAccount = {
   response: {
     200: Type.Object({}),
-    500: generic500
+    500: genericError
   }
 };

--- a/api/src/schemas/user/delete-user-token.ts
+++ b/api/src/schemas/user/delete-user-token.ts
@@ -1,5 +1,5 @@
 import { Type } from '@fastify/type-provider-typebox';
-import { generic500 } from '../types';
+import { genericError } from '../types';
 
 export const deleteUserToken = {
   response: {
@@ -10,6 +10,6 @@ export const deleteUserToken = {
       message: Type.Literal('userToken not found'),
       type: Type.Literal('info')
     }),
-    500: generic500
+    500: genericError
   }
 };

--- a/api/src/schemas/user/delete-user-token.ts
+++ b/api/src/schemas/user/delete-user-token.ts
@@ -10,6 +10,6 @@ export const deleteUserToken = {
       message: Type.Literal('userToken not found'),
       type: Type.Literal('info')
     }),
-    500: genericError
+    default: genericError
   }
 };

--- a/api/src/schemas/user/post-ms-username.ts
+++ b/api/src/schemas/user/post-ms-username.ts
@@ -1,4 +1,5 @@
 import { Type } from '@fastify/type-provider-typebox';
+import { genericError } from '../types';
 
 export const postMsUsername = {
   body: Type.Object({
@@ -16,10 +17,13 @@ export const postMsUsername = {
       type: Type.Literal('error'),
       message: Type.Literal('flash.ms.transcript.link-err-2')
     }),
-    403: Type.Object({
-      type: Type.Literal('error'),
-      message: Type.Literal('flash.ms.transcript.link-err-4')
-    }),
+    403: Type.Union([
+      Type.Object({
+        type: Type.Literal('error'),
+        message: Type.Literal('flash.ms.transcript.link-err-4')
+      }),
+      genericError
+    ]),
     500: Type.Union([
       Type.Object({
         type: Type.Literal('error'),

--- a/api/src/schemas/user/report-user.ts
+++ b/api/src/schemas/user/report-user.ts
@@ -18,6 +18,6 @@ export const reportUser = {
       type: Type.Literal('danger'),
       message: Type.Literal('flash.provide-username')
     }),
-    500: genericError
+    default: genericError
   }
 };

--- a/api/src/schemas/user/report-user.ts
+++ b/api/src/schemas/user/report-user.ts
@@ -1,5 +1,5 @@
 import { Type } from '@fastify/type-provider-typebox';
-import { generic500 } from '../types';
+import { genericError } from '../types';
 
 export const reportUser = {
   body: Type.Object({
@@ -18,6 +18,6 @@ export const reportUser = {
       type: Type.Literal('danger'),
       message: Type.Literal('flash.provide-username')
     }),
-    500: generic500
+    500: genericError
   }
 };

--- a/api/src/schemas/user/reset-my-progress.ts
+++ b/api/src/schemas/user/reset-my-progress.ts
@@ -4,6 +4,6 @@ import { genericError } from '../types';
 export const resetMyProgress = {
   response: {
     200: Type.Object({}),
-    500: genericError
+    default: genericError
   }
 };

--- a/api/src/schemas/user/reset-my-progress.ts
+++ b/api/src/schemas/user/reset-my-progress.ts
@@ -1,9 +1,9 @@
 import { Type } from '@fastify/type-provider-typebox';
-import { generic500 } from '../types';
+import { genericError } from '../types';
 
 export const resetMyProgress = {
   response: {
     200: Type.Object({}),
-    500: generic500
+    500: genericError
   }
 };

--- a/api/src/utils/error-formatting.ts
+++ b/api/src/utils/error-formatting.ts
@@ -34,6 +34,8 @@ export const formatProjectCompletedValidation = (
 ): FormattedError => {
   const error = getError(errors);
 
+  // TODO: split this into two functions. There's no need for it to handle both
+  // /project-completed and /save-challenge
   return error.instancePath === '' &&
     error.params.missingProperty === 'solution'
     ? {


### PR DESCRIPTION
- **fix: show generic error if CSRF error**
- **test: update tests to reflect new response**
- **refactor: generic500 -> genericError**
- **fix: use default to serialize all generic errors**
- **fix: provide correct schema for save-challenge**
- **fix: allow for CSRF errors as well as other 403s**

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

There's probably a better way to serialize 'default' errors, but I haven't found it. So, for now, I've gone with sharing the default error schema and using unions when the endpoint has a custom 500.

In the future, we probably won't need many 500 errors, since it should mean "something unexpected occurred" and so we're unlikely to be able to tell the user anything more specific than that. For now, I think this slightly messy approach will have to do.


<!-- Feel free to add any additional description of changes below this line -->
