### PR TITLE
Fix(UI): Changed searchbar text color for accessibility

### DIFF
--- a/client/src/components/search/searchBar/searchbar-base.css
+++ b/client/src/components/search/searchBar/searchbar-base.css
@@ -199,7 +199,7 @@ a[class^='ais-'] {
 .ais-SortBy,
 .ais-Stats,
 .ais-ToggleRefinement {
-  color: #3a4570;
+  color: #ffc168;
 }
 .ais-Breadcrumb-item--selected,
 .ais-HierarchicalMenu-item--selected,
@@ -603,16 +603,16 @@ a[class^='ais-'] {
   border-radius: 0px;
 }
 .ais-SearchBox-input::-webkit-input-placeholder {
-  color: var(--gray-15);
+  color: #ffc168;
 }
 .ais-SearchBox-input::-moz-placeholder {
-  color: var(--gray-15);
+  color: #ffc168;
 }
 .ais-SearchBox-input:-ms-input-placeholder {
-  color: var(--gray-15);
+  color: #ffc168;
 }
 .ais-SearchBox-input:-moz-placeholder {
-  color: var(--gray-15);
+  color: #ffc168;
 }
 .ais-SearchBox-submit,
 .ais-SearchBox-reset {
@@ -626,7 +626,7 @@ a[class^='ais-'] {
 }
 .ais-SearchBox-submitIcon path,
 .ais-SearchBox-resetIcon path {
-  fill: var(--gray-15);
+  fill: #ffc168;
 }
 .ais-SearchBox-submitIcon {
   width: 14px;

--- a/client/src/components/search/searchBar/searchbar.css
+++ b/client/src/components/search/searchBar/searchbar.css
@@ -16,7 +16,7 @@
 
 .fcc_searchBar strong,
 .fcc_searchBar a:hover {
-  color: var(--gray-00);
+  color: var(--red-00);
 }
 
 .fcc_search_wrapper {
@@ -81,7 +81,7 @@
 .fcc_searchBar .ais-Hits {
   z-index: 100;
   background-color: var(--gray-75);
-  color: var(--gray-00);
+  color: var(--red-00);
 }
 
 /* hits */

--- a/client/src/components/search/searchBar/searchbar.css
+++ b/client/src/components/search/searchBar/searchbar.css
@@ -16,7 +16,7 @@
 
 .fcc_searchBar strong,
 .fcc_searchBar a:hover {
-  color: var(--red-00);
+  color: var(--gray-00);
 }
 
 .fcc_search_wrapper {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #55711

<!-- Feel free to add any additional description of changes below this line -->

The issue was about readability. I tested on GitPod. I used the same orange I found in other places of the files to stay consistent. I went to other pages rather than just the home page to see if it would still appear orange. Screenshots attached.

![screenshot1](https://github.com/user-attachments/assets/e560ae5a-76cc-4459-b1a4-0122303d30c6)
![screenshot2](https://github.com/user-attachments/assets/8ec96c2d-c96e-46e0-bb5e-e491e4dfe9e8)