### PR TITLE
fix(e2e): update clearEditor to use ControlOrMeta

### DIFF
--- a/client/src/components/search/searchBar/search-bar-optimized.tsx
+++ b/client/src/components/search/searchBar/search-bar-optimized.tsx
@@ -13,8 +13,10 @@ const SearchBarOptimized = ({
   const searchUrl = searchPageUrl;
   const [value, setValue] = useState('');
   const inputElementRef = useRef<HTMLInputElement>(null);
+
   const onChange = (event: React.ChangeEvent<HTMLInputElement>) =>
     setValue(event.target.value);
+
   const onSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     if (value && value.length > 1) {
@@ -24,6 +26,7 @@ const SearchBarOptimized = ({
       inputElementRef.current?.blur();
     }
   };
+
   const onClick = () => {
     setValue('');
     inputElementRef.current?.focus();
@@ -38,6 +41,7 @@ const SearchBarOptimized = ({
             className='ais-SearchBox-form'
             onSubmit={onSubmit}
             role='search'
+            aria-label={t('search.ariaLabel')}
           >
             <label className='sr-only' htmlFor='ais-SearchBox-input'>
               {t('search.label')}
@@ -55,8 +59,17 @@ const SearchBarOptimized = ({
               type='search'
               value={value}
               ref={inputElementRef}
+              aria-label={t('search.ariaLabel')} {/* Added aria-label */}
+              aria-describedby='search-instructions'
             />
-            <button className='ais-SearchBox-submit' type='submit'>
+            <span id='search-instructions' className='sr-only'>
+              {t('search.instructions')}
+            </span>
+            <button
+              className='ais-SearchBox-submit'
+              type='submit'
+              aria-label={t('search.submit')}
+            >
               <Magnifier />
             </button>
             {value && (
@@ -64,6 +77,7 @@ const SearchBarOptimized = ({
                 className='ais-SearchBox-reset'
                 onClick={onClick}
                 type='button'
+                aria-label={t('search.reset')}
               >
                 <InputReset />
               </button>

--- a/client/src/components/search/searchBar/search-bar-optimized.tsx
+++ b/client/src/components/search/searchBar/search-bar-optimized.tsx
@@ -13,10 +13,8 @@ const SearchBarOptimized = ({
   const searchUrl = searchPageUrl;
   const [value, setValue] = useState('');
   const inputElementRef = useRef<HTMLInputElement>(null);
-
   const onChange = (event: React.ChangeEvent<HTMLInputElement>) =>
     setValue(event.target.value);
-
   const onSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     if (value && value.length > 1) {
@@ -26,7 +24,6 @@ const SearchBarOptimized = ({
       inputElementRef.current?.blur();
     }
   };
-
   const onClick = () => {
     setValue('');
     inputElementRef.current?.focus();
@@ -41,7 +38,6 @@ const SearchBarOptimized = ({
             className='ais-SearchBox-form'
             onSubmit={onSubmit}
             role='search'
-            aria-label={t('search.ariaLabel')}
           >
             <label className='sr-only' htmlFor='ais-SearchBox-input'>
               {t('search.label')}
@@ -59,17 +55,8 @@ const SearchBarOptimized = ({
               type='search'
               value={value}
               ref={inputElementRef}
-              aria-label={t('search.ariaLabel')} {/* Added aria-label */}
-              aria-describedby='search-instructions'
             />
-            <span id='search-instructions' className='sr-only'>
-              {t('search.instructions')}
-            </span>
-            <button
-              className='ais-SearchBox-submit'
-              type='submit'
-              aria-label={t('search.submit')}
-            >
+            <button className='ais-SearchBox-submit' type='submit'>
               <Magnifier />
             </button>
             {value && (
@@ -77,7 +64,6 @@ const SearchBarOptimized = ({
                 className='ais-SearchBox-reset'
                 onClick={onClick}
                 type='button'
-                aria-label={t('search.reset')}
               >
                 <InputReset />
               </button>

--- a/e2e/utils/editor.ts
+++ b/e2e/utils/editor.ts
@@ -23,7 +23,6 @@ export const focusEditor = async ({
 
   await getEditors(page).focus();
 };
-
 export async function clearEditor({
   page
 }: {
@@ -32,3 +31,4 @@ export async function clearEditor({
   await page.keyboard.press('ControlOrMeta+a');
   await page.keyboard.press('Backspace');
 }
+

--- a/e2e/utils/editor.ts
+++ b/e2e/utils/editor.ts
@@ -25,17 +25,10 @@ export const focusEditor = async ({
 };
 
 export async function clearEditor({
-  page,
-  browserName
+  page
 }: {
   page: Page;
-  browserName: string;
 }) {
-  // TODO: replace with ControlOrMeta when it's supported
-  if (browserName === 'webkit') {
-    await page.keyboard.press('Meta+a');
-  } else {
-    await page.keyboard.press('Control+a');
-  }
+  await page.keyboard.press('ControlOrMeta+a');
   await page.keyboard.press('Backspace');
 }

--- a/e2e/utils/editor.ts
+++ b/e2e/utils/editor.ts
@@ -23,12 +23,7 @@ export const focusEditor = async ({
 
   await getEditors(page).focus();
 };
-export async function clearEditor({
-  page
-}: {
-  page: Page;
-}) {
+export async function clearEditor({ page }: { page: Page }) {
   await page.keyboard.press('ControlOrMeta+a');
   await page.keyboard.press('Backspace');
 }
-


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #55318

<!-- Feel free to add any additional description of changes below this line -->

### Description

- Updated the `clearEditor` function in `e2e/utils/editor.ts` to use `ControlOrMeta+a` instead of checking for `browserName`.
- Removed the `browserName` parameter from the `clearEditor` function signature.
- Updated all function calls to `clearEditor` to remove the `browserName` argument.

