### PR TITLE
feat: add submodule tests

### DIFF
--- a/.github/workflows/curriculum-i18n-submodule.yml
+++ b/.github/workflows/curriculum-i18n-submodule.yml
@@ -1,0 +1,70 @@
+name: CI - Node.js - i18n - Submodule
+
+on:
+  # Run on push events, but only for the below branches
+  push:
+    branches:
+      - 'chore/update-i18n-curriculum-submodule'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test-curriculum:
+    name: Test Curriculum
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20.x]
+        # Exclude the languages that we currently run in the full CI suite.
+        locale:
+          - 'chinese'
+          - 'espanol'
+          - 'ukrainian'
+          - 'japanese'
+          - 'german'
+          - 'arabic'
+          - 'swahili'
+
+    steps:
+      - name: Checkout Source Files
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          submodules: 'recursive'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d #v3.0.0
+        with:
+          version: 9
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: pnpm
+
+      - name: Set Environment variables
+        run: |
+          cp sample.env .env
+          echo 'BUILD_WITH_SUBMODULE=true' >> .env
+        # TODO: Remove this ^ after migration is complete
+
+      - name: Install node_modules
+        run: pnpm install
+
+      # DONT REMOVE THIS STEP.
+      # TODO: Refactor and use re-usable workflow and shared artifacts
+      - name: Build Client in ${{ matrix.locale }}
+        env:
+          CURRICULUM_LOCALE: ${{ matrix.locale }}
+          CLIENT_LOCALE: ${{ matrix.locale }}
+        run: |
+          pnpm run build
+
+      - name: Run Tests
+        env:
+          CURRICULUM_LOCALE: ${{ matrix.locale }}
+          CLIENT_LOCALE: ${{ matrix.locale }}
+        run: pnpm test:curriculum

--- a/.github/workflows/e2e-playwright-submodule.yml
+++ b/.github/workflows/e2e-playwright-submodule.yml
@@ -1,0 +1,166 @@
+name: CI - E2E - Playwright - Submodule
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: ['CI - Node.js']
+    types:
+      - completed
+  # TODO: refactor with a workflow_call
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+    branches:
+      - 'main'
+      - 'next-**'
+      - 'e2e-**'
+
+jobs:
+  build-client:
+    name: Build Client
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        node-version: [20.x]
+
+    steps:
+      - name: Checkout Source Files
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          submodules: 'recursive'
+
+      - name: Checkout client-config
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          repository: freeCodeCamp/client-config
+          path: client-config
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d #v3.0.0
+        with:
+          version: 9
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: pnpm
+
+      - name: Set freeCodeCamp Environment Variables
+        run: |
+          cp sample.env .env
+          echo 'BUILD_WITH_SUBMODULE=true' >> .env
+        # TODO: Remove this ^ after migration is complete
+
+      - name: Install and Build
+        run: |
+          pnpm install
+          pnpm run build
+
+      - name: Move serve.json to Public Folder
+        run: cp client-config/serve.json client/public/serve.json
+
+      # We tar them for performance reasons - uploading a lot of files is slow.
+      - name: Tar Files
+        run: tar -cf client-artifact.tar client/public
+
+      - name: Upload Client Artifact
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+        with:
+          name: client-artifact
+          path: client-artifact.tar
+
+      - name: Upload Webpack Stats
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+        with:
+          name: webpack-stats
+          path: client/public/stats.json
+
+  playwright-run:
+    name: E2E Test
+    runs-on: ubuntu-22.04
+    needs: build-client
+    strategy:
+      fail-fast: false
+      matrix:
+        # Not Mobile Safari until we can get it working. Webkit and Mobile
+        # Chrome both work, so hopefully there are no Mobile Safari specific
+        # bugs.
+        browsers: [chromium, firefox, webkit, Mobile Chrome]
+        node-version: [20.x]
+
+    services:
+      mongodb:
+        image: mongo:4.4
+        ports:
+          - 27017:27017
+      # We need mailhog to catch any emails the api tries to send.
+      mailhog:
+        image: mailhog/mailhog
+        ports:
+          - 1025:1025 # SMTP server (listens for emails)
+          - 8025:8025 # HTTP server (so we can make requests to the api)
+
+    steps:
+      - name: Set Action Environment Variables
+        run: |
+          echo "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV
+
+      - name: Checkout Source Files
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          submodules: 'recursive'
+
+      - uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
+        with:
+          name: client-artifact
+
+      - name: Unpack Client Artifact
+        run: |
+          tar -xf client-artifact.tar
+          rm client-artifact.tar
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d #v3.0.0
+        with:
+          version: 9
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Set freeCodeCamp Environment Variables
+        run: |
+          cp sample.env .env
+          echo 'BUILD_WITH_SUBMODULE=true' >> .env
+        # TODO: Remove this ^ after migration is complete
+
+      - name: Install and Build
+        run: |
+          pnpm install
+          pnpm run create:shared
+          pnpm run build:curriculum
+          pnpm run build:server
+
+      - name: Seed Database with Certified User
+        run: pnpm run seed:certified-user
+
+      # start-ci uses pm2, so it needs to be installed globally
+      - name: Install pm2
+        run: npm i -g pm2
+
+      - name: Install playwright dependencies
+        run: npx playwright install --with-deps
+
+      - name: Run playwright tests
+        run: |
+          pnpm run start-ci &
+          sleep 10
+          npx playwright test --project="${{ matrix.browsers }}" --grep-invert 'third-party-donation.spec.ts'
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report-${{ matrix.browsers }}
+          path: playwright/reporter
+          retention-days: 30

