### PR TITLE
feat(client): display FED workshop blocks in grid layout

### DIFF
--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -115,7 +115,11 @@ class Block extends Component<BlockProps> {
     });
 
     const isGridBlock = challenges.some(({ challenge }) => {
-      return isGridBased(superBlock, challenge.challengeType);
+      return isGridBased({
+        superBlock,
+        challengeType: challenge.challengeType,
+        blockType: challenge.blockType
+      });
     });
 
     const isAudited = isAuditedSuperBlock(curriculumLocale, superBlock, {

--- a/client/src/templates/Introduction/super-block-intro.tsx
+++ b/client/src/templates/Introduction/super-block-intro.tsx
@@ -306,6 +306,7 @@ export const query = graphql`
             order
             superBlock
             dashedName
+            blockType
           }
         }
       }

--- a/client/src/utils/curriculum-layout.test.ts
+++ b/client/src/utils/curriculum-layout.test.ts
@@ -1,0 +1,37 @@
+import { BlockTypes } from '../../../shared/config/blocks';
+import { challengeTypes } from '../../../shared/config/challenge-types';
+import { SuperBlocks } from '../../../shared/config/curriculum';
+
+import { isGridBased, gridBasedSuperBlocks } from './curriculum-layout';
+
+describe('isGridBased', () => {
+  it(`should return false if challenge type is ${challengeTypes.pythonProject}`, () => {
+    expect(
+      isGridBased({
+        superBlock: SuperBlocks.SciCompPy,
+        challengeType: challengeTypes.pythonProject
+      })
+    ).toEqual(false);
+  });
+
+  it(`should return true if block type is ${BlockTypes.workshop}`, () => {
+    expect(
+      isGridBased({
+        superBlock: SuperBlocks.FrontEndDevelopment,
+        challengeType: challengeTypes.html,
+        blockType: BlockTypes.workshop
+      })
+    ).toEqual(true);
+  });
+
+  it('should return true if the superblock is one of `gridBasedSuperBlocks`', () => {
+    gridBasedSuperBlocks.forEach(item => {
+      expect(
+        isGridBased({
+          superBlock: item,
+          challengeType: challengeTypes.html
+        })
+      ).toEqual(true);
+    });
+  });
+});

--- a/client/src/utils/curriculum-layout.ts
+++ b/client/src/utils/curriculum-layout.ts
@@ -1,24 +1,30 @@
+import { BlockTypes } from '../../../shared/config/blocks';
 import { challengeTypes } from '../../../shared/config/challenge-types';
 import { SuperBlocks } from '../../../shared/config/curriculum';
 
 // Show a grid layout on the superblock level
 
-const gridBasedSuperBlocks = [
+export const gridBasedSuperBlocks = [
   SuperBlocks.RespWebDesignNew,
   SuperBlocks.JsAlgoDataStructNew,
   SuperBlocks.SciCompPy,
   SuperBlocks.A2English
 ];
 
-export const isGridBased = (
-  superBlock: SuperBlocks,
-  challengeType: unknown = null
-) => {
+export const isGridBased = ({
+  superBlock,
+  challengeType,
+  blockType
+}: {
+  superBlock: SuperBlocks;
+  challengeType: number;
+  blockType?: BlockTypes; // blockType is currently only available in FrontEndDevelopment blocks
+}) => {
   // Python projects should not be displayed as a grid, but should be displayed
   // as a list of projects. Otherwise, if we do not do this the project will be
   // shown as a single certification project.
-
   if (challengeType === challengeTypes.pythonProject) return false;
+  if (blockType === BlockTypes.workshop) return true;
   return gridBasedSuperBlocks.includes(superBlock);
 };
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR updates the `isGridBased` function to allow displaying workshop blocks in grid layout.

<details>
  <summary>Screenshot</summary>

<img width="783" alt="Screenshot 2024-09-13 at 06 56 07" src="https://github.com/user-attachments/assets/b378f1e1-78d1-4ef1-b214-dd93ca363303">
</details>
<!-- Feel free to add any additional description of changes below this line -->
