### PR TITLE
test: check that hotkeys are focused before use

### DIFF
--- a/client/src/templates/Challenges/components/hotkeys.tsx
+++ b/client/src/templates/Challenges/components/hotkeys.tsx
@@ -224,6 +224,7 @@ function Hotkeys({
     <>
       <HotKeys
         id='editor-layout'
+        data-playwright-test-label='hotkeys'
         allowChanges={true}
         handlers={handlers}
         innerRef={containerRef}

--- a/e2e/shortcuts-modal.spec.ts
+++ b/e2e/shortcuts-modal.spec.ts
@@ -28,6 +28,7 @@ const openModal = async (page: Page) => {
   // The editor pane is focused by default, so we need to escape or it will
   // capture the keyboard shortcuts
   await getEditors(page).press('Escape');
+  await expect(page.getByTestId('hotkeys')).toBeFocused();
   await page.keyboard.press('Shift+?');
 };
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This may fix the issue, but if it doesn't it will at least narrow it down.

Ref: https://github.com/freeCodeCamp/freeCodeCamp/actions/runs/10065049024/job/27824549782?pr=55629

<!-- Feel free to add any additional description of changes below this line -->
