### PR TITLE
fix(curriculum): update hint text to 'You should have' in the Luhn algorithm challenge

### DIFF
--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-how-to-work-with-numbers-and-strings-by-implementing-the-luhn-algorithm/65687f47f9001dd35bdcd5ab.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-how-to-work-with-numbers-and-strings-by-implementing-the-luhn-algorithm/65687f47f9001dd35bdcd5ab.md
@@ -11,7 +11,7 @@ Change the value of `card_number` such that `'INVALID!'` is printed to the conso
 
 # --hints--
 
-You could have `card_number = '4111-1111-4555-1141'` within the main function.
+You should have `card_number = '4111-1111-4555-1141'` within the main function.
 
 ```js
 ({

--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-how-to-work-with-numbers-and-strings-by-implementing-the-luhn-algorithm/656b47dc2cf39e37025dc033.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-how-to-work-with-numbers-and-strings-by-implementing-the-luhn-algorithm/656b47dc2cf39e37025dc033.md
@@ -11,7 +11,7 @@ Reverse the order of the digits in the last four digits of `card_number`, by usi
 
 # --hints--
 
-You could have `card_number_reversed = card_number[-1:-5:-1]` within the `verify_card_number` function. Expected `--fcc-actual--` to equal `--fcc-expected--`.
+You should have `card_number_reversed = card_number[-1:-5:-1]` within the `verify_card_number` function. Expected `--fcc-actual--` to equal `--fcc-expected--`.
 
 ```js
 ({


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Closes #55850

This pull request updates the hint text in step 13 and step 34 of the "Implementing the Luhn Algorithm" challenge within the Scientific Computing with Python curriculum. The original hint text stated "You could have," which has been corrected to "You should have" to provide clearer guidance to learners.

Files Updated:
- `curriculum/challenges/english/07-scientific-computing-with-python/learn-how-to-work-with-numbers-and-strings-by-implementing-the-luhn-algorithm/656b47dc2cf39e37025dc033.md`
- `curriculum/challenges/english/07-scientific-computing-with-python/learn-how-to-work-with-numbers-and-strings-by-implementing-the-luhn-algorithm/65687f47f9001dd35bdcd5ab.md`