### PR TITLE
fix(curriculum): adjust sentences

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/6610c87eac0f0b256d7b037e.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/6610c87eac0f0b256d7b037e.md
@@ -7,9 +7,9 @@ dashedName: step-62
 
 # --description--
 
-Because your function was no longer using the parameter, changing the value passed in the call did not affect it.
+Because your function was no longer using the parameter, changing the argument did not affect it.
 
-Go ahead and remove the `test` declaration from your `padRow` function. Also, remove the `return` statement, so your function is empty again.
+Go ahead and remove the `test` declaration and `return` statement from your `padRow` function, so the function is empty again.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Campers have been taught what an argument is. We should call it what it is, both as reinforcement and to correct the sentence (it read a little odd). I combined the next two sentences as well.