### PR TITLE
fix(curriculum): remove a code backtick for translation

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-form-validation-by-building-a-calorie-counter/63bf47fd40599f29827f484d.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-form-validation-by-building-a-calorie-counter/63bf47fd40599f29827f484d.md
@@ -9,7 +9,7 @@ dashedName: step-20
 
 The current pattern will match the exact text `"hello"`, which is not the desired behavior. Instead, you want to search for `+`, `-`, or spaces. Replace the pattern in your `regex` variable with `\+-` to match plus and minus characters.
 
-Note that you need to use the `backslash` `\` character to <dfn>escape</dfn> the `+` symbol because it has a special meaning in regular expressions.
+Note that you need to use the backslash `\` character to <dfn>escape</dfn> the `+` symbol because it has a special meaning in regular expressions.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!-- Feel free to add any additional description of changes below this line -->

I was translating this material and noticed that the word `backslash` is wrapped by backticks. This means that Crowdin does not allow me to translate it. However, `backslash` is just used to explain what `\` is and is not used in the code. So, I think the backticks can be removed for translation purposes.
