### PR TITLE
ci: re-enable pnpm caching

### DIFF
--- a/.github/workflows/node.js-tests.yml
+++ b/.github/workflows/node.js-tests.yml
@@ -146,6 +146,9 @@ jobs:
           echo pnpm version $(pnpm -v)
           pnpm install
 
+      - name: Install Chrome for Puppeteer
+        run: pnpm dlx puppeteer browsers install chrome
+
       - name: Run Tests
         run: pnpm test
 
@@ -191,6 +194,9 @@ jobs:
         run: |
           echo pnpm version $(pnpm -v)
           pnpm install
+
+      - name: Install Chrome for Puppeteer
+        run: pnpm dlx puppeteer browsers install chrome
 
       - name: Run Tests
         run: pnpm test
@@ -248,6 +254,9 @@ jobs:
           CLIENT_LOCALE: ${{ matrix.locale }}
         run: |
           pnpm run build
+
+      - name: Install Chrome for Puppeteer
+        run: pnpm dlx puppeteer browsers install chrome
 
       - name: Run Tests
         env:

--- a/.github/workflows/node.js-tests.yml
+++ b/.github/workflows/node.js-tests.yml
@@ -128,6 +128,7 @@ jobs:
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version: ${{ matrix.node-version }}
+          cache: pnpm
 
       - name: Set Environment variables
         run: |
@@ -175,6 +176,7 @@ jobs:
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version: ${{ matrix.node-version }}
+          cache: pnpm
 
       - name: Set Environment variables
         run: |
@@ -225,6 +227,7 @@ jobs:
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version: ${{ matrix.node-version }}
+          cache: pnpm
 
       - name: Set Environment variables
         run: |


### PR DESCRIPTION
- **ci: force download of puppeteer**
- **Revert "DEBUG: no caching"**

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Followup to https://github.com/freeCodeCamp/freeCodeCamp/pull/55427

Since Puppeteer 19 (specifically https://github.com/puppeteer/puppeteer/pull/9095), puppeteer downloads the browsers to folders inside ~/.cache/ (instead of inside node_modules). This means that the pnpm cache will no longer include them.

There are three obvious solutions: 1) stop caching entirely, 2) explicitly cache the download and 3) force download before testing

I went with the third option because it's quite quick and it should be clear what's happening.

<!-- Feel free to add any additional description of changes below this line -->
