### PR TITLE
fix(curriculum): improve rock, paper, scissors tests

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/review-dom-manipulation-by-building-a-rock-paper-scissors-game/663d4008cee64e05dfb08f0d.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/review-dom-manipulation-by-building-a-rock-paper-scissors-game/663d4008cee64e05dfb08f0d.md
@@ -41,13 +41,27 @@ assert.include(possibleResults, roundResultsMsg.innerText.replace(/\//g, "'"));
 Your `showResults` function should update the `computerScoreSpanElement` to show the updated score of the computer.
 
 ```js
-assert.equal(computerScoreSpanElement.innerText, computerScore);
+computerScore = 0;
+const oldRandomResult = getRandomComputerResult;
+getRandomComputerResult = () => "Rock";
+
+showResults("Scissors");
+assert.equal(computerScoreSpanElement.innerText, "1");
+
+getRandomComputerResult = oldRandomResult;
 ```
 
 Your `showResults` function should update the `playerScoreSpanElement` to show the updated score of the player.
 
 ```js
-assert.equal(playerScoreSpanElement.innerText, playerScore);
+playerScore = 0;
+const oldRandomResult = getRandomComputerResult;
+getRandomComputerResult = () => "Scissors";
+
+showResults("Rock");
+assert.equal(playerScoreSpanElement.innerText, "1");
+
+getRandomComputerResult = oldRandomResult;
 ```
 
 # --seed--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/review-dom-manipulation-by-building-a-rock-paper-scissors-game/663d5bebe2eef6128a0b1e75.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/review-dom-manipulation-by-building-a-rock-paper-scissors-game/663d5bebe2eef6128a0b1e75.md
@@ -28,7 +28,7 @@ Once you apply those changes, you will have completed the Rock, Paper, Scissors 
 Your `resetGame` function should set the `playerScore` to `0`.
 
 ```js
-rockBtn.click();
+playerScore = 1;
 resetGame();
 assert.equal(playerScore, 0);
 ```
@@ -36,7 +36,7 @@ assert.equal(playerScore, 0);
 Your `resetGame` function should set the `computerScore` to `0`.
 
 ```js
-rockBtn.click();
+computerScore = 1;
 resetGame();
 assert.equal(computerScore, 0);
 ```
@@ -44,7 +44,7 @@ assert.equal(computerScore, 0);
 Your `resetGame` function should set the `playerScoreSpanElement` to `0`.
 
 ```js
-rockBtn.click();
+playerScoreSpanElement.innerText = "1";
 resetGame();
 assert.equal(playerScoreSpanElement.innerText, "0");
 ```
@@ -52,7 +52,7 @@ assert.equal(playerScoreSpanElement.innerText, "0");
 Your `resetGame` function should set the `computerScoreSpanElement` to `0`.
 
 ```js
-rockBtn.click();
+computerScoreSpanElement.innerText = "1";
 resetGame();
 assert.equal(computerScoreSpanElement.innerText, "0");
 ```
@@ -61,6 +61,7 @@ Your `resetGame` function should set the `roundResultsMsg` to an empty string.
 
 ```js
 rockBtn.click();
+assert.notEqual(roundResultsMsg.innerText, "");
 resetGame();
 assert.equal(roundResultsMsg.innerText, "");
 ```
@@ -68,7 +69,7 @@ assert.equal(roundResultsMsg.innerText, "");
 Your `resetGame` function should set the `winnerMsgElement` to an empty string.
 
 ```js
-rockBtn.click();
+winnerMsgElement.innerText = "Player has won the game!";
 resetGame();
 assert.equal(winnerMsgElement.innerText, "");
 ```
@@ -76,19 +77,23 @@ assert.equal(winnerMsgElement.innerText, "");
 Your `resetGame` function should hide the `resetGameBtn`.
 
 ```js
+playerScore = 3;
+computerScore = 3;
 rockBtn.click();
+assert.notEqual(window.getComputedStyle(resetGameBtn).display, "none");
 resetGame();
-const computedStyle = window.getComputedStyle(resetGameBtn).display;
-assert.equal(computedStyle, "none");
+assert.equal(window.getComputedStyle(resetGameBtn).display, "none");
 ```
 
 Your `resetGame` function should show the `optionsContainer`.
 
 ```js
+playerScore = 3;
+computerScore = 3;
 rockBtn.click();
+assert.equal(window.getComputedStyle(optionsContainer).display, "none");
 resetGame();
-const computedStyle = window.getComputedStyle(optionsContainer).display;
-assert.notEqual(computedStyle, "none");
+assert.notEqual(window.getComputedStyle(optionsContainer).display, "none");
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

- - -
- Step 4:
  - Updated tests were passing with seed code.
  - Tests are assuming camper will use `getRoundResults`, which updates scores. Depending on the randomness luck in `getRoundResults`, and whether tie will be _drawn_ twice in a row, following code can fail 2, 1 or 0 tests. Why twice? One call to `showResults` is in seed code, second comes from test.
  ```javascript
  function showResults(userOption) {
    const result = getRoundResults(userOption);
    roundResultsMsg.innerText = result;
  };
  ```
  - If camper doesn't use `getRoundResults`, not changing the scores (and not updating them) will not cause the fail.
- Step 6:
  - Couple of updated tests could pass with seed code, again depending on the randomness.
  - Modifications are making tests setup more consistent, making sure targeted behavior will need to make expected change.