### PR TITLE
fix: comment dictionary with submodule

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -8,6 +8,7 @@ client/config/browser-scripts/*.json
 client/static
 curriculum/challenges/_meta/*/*
 curriculum/challenges/**/*
+curriculum/i18n-curriculum
 docs/**/*.md
 /playwright
 pnpm-lock.yaml

--- a/curriculum/get-challenges.js
+++ b/curriculum/get-challenges.js
@@ -51,6 +51,11 @@ function createCommentMap(dictionariesDir, englishDictionariesDir) {
   // in the comment map.
   const languages = fs.readdirSync(dictionariesDir);
 
+  // TODO: Remove this after migrating to i18n-curriculum
+  if (languages.includes('english')) {
+    languages.splice(languages.indexOf('english'), 1);
+  }
+
   // get all their dictionaries
   const dictionaries = languages.reduce(
     (acc, lang) => ({
@@ -101,7 +106,13 @@ function createCommentMap(dictionariesDir, englishDictionariesDir) {
     };
   }, {});
 
-  return { ...translatedCommentMap, ...untranslatableCommentMap };
+  const allComments = { ...translatedCommentMap, ...untranslatableCommentMap };
+
+  Object.keys(allComments).forEach(comment => {
+    allComments[comment].english = comment;
+  });
+
+  return allComments;
 }
 
 exports.createCommentMap = createCommentMap;

--- a/curriculum/get-challenges.js
+++ b/curriculum/get-challenges.js
@@ -45,16 +45,11 @@ const COMMENT_TRANSLATIONS = createCommentMap(
 );
 
 function createCommentMap(dictionariesDir, englishDictionariesDir) {
-  // get all the languages for which there are dictionaries. Note: this has to
-  // include the english dictionaries since translateCommentsInChallenge treats
-  // all languages equally and will simply remove comments if there is no entry
-  // in the comment map.
-  const languages = fs.readdirSync(dictionariesDir);
-
-  // TODO: Remove this after migrating to i18n-curriculum
-  if (languages.includes('english')) {
-    languages.splice(languages.indexOf('english'), 1);
-  }
+  // get all the languages for which there are dictionaries. Note: the english
+  // entries are created separately, so we remove it from languages.
+  const languages = fs
+    .readdirSync(dictionariesDir)
+    .filter(lang => lang !== 'english'); // TODO: Remove the filter after migrating to i18n-curriculum
 
   // get all their dictionaries
   const dictionaries = languages.reduce(
@@ -108,6 +103,8 @@ function createCommentMap(dictionariesDir, englishDictionariesDir) {
 
   const allComments = { ...translatedCommentMap, ...untranslatableCommentMap };
 
+  // the english entries need to be added here, because english is not in
+  // languages
   Object.keys(allComments).forEach(comment => {
     allComments[comment].english = comment;
   });


### PR DESCRIPTION
This adds the three things at the bottom of this PR: https://github.com/freeCodeCamp/freeCodeCamp/pull/55497 - So I can move some of the tests over to the i18n-curriculum repo and they will pass when I run them.

Updates the submodule to the latest commit.
Adds the i18n-curriculum to prettierIgnore
Adds the english dictionary comments to the comment map in a different way. There was an issue with them not getting added after removing the English stuff from the i18n-curriculum repo.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
