### PR TITLE
refactor: simplify curriculum ordering

### DIFF
--- a/client/src/components/Map/index.tsx
+++ b/client/src/components/Map/index.tsx
@@ -6,14 +6,17 @@ import { createSelector } from 'reselect';
 import {
   type SuperBlocks,
   SuperBlockStage,
-  stageOrder,
+  getStageOrder,
   superBlockStages
 } from '../../../../shared/config/curriculum';
 import { SuperBlockIcon } from '../../assets/icons/superblock-icon';
 import LinkButton from '../../assets/icons/link-button';
 import { Spacer, ButtonLink } from '../helpers';
 import { getSuperBlockTitleForMap } from '../../utils/superblock-map-titles';
-import { showUpcomingChanges } from '../../../config/env.json';
+import {
+  showUpcomingChanges,
+  showNewCurriculum
+} from '../../../config/env.json';
 
 import './map.css';
 
@@ -178,32 +181,28 @@ function Map({
 
   return (
     <div className='map-ui' data-test-label='curriculum-map'>
-      {stageOrder
-        .filter(
-          stage => showUpcomingChanges || stage !== SuperBlockStage.Upcoming
-        )
-        .map(stage => (
-          <>
-            <h2 className={forLanding ? 'big-heading' : ''}>
-              {t(superBlockHeadings[stage])}
-            </h2>
-            <ul key={stage}>
-              {superBlockStages[stage].map((superblock, i) => (
-                <MapLi
-                  key={superblock}
-                  superBlock={superblock}
-                  landing={forLanding}
-                  index={i}
-                  claimed={isClaimed(superblock)}
-                  showProgressionLines={stage === SuperBlockStage.Core}
-                  showNumbers={stage === SuperBlockStage.Core}
-                  completed={allSuperblockChallengesCompleted(superblock)}
-                />
-              ))}
-            </ul>
-            <Spacer size='medium' />
-          </>
-        ))}
+      {getStageOrder({ showNewCurriculum, showUpcomingChanges }).map(stage => (
+        <>
+          <h2 className={forLanding ? 'big-heading' : ''}>
+            {t(superBlockHeadings[stage])}
+          </h2>
+          <ul key={stage}>
+            {superBlockStages[stage].map((superblock, i) => (
+              <MapLi
+                key={superblock}
+                superBlock={superblock}
+                landing={forLanding}
+                index={i}
+                claimed={isClaimed(superblock)}
+                showProgressionLines={stage === SuperBlockStage.Core}
+                showNumbers={stage === SuperBlockStage.Core}
+                completed={allSuperblockChallengesCompleted(superblock)}
+              />
+            ))}
+          </ul>
+          <Spacer size='medium' />
+        </>
+      ))}
     </div>
   );
 }

--- a/client/src/components/Map/index.tsx
+++ b/client/src/components/Map/index.tsx
@@ -4,9 +4,10 @@ import { useTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 import {
-  SuperBlockStages,
-  SuperBlocks,
-  superBlockOrder
+  type SuperBlocks,
+  SuperBlockStage,
+  stageOrder,
+  superBlockStages
 } from '../../../../shared/config/curriculum';
 import { SuperBlockIcon } from '../../assets/icons/superblock-icon';
 import LinkButton from '../../assets/icons/link-button';
@@ -47,6 +48,16 @@ const linkSpacingStyle = {
   justifyContent: 'space-between',
   alignItems: 'center',
   gap: '15px'
+};
+
+const superBlockHeadings: { [key in SuperBlockStage]: string } = {
+  [SuperBlockStage.Core]: 'landing.core-certs-heading',
+  [SuperBlockStage.English]: 'landing.learn-english-heading',
+  [SuperBlockStage.Professional]: 'landing.professional-certs-heading',
+  [SuperBlockStage.Extra]: 'landing.interview-prep-heading',
+  [SuperBlockStage.Legacy]: 'landing.legacy-curriculum-heading',
+  [SuperBlockStage.New]: '', // TODO: add translation
+  [SuperBlockStage.Upcoming]: 'landing.upcoming-heading'
 };
 
 const mapStateToProps = createSelector(
@@ -167,107 +178,32 @@ function Map({
 
   return (
     <div className='map-ui' data-test-label='curriculum-map'>
-      <h2 className={forLanding ? 'big-heading' : ''}>
-        {t('landing.core-certs-heading')}
-      </h2>
-      <ul>
-        {superBlockOrder[SuperBlockStages.Core].map((superBlock, i) => (
-          <MapLi
-            key={i}
-            superBlock={superBlock}
-            landing={forLanding}
-            index={i}
-            claimed={isClaimed(superBlock)}
-            showProgressionLines={true}
-            showNumbers={true}
-            completed={allSuperblockChallengesCompleted(superBlock)}
-          />
+      {stageOrder
+        .filter(
+          stage => showUpcomingChanges || stage !== SuperBlockStage.Upcoming
+        )
+        .map(stage => (
+          <>
+            <h2 className={forLanding ? 'big-heading' : ''}>
+              {t(superBlockHeadings[stage])}
+            </h2>
+            <ul key={stage}>
+              {superBlockStages[stage].map((superblock, i) => (
+                <MapLi
+                  key={superblock}
+                  superBlock={superblock}
+                  landing={forLanding}
+                  index={i}
+                  claimed={isClaimed(superblock)}
+                  showProgressionLines={stage === SuperBlockStage.Core}
+                  showNumbers={stage === SuperBlockStage.Core}
+                  completed={allSuperblockChallengesCompleted(superblock)}
+                />
+              ))}
+            </ul>
+            <Spacer size='medium' />
+          </>
         ))}
-      </ul>
-      <Spacer size='medium' />
-      <h2 className={forLanding ? 'big-heading' : ''}>
-        {t('landing.learn-english-heading')}
-      </h2>
-      <ul>
-        {superBlockOrder[SuperBlockStages.English].map((superBlock, i) => (
-          <MapLi
-            key={i}
-            superBlock={superBlock}
-            landing={forLanding}
-            completed={allSuperblockChallengesCompleted(superBlock)}
-            claimed={isClaimed(superBlock)}
-            index={i}
-          />
-        ))}
-      </ul>
-      <Spacer size='medium' />
-      <h2 className={forLanding ? 'big-heading' : ''}>
-        {t('landing.professional-certs-heading')}
-      </h2>
-      <ul>
-        {superBlockOrder[SuperBlockStages.Professional].map((superBlock, i) => (
-          <MapLi
-            key={i}
-            superBlock={superBlock}
-            landing={forLanding}
-            completed={allSuperblockChallengesCompleted(superBlock)}
-            claimed={isClaimed(superBlock)}
-            index={i}
-          />
-        ))}
-      </ul>
-      <Spacer size='medium' />
-      <h2 className={forLanding ? 'big-heading' : ''}>
-        {t('landing.interview-prep-heading')}
-      </h2>
-      <ul>
-        {superBlockOrder[SuperBlockStages.Extra].map((superBlock, i) => (
-          <MapLi
-            key={i}
-            superBlock={superBlock}
-            landing={forLanding}
-            completed={allSuperblockChallengesCompleted(superBlock)}
-            claimed={isClaimed(superBlock)}
-            index={i}
-          />
-        ))}
-      </ul>
-      <Spacer size='medium' />
-      <h2 className={forLanding ? 'big-heading' : ''}>
-        {t('landing.legacy-curriculum-heading')}
-      </h2>
-      <ul>
-        {superBlockOrder[SuperBlockStages.Legacy].map((superBlock, i) => (
-          <MapLi
-            key={i}
-            superBlock={superBlock}
-            landing={forLanding}
-            completed={allSuperblockChallengesCompleted(superBlock)}
-            claimed={isClaimed(superBlock)}
-            index={i}
-          />
-        ))}
-      </ul>
-      {showUpcomingChanges && (
-        <>
-          <Spacer size='medium' />
-          <h2 className={forLanding ? 'big-heading' : ''}>
-            {t('landing.upcoming-heading')}
-          </h2>
-          <ul>
-            {superBlockOrder[SuperBlockStages.Upcoming].map((superBlock, i) => (
-              <MapLi
-                key={i}
-                superBlock={superBlock}
-                landing={forLanding}
-                completed={allSuperblockChallengesCompleted(superBlock)}
-                index={i}
-                claimed={isClaimed(superBlock)}
-              />
-            ))}
-          </ul>
-        </>
-      )}
     </div>
   );
 }

--- a/client/src/components/Map/index.tsx
+++ b/client/src/components/Map/index.tsx
@@ -49,12 +49,6 @@ const linkSpacingStyle = {
   gap: '15px'
 };
 
-const coreCurriculum = [
-  ...superBlockOrder[SuperBlockStages.FrontEnd],
-  ...superBlockOrder[SuperBlockStages.Backend],
-  ...superBlockOrder[SuperBlockStages.Python]
-];
-
 const mapStateToProps = createSelector(
   isSignedInSelector,
   currentCertsSelector,
@@ -177,7 +171,7 @@ function Map({
         {t('landing.core-certs-heading')}
       </h2>
       <ul>
-        {coreCurriculum.map((superBlock, i) => (
+        {superBlockOrder[SuperBlockStages.Core].map((superBlock, i) => (
           <MapLi
             key={i}
             superBlock={superBlock}

--- a/e2e/map.spec.ts
+++ b/e2e/map.spec.ts
@@ -2,20 +2,18 @@ import { test, expect } from '@playwright/test';
 import translations from '../client/i18n/locales/english/translations.json';
 import intro from '../client/i18n/locales/english/intro.json';
 
-import { SuperBlockStages, superBlockOrder } from '../shared/config/curriculum';
+import { SuperBlockStage, superBlockStages } from '../shared/config/curriculum';
 
 test.beforeEach(async ({ page }) => {
   await page.goto('/learn');
 });
 
 const superBlocksWithLinks = [
-  ...superBlockOrder[SuperBlockStages.FrontEnd],
-  ...superBlockOrder[SuperBlockStages.Backend],
-  ...superBlockOrder[SuperBlockStages.Python],
-  ...superBlockOrder[SuperBlockStages.English],
-  ...superBlockOrder[SuperBlockStages.Professional],
-  ...superBlockOrder[SuperBlockStages.Extra],
-  ...superBlockOrder[SuperBlockStages.Legacy]
+  ...superBlockStages[SuperBlockStage.Core],
+  ...superBlockStages[SuperBlockStage.English],
+  ...superBlockStages[SuperBlockStage.Professional],
+  ...superBlockStages[SuperBlockStage.Extra],
+  ...superBlockStages[SuperBlockStage.Legacy]
 ];
 
 const superBlockTitleOverride: Record<string, string> = {

--- a/shared/config/curriculum.test.ts
+++ b/shared/config/curriculum.test.ts
@@ -4,7 +4,6 @@ import {
   SuperBlockStage,
   superBlockStages,
   notAuditedSuperBlocks,
-  createSuperBlockMap,
   createFlatSuperBlockMap,
   getAuditedSuperBlocks
 } from './curriculum';
@@ -17,30 +16,6 @@ describe('superBlockOrder', () => {
     expect(superBlockOrderValues).toEqual(
       expect.arrayContaining(allSuperBlocks)
     );
-  });
-});
-
-describe('createSuperBlockMap', () => {
-  it('should return an object with New and Upcoming when { showNewCurriculum: true, showUpcomingChanges: true }', () => {
-    const result = createSuperBlockMap({
-      showNewCurriculum: true,
-      showUpcomingChanges: true
-    });
-    expect(result[SuperBlockStage.New]).toHaveLength(
-      superBlockStages[SuperBlockStage.New].length
-    );
-    expect(result[SuperBlockStage.Upcoming]).toHaveLength(
-      superBlockStages[SuperBlockStage.Upcoming].length
-    );
-  });
-
-  it('should return an object without New and Upcoming when { showNewCurriculum: false, showUpcomingChanges: false }', () => {
-    const result = createSuperBlockMap({
-      showNewCurriculum: false,
-      showUpcomingChanges: false
-    });
-    expect(result[SuperBlockStage.New]).toHaveLength(0);
-    expect(result[SuperBlockStage.Upcoming]).toHaveLength(0);
   });
 });
 

--- a/shared/config/curriculum.test.ts
+++ b/shared/config/curriculum.test.ts
@@ -68,7 +68,7 @@ describe('createFlatSuperBlockMap', () => {
 describe('Immutability of superBlockOrder, notAuditedSuperBlocks, and flatSuperBlockMap', () => {
   it('should not allow modification of superBlockOrder', () => {
     expect(() => {
-      superBlockOrder[SuperBlockStages.FrontEnd] = [];
+      superBlockOrder[SuperBlockStages.Core] = [];
     }).toThrowError(TypeError);
   });
 

--- a/shared/config/curriculum.test.ts
+++ b/shared/config/curriculum.test.ts
@@ -1,8 +1,8 @@
 import { Languages } from './i18n';
 import {
   SuperBlocks,
-  SuperBlockStages,
-  superBlockOrder,
+  SuperBlockStage,
+  superBlockStages,
   notAuditedSuperBlocks,
   createSuperBlockMap,
   createFlatSuperBlockMap,
@@ -12,7 +12,7 @@ import {
 describe('superBlockOrder', () => {
   it('should contain all SuperBlocks', () => {
     const allSuperBlocks = Object.values(SuperBlocks);
-    const superBlockOrderValues = Object.values(superBlockOrder).flat();
+    const superBlockOrderValues = Object.values(superBlockStages).flat();
     expect(superBlockOrderValues).toHaveLength(allSuperBlocks.length);
     expect(superBlockOrderValues).toEqual(
       expect.arrayContaining(allSuperBlocks)
@@ -26,11 +26,11 @@ describe('createSuperBlockMap', () => {
       showNewCurriculum: true,
       showUpcomingChanges: true
     });
-    expect(result[SuperBlockStages.New]).toHaveLength(
-      superBlockOrder[SuperBlockStages.New].length
+    expect(result[SuperBlockStage.New]).toHaveLength(
+      superBlockStages[SuperBlockStage.New].length
     );
-    expect(result[SuperBlockStages.Upcoming]).toHaveLength(
-      superBlockOrder[SuperBlockStages.Upcoming].length
+    expect(result[SuperBlockStage.Upcoming]).toHaveLength(
+      superBlockStages[SuperBlockStage.Upcoming].length
     );
   });
 
@@ -39,8 +39,8 @@ describe('createSuperBlockMap', () => {
       showNewCurriculum: false,
       showUpcomingChanges: false
     });
-    expect(result[SuperBlockStages.New]).toHaveLength(0);
-    expect(result[SuperBlockStages.Upcoming]).toHaveLength(0);
+    expect(result[SuperBlockStage.New]).toHaveLength(0);
+    expect(result[SuperBlockStage.Upcoming]).toHaveLength(0);
   });
 });
 
@@ -50,7 +50,7 @@ describe('createFlatSuperBlockMap', () => {
       showNewCurriculum: true,
       showUpcomingChanges: true
     });
-    expect(result).toHaveLength(Object.values(superBlockOrder).flat().length);
+    expect(result).toHaveLength(Object.values(superBlockStages).flat().length);
   });
 
   it('should return an array of SuperBlocks without New and Upcoming when { showNewCurriculum: false, showUpcomingChanges: false }', () => {
@@ -58,9 +58,9 @@ describe('createFlatSuperBlockMap', () => {
       showNewCurriculum: false,
       showUpcomingChanges: false
     });
-    const tempSuperBlockMap = { ...superBlockOrder };
-    tempSuperBlockMap[SuperBlockStages.New] = [];
-    tempSuperBlockMap[SuperBlockStages.Upcoming] = [];
+    const tempSuperBlockMap = { ...superBlockStages };
+    tempSuperBlockMap[SuperBlockStage.New] = [];
+    tempSuperBlockMap[SuperBlockStage.Upcoming] = [];
     expect(result).toHaveLength(Object.values(tempSuperBlockMap).flat().length);
   });
 });
@@ -68,7 +68,7 @@ describe('createFlatSuperBlockMap', () => {
 describe('Immutability of superBlockOrder, notAuditedSuperBlocks, and flatSuperBlockMap', () => {
   it('should not allow modification of superBlockOrder', () => {
     expect(() => {
-      superBlockOrder[SuperBlockStages.Core] = [];
+      superBlockStages[SuperBlockStage.Core] = [];
     }).toThrowError(TypeError);
   });
 

--- a/shared/config/curriculum.ts
+++ b/shared/config/curriculum.ts
@@ -47,23 +47,30 @@ export enum SuperBlockStage {
   Upcoming
 }
 
-// TODO: generate this with new and upcoming missing, depending on the env vars.
-export const stageOrder = [
+const defaultStageOrder = [
   SuperBlockStage.Core,
   SuperBlockStage.English,
   SuperBlockStage.Professional,
   SuperBlockStage.Extra,
-  SuperBlockStage.Legacy,
-  SuperBlockStage.New,
-  SuperBlockStage.Upcoming
+  SuperBlockStage.Legacy
 ];
+
+export function getStageOrder({
+  showNewCurriculum,
+  showUpcomingChanges
+}: Config): SuperBlockStage[] {
+  const stageOrder = [...defaultStageOrder];
+
+  if (showNewCurriculum) stageOrder.push(SuperBlockStage.New);
+  if (showUpcomingChanges) stageOrder.push(SuperBlockStage.Upcoming);
+  return stageOrder;
+}
 
 export type StageMap = {
   [key in SuperBlockStage]: SuperBlocks[];
 };
 
-// groups of superblocks on map, this should include all superblocks
-// new and upcoming superblocks are removed below
+// Groups of superblocks in learn map. This should include all superblocks.
 export const superBlockStages: StageMap = {
   [SuperBlockStage.Core]: [
     SuperBlocks.RespWebDesignNew,
@@ -282,31 +289,10 @@ type LanguagesConfig = Config & {
   language: string;
 };
 
-// removes new and upcoming from superBlockOrder
-// not used yet, will be used when adding progress indicators to map
-export function createSuperBlockMap({
-  showNewCurriculum,
-  showUpcomingChanges
-}: Config): StageMap {
-  const superBlockMap = { ...superBlockStages };
-  if (!showNewCurriculum) {
-    superBlockMap[SuperBlockStage.New] = [];
-  }
-  if (!showUpcomingChanges) {
-    superBlockMap[SuperBlockStage.Upcoming] = [];
-  }
-  return superBlockMap;
-}
-
-export function createFlatSuperBlockMap({
-  showNewCurriculum,
-  showUpcomingChanges
-}: Config): SuperBlocks[] {
-  const superBlockMap = createSuperBlockMap({
-    showNewCurriculum,
-    showUpcomingChanges
-  });
-  return stageOrder.map(stage => superBlockMap[stage]).flat();
+export function createFlatSuperBlockMap(config: Config): SuperBlocks[] {
+  return getStageOrder(config)
+    .map(stage => superBlockStages[stage])
+    .flat();
 }
 
 export function getAuditedSuperBlocks({

--- a/shared/config/curriculum.ts
+++ b/shared/config/curriculum.ts
@@ -38,9 +38,7 @@ export enum SuperBlocks {
  * 'Upcoming' is for development -> not shown on stag or prod anywhere
  */
 export enum SuperBlockStages {
-  FrontEnd,
-  Backend,
-  Python,
+  Core,
   English,
   Professional,
   Extra,
@@ -56,18 +54,14 @@ export type SuperBlockOrder = {
 // order of buttons on map, this should include all superblocks
 // new and upcoming superblocks are removed below
 export const superBlockOrder: SuperBlockOrder = {
-  [SuperBlockStages.FrontEnd]: [
+  [SuperBlockStages.Core]: [
     SuperBlocks.RespWebDesignNew,
     SuperBlocks.JsAlgoDataStructNew,
     SuperBlocks.FrontEndDevLibs,
-    SuperBlocks.DataVis
-  ],
-  [SuperBlockStages.Backend]: [
+    SuperBlocks.DataVis,
     SuperBlocks.RelationalDb,
     SuperBlocks.BackEndDevApis,
-    SuperBlocks.QualityAssurance
-  ],
-  [SuperBlockStages.Python]: [
+    SuperBlocks.QualityAssurance,
     SuperBlocks.SciCompPy,
     SuperBlocks.DataAnalysisPy,
     SuperBlocks.InfoSec,

--- a/shared/config/curriculum.ts
+++ b/shared/config/curriculum.ts
@@ -37,7 +37,7 @@ export enum SuperBlocks {
  * SuperBlockStages.Upcoming = SHOW_UPCOMING_CHANGES === 'true'
  * 'Upcoming' is for development -> not shown on stag or prod anywhere
  */
-export enum SuperBlockStages {
+export enum SuperBlockStage {
   Core,
   English,
   Professional,
@@ -47,14 +47,25 @@ export enum SuperBlockStages {
   Upcoming
 }
 
-export type SuperBlockOrder = {
-  [key in SuperBlockStages]: SuperBlocks[];
+// TODO: generate this with new and upcoming missing, depending on the env vars.
+export const stageOrder = [
+  SuperBlockStage.Core,
+  SuperBlockStage.English,
+  SuperBlockStage.Professional,
+  SuperBlockStage.Extra,
+  SuperBlockStage.Legacy,
+  SuperBlockStage.New,
+  SuperBlockStage.Upcoming
+];
+
+export type StageMap = {
+  [key in SuperBlockStage]: SuperBlocks[];
 };
 
-// order of buttons on map, this should include all superblocks
+// groups of superblocks on map, this should include all superblocks
 // new and upcoming superblocks are removed below
-export const superBlockOrder: SuperBlockOrder = {
-  [SuperBlockStages.Core]: [
+export const superBlockStages: StageMap = {
+  [SuperBlockStage.Core]: [
     SuperBlocks.RespWebDesignNew,
     SuperBlocks.JsAlgoDataStructNew,
     SuperBlocks.FrontEndDevLibs,
@@ -68,28 +79,28 @@ export const superBlockOrder: SuperBlockOrder = {
     SuperBlocks.MachineLearningPy,
     SuperBlocks.CollegeAlgebraPy
   ],
-  [SuperBlockStages.English]: [SuperBlocks.A2English],
-  [SuperBlockStages.Professional]: [SuperBlocks.FoundationalCSharp],
-  [SuperBlockStages.Extra]: [
+  [SuperBlockStage.English]: [SuperBlocks.A2English],
+  [SuperBlockStage.Professional]: [SuperBlocks.FoundationalCSharp],
+  [SuperBlockStage.Extra]: [
     SuperBlocks.TheOdinProject,
     SuperBlocks.CodingInterviewPrep,
     SuperBlocks.ProjectEuler,
     SuperBlocks.RosettaCode
   ],
-  [SuperBlockStages.Legacy]: [
+  [SuperBlockStage.Legacy]: [
     SuperBlocks.RespWebDesign,
     SuperBlocks.JsAlgoDataStruct,
     SuperBlocks.PythonForEverybody
   ],
-  [SuperBlockStages.New]: [],
-  [SuperBlockStages.Upcoming]: [
+  [SuperBlockStage.New]: [],
+  [SuperBlockStage.Upcoming]: [
     SuperBlocks.B1English,
     SuperBlocks.FrontEndDevelopment,
     SuperBlocks.UpcomingPython
   ]
 };
 
-Object.freeze(superBlockOrder);
+Object.freeze(superBlockStages);
 
 type NotAuditedSuperBlocks = {
   [key in Languages]: SuperBlocks[];
@@ -276,13 +287,13 @@ type LanguagesConfig = Config & {
 export function createSuperBlockMap({
   showNewCurriculum,
   showUpcomingChanges
-}: Config): SuperBlockOrder {
-  const superBlockMap = { ...superBlockOrder };
+}: Config): StageMap {
+  const superBlockMap = { ...superBlockStages };
   if (!showNewCurriculum) {
-    superBlockMap[SuperBlockStages.New] = [];
+    superBlockMap[SuperBlockStage.New] = [];
   }
   if (!showUpcomingChanges) {
-    superBlockMap[SuperBlockStages.Upcoming] = [];
+    superBlockMap[SuperBlockStage.Upcoming] = [];
   }
   return superBlockMap;
 }
@@ -291,14 +302,11 @@ export function createFlatSuperBlockMap({
   showNewCurriculum,
   showUpcomingChanges
 }: Config): SuperBlocks[] {
-  const superBlockMap = { ...superBlockOrder };
-  if (!showNewCurriculum) {
-    superBlockMap[SuperBlockStages.New] = [];
-  }
-  if (!showUpcomingChanges) {
-    superBlockMap[SuperBlockStages.Upcoming] = [];
-  }
-  return Object.values(superBlockMap).flat();
+  const superBlockMap = createSuperBlockMap({
+    showNewCurriculum,
+    showUpcomingChanges
+  });
+  return stageOrder.map(stage => superBlockMap[stage]).flat();
 }
 
 export function getAuditedSuperBlocks({


### PR DESCRIPTION
- **refactor: collapse core curriculum**
- **refactor: build learn map with stageOrder**
- **fix: drop New curriculum if not showNewCurriculum**

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

The superblock stages are basically the same, except that the first stage shows progress numbers and lines. That meant that I could simplify the rendering by just mapping over the stages.  Also, making the stage order explicit (an array) rather than implied allowed for a few more simplifications.

For production this is just a refactor, but if `SHOW_NEW_CURRICULUM` is true, then the client will try to render it (even if it's empty). The upshot of this being that you get an extra spacer and an empty heading. However, when we need the new curriculum it should be fine.

<!-- Feel free to add any additional description of changes below this line -->
