### PR TITLE
fix(client): improve editor performance

### DIFF
--- a/client/src/templates/Challenges/redux/selectors.js
+++ b/client/src/templates/Challenges/redux/selectors.js
@@ -16,8 +16,10 @@ export const challengeFilesSelector = state => state[ns].challengeFiles;
 export const challengeMetaSelector = state => state[ns].challengeMeta;
 export const challengeTestsSelector = state => state[ns].challengeTests;
 export const consoleOutputSelector = state => state[ns].consoleOut;
-export const completedChallengesIdsSelector = state =>
-  completedChallengesSelector(state).map(node => node.id);
+export const completedChallengesIdsSelector = createSelector(
+  completedChallengesSelector,
+  completedChallenges => completedChallenges.map(node => node.id)
+);
 export const isChallengeCompletedSelector = state => {
   const completedChallenges = completedChallengesSelector(state);
   const { id: currentChallengeId } = challengeMetaSelector(state);
@@ -119,17 +121,13 @@ export const currentBlockIdsSelector = createSelector(
   }
 );
 
-export const completedChallengesInBlockSelector = state => {
-  const completedChallengesIds = completedChallengesIdsSelector(state);
-  const currentBlockIds = currentBlockIdsSelector(state);
-  const { id } = challengeMetaSelector(state);
-
-  return getCompletedChallengesInBlock(
-    completedChallengesIds,
-    currentBlockIds,
-    id
-  );
-};
+export const completedChallengesInBlockSelector = createSelector(
+  completedChallengesIdsSelector,
+  currentBlockIdsSelector,
+  challengeMetaSelector,
+  (completedChallengesIds, currentBlockIds, { id }) =>
+    getCompletedChallengesInBlock(completedChallengesIds, currentBlockIds, id)
+);
 
 export const completedPercentageSelector = createSelector(
   isSignedInSelector,


### PR DESCRIPTION
Signed in users experience editor slow-down after completing a large
number (~40) of challenges.

I don't know why completedChallengesInBlockSelector becomes the
bottleneck, but memoizing it solves the immediate problem.

Closes https://github.com/freeCodeCamp/freeCodeCamp/pull/55726

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->
