### PR TITLE
feat(api): add swagger and prisma schema routes

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -19,3 +19,4 @@ shared/utils/get-lines.test.js
 shared/utils/is-audited.js
 shared/utils/validate.js
 shared/utils/validate.test.js
+api/database-schemas/*

--- a/api/.gitignore
+++ b/api/.gitignore
@@ -1,1 +1,2 @@
 dist/
+database-schemas

--- a/api/package.json
+++ b/api/package.json
@@ -48,6 +48,7 @@
     "dotenv-cli": "7.3.0",
     "jest": "29.7.0",
     "prisma": "5.5.2",
+    "prisma-json-schema-generator": "5.1.5",
     "supertest": "6.3.3",
     "ts-jest": "29.1.2"
   },

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -3,6 +3,11 @@ generator client {
   binaryTargets = ["native", "linux-musl-openssl-3.0.x"]
 }
 
+generator jsonSchema {
+  provider = "prisma-json-schema-generator"
+  output   = "../database-schemas"
+}
+
 datasource db {
   provider = "mongodb"
   url      = env("MONGOHQ_URL")

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -49,6 +49,7 @@ import {
   SENTRY_DSN
 } from './utils/env';
 import { isObjectID } from './utils/validation';
+import { documentationRoutes } from './routes/documentation';
 
 export type FastifyInstanceWithTypeProvider = FastifyInstance<
   RawServerDefault,
@@ -152,16 +153,17 @@ export const build = async (
     EMAIL_PROVIDER === 'ses' ? new SESProvider() : new NodemailerProvider();
   void fastify.register(mailer, { provider });
 
+  void fastify.register(documentationRoutes);
   // Swagger plugin
-  if (FCC_ENABLE_SWAGGER_UI) {
-    void fastify.register(fastifySwagger, {
-      openapi: {
-        info: {
-          title: 'freeCodeCamp API',
-          version: '1.0.0' // API version
-        }
+  void fastify.register(fastifySwagger, {
+    openapi: {
+      info: {
+        title: 'freeCodeCamp API',
+        version: '1.0.0' // API version
       }
-    });
+    }
+  });
+  if (FCC_ENABLE_SWAGGER_UI) {
     void fastify.register(fastifySwaggerUI, {
       uiConfig: {
         // Convert csrf_token cookie to csrf-token header

--- a/api/src/routes/documentation.ts
+++ b/api/src/routes/documentation.ts
@@ -1,0 +1,27 @@
+import { FastifyPluginCallbackTypebox } from '@fastify/type-provider-typebox';
+import { FastifyInstance, FastifyReply, FastifySchema } from 'fastify';
+
+import databaseJsonSchema from '../../database-schemas/json-schema.json';
+
+import { UpdateReqType } from '../utils';
+
+// eslint-disable-next-line jsdoc/require-param
+/**
+ * Additional GET routes for documentation about this API.
+ */
+export const documentationRoutes: FastifyPluginCallbackTypebox = (
+  fastify,
+  _options,
+  done
+) => {
+  fastify.get('/documentation/db-schema', getDatabaseSchema);
+  done();
+};
+
+async function getDatabaseSchema(
+  this: FastifyInstance,
+  _req: UpdateReqType<FastifySchema>,
+  reply: FastifyReply
+) {
+  return reply.send(databaseJsonSchema);
+}

--- a/api/src/utils/index.ts
+++ b/api/src/utils/index.ts
@@ -1,4 +1,12 @@
 import { randomBytes, createHash } from 'crypto';
