### PR TITLE
feat: gracefully redirect root path in development only

### DIFF
--- a/api-server/src/server/index.js
+++ b/api-server/src/server/index.js
@@ -83,7 +83,7 @@ app.start = _.once(function () {
   });
 });
 
-if (process.env.NODE_ENV === 'development') {
+if (process.env.FREECODECAMP_NODE_ENV === 'development') {
   app.get('/', (req, res) => {
     log('Mounting dev root redirect...');
     const { origin } = getRedirectParams(req);

--- a/api-server/src/server/index.js
+++ b/api-server/src/server/index.js
@@ -11,6 +11,7 @@ const morgan = require('morgan');
 
 const { sentry } = require('../../config/secrets');
 const { setupPassport } = require('./component-passport');
+const { getRedirectParams } = require('./utils/redirection.js');
 
 const log = createDebugger('fcc:server');
 const reqLogFormat = ':date[iso] :status :method :response-time ms - :url';
@@ -81,6 +82,14 @@ app.start = _.once(function () {
     });
   });
 });
+
+if (process.env.NODE_ENV === 'development') {
+  app.get('/', (req, res) => {
+    log('Mounting dev root redirect...');
+    const { origin } = getRedirectParams(req);
+    res.redirect(origin);
+  });
+}
 
 if (sentry.dsn === 'dsn_from_sentry_dashboard') {
   log('Sentry reporting disabled unless DSN is provided.');


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Maybe I'm wrong, maybe this is just a Naomi problem - I won't be offended if we close this.

But I work on apps that use port 3000 quite often. `localhost:3000` is in my history right next to `localhost:8000`. If I click the wrong one, I don't want a 404 page with a flash message. I want the API to read my mind and take me right where I meant to go. :3

<!-- Feel free to add any additional description of changes below this line -->
