### PR TITLE
fix(client): block intro - go to first lesson button link

### DIFF
--- a/client/src/templates/Introduction/intro.tsx
+++ b/client/src/templates/Introduction/intro.tsx
@@ -64,13 +64,28 @@ IntroductionPage.displayName = 'IntroductionPage';
 export default IntroductionPage;
 
 export const query = graphql`
-  query IntroPageBySlug($slug: String!) {
+  query IntroPageBySlug($slug: String!, $block: String!) {
     markdownRemark(fields: { slug: { eq: $slug } }) {
       frontmatter {
         block
         superBlock
       }
       html
+    }
+    allChallengeNode(
+      sort: { fields: [challenge___challengeOrder] }
+      filter: { challenge: { block: { eq: $block } } }
+      limit: 1
+    ) {
+      edges {
+        node {
+          challenge {
+            fields {
+              slug
+            }
+          }
+        }
+      }
     }
   }
 `;


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

- - -
- Due to accident in manually writing URL, I've found myself on the _block intro_ page. Ie. https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures-v8/review-algorithmic-thinking-by-building-a-dice-game/.
- Fixes issue causing _Go to the first lesson_ to always lead to a strange place, literally.