### PR TITLE
ci: get chrome version tied to puppeteer version

### DIFF
--- a/.github/workflows/node.js-tests.yml
+++ b/.github/workflows/node.js-tests.yml
@@ -148,7 +148,7 @@ jobs:
           pnpm install
 
       - name: Install Chrome for Puppeteer
-        run: pnpm dlx puppeteer browsers install chrome
+        run: pnpm -F=curriculum install-puppeteer
 
       - name: Run Tests
         run: pnpm test
@@ -198,7 +198,7 @@ jobs:
           pnpm install
 
       - name: Install Chrome for Puppeteer
-        run: pnpm dlx puppeteer browsers install chrome
+        run: pnpm -F=curriculum install-puppeteer
 
       - name: Run Tests
         run: pnpm test
@@ -259,7 +259,7 @@ jobs:
           pnpm run build
 
       - name: Install Chrome for Puppeteer
-        run: pnpm dlx puppeteer browsers install chrome
+        run: pnpm -F=curriculum install-puppeteer
 
       - name: Run Tests
         env:

--- a/curriculum/package.json
+++ b/curriculum/package.json
@@ -27,6 +27,7 @@
     "insert-challenge": "CALLING_DIR=$INIT_CWD ts-node --project ../tsconfig.json ../tools/challenge-helper-scripts/insert-challenge",
     "insert-step": "CALLING_DIR=$INIT_CWD ts-node --project ../tsconfig.json ../tools/challenge-helper-scripts/insert-step",
     "insert-task": "CALLING_DIR=$INIT_CWD ts-node --project ../tsconfig.json ../tools/challenge-helper-scripts/insert-task",
+    "install-puppeteer": "puppeteer browsers install chrome",
     "delete-step": "CALLING_DIR=$INIT_CWD ts-node --project ../tsconfig.json ../tools/challenge-helper-scripts/delete-step",
     "delete-challenge": "CALLING_DIR=$INIT_CWD ts-node --project ../tsconfig.json ../tools/challenge-helper-scripts/delete-challenge",
     "delete-task": "CALLING_DIR=$INIT_CWD ts-node --project ../tsconfig.json ../tools/challenge-helper-scripts/delete-task",


### PR DESCRIPTION
Using the installed puppeteer bin instead of dlx puppeteer, downloads the correct version.

See for example: https://github.com/freeCodeCamp/freeCodeCamp/actions/runs/9971456920/job/27553092576

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->
