### PR TITLE
feat(curriculum): add test number enumeration

### DIFF
--- a/client/src/templates/Challenges/components/test-suite.tsx
+++ b/client/src/templates/Challenges/components/test-suite.tsx
@@ -43,7 +43,7 @@ function TestSuite({ tests }: TestSuiteProps): JSX.Element {
             pass && !err ? t('icons.passed') : t('icons.failed');
           // Remove opening/closing <p> so screen reader will read both
           // status message and test text as one block.
-          text = text.replace(/^<p>|<\/p>$/g, '');
+          text = `${index + 1}. ${text.replace(/^<p>|<\/p>$/g, '')}`;
           return (
             <li
               className='test-result'

--- a/client/src/templates/Challenges/redux/execute-challenge-saga.js
+++ b/client/src/templates/Challenges/redux/execute-challenge-saga.js
@@ -232,6 +232,7 @@ function* executeTests(testRunner, tests, testTimeout = 5000) {
         newTest.stack = stack;
       }
 
+      newTest.message = newTest.message.replace(/<p>/, `<p>${i + 1}. `);
       yield put(updateConsole(newTest.message));
     } finally {
       testResults.push(newTest);

--- a/e2e/output.spec.ts
+++ b/e2e/output.spec.ts
@@ -13,7 +13,7 @@ const outputTexts = {
   > 1 | var
       |    ^`,
   empty: `// running tests
-  You should declare myName with the var keyword, ending with a semicolon
+  1. You should declare myName with the var keyword, ending with a semicolon
   // tests completed`,
   passed: `// running tests
 // tests completed`

--- a/e2e/test-suite.spec.ts
+++ b/e2e/test-suite.spec.ts
@@ -25,11 +25,15 @@ test.describe('Challenge Test Suite Component Tests', () => {
     await expect(page.getByTestId('test-result')).toHaveCount(3);
     await expect(page.getByText(translations.icons.initial)).toHaveCount(3);
     await expect(
-      page.getByText('You should not change code above the specified comment.')
+      page.getByText(
+        '1. You should not change code above the specified comment.'
+      )
     ).toBeVisible();
-    await expect(page.getByText('b should have a value of 7.')).toBeVisible();
     await expect(
-      page.getByText('a should be assigned to b with =.')
+      page.getByText('2. b should have a value of 7.')
+    ).toBeVisible();
+    await expect(
+      page.getByText('3. a should be assigned to b with =.')
     ).toBeVisible();
   });
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #52724
This PR builds on the discussion from #54257
<!-- Feel free to add any additional description of changes below this line -->

Added enumeration to challenge tests by inserting it into the test strings in `test-suite.tsx` for the instructions panel and `execute-challenge-saga.js` for the console output. I found an alternative solution that seems to achieve the same result by modifying the challenge markdown parsing. The code for that solution can be found [here](https://github.com/freeCodeCamp/freeCodeCamp/compare/main...kevin-wu01:freeCodeCamp:soln-test). I've opted for the former solution since it's less complex and aligns with what has been discussed. Though I'm happy to hear any additional thoughts.