### PR TITLE
fix(curriculum): fix code block ending backticks for translation

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/review-algorithmic-thinking-by-building-a-dice-game/657e230500602983e01fff6e.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/review-algorithmic-thinking-by-building-a-dice-game/657e230500602983e01fff6e.md
@@ -938,3 +938,4 @@ keepScoreBtn.addEventListener("click", () => {
     alert("Please select an option or roll the dice");
   }
 });
+```


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

While translating this file, I noticed that Crowdin wanted us to translate all the solution JS code. Here are some examples:

(The grey text on the left means it should not be translated. The yellow and blue text means it should be translated.)

![image](https://github.com/user-attachments/assets/b915b195-6417-4962-a674-225bbfb2cd28)

![image](https://github.com/user-attachments/assets/61c23136-2153-4d3f-ba05-fe80217f1568)


After some checking, I noticed that the solution JS code block does not have the ending backticks. This might be why Crowdin treats the JS code as regular text and asks us to translate it. 

This PR adds the ending backticks.
