### PR TITLE
fix: make challenge auditor use new i18n dir

### DIFF
--- a/tools/challenge-auditor/index.ts
+++ b/tools/challenge-auditor/index.ts
@@ -127,6 +127,8 @@ void (async () => {
     const langCurriculumDirectory = join(
       process.cwd(),
       'curriculum',
+      'i18n-curriculum',
+      'curriculum',
       'challenges',
       lang
     );


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

The i18n curriculum is only in the submodule (https://github.com/freeCodeCamp/freeCodeCamp/pull/55645) so auditor has to check those files.

<!-- Feel free to add any additional description of changes below this line -->
