### PR TITLE
fix(curriculum): detect if detectFullHouse is called in click handler

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/review-algorithmic-thinking-by-building-a-dice-game/657e0c2c6a9d37705146f34d.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/review-algorithmic-thinking-by-building-a-dice-game/657e0c2c6a9d37705146f34d.md
@@ -42,17 +42,10 @@ assert.strictEqual(scoreInputs[5].value, "0");
 assert.strictEqual(scoreSpans[5].innerText, ", score = 0");
 ```
 
-You should call your `detectFullHouse` function when your `rollDiceBtn` is clicked.
+When your `rollDiceBtn` is clicked it should call `detectFullHouse(diceValuesArr)`. The function should be called after `getHighestDuplicates(diceValuesArr)`.
 
 ```js
-const _rollDice = rollDice;
-rollDice = () => {};
-diceValuesArr = [1,1,1,2,2];
-rollDiceBtn.click();
-assert.isFalse(scoreInputs[2].disabled);
-assert.strictEqual(scoreInputs[2].value, "25");
-assert.strictEqual(scoreSpans[2].innerText, ", score = 25");
-rollDice = _rollDice;
+assert.match(code, /getHighestDuplicates\(diceValuesArr\);?\s*detectFullHouse\(diceValuesArr\);?\s*?}/);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/review-algorithmic-thinking-by-building-a-dice-game/657e0c2c6a9d37705146f34d.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/review-algorithmic-thinking-by-building-a-dice-game/657e0c2c6a9d37705146f34d.md
@@ -45,19 +45,14 @@ assert.strictEqual(scoreSpans[5].innerText, ", score = 0");
 You should call your `detectFullHouse` function when your `rollDiceBtn` is clicked.
 
 ```js
-const counts = (arr) => arr.reduce((counts, num) => {counts[num] = ++counts[num] || 1; return counts}, {});
-const isFullHouse = (arr) => arr.includes(3) && arr.includes(2) && arr.length === 2;
-// Absurdly high, but will either timeout or bail early when assertion runs.
-for (let i = 0; i < 100_000; i++) {
-  rolls = 0;
-  rollDiceBtn.click();
-  if (isFullHouse(diceValuesArr)) {
-    assert.isFalse(scoreInputs[2].disabled);
-    assert.strictEqual(scoreInputs[2].value, "25");
-    assert.strictEqual(scoreSpans[2].innerText, ", score = 25");
-    break;
-  }
-}
+const _rollDice = rollDice;
+rollDice = () => {};
+diceValuesArr = [1,1,1,2,2];
+rollDiceBtn.click();
+assert.isFalse(scoreInputs[2].disabled);
+assert.strictEqual(scoreInputs[2].value, "25");
+assert.strictEqual(scoreSpans[2].innerText, ", score = 25");
+rollDice = _rollDice;
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Closes #55460

Edit: The function overwrite only works because Babel is removing the const declaration, and if we ever changed that config it would break. So that is probably not a good idea to rely on.

I added a regex instead. There is another PR for this, but I wanted to add something simple, just in case.


<s>Instead of the loop we have now:

- We disable the `rollDice` function.
- Set `diceValuesArr` to a full house.
- Click the `rollDiceBtn` button and perform the same tests as we do in the full house test.

This should work, unless I have missed something obvious?</s>
