### PR TITLE
fixed(curriculum): Improved the HTML test flexibility in Step 12

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5dfa22d1b521be39a3de7be0.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5dfa22d1b521be39a3de7be0.md
@@ -52,7 +52,8 @@ assert.isNotTrue(/^\s+|\s+$/.test(innerContent));
 After nesting the anchor (`a`) element, the only `p` element content visible in the browser should be `See more cat photos in our gallery.` Double check the text, spacing, or punctuation of both the `p` and nested anchor element.
 
 ```js
-assert.match(code, /<p>see more <a[^>]*>cat photos<\/a> in our gallery\.?<\/p>/i)
+assert.match(code, /<p>\s*see more\s*<a[^>]*>\s*cat photos\s*<\/a>\s*in our gallery\.?\s*<\/p>/i)
+
 ```
 
 # --seed--


### PR DESCRIPTION
… assert.match() to allow for whitespace

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #56035

<!-- Feel free to add any additional description of changes below this line -->

Improved HTML white space flexibility in step 12 by updating regex in assert.match() to allow for whitespace.