### PR TITLE
feat: add a sparse-checkout workflow

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+
+# Usage instructions for cloning and setting up sparse-checkout
+# 1. Clone the repository sparsely:
+#    git clone --filter=blob:none --sparse https://github.com/freeCodeCamp/freeCodeCamp.git
+
+# 2. Navigate into the repository directory:
+#    cd freeCodeCamp
+
+# 3. Initialize sparse-checkout to include the script:
+#    git sparse-checkout init --no-cone
+#    git sparse-checkout add bootstrap.sh
+
+# 4. Check out the main branch:
+#    git checkout main
+
+# 5. Run the script with the desired operation:
+#    ./bootstrap.sh --checkout <language1> <language2> ...
+#    ./bootstrap.sh --checkout-all
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Configuration for language folders
+LANGUAGE_FOLDERS=(
+  "arabic"
+  "chinese"
+  "chinese-traditional"
+  "english"
+  "espanol"
+  "german"
+  "italian"
+  "japanese"
+  "korean"
+  "portuguese"
+  "swahili"
+  "ukrainian"
+)
+
+# Function to initialize sparse-checkout with the base configuration
+initialize_sparse_checkout() {
+  echo -e "${BLUE} :> Initializing sparse-checkout with base configuration...${NC}"
+  git sparse-checkout init --no-cone || {
+    echo -e "${RED} :> [ERROR] Failed to initialize sparse-checkout.${NC}"
+    exit 1
+  }
+  echo -e "${GREEN} :> Sparse-checkout initialized.${NC}"
+}
+
+# Function to check out specific language folders
+checkout_languages() {
+  echo -e "${BLUE} :> Checking out language folders: $*...${NC}"
+
+  git sparse-checkout set "/*" || {
+    echo -e "${RED} :> [ERROR] Failed to set sparse-checkout.${NC}"
+    exit 1
+  }
+
+  git sparse-checkout add \
+    "!/curriculum/challenges" \
+    "!/curriculum/dictionaries" \
+    "/curriculum/challenges/meta" \
+    "/curriculum/challenges/.markdownlint.yaml" ||
+    {
+      echo -e "${RED} :> [ERROR] Failed to remove language folders: $lang.${NC}"
+      exit 1
+    }
+
+  for language in "$@"; do
+    found=false
+    for lang in "${LANGUAGE_FOLDERS[@]}"; do
+      if [[ "$lang" == "$language" ]]; then
+        found=true
+        git sparse-checkout add "/curriculum/challenges/$language" "/curriculum/dictionaries/$language" || {
+          echo -e "${RED} :> [ERROR] Failed to add language folders: $language.${NC}"
+          exit 1
+        }
+        break
+      fi
+    done
+    if [[ $found == false ]]; then
+      echo -e "${YELLOW} :> [WARNING] Invalid language specified: $language. Skipping...${NC}"
+    fi
+  done
+
+  echo -e "${GREEN} :> Checkout of specified languages completed.${NC}"
+}
+
+# Function to check out all language folders
+checkout_all_languages() {
+  echo -e "${BLUE} :> Checking out all language folders...${NC}"
+  git sparse-checkout disable || {
+    echo -e "${RED} :> [ERROR] Failed to disable sparse-checkout.${NC}"
+    exit 1
+  }
+  echo -e "${GREEN} :> Checkout of all language folders completed.${NC}"
+}
+
+# Function to ensure the repository is in a clean state
+check_clean_state() {
+  output=$(git status --porcelain)
+  if [[ -n ${output} ]]; then
+    echo -e "${RED} :> [ERROR] Uncommitted changes exist. Please commit or stash your changes before running the script.${NC}"
+    exit 1
+  fi
+}
+
+# Function to print usage information
+usage() {
+  echo -e "${BLUE}Usage:${NC}"
+  echo "$0 [--checkout <language1> <language2> ... | --checkout-all | --help ]"
+  echo -e "${BLUE}Options:${NC}"
+  echo -e "${BLUE}  --checkout <language1> <language2> ...   Check out the specified language folders${NC}"
+  echo -e "${BLUE}  --checkout-all                           Check out all language folders${NC}"
+  echo -e "${BLUE}  --help, -h                               Display this help message${NC}"
+}
+
+# Main script logic
+main() {
+  OPERATION=$1
+  shift
+
+  # Ensure the script is being run inside the repository directory
+  if [ ! -d ".git" ]; then
+    echo -e "${RED} :> [ERROR] This script must be run inside a Git repository.${NC}"
+    exit 1
+  fi
+
+  check_clean_state
+
+  case $OPERATION in
+  --initialize | --init)
+    initialize_sparse_checkout
+    ;;
+  --checkout)
+    if [ $# -eq 0 ]; then
+      echo -e "${RED} :> [ERROR] No languages specified.${NC}"
+      usage
+      exit 1
+    fi
+    checkout_languages "$@"
+    ;;
+  --checkout-all)
+    checkout_all_languages
+    ;;
+  --help | -h | '')
+    usage
+    ;;
+  *)
+    echo -e "${RED} :> [ERROR] Invalid option.${NC}"
+    usage
+    ;;
+  esac
+}
+
+main "$@"


