### PR TITLE
feat(curriculum-tests): check that ObjectId filenames match challenge ID

### DIFF
--- a/curriculum/get-challenges.js
+++ b/curriculum/get-challenges.js
@@ -276,6 +276,16 @@ function generateChallengeCreator(lang, englishPath, i18nPath) {
       ({ id }) => id === challenge.id
     );
 
+    const isObjectIdFilename = /[a-z0-9]{24}\.md$/.test(englishPath);
+    if (isObjectIdFilename) {
+      const filename = englishPath.split('/').pop();
+      if (filename !== `${challenge.id}.md`) {
+        throw Error(
+          `Filename ${filename} does not match challenge id ${challenge.id}`
+        );
+      }
+    }
+
     challenge.block = meta.dashedName;
     challenge.blockType = meta.blockType;
     challenge.hasEditableBoundaries = !!meta.hasEditableBoundaries;


### PR DESCRIPTION
We had some PR's where the ID filename got mixed up and didn't match the challenge id. This adds a test to make sure files with object id filenames match the challenge id.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
