### PR TITLE
feat: reduce preview debounce timer

### DIFF
--- a/client/src/templates/Challenges/redux/execute-challenge-saga.js
+++ b/client/src/templates/Challenges/redux/execute-challenge-saga.js
@@ -255,7 +255,9 @@ export function* previewChallengeSaga(action) {
     yield put(initLogs());
     yield put(initConsole(''));
   }
-  yield delay(700);
+  // long enough so that holding down a key will only send one request, but not
+  // so long that it feels unresponsive
+  yield delay(30);
 
   const logProxy = yield channel();
   const proxyLogger = args => logProxy.put(args);


### PR DESCRIPTION
Since the saga takes the latest action (and discards the rest) the delay
functions as a debounce. I chose 30ms to strike a balance between
responsiveness and preventing renders if the learner is, say, holding
down a key.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->