### PR DESCRIPTION
This PR aims to be the most non-intrusive approach to manage getting the files that one needs for working on the platform.

The strategy is as follows:

- We have close to 90K files related to curriculum.
- A fresh clone, of the repo (before this PR lands) has these stats:
  
  ```shell
  ❯ git clone https://github.com/freeCodeCamp/freeCodeCamp.git
  ```

  ```shell
  ❯ git count-objects -vH
	count: 0
	size: 0 bytes
	in-pack: 551871
	packs: 2
	size-pack: 438.05 MiB
	prune-packable: 0
	garbage: 0
	size-garbage: 0 bytes
  ```

- We could instead use `--sparse` and `--filter=blob:none` to get only git related information.

  ```shell
	❯ git clone --filter=blob:none --sparse https://github.com/freeCodeCamp/freeCodeCamp.git
  ```
  ```shell
	❯ git count-objects -vH
	count: 0
	size: 0 bytes
	in-pack: 249102
	packs: 3
	size-pack: 59.60 MiB
	prune-packable: 0
	garbage: 0
	size-garbage: 0 bytes
  ```

- Now to get the actual files in the filesystem we would do something along the lines of 

  ```bash
  git sparse-checkout init
  git sparse add api
  git sparse add client
  ...
  git checkout main
  ```
- However doing the above manually is tedious and error prone. Instead this PR adds a bash script to help. There are detailed commands and steps are in the comments in the file.

  Critically, downloading the needed directories:

  ```shell
	❯ ./bootstrap.sh --checkout english
	 :> Checking out language folders: english...
	 :> Initializing sparse-checkout with base configuration...
	remote: Enumerating objects: 229, done.
	remote: Counting objects: 100% (113/113), done.
	remote: Compressing objects: 100% (48/48), done.
	remote: Total 229 (delta 87), reused 65 (delta 65), pack-reused 116
	Receiving objects: 100% (229/229), 170.02 KiB | 1.16 MiB/s, done.
	Resolving deltas: 100% (133/133), done.
	 :> Sparse-checkout initialized.
	remote: Enumerating objects: 7288, done.
	remote: Counting objects: 100% (5740/5740), done.
	remote: Compressing objects: 100% (4784/4784), done.
	remote: Total 7288 (delta 1310), reused 956 (delta 956), pack-reused 1548
	Receiving objects: 100% (7288/7288), 6.21 MiB | 7.00 MiB/s, done.
	Resolving deltas: 100% (1853/1853), done.
	Updating files: 100% (7288/7288), done.
	 :> Checkout of specified languages completed.
  ```

  reduces the repos size on the local machine:

  ```shell
	❯ git count-objects -vH
	count: 0
	size: 0 bytes
	in-pack: 256619
	packs: 5
	size-pack: 66.18 MiB
	prune-packable: 0
	garbage: 0
	size-garbage: 0 bytes
  ```

  and the count of files, for example:

  ```shell
	❯ cd curriculum/challenges/english
	❯ find . -type f | wc -l
	    7286
  ```

> [!NOTE] 
> This PR aims to have minimal impact.

- This PR should will not affect any existing flows that we have like CI & CD.
- The idea is to add instructions for using this script and workflows to our documentation. - Contributors can simply opt-in to follow this workflow to grab only the needed parts of the repository.
- Follow-up PRs may optimize some automations like CI, etc. but that is left to discretion of the dev-team.