### PR TITLE
feat: cache manifest for one day

### DIFF
--- a/client/serve/serve.json
+++ b/client/serve/serve.json
@@ -36,6 +36,15 @@
           "value": "public, max-age=14400, stale-while-revalidate=172800, must-revalidate"
         }
       ]
+    },
+    {
+      "source": "manifest.webmanifest",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=86400, stale-while-revalidate=86400, must-revalidate"
+        }
+      ]
     }
   ],
   "trailingSlash": false,


### PR DESCRIPTION
I think that's long enough to keep the number of requests acceptably low
If we forget to change this before updating the manifest, it's also not
too long a period to have, say, broken icons.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->