--- a/.github/workflows/i18n-validate-builds-submodule.yml
+++ b/.github/workflows/i18n-validate-builds-submodule.yml
@@ -1,0 +1,42 @@
+name: i18n - Build Validation - Submodule
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  ci:
+    name: Validate i18n Builds
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        node-version: [20.x]
+
+    steps:
+      - name: Checkout Source Files
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          submodules: 'recursive'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d #v3.0.0
+        with:
+          version: 9
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: pnpm
+
+      - name: Set freeCodeCamp Environment Variables
+        run: |
+          cp sample.env .env
+          echo 'BUILD_WITH_SUBMODULE=true' >> .env
+        # TODO: Remove this ^ after migration is complete
+
+      - name: Install Dependencies
+        run: pnpm install
+
+      - name: Validate Challenge Files
+        run: pnpm run audit-challenges

--- a/.github/workflows/i18n-validate-prs-submodule.yml
+++ b/.github/workflows/i18n-validate-prs-submodule.yml
@@ -1,0 +1,59 @@
+name: i18n - Curriculum PR Validation - Submodule
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  ci:
+    name: Validate i18n Builds
+    # run only on PRs that camperbot opens with title that matches the curriculum sync
+    if: ${{ github.event.pull_request.user.login == 'camperbot' && contains(github.event.pull_request.title, 'chore(i18n,learn)') }}
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        node-version: [20.x]
+
+    steps:
+      - name: Checkout Source Files
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          submodules: 'recursive'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d #v3.0.0
+        with:
+          version: 9
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: pnpm
+
+      - name: Set freeCodeCamp Environment Variables
+        run: |
+          cp sample.env .env
+          echo 'BUILD_WITH_SUBMODULE=true' >> .env
+        # TODO: Remove this ^ after migration is complete
+
+      - name: Install Dependencies
+        run: pnpm install
+
+      - name: Validate Challenge Files
+        id: validate
+        run: pnpm run audit-challenges
+
+      - name: Create Comment
+        # Run if the validate challenge files step fails, specifically. Note that we need the failure() call for this step to trigger if the action fails.
+        if: ${{ failure() && steps.validate.conclusion == 'failure' }}
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6
+        with:
+          github-token: ${{secrets.CAMPERBOT_NO_TRANSLATE}}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: "Hey @freecodecamp/i18n, it looks like we have new English curriculum files that need to be translated."
+            })

--- a/.github/workflows/node.js-tests-submodule.yml
+++ b/.github/workflows/node.js-tests-submodule.yml
@@ -161,7 +161,7 @@ jobs:
           pnpm install
 
       - name: Install Chrome for Puppeteer
