### PR TITLE
fix(client): parse learner code with DOMParser

### DIFF
--- a/client/src/templates/Challenges/rechallenge/transformers.js
+++ b/client/src/templates/Challenges/rechallenge/transformers.js
@@ -245,12 +245,7 @@ const parseAndTransform = async function (transform, contents) {
   const parser = new DOMParser();
   const newDoc = parser.parseFromString(contents, 'text/html');
 
-  try {
-    return await transform(newDoc.documentElement, newDoc);
-  } catch (e) {
-    console.error(e);
-    return contents;
-  }
+  return await transform(newDoc.documentElement, newDoc);
 };
 
 const transformHtml = async function (file) {

--- a/client/src/templates/Challenges/rechallenge/transformers.js
+++ b/client/src/templates/Challenges/rechallenge/transformers.js
@@ -219,7 +219,7 @@ export const embedFilesInHtml = async function (challengeFiles) {
   };
 
   if (indexHtml) {
-    const { contents } = await transformWithFrame(
+    const { contents } = await parseAndTransform(
       embedStylesAndScript,
       indexHtml.contents
     );
@@ -243,30 +243,17 @@ function challengeFilesToObject(challengeFiles) {
   return { indexHtml, indexJsx, stylesCss, scriptJs };
 }
 
-const transformWithFrame = async function (transform, contents) {
-  // we use iframe here since file.contents is destined to be be inserted into
-  // the root of an iframe.
-  const frame = document.createElement('iframe');
-  frame.style = 'display: none';
+const parseAndTransform = async function (transform, contents) {
+  // store the original contents the transform fails
   let out = { contents };
+
+  const parser = new DOMParser();
+  const newDoc = parser.parseFromString(contents, 'text/html');
+
   try {
-    // the frame needs to be inserted into the document to create the html
-    // element
-    document.body.appendChild(frame);
-    // replace the root element with user code
-    frame.contentDocument.documentElement.innerHTML = contents;
-    // grab the contents now, in case the transformation fails
-    out = { contents: frame.contentDocument.documentElement.innerHTML };
-    // it's important to pass around the documentElement and NOT the frame
-    // itself. It appears that the frame's documentElement can get replaced by a
-    // blank documentElement without the contents. This seems only to happen on
-    // Firefox.
-    out = await transform(
-      frame.contentDocument.documentElement,
-      frame.contentDocument
-    );
-  } finally {
-    document.body.removeChild(frame);
+    out = await transform(newDoc.documentElement, newDoc);
+  } catch (e) {
+    console.error(e);
   }
   return out;
 };
@@ -280,7 +267,7 @@ const transformHtml = async function (file) {
     return { contents: documentElement.innerHTML };
   };
 
-  const { contents } = await transformWithFrame(transform, file.contents);
+  const { contents } = await parseAndTransform(transform, file.contents);
   return transformContents(() => contents, file);
 };
 

--- a/client/src/templates/Challenges/rechallenge/transformers.js
+++ b/client/src/templates/Challenges/rechallenge/transformers.js
@@ -213,13 +213,11 @@ export const embedFilesInHtml = async function (challengeFiles) {
       script.removeAttribute('src');
       script.setAttribute('data-src', 'script.js');
     }
-    return {
-      contents: documentElement.innerHTML
-    };
+    return documentElement.innerHTML;
   };
 
   if (indexHtml) {
-    const { contents } = await parseAndTransform(
+    const contents = await parseAndTransform(
       embedStylesAndScript,
       indexHtml.contents
     );
@@ -244,18 +242,15 @@ function challengeFilesToObject(challengeFiles) {
 }
 
 const parseAndTransform = async function (transform, contents) {
-  // store the original contents the transform fails
-  let out = { contents };
-
   const parser = new DOMParser();
   const newDoc = parser.parseFromString(contents, 'text/html');
 
   try {
-    out = await transform(newDoc.documentElement, newDoc);
+    return await transform(newDoc.documentElement, newDoc);
   } catch (e) {
     console.error(e);
+    return contents;
   }
-  return out;
 };
 
 const transformHtml = async function (file) {
@@ -264,10 +259,10 @@ const transformHtml = async function (file) {
       transformSASS(documentElement),
       transformScript(documentElement)
     ]);
-    return { contents: documentElement.innerHTML };
+    return documentElement.innerHTML;
   };
 
-  const { contents } = await parseAndTransform(transform, file.contents);
+  const contents = await parseAndTransform(transform, file.contents);
   return transformContents(() => contents, file);
 };
 

--- a/curriculum/test/test-challenges.js
+++ b/curriculum/test/test-challenges.js
@@ -77,6 +77,7 @@ const handleRejection = err => {
 
 const dom = new jsdom.JSDOM('');
 global.document = dom.window.document;
+global.DOMParser = dom.window.DOMParser;
 
 const oldRunnerFail = Mocha.Runner.prototype.fail;
 Mocha.Runner.prototype.fail = function (test, err) {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

DOMParser lets us parse the learner code into a DOM document without a complicated process of generating invisible iframes. This is both more direct and means that `link` elements are no longer processed while we transform the learner's code.

<!-- Feel free to add any additional description of changes below this line -->
