### PR TITLE
fix(client): concat user code before transforming

### DIFF
--- a/client/src/templates/Challenges/rechallenge/transformers.js
+++ b/client/src/templates/Challenges/rechallenge/transformers.js
@@ -12,7 +12,6 @@ import {
 import sassData from '../../../../../client/config/browser-scripts/sass-compile.json';
 import {
   transformContents,
-  transformHeadTailAndContents,
   setExt,
   compileHeadTail
 } from '../../../../../shared/utils/polyvinyl';
@@ -115,10 +114,7 @@ const babelTransformer = loopProtectOptions => {
         await loadBabel();
         await loadPresetEnv();
         const babelOptions = getBabelOptions(presetsJS, loopProtectOptions);
-        return transformHeadTailAndContents(
-          babelTransformCode(babelOptions),
-          code
-        );
+        return transformContents(babelTransformCode(babelOptions), code);
       }
     ],
     [
@@ -128,10 +124,7 @@ const babelTransformer = loopProtectOptions => {
         await loadPresetReact();
         const babelOptions = getBabelOptions(presetsJSX, loopProtectOptions);
         return flow(
-          partial(
-            transformHeadTailAndContents,
-            babelTransformCode(babelOptions)
-          ),
+          partial(transformContents, babelTransformCode(babelOptions)),
           partial(setExt, 'js')
         )(code);
       }
@@ -276,12 +269,9 @@ const htmlTransformer = cond([
 
 export const getTransformers = loopProtectOptions => [
   replaceNBSP,
+  compileHeadTail,
   babelTransformer(loopProtectOptions),
-  partial(compileHeadTail, ''),
   htmlTransformer
 ];
 
-export const getPythonTransformers = () => [
-  replaceNBSP,
-  partial(compileHeadTail, '')
-];
+export const getPythonTransformers = () => [replaceNBSP, compileHeadTail];

--- a/shared/utils/polyvinyl.js
+++ b/shared/utils/polyvinyl.js
@@ -120,11 +120,11 @@ function clearHeadTail(poly) {
   };
 }
 
-// compileHeadTail(padding: String, poly: PolyVinyl) => PolyVinyl
-function compileHeadTail(padding = '', poly) {
+// compileHeadTail(poly: PolyVinyl) => PolyVinyl
+function compileHeadTail(poly) {
   return clearHeadTail(
     transformContents(
-      () => [poly.head, poly.contents, poly.tail].join(padding),
+      () => [poly.head, poly.contents, poly.tail].join('\n'),
       poly
     )
   );
@@ -145,18 +145,6 @@ function transformContents(wrap, poly) {
   return newPoly;
 }
 
-// transformHeadTailAndContents(
-//   wrap: (source: String) => String,
-//   poly: PolyVinyl
-// ) => PolyVinyl
-function transformHeadTailAndContents(wrap, poly) {
-  return {
-    ...transformContents(wrap, poly),
-    head: wrap(poly.head),
-    tail: wrap(poly.tail)
-  };
-}
-
 module.exports = {
   createPoly,
   isPoly,
@@ -165,6 +153,5 @@ module.exports = {
   setImportedFiles,
   compileHeadTail,
   regeneratePathAndHistory,
-  transformContents,
-  transformHeadTailAndContents
+  transformContents
 };


### PR DESCRIPTION
This makes more sense since the transformers (Babel and, soon, TS) should consider the combined code to be a single file.

For instance, if a type is defined in the head it can only be used in the contents if TS knows the two sources should be combined.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->
