### PR TITLE
fix(api-server): add x.com to valid twitter domains

### DIFF
--- a/api-server/src/server/boot/settings.js
+++ b/api-server/src/server/boot/settings.js
@@ -254,7 +254,7 @@ const updatePrivacyTerms = (req, res, next) => {
 const allowedSocialsAndDomains = {
   githubProfile: 'github.com',
   linkedin: 'linkedin.com',
-  twitter: 'twitter.com',
+  twitter: ['twitter.com', 'x.com'],
   website: ''
 };
 
@@ -280,7 +280,9 @@ export function updateMySocials(...args) {
         const url = new URL(val);
         const topDomain = url.hostname.split('.').slice(-2);
         if (topDomain.length === 2) {
-          return topDomain.join('.') === domain;
+          return Array.isArray(domain)
+            ? domain.some(d => topDomain.join('.') === d)
+            : topDomain.join('.') === domain;
         }
         return false;
       } catch (e) {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #55579

<!-- Feel free to add any additional description of changes below this line -->

Not sure if this is really all there is to it, but it seems to work.

It should allow any site to have multiple valid domains in an array.

---

`test-server` is passing, but `test:api` fails a bunch, but it is the same that fail on main, so I assume I had nothing to do with it.
