### PR TITLE
fix: block order and more placeholders

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -1751,19 +1751,6 @@
         "title": "11",
         "intro": []
       },
-      "workshop-final-exams-table": {
-        "title": "Build a Final Exams Table",
-        "intro": [
-          "In this workshop, you will learn how to work with HTML tables by building a table of final exams."
-        ]
-      },
-      "workshop-greeting-bot": {
-        "title": "Build a Greeting Bot",
-        "intro": [
-          "For this workshop, you will learn how to work with JavaScript fundamentals by building a greeting bot.",
-          "You will learn about variables, <code>let</code>, <code>const</code>, <code>console.log</code> and basic string usage."
-        ]
-      },
       "workshop-blog-page": {
         "title": "Build a Cat Blog Page",
         "intro": [
@@ -1798,9 +1785,11 @@
         "title": "19",
         "intro": []
       },
-      "20": {
-        "title": "20",
-        "intro": []
+      "workshop-final-exams-table": {
+        "title": "Build a Final Exams Table",
+        "intro": [
+          "In this workshop, you will learn how to work with HTML tables by building a table of final exams."
+        ]
       },
       "21": {
         "title": "21",
@@ -2126,6 +2115,10 @@
         "title": "101",
         "intro": []
       },
+      "102": {
+        "title": "102",
+        "intro": []
+      },
       "103": {
         "title": "103",
         "intro": []
@@ -2232,6 +2225,693 @@
       },
       "129": {
         "title": "129",
+        "intro": []
+      },
+      "130": {
+        "title": "130",
+        "intro": []
+      },
+      "workshop-greeting-bot": {
+        "title": "Build a Greeting Bot",
+        "intro": [
+          "For this workshop, you will learn how to work with JavaScript fundamentals by building a greeting bot.",
+          "You will learn about variables, <code>let</code>, <code>const</code>, <code>console.log</code> and basic string usage."
+        ]
+      },
+      "132": {
+        "title": "132",
+        "intro": []
+      },
+      "133": {
+        "title": "133",
+        "intro": []
+      },
+      "134": {
+        "title": "134",
+        "intro": []
+      },
+      "135": {
+        "title": "135",
+        "intro": []
+      },
+      "136": {
+        "title": "136",
+        "intro": []
+      },
+      "137": {
+        "title": "137",
+        "intro": []
+      },
+      "138": {
+        "title": "138",
+        "intro": []
+      },
+      "139": {
+        "title": "139",
+        "intro": []
+      },
+      "140": {
+        "title": "140",
+        "intro": []
+      },
+      "141": {
+        "title": "141",
+        "intro": []
+      },
+      "142": {
+        "title": "142",
+        "intro": []
+      },
+      "143": {
+        "title": "143",
+        "intro": []
+      },
+      "144": {
+        "title": "144",
+        "intro": []
+      },
+      "145": {
+        "title": "145",
+        "intro": []
+      },
+      "146": {
+        "title": "146",
+        "intro": []
+      },
+      "147": {
+        "title": "147",
+        "intro": []
+      },
+      "148": {
+        "title": "148",
+        "intro": []
+      },
+      "149": {
+        "title": "149",
+        "intro": []
+      },
+      "150": {
+        "title": "150",
+        "intro": []
+      },
+      "151": {
+        "title": "151",
+        "intro": []
+      },
+      "152": {
+        "title": "152",
+        "intro": []
+      },
+      "153": {
+        "title": "153",
+        "intro": []
+      },
+      "154": {
+        "title": "154",
+        "intro": []
+      },
+      "155": {
+        "title": "155",
+        "intro": []
+      },
+      "156": {
+        "title": "156",
+        "intro": []
+      },
+      "157": {
+        "title": "157",
+        "intro": []
+      },
+      "158": {
+        "title": "158",
+        "intro": []
+      },
+      "159": {
+        "title": "159",
+        "intro": []
+      },
+      "160": {
+        "title": "160",
+        "intro": []
+      },
+      "161": {
+        "title": "161",
+        "intro": []
+      },
+      "162": {
+        "title": "162",
+        "intro": []
+      },
+      "163": {
+        "title": "163",
+        "intro": []
+      },
+      "164": {
+        "title": "164",
+        "intro": []
+      },
+      "165": {
+        "title": "165",
+        "intro": []
+      },
+      "166": {
+        "title": "166",
+        "intro": []
+      },
+      "167": {
+        "title": "167",
+        "intro": []
+      },
+      "168": {
+        "title": "168",
+        "intro": []
+      },
+      "169": {
+        "title": "169",
+        "intro": []
+      },
+      "170": {
+        "title": "170",
+        "intro": []
+      },
+      "171": {
+        "title": "171",
+        "intro": []
+      },
+      "172": {
+        "title": "172",
+        "intro": []
+      },
+      "173": {
+        "title": "173",
+        "intro": []
+      },
+      "174": {
+        "title": "174",
+        "intro": []
+      },
+      "175": {
+        "title": "175",
+        "intro": []
+      },
+      "176": {
+        "title": "176",
+        "intro": []
+      },
+      "177": {
+        "title": "177",
+        "intro": []
+      },
+      "178": {
+        "title": "178",
+        "intro": []
+      },
+      "179": {
+        "title": "179",
+        "intro": []
+      },
+      "180": {
+        "title": "180",
+        "intro": []
+      },
+      "181": {
+        "title": "181",
+        "intro": []
+      },
+      "182": {
+        "title": "182",
+        "intro": []
+      },
+      "183": {
+        "title": "183",
+        "intro": []
+      },
+      "184": {
+        "title": "184",
+        "intro": []
+      },
+      "185": {
+        "title": "185",
+        "intro": []
+      },
+      "186": {
+        "title": "186",
+        "intro": []
+      },
+      "187": {
+        "title": "187",
+        "intro": []
+      },
+      "188": {
+        "title": "188",
+        "intro": []
+      },
+      "189": {
+        "title": "189",
+        "intro": []
+      },
+      "190": {
+        "title": "190",
+        "intro": []
+      },
+      "191": {
+        "title": "191",
+        "intro": []
+      },
+      "192": {
+        "title": "192",
+        "intro": []
+      },
+      "193": {
+        "title": "193",
+        "intro": []
+      },
+      "194": {
+        "title": "194",
+        "intro": []
+      },
+      "195": {
+        "title": "195",
+        "intro": []
+      },
+      "196": {
+        "title": "196",
+        "intro": []
+      },
+      "197": {
+        "title": "197",
+        "intro": []
+      },
+      "198": {
+        "title": "198",
+        "intro": []
+      },
+      "199": {
+        "title": "199",
+        "intro": []
+      },
+      "200": {
+        "title": "200",
+        "intro": []
+      },
+      "201": {
+        "title": "201",
+        "intro": []
+      },
+      "202": {
+        "title": "202",
+        "intro": []
+      },
+      "203": {
+        "title": "203",
+        "intro": []
+      },
+      "204": {
+        "title": "204",
+        "intro": []
+      },
+      "205": {
+        "title": "205",
+        "intro": []
+      },
+      "206": {
+        "title": "206",
+        "intro": []
+      },
+      "207": {
+        "title": "207",
+        "intro": []
+      },
+      "208": {
+        "title": "208",
+        "intro": []
+      },
+      "209": {
+        "title": "209",
+        "intro": []
+      },
+      "210": {
+        "title": "210",
+        "intro": []
+      },
+      "211": {
+        "title": "211",
+        "intro": []
+      },
+      "212": {
+        "title": "212",
+        "intro": []
+      },
+      "213": {
+        "title": "213",
+        "intro": []
+      },
+      "214": {
+        "title": "214",
+        "intro": []
+      },
+      "215": {
+        "title": "215",
+        "intro": []
+      },
+      "216": {
+        "title": "216",
+        "intro": []
+      },
+      "217": {
+        "title": "217",
+        "intro": []
+      },
+      "218": {
+        "title": "218",
+        "intro": []
+      },
+      "219": {
+        "title": "219",
+        "intro": []
+      },
+      "220": {
+        "title": "220",
+        "intro": []
+      },
+      "221": {
+        "title": "221",
+        "intro": []
+      },
+      "222": {
+        "title": "222",
+        "intro": []
+      },
+      "223": {
+        "title": "223",
+        "intro": []
+      },
+      "224": {
+        "title": "224",
+        "intro": []
+      },
+      "225": {
+        "title": "225",
+        "intro": []
+      },
+      "226": {
+        "title": "226",
+        "intro": []
+      },
+      "227": {
+        "title": "227",
+        "intro": []
+      },
+      "228": {
+        "title": "228",
+        "intro": []
+      },
+      "229": {
+        "title": "229",
+        "intro": []
+      },
+      "230": {
+        "title": "230",
+        "intro": []
+      },
+      "230": {
+        "title": "230",
+        "intro": []
+      },
+      "232": {
+        "title": "232",
+        "intro": []
+      },
+      "233": {
+        "title": "233",
+        "intro": []
+      },
+      "234": {
+        "title": "234",
+        "intro": []
+      },
+      "235": {
+        "title": "235",
+        "intro": []
+      },
+      "236": {
+        "title": "236",
+        "intro": []
+      },
+      "237": {
+        "title": "237",
+        "intro": []
+      },
+      "238": {
+        "title": "238",
+        "intro": []
+      },
+      "239": {
+        "title": "239",
+        "intro": []
+      },
+      "240": {
+        "title": "240",
+        "intro": []
+      },
+      "241": {
+        "title": "241",
+        "intro": []
+      },
+      "242": {
+        "title": "242",
+        "intro": []
+      },
+      "243": {
+        "title": "243",
+        "intro": []
+      },
+      "244": {
+        "title": "244",
+        "intro": []
+      },
+      "245": {
+        "title": "245",
+        "intro": []
+      },
+      "246": {
+        "title": "246",
+        "intro": []
+      },
+      "247": {
+        "title": "247",
+        "intro": []
+      },
+      "248": {
+        "title": "248",
+        "intro": []
+      },
+      "249": {
+        "title": "249",
+        "intro": []
+      },
+      "250": {
+        "title": "250",
+        "intro": []
+      },
+      "251": {
+        "title": "251",
+        "intro": []
+      },
+      "252": {
+        "title": "252",
+        "intro": []
+      },
+      "253": {
+        "title": "253",
+        "intro": []
+      },
+      "254": {
+        "title": "254",
+        "intro": []
+      },
+      "255": {
+        "title": "255",
+        "intro": []
+      },
+      "256": {
+        "title": "256",
+        "intro": []
+      },
+      "257": {
+        "title": "257",
+        "intro": []
+      },
+      "258": {
+        "title": "258",
+        "intro": []
+      },
+      "259": {
+        "title": "259",
+        "intro": []
+      },
+      "260": {
+        "title": "260",
+        "intro": []
+      },
+      "261": {
+        "title": "261",
+        "intro": []
+      },
+      "262": {
+        "title": "262",
+        "intro": []
+      },
+      "263": {
+        "title": "263",
+        "intro": []
+      },
+      "264": {
+        "title": "264",
+        "intro": []
+      },
+      "265": {
+        "title": "265",
+        "intro": []
+      },
+      "266": {
+        "title": "266",
+        "intro": []
+      },
+      "267": {
+        "title": "267",
+        "intro": []
+      },
+      "268": {
+        "title": "268",
+        "intro": []
+      },
+      "269": {
+        "title": "269",
+        "intro": []
+      },
+      "270": {
+        "title": "270",
+        "intro": []
+      },
+      "271": {
+        "title": "271",
+        "intro": []
+      },
+      "272": {
+        "title": "272",
+        "intro": []
+      },
+      "273": {
+        "title": "273",
+        "intro": []
+      },
+      "274": {
+        "title": "274",
+        "intro": []
+      },
+      "275": {
+        "title": "275",
+        "intro": []
+      },
+      "276": {
+        "title": "276",
+        "intro": []
+      },
+      "277": {
+        "title": "277",
+        "intro": []
+      },
+      "278": {
+        "title": "278",
+        "intro": []
+      },
+      "279": {
+        "title": "279",
+        "intro": []
+      },
+      "280": {
+        "title": "280",
+        "intro": []
+      },
+      "281": {
+        "title": "281",
+        "intro": []
+      },
+      "282": {
+        "title": "282",
+        "intro": []
+      },
+      "283": {
+        "title": "283",
+        "intro": []
+      },
+      "284": {
+        "title": "284",
+        "intro": []
+      },
+      "285": {
+        "title": "285",
+        "intro": []
+      },
+      "286": {
+        "title": "286",
+        "intro": []
+      },
+      "287": {
+        "title": "287",
+        "intro": []
+      },
+      "288": {
+        "title": "288",
+        "intro": []
+      },
+      "289": {
+        "title": "289",
+        "intro": []
+      },
+      "290": {
+        "title": "290",
+        "intro": []
+      },
+      "291": {
+        "title": "291",
+        "intro": []
+      },
+      "292": {
+        "title": "292",
+        "intro": []
+      },
+      "293": {
+        "title": "293",
+        "intro": []
+      },
+      "294": {
+        "title": "294",
+        "intro": []
+      },
+      "295": {
+        "title": "295",
+        "intro": []
+      },
+      "296": {
+        "title": "296",
+        "intro": []
+      },
+      "297": {
+        "title": "297",
+        "intro": []
+      },
+      "298": {
+        "title": "298",
+        "intro": []
+      },
+      "299": {
+        "title": "299",
+        "intro": []
+      },
+      "300": {
+        "title": "300",
         "intro": []
       },
       "front-end-development-certification-exam": {


### PR DESCRIPTION
follow up to https://github.com/freeCodeCamp/freeCodeCamp/pull/55833

Adds more placeholders to get to the end of the JS section. Fixes the order of a few merged PR's

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
