### PR TITLE
fix(client): conditional rendering of breadcrumb/spacers

### DIFF
--- a/client/src/components/layouts/default.tsx
+++ b/client/src/components/layouts/default.tsx
@@ -261,14 +261,12 @@ function DefaultLayout({
           {isChallenge &&
             !examInProgress &&
             (isRenderBreadcrumb ? (
-              <>
-                <div className='breadcrumbs-demo'>
-                  <BreadCrumb
-                    block={block as string}
-                    superBlock={superBlock as string}
-                  />
-                </div>
-              </>
+              <div className='breadcrumbs-demo'>
+                <BreadCrumb
+                  block={block as string}
+                  superBlock={superBlock as string}
+                />
+              </div>
             ) : isExSmallViewportHeight ? (
               <Spacer size='xxSmall' />
             ) : (

--- a/client/src/components/layouts/default.tsx
+++ b/client/src/components/layouts/default.tsx
@@ -258,18 +258,22 @@ function DefaultLayout({
             />
           ) : null}
           <SignoutModal />
-          {isChallenge && !examInProgress && isRenderBreadcrumb ? (
-            <div className='breadcrumbs-demo'>
-              <BreadCrumb
-                block={block as string}
-                superBlock={superBlock as string}
-              />
-            </div>
-          ) : isExSmallViewportHeight ? (
-            <Spacer size='xxSmall' />
-          ) : (
-            <Spacer size='small' />
-          )}
+          {isChallenge &&
+            !examInProgress &&
+            (isRenderBreadcrumb ? (
+              <>
+                <div className='breadcrumbs-demo'>
+                  <BreadCrumb
+                    block={block as string}
+                    superBlock={superBlock as string}
+                  />
+                </div>
+              </>
+            ) : isExSmallViewportHeight ? (
+              <Spacer size='xxSmall' />
+            ) : (
+              <Spacer size='small' />
+            ))}
           {fetchState.complete && children}
         </div>
         {showFooter && <Footer />}

--- a/client/src/components/layouts/default.tsx
+++ b/client/src/components/layouts/default.tsx
@@ -267,10 +267,8 @@ function DefaultLayout({
                   superBlock={superBlock as string}
                 />
               </div>
-            ) : isExSmallViewportHeight ? (
-              <Spacer size='xxSmall' />
             ) : (
-              <Spacer size='small' />
+              <Spacer size={isExSmallViewportHeight ? 'xxSmall' : 'small'} />
             ))}
           {fetchState.complete && children}
         </div>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #55622

<!-- Feel free to add any additional description of changes below this line -->

As far as I can tell, the spacers are not meant to render on all pages without breadcrumbs. Only in the editor when breadcrumbs are not rendered.
