### PR TITLE
fix: inlining code examples in upper jaw

### DIFF
--- a/client/src/components/layouts/global.css
+++ b/client/src/components/layouts/global.css
@@ -560,10 +560,6 @@ pre[class*='language-'] {
   border-radius: 0;
 }
 
-details pre[class*='language-'] {
-  min-width: max-content;
-}
-
 /* TODO: Move this rule to @freecodecamp/ui. */
 pre {
   color: inherit;

--- a/client/src/components/layouts/global.css
+++ b/client/src/components/layouts/global.css
@@ -560,6 +560,10 @@ pre[class*='language-'] {
   border-radius: 0;
 }
 
+details pre[class*='language-'] {
+  min-width: max-content;
+}
+
 /* TODO: Move this rule to @freecodecamp/ui. */
 pre {
   color: inherit;
@@ -672,9 +676,9 @@ pre code {
   text-align: justify;
 }
 
-/* Port from Bootstrap as the Col component from @freecodecamp/ui 
+/* Port from Bootstrap as the Col component from @freecodecamp/ui
    doesn't fully support the xs-8 + xs-4 layout.
-   TODO: Remove these and replace the classes with Col 
+   TODO: Remove these and replace the classes with Col
    once https://github.com/freeCodeCamp/ui/issues/162 is resolved. */
 .col-xs-8,
 .col-xs-4 {

--- a/client/src/templates/Challenges/classic/editor.css
+++ b/client/src/templates/Challenges/classic/editor.css
@@ -269,6 +269,11 @@ textarea.inputarea {
   cursor: pointer;
 }
 
+.code-details-overflow-container {
+  max-width: 100%;
+  overflow-x: auto;
+}
+
 /* overwriting default arrow styles for accessibility */
 :root {
   --monaco-scrollbar-arrow-box-size: 0;

--- a/client/src/templates/Challenges/classic/editor.css
+++ b/client/src/templates/Challenges/classic/editor.css
@@ -269,9 +269,8 @@ textarea.inputarea {
   cursor: pointer;
 }
 
-.code-details-overflow-container {
-  max-width: 100%;
-  overflow-x: auto;
+.editor-upper-jaw pre code {
+  white-space: pre;
 }
 
 /* overwriting default arrow styles for accessibility */

--- a/client/src/templates/Challenges/utils/index.ts
+++ b/client/src/templates/Challenges/utils/index.ts
@@ -98,12 +98,8 @@ export function makePrismCollapsible(
   summary.classList.add('code-details-summary');
   summary.innerHTML = i18next.t('learn.example-code');
 
-  const exampleOverflowContainer = document.createElement('div');
-  exampleOverflowContainer.classList.add('code-details-overflow-container');
-
-  details.appendChild(exampleOverflowContainer);
   details.appendChild(summary);
-  exampleOverflowContainer.appendChild(preElem.cloneNode(true));
+  details.appendChild(preElem.cloneNode(true));
   details.open = true;
 
   sectionElem.replaceChild(details, preElem);

--- a/client/src/templates/Challenges/utils/index.ts
+++ b/client/src/templates/Challenges/utils/index.ts
@@ -98,8 +98,12 @@ export function makePrismCollapsible(
   summary.classList.add('code-details-summary');
   summary.innerHTML = i18next.t('learn.example-code');
 
+  const exampleOverflowContainer = document.createElement('div');
+  exampleOverflowContainer.classList.add('code-details-overflow-container');
+
+  details.appendChild(exampleOverflowContainer);
   details.appendChild(summary);
-  details.appendChild(preElem.cloneNode(true));
+  exampleOverflowContainer.appendChild(preElem.cloneNode(true));
   details.open = true;
 
   sectionElem.replaceChild(details, preElem);


### PR DESCRIPTION
Examples should not inline as they may cause confusion for the camper. See below mentioned issue.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Before:
<img width="586" alt="image" src="https://github.com/user-attachments/assets/4a21211d-68e9-440c-9368-d7e16807fa41">

After:
<img width="586" alt="image" src="https://github.com/user-attachments/assets/47404902-c929-4c65-8766-d86280ee947c">


Closes #56035

<!-- Feel free to add any additional description of changes below this line -->
