### PR TITLE
fix: relax cookie settings in development

### DIFF
--- a/api/src/plugins/cookies.test.ts
+++ b/api/src/plugins/cookies.test.ts
@@ -7,7 +7,8 @@ import cookies from './cookies';
 // eslint-disable-next-line @typescript-eslint/no-unsafe-return
 jest.mock('../utils/env', () => ({
   ...jest.requireActual('../utils/env'),
-  COOKIE_DOMAIN: 'www.example.com'
+  COOKIE_DOMAIN: 'www.example.com',
+  FREECODECAMP_NODE_ENV: 'not-development'
 }));
 
 describe('cookies', () => {

--- a/api/src/plugins/cookies.ts
+++ b/api/src/plugins/cookies.ts
@@ -2,7 +2,11 @@ import fastifyCookie from '@fastify/cookie';
 import { FastifyPluginCallback } from 'fastify';
 import fp from 'fastify-plugin';
 
-import { COOKIE_DOMAIN, COOKIE_SECRET } from '../utils/env';
+import {
+  COOKIE_DOMAIN,
+  COOKIE_SECRET,
+  FREECODECAMP_NODE_ENV
+} from '../utils/env';
 
 /**
  * Signs a cookie value by prefixing it with "s:" and using the COOKIE_SECRET.
@@ -44,12 +48,12 @@ const cookies: FastifyPluginCallback = (fastify, _options, done) => {
     },
     parseOptions: {
       domain: COOKIE_DOMAIN,
-      httpOnly: true,
+      httpOnly: FREECODECAMP_NODE_ENV !== 'development',
       // Path is necessary to ensure that only one cookie is set and it is valid
       // for all routes.
       path: '/',
       sameSite: 'lax',
-      secure: true,
+      secure: FREECODECAMP_NODE_ENV !== 'development',
       signed: true
     }
   });

--- a/client/src/utils/ajax.ts
+++ b/client/src/utils/ajax.ts
@@ -26,6 +26,8 @@ const defaultOptions: RequestInit = {
 function getCSRFToken() {
   const token =
     typeof window !== 'undefined' ? cookies.get('csrf_token') : null;
+
+  console.log(token);
   return token ?? '';
 }
 

--- a/client/src/utils/ajax.ts
+++ b/client/src/utils/ajax.ts
@@ -26,8 +26,6 @@ const defaultOptions: RequestInit = {
 function getCSRFToken() {
   const token =
     typeof window !== 'undefined' ? cookies.get('csrf_token') : null;
-
-  console.log(token);
   return token ?? '';
 }
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Unless both httpOnly and secure are false in development, the client cannot see the csrf_token cookie and a lot of requests will fail as a result.

<!-- Feel free to add any additional description of changes below this line -->
