### PR TITLE
fix(curriculum): Update tests, remove reference to self-closing element

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-colors-by-building-a-set-of-colored-markers/61695d1fbc003856628bf561.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-colors-by-building-a-set-of-colored-markers/61695d1fbc003856628bf561.md
@@ -7,9 +7,9 @@ dashedName: step-4
 
 # --description--
 
-To tell browsers how to encode characters on your page, set the `charset` to `utf-8`. `utf-8` is a universal character set that includes almost every character from all human languages.
+The `charset` attribute specifies the character encoding used by the document. `utf-8` (Unicode Transformation Format – 8-bit) is a character encoding standard used for electronic communication.
 
-Inside the `head` element, nest a `meta` element with the attribute `charset` set to `utf-8`. Remember that `meta` elements are self-closing, and do not need a closing tag.
+Inside the `head` element, nest a `meta` element with the attribute `charset` set to `"utf-8"`.
 
 # --hints--
 
@@ -17,21 +17,28 @@ You should have one `meta` element.
 
 ```js
 const meta = document.querySelectorAll('meta');
-assert(meta?.length === 1);
+assert.strictEqual(meta?.length, 1);
 ```
 
-Your `meta` element should be a self-closing element.
+Your `meta` element should be a void element, it should not have a closing tag `</meta>`.
 
 ```js
-assert(code.match(/<\/meta>/i) === null);
+assert.notMatch(code, /<\/meta>/i);
 ```
 
-Your `meta` element should have a `charset` attribute set to `utf-8`.
+Your `meta` element should have a `charset` attribute set to the value `"utf-8"`.
 
 ```js
 const meta = [...document.querySelectorAll('meta')];
 const target = meta?.find(m => m?.getAttribute('charset')?.toLowerCase() === 'utf-8');
 assert.exists(target);
+```
+
+Your `meta` element should be inside the `head` element.
+
+```js
+const metaElementRegex = /<head\s*>(?:.|\r|\n)*?<meta(?:.|\r|\n)*?<\/head\s*>/i;
+assert.match(code, metaElementRegex);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-colors-by-building-a-set-of-colored-markers/616965351e74d4689eb6de30.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-colors-by-building-a-set-of-colored-markers/616965351e74d4689eb6de30.md
@@ -20,6 +20,13 @@ const meta = document.querySelectorAll('meta');
 assert.strictEqual(meta?.length, 2);
 ```
 
+Your new `meta` element should be a void element, it should not have a closing tag `</meta>`.
+
+```js
+assert.notMatch(code, /<\/meta>/i);
+```
+
+
 Your new `meta` element should have a `name` attribute set to `"viewport"`, and a `content` attribute set to `"width=device-width, initial-scale=1.0"`.
 
 ```js

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-colors-by-building-a-set-of-colored-markers/616965351e74d4689eb6de30.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-colors-by-building-a-set-of-colored-markers/616965351e74d4689eb6de30.md
@@ -7,9 +7,9 @@ dashedName: step-5
 
 # --description--
 
-You can have multiple self-closing `meta` elements on a web page. Each `meta` element adds information about the page that cannot be expressed by other HTML elements.
+You can have multiple `meta` elements on a web page. Each `meta` element adds information about the page that cannot be expressed by other HTML elements.
 
-Add another self-closing `meta` element within the `head`. Give it a `name` attribute set to `viewport` and a `content` attribute set to `width=device-width, initial-scale=1.0` so your page looks the same on all devices.
+Add another `meta` element within the `head`. Give it a `name` attribute set to `"viewport"` and a `content` attribute set to `"width=device-width, initial-scale=1.0"` so your page looks the same on all devices.
 
 # --hints--
 
@@ -17,22 +17,23 @@ You should have two `meta` elements.
 
 ```js
 const meta = document.querySelectorAll('meta');
-assert(meta?.length === 2);
+assert.strictEqual(meta?.length, 2);
 ```
 
-Your new `meta` element should be a self-closing element.
-
-```js
-assert(code.match(/<\/meta>/i) === null);
-```
-
-Your new `meta` element should have a `name` attribute set to `viewport`, and a `content` attribute set to `width=device-width, initial-scale=1.0`.
+Your new `meta` element should have a `name` attribute set to `"viewport"`, and a `content` attribute set to `"width=device-width, initial-scale=1.0"`.
 
 ```js
 const meta = [...document.querySelectorAll('meta')];
