### PR TITLE
feat: allow TS to be used in challenges

### DIFF
--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -191,6 +191,7 @@ const modeMap = {
   html: 'html',
   js: 'javascript',
   jsx: 'javascript',
+  ts: 'typescript',
   py: 'python',
   python: 'python'
 };

--- a/client/src/templates/Challenges/classic/multifile-editor.tsx
+++ b/client/src/templates/Challenges/classic/multifile-editor.tsx
@@ -22,6 +22,7 @@ export type VisibleEditors = {
   indexjsx?: boolean;
   stylescss?: boolean;
   scriptjs?: boolean;
+  indexts?: boolean;
   mainpy?: boolean;
 };
 type MultifileEditorProps = Pick<
@@ -78,7 +79,14 @@ const MultifileEditor = (props: MultifileEditorProps) => {
     isUsingKeyboardInTablist,
     resizeProps,
     title,
-    visibleEditors: { stylescss, indexhtml, scriptjs, indexjsx, mainpy },
+    visibleEditors: {
+      stylescss,
+      indexhtml,
+      scriptjs,
+      indexts,
+      indexjsx,
+      mainpy
+    },
     usesMultifileEditor,
     showProjectPreview
   } = props;
@@ -103,6 +111,7 @@ const MultifileEditor = (props: MultifileEditorProps) => {
   if (stylescss) editorKeys.push('stylescss');
   if (scriptjs) editorKeys.push('scriptjs');
   if (mainpy) editorKeys.push('mainpy');
+  if (indexts) editorKeys.push('indexts');
 
   const editorAndSplitterKeys = editorKeys.reduce((acc: string[] | [], key) => {
     if (acc.length === 0) {

--- a/client/utils/__fixtures__/challenges.ts
+++ b/client/utils/__fixtures__/challenges.ts
@@ -2,6 +2,20 @@ import { ChallengeFile } from "../../src/redux/prop-types";
 
 export const challengeFiles: ChallengeFile[] = [
   {
+    id: '0',
+    contents: 'some ts',
+    error: null,
+    ext: 'ts',
+    head: '',
+    history: ['index.ts'],
+    fileKey: 'indexts',
+    name: 'index',
+    seed: 'some ts',
+    tail: '',
+    editableRegionBoundaries: [],
+    usesMultifileEditor: true,
+  },
+  {
     id: '1',
     contents: 'some css',
     error: null,

--- a/client/utils/sort-challengefiles.js
+++ b/client/utils/sort-challengefiles.js
@@ -9,6 +9,8 @@ exports.sortChallengeFiles = function sortChallengeFiles(challengeFiles) {
     if (b.history[0] === 'index.jsx') return 1;
     if (a.history[0] === 'script.js') return -1;
     if (b.history[0] === 'script.js') return 1;
+    if (a.history[0] === 'index.ts') return -1;
+    if (b.history[0] === 'index.ts') return 1;
     return 0;
   });
   return xs;

--- a/client/utils/sort-challengefiles.test.js
+++ b/client/utils/sort-challengefiles.test.js
@@ -14,10 +14,16 @@ describe('sort-files', () => {
       expect(sorted.length).toEqual(expected.length);
     });
 
-    it('should sort the objects into html, css, jsx, js order', () => {
+    it('should sort the objects into html, css, jsx, js, ts order', () => {
       const sorted = sortChallengeFiles(challengeFiles);
       const sortedKeys = sorted.map(({ fileKey }) => fileKey);
-      const expected = ['indexhtml', 'stylescss', 'indexjsx', 'scriptjs'];
+      const expected = [
+        'indexhtml',
+        'stylescss',
+        'indexjsx',
+        'scriptjs',
+        'indexts'
+      ];
       expect(sortedKeys).toStrictEqual(expected);
     });
   });

--- a/tools/challenge-parser/parser/plugins/utils/get-file-visitor.js
+++ b/tools/challenge-parser/parser/plugins/utils/get-file-visitor.js
@@ -8,9 +8,10 @@ const keyToSection = {
   head: 'before-user-code',
   tail: 'after-user-code'
 };
-const supportedLanguages = ['js', 'css', 'html', 'jsx', 'py'];
+const supportedLanguages = ['js', 'css', 'html', 'jsx', 'py', 'ts'];
 const longToShortLanguages = {
   javascript: 'js',
+  typescript: 'ts',
   python: 'py'
 };
 


### PR DESCRIPTION
The TS code doesn't get compiled, yet, but the ts tab will appear in
multifile challenges and syntax highlighting will work for both
multifile and single file challenges.

To see this, just change a challenge code block in challenge from \`\`\`js
to \`\`\`ts

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
