### PR TITLE
fix(curriculum): tests passing with seed code in Dice game

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/review-algorithmic-thinking-by-building-a-dice-game/657a19e477dc04e36a86dffc.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/review-algorithmic-thinking-by-building-a-dice-game/657a19e477dc04e36a86dffc.md
@@ -63,7 +63,7 @@ assert.isFalse(rulesContainer.checkVisibility());
 resetState();
 ```
 
-When your `rulesBtn` is clicked twice, your `rulesBtn` should say `Show Rules`.
+When your `rulesBtn` is clicked twice, your `rulesBtn` should say `Show rules`.
 
 ```js
 rulesBtn.click();

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/review-algorithmic-thinking-by-building-a-dice-game/657a19e477dc04e36a86dffc.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/review-algorithmic-thinking-by-building-a-dice-game/657a19e477dc04e36a86dffc.md
@@ -24,40 +24,66 @@ When your `rulesBtn` is clicked, your `isModalShowing` should be `true`.
 ```js
 rulesBtn.click();
 assert.isTrue(isModalShowing);
+resetState();
 ```
 
 When your `rulesBtn` is clicked, your `rulesContainer` should be visible.
 
 ```js
+rulesBtn.click();
 assert.isTrue(rulesContainer.checkVisibility());
+resetState();
 ```
 
 When your `rulesBtn` is clicked, your `rulesBtn` should say `Hide Rules`.
 
 ```js
+rulesBtn.click();
 assert.strictEqual(rulesBtn.innerText.trim(), "Hide Rules");
+resetState();
 ```
 
-When your `rulesBtn` is clicked again, your `isModalShowing` should be `false`.
+When your `rulesBtn` is clicked twice, your `isModalShowing` should be `false`.
 
 ```js
 rulesBtn.click();
+assert.isTrue(isModalShowing);
+rulesBtn.click();
 assert.isFalse(isModalShowing);
+resetState();
 ```
 
-When your `rulesBtn` is clicked again, your `rulesContainer` should not be visible.
+When your `rulesBtn` is clicked twice, your `rulesContainer` should not be visible.
 
 ```js
+rulesBtn.click();
+assert.isTrue(rulesContainer.checkVisibility());
+rulesBtn.click();
 assert.isFalse(rulesContainer.checkVisibility());
+resetState();
 ```
 
-When your `rulesBtn` is clicked again, your `rulesBtn` should say `Show Rules`.
+When your `rulesBtn` is clicked twice, your `rulesBtn` should say `Show Rules`.
 
 ```js
+rulesBtn.click();
+assert.strictEqual(rulesBtn.innerText.trim(), "Hide Rules");
+rulesBtn.click();
 assert.strictEqual(rulesBtn.innerText.trim(), "Show Rules");
+resetState();
 ```
 
 # --seed--
+
+## --after-user-code--
+
+```js
+function resetState() {
+  isModalShowing = false;
+  rulesBtn.textContent = 'Show rules';
+  rulesContainer.style.display = 'none';
+}
+```
 
 ## --seed-contents--
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/review-algorithmic-thinking-by-building-a-dice-game/657dfeef78fe0364bd241d7f.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/review-algorithmic-thinking-by-building-a-dice-game/657dfeef78fe0364bd241d7f.md
@@ -83,18 +83,30 @@ for (const element of scoreSpans) {
 You should call your `resetGame` function after displaying the alert in your `keepScoreBtn` listener.
 
 ```js
-const messages = []
+let called = false;
+const oldReset = resetGame;
+resetGame = () => {
+  called = true;
+  oldReset();
+}
+
+const messages = [];
 const oldAlert = alert;
+const oldWindow = window.alert;;
 alert = (msg) => {messages.push(msg)};
-const oldWindow = window.alert;
 window.alert = (msg) => {messages.push(msg)};
 
-rolls = 4;
+rolls = 1;
+round = 6;
 rollDiceBtn.click();
+document.querySelector('#none').click();
+keepScoreBtn.click();
 assert.lengthOf(messages, 0);
-rollDiceBtn.click();
+assert.isFalse(called);
 new Promise(resolve => setTimeout(resolve, 1000)).then(() => {
-  assert.lengthOf(messages, 0);
+  assert.lengthOf(messages, 1);
+  assert.isTrue(called);
+  resetGame = oldReset;
   alert = oldAlert;
   window.alert = oldWindow;
 });

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/review-algorithmic-thinking-by-building-a-dice-game/657dfeef78fe0364bd241d7f.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/review-algorithmic-thinking-by-building-a-dice-game/657dfeef78fe0364bd241d7f.md
@@ -92,7 +92,7 @@ resetGame = () => {
 
 const messages = [];
 const oldAlert = alert;
-const oldWindow = window.alert;;
+const oldWindow = window.alert;
 alert = (msg) => {messages.push(msg)};
 window.alert = (msg) => {messages.push(msg)};
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Closes #55744

- - -
- Step 2: Two tests regarding clicking _again_ were passing with seed code, as technically what they checked had correct values (initial ones). I've changed all tests, to start from fresh state, and in case of multiple clicks, check intermediate values as well - it feels to more accurately verify if code is working as intended.
- Step 12: Fixed always passing test. Part checking, at the same time, if alert was used is just to double confirm `resetGame()` was added in the right place. 