### PR TITLE
feat(api): add `updateCount` field to user

### DIFF
--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -134,7 +134,7 @@ model user {
   /// Used to track the number of times the user's record was written to.
   ///
   /// This has the main benefit of allowing concurrent ops to check for race conditions.
-  updateCount                  Int                           @default(0)
+  updateCount                  Int?                          @default(0)
   username                     String // TODO(Post-MVP): make this unique
   usernameDisplay              String? // Undefined
   verificationToken            String? // Undefined

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -110,10 +110,6 @@ model user {
   isCollegeAlgebraPyCertV8     Boolean? // Undefined
   isUpcomingPythonCertV8       Boolean? // Undefined
   keyboardShortcuts            Boolean? // Undefined
-  /// `lastUpdated` is used to track the last time the user's record was written to.
-  ///
-  /// This has the main benefit of allowing concurrent ops to check for race conditions.
-  lastUpdated                  Int                           @default(0)
   linkedin                     String? // Null | Undefined
   location                     String? // Null
   name                         String? // Null
@@ -135,6 +131,10 @@ model user {
   timezone                     String? // Undefined
   twitter                      String? // Null | Undefined
   unsubscribeId                String
+  /// Used to track the number of times the user's record was written to.
+  ///
+  /// This has the main benefit of allowing concurrent ops to check for race conditions.
+  updateCount                  Int                           @default(0)
   username                     String // TODO(Post-MVP): make this unique
   usernameDisplay              String? // Undefined
   verificationToken            String? // Undefined

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -55,11 +55,6 @@ type ProfileUI {
   showTimeLine  Boolean? // Undefined
 }
 
-// Currently unused, so commented out.
-// type ProgressTimestamp {
-//   timestamp Float
-// }
-
 type SavedChallengeFile {
   contents String
   ext      String
@@ -74,11 +69,11 @@ type SavedChallenge {
   lastSavedDate Float
 }
 
+/// Corresponds to the `user` collection.
 model user {
   id                           String                        @id @default(auto()) @map("_id") @db.ObjectId
   about                        String
   acceptedPrivacyTerms         Boolean
-  // badges    Json? // Undefined | { coreTeam [][] } removed, as new API never uses it.
   completedChallenges          CompletedChallenge[]
   completedExams               CompletedExam[] // Undefined
   currentChallengeId           String?
@@ -88,7 +83,6 @@ model user {
   emailVerified                Boolean
   emailVerifyTTL               DateTime? // Null | Undefined
   externalId                   String
-  // github    String? Removed, because value was only ever found to be Null
   githubProfile                String? // Undefined
   isApisMicroservicesCert      Boolean? // Undefined
   isBackEndCert                Boolean? // Undefined
@@ -116,6 +110,10 @@ model user {
   isCollegeAlgebraPyCertV8     Boolean? // Undefined
   isUpcomingPythonCertV8       Boolean? // Undefined
   keyboardShortcuts            Boolean? // Undefined
+  /// `lastUpdated` is used to track the last time the user's record was written to.
+  ///
+  /// This has the main benefit of allowing concurrent ops to check for race conditions.
+  lastUpdated                  Int                           @default(0)
   linkedin                     String? // Null | Undefined
   location                     String? // Null
   name                         String? // Null
@@ -127,7 +125,10 @@ model user {
   portfolio                    Portfolio[]
   profileUI                    ProfileUI? // Undefined
   progressTimestamps           Json? // ProgressTimestamp[] | Null[] | Int64[] | Double[] - TODO: NORMALIZE
-  // rand Float? // Undefined removed, as new API never uses it.
+  /// A random number between 0 and 1.
+  ///
+  /// Valuable for selectively performing random logic.
+  rand                         Float?
   savedChallenges              SavedChallenge[] // Undefined | SavedChallenge[]
   sendQuincyEmail              Boolean
   theme                        String? // Undefined

--- a/api/src/db/extensions.test.ts
+++ b/api/src/db/extensions.test.ts
@@ -1,0 +1,108 @@
+import { defaultUserEmail, setupServer } from '../../jest.utils';
+import { createUserInput } from '../utils/create-user';
+
+describe('prisma client extensions', () => {
+  setupServer();
+
+  beforeEach(async () => {
+    await fastifyTestInstance.prisma.user.deleteMany({
+      where: { email: defaultUserEmail }
+    });
+  });
+
+  afterAll(async () => {
+    await fastifyTestInstance.prisma.user.deleteMany({
+      where: { email: defaultUserEmail }
+    });
+  });
+
+  describe('updateCount', () => {
+    it('should default to 0', async () => {
+      const user = await fastifyTestInstance.prisma.user.create({
+        data: createUserInput(defaultUserEmail)
+      });
+
+      expect(user).toMatchObject({
+        updateCount: 0
+      });
+    });
+
+    it('should increment by one for updates and creates', async () => {
+      const user = await fastifyTestInstance.prisma.user.create({
+        data: createUserInput(defaultUserEmail)
+      });
+
+      const updateUser = await fastifyTestInstance.prisma.user.update({
+        where: { id: user.id },
+        data: { username: 'any-change' }
+      });
+
+      expect(updateUser).toMatchObject({
+        username: 'any-change',
+        updateCount: 1
+      });
+
+      const _updateManyResult =
+        await fastifyTestInstance.prisma.user.updateMany({
+          where: { id: user.id },
+          // Even no change to values updates the updateCount
+          data: { username: 'any-change' }
+        });
+
+      const updateManyUser = await fastifyTestInstance.prisma.user.findUnique({
+        where: { id: user.id }
+      });
+
+      expect(updateManyUser).toMatchObject({
+        username: 'any-change',
+        updateCount: 2
+      });
+
+      const upsertUser = await fastifyTestInstance.prisma.user.upsert({
+        where: { id: user.id },
+        create: createUserInput(defaultUserEmail),
+        update: { username: 'upser-user' }
+      });
+
+      expect(upsertUser).toMatchObject({
+        username: 'upser-user',
+        updateCount: 3
+      });
+    });
+
+    it("should not increment for 'find' queries", async () => {
+      const user = await fastifyTestInstance.prisma.user.create({
+        data: createUserInput(defaultUserEmail)
+      });
+
+      const findUniqueUser = await fastifyTestInstance.prisma.user.findUnique({
+        where: { id: user.id }
+      });
+
+      expect(findUniqueUser).toMatchObject({
+        updateCount: 0
+      });
+
+      const findManyUsers = await fastifyTestInstance.prisma.user.findMany();
+
+      expect(findManyUsers).toHaveLength(1);
+      expect(findManyUsers[0]).toMatchObject({
+        updateCount: 0
+      });
+
+      const findFirstUser = await fastifyTestInstance.prisma.user.findFirst();
+
+      expect(findFirstUser).toMatchObject({
+        updateCount: 0
+      });
+
+      const findRawUser = await fastifyTestInstance.prisma.user.findRaw({
+        filter: { email: defaultUserEmail }
+      });
+
+      expect(findRawUser[0]).toMatchObject({
+        updateCount: 0
+      });
+    });
+  });
+});

--- a/api/src/db/extensions.test.ts
+++ b/api/src/db/extensions.test.ts
@@ -42,12 +42,11 @@ describe('prisma client extensions', () => {
         updateCount: 1
       });
 
-      const _updateManyResult =
-        await fastifyTestInstance.prisma.user.updateMany({
-          where: { id: user.id },
-          // Even no change to values updates the updateCount
-          data: { username: 'any-change' }
-        });
+      await fastifyTestInstance.prisma.user.updateMany({
+        where: { id: user.id },
+        // Even no change to values updates the updateCount
+        data: { username: 'any-change' }
+      });
 
       const updateManyUser = await fastifyTestInstance.prisma.user.findUnique({
         where: { id: user.id }

--- a/api/src/db/prisma.ts
+++ b/api/src/db/prisma.ts
@@ -49,25 +49,8 @@ function extendClient(prisma: PrismaClient) {
         },
         async upsert({ args, query }) {
           args.update.updateCount = { increment: 1 };
-          args.create.updateCount = 0;
           return query(args);
         },
-        async create({ args, query }) {
-          args.data.updateCount = 0;
-          return query(args);
-        },
-        async createMany({ args, query }) {
-          const data = args.data;
-          if (Array.isArray(data)) {
-            data.forEach(data => {
-              data.updateCount = 0;
-            });
-          } else {
-            data.updateCount = 0;
-          }
-
-          return query(args);
-        }
         // NOTE: raw ops are untouched, as it is meant to be a direct passthrough to mongodb
         // async findRaw({ model, operation, args, query }) {}
         // async aggregateRaw({ model, operation, args, query }) {}

--- a/api/src/db/prisma.ts
+++ b/api/src/db/prisma.ts
@@ -7,18 +7,12 @@ import { MONGOHQ_URL } from '../utils/env';
 
 declare module 'fastify' {
   interface FastifyInstance {
-    prisma: PrismaClient;
+    prisma: ReturnType<typeof getExtendedClient>;
   }
 }
 
 const prismaPlugin: FastifyPluginAsync = fp(async (server, _options) => {
-  const prisma = new PrismaClient({
-    datasources: {
-      db: {
-        url: MONGOHQ_URL
-      }
-    }
-  });
+  const prisma = getExtendedClient();
 
   await prisma.$connect();
 
@@ -28,5 +22,60 @@ const prismaPlugin: FastifyPluginAsync = fp(async (server, _options) => {
     await server.prisma.$disconnect();
   });
 });
+
+// TODO: It would be nice to split this up into multiple update functions,
+//       but the types are a pain.
+// TODO: Multiple extended clients can be used for different restrictions (e.g. session vs non-session users)
+// TODO: Could be used to add other _easily forgotten_ fields like `progressTimestamp`
+function getExtendedClient() {
+  const prisma = new PrismaClient({
+    datasources: {
+      db: {
+        url: MONGOHQ_URL
+      }
+    }
+  }).$extends({
+    query: {
+      user: {
+        async update({ args, query }) {
+          args.data.lastUpdated = Date.now();
+          return query(args);
+        },
+        async updateMany({ args, query }) {
+          args.data.lastUpdated = Date.now();
+          return query(args);
+        },
+        async upsert({ args, query }) {
+          const lastUpdated = Date.now();
+          args.update.lastUpdated = lastUpdated;
+          args.create.lastUpdated = lastUpdated;
+          return query(args);
+        },
+        async create({ args, query }) {
+          args.data.lastUpdated = Date.now();
+          return query(args);
+        },
+        async createMany({ args, query }) {
+          const data = args.data;
+          const lastUpdated = Date.now();
+          if (Array.isArray(data)) {
+            data.forEach(data => {
+              data.lastUpdated = lastUpdated;
+            });
+          } else {
+            data.lastUpdated = lastUpdated;
+          }
+
+          return query(args);
+        }
+        // NOTE: raw ops are untouched, as it is meant to be a direct passthrough to mongodb
+        // async findRaw({ model, operation, args, query }) {}
+        // async aggregateRaw({ model, operation, args, query }) {}
+      }
+    }
+  });
+
+  return prisma;
+}
 
 export default prismaPlugin;

--- a/api/src/db/prisma.ts
+++ b/api/src/db/prisma.ts
@@ -7,12 +7,20 @@ import { MONGOHQ_URL } from '../utils/env';
 
 declare module 'fastify' {
   interface FastifyInstance {
-    prisma: ReturnType<typeof getExtendedClient>;
+    prisma: ReturnType<typeof extendClient>;
   }
 }
 
 const prismaPlugin: FastifyPluginAsync = fp(async (server, _options) => {
-  const prisma = getExtendedClient();
+  const prisma = extendClient(
+    new PrismaClient({
+      datasources: {
+        db: {
+          url: MONGOHQ_URL
+        }
+      }
+    })
+  );
 
   await prisma.$connect();
 
@@ -27,14 +35,8 @@ const prismaPlugin: FastifyPluginAsync = fp(async (server, _options) => {
 //       but the types are a pain.
 // TODO: Multiple extended clients can be used for different restrictions (e.g. session vs non-session users)
 // TODO: Could be used to add other _easily forgotten_ fields like `progressTimestamp`
-function getExtendedClient() {
-  const prisma = new PrismaClient({
-    datasources: {
-      db: {
-        url: MONGOHQ_URL
-      }
-    }
-  }).$extends({
+function extendClient(prisma: PrismaClient) {
+  return prisma.$extends({
     query: {
       user: {
         async update({ args, query }) {
@@ -74,8 +76,6 @@ function getExtendedClient() {
       }
     }
   });
-
-  return prisma;
 }
 
 export default prismaPlugin;

--- a/api/src/db/prisma.ts
+++ b/api/src/db/prisma.ts
@@ -38,32 +38,30 @@ function getExtendedClient() {
     query: {
       user: {
         async update({ args, query }) {
-          args.data.lastUpdated = Date.now();
+          args.data.updateCount = { increment: 1 };
           return query(args);
         },
         async updateMany({ args, query }) {
-          args.data.lastUpdated = Date.now();
+          args.data.updateCount = { increment: 1 };
           return query(args);
         },
         async upsert({ args, query }) {
-          const lastUpdated = Date.now();
-          args.update.lastUpdated = lastUpdated;
-          args.create.lastUpdated = lastUpdated;
+          args.update.updateCount = { increment: 1 };
+          args.create.updateCount = 0;
           return query(args);
         },
         async create({ args, query }) {
-          args.data.lastUpdated = Date.now();
+          args.data.updateCount = 0;
           return query(args);
         },
         async createMany({ args, query }) {
           const data = args.data;
-          const lastUpdated = Date.now();
           if (Array.isArray(data)) {
             data.forEach(data => {
-              data.lastUpdated = lastUpdated;
+              data.updateCount = 0;
             });
           } else {
-            data.lastUpdated = lastUpdated;
+            data.updateCount = 0;
           }
 
           return query(args);

--- a/api/src/db/prisma.ts
+++ b/api/src/db/prisma.ts
@@ -50,7 +50,7 @@ function extendClient(prisma: PrismaClient) {
         async upsert({ args, query }) {
           args.update.updateCount = { increment: 1 };
           return query(args);
-        },
+        }
         // NOTE: raw ops are untouched, as it is meant to be a direct passthrough to mongodb
         // async findRaw({ model, operation, args, query }) {}
         // async aggregateRaw({ model, operation, args, query }) {}


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This is in preparation for future changes. The `updateCount` field will definitely be used by any normalization scripts we run, but it is also useful for other reasons.

This will be followed up with a `schemaVersion` field that the normalization scripts will have to set and read.

**Note**: You will need to run `pnpm prisma -- generate` to get the up-to-date types.

- We decided to keep `rand`, even though we do not use it, because it has usefulnesses
  - A PR might need to be made to properly generate it
-  The `ProgressTimestamp` type is removed because we will never use it

The `///` are doc comments which are supposed to show up with intellisense. However, there is a bug in Prisma at the moment which breaks them for extended clients. A report has been filed.

**Relevant Docs**:
- https://www.prisma.io/docs/orm/prisma-schema/overview#comments
- https://www.prisma.io/docs/orm/prisma-client/client-extensions