### PR TITLE
chore(curriculum, tools): move assignment headings out of question

### DIFF
--- a/curriculum/challenges/english/16-the-odin-project/top-introduction-to-flexbox/introduction-flexbox-lesson-j.md
+++ b/curriculum/challenges/english/16-the-odin-project/top-introduction-to-flexbox/introduction-flexbox-lesson-j.md
@@ -20,11 +20,11 @@ Remove `flex: 1` from `.item` and add `justify-content: space-between` to `.cont
 
 `justify-content` aligns items across the **main axis**. There are a few values that you can use here. You'll learn the rest of them in the reading assignments, but for now try changing it to center, which should center the boxes along the main axis.
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Before moving on to the next lesson, see what is possible with the `justify-content` property. Read this [interactive article on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content) and play around with the different values of `justify-content` on the example.
+
+# --question--
 
 ## --text--
 

--- a/curriculum/challenges/english/16-the-odin-project/top-introduction-to-flexbox/introduction-flexbox-lesson-k.md
+++ b/curriculum/challenges/english/16-the-odin-project/top-introduction-to-flexbox/introduction-flexbox-lesson-k.md
@@ -16,11 +16,11 @@ To change the placement of items along the cross axis use `align-items`. Try get
 
 Because `justify-content` and `align-items` are based on the main and cross axis of your container, their behavior changes when you change the flex-direction of a flex-container. For example, when you change `flex-direction` to `column`, `justify-content` aligns vertically and `align-items` aligns horizontally. The most common behavior, however, is the default, i.e. `justify-content` aligns items horizontally (because the main axis defaults to horizontal), and `align-items` aligns them vertically. One of the biggest sticking points that beginners have with flexbox is confusion when this behavior changes.
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Before moving on to the next lesson, see if you can figure out how `align-items` behaves when you change the `flex-direction` property to `column`.
+
+# --question--
 
 ## --text--
 

--- a/curriculum/challenges/english/16-the-odin-project/top-learn-block-and-inline/learn-block-and-inline-lesson-b.md
+++ b/curriculum/challenges/english/16-the-odin-project/top-learn-block-and-inline/learn-block-and-inline-lesson-b.md
@@ -8,11 +8,11 @@ dashedName: learn-block-and-inline-lesson-b
 
 Inline elements, however, do not start on a new line. They appear in line with whatever elements they are placed beside. A clear example of an inline element is a link, or `<a>` tag. If you stick one of these in the middle of a paragraph of text, it will behave like a part of the paragraph. <a  href="https://www.freecodecamp.org/" target="_blank">(Like this)</a> The link’s text will sit alongside other words in that paragraph. Additionally, padding and margin behave differently on inline elements. In general, you do not want to try to put extra padding or margin on inline elements.
 
-# --question-- 
-
-## --assignment--
+# --assignment--
 
 Search the web for a list of `block` elements and a list of `inline` elements. 
+
+# --question-- 
 
 ## --text--
 

--- a/curriculum/challenges/english/16-the-odin-project/top-learn-to-solve-problems-and-understand-errors/learn-to-solve-problems-and-understand-errors-lesson-a.md
+++ b/curriculum/challenges/english/16-the-odin-project/top-learn-to-solve-problems-and-understand-errors/learn-to-solve-problems-and-understand-errors-lesson-a.md
@@ -21,11 +21,11 @@ New programmers often find problem solving the hardest skill to build. It's not 
 
 The best way to improve your problem solving ability is by building experience by making lots and lots of programs. The more practice you have the better you'll be prepared to solve real world problems.
 
-# --question-- 
-
-## --assignment--
+# --assignment--
 
 Read <a href="https://www.freecodecamp.org/news/how-to-think-like-a-programmer-lessons-in-problem-solving-d1d8bf1de7d2/" target="_blank">How to Think Like a Programmer - Lessons in Problem Solving</a> by Richard Reis.
+
+# --question-- 
 
 ## --text--
 

--- a/curriculum/challenges/english/16-the-odin-project/top-learn-to-solve-problems-and-understand-errors/learn-to-solve-problems-and-understand-errors-lesson-b.md
+++ b/curriculum/challenges/english/16-the-odin-project/top-learn-to-solve-problems-and-understand-errors/learn-to-solve-problems-and-understand-errors-lesson-b.md
@@ -25,10 +25,10 @@ Now that you know what you’re aiming to solve, don’t jump into coding just y
 
 The last question is where you will write out an algorithm to solve the problem. You can think of an algorithm as a recipe for solving a particular problem. It defines the steps that need to be taken by the computer to solve a problem in pseudocode.
 
-# --question-- 
-
-## --assignment--
+# --assignment--
 Watch <a href="https://www.youtube.com/watch?v=azcrPFhaY9k" target="_blank">How to Begin Thinking Like a Programmer</a> by Coding Tech. It’s an hour long but packed full of information and definitely worth your time watching.
+
+# --question-- 
 
 ## --text--
 

--- a/curriculum/challenges/english/16-the-odin-project/top-learn-to-solve-problems-and-understand-errors/learn-to-solve-problems-and-understand-errors-lesson-c.md
+++ b/curriculum/challenges/english/16-the-odin-project/top-learn-to-solve-problems-and-understand-errors/learn-to-solve-problems-and-understand-errors-lesson-c.md
@@ -22,11 +22,11 @@ Print the value of the counter variable
 
 This is a basic program to demonstrate how pseudocode looks. There will be more examples of pseudocode included in the assignments.
 
+# --assignment--
+
+Read this <a href="https://builtin.com/data-science/pseudocode" target="_blank"> Pseudocode: What It Is and How to Write It</a> article from Built In.
 
 # --question-- 
-
-## --assignment--
-Read this <a href="https://builtin.com/data-science/pseudocode" target="_blank"> Pseudocode: What It Is and How to Write It</a> article from Built In.
 
 ## --text--
 

--- a/tools/challenge-helper-scripts/helpers/get-challenge-template.ts
+++ b/tools/challenge-helper-scripts/helpers/get-challenge-template.ts
@@ -140,11 +140,11 @@ export const getAssignmentChallengeTemplate = (
 
 ${options.title} description.
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 ${options.title} assignment!
+
+# --question--
 
 ## --text--
 
@@ -233,7 +233,7 @@ export const getDialogueChallengeTemplate = (
 
 Watch the video below to understand the context of the upcoming lessons.
 
-## --assignment--
+# --assignment--
 
 Watch the video.
 `;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

We had #51921 to move the `--assignment--` headings out of `--question--`. I found a couple instances left that need to be updated.

<!-- Feel free to add any additional description of changes below this line -->
