### PR TITLE
fix(test): change alert query in basic css test

### DIFF
--- a/client/src/templates/Introduction/components/super-block-intro.tsx
+++ b/client/src/templates/Introduction/components/super-block-intro.tsx
@@ -81,11 +81,7 @@ function SuperBlockIntro(props: SuperBlockIntroProps): JSX.Element {
         <p dangerouslySetInnerHTML={{ __html: str }} key={i} />
       ))}
       {superBlockNoteText && (
-        <div
-          role='alert'
-          className='alert alert-info'
-          style={{ marginTop: '2rem' }}
-        >
+        <div className='alert alert-info' style={{ marginTop: '2rem' }}>
           {superBlockNoteText}
         </div>
       )}

--- a/client/src/templates/Introduction/components/super-block-intro.tsx
+++ b/client/src/templates/Introduction/components/super-block-intro.tsx
@@ -81,7 +81,11 @@ function SuperBlockIntro(props: SuperBlockIntroProps): JSX.Element {
         <p dangerouslySetInnerHTML={{ __html: str }} key={i} />
       ))}
       {superBlockNoteText && (
-        <div className='alert alert-info' style={{ marginTop: '2rem' }}>
+        <div
+          role='alert'
+          className='alert alert-info'
+          style={{ marginTop: '2rem' }}
+        >
           {superBlockNoteText}
         </div>
       )}

--- a/e2e/basic-css.spec.ts
+++ b/e2e/basic-css.spec.ts
@@ -1,5 +1,4 @@
 import { test, expect } from '@playwright/test';
-import { alertToBeVisible } from './utils/alerts';
 
 const locations = {
   index: '/learn/responsive-web-design/#basic-css'
@@ -59,7 +58,7 @@ test.describe('Responsive Web Design Projects - Basic CSS', () => {
   test('renders', async ({ page }) => {
     await page.goto(locations.index);
 
-    await alertToBeVisible(page, warningMessage);
+    await expect(page.getByText(warningMessage)).toBeVisible();
 
     for (const lessonName of lessonNames) {
       await expect(

--- a/e2e/basic-css.spec.ts
+++ b/e2e/basic-css.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { alertToBeVisible } from './utils/alerts';
 
 const locations = {
   index: '/learn/responsive-web-design/#basic-css'
@@ -58,9 +59,7 @@ test.describe('Responsive Web Design Projects - Basic CSS', () => {
   test('renders', async ({ page }) => {
     await page.goto(locations.index);
 
-    await expect(page.locator('.alert.alert-info')).toContainText(
-      warningMessage
-    );
+    await alertToBeVisible(page, warningMessage);
 
     for (const lessonName of lessonNames) {
       await expect(


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #55523
<!-- Feel free to add any additional description of changes below this line -->
I used the alert utility to determine if the alert was visible. 