### PR TITLE
refactor(client): move punctuation mark to translation string

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -408,7 +408,7 @@
     "rsa-forum": "<strong>Before making a new post</strong> please <0>check if your question has already been answered on the forum</0>.",
     "reset": "Reset this lesson?",
     "reset-warn": "Are you sure you wish to reset this lesson? The editors and tests will be reset.",
-    "reset-warn-2": "This cannot be undone",
+    "reset-warn-2": "This cannot be undone.",
     "scrimba-tip": "Tip: If the mini-browser is covering the code, click and drag to move it. Also, feel free to stop and edit the code in the video at any time.",
     "chal-preview": "Challenge Preview",
     "donation-record-not-found": "Your donation record has not been found.",

--- a/client/src/templates/Challenges/components/reset-modal.tsx
+++ b/client/src/templates/Challenges/components/reset-modal.tsx
@@ -45,13 +45,11 @@ function ResetModal({ reset, close, isOpen }: ResetModalProps): JSX.Element {
       <Modal.Header showCloseButton={true} closeButtonClassNames='close'>
         {t('learn.reset')}
       </Modal.Header>
-      <Modal.Body>
-        <div className='text-center'>
-          <p>{t('learn.reset-warn')}</p>
-          <p>
-            <em>{t('learn.reset-warn-2')}</em>.
-          </p>
-        </div>
+      <Modal.Body alignment='center'>
+        <p>{t('learn.reset-warn')}</p>
+        <p>
+          <em>{t('learn.reset-warn-2')}</em>
+        </p>
       </Modal.Body>
       <Modal.Footer>
         <Button


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Moves the stray period in the `ResetModal` component to its translation string (I almost deleted the period by accident).

<!-- Feel free to add any additional description of changes below this line -->
