### PR TITLE
fix(curriculum) fixed vague wording as specified in issue #55373

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/review-dom-manipulation-by-building-a-rock-paper-scissors-game/663d5697d80fef0eea026672.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/review-dom-manipulation-by-building-a-rock-paper-scissors-game/663d5697d80fef0eea026672.md
@@ -17,9 +17,7 @@ If there is a winner, you will want to show the `resetGameBtn` button and hide t
 
 **Tips**
 
-- Set the display property of `resetGameBtn` as block.
-
-- You can use the `el.style.display` property to show the `resetGameBtn` button and hide the `optionsContainer`. Here `el` refers to any element in reference.
+Use the `style.display` property on an element, with the value `"block"` or `"none"`, to show or hide the element.
 
 # --hints--
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/review-dom-manipulation-by-building-a-rock-paper-scissors-game/663d5697d80fef0eea026672.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/review-dom-manipulation-by-building-a-rock-paper-scissors-game/663d5697d80fef0eea026672.md
@@ -17,7 +17,9 @@ If there is a winner, you will want to show the `resetGameBtn` button and hide t
 
 **Tips**
 
-- You can use the `el.style.display` property to show the `resetGameBtn` button and hide the `optionsContainer`.
+- Set the display property of `resetGameBtn` as block.
+
+- You can use the `el.style.display` property to show the `resetGameBtn` button and hide the `optionsContainer`. Here `el` refers to any element in reference.
 
 # --hints--
 
@@ -33,6 +35,7 @@ if (playerScore === 3) {
 } else {
   assert.equal(winnerMsgElement.innerText, "Computer has won the game!");
 }
+
 ```
 
 You should hide the `optionsContainer` and if the player or computer has reached three points.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.


Closes #55373 


In the issue it was mentioned by @hbar1st that the display property of resetBtn was never specified in the text and what exactly does el means. I specified exactly that in hopes of making step-5 more user understandable.
Affected Page- https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures-v8/review-dom-manipulation-by-building-a-rock-paper-scissors-game/step-5
![image](https://github.com/freeCodeCamp/freeCodeCamp/assets/130065975/c59b4ddb-28a8-4701-83a7-aa3e4d953401)

