### PR TITLE
fix(curriculum): add back ticks to variable name Platformer Game step 20

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/649a75a844f2ea3a0060d807.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/649a75a844f2ea3a0060d807.md
@@ -7,7 +7,7 @@ dashedName: step-20
 
 # --description--
 
-Below your `ctx.fillStyle`, you need to create the player's shape by calling the `fillRect()` method on the ctx object which you instantiated earlier. 
+Below your `ctx.fillStyle`, you need to create the player's shape by calling the `fillRect()` method on the `ctx` object which you instantiated earlier. 
 
 ```js
 fillRect(x, y, width, height)


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related to #54174

<!-- Feel free to add any additional description of changes below this line -->

Add backticks to the `ctx` variable.

![image](https://github.com/freeCodeCamp/freeCodeCamp/assets/153783117/67df09d7-5daa-4a72-9537-6f8b726ee993)
