### PR TITLE
fix(curriculum): Update tests, remove reference to self-closing element

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-animation-by-building-a-ferris-wheel/6140c7e645d8e905819f1dd4.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-animation-by-building-a-ferris-wheel/6140c7e645d8e905819f1dd4.md
@@ -15,88 +15,100 @@ Set the `title` to `Ferris Wheel`.
 
 # --hints--
 
-Your code should contain the `DOCTYPE` reference.
+Your code should contain the `DOCTYPE` preamble.
 
 ```js
-assert(code.match(/<!DOCTYPE/gi));
+assert.match(code, /<!DOCTYPE/gi);
 ```
 
-You should include a space after the `DOCTYPE` reference.
+You should include a space after the `DOCTYPE` preamble.
 
 ```js
-assert(code.match(/<!DOCTYPE\s+/gi));
+assert.match(code, /<!DOCTYPE\s+/gi);
 ```
 
 You should define the document type to be `html`.
 
 ```js
-assert(code.match(/<!DOCTYPE\s+html/gi));
+assert.match(code, /<!DOCTYPE\s+html/gi);
 ```
 
 You should close the `DOCTYPE` declaration with a `>` after the type.
 
 ```js
-assert(code.match(/<!DOCTYPE\s+html\s*>/gi));
+assert.match(code, /<!DOCTYPE\s+html\s*>/gi);
 ```
 
 Your `html` element should have an opening tag with a `lang` attribute of `en`.
 
 ```js
-assert(code.match(/<html\s+lang\s*=\s*('|")en\1\s*>/gi));
+assert.match(code, /<html\s+lang\s*=\s*('|")en\1\s*>/gi);
 ```
 
 Your `html` element should have a closing tag.
 
 ```js
-assert(code.match(/<\/html\s*>/));
+assert.match(code, /<\/html\s*>/);
 ```
 
 Your `DOCTYPE` declaration should be at the beginning of your HTML.
 
 ```js
-assert(__helpers.removeHtmlComments(code).match(/^\s*<!DOCTYPE\s+html\s*>/i));
+assert.match(__helpers.removeHtmlComments(code), /^\s*<!DOCTYPE\s+html\s*>/i);
 ```
 
 You should have an opening `head` tag.
 
 ```js
-assert(code.match(/<head\s*>/i));
+assert.match(code, /<head\s*>/i);
 ```
 
 You should have a closing `head` tag.
 
 ```js
-assert(code.match(/<\/head\s*>/i));
+assert.match(code, /<\/head\s*>/i);
 ```
 
 You should have an opening `body` tag.
 
 ```js
-assert(code.match(/<body\s*>/i));
+assert.match(code, /<body\s*>/i);
 ```
 
 You should have a closing `body` tag.
 
 ```js
-assert(code.match(/<\/body\s*>/i));
+assert.match(code, /<\/body\s*>/i);
 ```
 
-The `head` and `body` elements should be siblings.
+Your `body` element should be the first element after the `head` element.
 
 ```js
-assert(document.querySelector('head')?.nextElementSibling?.localName === 'body');
+assert.match(code, /<\/head\s*>\s*<body\s*>/i);
 ```
 
-The `head` element should be within the `html` element.
+Your `head` and `body` elements should be siblings.
 
 ```js
-assert([...document.querySelector('html')?.children].some(x => x?.localName === 'head'));
+assert.strictEqual(document.querySelector('head')?.nextElementSibling?.localName, 'body');
 ```
 
-The `body` element should be within the `html` element.
+Your `head` element should be the first element inside your `html` element.
 
 ```js
-assert([...document.querySelector('html')?.children].some(x => x?.localName === 'body'));
+assert.match(code, /<html\s+lang\s*=\s*('|")en\1\s*>\s*<head\s*>/);
+```
+
+Your `head` element should be within the `html` element.
+
+```js
+assert.isTrue([...document.querySelector('html')?.children].some(x => x?.localName === 'head'));
+```
+
+Your `body` element should be within the `html` element.
+
+```js
+assert.isTrue([...document.querySelector('html')?.children].some(x => x?.localName === 'body'));
 ```
 
 Your code should have a `meta` element.
