### PR TITLE
feat(curriculum): use correct terms skyline project step 4

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-variables-by-building-a-city-skyline/5d822fd413a79914d39e98cc.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-variables-by-building-a-city-skyline/5d822fd413a79914d39e98cc.md
@@ -63,7 +63,7 @@ const heads = document.querySelectorAll('head');
 assert.equal(heads?.length, 1);
 ```
 
-You should have one self-closing `link` element.
+You should have one void `link` element.
 
 ```js
 assert(document.querySelectorAll('link').length === 1);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related #55342

<!-- Feel free to add any additional description of changes below this line -->
This is the last reference to `self-closing` in the modern HTML curriculum. There is still the old Responsive curriculum like 
https://github.com/freeCodeCamp/freeCodeCamp/blob/7009d13c006c5ad2a08c74f5e7500b29681a5de5/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/create-a-horizontal-line-using-the-hr-element.md#L18 and https://github.com/freeCodeCamp/freeCodeCamp/blob/7009d13c006c5ad2a08c74f5e7500b29681a5de5/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/nest-many-elements-within-a-single-div-element.md#L16 and the Odin project. 

https://github.com/freeCodeCamp/freeCodeCamp/blob/7009d13c006c5ad2a08c74f5e7500b29681a5de5/curriculum/challenges/english/16-the-odin-project/top-learn-css-foundations/css-foundations-lesson-f.md#L12 

