### PR TITLE
fix(client): lower jaw test result announcements

### DIFF
--- a/client/src/templates/Challenges/classic/lower-jaw.tsx
+++ b/client/src/templates/Challenges/classic/lower-jaw.tsx
@@ -79,8 +79,8 @@ const sentenceArray = [
   'learn.sorry-dont-giveup'
 ];
 
-const sentencePicker = (currentAttempts: number) => {
-  return sentenceArray[currentAttempts % sentenceArray.length];
+const sentencePicker = (shownAttempts: number) => {
+  return sentenceArray[shownAttempts % sentenceArray.length];
 };
 
 const LowerButtonsPanel = ({
@@ -193,12 +193,12 @@ const LowerJaw = ({
   isSignedIn,
   updateContainer
 }: LowerJawProps): JSX.Element => {
-  const hintRef = React.useRef('');
+  const [shownHint, setShownHint] = useState(hint);
   const [quote, setQuote] = useState(randomCompliment());
   const [runningTests, setRunningTests] = useState(false);
   const [testFeedbackHeight, setTestFeedbackHeight] = useState(0);
-  const [currentAttempts, setCurrentAttempts] = useState(attempts);
-  const [isFeedbackHidden, setIsFeedbackHidden] = useState(false);
+  const [shownAttempts, setShownAttempts] = useState(attempts);
+  const [isFeedbackHidden, setIsFeedbackHidden] = useState(true);
   const { t } = useTranslation();
   const testFeedbackRef = React.createRef<HTMLDivElement>();
 
@@ -219,34 +219,38 @@ const LowerJaw = ({
   const showShareButton =
     challengeIsCompleted && completedPercent === isBlockCompleted;
 
+  // Attempts should only be zero when the step is reset, so we should reset
+  // the state here.
+  if (attempts !== shownAttempts && attempts === 0) {
+    setShownAttempts(0);
+    setRunningTests(false);
+    setIsFeedbackHidden(false);
+    setShownHint('');
+  }
   useEffect(() => {
-    // prevent unnecessary updates:
-    if (attempts === currentAttempts) return;
-    // Attempts should only be zero when the step is reset, so we should reset
-    // the state here.
-    if (attempts === 0) {
-      setCurrentAttempts(0);
-      setRunningTests(false);
-      setIsFeedbackHidden(false);
-      hintRef.current = '';
-    } else if (attempts > 0 && hint) {
+    if (attempts > shownAttempts) {
       //hide the feedback from SR until the "Running tests" are displayed and removed.
       setIsFeedbackHidden(true);
       setRunningTests(true);
       //to prevent the changing attempts value from immediately triggering a new
-      //render, the rendered component only depends on currentAttempts. Since
-      //currentAttempts is updated with when the feedback is hidden, the screen
-      //reader should only read out the new message.
-      setCurrentAttempts(attempts);
-      hintRef.current = hint;
-
+      //render, the rendered component only depends on shownAttempts. Since
+      //shownAttempts is updated with when the feedback is hidden, the screen
+      //reader should only read out the new message. Note: this starts with the
+      //second encouragement since attempts starts at 1.
+      setShownAttempts(attempts);
       //display the test feedback contents.
       setTimeout(() => {
         setRunningTests(false);
         setIsFeedbackHidden(false);
       }, 300);
     }
-  }, [attempts, hint, currentAttempts]);
+  }, [attempts, shownAttempts]);
+
+  useEffect(() => {
+    // Since there's no guarantee that hint and attempts update in the same
+    // render, hints have to be updated separately.
+    if (hint) setShownHint(hint);
+  }, [hint]);
 
   useEffect(() => {
     if (challengeIsCompleted) {
@@ -280,9 +284,9 @@ const LowerJaw = ({
   });
 
   const isAttemptsLargerThanTest =
-    currentAttempts &&
+    shownAttempts &&
     testsLength &&
-    (currentAttempts >= testsLength || currentAttempts >= 3);
+    (shownAttempts >= testsLength || shownAttempts >= 3);
 
   const isDesktop = window.innerWidth > MAX_MOBILE_WIDTH;
   const isMacOS = navigator.userAgent.includes('Mac OS');
@@ -373,13 +377,13 @@ const LowerJaw = ({
             </span>
           </>
         )}
-        {hintRef.current && !challengeIsCompleted && (
+        {shownHint && !challengeIsCompleted && (
           <LowerJawTips
             data-testid='lowerJaw-tips'
             showFeedback={isFeedbackHidden}
             testText={t('learn.test')}
-            htmlDescription={`${hintRef.current}`}
-            learnEncouragementText={t(sentencePicker(currentAttempts))}
+            htmlDescription={shownHint ?? ''}
+            learnEncouragementText={t(sentencePicker(shownAttempts))}
           />
         )}
       </div>

--- a/client/src/templates/Challenges/classic/lower-jaw.tsx
+++ b/client/src/templates/Challenges/classic/lower-jaw.tsx
@@ -193,7 +193,6 @@ const LowerJaw = ({
   isSignedIn,
   updateContainer
 }: LowerJawProps): JSX.Element => {
-  const [shownHint, setShownHint] = useState(hint);
   const [quote, setQuote] = useState(randomCompliment());
   const [runningTests, setRunningTests] = useState(false);
   const [testFeedbackHeight, setTestFeedbackHeight] = useState(0);
@@ -225,7 +224,6 @@ const LowerJaw = ({
     setShownAttempts(0);
     setRunningTests(false);
     setIsFeedbackHidden(false);
-    setShownHint('');
   }
   useEffect(() => {
     if (attempts > shownAttempts) {
@@ -245,12 +243,6 @@ const LowerJaw = ({
       }, 300);
     }
   }, [attempts, shownAttempts]);
-
-  useEffect(() => {
-    // Since there's no guarantee that hint and attempts update in the same
-    // render, hints have to be updated separately.
-    if (hint) setShownHint(hint);
-  }, [hint]);
 
   useEffect(() => {
     if (challengeIsCompleted) {
@@ -377,12 +369,12 @@ const LowerJaw = ({
             </span>
           </>
         )}
-        {shownHint && !challengeIsCompleted && (
+        {hint && !challengeIsCompleted && (
           <LowerJawTips
             data-testid='lowerJaw-tips'
             showFeedback={isFeedbackHidden}
             testText={t('learn.test')}
-            htmlDescription={shownHint ?? ''}
+            htmlDescription={hint ?? ''}
             learnEncouragementText={t(sentencePicker(shownAttempts))}
           />
         )}

--- a/client/src/templates/Challenges/classic/lower-jaw.tsx
+++ b/client/src/templates/Challenges/classic/lower-jaw.tsx
@@ -193,6 +193,7 @@ const LowerJaw = ({
   isSignedIn,
   updateContainer
 }: LowerJawProps): JSX.Element => {
+  const [shownHint, setShownHint] = useState(hint);
   const [quote, setQuote] = useState(randomCompliment());
   const [runningTests, setRunningTests] = useState(false);
   const [testFeedbackHeight, setTestFeedbackHeight] = useState(0);
@@ -224,6 +225,7 @@ const LowerJaw = ({
     setShownAttempts(0);
     setRunningTests(false);
     setIsFeedbackHidden(false);
+    setShownHint('');
   }
   useEffect(() => {
     if (attempts > shownAttempts) {
@@ -243,6 +245,12 @@ const LowerJaw = ({
       }, 300);
     }
   }, [attempts, shownAttempts]);
+
+  useEffect(() => {
+    // Since there's no guarantee that hint and attempts update in the same
+    // render, hints have to be updated separately.
+    if (hint) setShownHint(hint);
+  }, [hint]);
 
   useEffect(() => {
     if (challengeIsCompleted) {
@@ -369,12 +377,12 @@ const LowerJaw = ({
             </span>
           </>
         )}
-        {hint && !challengeIsCompleted && (
+        {shownHint && !challengeIsCompleted && (
           <LowerJawTips
             data-testid='lowerJaw-tips'
             showFeedback={isFeedbackHidden}
             testText={t('learn.test')}
-            htmlDescription={hint ?? ''}
+            htmlDescription={shownHint ?? ''}
             learnEncouragementText={t(sentencePicker(shownAttempts))}
           />
         )}


### PR DESCRIPTION
- **fix(client): lower jaw annoucements**
- **feat: refresh lower jaw on changes**

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

The issue was caused by React batching renders for some events, but not others. Since it's not something we can (easily?) control, I tried to make sure that the lower jaw works regardless. i.e. if `attempts` changes on a separate render to `hint`, that's fine, and it should work if they change on the same render.

This _should_ keep the screen reader behaviour we want, but I'm not 100% sure what the desired behaviour actually is. It's quite possible I broke something, though I did check that Orca still reads the hints when you run the tests (and only once!)

The last commit changes the UX a bit, so I'm happy to either not do that or create a separate PR for it. @ahmaxed could you weigh in on the UX?

Closes https://github.com/freeCodeCamp/freeCodeCamp/issues/55986

<!-- Feel free to add any additional description of changes below this line -->
