### PR TITLE
fix(e2e): match footer items exactly

### DIFF
--- a/e2e/footer.spec.ts
+++ b/e2e/footer.spec.ts
@@ -152,7 +152,7 @@ test.describe('Footer bottom section', () => {
     }
 
     for (const item of BOTTOM_LINKS) {
-      const link = page.getByRole('link', { name: item.title });
+      const link = page.getByRole('link', { name: item.title, exact: true });
 
       await expect(link).toBeVisible();
       await expect(link).toHaveAttribute('href', item.href);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

A test in `footer.spec.ts` is failing in CI:

<img width="1203" alt="Screenshot 2024-07-04 at 15 22 14" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/1112c9fc-208a-4fed-94ca-3cdc4c91982e">

I think this is because we now have the "Open Source for Devs" article in the Trending Guides section (https://github.com/freeCodeCamp/cdn/pull/269/files#diff-90482ab5ce84eccc7f8b8eb70645ca43dd0a381df76545b2817bd7891fa0f99fR11), and it matches the existing query for footer links.

The fix is to enable the `exact` option of `getByRole`.

<!-- Feel free to add any additional description of changes below this line -->
