### PR TITLE
fix(curriculum): wrap words in backticks in English course

### DIFF
--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657b69e10d6606a0185d4d4f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657b69e10d6606a0185d4d4f.md
@@ -9,7 +9,7 @@ dashedName: task-23
 
 # --description--
 
-So far you have learned how to create questions with the verb to be. In sentences with the verb `to be` (am, is, are) you just have to change the order of the noun and the verb to create a question. Like this:
+So far you have learned how to create questions with the verb `to be`. In sentences with the verb `to be` (am, is, are) you just have to change the order of the noun and the verb to create a question. Like this:
 
 `You are a developer` -> `Are you a developer?`
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657dce8ff35869721311a5e3.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657dce8ff35869721311a5e3.md
@@ -21,7 +21,7 @@ Which sentence is correct for describing one place near you?
 
 ### --feedback--
 
-`There are` is used for plural nouns, and `bank` is singular. You’ll learn about there are in the next few lessons. 
+`There are` is used for plural nouns, and `bank` is singular. You’ll learn about `there are` in the next few lessons. 
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657dcee413423174ca3747f5.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657dcee413423174ca3747f5.md
@@ -7,7 +7,7 @@ dashedName: task-112
 
 # --description--
 
-To elaborate a question using `there is` you just need to change the order of the verb to be, like so:
+To elaborate a question using `there is` you just need to change the order of the verb `to be`, like so:
 
 `There is an ATM nearby` -> `Is there an ATM nearby?`
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #56097

<!-- Feel free to add any additional description of changes below this line -->

I have wrapped the necessary words in backticks in the following files:

- [ freeCodeCamp/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657dce8ff35869721311a5e3.md](url)
- [freeCodeCamp/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657b69e10d6606a0185d4d4f.md](url)
- [freeCodeCamp/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657dcee413423174ca3747f5.md](url)