### PR TITLE
fix: flaky code-saving test

### DIFF
--- a/e2e/multifile-cert-projects.spec.ts
+++ b/e2e/multifile-cert-projects.spec.ts
@@ -5,10 +5,10 @@ import { isMacOS } from './utils/user-agent';
 test.use({ storageState: 'playwright/.auth/certified-user.json' });
 test.describe('multifileCertProjects', () => {
   test.beforeEach(async ({ page }) => {
+    execSync('node ./tools/scripts/seed/seed-demo-user certified-user');
     await page.goto(
       'learn/2022/responsive-web-design/build-a-tribute-page-project/build-a-tribute-page'
     );
-    execSync('node ./tools/scripts/seed/seed-demo-user certified-user');
   });
   test('should save and reload user code', async ({ page, isMobile }) => {
     await focusEditor({ page, isMobile });

--- a/e2e/multifile-cert-projects.spec.ts
+++ b/e2e/multifile-cert-projects.spec.ts
@@ -1,7 +1,6 @@
 import { execSync } from 'child_process';
 import { test, expect } from '@playwright/test';
-import { focusEditor } from './utils/editor';
-import { isMacOS } from './utils/user-agent';
+import { clearEditor, focusEditor } from './utils/editor';
 test.use({ storageState: 'playwright/.auth/certified-user.json' });
 test.describe('multifileCertProjects', () => {
   test.beforeEach(async ({ page }) => {
@@ -10,25 +9,26 @@ test.describe('multifileCertProjects', () => {
       'learn/2022/responsive-web-design/build-a-tribute-page-project/build-a-tribute-page'
     );
   });
-  test('should save and reload user code', async ({ page, isMobile }) => {
+
+  const success =
+    /Your code was saved to the database\. It will be here when you return\./;
+  const tooFast =
+    /Slow Down! Your code was not saved\. Try again in a few seconds\./;
+
+  test('should save and reload user code', async ({
+    page,
+    isMobile,
+    browserName
+  }) => {
     await focusEditor({ page, isMobile });
-
-    if (isMacOS) {
-      await page.keyboard.press('Meta+A');
-    } else {
-      await page.keyboard.press('Control+A');
-    }
-
-    await page.keyboard.press('Backspace');
+    await clearEditor({ page, browserName });
 
     await page.keyboard.type('save1text');
     await expect(page.getByText('save1text')).toBeVisible();
 
     await page.getByRole('button', { name: 'Save your Code' }).click();
 
-    await expect(page.getByTestId('flash-message')).toContainText(
-      /Your code was saved to the database\. It will be here when you return\./
-    );
+    await expect(page.getByTestId('flash-message')).toContainText(success);
 
     await page.reload();
 
@@ -37,15 +37,11 @@ test.describe('multifileCertProjects', () => {
 
   test('should save using ctrl+s hotkey and persist through navigation', async ({
     page,
-    isMobile
+    isMobile,
+    browserName
   }) => {
     await focusEditor({ page, isMobile });
-
-    if (isMacOS) {
-      await page.keyboard.press('Meta+A');
-    } else {
-      await page.keyboard.press('Control+A');
-    }
+    await clearEditor({ page, browserName });
 
     await page.keyboard.type('save2text');
     await expect(page.getByText('save2text')).toBeVisible();
@@ -53,9 +49,7 @@ test.describe('multifileCertProjects', () => {
     await page.keyboard.down('Control');
     await page.keyboard.press('KeyS');
 
-    await expect(page.getByTestId('flash-message')).toContainText(
-      /Your code was saved to the database\. It will be here when you return\./
-    );
+    await expect(page.getByTestId('flash-message')).toContainText(success);
 
     await page.getByRole('button', { name: 'Close' }).click();
 
@@ -70,8 +64,6 @@ test.describe('multifileCertProjects', () => {
     await page.keyboard.down('Control');
     await page.keyboard.press('KeyS');
 
-    await expect(page.getByTestId('flash-message')).toContainText(
-      /Slow Down! Your code was not saved\. Try again in a few seconds\./
-    );
+    await expect(page.getByTestId('flash-message')).toContainText(tooFast);
   });
 });


### PR DESCRIPTION
- **fix: seed before visiting page**
- **refactor: use test helpers**

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

The problem was that the seeding and page loading were in the wrong order. Seeding should happen first, so that the page is setup correctly.

Everything else is just refactoring.

<!-- Feel free to add any additional description of changes below this line -->
