### PR TITLE
test(api): flaky rate-limit test

### DIFF
--- a/api/src/routes/auth.test.ts
+++ b/api/src/routes/auth.test.ts
@@ -61,12 +61,16 @@ describe('auth0 routes', () => {
     });
 
     it('should be rate-limited', async () => {
-      await Promise.all(
-        [...Array(10).keys()].map(() => superGet('/mobile-login'))
-      );
-
+      // Rather than spamming the endpoint, we can check the headers.
       const res = await superGet('/mobile-login');
-      expect(res.status).toBe(429);
+      // These headers are semi-official
+      // https://www.ietf.org/archive/id/draft-polli-ratelimit-headers-02.html
+      // so should not depend on the details of the rate-limiting library
+      expect(res.headers['ratelimit-limit']).toBe('10');
+      expect(res.headers['ratelimit-remaining']).toBe('9');
+
+      const res2 = await superGet('/mobile-login');
+      expect(res2.headers['ratelimit-remaining']).toBe('8');
     });
 
     it('should return 401 if the authorization header is invalid', async () => {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

The current rate-limit test is quite flaky, https://github.com/freeCodeCamp/freeCodeCamp/actions/runs/10870664752/job/30163665222, so I changed it to a less direct, but, hopefully, more reliable test.

<!-- Feel free to add any additional description of changes below this line -->
