### PR TITLE
fix(curriculum): is keyword is properly introduced after first usage

### DIFF
--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-the-bisection-method-by-finding-the-square-root-of-a-number/65ef1d5e3d2927c5e0f4997b.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-the-bisection-method-by-finding-the-square-root-of-a-number/65ef1d5e3d2927c5e0f4997b.md
@@ -7,9 +7,9 @@ dashedName: step-17
 
 # --description--
 
-Outside the for loop, create an `if` statement to check if the value of `root is None`. If it is, print the message `'Failed to converge within {max_iterations} iterations.'`. Remember to format the message using an f-string.
+In Python, the `is` keyword checks for object identity. It's used to determine if two variables point to the same object in memory. In contrast to `is`, the equality operator (`==`) determines if the values of two objects are the same, regardless of whether they are the same object in memory.
 
-Note that `is` is different from `==`. In Python, `is` checks for object identity. It's used to determine if two variables point to the same object in memory. In contrast to `is`, `==` determines if the values of two objects are the same, regardless of whether they are the same object in memory.
+Outside the for loop, create an `if` statement to check if  `root is None`. If it is, print the message `'Failed to converge within {max_iterations} iterations.'`. Remember to format the message using an f-string.
 
 # --hints--
 

--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-the-bisection-method-by-finding-the-square-root-of-a-number/65ef1d5e3d2927c5e0f4997b.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-the-bisection-method-by-finding-the-square-root-of-a-number/65ef1d5e3d2927c5e0f4997b.md
@@ -7,7 +7,9 @@ dashedName: step-17
 
 # --description--
 
-Outside the for loop, create an `if` statement to check if the value of `root` is still `None`. If it is, print the message `'Failed to converge within {max_iterations} iterations.'`. Remember to format the message using an f-string.
+Outside the for loop, create an `if` statement to check if the value of `root is None`. If it is, print the message `'Failed to converge within {max_iterations} iterations.'`. Remember to format the message using an f-string.
+
+Note that `is` is different from `==`. In Python, `is` checks for object identity. It's used to determine if two variables point to the same object in memory. In contrast to `is`, `==` determines if the values of two objects are the same, regardless of whether they are the same object in memory.
 
 # --hints--
 

--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-tree-traversal-by-building-a-binary-search-tree/65c4f22498d22ed775ef8efb.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-tree-traversal-by-building-a-binary-search-tree/65c4f22498d22ed775ef8efb.md
@@ -9,7 +9,7 @@ dashedName: step-10
 
 Now you need to check if the `node` parameter is `None`. If it is, this means that the method has reached a leaf node or an empty spot in the tree where the new node should be inserted.
 
-Inside the `_insert` method body, replace `pass` with an `if` statement that checks if `node is None`. Note that `is` is different from `==`. In Python, `is` checks for object identity. It's used to determine if two variables point to the same object in memory. In contrast to `is`, `==` determines if the values of two objects are the same, regardless of whether they are the same object in memory. 
+Inside the `_insert` method body, replace `pass` with an `if` statement that checks if `node is None`.
 
 Inside the new `if` block, return `TreeNode(key)` to  create a new `TreeNode` instance with the provided key. This will become the new leaf node, effectively inserting the key into the tree.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #55311

<!-- Feel free to add any additional description of changes below this line -->

![image](https://github.com/freeCodeCamp/freeCodeCamp/assets/153783117/f06efabb-45ca-454a-b648-979c6bf88efe)

![image](https://github.com/freeCodeCamp/freeCodeCamp/assets/153783117/36a64ae6-8aab-4432-be5c-291034ec4447)
