### PR TITLE
fix(curriculum): add empty line in box model assignment section

### DIFF
--- a/curriculum/challenges/english/16-the-odin-project/top-the-box-model/the-box-model-lesson-d.md
+++ b/curriculum/challenges/english/16-the-odin-project/top-the-box-model/the-box-model-lesson-d.md
@@ -13,6 +13,7 @@ In the Elements pane, you can see the entire HTML structure of your page. You ca
 When an element is selected, the Styles tab will show all the currently applied styles, as well as any styles that are being overwritten (indicated by a strikethrough of the text). For example, if you use the inspector to click on the “Your Career in Web Development Starts Here” header on <a href="https://www.theodinproject.com/" target="_blank">the The Odin Project homepage</a>, on the right-hand side you’ll see all the styles that are currently affecting the element, as seen below:
 
 <img src="https://cdn.freecodecamp.org/curriculum/odin-project/the-box-model/overwritten-style.png" alt="CSS code snippet in the developer console showing .hero_main-heading with applied margin-bottom: 100px, padding-bottom: 1.875rem, .accent color #ce973e. h1 style rules include font-size, weight, letter-spacing, with its margin-bottom: 2rem overridden.">
+
 # --assignment--
 
 Play around with Chrome Dev Tools and see if you can answer the following question.


### PR DESCRIPTION
### Description:
This PR fixes the display issue in the assignment section of the Box Model lesson. The problem was caused by missing empty lines between sections, which disrupted the rendering of the content. By adding the necessary empty lines in the Markdown file, the content is now properly formatted and displays correctly.

### Changes made:
- Added empty lines between specific sections in the Box Model lesson's assignment file to fix the formatting issue.

### Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

### Issue:
This PR closes #56020
