### PR TITLE
fix(curriculum): Merge Sort algorithm step 10 requires spaces to pass

### DIFF
--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-data-structures-by-building-the-merge-sort-algorithm/656680b0fc79f2c38a34d90e.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-data-structures-by-building-the-merge-sort-algorithm/656680b0fc79f2c38a34d90e.md
@@ -52,7 +52,7 @@ You should have a variable named `right_array_index` inside your `merge_sort` fu
     const merge_sort = __helpers.python.getDef("\n" + transformedCode, "merge_sort");
     const { function_body } = merge_sort;
 
-    assert.match(function_body, /right_array_index\s*(?!=)\s*/);
+    assert.match(function_body, /right_array_index/);
   }
 })
 ```

--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-data-structures-by-building-the-merge-sort-algorithm/656680b0fc79f2c38a34d90e.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-data-structures-by-building-the-merge-sort-algorithm/656680b0fc79f2c38a34d90e.md
@@ -81,7 +81,7 @@ You should have a variable named `sorted_index` inside your `merge_sort` functio
     const merge_sort = __helpers.python.getDef("\n" + transformedCode, "merge_sort");
     const { function_body } = merge_sort;
 
-    assert.match(function_body, /sorted_index\s*(?!=)\s*/);
+    assert.match(function_body, /sorted_index/);
   }
 })
 ```

--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-data-structures-by-building-the-merge-sort-algorithm/656680b0fc79f2c38a34d90e.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-data-structures-by-building-the-merge-sort-algorithm/656680b0fc79f2c38a34d90e.md
@@ -24,7 +24,7 @@ You should have a variable named `left_array_index` inside your `merge_sort` fun
     const merge_sort = __helpers.python.getDef("\n" + transformedCode, "merge_sort");
     const { function_body } = merge_sort;
 
-    assert.match(function_body, /left_array_index\s*(?!=)/);
+    assert.match(function_body, /left_array_index\s*(?!=)\s*/);
   }
 })
 ```
@@ -52,7 +52,7 @@ You should have a variable named `right_array_index` inside your `merge_sort` fu
     const merge_sort = __helpers.python.getDef("\n" + transformedCode, "merge_sort");
     const { function_body } = merge_sort;
 
-    assert.match(function_body, /right_array_index\s*(?!=)/);
+    assert.match(function_body, /right_array_index\s*(?!=)\s*/);
   }
 })
 ```
@@ -81,7 +81,7 @@ You should have a variable named `sorted_index` inside your `merge_sort` functio
     const merge_sort = __helpers.python.getDef("\n" + transformedCode, "merge_sort");
     const { function_body } = merge_sort;
 
-    assert.match(function_body, /sorted_index\s*(?!=)/);
+    assert.match(function_body, /sorted_index\s*(?!=)\s*/);
   }
 })
 ```

--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-data-structures-by-building-the-merge-sort-algorithm/656680b0fc79f2c38a34d90e.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-data-structures-by-building-the-merge-sort-algorithm/656680b0fc79f2c38a34d90e.md
@@ -24,7 +24,7 @@ You should have a variable named `left_array_index` inside your `merge_sort` fun
     const merge_sort = __helpers.python.getDef("\n" + transformedCode, "merge_sort");
     const { function_body } = merge_sort;
 
-    assert.match(function_body, /left_array_index\s*(?!=)\s*/);
+    assert.match(function_body, /left_array_index/);
   }
 })
 ```


### PR DESCRIPTION
This pull request fixes the issue number #55977 by adding /s* in the regular expressions.  The issue is fixed.

Fix #55977

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #55977

<!-- Feel free to add any additional description of changes below this line -->
