### PR TITLE
fix(curriculum): update tests, remove self-closing

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/62cc5b1779e4d313466f73c5.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/62cc5b1779e4d313466f73c5.md
@@ -7,48 +7,59 @@ dashedName: step-5
 
 # --description--
 
-Nest a self-closing `link` element within the `head` element. Give it a `rel` attribute with value of `stylesheet` and an `href` attribute with a value of `styles.css`.
+Nest a `link` element within the `head` element. Give it a `rel` attribute with a value of `stylesheet` and an `href` attribute with a value of `styles.css`.
 
 # --hints--
 
 Your code should have a `link` element.
 
 ```js
-assert.exists(document.querySelector('link'));
+assert.isNotNull(document.querySelector('link'));
 ```
 
 You should not change your existing `head` tags. Make sure you did not delete the closing tag.
 
 ```js
 const heads = document.querySelectorAll('head');
-assert.equal(heads?.length, 1);
+assert.strictEqual(heads?.length, 1);
 ```
 
-You should have one self-closing `link` element.
+You should have one `link` element.
 
 ```js
-assert(document.querySelectorAll('link').length === 1);
+assert.strictEqual(document.querySelectorAll('link')?.length, 1);
 ```
 
-Your `link` element should be within your `head` element.
+Your `link` element should be a void element, it should not have an end tag `</link>`.
 
 ```js
-assert.exists(document.querySelector('head > link'));
+assert.notMatch(code, /<\/link>/);
+```
+
+Your `link` element should be inside your `head` element.
+
+```js
+const headContentRegex = /(?<=<head\s*>)(?:.|\s*)*?(?=<\/head\s*>)/;
+const headElementContent = code.match(headContentRegex);
+
+const headElement = document.createElement("head");
+headElement.innerHTML = headElementContent;
+assert.isNotNull(headElement.querySelector('link'));
 ```
 
 Your `link` element should have a `rel` attribute with the value `stylesheet`.
 
 ```js
-const link_element = document.querySelector('link');
-const rel = link_element.getAttribute("rel");
-assert.equal(rel, "stylesheet");
+const linkElement = document.querySelector('link');
+const rel = linkElement?.getAttribute("rel");
+assert.strictEqual(rel, "stylesheet");
 ```
 
 Your `link` element should have an `href` attribute with the value `styles.css`.
 
 ```js
 const link = document.querySelector('link');
-assert.equal(link.dataset.href, "styles.css");
+assert.strictEqual(link?.dataset.href, "styles.css");
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related #55342

The test that checks the element is placed inside the head element was not working.