### PR TITLE
fix(curriculum): typo in problem 311 of Project Euler

### DIFF
--- a/curriculum/challenges/english/18-project-euler/project-euler-problems-301-to-400/problem-311-biclinic-integral-quadrilaterals.md
+++ b/curriculum/challenges/english/18-project-euler/project-euler-problems-301-to-400/problem-311-biclinic-integral-quadrilaterals.md
@@ -16,7 +16,7 @@ We'll call $ABCD$ a biclinic integral quadrilateral if $AO = CO ≤ BO = DO$.
 
 For example, the following quadrilateral is a biclinic integral quadrilateral: $AB = 19$, $BC = 29$, $CD = 37$, $AD = 43$, $BD = 48$ and $AO = CO = 23$.
 
-<img alt="quadrilateral ABCD, with point O, an midpoint of BD" src="https://cdn.freecodecamp.org/curriculum/project-euler/biclinic-integral-quadrilaterals.gif" style="background-color: white; padding: 10px; display: block; margin-right: auto; margin-left: auto; margin-bottom: 1.2rem;">
+<img alt="quadrilateral ABCD, with point O, a midpoint of BD" src="https://cdn.freecodecamp.org/curriculum/project-euler/biclinic-integral-quadrilaterals.gif" style="background-color: white; padding: 10px; display: block; margin-right: auto; margin-left: auto; margin-bottom: 1.2rem;">
 
 Let $B(N)$ be the number of distinct biclinic integral quadrilaterals $ABCD$ that satisfy ${AB}^2 + {BC}^2 + {CD}^2 + {AD}^2 ≤ N$. We can verify that $B(10\\,000) = 49$ and $B(1\\,000\\,000) = 38239$.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #55309 

<!-- Feel free to add any additional description of changes below this line -->
The issue description was straightforward, a typo had to be fixed on the markdown file of **Problem 311: Biclinic Integral Quadrilaterals**, which is done in this PR.
