### PR TITLE
fix(curriculum): test for meta element, and a few fixes

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60f0286404aefb0562a4fdf9.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60f0286404aefb0562a4fdf9.md
@@ -7,7 +7,7 @@ dashedName: step-4
 
 # --description--
 
-Add a `title` and a `meta` element to the `head`. Give your project a title of `Registration Form`, and give a `charset` attribute with a value of `UTF-8` to your `meta` element.
+Add a `title` and `meta` element inside the `head` element. Give your project a title of `Registration Form`, and add the `charset` attribute with a value of `utf-8` to your `meta` element.
 
 # --hints--
 
@@ -18,24 +18,35 @@ const title = document.querySelector('title');
 assert.exists(title);
 ```
 
-The `title` element should be within the `head` element.
+Your `title` element should be within the `head` element.
 
 ```js
 assert.exists(document.querySelector('head > title'));
 ```
 
-Your project should have a title of `Registration Form`.
-
-```js
-const title = document.querySelector('title');
-assert.equal(title.text.toLowerCase(), 'registration form')
-```
-
-Remember, the casing and spelling matters for the title.
+Your project should have a title of `Registration Form`. Remember, the casing and spelling matters for the title.
 
 ```js
 const title = document.querySelector('title');
 assert.equal(title.text, 'Registration Form');
+```
+
+You should create a `meta` element within the `head` element.
+
+```js
+assert.exists(document.querySelector('head > meta'));
+```
+
+You should give the `meta` element a `charset` attribute with the value of `utf-8`.
+
+```js
+assert.equal(document.querySelector('head > meta')?.getAttribute('charset')?.toLowerCase(), 'utf-8');
+```
+
+Your `meta` element should be a void element, it does not have an end tag `</meta>`.
+
+```js
+assert.notMatch(code, /<\/meta\s*>?/i);
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #55377

<!-- Feel free to add any additional description of changes below this line -->

- Update tests to check for meta element.
- Removed one title test that didn't seem necessary.
- Change the text a bit.

---

I added the term void element to this challenge. There is an issue for this [here](https://github.com/freeCodeCamp/freeCodeCamp/issues/55342). To make sure the term doesn't show up randomly, we have to remember to (asap) update the first few challenges where void elements are taught. The cat photo app is the first one that should be changed as soon as possible. Edit: I updated the cat photo app.
