### PR TITLE
refactor(client): render lower jaw via React portal

### DIFF
--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -127,7 +127,6 @@ interface EditorProperties {
   outputZoneTop: number;
   outputZoneId: string;
   descriptionNode?: HTMLDivElement;
-  outputNode?: HTMLDivElement;
   descriptionWidget?: editor.IContentWidget;
   outputWidget?: editor.IOverlayWidget;
 }
@@ -799,14 +798,13 @@ const Editor = (props: EditorProps): JSX.Element => {
   }
 
   function createOutputNode(editor: editor.IStandaloneCodeEditor) {
-    if (dataRef.current.outputNode) return dataRef.current.outputNode;
+    if (lowerJawContainer) return lowerJawContainer;
     const outputNode = document.createElement('div');
     outputNode.classList.add('editor-lower-jaw');
     outputNode.setAttribute('id', 'editor-lower-jaw');
     outputNode.style.left = `${editor.getLayoutInfo().contentLeft}px`;
     outputNode.style.width = `${getEditorContentWidth(editor)}px`;
     outputNode.style.top = getOutputZoneTop();
-    dataRef.current.outputNode = outputNode;
     setLowerJawContainer(outputNode);
     return outputNode;
   }
@@ -1231,7 +1229,6 @@ const Editor = (props: EditorProps): JSX.Element => {
 
   useEffect(() => {
     const { model, insideEditDecId } = dataRef.current;
-    const lowerJawElement = dataRef.current.outputNode;
     const isChallengeComplete = challengeIsComplete();
     const range = model?.getDecorationRange(insideEditDecId);
     if (range && isChallengeComplete) {
@@ -1243,7 +1240,6 @@ const Editor = (props: EditorProps): JSX.Element => {
         }
       );
     }
-    dataRef.current.outputNode = lowerJawElement;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.tests]);
 

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -717,12 +717,12 @@ const Editor = (props: EditorProps): JSX.Element => {
   // TODO: there's a potential performance gain to be had by only updating when
   // the outputViewZone has actually changed.
   const updateOutputViewZone = (
-    outputNode: HTMLDivElement,
+    lowerJawContainer: HTMLDivElement,
     editor?: editor.IStandaloneCodeEditor
   ) => {
     if (!editor) return;
     // make sure the overlayWidget has resized before using it to set the height
-    outputNode.style.width = `${getEditorContentWidth(editor)}px`;
+    lowerJawContainer.style.width = `${getEditorContentWidth(editor)}px`;
     // We have to wait for the viewZone to finish rendering before adjusting the
     // position of the overlayWidget (i.e. trigger it via onComputedHeight). If
     // not the editor may report the wrong value for position of the lines.
@@ -730,7 +730,7 @@ const Editor = (props: EditorProps): JSX.Element => {
       changeAccessor.removeZone(dataRef.current.outputZoneId);
       const viewZone = {
         afterLineNumber: getLastLineOfEditableRegion(),
-        heightInPx: outputNode.offsetHeight,
+        heightInPx: lowerJawContainer.offsetHeight,
         domNode: document.createElement('div'),
         onComputedHeight: () =>
           dataRef.current.outputWidget &&
@@ -797,16 +797,16 @@ const Editor = (props: EditorProps): JSX.Element => {
     return editor.getLayoutInfo().contentWidth - getScrollbarWidth();
   }
 
-  function createOutputNode(editor: editor.IStandaloneCodeEditor) {
+  function createLowerJawContainer(editor: editor.IStandaloneCodeEditor) {
     if (lowerJawContainer) return lowerJawContainer;
-    const outputNode = document.createElement('div');
-    outputNode.classList.add('editor-lower-jaw');
-    outputNode.setAttribute('id', 'editor-lower-jaw');
-    outputNode.style.left = `${editor.getLayoutInfo().contentLeft}px`;
-    outputNode.style.width = `${getEditorContentWidth(editor)}px`;
-    outputNode.style.top = getOutputZoneTop();
-    setLowerJawContainer(outputNode);
-    return outputNode;
+    const container = document.createElement('div');
+    container.classList.add('editor-lower-jaw');
+    container.setAttribute('id', 'editor-lower-jaw');
+    container.style.left = `${editor.getLayoutInfo().contentLeft}px`;
+    container.style.width = `${getEditorContentWidth(editor)}px`;
+    container.style.top = getOutputZoneTop();
+    setLowerJawContainer(container);
+    return container;
   }
 
   function createScrollGutterNode(
@@ -1067,7 +1067,7 @@ const Editor = (props: EditorProps): JSX.Element => {
   function addWidgetsToRegions(editor: editor.IStandaloneCodeEditor) {
     const descriptionNode = createDescription(editor);
 
-    const outputNode = createOutputNode(editor);
+    const lowerJawNode = createLowerJawContainer(editor);
 
     if (!dataRef.current.descriptionWidget) {
       dataRef.current.descriptionWidget = createWidget(
@@ -1093,7 +1093,7 @@ const Editor = (props: EditorProps): JSX.Element => {
       dataRef.current.outputWidget = createWidget(
         editor,
         'output.widget',
-        outputNode,
+        lowerJawNode,
         getOutputZoneTop
       );
       editor.addOverlayWidget(dataRef.current.outputWidget);

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -11,7 +11,7 @@ import { OS } from 'monaco-editor/esm/vs/base/common/platform.js';
 import Prism from 'prismjs';
 import React, { useEffect, Suspense, MutableRefObject, useRef } from 'react';
 import { createPortal } from 'react-dom';
-import { Provider, connect, useStore } from 'react-redux';
+import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 import store from 'store';
 
@@ -242,7 +242,6 @@ const initialData: EditorProperties = {
 };
 
 const Editor = (props: EditorProps): JSX.Element => {
-  const reduxStore = useStore();
   const { t } = useTranslation();
   const { editorRef, initTests, resetAttempts, isMobileLayout } = props;
   // These refs are used during initialisation of the editor as well as by
@@ -1291,22 +1290,20 @@ const Editor = (props: EditorProps): JSX.Element => {
       </span>
       {lowerJawContainer !== null &&
         createPortal(
-          <Provider store={reduxStore}>
-            <LowerJaw
-              openHelpModal={props.openHelpModal}
-              openResetModal={props.openResetModal}
-              tryToExecuteChallenge={tryToExecuteChallenge}
-              hint={props.output[1]}
-              testsLength={props.tests.length}
-              attempts={attemptsRef.current}
-              challengeIsCompleted={challengeIsComplete()}
-              tryToSubmitChallenge={tryToSubmitChallenge}
-              isSignedIn={props.isSignedIn}
-              updateContainer={() =>
-                updateOutputViewZone(lowerJawContainer, dataRef.current.editor)
-              }
-            />
-          </Provider>,
+          <LowerJaw
+            openHelpModal={props.openHelpModal}
+            openResetModal={props.openResetModal}
+            tryToExecuteChallenge={tryToExecuteChallenge}
+            hint={props.output[1]}
+            testsLength={props.tests.length}
+            attempts={attemptsRef.current}
+            challengeIsCompleted={challengeIsComplete()}
+            tryToSubmitChallenge={tryToSubmitChallenge}
+            isSignedIn={props.isSignedIn}
+            updateContainer={() =>
+              updateOutputViewZone(lowerJawContainer, dataRef.current.editor)
+            }
+          />,
           lowerJawContainer
         )}
     </Suspense>

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -719,14 +719,15 @@ const Editor = (props: EditorProps): JSX.Element => {
   // the outputViewZone has actually changed.
   const updateOutputViewZone = (
     outputNode: HTMLDivElement,
-    editor: editor.IStandaloneCodeEditor
+    editor?: editor.IStandaloneCodeEditor
   ) => {
+    if (!editor) return;
     // make sure the overlayWidget has resized before using it to set the height
     outputNode.style.width = `${getEditorContentWidth(editor)}px`;
     // We have to wait for the viewZone to finish rendering before adjusting the
     // position of the overlayWidget (i.e. trigger it via onComputedHeight). If
     // not the editor may report the wrong value for position of the lines.
-    editor?.changeViewZones(changeAccessor => {
+    editor.changeViewZones(changeAccessor => {
       changeAccessor.removeZone(dataRef.current.outputZoneId);
       const viewZone = {
         afterLineNumber: getLastLineOfEditableRegion(),
@@ -1281,8 +1282,6 @@ const Editor = (props: EditorProps): JSX.Element => {
         ? 'vs-custom'
         : editorSystemTheme;
 
-  const editor = dataRef.current.editor!;
-
   return (
     <Suspense fallback={<Loader loaderDelay={600} />}>
       <span className='notranslate'>
@@ -1308,7 +1307,7 @@ const Editor = (props: EditorProps): JSX.Element => {
               tryToSubmitChallenge={tryToSubmitChallenge}
               isSignedIn={props.isSignedIn}
               updateContainer={() =>
-                updateOutputViewZone(lowerJawContainer, editor)
+                updateOutputViewZone(lowerJawContainer, dataRef.current.editor)
               }
             />
           </Provider>,


### PR DESCRIPTION
- **refactor: put lowerjaw in editor with createPortal**
- **refactor: allow for editor being nullish**
- **refactor: remove outputNode ref in favour of state**
- **refactor: rename outputNode**

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

While `ReactDOM.render` mostly works, it's a bit of a hack and it does not work with Gatsby's `useStaticQuery` hook. `createPortal`, in contrast, was created for exactly this scenario and works fine with `useStaticQuery`.

<!-- Feel free to add any additional description of changes below this line -->
