### PR TITLE
fix(curriculum): ensure complete removal of myTaskArr and related loc…

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ff24b80431f62ec6b93f65.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64ff24b80431f62ec6b93f65.md
@@ -14,7 +14,31 @@ Remove the `myTaskArr` array and all of the code for `localStorage` because you 
 You should remove `myTaskArr` and all the code related to `localStorage` that you've just learned.
 
 ```js
-assert.notMatch(code, /const\s+myTaskArr\s*=\s*\[\s*\{\s*task:\s('|")Walk\s*the\s*Dog\1\s*,\s*date:\s*('|")22-04-2022\2\s*\}\s*,\s*\{\s*task:\s('|")Read\s*some\s*books\3\s*,\s*date:\s*('|")02-11-2023\4\s*\}\s*,\s*\{\s*task:\s('|")Watch\s*football\5\s*,\s*date:\s*('|")10-08-2021\6\s*\}\s*,\s*\]\s*;?\s*localStorage\.setItem\(('|")data\7\s*,\s*JSON\.stringify\(\s*myTaskArr\s*\)\s*\)\s*;?\s*localStorage\.clear\(\s*\)\s*;?\s*const\s+getTaskArr\s*=\s*localStorage\.getItem\(\s*('|")data\8\s*\)\s*console\.log\(\s*getTaskArr\s*\)\s*const\s+getTaskArrObj\s*=\s*JSON\.parse\(\s*localStorage\.getItem\(\s*('|")data\9\s*\)\s*\)\s*;?\s*console\.log\(\s*getTaskArrObj\s*\)\s*;?/)
+assert.notMatch(code, /const\s+myTaskArr\s*=\s*\[\s*\{\s*task:\s*('|")Walk\s*the\s*Dog\1\s*,\s*date:\s*('|")22-04-2022\2\s*\}\s*,\s*\{\s*task:\s*('|")Read\s*some\s*books\3\s*,\s*date:\s*('|")02-11-2023\4\s*\}\s*,\s*\{\s*task:\s*('|")Watch\s*football\5\s*,\s*date:\s*('|")10-08-2021\6\s*\}\s*\]\s*;?\s*localStorage\.setItem\(('|")data\7\s*,\s*JSON\.stringify\(\s*myTaskArr\s*\)\s*;?\)\s*;?\s*localStorage\.clear\(\s*\)\s*;?\s*const\s+getTaskArr\s*=\s*localStorage\.getItem\(\s*('|")data\8\s*\)\s*console\.log\(\s*getTaskArr\s*\)\s*const\s+getTaskArrObj\s*=\s*JSON\.parse\(\s*localStorage\.getItem\(\s*('|")data\9\s*\)\s*\)\s*;?\s*console\.log\(\s*getTaskArrObj\s*\)\s*;?/);
+```
+
+You should remove any remaining references to `myTaskArr` anywhere in the code.
+
+```js
+assert.notMatch(code, /myTaskArr/);
+```
+
+You should remove any reference to `localStorage.getItem` for the item `"data"`.
+
+```js
+assert.notMatch(code, /localStorage\.getItem\(\s*('|")data\1\s*\)/);
+```
+
+You should remove any reference to `localStorage.clear()` from your code.
+
+```js
+assert.notMatch(code, /localStorage\.clear\(\s*\)\s*;?/);
+```
+
+You should remove any remaining references to `getTaskArrObj` anywhere in the code.
+
+```js
+assert.notMatch(code, /getTaskArrObj/);
 ```
 
 # --seed--


### PR DESCRIPTION
…alStorage items

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #55714 

<!-- Feel free to add any additional description of changes below this line -->

This PR enhances the test cases to ensure that campers completely remove the myTaskArr array and all related localStorage items in their code. Previously, the tests would pass even if only one or two tasks were deleted. With these changes, the tests will require the camper to fully remove all instances of myTaskArr and any associated localStorage items to proceed.

Changes Made:

1. **Regex Pattern Update**: Modified the regex pattern in the assert.notMatch function to comprehensively check the absence of any references to myTaskArr and related localStorage items.
2. **Additional Assertions: Added assertions to ensure**:
   - No declaration or use of myTaskArr exists in the code.
   - No retrieval of localStorage item "data".
   -  No setting of localStorage item "data" with myTaskArr.

