### PR TITLE
fix: ignore block order for all upcoming blocks

### DIFF
--- a/curriculum/challenges/_meta/build-a-polygon-area-calculator-project/meta.json
+++ b/curriculum/challenges/_meta/build-a-polygon-area-calculator-project/meta.json
@@ -3,7 +3,7 @@
   "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "dashedName": "build-a-polygon-area-calculator-project",
-  "order": 15,
+  "order": 16,
   "superBlock": "scientific-computing-with-python",
   "challengeOrder": [
     {

--- a/curriculum/challenges/_meta/build-a-probability-calculator-project/meta.json
+++ b/curriculum/challenges/_meta/build-a-probability-calculator-project/meta.json
@@ -3,7 +3,7 @@
   "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "dashedName": "build-a-probability-calculator-project",
-  "order": 17,
+  "order": 18,
   "superBlock": "scientific-computing-with-python",
   "challengeOrder": [
     {

--- a/curriculum/challenges/_meta/learn-encapsulation-by-building-a-projectile-trajectory-calculator/meta.json
+++ b/curriculum/challenges/_meta/learn-encapsulation-by-building-a-projectile-trajectory-calculator/meta.json
@@ -4,7 +4,7 @@
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "dashedName": "learn-encapsulation-by-building-a-projectile-trajectory-calculator",
-  "order": 16,
+  "order": 17,
   "superBlock": "scientific-computing-with-python",
   "challengeOrder": [
     {

--- a/curriculum/challenges/_meta/learn-interfaces-by-building-an-equation-solver/meta.json
+++ b/curriculum/challenges/_meta/learn-interfaces-by-building-an-equation-solver/meta.json
@@ -4,7 +4,7 @@
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "dashedName": "learn-interfaces-by-building-an-equation-solver",
-  "order": 15,
+  "order": 16,
   "superBlock": "scientific-computing-with-python",
   "challengeOrder": [
     {

--- a/curriculum/challenges/_meta/learn-interfaces-by-building-an-equation-solver/meta.json
+++ b/curriculum/challenges/_meta/learn-interfaces-by-building-an-equation-solver/meta.json
@@ -4,7 +4,7 @@
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "dashedName": "learn-interfaces-by-building-an-equation-solver",
-  "order": 16,
+  "order": 15,
   "superBlock": "scientific-computing-with-python",
   "challengeOrder": [
     {

--- a/curriculum/test/test-challenges.js
+++ b/curriculum/test/test-challenges.js
@@ -282,16 +282,8 @@ function populateTestsForLang({ lang, challenges, meta, superBlocks }) {
 
   if (!process.env.FCC_BLOCK && !process.env.FCC_CHALLENGE_ID) {
     describe('Assert meta order', function () {
-      /** This array can be used to skip a superblock - we'll use this
-       * when we are working on the new project-based curriculum for
-       * a superblock (because keeping those challenges in order is
-       * tricky and needs cleaning up before deploying).
-       */
-      const superBlocksUnderDevelopment = ['scientific-computing-with-python'];
       const superBlocks = new Set([
-        ...Object.values(meta)
-          .map(el => el.superBlock)
-          .filter(el => !superBlocksUnderDevelopment.includes(el))
+        ...Object.values(meta).map(el => el.superBlock)
       ]);
       superBlocks.forEach(superBlock => {
         const filteredMeta = Object.values(meta)
@@ -316,9 +308,12 @@ function populateTestsForLang({ lang, challenges, meta, superBlocks }) {
           );
         });
         filteredMeta.forEach((meta, index) => {
-          it(`${meta.superBlock} ${meta.name} must be in order`, function () {
-            assert.equal(meta.order, index);
-          });
+          // ignore block order for upcoming blocks
+          if (!meta.isUpcomingChange) {
+            it(`${meta.superBlock} ${meta.name} must be in order`, function () {
+              assert.equal(meta.order, index);
+            });
+          }
         });
       });
     });


### PR DESCRIPTION
This allows any block order in upcoming blocks to make development easier.

To test:

change a block order of a live block, e.g. change order to 100 in the es6 meta.json and run `FCC_SUPERBLOCK='javascript-algorithms-and-data-structures' pnpm test:curriculum` - it fails

change a block order of an upcoming block, e.g. change the order to 5 in the front-end-development-certification-exam meta.json and run `FCC_SUPERBLOCK='front-end-develop' pnpm test:curriculum ` - it passes

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
