### PR TITLE
fix(api): add missing build step and use faster OS

### DIFF
--- a/docker/new-api/Dockerfile
+++ b/docker/new-api/Dockerfile
@@ -57,6 +57,7 @@ USER node
 WORKDIR /home/node/fcc
 COPY --from=builder --chown=node:node /home/node/build/api/dist/ ./
 COPY --from=builder --chown=node:node /home/node/build/api/package.json api/
+COPY --from=builder --chown=node:node /home/node/build/shared/config/curriculum.json shared/config/
 
 COPY --from=deps --chown=node:node /home/node/build/node_modules/ node_modules/
 COPY --from=deps --chown=node:node /home/node/build/shared/node_modules/ shared/node_modules/

--- a/docker/new-api/Dockerfile
+++ b/docker/new-api/Dockerfile
@@ -51,7 +51,7 @@ RUN pnpm config set dedupe-peer-dependents false
 RUN pnpm install --prod --ignore-scripts -F=shared -F=api --frozen-lockfile
 RUN cd api && npx prisma@$(jq -r '.devDependencies.prisma' < package.json) generate
 
-FROM node:20-alpine
+FROM node:20-bookworm
 RUN npm i -g pm2@4
 USER node
 WORKDIR /home/node/fcc


### PR DESCRIPTION
- **fix: include built curriculum in image**
- **perf: use debian instead of alpine**

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

I don't know what the problem with alpine was, but I noticed that it would take roughly 90ms to handle /update-my-keyboard-shortcuts while the debian-based image was closer to 50ms.

For completeness, I checked the api-server and it was around the 50ms mark, too.

<!-- Feel free to add any additional description of changes below this line -->
