### PR TITLE
chore(curriculum): add placeholder fed blocks in intro.json

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -1696,6 +1696,14 @@
     "title": "Front End Development",
     "intro": ["placeholder"],
     "blocks": {
+      "0": {
+        "title": "0",
+        "intro": []
+      },
+      "1": {
+        "title": "1",
+        "intro": []
+      },
       "workshop-cat-photo-app": {
         "title": "Build a Cat Photo App",
         "intro": [
@@ -1709,9 +1717,9 @@
           "For this lab, you will create a web page of your favorite recipe."
         ]
       },
-      "front-end-development-certification-exam": {
-        "title": "Front End Development Certification Exam",
-        "intro": ["", ""]
+      "4": {
+        "title": "4",
+        "intro": []
       },
       "lab-travel-agency-page": {
         "title": "Build a Travel Agency Page",
@@ -1719,15 +1727,503 @@
           "For this lab, you will create a web page of a travel agency."
         ]
       },
+      "6": {
+        "title": "6",
+        "intro": []
+      },
+      "lab-video-compilation-page": {
+        "title": "Build a Video Compilation Page",
+        "intro": ["For this lab, you will create a video compilation web page."]
+      },
+      "8": {
+        "title": "8",
+        "intro": []
+      },
+      "9": {
+        "title": "9",
+        "intro": []
+      },
+      "10": {
+        "title": "10",
+        "intro": []
+      },
+      "11": {
+        "title": "11",
+        "intro": []
+      },
       "workshop-blog-page": {
         "title": "Build a Cat Blog Page",
         "intro": [
           "In this workshop, you will learn how to build an HTML only blog page using semantic elements including the main, nav, article and footer elements."
         ]
       },
-      "lab-video-compilation-page": {
-        "title": "Build a Video Compilation Page",
-        "intro": ["For this lab, you will create a video compilation web page."]
+      "13": {
+        "title": "13",
+        "intro": []
+      },
+      "14": {
+        "title": "14",
+        "intro": []
+      },
+      "15": {
+        "title": "15",
+        "intro": []
+      },
+      "16": {
+        "title": "16",
+        "intro": []
+      },
+      "17": {
+        "title": "17",
+        "intro": []
+      },
+      "18": {
+        "title": "18",
+        "intro": []
+      },
+      "19": {
+        "title": "19",
+        "intro": []
+      },
+      "20": {
+        "title": "20",
+        "intro": []
+      },
+      "21": {
+        "title": "21",
+        "intro": []
+      },
+      "22": {
+        "title": "22",
+        "intro": []
+      },
+      "23": {
+        "title": "23",
+        "intro": []
+      },
+      "24": {
+        "title": "24",
+        "intro": []
+      },
+      "25": {
+        "title": "25",
+        "intro": []
+      },
+      "26": {
+        "title": "26",
+        "intro": []
+      },
+      "27": {
+        "title": "27",
+        "intro": []
+      },
+      "28": {
+        "title": "28",
+        "intro": []
+      },
+      "29": {
+        "title": "29",
+        "intro": []
+      },
+      "30": {
+        "title": "30",
+        "intro": []
+      },
+      "31": {
+        "title": "31",
+        "intro": []
+      },
+      "32": {
+        "title": "32",
+        "intro": []
+      },
+      "33": {
+        "title": "33",
+        "intro": []
+      },
+      "34": {
+        "title": "34",
+        "intro": []
+      },
+      "35": {
+        "title": "35",
+        "intro": []
+      },
+      "36": {
+        "title": "36",
+        "intro": []
+      },
+      "37": {
+        "title": "37",
+        "intro": []
+      },
+      "38": {
+        "title": "38",
+        "intro": []
+      },
+      "39": {
+        "title": "39",
+        "intro": []
+      },
+      "40": {
+        "title": "40",
+        "intro": []
+      },
+      "41": {
+        "title": "41",
+        "intro": []
+      },
+      "42": {
+        "title": "42",
+        "intro": []
+      },
+      "43": {
+        "title": "43",
+        "intro": []
+      },
+      "44": {
+        "title": "44",
+        "intro": []
+      },
+      "45": {
+        "title": "45",
+        "intro": []
+      },
+      "46": {
+        "title": "46",
+        "intro": []
+      },
+      "47": {
+        "title": "47",
+        "intro": []
+      },
+      "48": {
+        "title": "48",
+        "intro": []
+      },
+      "49": {
+        "title": "49",
+        "intro": []
+      },
+      "50": {
+        "title": "50",
+        "intro": []
+      },
+      "51": {
+        "title": "51",
+        "intro": []
+      },
+      "52": {
+        "title": "52",
+        "intro": []
+      },
+      "53": {
+        "title": "53",
+        "intro": []
+      },
+      "54": {
+        "title": "54",
+        "intro": []
+      },
+      "55": {
+        "title": "55",
+        "intro": []
+      },
+      "56": {
+        "title": "56",
+        "intro": []
+      },
+      "57": {
+        "title": "57",
+        "intro": []
+      },
+      "58": {
+        "title": "58",
+        "intro": []
+      },
+      "59": {
+        "title": "59",
+        "intro": []
+      },
+      "60": {
+        "title": "60",
+        "intro": []
+      },
+      "61": {
+        "title": "61",
+        "intro": []
+      },
+      "62": {
+        "title": "62",
+        "intro": []
+      },
+      "63": {
+        "title": "63",
+        "intro": []
+      },
+      "64": {
+        "title": "64",
+        "intro": []
+      },
+      "65": {
+        "title": "65",
+        "intro": []
+      },
+      "66": {
+        "title": "66",
+        "intro": []
+      },
+      "67": {
+        "title": "67",
+        "intro": []
+      },
+      "68": {
+        "title": "68",
+        "intro": []
+      },
+      "69": {
+        "title": "69",
+        "intro": []
+      },
+      "70": {
+        "title": "70",
+        "intro": []
+      },
+      "71": {
+        "title": "71",
+        "intro": []
+      },
+      "72": {
+        "title": "72",
+        "intro": []
+      },
+      "73": {
+        "title": "73",
+        "intro": []
+      },
+      "74": {
+        "title": "74",
+        "intro": []
+      },
+      "75": {
+        "title": "75",
+        "intro": []
+      },
+      "76": {
+        "title": "76",
+        "intro": []
+      },
+      "77": {
+        "title": "77",
+        "intro": []
+      },
+      "78": {
+        "title": "78",
+        "intro": []
+      },
+      "79": {
+        "title": "79",
+        "intro": []
+      },
+      "80": {
+        "title": "80",
+        "intro": []
+      },
+      "81": {
+        "title": "81",
+        "intro": []
+      },
+      "82": {
+        "title": "82",
+        "intro": []
+      },
+      "83": {
+        "title": "83",
+        "intro": []
+      },
+      "84": {
+        "title": "84",
+        "intro": []
+      },
+      "85": {
+        "title": "85",
+        "intro": []
+      },
+      "86": {
+        "title": "86",
+        "intro": []
+      },
+      "87": {
+        "title": "87",
+        "intro": []
+      },
+      "88": {
+        "title": "88",
+        "intro": []
+      },
+      "89": {
+        "title": "89",
+        "intro": []
+      },
+      "90": {
+        "title": "90",
+        "intro": []
+      },
+      "91": {
+        "title": "91",
+        "intro": []
+      },
+      "92": {
+        "title": "92",
+        "intro": []
+      },
+      "93": {
+        "title": "93",
+        "intro": []
+      },
+      "94": {
+        "title": "94",
+        "intro": []
+      },
+      "95": {
+        "title": "95",
+        "intro": []
+      },
+      "96": {
+        "title": "96",
+        "intro": []
+      },
+      "97": {
+        "title": "97",
+        "intro": []
+      },
+      "98": {
+        "title": "98",
+        "intro": []
+      },
+      "99": {
+        "title": "99",
+        "intro": []
+      },
+      "100": {
+        "title": "100",
+        "intro": []
+      },
+      "101": {
+        "title": "101",
+        "intro": []
+      },
+      "103": {
+        "title": "103",
+        "intro": []
+      },
+      "104": {
+        "title": "104",
+        "intro": []
+      },
+      "105": {
+        "title": "105",
+        "intro": []
+      },
+      "106": {
+        "title": "106",
+        "intro": []
+      },
+      "107": {
+        "title": "107",
+        "intro": []
+      },
+      "108": {
+        "title": "108",
+        "intro": []
+      },
+      "109": {
+        "title": "109",
+        "intro": []
+      },
+      "110": {
+        "title": "110",
+        "intro": []
+      },
+      "111": {
+        "title": "111",
+        "intro": []
+      },
+      "112": {
+        "title": "112",
+        "intro": []
+      },
+      "113": {
+        "title": "113",
+        "intro": []
+      },
+      "114": {
+        "title": "114",
+        "intro": []
+      },
+      "115": {
+        "title": "115",
+        "intro": []
+      },
+      "116": {
+        "title": "116",
+        "intro": []
+      },
+      "117": {
+        "title": "117",
+        "intro": []
+      },
+      "118": {
+        "title": "118",
+        "intro": []
+      },
+      "119": {
+        "title": "119",
+        "intro": []
+      },
+      "120": {
+        "title": "120",
+        "intro": []
+      },
+      "121": {
+        "title": "121",
+        "intro": []
+      },
+      "122": {
+        "title": "122",
+        "intro": []
+      },
+      "123": {
+        "title": "123",
+        "intro": []
+      },
+      "124": {
+        "title": "124",
+        "intro": []
+      },
+      "125": {
+        "title": "125",
+        "intro": []
+      },
+      "126": {
+        "title": "126",
+        "intro": []
+      },
+      "127": {
+        "title": "127",
+        "intro": []
+      },
+      "128": {
+        "title": "128",
+        "intro": []
+      },
+      "129": {
+        "title": "129",
+        "intro": []
+      },
+      "front-end-development-certification-exam": {
+        "title": "Front End Development Certification Exam",
+        "intro": ["", ""]
       }
     }
   },


### PR DESCRIPTION
Since we are adding so many new blocks, this file always creates conflicts on open PR's that create a new block after a new block gets added. This adds placeholder blocks up to the end of the CSS section. Now, we can just replace these placeholders with the new titles and it shouldn't create conflicts on other PR's that touch this file.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
