### PR TITLE
feat: transform JSX in scripts

### DIFF
--- a/client/src/templates/Challenges/rechallenge/transformers.js
+++ b/client/src/templates/Challenges/rechallenge/transformers.js
@@ -177,9 +177,17 @@ async function transformSASS(documentElement) {
 async function transformScript(documentElement) {
   await loadBabel();
   await loadPresetEnv();
+  await loadPresetReact();
   const scriptTags = documentElement.querySelectorAll('script');
   scriptTags.forEach(script => {
-    script.innerHTML = babelTransformCode(getBabelOptions(presetsJS))(
+    const isBabel = script.type === 'text/babel';
+    // TODO: make the use of JSX conditional on more than just the script type.
+    // It should only be used for React challenges since it would be confusing
+    // for learners to see the results of a transformation they didn't ask for.
+    const options = isBabel ? presetsJSX : presetsJS;
+
+    if (isBabel) script.removeAttribute('type'); // otherwise the browser will ignore the script
+    script.innerHTML = babelTransformCode(getBabelOptions(options))(
       script.innerHTML
     );
   });


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

There's a lot to do before this is robust, but with this small change you can render inline JSX. This does mean that every challenge that uses `type="text/babel"` will compile JSX, but I plan to fix that soon. Also, there aren't any challenges that use it at the moment.

For future reference, I tried to do this without making use of our transformation pipeline, but I couldn't see a nice way to handle imports. Typically what you do is import the module

```html
<script
   data-plugins="transform-modules-umd"
   type="text/babel"
   src="thing-you-want.js">
</script>
```

and then use that module

```html
 <script
   data-plugins="transform-modules-umd"
   data-type="module"
   type="text/babel"
>
   import { thing } from './thing-you-want.js';
 </script>
 ```

but `thing-you-want.js` doesn't exist and so the first script doesn't attach the "module" to the global scope in a way that the importing script can use (via its "moduleId").  You can create custom presets for `transform-modules-umd`, to force the  moduleId, but you need one per file you'd like to import and it gets messy quickly.

I could be missing something obvious, but for now it seems easier to rely on the transformation pipeline.

---

To test:

1. Go to http://localhost:8000/learn/2022/responsive-web-design/learn-html-by-building-a-cat-photo-app/step-3
2. Replace all text in the index.html editor with the contents of https://gist.githubusercontent.com/gaearon/0275b1e1518599bbeafcde4722e79ed1/raw/db72dcbf3384ee1708c4a07d3be79860db04bff0/example.html
3. See "Hello, world!" in the preview

<!-- Feel free to add any additional description of changes below this line -->
