### PR TITLE
feat(api): redirect auth requests if already signed in

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -225,7 +225,8 @@ export const build = async (
   // Routes for signed out users:
   void fastify.register(async function (fastify) {
     fastify.addHook('onRequest', fastify.authorize);
-    fastify.addHook('onRequest', fastify.redirectIfSignedIn);
+    // TODO(Post-MVP): add the redirectIfSignedIn hook here, rather than in the
+    // mobileAuth0Routes and authRoutes plugins.
     await fastify.register(mobileAuth0Routes);
     // TODO: consolidate with LOCAL_MOCK_AUTH
     if (FCC_ENABLE_DEV_LOGIN_MODE) {

--- a/api/src/plugins/auth0.test.ts
+++ b/api/src/plugins/auth0.test.ts
@@ -8,6 +8,7 @@ import cookies, { sign, unsign } from './cookies';
 import { auth0Client } from './auth0';
 import redirectWithMessage, { formatMessage } from './redirect-with-message';
 import auth from './auth';
+import bouncer from './bouncer';
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-return
 jest.mock('../utils/env', () => ({
@@ -24,6 +25,7 @@ describe('auth0 plugin', () => {
     await fastify.register(cookies);
     await fastify.register(redirectWithMessage);
     await fastify.register(auth);
+    await fastify.register(bouncer);
     await fastify.register(auth0Client);
     await fastify.register(prismaPlugin);
   });

--- a/api/src/plugins/auth0.ts
+++ b/api/src/plugins/auth0.ts
@@ -158,5 +158,7 @@ export const auth0Client: FastifyPluginCallbackTypebox = fp(
 
     done();
   },
-  { dependencies: ['redirect-with-message'] }
+  // TODO(Post-MVP): remove bouncer dependency when moving redirectIfSignedIn
+  // out of this plugin.
+  { dependencies: ['redirect-with-message', 'bouncer'] }
 );

--- a/api/src/plugins/auth0.ts
+++ b/api/src/plugins/auth0.ts
@@ -53,21 +53,28 @@ export const auth0Client: FastifyPluginCallbackTypebox = fp(
       }
     });
 
-    fastify.get('/signin', async function (request, reply) {
-      const returnTo = request.headers.referer ?? `${HOME_LOCATION}/learn`;
-      void reply.setCookie('login-returnto', returnTo, {
-        domain: COOKIE_DOMAIN,
-        httpOnly: true,
-        secure: true,
-        signed: true,
-        sameSite: 'lax'
-      });
+    void fastify.register(function (fastify, _options, done) {
+      // TODO(Post-MVP): move this into the app, so that we add this hook once for
+      // all auth routes.
+      fastify.addHook('onRequest', fastify.redirectIfSignedIn);
 
-      const redirectUrl = await this.auth0OAuth.generateAuthorizationUri(
-        request,
-        reply
-      );
-      void reply.redirect(redirectUrl);
+      fastify.get('/signin', async function (request, reply) {
+        const returnTo = request.headers.referer ?? `${HOME_LOCATION}/learn`;
+        void reply.setCookie('login-returnto', returnTo, {
+          domain: COOKIE_DOMAIN,
+          httpOnly: true,
+          secure: true,
+          signed: true,
+          sameSite: 'lax'
+        });
+
+        const redirectUrl = await this.auth0OAuth.generateAuthorizationUri(
+          request,
+          reply
+        );
+        void reply.redirect(redirectUrl);
+      });
+      done();
     });
 
     // TODO: use a schema to validate the query params.

--- a/api/src/plugins/bouncer.test.ts
+++ b/api/src/plugins/bouncer.test.ts
@@ -40,7 +40,7 @@ describe('bouncer', () => {
       fastify.addHook('onRequest', fastify.send401IfNoUser);
     });
 
-    it('should return 401 if no user is present', async () => {
+    it('should return 401 if NO user is present', async () => {
       const message = {
         type: 'danger',
         content: 'Something undesirable occurred'
@@ -83,7 +83,10 @@ describe('bouncer', () => {
     });
     const redirectLocation = `${HOME_LOCATION}?${formatMessage({ type: 'info', content: 'Only authenticated users can access this route. Please sign in and try again.' })}`;
 
-    it('should redirect to HOME_LOCATION if no user is present', async () => {
+    // TODO(Post-MVP): make the redirects consistent between redirectIfNoUser
+    // and redirectIfSignedIn. Either both should redirect to the referer or
+    // both should redirect to HOME_LOCATION.
+    it('should redirect to HOME_LOCATION if NO user is present', async () => {
       const message = {
         type: 'danger',
         content: 'At the moment, content is ignored'
@@ -107,6 +110,49 @@ describe('bouncer', () => {
         done();
       });
 
+      const res = await fastify.inject({
+        method: 'GET',
+        url: '/'
+      });
+
+      expect(res.json()).toEqual({ foo: 'bar' });
+      expect(res.statusCode).toEqual(200);
+    });
+  });
+
+  describe('redirectIfSignedIn', () => {
+    beforeEach(() => {
+      fastify.addHook('onRequest', fastify.redirectIfSignedIn);
+    });
+
+    it('should redirect to the referer if a user is present', async () => {
+      authorizeSpy.mockImplementationOnce((req, _reply, done) => {
+        req.user = { id: '123' };
+        done();
+      });
+      const res = await fastify.inject({
+        method: 'GET',
+        url: '/',
+        headers: {
+          referer: 'https://www.freecodecamp.org/some/other/path'
+        }
+      });
+
+      expect(res.headers.location).toBe(
+        'https://www.freecodecamp.org/some/other/path'
+      );
+      expect(res.statusCode).toEqual(302);
+    });
+
+    it('should not alter the response if NO user is present', async () => {
+      const message = {
+        type: 'danger',
+        content: 'At the moment, content is ignored'
+      };
+      authorizeSpy.mockImplementationOnce((req, _reply, done) => {
+        req.accessDeniedMessage = message;
+        done();
+      });
       const res = await fastify.inject({
         method: 'GET',
         url: '/'

--- a/api/src/plugins/bouncer.test.ts
+++ b/api/src/plugins/bouncer.test.ts
@@ -116,48 +116,4 @@ describe('bouncer', () => {
       expect(res.statusCode).toEqual(200);
     });
   });
-
-  describe('fallback hook', () => {
-    it('should reject unauthed requests when no other reject hooks are added', async () => {
-      const message = {
-        type: 'danger',
-        content: 'Something undesirable occurred'
-      };
-      authorizeSpy.mockImplementationOnce((req, _reply, done) => {
-        req.accessDeniedMessage = message;
-        done();
-      });
-      const res = await fastify.inject({
-        method: 'GET',
-        url: '/'
-      });
-
-      expect(res.json()).toStrictEqual({
-        type: message.type,
-        message: message.content
-      });
-    });
-
-    it('should not be called if another reject hook is added', async () => {
-      const redirectLocation = `${HOME_LOCATION}?${formatMessage({ type: 'info', content: 'Only authenticated users can access this route. Please sign in and try again.' })}`;
-      const message = {
-        type: 'danger',
-        content: 'Something undesirable occurred'
-      };
-      // using redirectIfNoUser as the reject hook since then it's obvious that
-      // the fallback hook is not called.
-      fastify.addHook('onRequest', fastify.redirectIfNoUser);
-      authorizeSpy.mockImplementationOnce((req, _reply, done) => {
-        req.accessDeniedMessage = message;
-        done();
-      });
-      const res = await fastify.inject({
-        method: 'GET',
-        url: '/'
-      });
-
-      expect(res.headers.location).toBe(redirectLocation);
-      expect(res.statusCode).toEqual(302);
-    });
-  });
 });

--- a/api/src/plugins/bouncer.ts
+++ b/api/src/plugins/bouncer.ts
@@ -10,6 +10,7 @@ declare module 'fastify' {
   interface FastifyInstance {
     send401IfNoUser: (req: FastifyRequest, reply: FastifyReply) => void;
     redirectIfNoUser: (req: FastifyRequest, reply: FastifyReply) => void;
+    redirectIfSignedIn: (req: FastifyRequest, reply: FastifyReply) => void;
   }
 }
 
@@ -36,6 +37,16 @@ const plugin: FastifyPluginCallback = (fastify, _options, done) => {
           content:
             'Only authenticated users can access this route. Please sign in and try again.'
         });
+      }
+    }
+  );
+
+  fastify.decorate(
+    'redirectIfSignedIn',
+    async function (req: FastifyRequest, reply: FastifyReply) {
+      if (req.user) {
+        const { returnTo } = getRedirectParams(req);
+        await reply.redirect(returnTo);
       }
     }
   );

--- a/api/src/plugins/bouncer.ts
+++ b/api/src/plugins/bouncer.ts
@@ -40,8 +40,6 @@ const plugin: FastifyPluginCallback = (fastify, _options, done) => {
     }
   );
 
-  fastify.addHook('preParsing', fastify.send401IfNoUser);
-
   done();
 };
 

--- a/api/src/plugins/bouncer.ts
+++ b/api/src/plugins/bouncer.ts
@@ -54,4 +54,7 @@ const plugin: FastifyPluginCallback = (fastify, _options, done) => {
   done();
 };
 
-export default fp(plugin, { dependencies: ['auth', 'redirect-with-message'] });
+export default fp(plugin, {
+  dependencies: ['auth', 'redirect-with-message'],
+  name: 'bouncer'
+});

--- a/api/src/routes/auth.ts
+++ b/api/src/routes/auth.ts
@@ -56,6 +56,10 @@ export const mobileAuth0Routes: FastifyPluginCallback = (
     })
   );
 
+  // TODO(Post-MVP): move this into the app, so that we add this hook once for
+  // all auth routes.
+  fastify.addHook('onRequest', fastify.redirectIfSignedIn);
+
   fastify.get('/mobile-login', async req => {
     const email = await getEmailFromAuth0(req);
 


### PR DESCRIPTION
- **feat: remove fallback bouncer hook**
- **feat: add redirection hook for signed in users**
- **feat: use redirect hook in app**

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

There's no need to send signed in users through the auth flow. This recreates the behaviour of `ifUserRedirect` from the api-server.

Also, I removed the authenticate fallback. It's possible to keep it and add the `redirectIfSignedIn` decorator separately, but the fact it's already making things harder than they should be made me rethink the approach. We'll just have to be careful!

<!-- Feel free to add any additional description of changes below this line -->
