### PR TITLE
fix(client): use source head/tail if challenge is saved

### DIFF
--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -177,11 +177,11 @@ const defaultOutput = `
 */`;
 
 function ShowClassic({
-  challengeFiles: reduxChallengeFiles,
+  challengeFiles,
   data: {
     challengeNode: {
       challenge: {
-        challengeFiles,
+        challengeFiles: seedChallengeFiles,
         block,
         title,
         description,
@@ -364,7 +364,7 @@ function ShowClassic({
     });
 
     createFiles(
-      mergeChallengeFiles(challengeFiles, savedChallenge?.challengeFiles)
+      mergeChallengeFiles(seedChallengeFiles, savedChallenge?.challengeFiles)
     );
 
     initTests(tests);
@@ -417,9 +417,9 @@ function ShowClassic({
     isUsingKeyboardInTablist
   }: RenderEditorArgs) => {
     return (
-      reduxChallengeFiles && (
+      challengeFiles && (
         <MultifileEditor
-          challengeFiles={reduxChallengeFiles}
+          challengeFiles={challengeFiles}
           block={block}
           superBlock={superBlock}
           containerRef={containerRef}
@@ -484,7 +484,7 @@ function ShowClassic({
         )}
         {!isMobile && (
           <DesktopLayout
-            challengeFiles={reduxChallengeFiles}
+            challengeFiles={challengeFiles}
             challengeType={challengeType}
             editor={renderEditor({
               isMobileLayout: false,

--- a/client/src/templates/Challenges/redux/index.js
+++ b/client/src/templates/Challenges/redux/index.js
@@ -2,6 +2,7 @@ import { isEmpty } from 'lodash-es';
 import { handleActions } from 'redux-actions';
 
 import { getLines } from '../../../../../shared/utils/get-lines';
+import { mergeChallengeFiles } from '../classic/saved-challenges';
 import { getTargetEditor } from '../utils/get-target-editor';
 import { actionTypes, ns } from './action-types';
 import codeStorageEpic from './code-storage-epic';
@@ -110,7 +111,9 @@ export const reducer = handleActions(
     },
     [actionTypes.storedCodeFound]: (state, { payload }) => ({
       ...state,
-      challengeFiles: payload
+      challengeFiles: state.challengeFiles.length
+        ? mergeChallengeFiles(state.challengeFiles, payload)
+        : payload
     }),
     [actionTypes.initTests]: (state, { payload }) => ({
       ...state,


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This is mostly an issue in development, when changing the head/tail is a common occurrence, but is also a problem in production. If a learner saves their code and we push an update to a challenge's `--before-user-code--` or `--after-user-code--` then the next time they revisit that lesson it's likely to be broken.

The first commit fixes the issue and the second is just a refactor.

Closes https://github.com/freeCodeCamp/freeCodeCamp/issues/55554

<!-- Feel free to add any additional description of changes below this line -->
