### PR TITLE
fix(curriculum): tests passing with seed code in Calorie counter

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-form-validation-by-building-a-calorie-counter/63b60cfaca25bb27edd40f62.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-form-validation-by-building-a-calorie-counter/63b60cfaca25bb27edd40f62.md
@@ -14,13 +14,15 @@ Finally, you need to link your JavaScript file to your HTML. Create a `script` e
 You should have a `script` element.
 
 ```js
-assert.isAtLeast(document.querySelectorAll('script')?.length, 1);
+const bodyEnding = code.split(/<\/main>/)?.[1]?.split(/<\/body>/)?.[0];
+assert.match(bodyEnding, /<script[^>]*>\s*<\/script>/);
 ```
 
 Your `script` element should have the `src` set to `./script.js`.
 
 ```js
-assert.match(code, /script\s*?src\s*?=\s*?('|")(\.\/)?script\.js\1/);
+const bodyEnding = code.split(/<\/main>/)?.[1]?.split(/<\/body>/)?.[0];
+assert.match(bodyEnding, /<script\s*src\s*=\s*('|")(\.\/)?script\.js\1\s*>\s*<\/script>/);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-form-validation-by-building-a-calorie-counter/63b61490e633a22b4593e62f.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-form-validation-by-building-a-calorie-counter/63b61490e633a22b4593e62f.md
@@ -26,7 +26,7 @@ assert.match(code, /document\.getElementById\(\s*('|")add-entry\1\s*\)/g);
 You should assign the `#add-entry` element to `addEntryButton`.
 
 ```js
-assert.equal(addEntryButton, document.getElementById('add-entry'));
+assert.deepEqual(addEntryButton, document.getElementById('add-entry'));
 ```
 
 You should declare a variable called `clearButton`.
