### PR TITLE
fix(ui): editable region boundaries not persisting on refresh

### DIFF
--- a/client/src/redux/prop-types.ts
+++ b/client/src/redux/prop-types.ts
@@ -364,6 +364,7 @@ export type SavedChallengeFile = {
   ext: Ext;
   name: string;
   history?: string[];
+  editableRegionBoundaries?: number[];
   contents: string;
 };
 

--- a/client/src/templates/Challenges/classic/saved-challenges.ts
+++ b/client/src/templates/Challenges/classic/saved-challenges.ts
@@ -23,6 +23,8 @@ export function mergeChallengeFiles(
 
   return sortedChallengeFiles.map((file, index) => ({
     ...file,
-    contents: sortedSavedChallengeFiles[index].contents
+    contents: sortedSavedChallengeFiles[index].contents,
+    editableRegionBoundaries:
+      sortedSavedChallengeFiles[index].editableRegionBoundaries
   }));
 }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #55636

<!-- Feel free to add any additional description of changes below this line -->

**Issue**
Despite the challenge files being saved, only their contents (code) were being restored on a reload. This lead to incorrect editable region boundaries since it would fallback to the seed values.

**Fix**
Implemented restoration of editable region boundaries along with the file contents.

**Outcome**
Since we always restore the updated editable region boundaries from local storage, we always have the optimal bounds as per the saved code.

![ScreenRecording2024-07-25at4 15 16PM-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/ec75f531-dc50-4789-827d-fa3dae1bb3b9)

