### PR TITLE
fix(curriculum): replace head content regex

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-responsive-web-design-by-building-a-piano/612e83ec2eca1e370f830511.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-responsive-web-design-by-building-a-piano/612e83ec2eca1e370f830511.md
@@ -33,7 +33,7 @@ assert.strictEqual(document.querySelectorAll('link')?.length, 1);
 Your `link` element should be inside your `head` element.
 
 ```js
-const headContentRegex = /(?<=<head\s*>)(?:.|\s*)*?(?=<\/head\s*>)/;
+const headContentRegex = /(?<=<head\s*>)[\S|\s]*(?=<\/head\s*>)/;
 const headElementContent = code.match(headContentRegex);
 
 const headElement = document.createElement("head");


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

The old regex can lock up the browser if the head element is missing the closing tag. This should fix that and still work as expected.