-const reValidContent = /^\s*width\s*=\s*device-width\s*,\s*initial-scale\s*=\s*1(?:\.0)?\s*$/;
-const target = meta?.find(m => m?.getAttribute('name') === 'viewport' && reValidContent.test(m?.getAttribute('content')));
+const contentAttrRegex = /^\s*width\s*=\s*device-width\s*,\s*initial-scale\s*=\s*1(?:\.0)?\s*$/i;
+const target = meta?.find(m => m?.getAttribute('name')?.toLowerCase()?.replace(/\s*/g, '') === 'viewport' && contentAttrRegex.test(m?.getAttribute('content')));
 assert.exists(target);
+```
+
+Your new `meta` element should be inside the `head` element.
+
+```js
+const metaElementRegex = /<head\s*>(?:.|\r|\n)*?<meta\s+name\s*=\s*('|"|`)\s*viewport\s*\1\s+content\s*=\s*\1\s*width\s*=\s*device-width\s*,\s*initial-scale\s*=\s*1(?:\.0)?\s*\1(?:.|\r|\n)*?<\/head\s*>/i;
+assert.match(code, metaElementRegex);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-colors-by-building-a-set-of-colored-markers/61696ef7ac756c829f9e4048.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-colors-by-building-a-set-of-colored-markers/61696ef7ac756c829f9e4048.md
@@ -9,35 +9,42 @@ dashedName: step-7
 
 In this project you'll work with an external CSS file to style the page. We've already created a `styles.css` file for you. But before you can use it, you'll need to link it to the page.
 
-Nest a `link` element within the `head` element. Give it a `rel` attribute set to `stylesheet` and an `href` attribute set to `styles.css`.
+Nest a `link` element within the `head` element. Give it a `rel` attribute set to `"stylesheet"` and an `href` attribute set to `"styles.css"`.
 
 # --hints--
 
-You should have one self-closing `link` element.
+You should have one `link` element.
 
 ```js
-assert(document.querySelectorAll('link').length === 1);
+assert.strictEqual(document.querySelectorAll('link')?.length, 1);
 ```
 
-Your `link` element should be within your `head` element.
+Your `link` element should be a void element, it should not have a closing tag `</link>`.
 
 ```js
-assert.exists(document.querySelector('head > link'));
+assert.notMatch(code, /<\/link>/i);
 ```
 
-Your `link` element should have a `rel` attribute with the value `stylesheet`.
+Your `link` element should have a `rel` attribute with the value `"stylesheet"`.
 
 ```js
-const link_element = document.querySelector('link');
-const rel = link_element.getAttribute("rel");
-assert.equal(rel, "stylesheet");
+const linkElement = document.querySelector('link');
+const rel = linkElement?.getAttribute("rel")?.toLowerCase();
+assert.strictEqual(rel, "stylesheet");
 ```
 
-Your `link` element should have an `href` attribute with the value `styles.css`.
+Your `link` element should have an `href` attribute with the value `"styles.css"`.
 
 ```js
-const link = document.querySelector('link');
-assert.equal(link.dataset.href, "styles.css");
+const linkElement = document.querySelector('link');
+assert.strictEqual(linkElement?.dataset?.href, "styles.css");
+```
+
+Your `link` element should be inside the `head` element.
+
+```js
+const linkElementRegex = /<head\s*>(?:.|\r|\n)*?<link(?:.|\r|\n)*?<\/head\s*>/i;
+assert.match(code, linkElementRegex);
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related #55342

<!-- Feel free to add any additional description of changes below this line -->

- Updated tests.
- Updated the text about `charset` and `utf-8`.
- Removed reference to self-closing elements.

---

`querySelector` placement tests `head > someElement` does not work with elements inside `head` when I tested it. I'm sure we have more placement tests that are missing or do not work (e.g. title element placement in step 3).

There are a lot of allowed whitespace and uppercase values with these attributes. Which we do not always account for (but it's not necessarily worth it).