### PR TITLE
fix(i18n): remove typo from To-do list intro

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -1785,7 +1785,7 @@
       "lab-stylized-to-do-list": {
         "title": "Build a Stylized To-Do List",
         "intro": [
-          "In this lab, you'll build a To-Do list with and apply different styles to the links"
+          "In this lab, you'll build a To-Do list and apply different styles to the links"
         ]
       },
       "humj": { "title": "44", "intro": [] },


### PR DESCRIPTION
**Description:**
This PR fixes the typo in intro.json under i18n -> locales -> english. The word **"with"** in line **1788** caused a grammatical error to the sentence and is unnecessary. The word should be removed to ensure a proper grammar.

**Changes made:**
Removed the word **"with"** from line number **1788** to fix the issue.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

**Checklist:**
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #56065

<!-- Feel free to add any additional description of changes below this line -->
