### PR TITLE
fix(curriculum): update tests, remove self-closing

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-responsive-web-design-by-building-a-piano/612e83ec2eca1e370f830511.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-responsive-web-design-by-building-a-piano/612e83ec2eca1e370f830511.md
@@ -7,48 +7,53 @@ dashedName: step-8
 
 # --description--
 
-Add a `link` element within your `head` element. For that `link` element, set the `rel` attribute to `stylesheet` and the `href` to `./styles.css`.
+Add a `link` element inside your `head` element. Give it a `rel` attribute set to `stylesheet` and an `href` attribute set to `styles.css`.
 
 # --hints--
 
 Your code should have a `link` element.
 
 ```js
-assert.match(code, /<link/)
+assert.isNotNull(document.querySelector('link'));
 ```
 
 You should not change your existing `head` tags. Make sure you did not delete the closing tag.
 
 ```js
-const heads = document.querySelectorAll('head');
-assert.equal(heads?.length, 1);
+const headElements = document.querySelectorAll('head');
+assert.strictEqual(headElements?.length, 1);
 ```
 
-You should have one self-closing `link` element.
+You should have one `link` element.
 
 ```js
-assert(document.querySelectorAll('link').length === 1);
+assert.strictEqual(document.querySelectorAll('link')?.length, 1);
 ```
 
-Your `link` element should be within your `head` element.
+Your `link` element should be inside your `head` element.
 
 ```js
-assert.exists(document.querySelector('head > link'));
+const headContentRegex = /(?<=<head\s*>)(?:.|\s*)*?(?=<\/head\s*>)/;
+const headElementContent = code.match(headContentRegex);
+
+const headElement = document.createElement("head");
+headElement.innerHTML = headElementContent;
+assert.isNotNull(headElement.querySelector('link'));
 ```
 
 Your `link` element should have a `rel` attribute with the value `stylesheet`.
 
 ```js
-const link_element = document.querySelector('link');
-const rel = link_element.getAttribute("rel");
-assert.equal(rel, "stylesheet");
+const linkElement = document.querySelector('link');
+const rel = linkElement?.getAttribute("rel");
+assert.strictEqual(rel, "stylesheet");
 ```
 
 Your `link` element should have an `href` attribute with the value `styles.css`.
 
 ```js
-const link = document.querySelector('link');
-assert.equal(link.dataset.href, "styles.css");
+const linkElement = document.querySelector('link');
+assert.strictEqual(linkElement?.dataset.href, "styles.css");
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related #55342

The test that checks the element is placed inside the head element was not working.
