### PR TITLE
fix(curriculum): check position of if statement - calorie counter New JS Project

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-form-validation-by-building-a-calorie-counter/63c9e45519caf31b987fbb5f.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-form-validation-by-building-a-calorie-counter/63c9e45519caf31b987fbb5f.md
@@ -29,6 +29,12 @@ Your `if` statement should use `return` to end the function execution.
 assert.match(calculateCalories.toString(), /if\s*\(\s*isError\s*\)\s*\{?\s*return\s*;?\s*\}?\s*/);
 ```
 
+Your `if` statement should be placed after the last `getCaloriesFromInputs` function call.
+
+```js
+assert.match(code, /if\s*\(\s*isError\s*\)\s*\{?\s*return\s*;?\s*\}?\s*\}\s*function\s+/);
+```
+
 # --seed--
 
 ## --seed-contents--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-form-validation-by-building-a-calorie-counter/63c9e45519caf31b987fbb5f.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-form-validation-by-building-a-calorie-counter/63c9e45519caf31b987fbb5f.md
@@ -11,13 +11,7 @@ Your `getCaloriesFromInputs` function will set the global error flag to `true` i
 
 # --hints--
 
-Your `calculateCalories` function should have an `if` statement.
-
-```js
-assert.match(calculateCalories.toString(), /if\s*\(/);
-```
-
-Your `if` statement should check the truthiness of the `isError` variable.
+Your `calculateCalories` function should have an `if` statement that checks the truthiness of the `isError` variable.
 
 ```js
 assert.match(calculateCalories.toString(), /if\s*\(\s*isError\s*\)/);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #55303

<!-- Feel free to add any additional description of changes below this line -->

Regex checks `code` for `if` statement position.

---

Notes:

If we just check what comes before the if statement and the camper for whatever reason alters the function call order that would fail.

If we just check for the closing function bracket they can close the function in the wrong place, BTW they can pass the previous tests doing that now as well.

```
function calculateCalories(e) {
  e.preventDefault();
  isError = false;

  if(isError) {
    return;
  }
}
// Other function body code
```