@@ -109,7 +121,14 @@ assert.exists(meta);
 Your `meta` element should have a `charset` attribute with the value `UTF-8`.
 
 ```js
-assert.match(code, /<meta[\s\S]+?charset=('|"|`)UTF-8\1/i)
+assert.match(code, /<meta\s+charset=('|"|`)UTF-8\1/i);
+```
+
+Your `meta` element should be inside the `head` element.
+
+```js
+const regex = /<head\s*>(?:.|\r|\n)*?<meta\s+charset=('|"|`)utf-8\1(?:.|\r|\n)*?<\/head\s*>/i;
+assert.match(code, regex);
 ```
 
 Your code should have a `title` element.
@@ -123,26 +142,26 @@ Your project should have a title of `Ferris Wheel`.
 
 ```js
 const title = document.querySelector('title');
-assert.equal(title?.text?.trim()?.toLowerCase(), 'ferris wheel')
+assert.strictEqual(title?.text?.trim()?.toLowerCase(), 'ferris wheel');
 ```
 
 Remember, the casing and spelling matter for the title.
 
 ```js
 const title = document.querySelector('title');
-assert.equal(title?.text?.trim(), 'Ferris Wheel');
+assert.strictEqual(title?.text?.trim(), 'Ferris Wheel');
 ```
 
 Your code should have a `link` element.
 
 ```js
-assert.match(code, /<link/)
+assert.match(code, /<link/);
 ```
 
-You should have one self-closing `link` element.
+You should have one `link` element.
 
 ```js
-assert(document.querySelectorAll('link').length === 1);
+assert.strictEqual(document.querySelectorAll('link').length, 1);
 ```
 
 Your `link` element should be within your `head` element.
@@ -154,16 +173,16 @@ assert.exists(document.querySelector('head > link'));
 Your `link` element should have a `rel` attribute with the value `stylesheet`.
 
 ```js
-const link_element = document.querySelector('link');
-const rel = link_element.getAttribute("rel");
-assert.equal(rel, "stylesheet");
+const linkElement = document.querySelector('link');
+const rel = linkElement?.getAttribute("rel");
+assert.strictEqual(rel, "stylesheet");
 ```
 
 Your `link` element should have an `href` attribute with the value `styles.css`.
 
 ```js
-const link = document.querySelector('link');
-assert.equal(link.dataset.href, "styles.css");
+const linkElement = document.querySelector('link');
+assert.strictEqual(linkElement?.dataset?.href, "styles.css");
 ```
 
 # --seed--

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-animation-by-building-a-ferris-wheel/6140c7e645d8e905819f1dd4.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-animation-by-building-a-ferris-wheel/6140c7e645d8e905819f1dd4.md
@@ -15,7 +15,7 @@ Set the `title` to `Ferris Wheel`.
 
 # --hints--
 
-Your code should contain the `DOCTYPE` preamble.
+Your code should contain the `DOCTYPE` declaration.
 
 ```js
 assert.match(code, /<!DOCTYPE/gi);

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-animation-by-building-a-ferris-wheel/6140c7e645d8e905819f1dd4.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-animation-by-building-a-ferris-wheel/6140c7e645d8e905819f1dd4.md
@@ -21,7 +21,7 @@ Your code should contain the `DOCTYPE` declaration.
 assert.match(code, /<!DOCTYPE/gi);
 ```
 
-You should include a space after the `DOCTYPE` preamble.
+You should include a space after the `DOCTYPE` declaration.
 
 ```js
 assert.match(code, /<!DOCTYPE\s+/gi);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related #55342

I was just going to remove the reference to self-closing element, but I started looking at the test and wanted to update them a bit. I have regrets, lol.

Some of the extra element placement tests are to avoid issues with browser magic. E.g. the body element placement test, is because if you add the body element before the head element the browser does its magic, and you end up with the content of the head element inside the body element, but the position of the two elements are corrected.

I'm not sure the tests will catch all possible errors, but it should be a little better now.

---

Note to self, `\n` does not work on Linux/WSL. Spent way to much time on a regex that worked on Windows (VS Code and on regexr.com) but kept failing the tests in WSL. I should have known better.
