### PR TITLE
fix(tools/scripts): (E2E) Updating clearEditor util to use ControlOrMeta key

### DIFF
--- a/e2e/utils/editor.ts
+++ b/e2e/utils/editor.ts
@@ -24,18 +24,8 @@ export const focusEditor = async ({
   await getEditors(page).focus();
 };
 
-export async function clearEditor({
-  page,
-  browserName
-}: {
-  page: Page;
-  browserName: string;
-}) {
+export async function clearEditor({ page }: { page: Page }) {
   // TODO: replace with ControlOrMeta when it's supported
-  if (browserName === 'webkit') {
-    await page.keyboard.press('Meta+a');
-  } else {
-    await page.keyboard.press('Control+a');
-  }
+  await page.keyboard.press('ControlOrMeta+a');
   await page.keyboard.press('Backspace');
 }

--- a/e2e/utils/editor.ts
+++ b/e2e/utils/editor.ts
@@ -25,7 +25,6 @@ export const focusEditor = async ({
 };
 
 export async function clearEditor({ page }: { page: Page }) {
-  // TODO: replace with ControlOrMeta when it's supported
   await page.keyboard.press('ControlOrMeta+a');
   await page.keyboard.press('Backspace');
 }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #55318


<!-- Feel free to add any additional description of changes below this line -->

replacing: 
` if (browserName === 'webkit') { 
   await page.keyboard.press('Meta+a'); 
 } else { 
   await page.keyboard.press('Control+a'); 
 } `
 
 with:
 `await page.keyboard.press('ControlOrMeta+a');`
 
 As well as removed `browserName` from the function signature.
