### PR TITLE
fix(client): empty space below codePane after resizing classic layout

### DIFF
--- a/client/src/templates/Challenges/classic/desktop-layout.tsx
+++ b/client/src/templates/Challenges/classic/desktop-layout.tsx
@@ -237,8 +237,9 @@ const DesktopLayout = (props: DesktopLayoutProps): JSX.Element => {
               orientation='horizontal'
             >
               <ReflexElement
-                flex={codePane.flex}
                 name='codePane'
+                {...(!isMultifileCertProject &&
+                  !projectBasedChallenge && { flex: codePane.flex })}
                 {...reflexProps}
                 {...resizeProps}
               >

--- a/client/src/templates/Challenges/classic/desktop-layout.tsx
+++ b/client/src/templates/Challenges/classic/desktop-layout.tsx
@@ -182,6 +182,8 @@ const DesktopLayout = (props: DesktopLayoutProps): JSX.Element => {
     : false;
   const displayPreviewConsole =
     (projectBasedChallenge || isMultifileCertProject) && showConsole;
+  const hasVerticalResizableCodePane =
+    !isMultifileCertProject && !projectBasedChallenge;
   const {
     codePane,
     editorPane,
@@ -238,8 +240,7 @@ const DesktopLayout = (props: DesktopLayoutProps): JSX.Element => {
             >
               <ReflexElement
                 name='codePane'
-                {...(!isMultifileCertProject &&
-                  !projectBasedChallenge && { flex: codePane.flex })}
+                {...(hasVerticalResizableCodePane && { flex: codePane.flex })}
                 {...reflexProps}
                 {...resizeProps}
               >


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Closes #55931

- - -
- `flex` attribute/value is added to `codePane` in a limited number of cases.