+import { type TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
+import {
+  type FastifyRequest,
+  type FastifySchema,
+  type RawRequestDefaultExpression,
+  type RawServerDefault,
+  type RouteGenericInterface
+} from 'fastify';
 
 /**
  * Utility to encode a buffer to a base64 URI.
@@ -19,3 +27,11 @@ function sha256(buf: Buffer) {
   return createHash('sha256').update(buf).digest();
 }
 export const challenge = base64URLEncode(sha256(Buffer.from(verifier)));
+
+export type UpdateReqType<Schema extends FastifySchema> = FastifyRequest<
+  RouteGenericInterface,
+  RawServerDefault,
+  RawRequestDefaultExpression<RawServerDefault>,
+  Schema,
+  TypeBoxTypeProvider
+>;

--- a/docker/new-api/Dockerfile
+++ b/docker/new-api/Dockerfile
@@ -23,7 +23,7 @@ RUN pnpm config set dedupe-peer-dependents false
 # the right version of prisma.
 RUN pnpm install -F=api -F=curriculum -F tools/scripts/build -F challenge-parser \
   --frozen-lockfile --ignore-scripts
-RUN cd api && npx prisma@$(jq -r '.devDependencies.prisma' < package.json) generate
+RUN cd api && npm i -g prisma-json-schema-generator@$(jq -r '.devDependencies.["prisma-json-schema-generator"]' < package.json) && npx prisma@$(jq -r '.devDependencies.prisma' < package.json) generate
 
 # The api needs to source curriculum.json and build:curriculum relies on the
 # following env vars.

--- a/docker/new-api/Dockerfile
+++ b/docker/new-api/Dockerfile
@@ -49,7 +49,7 @@ RUN npm i -g pnpm@9
 # consistency.
 RUN pnpm config set dedupe-peer-dependents false
 RUN pnpm install --prod --ignore-scripts -F=shared -F=api --frozen-lockfile
-RUN cd api && npx prisma@$(jq -r '.devDependencies.prisma' < package.json) generate
+RUN cd api && npm i -g prisma-json-schema-generator@$(jq -r '.devDependencies.["prisma-json-schema-generator"]' < package.json) && npx prisma@$(jq -r '.devDependencies.prisma' < package.json) generate
 
 FROM node:20-bookworm
 RUN npm i -g pm2@4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -274,6 +274,9 @@ importers:
       prisma:
         specifier: 5.5.2
         version: 5.5.2
+      prisma-json-schema-generator:
+        specifier: 5.1.5
+        version: 5.1.5
       supertest:
         specifier: 6.3.3
         version: 6.3.3
@@ -3482,11 +3485,35 @@ packages:
       prisma:
         optional: true
 
+  '@prisma/debug@5.8.1':
+    resolution: {integrity: sha512-tjuw7eA0Us3T42jx9AmAgL58rzwzpFGYc3R7Y4Ip75EBYrKMBA1YihuWMcBC92ILmjlQ/u3p8VxcIE0hr+fZfg==}
+
   '@prisma/engines-version@5.5.1-1.aebc046ce8b88ebbcb45efe31cbe7d06fd6abc0a':
     resolution: {integrity: sha512-O+qHFnZvAyOFk1tUco2/VdiqS0ym42a3+6CYLScllmnpbyiTplgyLt2rK/B9BTjYkSHjrgMhkG47S0oqzdIckA==}
 
+  '@prisma/engines-version@5.8.1-1.78caf6feeaed953168c64e15a249c3e9a033ebe2':
+    resolution: {integrity: sha512-f5C3JM3l9yhGr3cr4FMqWloFaSCpNpMi58Om22rjD2DOz3owci2mFdFXMgnAGazFPKrCbbEhcxdsRfspEYRoFQ==}
+
   '@prisma/engines@5.5.2':
     resolution: {integrity: sha512-Be5hoNF8k+lkB3uEMiCHbhbfF6aj1GnrTBnn5iYFT7GEr3TsOEp1soviEcBR0tYCgHbxjcIxJMhdbvxALJhAqg==}
+
+  '@prisma/engines@5.8.1':
+    resolution: {integrity: sha512-TJgYLRrZr56uhqcXO4GmP5be+zjCIHtLDK20Cnfg+o9d905hsN065QOL+3Z0zQAy6YD31Ol4u2kzSfRmbJv/uA==}
+
+  '@prisma/fetch-engine@5.8.1':
+    resolution: {integrity: sha512-+bgjjoSFa6uYEbAPlklfoVSStOEfcpheOjoBoNsNNSQdSzcwE2nM4Q0prun0+P8/0sCHo18JZ9xqa8gObvgOUw==}
+
+  '@prisma/generator-helper@5.8.1':
+    resolution: {integrity: sha512-2EDd0o+GHfbX1dtw5BnfOz3hQB7AtYrwe4YNiKfo2UDBvB/ne/ChZa3b/vBm/GKpjW2Xaymct8D9oIHev3juzQ==}
+
+  '@prisma/get-platform@5.8.1':
+    resolution: {integrity: sha512-wnA+6HTFcY+tkykMokix9GiAkaauPC5W/gg0O5JB0J8tCTNWrqpnQ7AsaGRfkYUbeOIioh6woDjQrGTTRf1Zag==}
+
+  '@prisma/internals@5.8.1':
+    resolution: {integrity: sha512-9okoCgLeMqql58IbEG3YmzgNLRUQdN+qZUYp2DojWC7VAmL9TSOKQ5Dcc0588cKAsCBBDUQ2jfdflorYkzeFKw==}
+
+  '@prisma/prisma-schema-wasm@5.8.1-1.78caf6feeaed953168c64e15a249c3e9a033ebe2':
+    resolution: {integrity: sha512-UAJANliORe2V/s7yDMx5EKOCj2PIbwX7yusKckxMBDb+ozaQF31c3CBwnZW/ZEdhBoZjrKw8bQlqwZudWXmiKA==}
 
   '@puppeteer/browsers@2.2.3':
     resolution: {integrity: sha512-bJ0UBsk0ESOs6RFcLXOt99a3yTDcOKlzfjad+rhFwdaG1Lu/Wzq58GHYCDTlZ9z6mldf4g+NTb+TXEfe0PpnsQ==}
@@ -11283,6 +11310,10 @@ packages:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  prisma-json-schema-generator@5.1.5:
+    resolution: {integrity: sha512-OHyPkwgIhMf+z8fToj8D4xMX55RVok5ugDa7J2VdMukcNIaAewWhe3k7Jv2YflJZE+6cB6LMWfkub+OGcFG+wA==}
+    hasBin: true
+
   prisma@5.5.2:
     resolution: {integrity: sha512-WQtG6fevOL053yoPl6dbHV+IWgKo25IRN4/pwAGqcWmg7CrtoCzvbDbN9fXUc7QS2KK0LimHIqLsaCOX/vHl8w==}
     engines: {node: '>=16.13'}
@@ -17804,9 +17835,47 @@ snapshots:
     optionalDependencies:
       prisma: 5.5.2
 
+  '@prisma/debug@5.8.1': {}
+
   '@prisma/engines-version@5.5.1-1.aebc046ce8b88ebbcb45efe31cbe7d06fd6abc0a': {}
 
+  '@prisma/engines-version@5.8.1-1.78caf6feeaed953168c64e15a249c3e9a033ebe2': {}
+
   '@prisma/engines@5.5.2': {}
+
+  '@prisma/engines@5.8.1':
+    dependencies:
+      '@prisma/debug': 5.8.1
+      '@prisma/engines-version': 5.8.1-1.78caf6feeaed953168c64e15a249c3e9a033ebe2
+      '@prisma/fetch-engine': 5.8.1
+      '@prisma/get-platform': 5.8.1
+
+  '@prisma/fetch-engine@5.8.1':
+    dependencies:
+      '@prisma/debug': 5.8.1
+      '@prisma/engines-version': 5.8.1-1.78caf6feeaed953168c64e15a249c3e9a033ebe2
+      '@prisma/get-platform': 5.8.1
+
+  '@prisma/generator-helper@5.8.1':
+    dependencies:
+      '@prisma/debug': 5.8.1
+
+  '@prisma/get-platform@5.8.1':
+    dependencies:
+      '@prisma/debug': 5.8.1
+
+  '@prisma/internals@5.8.1':
+    dependencies:
+      '@prisma/debug': 5.8.1
+      '@prisma/engines': 5.8.1
+      '@prisma/fetch-engine': 5.8.1
+      '@prisma/generator-helper': 5.8.1
+      '@prisma/get-platform': 5.8.1
+      '@prisma/prisma-schema-wasm': 5.8.1-1.78caf6feeaed953168c64e15a249c3e9a033ebe2
+      arg: 5.0.2
+      prompts: 2.4.2
+
+  '@prisma/prisma-schema-wasm@5.8.1-1.78caf6feeaed953168c64e15a249c3e9a033ebe2': {}
 
   '@puppeteer/browsers@2.2.3':
     dependencies:
@@ -28400,6 +28469,11 @@ snapshots:
       '@jest/schemas': 29.6.3
       ansi-styles: 5.2.0
       react-is: 18.2.0
+
+  prisma-json-schema-generator@5.1.5:
+    dependencies:
+      '@prisma/generator-helper': 5.8.1
+      '@prisma/internals': 5.8.1
 
   prisma@5.5.2:
     dependencies:


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

- Enables Swagger's schema routes in production (not the UI)
- Adds `prisma-json-schema-generator` to generate json schema from prisma (recommended by prisma)
- Adds a `/documentation/db-schema` route to serve said schema

Running `prisma generate` generates the schema at `api/database-schemas/json-schema.json` - name is NOT configurable.

Motivation for this:
1) Clients will definitely want the route typings
2) Some clients want whole and partial definitions from the database - it would be nice to make them available to make the `schema.prisma` the source of truth

This should be fairly innocuous.