### PR TITLE
test: start mailhog before running playwright

### DIFF
--- a/e2e/report-user.spec.ts
+++ b/e2e/report-user.spec.ts
@@ -7,9 +7,6 @@ import {
 } from './utils/mailhog';
 test.use({ storageState: 'playwright/.auth/certified-user.json' });
 
-// To run this test you will need to run the email server.
-// To do this: https://contribute.freecodecamp.org/#/how-to-catch-outgoing-emails-locally?id=using-mailhog
-
 test.beforeEach(async () => {
   await deleteAllEmails();
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -89,8 +89,9 @@ export default defineConfig({
 
   /* Some tests make the api send emails, so we need mailhog to catch them */
   webServer: {
-    command: 'docker run -d --network host mailhog/mailhog',
+    command: 'docker run -d -p 1025:1025 -p 8025:8025 mailhog/mailhog',
     port: 1025,
-    reuseExistingServer: true
+    reuseExistingServer: true,
+    timeout: 180000
   }
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -85,12 +85,12 @@ export default defineConfig({
     //   name: 'Google Chrome',
     //   use: { ...devices['Desktop Chrome'], channel: 'chrome' }
     // }
-  ]
+  ],
 
-  /* Run your local dev server before starting the tests */
-  // webServer: {
-  //   command: 'npm run start',
-  //   url: 'http://127.0.0.1:3000',
-  //   reuseExistingServer: !process.env.CI,
-  // },
+  /* Some tests make the api send emails, so we need mailhog to catch them */
+  webServer: {
+    command: 'docker run -d --network host mailhog/mailhog',
+    port: 1025,
+    reuseExistingServer: true
+  }
 });


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

It's easy to forget that mailhog has to be running for some of the playwright tests to work. With these changes, you don't have to remember.

It doesn't require docker to be installed, but it does mean that either you have docker installed OR you have to start mailhog before running playwright.

<!-- Feel free to add any additional description of changes below this line -->