@@ -44,13 +44,14 @@ assert.match(code, /document\.getElementById\(\s*('|")clear\1\s*\)/g);
 You should assign the `#clear` element to `clearButton`.
 
 ```js
-assert.equal(clearButton, document.getElementById('clear'));
+assert.deepEqual(clearButton, document.getElementById('clear'));
 ```
 
 You should declare a variable called `output`.
 
 ```js
-assert.isDefined(output);
+// .isDefined cannot be used for `output`, as browser defines such variable on it own.
+assert.match(code, /const\s+output/);
 ```
 
 You should use `document.getElementById()` to get the `#output` element.
@@ -62,7 +63,9 @@ assert.match(code, /document\.getElementById\(\s*('|")output\1\s*\)/g);
 You should assign the `#output` element to `output`.
 
 ```js
-assert.equal(output, document.getElementById("output"));
+// assert.deepEqual(output, document.getElementById('output')); cannot be used,
+// as browser defines `output` variable on it own for `#output`.
+assert.match(code, /const\s+output\s*=\s*document.getElementById\(('|")output\1\)/);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-form-validation-by-building-a-calorie-counter/63bf461011fca327d3b60fa8.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-form-validation-by-building-a-calorie-counter/63bf461011fca327d3b60fa8.md
@@ -19,24 +19,6 @@ Declare a `regex` variable and assign it the value from the example above. In fu
 
 # --hints--
 
-You should remove the `cleanStrArray` variable.
-
-```js
-assert.notMatch(cleanInputString.toString(), /cleanStrArray/);
-```
-
-You should remove the `strArray` variable.
-
-```js
-assert.notMatch(cleanInputString.toString(), /strArray/);
-```
-
-You should not have a `for` loop.
-
-```js
-assert.notMatch(cleanInputString.toString(), /for/);
-```
-
 You should declare a `regex` variable.
 
 ```js

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-form-validation-by-building-a-calorie-counter/63c8c15fd337ad24b9b68049.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-form-validation-by-building-a-calorie-counter/63c8c15fd337ad24b9b68049.md
@@ -26,7 +26,8 @@ Add an `if` statement that checks if `invalidInputMatch` is truthy.
 You should add an `if` statement to your `getCaloriesFromInputs` function.
 
 ```js
-assert.match(getCaloriesFromInputs.toString(), /if\s*\(/);
+const functionCode = code.split(/getCaloriesFromInputs/)?.[1]?.split(/\}\s*\}/)?.[0];
+assert.match(functionCode, /if\s*\(/);
 ```
 
 You should check the truthiness of `invalidInputMatch` in your `if` condition.
@@ -38,7 +39,8 @@ assert.match(getCaloriesFromInputs.toString(), /if\s*\(\s*invalidInputMatch\s*\)
 Your `if` statement should be inside your `for` loop.
 
 ```js
-assert.isBelow(getCaloriesFromInputs.toString().indexOf("for"), getCaloriesFromInputs.toString().indexOf("if"));
+const forCode = code.split(/getCaloriesFromInputs/)?.[1]?.split(/for\s*\(/)?.[1]?.split(/\}/)?.[0];
+assert.match(forCode, /if\s*\(\s*invalidInputMatch\s*\)/);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-form-validation-by-building-a-calorie-counter/63c9e8fe3a6f022a05a04675.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-form-validation-by-building-a-calorie-counter/63c9e8fe3a6f022a05a04675.md
@@ -14,32 +14,64 @@ Using the same interpolation syntax, add a second `p` element with the text `con
 You should add a second `p` element to your template literal.
 
 ```js
-const htmlString = code.split(/output\s*\.\s*innerHTML\s*=\s*/)[1].split(/`/)[1];
-assert.isAtLeast(htmlString.match(/<p>/g).length, 2);
+assert.isAtLeast(getTemplateContents(code)?.match(/<p>[^<]*<\/p>/g)?.length, 2);
 ```
 
 Your second `p` element should be on a new line.
 
 ```js
-const htmlString = code.split(/output\s*\.\s*innerHTML\s*=\s*/)[1].split(/`/)[1];
-assert.match(htmlString, /\n\s*<p/)
+assert.match(getTemplateContents(code), /<hr>\s*<p>[^<]*<\/p>\n\s*<p>[^<]*<\/p>/);
 ```
 
 Your second `p` element should come after your existing `p` element.
 
 ```js
-const htmlString = code.split(/output\s*\.\s*innerHTML\s*=\s*/)[1].split(/`/)[1];
-assert(htmlString.match(/<p>\$\{budgetCalories\}\s*Calories\s*Budgeted<\/p>\n\s*<p/));
+assert.match(getTemplateContents(code), /<p>\$\{budgetCalories\}\s*Calories\s*Budgeted<\/p>\s*<p>/);
 ```
 
 Your second `p` element should have the text `${consumedCalories} Calories Consumed`.
 
 ```js
-const htmlString = code.split(/output\s*\.\s*innerHTML\s*=\s*/)[1].split(/`/)[1];
-assert(htmlString.match(/<p>\$\{consumedCalories\}\s*Calories\s*Consumed<\/p>/));
+const secondP = getTemplateContents(code)?.split(/<p>/)?.[2];
+assert.match(secondP, /\$\{consumedCalories\}\s*Calories\s*Consumed<\/p>/);
+```
+
+You should add a third `p` element to your template literal.
+
+```js
+assert.lengthOf(getTemplateContents(code)?.match(/<p>[^<]*<\/p>/g), 3);
+```
+
+Your third `p` element should be on a new line.
+
+```js
+assert.match(getTemplateContents(code), /<hr>\s*<p>[^<]*<\/p>\s*<p>[^<]*<\/p>\n\s*<p>[^<]*<\/p>/);
+```
+
+Your third `p` element should come after your second existing `p` element.
+
+```js
+assert.match(getTemplateContents(code), /<p>\$\{consumedCalories\}\s*Calories\s*Consumed<\/p>\s*<p>/);
+```
+
+Your third `p` element should have the text `${exerciseCalories} Calories Burned`.
+
+```js
+const thirdP = getTemplateContents(code)?.split(/<p>/)?.[3];
+assert.match(thirdP, /\$\{exerciseCalories\}\s*Calories\s*Burned<\/p>/);
 ```
 
 # --seed--
+
+## --after-user-code--
+
+```js
+function getTemplateContents(code) {
+  return code
+    .split(/output\s*\.\s*innerHTML\s*=\s*/)?.[1]
+    ?.split(/`/)?.[1];
+}
+```
 
 ## --seed-contents--
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

- - -
- Step 13: browser is doing shenanigans  
- Step 19: Tests unrelated to current seed code or task in challenge.
- Step 62: `getCaloriesFromInputs.toString()` contains added loop protection, which uses `if`.
- Step 86:
  - Augmented existsing tests.
  - Added tests for thrid `<p>`.