### PR TITLE
fix(a11y): FAQ accordion and skip content link on /donate

### DIFF
--- a/client/src/components/Donation/donation-text-components.tsx
+++ b/client/src/components/Donation/donation-text-components.tsx
@@ -20,7 +20,9 @@ export const CtaText = (): JSX.Element => {
   const { t } = useTranslation();
   return (
     <>
-      <h1 data-playwright-test-label='main-head'>{t('donate.help-more')}</h1>
+      <h1 data-playwright-test-label='main-head' id='content-start'>
+        {t('donate.help-more')}
+      </h1>
       <Spacer size='medium' />
       <p data-playwright-test-label='donate-text-1'>{t('donate.efficiency')}</p>
       <p data-playwright-test-label='donate-text-2'>
@@ -82,14 +84,15 @@ const FaqItem = (
         className='map-title'
         onClick={() => setExpanded(!isExpanded)}
         aria-expanded={isExpanded}
+        aria-controls={`donate-faq-content-${key}`}
       >
         <Caret />
         <h3>{title}</h3>
       </button>
       {isExpanded && (
-        <>
-          <div className='map-challenges-ul'>{text}</div>
-        </>
+        <div className='map-challenges-ul' id={`donate-faq-content-${key}`}>
+          {text}
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR makes the following changes to the /donate page:
- Adds an `id` to the page's `h1`, so that the skip content link has a target to focus on
- Adds `aria-controls` to the FAQ accordion buttons to associate them with the content they control

<!-- Feel free to add any additional description of changes below this line -->
