### PR TITLE
fix(curriculum): replace misleading return in Expense Tracker project, step 21

### DIFF
--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-lambda-functions-by-building-an-expense-tracker/65823ff0d4b991510fade1a8.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-lambda-functions-by-building-an-expense-tracker/65823ff0d4b991510fade1a8.md
@@ -7,11 +7,11 @@ dashedName: step-21
 
 # --description--
 
-Within the `filter_expenses_by_category` function, replace `pass` with a `lambda` function. Use `expense` as the parameter and return the comparison between the value of the `'category'` key of the `expense` dictionary and `category` using the equality operator.
+Within the `filter_expenses_by_category` function, replace `pass` with a `lambda` function. Use `expense` as the parameter and evaluate the comparison between the value of the `'category'` key of the `expense` dictionary and `category` using the equality operator.
 
 # --hints--
 
-You should create a `lambda` function that uses a parameter named `expense` and returns the expression `expense['category'] == category` inside the `filter_expenses_by_category` function.
+You should create a `lambda` function that uses a parameter named `expense` and evaluate the expression `expense['category'] == category` inside the `filter_expenses_by_category` function.
 
 ```js
 ({ test: () => assert(runPython(`_Node(_code).find_function("filter_expenses_by_category").has_stmt("lambda expense: expense['category'] == category")`)) })

--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-lambda-functions-by-building-an-expense-tracker/65823ff0d4b991510fade1a8.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-lambda-functions-by-building-an-expense-tracker/65823ff0d4b991510fade1a8.md
@@ -11,7 +11,7 @@ Within the `filter_expenses_by_category` function, replace `pass` with a `lambda
 
 # --hints--
 
-You should create a `lambda` function that uses a parameter named `expense` and evaluate the expression `expense['category'] == category` inside the `filter_expenses_by_category` function.
+You should create a `lambda` function that uses a parameter named `expense` and evaluates the expression `expense['category'] == category` inside the `filter_expenses_by_category` function.
 
 ```js
 ({ test: () => assert(runPython(`_Node(_code).find_function("filter_expenses_by_category").has_stmt("lambda expense: expense['category'] == category")`)) })


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
As reported in some forum posts the use of "return" is cause of confusion.
