### PR TITLE
refactor: remove hasNotes in favour of !!notes

### DIFF
--- a/client/src/templates/Challenges/classic/desktop-layout.tsx
+++ b/client/src/templates/Challenges/classic/desktop-layout.tsx
@@ -22,6 +22,7 @@ import {
   isAdvancingToChallengeSelector
 } from '../redux/selectors';
 import PreviewPortal from '../components/preview-portal';
+import Notes from '../components/notes';
 import ActionRow from './action-row';
 
 type Pane = { flex: number };
@@ -31,7 +32,6 @@ interface DesktopLayoutProps {
   challengeType: number;
   editor: ReactElement | null;
   hasEditableBoundaries: boolean;
-  hasNotes: boolean;
   hasPreview: boolean;
   instructions: ReactElement;
   isAdvancing: boolean;
@@ -44,7 +44,7 @@ interface DesktopLayoutProps {
     previewPane: Pane;
     testsPane: Pane;
   };
-  notes: ReactElement;
+  notes: string;
   onPreviewResize: () => void;
   preview: ReactElement;
   resizeProps: ResizeProps;
@@ -146,7 +146,6 @@ const DesktopLayout = (props: DesktopLayoutProps): JSX.Element => {
     instructions,
     editor,
     testOutput,
-    hasNotes,
     hasPreview,
     isAdvancing,
     isFirstStep,
@@ -175,7 +174,7 @@ const DesktopLayout = (props: DesktopLayoutProps): JSX.Element => {
     challengeType === challengeTypes.multifilePythonCertProject;
   const displayPreviewPane = hasPreview && showPreviewPane;
   const displayPreviewPortal = hasPreview && showPreviewPortal;
-  const displayNotes = projectBasedChallenge ? showNotes && hasNotes : false;
+  const displayNotes = projectBasedChallenge ? showNotes && !!notes : false;
   const displayEditorConsole = !(
     projectBasedChallenge || isMultifileCertProject
   )
@@ -197,7 +196,7 @@ const DesktopLayout = (props: DesktopLayoutProps): JSX.Element => {
       {(projectBasedChallenge || isMultifileCertProject) && (
         <ActionRow
           hasPreview={hasPreview}
-          hasNotes={hasNotes}
+          hasNotes={!!notes}
           isProjectBasedChallenge={projectBasedChallenge}
           showConsole={showConsole}
           showNotes={showNotes}
@@ -260,7 +259,7 @@ const DesktopLayout = (props: DesktopLayoutProps): JSX.Element => {
         {displayNotes && <ReflexSplitter propagate={true} {...resizeProps} />}
         {displayNotes && (
           <ReflexElement flex={notesPane.flex} {...resizeProps}>
-            {notes}
+            <Notes notes={notes} />
           </ReflexElement>
         )}
 

--- a/client/src/templates/Challenges/classic/mobile-layout.tsx
+++ b/client/src/templates/Challenges/classic/mobile-layout.tsx
@@ -1,5 +1,5 @@
 import i18next from 'i18next';
-import React, { Component, ReactElement } from 'react';
+import React, { Component } from 'react';
 import { faWindowRestore } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { createSelector } from 'reselect';
@@ -19,16 +19,16 @@ import {
 import { TOOL_PANEL_HEIGHT } from '../../../../config/misc';
 import ToolPanel from '../components/tool-panel';
 import PreviewPortal from '../components/preview-portal';
+import Notes from '../components/notes';
 import EditorTabs from './editor-tabs';
 
 interface MobileLayoutProps {
   editor: JSX.Element | null;
   guideUrl: string;
   hasEditableBoundaries: boolean;
-  hasNotes: boolean;
   hasPreview: boolean;
   instructions: JSX.Element;
-  notes: ReactElement;
+  notes: string;
   preview: JSX.Element;
   onPreviewResize: () => void;
   windowTitle: string;
@@ -154,7 +154,6 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
       instructions,
       editor,
       testOutput,
-      hasNotes,
       hasPreview,
       notes,
       preview,
@@ -233,7 +232,7 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
             <TabsTrigger value={tabs.editor}>
               {i18next.t('learn.editor-tabs.code')}
             </TabsTrigger>
-            {hasNotes && usesMultifileEditor && (
+            {!!notes && usesMultifileEditor && (
               <TabsTrigger value={tabs.notes}>
                 {i18next.t('learn.editor-tabs.notes')}
               </TabsTrigger>
@@ -272,13 +271,13 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
           >
             {testOutput}
           </TabsContent>
-          {hasNotes && usesMultifileEditor && (
+          {!!notes && usesMultifileEditor && (
             <TabsContent
               tabIndex={-1}
               className='tab-content'
               value={tabs.notes}
             >
-              {notes}
+              <Notes notes={notes} />
             </TabsContent>
           )}
           {hasPreview && (

--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -33,7 +33,6 @@ import ChallengeTitle from '../components/challenge-title';
 import CompletionModal from '../components/completion-modal';
 import HelpModal from '../components/help-modal';
 import ShortcutsModal from '../components/shortcuts-modal';
-import Notes from '../components/notes';
 import Output from '../components/output';
 import Preview, { type PreviewProps } from '../components/preview';
 import ProjectPreviewModal from '../components/project-preview-modal';
@@ -458,12 +457,11 @@ function ShowClassic({
             })}
             guideUrl={getGuideUrl({ forumTopicId, title })}
             hasEditableBoundaries={hasEditableBoundaries}
-            hasNotes={!!notes}
             hasPreview={showPreview}
             instructions={renderInstructionsPanel({
               showToolPanel: false
             })}
-            notes={<Notes notes={notes} />}
+            notes={notes}
             onPreviewResize={onPreviewResize}
             preview={
               <StepPreview
@@ -498,7 +496,7 @@ function ShowClassic({
             })}
             isFirstStep={isFirstStep}
             layoutState={layout}
-            notes={<Notes notes={notes} />}
+            notes={notes}
             onPreviewResize={onPreviewResize}
             preview={
               <StepPreview


### PR DESCRIPTION
hasNotes is simply !!notes, so having both feels wasteful.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->
