### PR TITLE
learn-form-validation-by-building-a-calorie-counter step 69 quotation…

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-form-validation-by-building-a-calorie-counter/63c9bf80558d780e848b2987.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-form-validation-by-building-a-calorie-counter/63c9bf80558d780e848b2987.md
@@ -22,13 +22,13 @@ assert.match(calculateCalories.toString(), /breakfastNumberInputs\s*=/);
 You should call `document.querySelectorAll()` with `#breakfast input[type=number]`.
 
 ```js
-assert.match(calculateCalories.toString(), /document\.querySelectorAll\(\s*('|")#breakfast input\[\s*type=number\s*\]\s*\1\s*\)/);
+assert.match(calculateCalories.toString(), /document\.querySelectorAll\(\s*('|")#breakfast input\[\s*('|")type=number\s*\]\s*\1\s*\)/);
 ```
 
 You should assign the result of your `document.querySelectorAll()` call to `breakfastNumberInputs`.
 
 ```js
-assert.match(calculateCalories.toString(), /breakfastNumberInputs\s*=\s*document\.querySelectorAll\(\s*('|")#breakfast input\[\s*type=number\s*\]\s*\1\s*\)/);
+assert.match(calculateCalories.toString(), /breakfastNumberInputs\s*=\s*document\.querySelectorAll\(\s*('|")#breakfast input\[\s*('|")type=number\s*\]\s*\1\s*\)/);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-form-validation-by-building-a-calorie-counter/63c9bf80558d780e848b2987.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-form-validation-by-building-a-calorie-counter/63c9bf80558d780e848b2987.md
@@ -9,7 +9,7 @@ dashedName: step-69
 
 Your function needs to get the values from the entries the user has added.
 
-Declare a `breakfastNumberInputs` variable, and give it the value of calling `document.querySelectorAll()` with the selector `#breakfast input[type=number]`. This will return any `number` inputs that are in the `#breakfast` element.
+Declare a `breakfastNumberInputs` variable, and give it the value of calling `document.querySelectorAll()` with the selector `#breakfast input[type="number"]`. This will return any `number` inputs that are in the `#breakfast` element.
 
 # --hints--
 
@@ -19,16 +19,16 @@ You should declare a `breakfastNumberInputs` variable.
 assert.match(calculateCalories.toString(), /breakfastNumberInputs\s*=/);
 ```
 
-You should call `document.querySelectorAll()` with `#breakfast input[type=number]`.
+You should call `document.querySelectorAll()` with `#breakfast input[type="number"]`.
 
 ```js
-assert.match(calculateCalories.toString(), /document\.querySelectorAll\(\s*('|")#breakfast input\[\s*('|")type=number\s*\]\s*\1\s*\)/);
+assert.match(calculateCalories.toString(), /document\.querySelectorAll\(\s*('|"|`)#breakfast input\[\s*type=('|")number('|")\s*\]\s*\1\s*\)/);
 ```
 
 You should assign the result of your `document.querySelectorAll()` call to `breakfastNumberInputs`.
 
 ```js
-assert.match(calculateCalories.toString(), /breakfastNumberInputs\s*=\s*document\.querySelectorAll\(\s*('|")#breakfast input\[\s*('|")type=number\s*\]\s*\1\s*\)/);
+assert.match(calculateCalories.toString(), /breakfastNumberInputs\s*=\s*document\.querySelectorAll\(\s*('|"|`)#breakfast input\[\s*type=('|")number('|")\s*\]\s*\1\s*\)/);
 ```
 
 # --seed--


### PR DESCRIPTION
… marks bug fix

Fix for bug described in Standardize Quotation Marks in Attribute Values #56081, where tests don't pass successfully with quotation marks on the type attribute value

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

The bug was that the code wasn't passing the tests if the quotation marks were there around the type attribute value, so I added a ('|") before the type=number in the assert.match() checks. 

