### PR TITLE
fix(curriculum): replace self-closing with void element

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5dc23f9bf86c76b9248c6eba.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5dc23f9bf86c76b9248c6eba.md
@@ -7,7 +7,7 @@ dashedName: step-7
 
 # --description--
 
-You can add images to your website by using the `img` element. `img` elements have an opening tag without a closing tag. A tag for an element without a closing tag is known as a <dfn>self-closing tag</dfn>.
+You can add images to your website by using the `img` element. `img` elements have an opening tag without a closing tag. A tag for an element without a closing tag is known as a <dfn>void element</dfn>.
 
 Add an `img` element below the `p` element. At this point, no image will show up in the browser.
 
@@ -19,7 +19,7 @@ Your `img` element should have an opening tag. Opening tags have this syntax: `<
 assert(document.querySelector('img'));
 ```
 
-Your `img` element should not have a closing tag. Closing tags have a `/` just after the `<` character.
+Your `img` element should not have a closing tag `</img>`.
 
 ```js
 assert(!code.match(/<\/img\>/));

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5ef9b03c81a63668521804d8.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5ef9b03c81a63668521804d8.md
@@ -7,7 +7,7 @@ dashedName: step-37
 
 # --description--
 
-The `input` element allows you several ways to collect data from a web form. Like `img` elements, `input` elements are <dfn>self-closing</dfn> and do not need closing tags.
+The `input` element allows you several ways to collect data from a web form. Like `img` elements, `input` elements are a <dfn>void element</dfn> and do not need closing tags.
 
 Nest an `input` element in the `form` element.
 

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5ef9b03c81a63668521804dc.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5ef9b03c81a63668521804dc.md
@@ -15,7 +15,7 @@ Here is an example of a radio button with the option of `cat`:
 <input type="radio"> cat
 ```
 
-Remember that `input` elements are <dfn>self-closing</dfn>.
+Remember that an `input` element is a void element.
 
 Before the text input, add a radio button with the option set as:
 

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/62bb4009e3458a128ff57d5d.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/62bb4009e3458a128ff57d5d.md
@@ -7,7 +7,7 @@ dashedName: step-69
 
 # --description--
 
-You can set browser behavior by adding self-closing `meta` elements in the `head`. Here's an example:
+You can set browser behavior by adding `meta` elements in the `head`. Here's an example:
 
 ```html
 <meta attribute="value">
@@ -15,13 +15,13 @@ You can set browser behavior by adding self-closing `meta` elements in the `head
 
 Inside the `head` element, nest a `meta` element with an attribute named `charset`. Set to the value to `utf-8` which tells the browser how to encode characters for the page. 
 
-Note that `meta` elements are self-closing.
+Note that the `meta` element is a void element.
 
 With that last change, you have completed the Cat Photo App project. Congratulations!
 
 # --hints--
 
-You should create a self-closing `meta` element within the `head` element.
+You should create a `meta` element within the `head` element.
 
 ```js
 assert.exists(document.querySelector('head > meta'));
@@ -33,7 +33,7 @@ You should give the `meta` element a `charset` of `UTF-8`.
 assert.equal(document.querySelector('head > meta')?.getAttribute('charset')?.toLowerCase(), 'utf-8');
 ```
 
-Your `meta` element should be a self-closing tag, you don't need to add `</meta>`.
+Your `meta` element should be a void element, you don't need to add `</meta>`.
 
 ```js
 assert.notMatch(code, /<\/meta\s*>?/i);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related #55342

<!-- Feel free to add any additional description of changes below this line -->

We seem to be over using `dfn`, I kept it for two challenge steps but removed it from one. As far as I know, we aren't meant to keep using it after the term has been defined.