### PR TITLE
fix(a11y): associate block content panel with the header

### DIFF
--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -250,6 +250,7 @@ class Block extends Component<BlockProps> {
             <h3 className='block-grid-title'>
               <button
                 aria-expanded={isExpanded ? 'true' : 'false'}
+                aria-controls={`${blockDashedName}-panel`}
                 className='block-header'
                 onClick={() => {
                   this.handleBlockClick();
@@ -281,14 +282,16 @@ class Block extends Component<BlockProps> {
                 </Link>
               </div>
             )}
-            {isExpanded && <BlockIntros intros={blockIntroArr} />}
             {isExpanded && (
-              <Challenges
-                challengesWithCompleted={challengesWithCompleted}
-                isProjectBlock={isProjectBlock}
-                isGridMap={true}
-                blockTitle={blockTitle}
-              />
+              <div id={`${blockDashedName}-panel`}>
+                <BlockIntros intros={blockIntroArr} />
+                <Challenges
+                  challengesWithCompleted={challengesWithCompleted}
+                  isProjectBlock={isProjectBlock}
+                  isGridMap={true}
+                  blockTitle={blockTitle}
+                />
+              </div>
             )}
           </div>
         </ScrollableAnchor>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Adds `aria-controls` to each block header `button` to associate them with the panel that they trigger/control.

<!-- Feel free to add any additional description of changes below this line -->
