### PR TITLE
fix: audio not loading on ios

### DIFF
--- a/client/src/templates/Challenges/components/scene/scene.tsx
+++ b/client/src/templates/Challenges/components/scene/scene.tsx
@@ -34,9 +34,7 @@ export function Scene({
   const hasTimestamps = startTimestamp !== null && finishTimestamp !== null;
   const audioTimestamp = hasTimestamps ? `#t=${startTimestamp}` : '';
 
-  const audioRef = useRef<HTMLAudioElement>(
-    new Audio(`${sounds}/${audio.filename}${audioTimestamp}`)
-  );
+  const audioRef = useRef<HTMLAudioElement>(new Audio());
 
   // if there are timestamps, we use the difference between them as the duration
   // if not, we assume we're playing the whole audio file.
@@ -46,7 +44,13 @@ export function Scene({
 
   // on mount
   useEffect(() => {
-    audioRef.current.addEventListener('canplaythrough', audioLoaded);
+    const { current } = audioRef;
+
+    if (current) {
+      current.addEventListener('canplaythrough', audioLoaded);
+      current.src = `${sounds}/${audio.filename}${audioTimestamp}`;
+      current.load();
+    }
 
     // preload images
     loadImage(`${backgrounds}/${setup.background}`);
@@ -64,13 +68,20 @@ export function Scene({
 
     // on unmount
     return () => {
-      const { current } = audioRef;
-
-      current.pause();
-      current.currentTime = 0;
-      current.removeEventListener('canplaythrough', audioLoaded);
+      if (current) {
+        current.pause();
+        current.currentTime = 0;
+        current.removeEventListener('canplaythrough', audioLoaded);
+      }
     };
-  }, [audioRef, setup.background, setup.characters, commands]);
+  }, [
+    audioRef,
+    audio.filename,
+    audioTimestamp,
+    setup.background,
+    setup.characters,
+    commands
+  ]);
 
   const initBackground = setup.background;
   const initDialogue = { label: '', text: '', align: 'left' };
@@ -93,7 +104,7 @@ export function Scene({
     if (isPlaying) {
       playScene();
     } else {
-      finishScene();
+      resetScene();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isPlaying]);
@@ -195,10 +206,15 @@ export function Scene({
     });
   };
 
-  const finishScene = () => {
-    audioRef.current.pause();
-    audioRef.current.src = `${sounds}/${audio.filename}${audioTimestamp}`;
-    audioRef.current.currentTime = audio.startTimestamp || 0;
+  const resetScene = () => {
+    const { current } = audioRef;
+    if (current) {
+      current.pause();
+      current.src = `${sounds}/${audio.filename}${audioTimestamp}`;
+      current.load();
+      current.currentTime = audio.startTimestamp || 0;
+    }
+
     setShowDialogue(false);
     setDialogue(initDialogue);
     setCharacters(initCharacters);

--- a/client/src/templates/Challenges/components/scene/scene.tsx
+++ b/client/src/templates/Challenges/components/scene/scene.tsx
@@ -46,8 +46,6 @@ export function Scene({
 
   // on mount
   useEffect(() => {
-    audioRef.current.addEventListener('canplaythrough', audioLoaded);
-
     // preload images
     loadImage(`${backgrounds}/${setup.background}`);
 
@@ -62,13 +60,14 @@ export function Scene({
       )
       .forEach(loadImage);
 
+    setSceneIsReady(true);
+
     // on unmount
     return () => {
       const { current } = audioRef;
 
       current.pause();
       current.currentTime = 0;
-      current.removeEventListener('canplaythrough', audioLoaded);
     };
   }, [audioRef, setup.background, setup.characters, commands]);
 
@@ -97,10 +96,6 @@ export function Scene({
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isPlaying]);
-
-  const audioLoaded = () => {
-    setSceneIsReady(true);
-  };
 
   let start = 0;
   let stopAudio = false;

--- a/client/src/templates/Challenges/components/scene/scene.tsx
+++ b/client/src/templates/Challenges/components/scene/scene.tsx
@@ -46,6 +46,8 @@ export function Scene({
 
   // on mount
   useEffect(() => {
+    audioRef.current.addEventListener('canplaythrough', audioLoaded);
+
     // preload images
     loadImage(`${backgrounds}/${setup.background}`);
 
@@ -60,14 +62,13 @@ export function Scene({
       )
       .forEach(loadImage);
 
-    setSceneIsReady(true);
-
     // on unmount
     return () => {
       const { current } = audioRef;
 
       current.pause();
       current.currentTime = 0;
+      current.removeEventListener('canplaythrough', audioLoaded);
     };
   }, [audioRef, setup.background, setup.characters, commands]);
 
@@ -96,6 +97,10 @@ export function Scene({
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isPlaying]);
+
+  const audioLoaded = () => {
+    setSceneIsReady(true);
+  };
 
   let start = 0;
   let stopAudio = false;


### PR DESCRIPTION
The `canplaythrough` event wasn't firing on pages where the audio `startTimestamp` was `0` - only on ios browsers. Here's [a post with some more info and a solution.](https://stackoverflow.com/questions/49792768/js-html5-audio-why-is-canplaythrough-not-fired-on-ios-safari)

This seems to fix it - I have tested with ios simulator. Let me know if anyone wants a demo for review.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
