### PR TITLE
feat(api): implement authorization code flow in the new api

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -9,6 +9,7 @@
     "@fastify/cookie": "9.4.0",
     "@fastify/csrf-protection": "6.4.1",
     "@fastify/express": "^2.3.0",
+    "@fastify/oauth2": "7.8.1",
     "@fastify/swagger": "8.14.0",
     "@fastify/swagger-ui": "1.10.2",
     "@fastify/type-provider-typebox": "3.6.0",

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -26,7 +26,7 @@ import redirectWithMessage from './plugins/redirect-with-message';
 import security from './plugins/security';
 import codeFlowAuth from './plugins/code-flow-auth';
 import notFound from './plugins/not-found';
-import { mobileAuth0Routes } from './routes/auth';
+import { authRoutes, mobileAuth0Routes } from './routes/auth';
 import { devAuthRoutes } from './routes/auth-dev';
 import {
   protectedCertificateRoutes,
@@ -220,8 +220,11 @@ export const build = async (
 
   // Routes not requiring authentication
   void fastify.register(mobileAuth0Routes);
+  // TODO: consolidate with LOCAL_MOCK_AUTH
   if (FCC_ENABLE_DEV_LOGIN_MODE) {
     void fastify.register(devAuthRoutes);
+  } else {
+    void fastify.register(authRoutes);
   }
   void fastify.register(chargeStripeRoute);
   void fastify.register(emailSubscribtionRoutes);

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -40,6 +40,7 @@ import { emailSubscribtionRoutes } from './routes/email-subscription';
 import { settingRoutes, settingRedirectRoutes } from './routes/settings';
 import { statusRoute } from './routes/status';
 import { userGetRoutes, userRoutes, userPublicGetRoutes } from './routes/user';
+import { signoutRoute } from './routes/signout';
 import {
   API_LOCATION,
   EMAIL_PROVIDER,
@@ -227,6 +228,7 @@ export const build = async (
     void fastify.register(authRoutes);
   }
   void fastify.register(chargeStripeRoute);
+  void fastify.register(signoutRoute);
   void fastify.register(emailSubscribtionRoutes);
   void fastify.register(userPublicGetRoutes);
   void fastify.register(unprotectedCertificateRoutes);

--- a/api/src/plugins/auth0.test.ts
+++ b/api/src/plugins/auth0.test.ts
@@ -380,11 +380,13 @@ describe('auth0 plugin', () => {
           showTimeLine: false
         },
         progressTimestamps: [expect.any(Number)],
+        rand: null,
         savedChallenges: [],
         sendQuincyEmail: false,
         theme: 'default',
         timezone: null,
         twitter: null,
+        updateCount: 0,
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         username: expect.stringMatching(fccUuidRe),
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment

--- a/api/src/plugins/auth0.test.ts
+++ b/api/src/plugins/auth0.test.ts
@@ -84,6 +84,8 @@ describe('auth0 plugin', () => {
         'getAccessTokenFromAuthorizationCodeFlow'
       );
       userinfoSpy = jest.spyOn(fastify.auth0OAuth, 'userinfo');
+      // @ts-expect-error - Only mocks part of the Sentry object.
+      fastify.Sentry = { captureException: () => '' };
     });
 
     afterEach(async () => {
@@ -125,22 +127,6 @@ describe('auth0 plugin', () => {
       expect(fastify.log.error).toHaveBeenCalledWith(
         'Auth failed: invalid state'
       );
-      expect(res.statusCode).toBe(302);
-    });
-
-    // TODO(Post-MVP): Expand the logging.
-    it('should not log errors if the state is valid', async () => {
-      jest.spyOn(fastify.log, 'error');
-      getAccessTokenFromAuthorizationCodeFlowSpy.mockRejectedValueOnce(
-        'any other error'
-      );
-      const res = await fastify.inject({
-        method: 'GET',
-        url: '/auth/auth0/callback?state=doesnt-matter' // state is not checked
-        // because the spy is mocking the method
-      });
-
-      expect(fastify.log.error).not.toHaveBeenCalled();
       expect(res.statusCode).toBe(302);
     });
 

--- a/api/src/plugins/auth0.test.ts
+++ b/api/src/plugins/auth0.test.ts
@@ -1,6 +1,7 @@
 import Fastify, { FastifyInstance } from 'fastify';
 
 import { AUTH0_DOMAIN } from '../utils/env';
+import prismaPlugin from '../db/prisma';
 // import cookies from './cookies';
 import { auth0Client } from './auth0';
 
@@ -12,6 +13,7 @@ describe('auth0 plugin', () => {
     // TODO: Uncomment when a test fails because of the lack of it.
     // await fastify.register(cookies);
     await fastify.register(auth0Client);
+    await fastify.register(prismaPlugin);
   });
 
   afterEach(async () => {
@@ -97,6 +99,15 @@ describe('auth0 plugin', () => {
 
       expect(fastify.log.error).not.toHaveBeenCalled();
       expect(res.statusCode).toBe(302);
+    });
+
+    it('should not create a user if the state is invalid', async () => {
+      await fastify.inject({
+        method: 'GET',
+        url: '/auth/auth0/callback?state=invalid'
+      });
+
+      expect(await fastify.prisma.user.count()).toBe(0);
     });
   });
 });

--- a/api/src/plugins/auth0.test.ts
+++ b/api/src/plugins/auth0.test.ts
@@ -9,7 +9,7 @@ import redirectWithMessage, { formatMessage } from './redirect-with-message';
 describe('auth0 plugin', () => {
   let fastify: FastifyInstance;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     fastify = Fastify();
     // TODO: Uncomment when a test fails because of the lack of it.
     // await fastify.register(cookies);
@@ -18,7 +18,7 @@ describe('auth0 plugin', () => {
     await fastify.register(prismaPlugin);
   });
 
-  afterEach(async () => {
+  afterAll(async () => {
     await fastify.close();
   });
 

--- a/api/src/plugins/auth0.test.ts
+++ b/api/src/plugins/auth0.test.ts
@@ -12,7 +12,7 @@ describe('auth0 plugin', () => {
 
   beforeAll(async () => {
     fastify = Fastify();
-    // TODO: Uncomment when a test fails because of the lack of it.
+
     await fastify.register(cookies);
     await fastify.register(redirectWithMessage);
     await fastify.register(codeFlowAuth);
@@ -42,6 +42,13 @@ describe('auth0 plugin', () => {
     const email = 'new@user.com';
     let getAccessTokenFromAuthorizationCodeFlowSpy: jest.SpyInstance;
     let userinfoSpy: jest.SpyInstance;
+
+    const mockAuthSuccess = () => {
+      getAccessTokenFromAuthorizationCodeFlowSpy.mockResolvedValueOnce({
+        token: 'any token'
+      });
+      userinfoSpy.mockResolvedValueOnce(Promise.resolve({ email }));
+    };
 
     beforeEach(() => {
       getAccessTokenFromAuthorizationCodeFlowSpy = jest.spyOn(
@@ -139,11 +146,7 @@ describe('auth0 plugin', () => {
     });
 
     it('creates a user if the state is valid', async () => {
-      getAccessTokenFromAuthorizationCodeFlowSpy.mockResolvedValueOnce({
-        token: 'any token'
-      });
-      userinfoSpy.mockResolvedValueOnce(Promise.resolve({ email }));
-
+      mockAuthSuccess();
       await fastify.inject({
         method: 'GET',
         url: '/auth/auth0/callback?state=valid'
@@ -185,10 +188,7 @@ describe('auth0 plugin', () => {
     });
 
     it('redirects the signin-success message on success', async () => {
-      getAccessTokenFromAuthorizationCodeFlowSpy.mockResolvedValueOnce({
-        token: 'any token'
-      });
-      userinfoSpy.mockResolvedValueOnce(Promise.resolve({ email }));
+      mockAuthSuccess();
 
       const res = await fastify.inject({
         method: 'GET',
@@ -202,10 +202,7 @@ describe('auth0 plugin', () => {
     });
 
     it('should set the jwt_access_token cookie', async () => {
-      getAccessTokenFromAuthorizationCodeFlowSpy.mockResolvedValueOnce({
-        token: 'any token'
-      });
-      userinfoSpy.mockResolvedValueOnce(Promise.resolve({ email }));
+      mockAuthSuccess();
 
       const res = await fastify.inject({
         method: 'GET',

--- a/api/src/plugins/auth0.test.ts
+++ b/api/src/plugins/auth0.test.ts
@@ -4,6 +4,7 @@ import { AUTH0_DOMAIN } from '../utils/env';
 import prismaPlugin from '../db/prisma';
 // import cookies from './cookies';
 import { auth0Client } from './auth0';
+import redirectWithMessage from './redirect-with-message';
 
 describe('auth0 plugin', () => {
   let fastify: FastifyInstance;
@@ -12,6 +13,7 @@ describe('auth0 plugin', () => {
     fastify = Fastify();
     // TODO: Uncomment when a test fails because of the lack of it.
     // await fastify.register(cookies);
+    await fastify.register(redirectWithMessage);
     await fastify.register(auth0Client);
     await fastify.register(prismaPlugin);
   });

--- a/api/src/plugins/auth0.test.ts
+++ b/api/src/plugins/auth0.test.ts
@@ -1,0 +1,85 @@
+import Fastify, { FastifyInstance } from 'fastify';
+import jwt from 'jsonwebtoken';
+
+import { AUTH0_DOMAIN, JWT_SECRET } from '../utils/env';
+// import cookies from './cookies';
+import { auth0Client } from './auth0';
+
+describe('auth0 plugin', () => {
+  let fastify: FastifyInstance;
+
+  beforeEach(async () => {
+    fastify = Fastify();
+    // TODO: Uncomment when a test fails because of the lack of it.
+    // await fastify.register(cookies);
+    await fastify.register(auth0Client);
+  });
+
+  afterEach(async () => {
+    await fastify.close();
+  });
+
+  describe('GET /signin', () => {
+    it('should redirect to the auth0 login page', async () => {
+      const res = await fastify.inject({
+        method: 'GET',
+        url: '/signin'
+      });
+
+      const redirectUrl = new URL(res.headers.location!);
+      expect(redirectUrl.host).toMatch(AUTH0_DOMAIN);
+      expect(redirectUrl.pathname).toBe('/authorize');
+      expect(res.statusCode).toBe(302);
+    });
+
+    it('should add the returnTo, origin and pathPrefix to the state', async () => {
+      const res = await fastify.inject({
+        method: 'GET',
+        url: '/signin',
+        headers: {
+          Referer: 'https://www.freecodecamp.org/espanol/settings'
+        }
+      });
+
+      const redirectUrl = new URL(res.headers.location!);
+      const stateParam = redirectUrl.searchParams.get('state');
+      const state = jwt.verify(stateParam as string, JWT_SECRET) as Record<
+        string,
+        string
+      >;
+      expect(state.returnTo).toBe(
+        'https://www.freecodecamp.org/espanol/settings'
+      );
+      expect(state.origin).toBe('https://www.freecodecamp.org');
+      expect(state.pathPrefix).toBe('espanol');
+    });
+  });
+
+  describe('GET /auth/auth0/callback', () => {
+    let getAccessTokenFromAuthorizationCodeFlowSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      getAccessTokenFromAuthorizationCodeFlowSpy = jest.spyOn(
+        fastify.auth0OAuth,
+        'getAccessTokenFromAuthorizationCodeFlow'
+      );
+    });
+
+    it('should redirect to auth0 if authentication fails', async () => {
+      getAccessTokenFromAuthorizationCodeFlowSpy.mockRejectedValueOnce(
+        'any error'
+      );
+
+      const res = await fastify.inject({
+        method: 'GET',
+        url: '/auth/auth0/callback'
+      });
+
+      const redirectUrl = new URL(res.headers.location!);
+      expect(redirectUrl.host).toMatch(AUTH0_DOMAIN);
+      expect(res.statusCode).toBe(302);
+    });
+
+    it('should log an error if the state is invalid', async () => {});
+  });
+});

--- a/api/src/plugins/auth0.test.ts
+++ b/api/src/plugins/auth0.test.ts
@@ -302,6 +302,7 @@ describe('auth0 plugin', () => {
       const uuidRe = /^[a-f0-9]{8}-([a-f0-9]{4}-){3}[a-f0-9]{12}$/;
       const fccUuidRe = /^fcc-[a-f0-9]{8}-([a-f0-9]{4}-){3}[a-f0-9]{12}$/;
       const unsubscribeIdRe = new RegExp(`^[${nanoidCharSet}]{21}$`);
+      const mongodbIdRe = /^[a-f0-9]{24}$/;
 
       await fastify.inject({
         method: 'GET',
@@ -312,24 +313,33 @@ describe('auth0 plugin', () => {
         where: { email }
       });
 
-      expect(user).toMatchObject({
+      expect(user).toEqual({
         about: '',
         acceptedPrivacyTerms: false,
         completedChallenges: [],
+        completedExams: [],
         currentChallengeId: '',
+        donationEmails: [],
         email,
+        emailAuthLinkTTL: null,
         emailVerified: true,
+        emailVerifyTTL: null,
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         externalId: expect.stringMatching(uuidRe),
+        githubProfile: null,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        id: expect.stringMatching(mongodbIdRe),
         is2018DataVisCert: false,
         is2018FullStackCert: false,
         isApisMicroservicesCert: false,
         isBackEndCert: false,
         isBanned: false,
         isCheater: false,
+        isClassroomAccount: null,
         isDataAnalysisPyCertV7: false,
         isDataVisCert: false,
         isDonating: false,
+        isFoundationalCSharpCertV8: false,
         isFrontEndCert: false,
         isFrontEndLibsCert: false,
         isFullStackCert: false,
@@ -337,18 +347,26 @@ describe('auth0 plugin', () => {
         isInfosecCertV7: false,
         isInfosecQaCert: false,
         isJsAlgoDataStructCert: false,
+        isJsAlgoDataStructCertV8: false,
         isMachineLearningPyCertV7: false,
         isQaCertV7: false,
         isRelationalDatabaseCertV8: false,
         isCollegeAlgebraPyCertV8: false,
         isRespWebDesignCert: false,
         isSciCompPyCertV7: false,
+        isUpcomingPythonCertV8: null,
         keyboardShortcuts: false,
+        linkedin: null,
         location: '',
         name: '',
+        needsModeration: false,
+        newEmail: null,
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         unsubscribeId: expect.stringMatching(unsubscribeIdRe),
+        partiallyCompletedChallenges: [],
+        password: null,
         picture: '',
+        portfolio: [],
         profileUI: {
           isLocked: false,
           showAbout: false,
@@ -362,12 +380,18 @@ describe('auth0 plugin', () => {
           showTimeLine: false
         },
         progressTimestamps: [expect.any(Number)],
+        savedChallenges: [],
         sendQuincyEmail: false,
         theme: 'default',
+        timezone: null,
+        twitter: null,
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         username: expect.stringMatching(fccUuidRe),
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        usernameDisplay: expect.stringMatching(fccUuidRe)
+        usernameDisplay: expect.stringMatching(fccUuidRe),
+        verificationToken: null,
+        website: null,
+        yearsTopContributor: []
       });
       expect(user.username).toBe(user.usernameDisplay);
     });

--- a/api/src/plugins/auth0.test.ts
+++ b/api/src/plugins/auth0.test.ts
@@ -166,6 +166,22 @@ describe('auth0 plugin', () => {
       expect(await fastify.prisma.user.count()).toBe(0);
     });
 
+    it('handles invalid userinfo responses', async () => {
+      getAccessTokenFromAuthorizationCodeFlowSpy.mockResolvedValueOnce({
+        token: 'any token'
+      });
+      userinfoSpy.mockResolvedValueOnce(Promise.resolve({}));
+
+      const res = await fastify.inject({
+        method: 'GET',
+        url: '/auth/auth0/callback?state=valid'
+      });
+
+      expect(res.headers.location).toMatch('/signin');
+      expect(res.statusCode).toBe(302);
+      expect(await fastify.prisma.user.count()).toBe(0);
+    });
+
     it('redirects the signin-success message on success', async () => {
       getAccessTokenFromAuthorizationCodeFlowSpy.mockResolvedValueOnce({
         token: 'any token'

--- a/api/src/plugins/auth0.test.ts
+++ b/api/src/plugins/auth0.test.ts
@@ -93,7 +93,7 @@ describe('auth0 plugin', () => {
       await fastify.prisma.user.deleteMany({ where: { email } });
     });
 
-    it('should redirect to /signin if authentication fails', async () => {
+    it('should redirect to the client if authentication fails', async () => {
       getAccessTokenFromAuthorizationCodeFlowSpy.mockRejectedValueOnce(
         'any error'
       );
@@ -103,17 +103,21 @@ describe('auth0 plugin', () => {
         url: '/auth/auth0/callback'
       });
 
-      expect(res.headers.location).toMatch('/signin');
+      expect(res.headers.location).toMatch(
+        `${HOME_LOCATION}/learn?${formatMessage({ type: 'danger', content: 'flash.generic-error' })}`
+      );
       expect(res.statusCode).toBe(302);
     });
 
-    it('should redirect to the /signin if the state is invalid', async () => {
+    it('should redirect to the client if the state is invalid', async () => {
       const res = await fastify.inject({
         method: 'GET',
         url: '/auth/auth0/callback?state=invalid'
       });
 
-      expect(res.headers.location).toMatch('/signin');
+      expect(res.headers.location).toMatch(
+        `${HOME_LOCATION}/learn?${formatMessage({ type: 'danger', content: 'flash.generic-error' })}`
+      );
       expect(res.statusCode).toBe(302);
     });
 

--- a/api/src/plugins/auth0.ts
+++ b/api/src/plugins/auth0.ts
@@ -99,6 +99,9 @@ export const auth0Client: FastifyPluginCallbackTypebox = fp(
         // functions.
         if (error instanceof Error && error.message === 'Invalid state') {
           fastify.log.error('Auth failed: invalid state');
+        } else {
+          fastify.log.error('Auth failed', error);
+          fastify.Sentry.captureException(error);
         }
         return reply.redirect(302, '/signin');
       }
@@ -111,8 +114,8 @@ export const auth0Client: FastifyPluginCallbackTypebox = fp(
         email = userinfo.email;
         if (typeof email !== 'string') throw Error('Invalid userinfo response');
       } catch (error) {
-        // TODO: send to Sentry
         fastify.log.error('Auth failed', error);
+        fastify.Sentry.captureException(error);
         return reply.redirect(302, '/signin');
       }
 

--- a/api/src/plugins/auth0.ts
+++ b/api/src/plugins/auth0.ts
@@ -1,4 +1,4 @@
-import fastifyOauth2 from '@fastify/oauth2';
+import fastifyOauth2, { type OAuth2Namespace } from '@fastify/oauth2';
 import { type FastifyPluginCallbackTypebox } from '@fastify/type-provider-typebox';
 import fp from 'fastify-plugin';
 
@@ -16,6 +16,12 @@ import {
   getLoginRedirectParams,
   getPrefixedLandingPath
 } from '../utils/redirection';
+
+declare module 'fastify' {
+  interface FastifyInstance {
+    auth0OAuth: OAuth2Namespace;
+  }
+}
 
 /**
  * Fastify plugin for Auth0 authentication. This uses fastify-plugin to expose

--- a/api/src/plugins/auth0.ts
+++ b/api/src/plugins/auth0.ts
@@ -12,6 +12,7 @@ import {
 } from '../utils/env';
 import { findOrCreateUser } from '../routes/helpers/auth-helpers';
 import { createAccessToken } from '../utils/tokens';
+import { getLoginRedirectParams } from '../utils/redirection';
 
 /**
  * Fastify plugin for Auth0 authentication. This uses fastify-plugin to expose
@@ -77,6 +78,8 @@ export const auth0Client: FastifyPluginCallbackTypebox = fp(
         }
       }
 
+      const { returnTo } = getLoginRedirectParams(request);
+
       let token;
       try {
         token = (
@@ -109,7 +112,7 @@ export const auth0Client: FastifyPluginCallbackTypebox = fp(
       reply.setAccessTokenCookie(createAccessToken(id));
       // TODO: implement whatever set-cookieing the api-server does as well as
       // handling i18n clients.
-      void reply.redirectWithMessage(`${HOME_LOCATION}/learn`, {
+      void reply.redirectWithMessage(returnTo, {
         type: 'success',
         content: 'flash.signin-success'
       });

--- a/api/src/plugins/auth0.ts
+++ b/api/src/plugins/auth0.ts
@@ -29,8 +29,6 @@ import {
  */
 export const auth0Client: FastifyPluginCallbackTypebox = fp(
   (fastify, _options, done) => {
-    // @ts-expect-error - when using discovery, client.auth is not allowed by the
-    // code, but required by the types.
     void fastify.register(fastifyOauth2, {
       name: 'auth0OAuth',
       scope: ['openid', 'email', 'profile'], // TODO: check what scopes the api-server uses

--- a/api/src/plugins/auth0.ts
+++ b/api/src/plugins/auth0.ts
@@ -80,6 +80,7 @@ export const auth0Client: FastifyPluginCallbackTypebox = fp(
           email: string;
         };
         email = userinfo.email;
+        if (typeof email !== 'string') throw Error('Invalid userinfo response');
       } catch (error) {
         // TODO: send to Sentry
         fastify.log.error('Auth failed', error);

--- a/api/src/plugins/auth0.ts
+++ b/api/src/plugins/auth0.ts
@@ -62,5 +62,6 @@ export const auth0Client: FastifyPluginCallbackTypebox = fp(
     });
 
     done();
-  }
+  },
+  { dependencies: ['redirect-with-message'] }
 );

--- a/api/src/plugins/auth0.ts
+++ b/api/src/plugins/auth0.ts
@@ -10,6 +10,7 @@ import {
   HOME_LOCATION
 } from '../utils/env';
 import { findOrCreateUser } from '../routes/helpers/auth-helpers';
+import { createAccessToken } from '../utils/tokens';
 
 /**
  * Fastify plugin for Auth0 authentication. This uses fastify-plugin to expose
@@ -87,8 +88,8 @@ export const auth0Client: FastifyPluginCallbackTypebox = fp(
         return reply.redirect(302, '/signin');
       }
 
-      await findOrCreateUser(fastify, email);
-
+      const { id } = await findOrCreateUser(fastify, email);
+      reply.setAccessTokenCookie(createAccessToken(id));
       // TODO: implement whatever set-cookieing the api-server does as well as
       // handling i18n clients.
       void reply.redirectWithMessage(`${HOME_LOCATION}/learn`, {

--- a/api/src/plugins/auth0.ts
+++ b/api/src/plugins/auth0.ts
@@ -1,0 +1,73 @@
+import fastifyOauth2 from '@fastify/oauth2';
+import { type FastifyPluginCallbackTypebox } from '@fastify/type-provider-typebox';
+import jwt from 'jsonwebtoken';
+import fp from 'fastify-plugin';
+
+import {
+  API_LOCATION,
+  AUTH0_CLIENT_ID,
+  AUTH0_CLIENT_SECRET,
+  AUTH0_DOMAIN,
+  JWT_SECRET
+} from '../utils/env';
+import { getRedirectParams } from '../utils/redirection';
+
+/**
+ * Fastify plugin for Auth0 authentication. This uses fastify-plugin to expose
+ * the auth0OAuth decorator (for easier testing), but to maintain encapsulation
+ * it should be registered in a plugin. That prevents auth0OAuth from being
+ * available globally.
+ *
+ * @param fastify - The Fastify instance.
+ * @param _options - The plugin options.
+ * @param done - The callback function.
+ */
+export const auth0Client: FastifyPluginCallbackTypebox = fp(
+  (fastify, _options, done) => {
+    // @ts-expect-error - when using discovery, client.auth is not allowed by the
+    // code, but required by the types.
+    void fastify.register(fastifyOauth2, {
+      name: 'auth0OAuth',
+      scope: ['openid', 'email', 'profile'], // TODO: check what scopes the api-server uses
+      credentials: {
+        client: {
+          id: AUTH0_CLIENT_ID,
+          secret: AUTH0_CLIENT_SECRET
+        }
+      },
+      startRedirectPath: '/signin',
+      discovery: { issuer: `https://${AUTH0_DOMAIN}` },
+      callbackUri: `${API_LOCATION}/auth/auth0/callback`,
+      generateStateFunction: request => {
+        return jwt.sign(getRedirectParams(request), JWT_SECRET);
+      },
+      checkStateFunction: (_state, callback) => {
+        return callback(new Error('Not implemented'));
+      }
+    });
+
+    fastify.get('/auth/auth0/callback', async function (request, reply) {
+      let token;
+      try {
+        token = (
+          await this.auth0OAuth.getAccessTokenFromAuthorizationCodeFlow(request)
+        ).token;
+      } catch (error) {
+        const uri = await fastify.auth0OAuth.generateAuthorizationUri(
+          request,
+          reply
+        );
+        return reply.redirect(302, uri);
+      }
+
+      // TODO: use userinfo.email to find or create a user
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const userinfo = await fastify.auth0OAuth.userinfo(token);
+
+      // TODO: implement whatever redirects and set-cookieing the api-server does
+      void reply.send({ msg: 'success' });
+    });
+
+    done();
+  }
+);

--- a/api/src/plugins/auth0.ts
+++ b/api/src/plugins/auth0.ts
@@ -41,7 +41,12 @@ export const auth0Client: FastifyPluginCallbackTypebox = fp(
         }
       },
       discovery: { issuer: `https://${AUTH0_DOMAIN}` },
-      callbackUri: `${API_LOCATION}/auth/auth0/callback`
+      callbackUri: `${API_LOCATION}/auth/auth0/callback`,
+      cookie: {
+        // It's important not to sign the cookie, since the OAuth2 plugin will
+        // not unsign it.
+        signed: false
+      }
     });
 
     fastify.get('/signin', async function (request, reply) {

--- a/api/src/plugins/auth0.ts
+++ b/api/src/plugins/auth0.ts
@@ -67,7 +67,7 @@ export const auth0Client: FastifyPluginCallbackTypebox = fp(
         request,
         reply
       );
-      void reply.redirect(302, redirectUrl);
+      void reply.redirect(redirectUrl);
     });
 
     // TODO: use a schema to validate the query params.
@@ -81,7 +81,7 @@ export const auth0Client: FastifyPluginCallbackTypebox = fp(
           error_description === 'Access denied from your location';
 
         if (blockedByLaw) {
-          return reply.redirect(302, `${HOME_LOCATION}/blocked`);
+          return reply.redirect(`${HOME_LOCATION}/blocked`);
         } else {
           return reply.redirectWithMessage(`${HOME_LOCATION}/learn`, {
             type: 'info',
@@ -126,7 +126,7 @@ export const auth0Client: FastifyPluginCallbackTypebox = fp(
       } catch (error) {
         fastify.log.error('Auth failed', error);
         fastify.Sentry.captureException(error);
-        return reply.redirect(302, '/signin');
+        return reply.redirect('/signin');
       }
 
       const { id, acceptedPrivacyTerms } = await findOrCreateUser(

--- a/api/src/plugins/auth0.ts
+++ b/api/src/plugins/auth0.ts
@@ -37,7 +37,7 @@ export const auth0Client: FastifyPluginCallbackTypebox = fp(
   (fastify, _options, done) => {
     void fastify.register(fastifyOauth2, {
       name: 'auth0OAuth',
-      scope: ['openid', 'email', 'profile'], // TODO: check what scopes the api-server uses
+      scope: ['openid', 'email', 'profile'],
       credentials: {
         client: {
           id: AUTH0_CLIENT_ID,

--- a/api/src/routes/auth-dev.test.ts
+++ b/api/src/routes/auth-dev.test.ts
@@ -1,11 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import {
-  defaultUserEmail,
-  devLogin,
-  setupServer,
-  superRequest
-} from '../../jest.utils';
+import { defaultUserEmail, setupServer, superRequest } from '../../jest.utils';
 import { HOME_LOCATION } from '../utils/env';
 import { nanoidCharSet } from '../utils/create-user';
 
@@ -195,41 +190,6 @@ describe('dev login', () => {
 
       expect(res.status).toBe(302);
       expect(res.headers.location).toBe(`${HOME_LOCATION}/learn`);
-    });
-  });
-
-  describe('GET /signout', () => {
-    beforeEach(async () => {
-      await devLogin();
-    });
-    it('should clear all the cookies', async () => {
-      const res = await superRequest('/signout', { method: 'GET' });
-
-      const setCookie = res.headers['set-cookie'];
-      expect(setCookie).toEqual(
-        expect.arrayContaining([
-          expect.stringMatching(
-            /^jwt_access_token=; Path=\/; Expires=Thu, 01 Jan 1970 00:00:00 GMT/
-          ),
-          expect.stringMatching(
-            /^csrf_token=; Path=\/; Expires=Thu, 01 Jan 1970 00:00:00 GMT/
-          ),
-          expect.stringMatching(
-            /^_csrf=; Path=\/; Expires=Thu, 01 Jan 1970 00:00:00 GMT/
-          )
-        ])
-      );
-      expect(setCookie).toHaveLength(3);
-    });
-
-    it('should redirect to / on the client by default', async () => {
-      const res = await superRequest('/signout', { method: 'GET' });
-
-      // This happens because localhost:8000 is not an allowed origin and so
-      // normalizeParams rejects it and sets the returnTo to /learn. TODO:
-      // separate the validation and normalization logic.
-      expect(res.headers.location).toBe(`${HOME_LOCATION}/learn`);
-      expect(res.status).toBe(302);
     });
   });
 });

--- a/api/src/routes/auth-dev.test.ts
+++ b/api/src/routes/auth-dev.test.ts
@@ -41,6 +41,7 @@ describe('dev login', () => {
       const uuidRe = /^[a-f0-9]{8}-([a-f0-9]{4}-){3}[a-f0-9]{12}$/;
       const fccUuidRe = /^fcc-[a-f0-9]{8}-([a-f0-9]{4}-){3}[a-f0-9]{12}$/;
       const unsubscribeIdRe = new RegExp(`^[${nanoidCharSet}]{21}$`);
+      const mongodbIdRe = /^[a-f0-9]{24}$/;
 
       await superRequest('/signin', { method: 'GET' });
       const user = await fastifyTestInstance.prisma.user.findFirstOrThrow({
@@ -51,19 +52,29 @@ describe('dev login', () => {
         about: '',
         acceptedPrivacyTerms: false,
         completedChallenges: [],
+        completedExams: [],
         currentChallengeId: '',
+        donationEmails: [],
         email: defaultUserEmail,
+        emailAuthLinkTTL: null,
         emailVerified: true,
+        emailVerifyTTL: null,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         externalId: expect.stringMatching(uuidRe),
+        githubProfile: null,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        id: expect.stringMatching(mongodbIdRe),
         is2018DataVisCert: false,
         is2018FullStackCert: false,
         isApisMicroservicesCert: false,
         isBackEndCert: false,
         isBanned: false,
         isCheater: false,
+        isClassroomAccount: null,
         isDataAnalysisPyCertV7: false,
         isDataVisCert: false,
         isDonating: false,
+        isFoundationalCSharpCertV8: false,
         isFrontEndCert: false,
         isFrontEndLibsCert: false,
         isFullStackCert: false,
@@ -71,17 +82,26 @@ describe('dev login', () => {
         isInfosecCertV7: false,
         isInfosecQaCert: false,
         isJsAlgoDataStructCert: false,
+        isJsAlgoDataStructCertV8: false,
         isMachineLearningPyCertV7: false,
         isQaCertV7: false,
         isRelationalDatabaseCertV8: false,
         isCollegeAlgebraPyCertV8: false,
         isRespWebDesignCert: false,
         isSciCompPyCertV7: false,
+        isUpcomingPythonCertV8: null,
         keyboardShortcuts: false,
+        linkedin: null,
         location: '',
         name: '',
+        needsModeration: false,
+        newEmail: null,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         unsubscribeId: expect.stringMatching(unsubscribeIdRe),
+        partiallyCompletedChallenges: [],
+        password: null,
         picture: '',
+        portfolio: [],
         profileUI: {
           isLocked: false,
           showAbout: false,
@@ -95,10 +115,18 @@ describe('dev login', () => {
           showTimeLine: false
         },
         progressTimestamps: [expect.any(Number)],
+        savedChallenges: [],
         sendQuincyEmail: false,
         theme: 'default',
+        timezone: null,
+        twitter: null,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         username: expect.stringMatching(fccUuidRe),
-        usernameDisplay: expect.stringMatching(fccUuidRe)
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        usernameDisplay: expect.stringMatching(fccUuidRe),
+        verificationToken: null,
+        website: null,
+        yearsTopContributor: []
       });
       expect(user.username).toBe(user.usernameDisplay);
     });

--- a/api/src/routes/auth-dev.ts
+++ b/api/src/routes/auth-dev.ts
@@ -46,11 +46,5 @@ export const devAuthRoutes: FastifyPluginCallback = (
     await handleRedirects(req, reply);
   });
 
-  fastify.get('/signout', async (req, reply) => {
-    reply.clearOurCookies();
-
-    const { returnTo } = getRedirectParams(req);
-    await reply.redirect(returnTo);
-  });
   done();
 };

--- a/api/src/routes/auth.test.ts
+++ b/api/src/routes/auth.test.ts
@@ -1,0 +1,33 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import { createSuperRequest, devLogin, setupServer } from '../../jest.utils';
+import { AUTH0_DOMAIN } from '../utils/env';
+
+jest.mock('../utils/env', () => {
+  console.log('mocking env');
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  return {
+    ...jest.requireActual('../utils/env'),
+    FCC_ENABLE_DEV_LOGIN_MODE: false
+  };
+});
+
+describe('auth0 routes', () => {
+  setupServer();
+  describe('GET /signin', () => {
+    let superGet: ReturnType<typeof createSuperRequest>;
+    beforeAll(async () => {
+      const setCookies = await devLogin();
+
+      superGet = createSuperRequest({ method: 'GET', setCookies });
+    });
+    it('should redirect to the auth0 login page', async () => {
+      const res = await superGet('/signin');
+
+      expect(res.status).toBe(302);
+      expect(res.headers.location).toMatch(
+        // TODO: create regex escape function and apply to AUTH0_DOMAIN
+        new RegExp(`https://${AUTH0_DOMAIN}/authorize`)
+      );
+    });
+  });
+});

--- a/api/src/routes/auth.test.ts
+++ b/api/src/routes/auth.test.ts
@@ -28,7 +28,5 @@ describe('auth0 routes', () => {
       expect(redirectUrl.host).toMatch(AUTH0_DOMAIN);
       expect(redirectUrl.pathname).toBe('/authorize');
     });
-
-    it.todo('should add the referer to the state');
   });
 });

--- a/api/src/routes/auth.test.ts
+++ b/api/src/routes/auth.test.ts
@@ -3,7 +3,6 @@ import { createSuperRequest, devLogin, setupServer } from '../../jest.utils';
 import { AUTH0_DOMAIN } from '../utils/env';
 
 jest.mock('../utils/env', () => {
-  console.log('mocking env');
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   return {
     ...jest.requireActual('../utils/env'),

--- a/api/src/routes/auth.test.ts
+++ b/api/src/routes/auth.test.ts
@@ -23,10 +23,12 @@ describe('auth0 routes', () => {
       const res = await superGet('/signin');
 
       expect(res.status).toBe(302);
-      expect(res.headers.location).toMatch(
-        // TODO: create regex escape function and apply to AUTH0_DOMAIN
-        new RegExp(`https://${AUTH0_DOMAIN}/authorize`)
-      );
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+      const redirectUrl = new URL(res.headers.location);
+      expect(redirectUrl.host).toMatch(AUTH0_DOMAIN);
+      expect(redirectUrl.pathname).toBe('/authorize');
     });
+
+    it.todo('should add the referer to the state');
   });
 });

--- a/api/src/routes/auth.ts
+++ b/api/src/routes/auth.ts
@@ -1,11 +1,23 @@
 import { FastifyPluginCallback, FastifyRequest } from 'fastify';
-
+import fastifyOauth2, { OAuth2Namespace } from '@fastify/oauth2';
 import rateLimit from 'express-rate-limit';
 // @ts-expect-error - no types
 import MongoStoreRL from 'rate-limit-mongo';
 
-import { AUTH0_DOMAIN, MONGOHQ_URL } from '../utils/env';
+import {
+  API_LOCATION,
+  AUTH0_CLIENT_ID,
+  AUTH0_CLIENT_SECRET,
+  AUTH0_DOMAIN,
+  MONGOHQ_URL
+} from '../utils/env';
 import { findOrCreateUser } from './helpers/auth-helpers';
+
+declare module 'fastify' {
+  interface FastifyInstance {
+    auth0OAuth: OAuth2Namespace;
+  }
+}
 
 const getEmailFromAuth0 = async (req: FastifyRequest) => {
   const auth0Res = await fetch(`https://${AUTH0_DOMAIN}/userinfo`, {
@@ -61,5 +73,41 @@ export const mobileAuth0Routes: FastifyPluginCallback = (
     await findOrCreateUser(fastify, email);
   });
 
+  done();
+};
+
+/**
+ * Route handler for authentication routes.
+ *
+ * @param fastify The Fastify instance.
+ * @param _options Options passed to the plugin via `fastify.register(plugin, options)`.
+ * @param done Callback to signal that the logic has completed.
+ */
+export const authRoutes: FastifyPluginCallback = (fastify, _options, done) => {
+  void fastify.register(fastifyOauth2, {
+    name: 'auth0OAuth',
+    scope: ['openid', 'email', 'profile'], // TODO: check what scopes the api-server uses
+    credentials: {
+      client: {
+        id: AUTH0_CLIENT_ID,
+        secret: AUTH0_CLIENT_SECRET
+      }
+    },
+    startRedirectPath: '/signin',
+    discovery: { issuer: `https://${AUTH0_DOMAIN}` },
+    callbackUri: `${API_LOCATION}/auth/auth0/callback`
+  });
+
+  fastify.get('/auth/auth0/callback', async function (request, reply) {
+    const { token } =
+      await this.auth0OAuth.getAccessTokenFromAuthorizationCodeFlow(request);
+
+    // TODO: use userinfo.email to find or create a user
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const userinfo = await fastify.auth0OAuth.userinfo(token);
+
+    // TODO: implement whatever redirects and set-cookieing the api-server does
+    void reply.send({ msg: 'success' });
+  });
   done();
 };

--- a/api/src/routes/auth.ts
+++ b/api/src/routes/auth.ts
@@ -1,5 +1,4 @@
 import { FastifyPluginCallback, FastifyRequest } from 'fastify';
-import { OAuth2Namespace } from '@fastify/oauth2';
 import rateLimit from 'express-rate-limit';
 // @ts-expect-error - no types
 import MongoStoreRL from 'rate-limit-mongo';
@@ -7,12 +6,6 @@ import MongoStoreRL from 'rate-limit-mongo';
 import { AUTH0_DOMAIN, MONGOHQ_URL } from '../utils/env';
 import { auth0Client } from '../plugins/auth0';
 import { findOrCreateUser } from './helpers/auth-helpers';
-
-declare module 'fastify' {
-  interface FastifyInstance {
-    auth0OAuth: OAuth2Namespace;
-  }
-}
 
 const getEmailFromAuth0 = async (req: FastifyRequest) => {
   const auth0Res = await fetch(`https://${AUTH0_DOMAIN}/userinfo`, {

--- a/api/src/routes/helpers/auth-helpers.ts
+++ b/api/src/routes/helpers/auth-helpers.ts
@@ -10,12 +10,12 @@ import { createUserInput } from '../../utils/create-user';
 export const findOrCreateUser = async (
   fastify: FastifyInstance,
   email: string
-): Promise<{ id: string }> => {
+): Promise<{ id: string; acceptedPrivacyTerms: boolean }> => {
   // TODO: handle the case where there are multiple users with the same email.
   // e.g. use findMany and throw an error if more than one is found.
   const existingUser = await fastify.prisma.user.findMany({
     where: { email },
-    select: { id: true }
+    select: { id: true, acceptedPrivacyTerms: true }
   });
   if (existingUser.length > 1) {
     fastify.Sentry.captureException(
@@ -27,7 +27,7 @@ export const findOrCreateUser = async (
     existingUser[0] ??
     (await fastify.prisma.user.create({
       data: createUserInput(email),
-      select: { id: true }
+      select: { id: true, acceptedPrivacyTerms: true }
     }))
   );
 };

--- a/api/src/routes/signout.test.ts
+++ b/api/src/routes/signout.test.ts
@@ -1,0 +1,41 @@
+import { devLogin, setupServer, superRequest } from '../../jest.utils';
+import { HOME_LOCATION } from '../utils/env';
+
+describe('GET /signout', () => {
+  setupServer();
+
+  beforeEach(async () => {
+    await devLogin();
+  });
+  it('should clear all the cookies', async () => {
+    const res = await superRequest('/signout', { method: 'GET' });
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+    const setCookie = res.headers['set-cookie'];
+    expect(setCookie).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(
+          /^jwt_access_token=; Path=\/; Expires=Thu, 01 Jan 1970 00:00:00 GMT/
+        ),
+        expect.stringMatching(
+          /^csrf_token=; Path=\/; Expires=Thu, 01 Jan 1970 00:00:00 GMT/
+        ),
+        expect.stringMatching(
+          /^_csrf=; Path=\/; Expires=Thu, 01 Jan 1970 00:00:00 GMT/
+        )
+      ])
+    );
+    expect(setCookie).toHaveLength(3);
+  });
+
+  it('should redirect to / on the client by default', async () => {
+    const res = await superRequest('/signout', { method: 'GET' });
+
+    // This happens because localhost:8000 is not an allowed origin and so
+    // normalizeParams rejects it and sets the returnTo to /learn. TODO:
+    // separate the validation and normalization logic.
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(res.headers.location).toBe(`${HOME_LOCATION}/learn`);
+    expect(res.status).toBe(302);
+  });
+});

--- a/api/src/routes/signout.ts
+++ b/api/src/routes/signout.ts
@@ -1,0 +1,27 @@
+import type { FastifyPluginCallback } from 'fastify';
+
+import { getRedirectParams } from '../utils/redirection';
+
+/**
+ * Route handler for signing out.
+ *
+ * @param fastify The Fastify instance.
+ * @param _options Options passed to the plugin via `fastify.register(plugin,
+ * options)`.
+ * @param done Callback to signal that the logic has completed.
+ */
+export const signoutRoute: FastifyPluginCallback = (
+  fastify,
+  _options,
+  done
+) => {
+  fastify.get('/signout', async (req, reply) => {
+    void reply.clearCookie('jwt_access_token');
+    void reply.clearCookie('csrf_token');
+    void reply.clearCookie('_csrf');
+
+    const { returnTo } = getRedirectParams(req);
+    await reply.redirect(returnTo);
+  });
+  done();
+};

--- a/api/src/utils/env.ts
+++ b/api/src/utils/env.ts
@@ -45,6 +45,8 @@ assert.ok(process.env.FREECODECAMP_NODE_ENV);
 assert.ok(isAllowedEnv(process.env.FREECODECAMP_NODE_ENV));
 assert.ok(process.env.EMAIL_PROVIDER);
 assert.ok(isAllowedProvider(process.env.EMAIL_PROVIDER));
+assert.ok(process.env.AUTH0_CLIENT_ID);
+assert.ok(process.env.AUTH0_CLIENT_SECRET);
 assert.ok(process.env.AUTH0_DOMAIN);
 assert.ok(process.env.AUTH0_AUDIENCE);
 assert.ok(process.env.API_LOCATION);
@@ -96,6 +98,12 @@ if (process.env.FREECODECAMP_NODE_ENV !== 'development') {
     'The Stripe secret should be changed from the default value.'
   );
   assert.notEqual(process.env.NODE_ENV, 'test');
+  assert.ok(process.env.AUTH0_CLIENT_SECRET);
+  assert.notEqual(
+    process.env.AUTH0_CLIENT_SECRET,
+    'client_secret_from_auth0_dashboard',
+    'The Auth0 client secret should be changed from the default value.'
+  );
 }
 
 export const HOME_LOCATION = process.env.HOME_LOCATION;
@@ -109,8 +117,10 @@ export const MONGOHQ_URL =
     : process.env.MONGOHQ_URL;
 
 export const FREECODECAMP_NODE_ENV = process.env.FREECODECAMP_NODE_ENV;
+export const AUTH0_CLIENT_ID = process.env.AUTH0_CLIENT_ID;
 export const AUTH0_DOMAIN = process.env.AUTH0_DOMAIN;
 export const AUTH0_AUDIENCE = process.env.AUTH0_AUDIENCE;
+export const AUTH0_CLIENT_SECRET = process.env.AUTH0_CLIENT_SECRET;
 export const PORT = process.env.PORT || '3000';
 export const HOST = process.env.HOST || 'localhost';
 export const API_LOCATION = process.env.API_LOCATION;

--- a/api/src/utils/env.ts
+++ b/api/src/utils/env.ts
@@ -57,8 +57,6 @@ assert.ok(process.env.STRIPE_SECRET_KEY);
 assert.ok(process.env.SHOW_UPCOMING_CHANGES);
 assert.ok(process.env.MONGOHQ_URL);
 assert.ok(process.env.COOKIE_SECRET);
-assert.ok(process.env.SHOW_UPCOMING_CHANGES);
-assert.ok(process.env.MONGOHQ_URL);
 
 if (process.env.FREECODECAMP_NODE_ENV !== 'development') {
   assert.ok(process.env.SES_ID);
@@ -100,13 +98,11 @@ if (process.env.FREECODECAMP_NODE_ENV !== 'development') {
     'The Stripe secret should be changed from the default value.'
   );
   assert.notEqual(process.env.NODE_ENV, 'test');
-  assert.ok(process.env.AUTH0_CLIENT_SECRET);
   assert.notEqual(
     process.env.AUTH0_CLIENT_SECRET,
     'client_secret_from_auth0_dashboard',
     'The Auth0 client secret should be changed from the default value.'
   );
-  assert.notEqual(process.env.NODE_ENV, 'test');
 }
 
 export const HOME_LOCATION = process.env.HOME_LOCATION;

--- a/api/src/utils/env.ts
+++ b/api/src/utils/env.ts
@@ -57,6 +57,8 @@ assert.ok(process.env.STRIPE_SECRET_KEY);
 assert.ok(process.env.SHOW_UPCOMING_CHANGES);
 assert.ok(process.env.MONGOHQ_URL);
 assert.ok(process.env.COOKIE_SECRET);
+assert.ok(process.env.SHOW_UPCOMING_CHANGES);
+assert.ok(process.env.MONGOHQ_URL);
 
 if (process.env.FREECODECAMP_NODE_ENV !== 'development') {
   assert.ok(process.env.SES_ID);
@@ -104,6 +106,7 @@ if (process.env.FREECODECAMP_NODE_ENV !== 'development') {
     'client_secret_from_auth0_dashboard',
     'The Auth0 client secret should be changed from the default value.'
   );
+  assert.notEqual(process.env.NODE_ENV, 'test');
 }
 
 export const HOME_LOCATION = process.env.HOME_LOCATION;

--- a/api/src/utils/redirection.test.ts
+++ b/api/src/utils/redirection.test.ts
@@ -1,11 +1,11 @@
-import { FastifyRequest } from 'fastify';
 import jwt from 'jsonwebtoken';
 
 import {
   getReturnTo,
   normalizeParams,
   getRedirectParams,
-  getPrefixedLandingPath
+  getPrefixedLandingPath,
+  getLoginRedirectParams
 } from './redirection';
 import { HOME_LOCATION } from './env';
 
@@ -148,12 +148,12 @@ describe('redirection', () => {
   });
 
   describe('getRedirectParams', () => {
-    it('should decorate the request object', () => {
-      const req: FastifyRequest = {
+    it('should return origin, pathPrefix and returnTo given valid headers', () => {
+      const req = {
         headers: {
           referer: `https://www.freecodecamp.org/espanol/learn/rosetta-code/`
         }
-      } as FastifyRequest;
+      };
 
       const expectedReturn = {
         origin: 'https://www.freecodecamp.org',
@@ -166,9 +166,9 @@ describe('redirection', () => {
     });
 
     it('should use HOME_LOCATION with missing referer', () => {
-      const req: FastifyRequest = {
+      const req = {
         headers: {}
-      } as FastifyRequest;
+      };
 
       const expectedReturn = {
         returnTo: `${HOME_LOCATION}/learn`,
@@ -181,11 +181,11 @@ describe('redirection', () => {
     });
 
     it('should use HOME_LOCATION with invalid referrer', () => {
-      const req: FastifyRequest = {
+      const req = {
         headers: {
           referer: 'invalid-url'
         }
-      } as FastifyRequest;
+      };
 
       const expectedReturn = {
         returnTo: `${HOME_LOCATION}/learn`,
@@ -194,6 +194,26 @@ describe('redirection', () => {
       };
 
       const result = getRedirectParams(req);
+      expect(result).toEqual(expectedReturn);
+    });
+  });
+
+  describe('getLoginRedirectParams', () => {
+    it('should use the login-returnto cookie if present', () => {
+      const mockReq = {
+        cookies: {
+          'login-returnto': 'https://www.freecodecamp.org/espanol/learn'
+        },
+        unsignCookie: (rawValue: string) => ({ value: rawValue })
+      };
+
+      const expectedReturn = {
+        origin: 'https://www.freecodecamp.org',
+        pathPrefix: 'espanol',
+        returnTo: 'https://www.freecodecamp.org/espanol/learn'
+      };
+
+      const result = getLoginRedirectParams(mockReq);
       expect(result).toEqual(expectedReturn);
     });
   });

--- a/api/src/utils/redirection.ts
+++ b/api/src/utils/redirection.ts
@@ -119,11 +119,12 @@ function getParamsFromUrl(
  *
  * @param req - A fastify Request.
  * @param req.headers - The request headers.
+ * @param req.headers.referer - The referer header.
  * @param _normalizeParams - The function to normalize the parameters.
  * @returns The redirect parameters.
  */
 export function getRedirectParams(
-  req: { headers: Record<string, string | undefined> },
+  req: { headers: { referer?: string } },
   _normalizeParams = normalizeParams
 ): RedirectParams {
   const url = req.headers['referer'];

--- a/api/src/utils/redirection.ts
+++ b/api/src/utils/redirection.ts
@@ -39,6 +39,12 @@ export function getReturnTo(
   return normalizeParams(params, _homeLocation);
 }
 
+type RedirectParams = {
+  returnTo: string;
+  origin: string;
+  pathPrefix: string;
+};
+
 /**
  * Normalize the parameters, making they're valid.
  *
@@ -50,13 +56,9 @@ export function getReturnTo(
  * @returns The normalized parameters.
  */
 export function normalizeParams(
-  {
-    returnTo,
-    origin,
-    pathPrefix
-  }: { returnTo?: string; origin?: string; pathPrefix?: string },
+  { returnTo, origin, pathPrefix }: Partial<RedirectParams>,
   _homeLocation = HOME_LOCATION
-) {
+): RedirectParams {
   // coerce to strings, just in case something weird and nefarious is happening
   // TODO: validate, don't coerce
   returnTo = '' + returnTo;
@@ -103,7 +105,7 @@ export function getPrefixedLandingPath(origin: string, pathPrefix?: string) {
 export function getRedirectParams(
   req: FastifyRequest,
   _normalizeParams = normalizeParams
-) {
+): RedirectParams {
   const url = req.headers['referer'];
   // since we do not always redirect the user back to the page they were on
   // we need client locale and origin to construct the redirect url.

--- a/api/src/utils/redirection.ts
+++ b/api/src/utils/redirection.ts
@@ -63,6 +63,8 @@ export function normalizeParams(
   returnTo = '' + returnTo;
   origin = '' + origin;
   pathPrefix = '' + pathPrefix;
+  // TODO(Post-MVP): consider adding HOME_LOCATION in allowedOrigins to allow
+  // redirection to work in development.
   // we add the '/' to prevent returns to
   // www.freecodecamp.org.somewhere.else.com
   if (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,6 +165,9 @@ importers:
       '@fastify/express':
         specifier: ^2.3.0
         version: 2.3.0
+      '@fastify/oauth2':
+        specifier: 7.8.1
+        version: 7.8.1
       '@fastify/swagger':
         specifier: 8.14.0
         version: 8.14.0
@@ -2992,6 +2995,9 @@ packages:
   '@fastify/fast-json-stringify-compiler@4.3.0':
     resolution: {integrity: sha512-aZAXGYo6m22Fk1zZzEUKBvut/CIIQe/BapEORnxiD5Qr0kPHqqI69NtEMCme74h+at72sPhbkb4ZrLd1W3KRLA==}
 
+  '@fastify/oauth2@7.8.1':
+    resolution: {integrity: sha512-PBIMizzgEOcUcttyfX1hC6CR9vESoI1lfNucBywgcqrxvknVg+zvBCgH2+oU8NvrpSDMtlY6nyuEYYZtVhDT7Q==}
+
   '@fastify/send@2.1.0':
     resolution: {integrity: sha512-yNYiY6sDkexoJR0D8IDy3aRP3+L4wdqCpvx5WP+VtEU58sn7USmKynBzDQex5X42Zzvw2gNzzYgP90UfWShLFA==}
 
@@ -3157,9 +3163,18 @@ packages:
     resolution: {integrity: sha512-QD1PhQk+s31P1ixsX0H0Suoupp3VMXzIVMSwobR3F3MSUO2YCV0B7xqLcUw/Bh8yuvd3LhpyqLQWTNcRmp6IdQ==}
     deprecated: Moved to 'npm install @sideway/address'
 
+  '@hapi/boom@10.0.1':
+    resolution: {integrity: sha512-ERcCZaEjdH3OgSJlyjVk8pHIFeus91CjKP3v+MpgBNp5IvGzP2l/bRiD78nqYcKPaZdbKkK5vDBVPd2ohHBlsA==}
+
   '@hapi/bourne@1.3.2':
     resolution: {integrity: sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA==}
     deprecated: This version has been deprecated and is no longer supported or maintained
+
+  '@hapi/bourne@3.0.0':
+    resolution: {integrity: sha512-Waj1cwPXJDucOib4a3bAISsKJVb15MKi9IvmTI/7ssVEm6sywXGjVJDhl6/umt1pK1ZS7PacXU3A1PmFKHEZ2w==}
+
+  '@hapi/hoek@11.0.4':
+    resolution: {integrity: sha512-PnsP5d4q7289pS2T2EgGz147BFJ2Jpb4yrEdkpz2IhgEUzos1S7HTl7ezWh1yfYzYlj89KzLdCRkqsP6SIryeQ==}
 
   '@hapi/hoek@8.5.1':
     resolution: {integrity: sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow==}
@@ -3178,6 +3193,9 @@ packages:
 
   '@hapi/topo@5.1.0':
     resolution: {integrity: sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==}
+
+  '@hapi/wreck@18.1.0':
+    resolution: {integrity: sha512-0z6ZRCmFEfV/MQqkQomJ7sl/hyxvcZM7LtuVqN3vdAO4vM9eBbowl0kaqQj9EJJQab+3Uuh1GxbGIBFy4NfJ4w==}
 
   '@headlessui/react@1.7.19':
     resolution: {integrity: sha512-Ll+8q3OlMJfJbAKM/+/Y2q6PPYbryqNTXDbryx7SXLIDamkF6iQFbriYHga0dY44PvDhvvBWCx1Xj4U5+G4hOw==}
@@ -12277,6 +12295,9 @@ packages:
   simple-get@4.0.1:
     resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
 
+  simple-oauth2@5.1.0:
+    resolution: {integrity: sha512-gWDa38Ccm4MwlG5U7AlcJxPv3lvr80dU7ARJWrGdgvOKyzSj1gr3GBPN1rABTedAYvC/LsGYoFuFxwDBPtGEbw==}
+
   simple-swizzle@0.2.2:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
 
@@ -17123,6 +17144,14 @@ snapshots:
     dependencies:
       fast-json-stringify: 5.8.0
 
+  '@fastify/oauth2@7.8.1':
+    dependencies:
+      '@fastify/cookie': 9.4.0
+      fastify-plugin: 4.5.1
+      simple-oauth2: 5.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@fastify/send@2.1.0':
     dependencies:
       '@lukeed/ms': 2.0.1
@@ -17375,7 +17404,15 @@ snapshots:
 
   '@hapi/address@2.1.4': {}
 
+  '@hapi/boom@10.0.1':
+    dependencies:
+      '@hapi/hoek': 11.0.4
+
   '@hapi/bourne@1.3.2': {}
+
+  '@hapi/bourne@3.0.0': {}
+
+  '@hapi/hoek@11.0.4': {}
 
   '@hapi/hoek@8.5.1': {}
 
@@ -17395,6 +17432,12 @@ snapshots:
   '@hapi/topo@5.1.0':
     dependencies:
       '@hapi/hoek': 9.3.0
+
+  '@hapi/wreck@18.1.0':
+    dependencies:
+      '@hapi/boom': 10.0.1
+      '@hapi/bourne': 3.0.0
+      '@hapi/hoek': 11.0.4
 
   '@headlessui/react@1.7.19(react-dom@16.14.0(react@16.14.0))(react@16.14.0)':
     dependencies:
@@ -29616,6 +29659,15 @@ snapshots:
       decompress-response: 6.0.0
       once: 1.4.0
       simple-concat: 1.0.1
+
+  simple-oauth2@5.1.0:
+    dependencies:
+      '@hapi/hoek': 11.0.4
+      '@hapi/wreck': 18.1.0
+      debug: 4.3.4(supports-color@8.1.1)
+      joi: 17.12.2
+    transitivePeerDependencies:
+      - supports-color
 
   simple-swizzle@0.2.2:
     dependencies:


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This should duplicate the behaviour of the api-server when it comes to authenticating with Auth0, including redirection after signing in. Note for QA: redirection relies on the referer header, so will not work locally. It should work in Gitpod if you add the HOME_LOCATION to the allowedOrigins.

<!-- Feel free to add any additional description of changes below this line -->
