### PR TITLE
fix(api): handle concurrent challenge submissions

### DIFF
--- a/api/src/utils/common-challenge-functions.ts
+++ b/api/src/utils/common-challenge-functions.ts
@@ -230,11 +230,8 @@ export async function updateUserChallengeData(
     }
   });
 
-  const updateData = {};
-
   return {
     alreadyCompleted,
-    updateData, // Might need to remove this variable as we're updating user object in this function now instead of in the endpoint handler
     completedDate: finalChallenge.completedDate,
     userSavedChallenges
   };

--- a/api/src/utils/common-challenge-functions.ts
+++ b/api/src/utils/common-challenge-functions.ts
@@ -216,21 +216,14 @@ export async function updateUserChallengeData(
     challenge => challenge.id !== challengeId
   );
 
-  if (needsModeration) {
-    await fastify.prisma.user.update({
-      where: { id: user.id },
-      data: {
-        needsModeration: true
-      }
-    });
-  }
-
   const { savedChallenges: userSavedChallenges } =
     await fastify.prisma.user.update({
       where: { id: user.id },
       data: {
         completedChallenges: userCompletedChallenges,
-        needsModeration,
+        // TODO: `needsModeration` should be handled closer to source, because it exists in 3 states: true, false, undefined/null
+        //       `undefined` in Prisma is a no-op
+        needsModeration: needsModeration || undefined,
         savedChallenges: savedChallengesUpdate,
         progressTimestamps: userProgressTimestamps,
         partiallyCompletedChallenges: userPartiallyCompletedChallenges

--- a/api/src/utils/common-challenge-functions.ts
+++ b/api/src/utils/common-challenge-functions.ts
@@ -175,10 +175,18 @@ export async function updateUserChallengeData(
       }
     : completedChallenge;
 
+  // TODO(Post-MVP): prevent concurrent completions of the same challenge by
+  // using optimistic concurrency control. i.e. the update should simultaneously
+  // check and update some property of the user record such that the same update
+  // can't be applied twice.
   const userCompletedChallenges = alreadyCompleted
     ? completedChallenges.map(x => (x.id === challengeId ? finalChallenge : x))
-    : [...completedChallenges, finalChallenge];
+    : { push: finalChallenge };
 
+  // We can't use push, because progressTimestamps is a JSON blob and, until
+  // we convert it to an array, push is not available. Since this could result
+  // in the completedChallenges and progressTimestamps arrays being out of sync,
+  // we should prioritize normalizing the data structure.
   const userProgressTimestamps =
     !alreadyCompleted && progressTimestamps && Array.isArray(progressTimestamps)
       ? [...progressTimestamps, newProgressTimeStamp]


### PR DESCRIPTION
- **refactor: drop unused property from helper**
- **fix: prevent updates from overwriting completions**
- **fix: push saved challenges**

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This is a little closer to how the api-server handles concurrent submissions (i.e. it pushes both). It's not perfect, though, since `progressTimestamps` can go out of sync with `completedChallenges`.

While we can recover the total number of points from `completedChallenges`, the date of the initial completion could get lost, so we should focus on normalizing the DB as soon as possible to minimize any inconsistencies.

Alternatively, I can use a raw mongo query to work around this.

<!-- Feel free to add any additional description of changes below this line -->
