### PR TITLE
fix: Rephrase the instructions in python case convertor

### DIFF
--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-list-comprehension-by-building-a-case-converter-program/657efa642593c5746acc5c81.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-list-comprehension-by-building-a-case-converter-program/657efa642593c5746acc5c81.md
@@ -9,7 +9,7 @@ dashedName: step-5
 
 Inside the `if` statement body, you need to convert any uppercase character to lowercase and prepend an underscore to this lowercase character.
 
-Use the `.lower()` string method to convert uppercase characters to lowercase characters. Then, prepend an underscore to the character. Assign the results to a variable named `converted_character`.
+Use the `.lower()` string method to convert uppercase characters to lowercase characters. Then, add an underscore before the character. Assign the results to a variable named `converted_character`.
 
 # --hints--
 


### PR DESCRIPTION
Changed the word prepend to a more descriptive words to help understand better to the non-native english speaker.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #56134

<!-- Feel free to add any additional description of changes below this line -->
