### PR TITLE
fix(curriculum): update tests, remove reference to self-closing

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-typography-by-building-a-nutrition-label/615f34ecc1091b4fd5a8a484.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-typography-by-building-a-nutrition-label/615f34ecc1091b4fd5a8a484.md
@@ -15,30 +15,48 @@ Also add a `link` element to link your `styles.css` file.
 
 # --hints--
 
-Your code should have two self-closing `link` elements.
+Your code should have two `link` elements.
 
 ```js
-assert(document.querySelectorAll('link').length === 2);
+assert.strictEqual(document.querySelectorAll('link').length, 2);
+```
+
+Your `link` elements should be void elements, they should not have a end tag `</link>`.
+
+```js
+assert.notMatch(code, /<\/link>/);
+```
+
+Your two `link` elements should be inside the `head` element.
+
+```js
+const headContentRegex = /(?<=<head\s*>)(?:.|\s*)*?(?=<\/head\s*>)/;
+const headElementContent = code.match(headContentRegex);
+
+const headElement = document.createElement("head");
+headElement.innerHTML = headElementContent;
+assert.strictEqual(headElement.querySelectorAll('link').length, 2);
 ```
 
 Both of your `link` elements should have the `rel` attribute set to `stylesheet`.
 
 ```js
 const links = [...document.querySelectorAll('link')];
-assert(links.every(link => link.getAttribute('rel') === 'stylesheet'));
+assert.isTrue(links.every(link => link.getAttribute('rel') === 'stylesheet'));
 ```
 
-One of your `link` elements should have an `href` attribute set to `./styles.css`.
+One of your `link` elements should have an `href` attribute set to `styles.css`.
 
 ```js
-assert.match(code, /\<link\s+(?:rel\s*=\s*('|"|`)stylesheet\1\s+href\s*=\s*('|"|`)(\.\/|\s*)styles\.css\2|href\s*=\s*('|"|`)(\.\/|\s*)styles\.css\4\s+rel\s*=\s*('|"|`)stylesheet\4)\s*(?:(\s*\>|\s*\/\s*\>))/);
+const styleElement = document.querySelector('[data-href]');
+assert.isNotNull(styleElement);
 ```
 
 One of your `link` elements should have an `href` attribute set to `https://fonts.googleapis.com/css?family=Open+Sans:400,700,800`.
 
 ```js
 const links = [...document.querySelectorAll('link')];
-assert(links.find(link => link?.getAttribute('href') === 'https://fonts.googleapis.com/css?family=Open+Sans:400,700,800'));
+assert.exists(links.find(link => link?.getAttribute('href') === 'https://fonts.googleapis.com/css?family=Open+Sans:400,700,800'));
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related #55342

<!-- Feel free to add any additional description of changes below this line -->

Added test to check the link elements are located inside the head element. Again, to be clear, we can not check the DOM directly using DOM methods, so we construct a head element from the code content.

Also to clarify, if needed, `document.querySelector('[data-href]')` returns `null` if the correct value is not used for the CSS file. `<link rel="stylesheet" href="styles.css">` always become `<link rel="stylesheet" data-href="styles.css">` in the DOM when written correctly.
