### PR TITLE
fix: simplify python and html previews

### DIFF
--- a/client/src/templates/Challenges/redux/execute-challenge-saga.js
+++ b/client/src/templates/Challenges/redux/execute-challenge-saga.js
@@ -242,10 +242,6 @@ function* executeTests(testRunner, tests, testTimeout = 5000) {
 
 function* preparePreview(action) {
   const flushLogs = action?.type !== actionTypes.previewMounted;
-  const isBuildEnabled = yield select(isBuildEnabledSelector);
-  if (!isBuildEnabled) {
-    return;
-  }
 
   const isExecuting = yield select(isExecutingSelector);
   // executeChallengeSaga flushes the logs, so there's no need to if that's
@@ -312,8 +308,13 @@ export function* updateHtmlPreview(logProxy) {
 }
 
 export function* updatePreviewSaga(action) {
-  const challengeData = yield select(challengeDataSelector);
+  const isBuildEnabled = yield select(isBuildEnabledSelector);
+  if (!isBuildEnabled) {
+    return;
+  }
+
   const logProxy = yield* preparePreview(action);
+  const challengeData = yield select(challengeDataSelector);
   if (
     challengeData.challengeType === challengeTypes.python ||
     challengeData.challengeType === challengeTypes.multifilePythonCertProject

--- a/client/src/templates/Challenges/redux/execute-challenge-saga.js
+++ b/client/src/templates/Challenges/redux/execute-challenge-saga.js
@@ -289,18 +289,7 @@ export function* updateHtmlPreview(logProxy) {
         const portalDocument = yield select(portalDocumentSelector);
         const finalDocument = portalDocument || document;
 
-        // Python challenges do not use the preview frame, they use a web worker
-        // to run the code. The UI is handled by the xterm component, so there
-        // is no need to update the preview frame.
-        if (
-          challengeData.challengeType === challengeTypes.python ||
-          challengeData.challengeType ===
-            challengeTypes.multifilePythonCertProject
-        ) {
-          yield updatePython(challengeData);
-        } else {
-          yield call(updatePreview, buildData, finalDocument, proxyLogger);
-        }
+        yield call(updatePreview, buildData, finalDocument, proxyLogger);
       } else if (isJavaScriptChallenge(challengeData)) {
         const runUserCode = getTestRunner(buildData, {
           proxyLogger

--- a/client/src/templates/Challenges/redux/execute-challenge-saga.test.js
+++ b/client/src/templates/Challenges/redux/execute-challenge-saga.test.js
@@ -14,7 +14,7 @@ function reducer(state = initialState, _action) {
   return state;
 }
 
-import { previewChallengeSaga } from './execute-challenge-saga';
+import { updatePreviewSaga } from './execute-challenge-saga';
 
 const challengeMounted = { type: 'challenge.challengeMounted' };
 const previewMounted = { type: 'challenge.previewMounted' };
@@ -22,7 +22,7 @@ const resetChallenge = { type: 'challenge.resetChallenge' };
 
 describe('execute-challenge-saga', () => {
   it('flushes logs on challengeMounted', () => {
-    return expectSaga(previewChallengeSaga, challengeMounted)
+    return expectSaga(updatePreviewSaga, challengeMounted)
       .withReducer(reducer)
       .put({ type: 'challenge.initLogs' })
       .silentRun();
@@ -30,13 +30,13 @@ describe('execute-challenge-saga', () => {
     // warnings. Increasing the timeout just makes the tests take longer.
   });
   it('flushes logs on reset', () => {
-    return expectSaga(previewChallengeSaga, resetChallenge)
+    return expectSaga(updatePreviewSaga, resetChallenge)
       .withReducer(reducer)
       .put({ type: 'challenge.initLogs' })
       .silentRun();
   });
   it('does not flush logs on previewMounted', () => {
-    return expectSaga(previewChallengeSaga, previewMounted)
+    return expectSaga(updatePreviewSaga, previewMounted)
       .withReducer(reducer)
       .not.put({ type: 'challenge.initLogs' })
       .silentRun();


### PR DESCRIPTION
- **fix(client): clear python console when user types**
- **refactor: remove redundant logic**
- **fix: abort preview if it is not possible to build**

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This separates the python and html preview rendering logic and creates a common setup that both can use.

In terms of feature changes, the only (intentional) difference is that when a learner types in the python editor, the console should get cleared. I.e. the same as for the html lessons.

<!-- Feel free to add any additional description of changes below this line -->
