### PR TITLE
refactor: use reject user-agents early

### DIFF
--- a/api/src/routes/user.test.ts
+++ b/api/src/routes/user.test.ts
@@ -1227,6 +1227,17 @@ Thanks and regards,
       });
 
       describe('GET', () => {
+        test('returns 400 status code if the user agent is blocked', async () => {
+          const response = await superGet(
+            '/api/users/get-public-profile?username=public-user'
+          ).set('User-Agent', 'curl');
+
+          expect(response.text).toBe(
+            'This endpoint is no longer available outside of the freeCodeCamp ecosystem'
+          );
+          expect(response.statusCode).toBe(400);
+        });
+
         test('returns 400 status code if the username param is missing', async () => {
           const res = await superGet('/api/users/get-public-profile');
           // TODO(Post-MVP): return something more informative


### PR DESCRIPTION
This seperates concerns: the handler doesn't need to consider user
agents and now it doesn't.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->
