### PR TITLE
feat(learn): add blockType to block meta

### DIFF
--- a/client/gatsby-node.js
+++ b/client/gatsby-node.js
@@ -76,6 +76,7 @@ exports.createPages = async function createPages({
           node {
             challenge {
               block
+              blockType
               certification
               challengeType
               dashedName

--- a/client/gatsby-node.js
+++ b/client/gatsby-node.js
@@ -264,6 +264,7 @@ exports.createSchemaCustomization = ({ actions }) => {
       challenge: Challenge
     }
     type Challenge {
+      blockType: String
       challengeFiles: [FileContents]
       notes: String
       url: String

--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -512,6 +512,14 @@
       "link-li-6": "Click \"Link Account\" to link your Microsoft username.",
       "transcript-label": "Your Microsoft Transcript Link",
       "invalid-transcript": "Your transcript link is not correct, it should have the following form: <1>https://learn.microsoft.com/LOCALE/users/USERNAME/transcript/ID</1> - check the UPPERCASE items in your link are correct."
+    },
+    "blockType": {
+      "lecture": "Lecture",
+      "workshop": "Workshop",
+      "lab": "Lab",
+      "review": "Review",
+      "quiz": "Quiz",
+      "exam": "Exam"
     }
   },
   "donate": {

--- a/client/src/redux/prop-types.ts
+++ b/client/src/redux/prop-types.ts
@@ -1,5 +1,6 @@
 import { HandlerProps } from 'react-reflex';
 import { SuperBlocks } from '../../../shared/config/curriculum';
+import { BlockTypes } from '../../../shared/config/blocks';
 import { Themes } from '../components/settings/theme';
 import { type CertTitle } from '../../config/cert-and-project-map';
 
@@ -178,6 +179,7 @@ export type ChallengeWithCompletedNode = {
 export type ChallengeNode = {
   challenge: {
     block: string;
+    blockType: BlockTypes;
     certification: string;
     challengeOrder: number;
     challengeType: number;

--- a/curriculum/challenges/_meta/front-end-development-certification-exam/meta.json
+++ b/curriculum/challenges/_meta/front-end-development-certification-exam/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Front End Development Certification Exam",
+  "blockType": "exam",
   "isUpcomingChange": true,
   "dashedName": "front-end-development-certification-exam",
   "helpCategory": "HTML-CSS",

--- a/curriculum/challenges/_meta/front-end-development-certification-exam/meta.json
+++ b/curriculum/challenges/_meta/front-end-development-certification-exam/meta.json
@@ -4,7 +4,7 @@
   "isUpcomingChange": true,
   "dashedName": "front-end-development-certification-exam",
   "helpCategory": "HTML-CSS",
-  "order": 387,
+  "order": 386,
   "superBlock": "front-end-development",
   "challengeOrder": [
     {

--- a/curriculum/challenges/_meta/lab-recipe-page/meta.json
+++ b/curriculum/challenges/_meta/lab-recipe-page/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Recipe Page",
+  "blockType": "lab",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "lab-recipe-page",

--- a/curriculum/challenges/_meta/workshop-blog-page/meta.json
+++ b/curriculum/challenges/_meta/workshop-blog-page/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Build a Cat Blog Page",
+  "blockType": "workshop",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,

--- a/curriculum/challenges/_meta/workshop-cat-photo-app/meta.json
+++ b/curriculum/challenges/_meta/workshop-cat-photo-app/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Build a Cat Photo App",
+  "blockType": "workshop",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,

--- a/curriculum/get-challenges.js
+++ b/curriculum/get-challenges.js
@@ -277,7 +277,7 @@ function generateChallengeCreator(lang, englishPath, i18nPath) {
     );
 
     challenge.block = meta.dashedName;
-    challenge.blockType = meta.blockType || null;
+    challenge.blockType = meta.blockType;
     challenge.hasEditableBoundaries = !!meta.hasEditableBoundaries;
     challenge.order = meta.order;
     // const superOrder = getSuperOrder(meta.superBlock);

--- a/curriculum/get-challenges.js
+++ b/curriculum/get-challenges.js
@@ -277,6 +277,7 @@ function generateChallengeCreator(lang, englishPath, i18nPath) {
     );
 
     challenge.block = meta.dashedName;
+    challenge.blockType = meta.blockType || null;
     challenge.hasEditableBoundaries = !!meta.hasEditableBoundaries;
     challenge.order = meta.order;
     // const superOrder = getSuperOrder(meta.superBlock);

--- a/curriculum/schema/__snapshots__/challenge-schema.test.js.snap
+++ b/curriculum/schema/__snapshots__/challenge-schema.test.js.snap
@@ -88,6 +88,7 @@ const schema = Joi.object()
   .keys({
     block: Joi.string().regex(slugRE).required(),
     blockId: Joi.objectId(),
+    blockType: Joi.valid('workshop', 'lab', 'lecture', 'quiz', 'exam'),
     challengeOrder: Joi.number(),
     certification: Joi.string().regex(slugWithSlashRE),
     challengeType: Joi.number().min(0).max(23).required(),

--- a/curriculum/schema/__snapshots__/challenge-schema.test.js.snap
+++ b/curriculum/schema/__snapshots__/challenge-schema.test.js.snap
@@ -90,13 +90,17 @@ const schema = Joi.object()
     block: Joi.string().regex(slugRE).required(),
     blockId: Joi.objectId(),
     blockType: Joi.when('superBlock', {
-      is: [
-        SuperBlocks.FrontEndDevelopment,
-      ],
-      then: Joi.valid('workshop', 'lab', 'lecture', 'quiz', 'exam').required(),
+      is: [SuperBlocks.FrontEndDevelopment],
+      then: Joi.valid(
+        'workshop',
+        'lab',
+        'lecture',
+        'review',
+        'quiz',
+        'exam'
+      ).required(),
       otherwise: Joi.valid(null)
-    }),    
-    //Joi.valid('workshop', 'lab', 'lecture', 'quiz', 'exam'),
+    }),
     challengeOrder: Joi.number(),
     certification: Joi.string().regex(slugWithSlashRE),
     challengeType: Joi.number().min(0).max(23).required(),

--- a/curriculum/schema/__snapshots__/challenge-schema.test.js.snap
+++ b/curriculum/schema/__snapshots__/challenge-schema.test.js.snap
@@ -5,7 +5,7 @@ exports[`challenge schema Notify mobile team BEFORE updating snapshot 1`] = `
 Joi.objectId = require('joi-objectid')(Joi);
 
 const { challengeTypes } = require('../../shared/config/challenge-types');
-const { SuperBlocks } = require('../../shared/config/superblocks');
+const { SuperBlocks } = require('../../shared/config/curriculum');
 const {
   availableCharacters,
   availableBackgrounds,

--- a/curriculum/schema/__snapshots__/challenge-schema.test.js.snap
+++ b/curriculum/schema/__snapshots__/challenge-schema.test.js.snap
@@ -5,6 +5,7 @@ exports[`challenge schema Notify mobile team BEFORE updating snapshot 1`] = `
 Joi.objectId = require('joi-objectid')(Joi);
 
 const { challengeTypes } = require('../../shared/config/challenge-types');
+const { SuperBlocks } = require('../../shared/config/superblocks');
 const {
   availableCharacters,
   availableBackgrounds,
@@ -88,7 +89,14 @@ const schema = Joi.object()
   .keys({
     block: Joi.string().regex(slugRE).required(),
     blockId: Joi.objectId(),
-    blockType: Joi.valid('workshop', 'lab', 'lecture', 'quiz', 'exam'),
+    blockType: Joi.when('superBlock', {
+      is: [
+        SuperBlocks.FrontEndDevelopment,
+      ],
+      then: Joi.valid('workshop', 'lab', 'lecture', 'quiz', 'exam').required(),
+      otherwise: Joi.valid(null)
+    }),    
+    //Joi.valid('workshop', 'lab', 'lecture', 'quiz', 'exam'),
     challengeOrder: Joi.number(),
     certification: Joi.string().regex(slugWithSlashRE),
     challengeType: Joi.number().min(0).max(23).required(),

--- a/curriculum/schema/challenge-schema.js
+++ b/curriculum/schema/challenge-schema.js
@@ -88,7 +88,14 @@ const schema = Joi.object()
     blockId: Joi.objectId(),
     blockType: Joi.when('superBlock', {
       is: [SuperBlocks.FrontEndDevelopment],
-      then: Joi.valid('workshop', 'lab', 'lecture', 'quiz', 'exam').required(),
+      then: Joi.valid(
+        'workshop',
+        'lab',
+        'lecture',
+        'review',
+        'quiz',
+        'exam'
+      ).required(),
       otherwise: Joi.valid(null)
     }),
     challengeOrder: Joi.number(),

--- a/curriculum/schema/challenge-schema.js
+++ b/curriculum/schema/challenge-schema.js
@@ -91,7 +91,6 @@ const schema = Joi.object()
       then: Joi.valid('workshop', 'lab', 'lecture', 'quiz', 'exam').required(),
       otherwise: Joi.valid(null)
     }),
-    //Joi.valid('workshop', 'lab', 'lecture', 'quiz', 'exam'),
     challengeOrder: Joi.number(),
     certification: Joi.string().regex(slugWithSlashRE),
     challengeType: Joi.number().min(0).max(23).required(),

--- a/curriculum/schema/challenge-schema.js
+++ b/curriculum/schema/challenge-schema.js
@@ -2,6 +2,7 @@ const Joi = require('joi');
 Joi.objectId = require('joi-objectid')(Joi);
 
 const { challengeTypes } = require('../../shared/config/challenge-types');
+const { SuperBlocks } = require('../../shared/config/superblocks');
 const {
   availableCharacters,
   availableBackgrounds,
@@ -85,7 +86,12 @@ const schema = Joi.object()
   .keys({
     block: Joi.string().regex(slugRE).required(),
     blockId: Joi.objectId(),
-    blockType: Joi.valid('workshop', 'lab', 'lecture', 'quiz', 'exam'),
+    blockType: Joi.when('superBlock', {
+      is: [SuperBlocks.FrontEndDevelopment],
+      then: Joi.valid('workshop', 'lab', 'lecture', 'quiz', 'exam').required(),
+      otherwise: Joi.valid(null)
+    }),
+    //Joi.valid('workshop', 'lab', 'lecture', 'quiz', 'exam'),
     challengeOrder: Joi.number(),
     certification: Joi.string().regex(slugWithSlashRE),
     challengeType: Joi.number().min(0).max(23).required(),

--- a/curriculum/schema/challenge-schema.js
+++ b/curriculum/schema/challenge-schema.js
@@ -2,7 +2,7 @@ const Joi = require('joi');
 Joi.objectId = require('joi-objectid')(Joi);
 
 const { challengeTypes } = require('../../shared/config/challenge-types');
-const { SuperBlocks } = require('../../shared/config/superblocks');
+const { SuperBlocks } = require('../../shared/config/curriculum');
 const {
   availableCharacters,
   availableBackgrounds,

--- a/curriculum/schema/challenge-schema.js
+++ b/curriculum/schema/challenge-schema.js
@@ -85,6 +85,7 @@ const schema = Joi.object()
   .keys({
     block: Joi.string().regex(slugRE).required(),
     blockId: Joi.objectId(),
+    blockType: Joi.valid('workshop', 'lab', 'lecture', 'quiz', 'exam'),
     challengeOrder: Joi.number(),
     certification: Joi.string().regex(slugWithSlashRE),
     challengeType: Joi.number().min(0).max(23).required(),

--- a/curriculum/schema/meta-schema.js
+++ b/curriculum/schema/meta-schema.js
@@ -6,6 +6,7 @@ const slugWithSlashRE = new RegExp('^[a-z0-9-/]+$');
 const schema = Joi.object()
   .keys({
     name: Joi.string().required(),
+    blockType: Joi.valid('workshop', 'lab', 'lecture', 'quiz', 'exam'),
     isUpcomingChange: Joi.boolean().required(),
     dashedName: Joi.string().regex(slugRE).required(),
     superBlock: Joi.string().regex(slugWithSlashRE).required(),

--- a/shared/config/blocks.ts
+++ b/shared/config/blocks.ts
@@ -1,0 +1,8 @@
+export enum BlockTypes {
+  workshop,
+  lab,
+  lecture,
+  review,
+  quiz,
+  exam
+}

--- a/shared/config/blocks.ts
+++ b/shared/config/blocks.ts
@@ -1,8 +1,8 @@
 export enum BlockTypes {
-  workshop,
-  lab,
-  lecture,
-  review,
-  quiz,
-  exam
+  lecture = 'lecture',
+  workshop = 'workshop',
+  lab = 'lab',
+  review = 'review',
+  quiz = 'quiz',
+  exam = 'exam'
 }


### PR DESCRIPTION
This adds the ability to add a blockType to the block meta.json files - so we can label the blocks.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

[ref](https://github.com/freeCodeCamp/fCC10/issues/12)

<!-- Feel free to add any additional description of changes below this line -->
