### PR TITLE
fix(curriculum): fix a typo in js course

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-functional-programming-by-building-a-spreadsheet/64498542cab69128ab24e4de.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-functional-programming-by-building-a-spreadsheet/64498542cab69128ab24e4de.md
@@ -19,7 +19,7 @@ You should add a second capture group to your `rangeRegex`.
 assert.match(code, /const\s+evalFormula\s*=\s*\(\s*x\s*,\s*cells\s*\)\s*=>\s*{\s*const\s+idToText\s*=\s*(\(\s*id\s*\)|id)\s*=>\s*cells\.find\(\s*(\(\s*cell\s*\)|cell)\s*=>\s*(?:cell\.id\s*===\s*id|id\s*===\s*cell\.id)\s*\)\.value\s*;?\s*const\s+rangeRegex\s*=\s*\/\(\[A-J\]\)\(.*\)\/\s*;?/);
 ```
 
-Your second capture group should have a character class.
+Your first capture group should have a character class.
 
 ```js
 assert.match(code, /const\s+evalFormula\s*=\s*\(\s*x\s*,\s*cells\s*\)\s*=>\s*{\s*const\s+idToText\s*=\s*(\(\s*id\s*\)|id)\s*=>\s*cells\.find\(\s*(\(\s*cell\s*\)|cell)\s*=>\s*(?:cell\.id\s*===\s*id|id\s*===\s*cell\.id)\s*\)\.value\s*;?\s*const\s+rangeRegex\s*=\s*\/\(\[A-J\]\)\(\[.*\]\??\)\/\s*;?/);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!-- Feel free to add any additional description of changes below this line -->

I was translating this file and noticed that line 22 and line 28 contradict each other. Based on the description, line 22 should be `first`.

Credit to translator `Daniel Rosa (danielrosa)` who first pointed out this issue in the Crowdin comment.

![image](https://github.com/user-attachments/assets/36ff0778-14e8-4d14-bda2-db474ce2eb2c)