-        run: pnpm dlx puppeteer browsers install chrome
+        run: pnpm -F=curriculum install-puppeteer
 
       - name: Run Tests
         run: pnpm test
@@ -215,7 +215,7 @@ jobs:
           pnpm install
 
       - name: Install Chrome for Puppeteer
-        run: pnpm dlx puppeteer browsers install chrome
+        run: pnpm -F=curriculum install-puppeteer
 
       - name: Run Tests
         run: pnpm test
@@ -280,7 +280,7 @@ jobs:
           pnpm run build
 
       - name: Install Chrome for Puppeteer
-        run: pnpm dlx puppeteer browsers install chrome
+        run: pnpm -F=curriculum install-puppeteer
 
       - name: Run Tests
         env:

--- a/.github/workflows/node.js-tests-submodule.yml
+++ b/.github/workflows/node.js-tests-submodule.yml
@@ -1,0 +1,289 @@
+name: CI - Node.js - Submodule
+
+on:
+  # Run on push events, but only for the below branches
+  push:
+    branches:
+      - 'main'
+      - 'prod-**'
+  # Run on pull requests, but only for the below targets
+  pull_request:
+    branches:
+      - 'main'
+      - 'next-**'
+  # Run on Merge Queue
+  merge_group:
+    types: [checks_requested]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        node-version: [20.x]
+      fail-fast: false
+
+    steps:
+      - name: Checkout Source Files
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          submodules: 'recursive'
+
+      - name: Check number of lockfiles
+        run: |
+          if [ $(find . -name 'package-lock.json' | grep -vc -e 'node_modules') -gt 0 ]
+          then
+            echo -e 'Error: found package-lock files in the repository.\nWe use pnpm workspaces to manage packages so all dependencies should be added via pnpm add'
+            exit 1
+          fi
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d #v3.0.0
+        with:
+          version: 9
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: pnpm
+
+      - name: Set Environment variables
+        run: |
+          cp sample.env .env
+          echo 'SHOW_NEW_CURRICULUM=true' >> .env
+          echo 'BUILD_WITH_SUBMODULE=true' >> .env
+          cat .env
+        # TODO: Remove this ^ after migration is complete
+
+      - name: Install node_modules
+        run: pnpm install
+
+      - name: Check formatting
+        run: |
+          pnpm prettier --check . || [ $? -eq 1 ] && printf "\nTip: Run 'pnpm run format' in your terminal to fix this.\n\n"
+
+      # The two prefixed installs are for the client update which are not,
+      # currently, built as workspaces.
+      - name: Lint Source Files
+        run: |
+          echo pnpm version $(pnpm -v)
+          pnpm run create:shared
+          pnpm run build:curriculum
+          pnpm run lint
+
+  # DONT REMOVE THIS JOB.
+  # TODO: Refactor and use re-usable workflow and shared artifacts
+  build:
+    name: Build
+    needs: lint
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        node-version: [20.x]
+
+    steps:
+      - name: Checkout Source Files
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          submodules: 'recursive'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d #v3.0.0
+        with:
+          version: 9
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: pnpm
+
+      - name: Set freeCodeCamp Environment Variables
+        run: |
+          cp sample.env .env
+          echo 'BUILD_WITH_SUBMODULE=true' >> .env
+        # TODO: Remove this ^ after migration is complete
+
+      - name: Install and Build
+        run: |
+          pnpm install
+          pnpm run build
+
+  test:
+    name: Test
+    needs: build
+    runs-on: ubuntu-22.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20.x]
+
+    steps:
+      - name: Checkout Source Files
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          submodules: 'recursive'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d #v3.0.0
+        with:
+          version: 9
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: pnpm
+
+      - name: Set Environment variables
+        run: |
+          cp sample.env .env
+          echo 'BUILD_WITH_SUBMODULE=true' >> .env
+          cat .env
+        # TODO: Remove this ^ after migration is complete
+
+      - name: Start MongoDB
+        uses: supercharge/mongodb-github-action@b0a1493307c4e9b82ed61f3858d606c5ff190c64 # v1.10.0
+        with:
+          mongodb-version: 6.0
+          mongodb-replica-set: test-rs
+          mongodb-port: 27017
+
+      - name: Install Dependencies
+        run: |
+          echo pnpm version $(pnpm -v)
+          pnpm install
+
+      - name: Install Chrome for Puppeteer
+        run: pnpm dlx puppeteer browsers install chrome
+
+      - name: Run Tests
+        run: pnpm test
+
+  test-upcoming:
+    name: Test - Upcoming Changes
+    needs: build
+    runs-on: ubuntu-22.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20.x]
+
+    steps:
+      - name: Checkout Source Files
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          submodules: 'recursive'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d #v3.0.0
+        with:
+          version: 9
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: pnpm
+
+      - name: Set Environment variables
+        run: |
+          cp sample.env .env
+          echo 'SHOW_UPCOMING_CHANGES=true' >> .env
+          echo 'SHOW_NEW_CURRICULUM=true' >> .env
+          echo 'BUILD_WITH_SUBMODULE=true' >> .env
+          cat .env
+        # TODO: Remove this ^ after migration is complete
+
+      - name: Start MongoDB
+        uses: supercharge/mongodb-github-action@b0a1493307c4e9b82ed61f3858d606c5ff190c64 # v1.10.0
+        with:
+          mongodb-version: 6.0
+          mongodb-replica-set: test-rs
+          mongodb-port: 27017
+
+      - name: Install Dependencies
+        run: |
+          echo pnpm version $(pnpm -v)
+          pnpm install
+
+      - name: Install Chrome for Puppeteer
+        run: pnpm dlx puppeteer browsers install chrome
+
+      - name: Run Tests
+        run: pnpm test
+
+  test-localization:
+    name: Test - i18n
+    needs: build
+    runs-on: ubuntu-22.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20.x]
+        locale: [portuguese, italian]
+
+    steps:
+      - name: Checkout Source Files
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          submodules: 'recursive'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d #v3.0.0
+        with:
+          version: 9
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: pnpm
+
+      - name: Set Environment variables
+        run: |
+          cp sample.env .env
+          echo 'BUILD_WITH_SUBMODULE=true' >> .env
+          cat .env
+        # TODO: Remove this ^ after migration is complete
+
+      - name: Start MongoDB
+        uses: supercharge/mongodb-github-action@b0a1493307c4e9b82ed61f3858d606c5ff190c64 # v1.10.0
+        with:
+          mongodb-version: 6.0
+          mongodb-replica-set: test-rs
+          mongodb-port: 27017
+
+      - name: Install Dependencies
+        env:
+          CURRICULUM_LOCALE: ${{ matrix.locale }}
+          CLIENT_LOCALE: ${{ matrix.locale }}
+        run: |
+          echo pnpm version $(pnpm -v)
+          pnpm install
+
+      # DONT REMOVE THIS STEP.
+      # TODO: Refactor and use re-usable workflow and shared artifacts
+      - name: Build Client in ${{ matrix.locale }}
+        env:
+          CURRICULUM_LOCALE: ${{ matrix.locale }}
+          CLIENT_LOCALE: ${{ matrix.locale }}
+        run: |
+          pnpm run build
+
+      - name: Install Chrome for Puppeteer
+        run: pnpm dlx puppeteer browsers install chrome
+
+      - name: Run Tests
+        env:
+          CURRICULUM_LOCALE: ${{ matrix.locale }}
+          CLIENT_LOCALE: ${{ matrix.locale }}
+        run: pnpm test


### PR DESCRIPTION
This adds five actions that run our tests using the submodule. They're identical to the existing tests of the same name except for two lines, the `with: submodules: 'recursive'` in the checkout source files step, and adding the `BUILD_WITH_SUBMODULE=true` env variable.

This also updates the submodule to the latest commit.
Adds the i18n-curriculum to prettierIgnore
And adds the english dictionary comments to the comment map in a different way. There was an issue with them not getting added after removing the English stuff from the i18n-curriculum repo.

With these tests, we should be confident to change our builds to use the submodule.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
