### PR TITLE
test(modal): add test for closing modal with Escape key

### DIFF
--- a/client/src/templates/Challenges/components/completion-modal.tsx
+++ b/client/src/templates/Challenges/components/completion-modal.tsx
@@ -128,7 +128,9 @@ class CompletionModal extends Component<
   }
 
   handleKeypress(e: React.KeyboardEvent): void {
-    if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
+    if (e.key === 'Escape') {
+      (this.props.closeModal as () => void)();
+    } else if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
       e.preventDefault();
       // Since Hotkeys also listens to Ctrl + Enter we have to stop this event
       // getting to it.

--- a/e2e/completion-modal.spec.ts
+++ b/e2e/completion-modal.spec.ts
@@ -33,6 +33,13 @@ test.describe('Challenge Completion Modal Tests (Signed Out)', () => {
     await expect(page.getByTestId('completion-success-icon')).not.toBeVisible();
   });
 
+  test('should close the modal when user presses Escape key', async ({
+    page
+  }) => {
+    await page.keyboard.press('Escape');
+    await expect(page.getByTestId('completion-success-icon')).not.toBeVisible();
+  });
+
   test('should display the text of go to next challenge button accordingly based on device type', async ({
     page,
     isMobile,
@@ -93,6 +100,13 @@ test.describe('Challenge Completion Modal Tests (Signed In)', () => {
 
   test('should close the modal after user click on close', async ({ page }) => {
     await page.getByRole('button', { name: 'close' }).click();
+    await expect(page.getByTestId('completion-success-icon')).not.toBeVisible();
+  });
+
+  test('should close the modal when user presses Escape key', async ({
+    page
+  }) => {
+    await page.keyboard.press('Escape');
     await expect(page.getByTestId('completion-success-icon')).not.toBeVisible();
   });
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #55423

<!-- Feel free to add any additional description of changes below this line -->

This pull request addresses the issue where the completion modal does not close when pressing the Escape key.

### Changes Made:

1. **client/src/templates/Challenges/components/completion-modal.tsx**
   - The `handleKeypress` function has been updated to handle the Escape key. This change ensures that pressing the Escape key will close the completion modal. This update provides a consistent user experience for both signed-in and signed-out users. Specifically, logic was added to detect the Escape key and trigger the modal to close.

2. **e2e/completion-modal.spec.ts**
   - Test cases have been added to ensure the completion modal closes when the Escape key is pressed. These tests verify that the Escape key functionality works correctly in both signed-in and signed-out states. The new test cases check that the modal is not visible after pressing the Escape key.

### Reason for Changes:

- The completion modal should be closable with the Escape key to align with common user expectations and accessibility standards.
- Previously, the Escape key was not being handled, which led to inconsistent behavior, especially for authenticated users with keyboard shortcuts enabled.
- The updates to the test file ensure that this new behavior is thoroughly tested and will remain functional in future updates.
