### PR TITLE
feat(client): add worker messaging module

### DIFF
--- a/client/src/templates/Challenges/utils/worker-messenger.ts
+++ b/client/src/templates/Challenges/utils/worker-messenger.ts
@@ -36,12 +36,13 @@ export function awaitResponse<
     const channel = new MessageChannel();
     // TODO: Figure out how to ensure the worker is ready and/or handle when it
     // is not.
-    setTimeout(() => {
+    const id = setTimeout(() => {
       channel.port1.close();
       reject(Error('No response from worker'));
     }, 5000);
 
     channel.port1.onmessage = (event: MessageEvent<MessageIn>) => {
+      clearTimeout(id);
       channel.port1.close();
       onMessage(event.data, resolve, reject);
     };

--- a/client/src/templates/Challenges/utils/worker-messenger.ts
+++ b/client/src/templates/Challenges/utils/worker-messenger.ts
@@ -1,0 +1,51 @@
+/**
+ * Sends a message to a web worker and awaits a response.
+ *
+ * @template MessageOut - The type of the message being sent to the worker.
+ * @template MessageIn - The type of the message expected from the worker. Must include a `type` and `value` property.
+ * @template Value - The type of the value expected in the response message.
+ *
+ * @param {Object} params - The parameters for the function.
+ * @param {Worker} params.worker - The web worker to send the message to.
+ * @param {MessageOut} params.message - The message to send to the worker.
+ * @param {Function} params.onMessage - A callback function to handle the response from the worker.
+ * @param {MessageIn} params.onMessage.response - The response message from the worker.
+ * @param {Function} params.onMessage.resolve - A function to resolve the promise with the response value.
+ * @param {Function} params.onMessage.reject - A function to reject the promise with an error message.
+ *
+ * @returns {Promise<Value>} A promise that resolves with the response value from the worker or rejects with an error message.
+ */
+export function awaitResponse<
+  MessageOut,
+  MessageIn extends { type: string; value: Value },
+  Value
+>({
+  worker,
+  message,
+  onMessage
+}: {
+  worker: Worker;
+  message: MessageOut;
+  onMessage: (
+    response: MessageIn,
+    resolve: (res: Value) => void,
+    reject: (err: string) => void
+  ) => void;
+}): Promise<Value> {
+  return new Promise((resolve, reject) => {
+    const channel = new MessageChannel();
+    // TODO: Figure out how to ensure the worker is ready and/or handle when it
+    // is not.
+    setTimeout(() => {
+      channel.port1.close();
+      reject(Error('No response from worker'));
+    }, 5000);
+
+    channel.port1.onmessage = (event: MessageEvent<MessageIn>) => {
+      channel.port1.close();
+      onMessage(event.data, resolve, reject);
+    };
+
+    worker.postMessage(message, [channel.port2]);
+  });
+}


### PR DESCRIPTION
The normal pattern for worker communication is via onMessage listeners. This makes for awkward code when all you really want is to be able to write code like this:
`const res = await fetch(...)`

This module creates a similar api, by abstracting over the message passing, so that the client can simply await the Promise'd response.

This will be used in the TypeScript lessons, since they want to send messages to a TS worker and get back compiled code.

Thanks to @sashee for the [excellent blog post](https://advancedweb.hu/how-to-use-async-await-with-postmessage/) pointing out how to use MessageChannel to achieve this. Any mistakes are my own!

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->
