### PR TITLE
test: use more memory in curriculum tests

### DIFF
--- a/curriculum/package.json
+++ b/curriculum/package.json
@@ -35,8 +35,8 @@
     "reorder-tasks": "CALLING_DIR=$INIT_CWD ts-node --project ../tsconfig.json ../tools/challenge-helper-scripts/reorder-tasks",
     "update-challenge-order": "CALLING_DIR=$INIT_CWD ts-node --project ../tsconfig.json ../tools/challenge-helper-scripts/update-challenge-order",
     "update-step-titles": "CALLING_DIR=$INIT_CWD ts-node --project ../tsconfig.json ../tools/challenge-helper-scripts/update-step-titles",
-    "test": "ts-node ./node_modules/mocha/bin/mocha.js --delay --exit --reporter progress --bail",
-    "test:full-output": "FULL_OUTPUT=true ts-node ./node_modules/mocha/bin/mocha.js --delay --reporter progress"
+    "test": "NODE_OPTIONS='--max-old-space-size=7168' ts-node ./node_modules/mocha/bin/mocha.js --delay --exit --reporter progress --bail",
+    "test:full-output": "NODE_OPTIONS='--max-old-space-size=7168' FULL_OUTPUT=true ts-node ./node_modules/mocha/bin/mocha.js --delay --reporter progress"
   },
   "devDependencies": {
     "@babel/core": "7.23.7",


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

While these tests get enough memory when they're run `pnpm test` in the root, it's often useful to run them separately and they still need access to more memory.

<!-- Feel free to add any additional description of changes below this line -->
