### PR TITLE
fix(curriculum): add location of if statement to requirement and hint

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/6610bf6fa14d700beed1b109.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/6610bf6fa14d700beed1b109.md
@@ -9,11 +9,11 @@ dashedName: step-87
 
 The <dfn>equality</dfn> operator `==` is used to check if two values are equal. To compare two values, you'd use a statement like `value == 8`.
 
-Add an `if` statement to your loop. The statement should check if `done` is equal to `count` using the equality operator.
+Below `done++` inside your loop, add an `if` statement. The statement should check if `done` is equal to `count` using the equality operator.
 
 # --hints--
 
-You should use an `if` statement in your loop.
+You should use an `if` statement in your loop. It should be added after `done++`.
 
 ```js
 assert.match(__helpers.removeJSComments(code), /while\s*\(\s*continueLoop\s*\)\s*\{\s*done\+\+;\s*if/);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


The location of the if statement should be in the requirements and hints. Right now, we assert it doesn't exist if it is in the wrong location.


Forum: https://forum.freecodecamp.org/t/building-a-pyramid-generator-step-87/704684
