### PR TITLE
fix(curriculum): wording in Building a Spreadsheet step 55

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-functional-programming-by-building-a-spreadsheet/646d3141790b3cb337dd611a.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-functional-programming-by-building-a-spreadsheet/646d3141790b3cb337dd611a.md
@@ -7,7 +7,7 @@ dashedName: step-55
 
 # --description--
 
-The callback function then has a parameter for each capture group in the regular expression. In your case, `rangeRegex` has four capture groups: the first letter, the first numbers, the second letter, and the second numbers.
+The callback function should have a parameter for each capture group in the regular expression. In your case, `rangeRegex` has four capture groups: the first letter, the first numbers, the second letter, and the second numbers.
 
 Give your callback function four more parameters to match those capture groups: `char1`, `num1`, `char2`, and `num2`. `char` will be short for `character`.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #55718 
<!-- Feel free to add any additional description of changes below this line -->
Updated Step 55 - Confusing wording as suggested by ([hbar1st](https://github.com/hbar1st)).
Thanks!
