### PR TITLE
fix(client): truncate outputs larger than 500_000

### DIFF
--- a/client/src/templates/Challenges/components/output.tsx
+++ b/client/src/templates/Challenges/components/output.tsx
@@ -11,17 +11,24 @@ interface OutputProps {
 }
 
 function Output({ defaultOutput, output }: OutputProps): JSX.Element {
-  const message = sanitizeHtml(
-    !isEmpty(output) ? output.join('\n') : defaultOutput,
-    {
-      allowedTags: ['b', 'i', 'em', 'strong', 'code', 'wbr']
-    }
-  );
+  const message = isEmpty(output) ? defaultOutput : output.join('\n');
+
+  const shouldTruncate = message?.length > 500_000;
+  const transformedMessage = shouldTruncate
+    ? `${message?.substring(0, 500_000)} Logs truncated. See browser console for more`
+    : message;
+
+  const sanitizedOutput = sanitizeHtml(transformedMessage, {
+    allowedTags: ['b', 'i', 'em', 'strong', 'code', 'wbr']
+  });
+
   return (
     <pre
       className='output-text'
       data-playwright-test-label='output-text'
-      dangerouslySetInnerHTML={{ __html: message }}
+      dangerouslySetInnerHTML={{
+        __html: sanitizedOutput
+      }}
       role='region'
       aria-label={i18next.t('learn.editor-tabs.console')}
       // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex

--- a/client/src/templates/Challenges/components/output.tsx
+++ b/client/src/templates/Challenges/components/output.tsx
@@ -11,24 +11,17 @@ interface OutputProps {
 }
 
 function Output({ defaultOutput, output }: OutputProps): JSX.Element {
-  const message = isEmpty(output) ? defaultOutput : output.join('\n');
-
-  const shouldTruncate = message?.length > 500_000;
-  const transformedMessage = shouldTruncate
-    ? `${message?.substring(0, 500_000)} Logs truncated. See browser console for more`
-    : message;
-
-  const sanitizedOutput = sanitizeHtml(transformedMessage, {
-    allowedTags: ['b', 'i', 'em', 'strong', 'code', 'wbr']
-  });
-
+  const message = sanitizeHtml(
+    !isEmpty(output) ? output.join('\n') : defaultOutput,
+    {
+      allowedTags: ['b', 'i', 'em', 'strong', 'code', 'wbr']
+    }
+  );
   return (
     <pre
       className='output-text'
       data-playwright-test-label='output-text'
-      dangerouslySetInnerHTML={{
-        __html: sanitizedOutput
-      }}
+      dangerouslySetInnerHTML={{ __html: message }}
       role='region'
       aria-label={i18next.t('learn.editor-tabs.console')}
       // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex

--- a/tools/client-plugins/browser-scripts/test-evaluator.ts
+++ b/tools/client-plugins/browser-scripts/test-evaluator.ts
@@ -8,14 +8,19 @@ const ctx: Worker & typeof globalThis = self as unknown as Worker &
 
 const __utils = (() => {
   const MAX_LOGS_SIZE = 64 * 1024;
+  const TRUNCATE_AT = 500_000;
 
   let logs: string[] = [];
 
   function flushLogs() {
     if (logs.length) {
+      let data = logs.join('\n');
+      if (data.length > TRUNCATE_AT) {
+        data = `${data.substring(0, TRUNCATE_AT)} Logs truncated. See browser console for more`;
+      }
       ctx.postMessage({
         type: 'LOG',
-        data: logs.join('\n')
+        data: data
       });
       logs = [];
     }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #55016

<!-- Feel free to add any additional description of changes below this line -->

To void large console output crashing the browser, we truncate the output.

---

When testing this, I noticed an odd crash. When I add HTML tags for the character symbol in the pyramid generator challenge, it is crashing with large loops (new crash type `Error code: STATUS_BREAKPOINT` in browser).

- It is only happening with large loops.
- It happens no matter when I truncate.
- It happens without `sanitizeHtml`.

https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures-v8/learn-introductory-javascript-by-building-a-pyramid-generator/step-64

Works

```
const character = "#";
const count = 8000;
```

```
const character = "<b";
const count = 2000;
```

Crashes

```
const character = "<b";
const count = 8000;
```
