### PR TITLE
feat(curriculum): add HTML and CSS quiz boilerplates

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -1735,7 +1735,12 @@
       },
       "szcd": { "title": "13", "intro": [] },
       "ijdq": { "title": "14", "intro": [] },
-      "pwwg": { "title": "15", "intro": [] },
+      "quiz-semantic-html": {
+        "title": "Semantic HTML Quiz",
+        "intro": [
+          "Test what you've learned in this quiz of semantic HTML knowledge."
+        ]
+      },
       "cfgp": { "title": "16", "intro": [] },
       "workshop-hotel-feedback-form": {
         "title": "Build a Hotel Feedback Form",
@@ -1758,21 +1763,37 @@
       "xdvu": { "title": "21", "intro": [] },
       "rsve": { "title": "22", "intro": [] },
       "xzam": { "title": "23", "intro": [] },
-      "isho": { "title": "24", "intro": [] },
+      "quiz-html-tables-and-forms": {
+        "title": "HTML Tables and Forms Quiz",
+        "intro": [
+          "Test what you've learned in this quiz of HTML tables and forms."
+        ]
+      },
+
       "ghoc": { "title": "25", "intro": [] },
       "lab-checkout-page": {
         "title": "Build a Checkout Page",
         "intro": ["In this lab, you will create an accessible checkout page."]
       },
       "fqai": { "title": "27", "intro": [] },
-      "cayd": { "title": "28", "intro": [] },
+      "quiz-html-accessibility": {
+        "title": "HTML Accessibility Quiz",
+        "intro": [
+          "Test what you've learned in this quiz of HTML accessibility knowledge."
+        ]
+      },
       "pspj": { "title": "29", "intro": [] },
       "qpra": { "title": "30", "intro": [] },
       "joim": { "title": "31", "intro": [] },
       "gvtb": { "title": "32", "intro": [] },
       "cqhu": { "title": "33", "intro": [] },
       "tmdc": { "title": "34", "intro": [] },
-      "hqia": { "title": "35", "intro": [] },
+      "quiz-computer-basics": {
+        "title": "Computer Basics Quiz",
+        "intro": [
+          "Test what you've learned in this quiz of basic computer knowledge."
+        ]
+      },
       "dxpc": { "title": "36", "intro": [] },
       "liti": { "title": "37", "intro": [] },
       "lab-business-card": {
@@ -1783,7 +1804,12 @@
       },
       "gnuk": { "title": "39", "intro": [] },
       "zlfj": { "title": "40", "intro": [] },
-      "ioqd": { "title": "41", "intro": [] },
+      "quiz-basic-css": {
+        "title": "Basic CSS Quiz",
+        "intro": [
+          "Test what you've learned in this quiz of basic CSS knowledge."
+        ]
+      },
       "sdul": { "title": "42", "intro": [] },
       "lab-stylized-to-do-list": {
         "title": "Build a Stylized To-Do List",
@@ -1794,12 +1820,22 @@
       "humj": { "title": "44", "intro": [] },
       "pahx": { "title": "45", "intro": [] },
       "rzdx": { "title": "46", "intro": [] },
-      "sgpy": { "title": "47", "intro": [] },
+      "quiz-css-backgrounds-and-borders": {
+        "title": "CSS Backgrounds and Borders Quiz",
+        "intro": [
+          "Test what you've learned in this quiz of backgrounds and borders in CSS."
+        ]
+      },
       "ljmt": { "title": "48", "intro": [] },
       "lxpk": { "title": "49", "intro": [] },
       "lzqy": { "title": "50", "intro": [] },
       "gvel": { "title": "51", "intro": [] },
-      "hgxz": { "title": "52", "intro": [] },
+      "quiz-design-fundamentals": {
+        "title": "Design Fundamentals Quiz",
+        "intro": [
+          "Test what you've learned in this quiz of UI design fundamentals."
+        ]
+      },
       "bgrw": { "title": "53", "intro": [] },
       "sbnz": { "title": "54", "intro": [] },
       "lab-event-flyer-page": {
@@ -1809,22 +1845,42 @@
         ]
       },
       "ywfm": { "title": "56", "intro": [] },
-      "yspe": { "title": "57", "intro": [] },
+      "quiz-css-relative-and-absolute-units": {
+        "title": "CSS Relative and Absolute Units Quiz",
+        "intro": [
+          "Test what you've learned in this quiz of relative and absolute units in CSS."
+        ]
+      },
       "ohhu": { "title": "58", "intro": [] },
       "syga": { "title": "59", "intro": [] },
       "sdym": { "title": "60", "intro": [] },
       "ivpx": { "title": "61", "intro": [] },
-      "xnph": { "title": "62", "intro": [] },
+      "quiz-css-pseudo-classes": {
+        "title": "CSS Pseudo-classes Quiz",
+        "intro": [
+          "Test what you've learned in this quiz of pseudo-classes in CSS."
+        ]
+      },
       "fvcj": { "title": "63", "intro": [] },
       "ogdb": { "title": "64", "intro": [] },
       "zxiy": { "title": "65", "intro": [] },
       "qpze": { "title": "66", "intro": [] },
-      "uqiy": { "title": "67", "intro": [] },
+      "quiz-css-colors": {
+        "title": "CSS Colors Quiz",
+        "intro": [
+          "Test what you've learned in this quiz of using colors in CSS."
+        ]
+      },
       "jnqt": { "title": "68", "intro": [] },
       "vkei": { "title": "69", "intro": [] },
       "jows": { "title": "70", "intro": [] },
       "ipmw": { "title": "71", "intro": [] },
-      "nxbr": { "title": "72", "intro": [] },
+      "quiz-styling-forms": {
+        "title": "Styling Forms Quiz",
+        "intro": [
+          "Test what you've learned in this quiz of how to style forms using CSS."
+        ]
+      },
       "qzcx": { "title": "73", "intro": [] },
       "wozq": { "title": "74", "intro": [] },
       "lab-confidential-email-page": {
@@ -1834,7 +1890,12 @@
         ]
       },
       "zter": { "title": "76", "intro": [] },
-      "rfiq": { "title": "77", "intro": [] },
+      "quiz-css-layout-and-effects": {
+        "title": "CSS Layout and Effects Quiz",
+        "intro": [
+          "Test what you've learned in this quiz of the box model, transforms, filters, and overflow in CSS."
+        ]
+      },
       "tcwi": { "title": "78", "intro": [] },
       "uptf": { "title": "79", "intro": [] },
       "lab-page-of-playing-cards": {
@@ -1844,7 +1905,12 @@
         ]
       },
       "kqao": { "title": "81", "intro": [] },
-      "habq": { "title": "82", "intro": [] },
+      "quiz-css-flexbox": {
+        "title": "CSS Flexbox Quiz",
+        "intro": [
+          "Test what you've learned in this quiz of using flexbox in CSS."
+        ]
+      },
       "vqut": { "title": "83", "intro": [] },
       "ujcf": { "title": "84", "intro": [] },
       "lab-newspaper-article": {
@@ -1854,12 +1920,20 @@
         ]
       },
       "hbme": { "title": "86", "intro": [] },
-      "ioby": { "title": "87", "intro": [] },
+      "quiz-css-typography": {
+        "title": "CSS Typography Quiz",
+        "intro": ["Test what you've learned in this quiz of typography in CSS."]
+      },
       "dyvj": { "title": "88", "intro": [] },
       "rjsv": { "title": "89", "intro": [] },
       "txmt": { "title": "90", "intro": [] },
       "fnde": { "title": "91", "intro": [] },
-      "gxjm": { "title": "92", "intro": [] },
+      "quiz-css-accessibility": {
+        "title": "CSS Accessibility Quiz",
+        "intro": [
+          "Test what you've learned in this quiz of making your webpage accessible with CSS."
+        ]
+      },
       "swpl": { "title": "93", "intro": [] },
       "hcje": { "title": "94", "intro": [] },
       "lab-book-inventory-app": {
@@ -1867,17 +1941,32 @@
         "intro": ["For this lab, you will create a book inventory app."]
       },
       "huyd": { "title": "96", "intro": [] },
-      "kbwy": { "title": "97", "intro": [] },
+      "quiz-css-attribute-selectors": {
+        "title": "CSS Attribute Selectors Quiz",
+        "intro": [
+          "Test what you've learned in this quiz of using attribute selectors in CSS."
+        ]
+      },
       "rxzk": { "title": "98", "intro": [] },
       "xobh": { "title": "99", "intro": [] },
       "pgyf": { "title": "100", "intro": [] },
       "rrtt": { "title": "101", "intro": [] },
-      "rbnd": { "title": "102", "intro": [] },
+      "quiz-css-positioning": {
+        "title": "CSS Positioning Quiz",
+        "intro": [
+          "Test what you've learned in this quiz of how positioning works in CSS."
+        ]
+      },
       "xebj": { "title": "103", "intro": [] },
       "jkdt": { "title": "104", "intro": [] },
       "cbbz": { "title": "105", "intro": [] },
       "xcti": { "title": "106", "intro": [] },
-      "scec": { "title": "107", "intro": [] },
+      "quiz-responsive-web-design": {
+        "title": "Responsive Web Design Quiz",
+        "intro": [
+          "Test what you've learned in this quiz of making your webpage responsive."
+        ]
+      },
       "mtbl": { "title": "108", "intro": [] },
       "vlov": { "title": "109", "intro": [] },
       "lab-availability-table": {
@@ -1885,14 +1974,22 @@
         "intro": ["For this lab, you will create an availability table."]
       },
       "sget": { "title": "111", "intro": [] },
-      "huge": { "title": "112", "intro": [] },
+      "quiz-css-variables": {
+        "title": "CSS Variables Quiz",
+        "intro": [
+          "Test what you've learned in this quiz of how using variables in CSS."
+        ]
+      },
       "agbl": { "title": "113", "intro": [] },
       "ogko": { "title": "114", "intro": [] },
       "harp": { "title": "115", "intro": [] },
       "nsiq": { "title": "116", "intro": [] },
       "geuv": { "title": "117", "intro": [] },
       "fdam": { "title": "118", "intro": [] },
-      "yqma": { "title": "119", "intro": [] },
+      "quiz-css-grid": {
+        "title": "CSS Grid Quiz",
+        "intro": ["Test what you've learned in this quiz of using grid in CSS."]
+      },
       "dorc": { "title": "120", "intro": [] },
       "adzu": { "title": "121", "intro": [] },
       "lab-moon-orbit": {
@@ -1909,7 +2006,12 @@
         ]
       },
       "lvqc": { "title": "125", "intro": [] },
-      "oxbd": { "title": "126", "intro": [] },
+      "quiz-css-animations": {
+        "title": "CSS Animations Quiz",
+        "intro": [
+          "Test what you've learned in this quiz of using animations in CSS."
+        ]
+      },
       "wvjx": { "title": "127", "intro": [] },
       "uquz": { "title": "128", "intro": [] },
       "kdgd": { "title": "129", "intro": [] },

--- a/client/src/pages/learn/front-end-development/quiz-basic-css/index.md
+++ b/client/src/pages/learn/front-end-development/quiz-basic-css/index.md
@@ -1,0 +1,9 @@
+---
+title: Introduction to the Basic CSS Quiz
+block: quiz-basic-css
+superBlock: front-end-development
+---
+
+## Introduction to the Basic CSS Quiz
+
+Test what you've learned in this quiz of basic CSS knowledge.

--- a/client/src/pages/learn/front-end-development/quiz-computer-basics/index.md
+++ b/client/src/pages/learn/front-end-development/quiz-computer-basics/index.md
@@ -1,0 +1,9 @@
+---
+title: Introduction to the Computer Basics Quiz
+block: quiz-computer-basics
+superBlock: front-end-development
+---
+
+## Introduction to the Computer Basics Quiz
+
+Test what you've learned in this quiz of basic computer knowledge.

--- a/client/src/pages/learn/front-end-development/quiz-css-accessibility/index.md
+++ b/client/src/pages/learn/front-end-development/quiz-css-accessibility/index.md
@@ -1,0 +1,9 @@
+---
+title: Introduction to the CSS Accessibility Quiz
+block: quiz-css-accessibility
+superBlock: front-end-development
+---
+
+## Introduction to the CSS Accessibility Quiz
+
+Test what you've learned in this quiz of making your webpage accessible with CSS.

--- a/client/src/pages/learn/front-end-development/quiz-css-animations/index.md
+++ b/client/src/pages/learn/front-end-development/quiz-css-animations/index.md
@@ -1,0 +1,9 @@
+---
+title: Introduction to the CSS Animations Quiz
+block: quiz-css-animations
+superBlock: front-end-development
+---
+
+## Introduction to the CSS Animations Quiz
+
+Test what you've learned in this quiz of using animations in CSS.

--- a/client/src/pages/learn/front-end-development/quiz-css-attribute-selectors/index.md
+++ b/client/src/pages/learn/front-end-development/quiz-css-attribute-selectors/index.md
@@ -1,0 +1,9 @@
+---
+title: Introduction to the CSS Attribute Selectors Quiz
+block: quiz-css-attribute-selectors
+superBlock: front-end-development
+---
+
+## Introduction to the CSS Attribute Selectors Quiz
+
+Test what you've learned in this quiz of using attribute selectors in CSS.

--- a/client/src/pages/learn/front-end-development/quiz-css-backgrounds-and-borders/index.md
+++ b/client/src/pages/learn/front-end-development/quiz-css-backgrounds-and-borders/index.md
@@ -1,0 +1,9 @@
+---
+title: Introduction to the CSS Backgrounds and Borders Quiz
+block: quiz-css-backgrounds-and-borders
+superBlock: front-end-development
+---
+
+## Introduction to the CSS Backgrounds and Borders Quiz
+
+Test what you've learned in this quiz of backgrounds and borders in CSS.

--- a/client/src/pages/learn/front-end-development/quiz-css-colors/index.md
+++ b/client/src/pages/learn/front-end-development/quiz-css-colors/index.md
@@ -1,0 +1,9 @@
+---
+title: Introduction to the CSS Colors Quiz
+block: quiz-css-colors
+superBlock: front-end-development
+---
+
+## Introduction to the CSS Colors Quiz
+
+Test what you've learned in this quiz of using colors in CSS.

--- a/client/src/pages/learn/front-end-development/quiz-css-flexbox/index.md
+++ b/client/src/pages/learn/front-end-development/quiz-css-flexbox/index.md
@@ -1,0 +1,9 @@
+---
+title: Introduction to the CSS Flexbox Quiz
+block: quiz-css-flexbox
+superBlock: front-end-development
+---
+
+## Introduction to the CSS Flexbox Quiz
+
+Test what you've learned in this quiz of using flexbox in CSS.

--- a/client/src/pages/learn/front-end-development/quiz-css-grid/index.md
+++ b/client/src/pages/learn/front-end-development/quiz-css-grid/index.md
@@ -1,0 +1,9 @@
+---
+title: Introduction to the CSS Grid Quiz
+block: quiz-css-grid
+superBlock: front-end-development
+---
+
+## Introduction to the CSS Grid Quiz
+
+Test what you've learned in this quiz of using grid in CSS.

--- a/client/src/pages/learn/front-end-development/quiz-css-layout-and-effects/index.md
+++ b/client/src/pages/learn/front-end-development/quiz-css-layout-and-effects/index.md
@@ -1,0 +1,9 @@
+---
+title: Introduction to the CSS Layout and Effects Quiz
+block: quiz-css-layout-and-effects
+superBlock: front-end-development
+---
+
+## Introduction to the CSS Layout and Effects Quiz
+
+Test what you've learned in this quiz of the box model, transforms, filters, and overflow in CSS.

--- a/client/src/pages/learn/front-end-development/quiz-css-positioning/index.md
+++ b/client/src/pages/learn/front-end-development/quiz-css-positioning/index.md
@@ -1,0 +1,9 @@
+---
+title: Introduction to the CSS Positioning Quiz
+block: quiz-css-positioning
+superBlock: front-end-development
+---
+
+## Introduction to the CSS Positioning Quiz
+
+Test what you've learned in this quiz of how positioning works in CSS.

--- a/client/src/pages/learn/front-end-development/quiz-css-pseudo-classes/index.md
+++ b/client/src/pages/learn/front-end-development/quiz-css-pseudo-classes/index.md
@@ -1,0 +1,9 @@
+---
+title: Introduction to the CSS Pseudo-classes Quiz
+block: quiz-css-pseudo-classes
+superBlock: front-end-development
+---
+
+## Introduction to the CSS Pseudo-classes Quiz
+
+Test what you've learned in this quiz of pseudo-classes in CSS.

--- a/client/src/pages/learn/front-end-development/quiz-css-relative-and-absolute-units/index.md
+++ b/client/src/pages/learn/front-end-development/quiz-css-relative-and-absolute-units/index.md
@@ -1,0 +1,9 @@
+---
+title: Introduction to the CSS Relative and Absolute Units Quiz
+block: quiz-css-relative-and-absolute-units
+superBlock: front-end-development
+---
+
+## Introduction to the CSS Relative and Absolute Units Quiz
+
+Test what you've learned in this quiz of relative and absolute units in CSS.

--- a/client/src/pages/learn/front-end-development/quiz-css-typography/index.md
+++ b/client/src/pages/learn/front-end-development/quiz-css-typography/index.md
@@ -1,0 +1,9 @@
+---
+title: Introduction to the CSS Typography Quiz
+block: quiz-css-typography
+superBlock: front-end-development
+---
+
+## Introduction to the CSS Typography Quiz
+
+Test what you've learned in this quiz of typography in CSS.

--- a/client/src/pages/learn/front-end-development/quiz-css-variables/index.md
+++ b/client/src/pages/learn/front-end-development/quiz-css-variables/index.md
@@ -1,0 +1,9 @@
+---
+title: Introduction to the CSS Variables Quiz
+block: quiz-css-variables
+superBlock: front-end-development
+---
+
+## Introduction to the CSS Variables Quiz
+
+Test what you've learned in this quiz of how using variables in CSS.

--- a/client/src/pages/learn/front-end-development/quiz-design-fundamentals/index.md
+++ b/client/src/pages/learn/front-end-development/quiz-design-fundamentals/index.md
@@ -1,0 +1,9 @@
+---
+title: Introduction to the Design Fundamentals Quiz
+block: quiz-design-fundamentals
+superBlock: front-end-development
+---
+
+## Introduction to the Design Fundamentals Quiz
+
+Test what you've learned in this quiz of UI design fundamentals.

--- a/client/src/pages/learn/front-end-development/quiz-html-accessibility/index.md
+++ b/client/src/pages/learn/front-end-development/quiz-html-accessibility/index.md
@@ -1,0 +1,9 @@
+---
+title: Introduction to the HTML Accessibility Quiz
+block: quiz-html-accessibility
+superBlock: front-end-development
+---
+
+## Introduction to the HTML Accessibility Quiz
+
+Test what you've learned in this quiz of HTML accessibility knowledge.

--- a/client/src/pages/learn/front-end-development/quiz-html-tables-and-forms/index.md
+++ b/client/src/pages/learn/front-end-development/quiz-html-tables-and-forms/index.md
@@ -1,0 +1,9 @@
+---
+title: Introduction to the HTML Tables and Forms Quiz
+block: quiz-html-tables-and-forms
+superBlock: front-end-development
+---
+
+## Introduction to the HTML Tables and Forms Quiz
+
+Test what you've learned in this quiz of HTML tables and forms.

--- a/client/src/pages/learn/front-end-development/quiz-responsive-web-design/index.md
+++ b/client/src/pages/learn/front-end-development/quiz-responsive-web-design/index.md
@@ -1,0 +1,9 @@
+---
+title: Introduction to the Responsive Web Design Quiz
+block: quiz-responsive-web-design
+superBlock: front-end-development
+---
+
+## Introduction to the Responsive Web Design Quiz
+
+Test what you've learned in this quiz of making your webpage responsive.

--- a/client/src/pages/learn/front-end-development/quiz-semantic-html/index.md
+++ b/client/src/pages/learn/front-end-development/quiz-semantic-html/index.md
@@ -1,0 +1,9 @@
+---
+title: Introduction to the Semantic HTML Quiz
+block: quiz-semantic-html
+superBlock: front-end-development
+---
+
+## Introduction to the Semantic HTML Quiz
+
+Test what you've learned in this quiz of semantic HTML knowledge.

--- a/client/src/pages/learn/front-end-development/quiz-styling-forms/index.md
+++ b/client/src/pages/learn/front-end-development/quiz-styling-forms/index.md
@@ -1,0 +1,9 @@
+---
+title: Introduction to the Styling Forms Quiz
+block: quiz-styling-forms
+superBlock: front-end-development
+---
+
+## Introduction to the Styling Forms Quiz
+
+Test what you've learned in this quiz of how to style forms using CSS.

--- a/client/utils/gatsby/challenge-page-creator.js
+++ b/client/utils/gatsby/challenge-page-creator.js
@@ -26,6 +26,11 @@ const superBlockIntro = path.resolve(
   __dirname,
   '../../src/templates/Introduction/super-block-intro.tsx'
 );
+const quiz = path.resolve(
+  __dirname,
+  '../../src/templates/Challenges/video/show.tsx'
+);
+
 const video = path.resolve(
   __dirname,
   '../../src/templates/Challenges/video/show.tsx'
@@ -61,6 +66,7 @@ const views = {
   classic,
   modern: classic,
   frontend,
+  quiz,
   video,
   codeAlly,
   odin,

--- a/client/utils/gatsby/challenge-page-creator.js
+++ b/client/utils/gatsby/challenge-page-creator.js
@@ -28,7 +28,7 @@ const superBlockIntro = path.resolve(
 );
 const quiz = path.resolve(
   __dirname,
-  '../../src/templates/Challenges/video/show.tsx'
+  '../../src/templates/Challenges/projects/backend/show.tsx'
 );
 
 const video = path.resolve(

--- a/curriculum/challenges/_meta/quiz-basic-css/meta.json
+++ b/curriculum/challenges/_meta/quiz-basic-css/meta.json
@@ -1,0 +1,10 @@
+{
+  "name": "Basic CSS Quiz",
+  "blockType": "quiz",
+  "isUpcomingChange": true,
+  "dashedName": "quiz-basic-css",
+  "order": 41,
+  "superBlock": "front-end-development",
+  "challengeOrder": [{ "id": "66ed8fa2f45ce3ece4053eab", "title": "Basic CSS Quiz" }],
+  "helpCategory": "HTML-CSS"
+}

--- a/curriculum/challenges/_meta/quiz-computer-basics/meta.json
+++ b/curriculum/challenges/_meta/quiz-computer-basics/meta.json
@@ -1,0 +1,10 @@
+{
+  "name": "Computer Basics Quiz",
+  "blockType": "quiz",
+  "isUpcomingChange": true,
+  "dashedName": "quiz-computer-basics",
+  "order": 35,
+  "superBlock": "front-end-development",
+  "challengeOrder": [{ "id": "66ed8fb9f45ce3ece4053eac", "title": "Computer Basics Quiz" }],
+  "helpCategory": "HTML-CSS"
+}

--- a/curriculum/challenges/_meta/quiz-css-accessibility/meta.json
+++ b/curriculum/challenges/_meta/quiz-css-accessibility/meta.json
@@ -1,0 +1,10 @@
+{
+  "name": "CSS Accessibility Quiz",
+  "blockType": "quiz",
+  "isUpcomingChange": true,
+  "dashedName": "quiz-css-accessibility",
+  "order": 92,
+  "superBlock": "front-end-development",
+  "challengeOrder": [{ "id": "66ed8fc1f45ce3ece4053ead", "title": "CSS Accessibility Quiz" }],
+  "helpCategory": "HTML-CSS"
+}

--- a/curriculum/challenges/_meta/quiz-css-animations/meta.json
+++ b/curriculum/challenges/_meta/quiz-css-animations/meta.json
@@ -1,0 +1,10 @@
+{
+  "name": "CSS Animations Quiz",
+  "blockType": "quiz",
+  "isUpcomingChange": true,
+  "dashedName": "quiz-css-animations",
+  "order": 126,
+  "superBlock": "front-end-development",
+  "challengeOrder": [{ "id": "66ed8fc9f45ce3ece4053eae", "title": "CSS Animations Quiz" }],
+  "helpCategory": "HTML-CSS"
+}

--- a/curriculum/challenges/_meta/quiz-css-attribute-selectors/meta.json
+++ b/curriculum/challenges/_meta/quiz-css-attribute-selectors/meta.json
@@ -1,0 +1,10 @@
+{
+  "name": "CSS Attribute Selectors Quiz",
+  "blockType": "quiz",
+  "isUpcomingChange": true,
+  "dashedName": "quiz-css-attribute-selectors",
+  "order": 97,
+  "superBlock": "front-end-development",
+  "challengeOrder": [{ "id": "66ed8fd0f45ce3ece4053eaf", "title": "CSS Attribute Selectors Quiz" }],
+  "helpCategory": "HTML-CSS"
+}

--- a/curriculum/challenges/_meta/quiz-css-backgrounds-and-borders/meta.json
+++ b/curriculum/challenges/_meta/quiz-css-backgrounds-and-borders/meta.json
@@ -1,0 +1,10 @@
+{
+  "name": "CSS Backgrounds and Borders Quiz",
+  "blockType": "quiz",
+  "isUpcomingChange": true,
+  "dashedName": "quiz-css-backgrounds-and-borders",
+  "order": 47,
+  "superBlock": "front-end-development",
+  "challengeOrder": [{ "id": "66ed8fd7f45ce3ece4053eb0", "title": "CSS Backgrounds and Borders Quiz" }],
+  "helpCategory": "HTML-CSS"
+}

--- a/curriculum/challenges/_meta/quiz-css-colors/meta.json
+++ b/curriculum/challenges/_meta/quiz-css-colors/meta.json
@@ -1,0 +1,10 @@
+{
+  "name": "CSS Colors Quiz",
+  "blockType": "quiz",
+  "isUpcomingChange": true,
+  "dashedName": "quiz-css-colors",
+  "order": 67,
+  "superBlock": "front-end-development",
+  "challengeOrder": [{ "id": "66ed8fe1f45ce3ece4053eb1", "title": "CSS Colors Quiz" }],
+  "helpCategory": "HTML-CSS"
+}

--- a/curriculum/challenges/_meta/quiz-css-flexbox/meta.json
+++ b/curriculum/challenges/_meta/quiz-css-flexbox/meta.json
@@ -1,0 +1,10 @@
+{
+  "name": "CSS Flexbox Quiz",
+  "blockType": "quiz",
+  "isUpcomingChange": true,
+  "dashedName": "quiz-css-flexbox",
+  "order": 82,
+  "superBlock": "front-end-development",
+  "challengeOrder": [{ "id": "66ed8fe7f45ce3ece4053eb2", "title": "CSS Flexbox Quiz" }],
+  "helpCategory": "HTML-CSS"
+}

--- a/curriculum/challenges/_meta/quiz-css-grid/meta.json
+++ b/curriculum/challenges/_meta/quiz-css-grid/meta.json
@@ -1,0 +1,10 @@
+{
+  "name": "CSS Grid Quiz",
+  "blockType": "quiz",
+  "isUpcomingChange": true,
+  "dashedName": "quiz-css-grid",
+  "order": 119,
+  "superBlock": "front-end-development",
+  "challengeOrder": [{ "id": "66ed8fedf45ce3ece4053eb3", "title": "CSS Grid Quiz" }],
+  "helpCategory": "HTML-CSS"
+}

--- a/curriculum/challenges/_meta/quiz-css-layout-and-effects/meta.json
+++ b/curriculum/challenges/_meta/quiz-css-layout-and-effects/meta.json
@@ -1,0 +1,10 @@
+{
+  "name": "CSS Layout and Effects Quiz",
+  "blockType": "quiz",
+  "isUpcomingChange": true,
+  "dashedName": "quiz-css-layout-and-effects",
+  "order": 77,
+  "superBlock": "front-end-development",
+  "challengeOrder": [{ "id": "66ed8ff4f45ce3ece4053eb4", "title": "CSS Layout and Effects Quiz" }],
+  "helpCategory": "HTML-CSS"
+}

--- a/curriculum/challenges/_meta/quiz-css-positioning/meta.json
+++ b/curriculum/challenges/_meta/quiz-css-positioning/meta.json
@@ -1,0 +1,10 @@
+{
+  "name": "CSS Positioning Quiz",
+  "blockType": "quiz",
+  "isUpcomingChange": true,
+  "dashedName": "quiz-css-positioning",
+  "order": 102,
+  "superBlock": "front-end-development",
+  "challengeOrder": [{ "id": "66ed8ffcf45ce3ece4053eb5", "title": "CSS Positioning Quiz" }],
+  "helpCategory": "HTML-CSS"
+}

--- a/curriculum/challenges/_meta/quiz-css-pseudo-classes/meta.json
+++ b/curriculum/challenges/_meta/quiz-css-pseudo-classes/meta.json
@@ -1,0 +1,10 @@
+{
+  "name": "CSS Pseudo-classes Quiz",
+  "blockType": "quiz",
+  "isUpcomingChange": true,
+  "dashedName": "quiz-css-pseudo-classes",
+  "order": 62,
+  "superBlock": "front-end-development",
+  "challengeOrder": [{ "id": "66ed9002f45ce3ece4053eb6", "title": "CSS Pseudo-classes Quiz" }],
+  "helpCategory": "HTML-CSS"
+}

--- a/curriculum/challenges/_meta/quiz-css-relative-and-absolute-units/meta.json
+++ b/curriculum/challenges/_meta/quiz-css-relative-and-absolute-units/meta.json
@@ -1,0 +1,10 @@
+{
+  "name": "CSS Relative and Absolute Units Quiz",
+  "blockType": "quiz",
+  "isUpcomingChange": true,
+  "dashedName": "quiz-css-relative-and-absolute-units",
+  "order": 57,
+  "superBlock": "front-end-development",
+  "challengeOrder": [{ "id": "66ed9009f45ce3ece4053eb7", "title": "CSS Relative and Absolute Units Quiz" }],
+  "helpCategory": "HTML-CSS"
+}

--- a/curriculum/challenges/_meta/quiz-css-typography/meta.json
+++ b/curriculum/challenges/_meta/quiz-css-typography/meta.json
@@ -1,0 +1,10 @@
+{
+  "name": "CSS Typography Quiz",
+  "blockType": "quiz",
+  "isUpcomingChange": true,
+  "dashedName": "quiz-css-typography",
+  "order": 87,
+  "superBlock": "front-end-development",
+  "challengeOrder": [{ "id": "66ed9010f45ce3ece4053eb8", "title": "CSS Typography Quiz" }],
+  "helpCategory": "HTML-CSS"
+}

--- a/curriculum/challenges/_meta/quiz-css-variables/meta.json
+++ b/curriculum/challenges/_meta/quiz-css-variables/meta.json
@@ -1,0 +1,10 @@
+{
+  "name": "CSS Variables Quiz",
+  "blockType": "quiz",
+  "isUpcomingChange": true,
+  "dashedName": "quiz-css-variables",
+  "order": 112,
+  "superBlock": "front-end-development",
+  "challengeOrder": [{ "id": "66ed9018f45ce3ece4053eb9", "title": "CSS Variables Quiz" }],
+  "helpCategory": "HTML-CSS"
+}

--- a/curriculum/challenges/_meta/quiz-design-fundamentals/meta.json
+++ b/curriculum/challenges/_meta/quiz-design-fundamentals/meta.json
@@ -1,0 +1,10 @@
+{
+  "name": "Design Fundamentals Quiz",
+  "blockType": "quiz",
+  "isUpcomingChange": true,
+  "dashedName": "quiz-design-fundamentals",
+  "order": 52,
+  "superBlock": "front-end-development",
+  "challengeOrder": [{ "id": "66ed901ff45ce3ece4053eba", "title": "Design Fundamentals Quiz" }],
+  "helpCategory": "HTML-CSS"
+}

--- a/curriculum/challenges/_meta/quiz-html-accessibility/meta.json
+++ b/curriculum/challenges/_meta/quiz-html-accessibility/meta.json
@@ -1,0 +1,10 @@
+{
+  "name": "HTML Accessibility Quiz",
+  "blockType": "quiz",
+  "isUpcomingChange": true,
+  "dashedName": "quiz-html-accessibility",
+  "order": 28,
+  "superBlock": "front-end-development",
+  "challengeOrder": [{ "id": "66ed9026f45ce3ece4053ebb", "title": "HTML Accessibility Quiz" }],
+  "helpCategory": "HTML-CSS"
+}

--- a/curriculum/challenges/_meta/quiz-html-tables-and-forms/meta.json
+++ b/curriculum/challenges/_meta/quiz-html-tables-and-forms/meta.json
@@ -1,0 +1,10 @@
+{
+  "name": "HTML Tables and Forms Quiz",
+  "blockType": "quiz",
+  "isUpcomingChange": true,
+  "dashedName": "quiz-html-tables-and-forms",
+  "order": 24,
+  "superBlock": "front-end-development",
+  "challengeOrder": [{ "id": "66ed902df45ce3ece4053ebc", "title": "HTML Tables and Forms Quiz" }],
+  "helpCategory": "HTML-CSS"
+}

--- a/curriculum/challenges/_meta/quiz-responsive-web-design/meta.json
+++ b/curriculum/challenges/_meta/quiz-responsive-web-design/meta.json
@@ -1,0 +1,10 @@
+{
+  "name": "Responsive Web Design Quiz",
+  "blockType": "quiz",
+  "isUpcomingChange": true,
+  "dashedName": "quiz-responsive-web-design",
+  "order": 107,
+  "superBlock": "front-end-development",
+  "challengeOrder": [{ "id": "66ed9034f45ce3ece4053ebd", "title": "Responsive Web Design Quiz" }],
+  "helpCategory": "HTML-CSS"
+}

--- a/curriculum/challenges/_meta/quiz-semantic-html/meta.json
+++ b/curriculum/challenges/_meta/quiz-semantic-html/meta.json
@@ -1,0 +1,10 @@
+{
+  "name": "Semantic HTML Quiz",
+  "blockType": "quiz",
+  "isUpcomingChange": true,
+  "dashedName": "quiz-semantic-html",
+  "order": 15,
+  "superBlock": "front-end-development",
+  "challengeOrder": [{ "id": "66ed903cf45ce3ece4053ebe", "title": "Semantic HTML Quiz" }],
+  "helpCategory": "HTML-CSS"
+}

--- a/curriculum/challenges/_meta/quiz-styling-forms/meta.json
+++ b/curriculum/challenges/_meta/quiz-styling-forms/meta.json
@@ -1,0 +1,10 @@
+{
+  "name": "Styling Forms Quiz",
+  "blockType": "quiz",
+  "isUpcomingChange": true,
+  "dashedName": "quiz-styling-forms",
+  "order": 72,
+  "superBlock": "front-end-development",
+  "challengeOrder": [{ "id": "66ed9043f45ce3ece4053ebf", "title": "Styling Forms Quiz" }],
+  "helpCategory": "HTML-CSS"
+}

--- a/curriculum/challenges/english/25-front-end-development/quiz-basic-css/66ed8fa2f45ce3ece4053eab.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-basic-css/66ed8fa2f45ce3ece4053eab.md
@@ -2,7 +2,7 @@
 id: 66ed8fa2f45ce3ece4053eab
 title: Basic CSS Quiz
 challengeType: 8
-dashedName: basic-css-quiz
+dashedName: quiz-basic-css
 ---
 
 # --description--

--- a/curriculum/challenges/english/25-front-end-development/quiz-basic-css/66ed8fa2f45ce3ece4053eab.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-basic-css/66ed8fa2f45ce3ece4053eab.md
@@ -1,0 +1,10 @@
+---
+id: 66ed8fa2f45ce3ece4053eab
+title: Basic CSS Quiz
+challengeType: 8
+dashedName: basic-css-quiz
+---
+
+# --description--
+
+Answer all of the questions below correctly to pass the quiz.

--- a/curriculum/challenges/english/25-front-end-development/quiz-computer-basics/66ed8fb9f45ce3ece4053eac.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-computer-basics/66ed8fb9f45ce3ece4053eac.md
@@ -1,0 +1,10 @@
+---
+id: 66ed8fb9f45ce3ece4053eac
+title: Computer Basics Quiz
+challengeType: 8
+dashedName: quiz-computer-basics
+---
+
+# --description--
+
+Answer all of the questions below correctly to pass the quiz.

--- a/curriculum/challenges/english/25-front-end-development/quiz-css-accessibility/66ed8fc1f45ce3ece4053ead.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-css-accessibility/66ed8fc1f45ce3ece4053ead.md
@@ -1,0 +1,10 @@
+---
+id: 66ed8fc1f45ce3ece4053ead
+title: CSS Accessibility Quiz
+challengeType: 8
+dashedName: quiz-css-accessibility
+---
+
+# --description--
+
+Answer all of the questions below correctly to pass the quiz.

--- a/curriculum/challenges/english/25-front-end-development/quiz-css-animations/66ed8fc9f45ce3ece4053eae.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-css-animations/66ed8fc9f45ce3ece4053eae.md
@@ -1,0 +1,10 @@
+---
+id: 66ed8fc9f45ce3ece4053eae
+title: CSS Animations Quiz
+challengeType: 8
+dashedName: quiz-css-animations
+---
+
+# --description--
+
+Answer all of the questions below correctly to pass the quiz.

--- a/curriculum/challenges/english/25-front-end-development/quiz-css-attribute-selectors/66ed8fd0f45ce3ece4053eaf.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-css-attribute-selectors/66ed8fd0f45ce3ece4053eaf.md
@@ -1,0 +1,10 @@
+---
+id: 66ed8fd0f45ce3ece4053eaf
+title: CSS Attribute Selectors Quiz
+challengeType: 8
+dashedName: quiz-css-attribute-selectors
+---
+
+# --description--
+
+Answer all of the questions below correctly to pass the quiz.

--- a/curriculum/challenges/english/25-front-end-development/quiz-css-backgrounds-and-borders/66ed8fd7f45ce3ece4053eb0.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-css-backgrounds-and-borders/66ed8fd7f45ce3ece4053eb0.md
@@ -1,0 +1,10 @@
+---
+id: 66ed8fd7f45ce3ece4053eb0
+title: CSS Backgrounds and Borders Quiz
+challengeType: 8
+dashedName: quiz-css-backgrounds-and-borders
+---
+
+# --description--
+
+Answer all of the questions below correctly to pass the quiz.

--- a/curriculum/challenges/english/25-front-end-development/quiz-css-colors/66ed8fe1f45ce3ece4053eb1.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-css-colors/66ed8fe1f45ce3ece4053eb1.md
@@ -1,0 +1,10 @@
+---
+id: 66ed8fe1f45ce3ece4053eb1
+title: CSS Colors Quiz
+challengeType: 8
+dashedName: quiz-css-colors
+---
+
+# --description--
+
+Answer all of the questions below correctly to pass the quiz.

--- a/curriculum/challenges/english/25-front-end-development/quiz-css-flexbox/66ed8fe7f45ce3ece4053eb2.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-css-flexbox/66ed8fe7f45ce3ece4053eb2.md
@@ -1,0 +1,10 @@
+---
+id: 66ed8fe7f45ce3ece4053eb2
+title: CSS Flexbox Quiz
+challengeType: 8
+dashedName: quiz-css-flexbox
+---
+
+# --description--
+
+Answer all of the questions below correctly to pass the quiz.

--- a/curriculum/challenges/english/25-front-end-development/quiz-css-grid/66ed8fedf45ce3ece4053eb3.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-css-grid/66ed8fedf45ce3ece4053eb3.md
@@ -1,0 +1,10 @@
+---
+id: 66ed8fedf45ce3ece4053eb3
+title: CSS Grid Quiz
+challengeType: 8
+dashedName: quiz-css-grid
+---
+
+# --description--
+
+Answer all of the questions below correctly to pass the quiz.

--- a/curriculum/challenges/english/25-front-end-development/quiz-css-layout-and-effects/66ed8ff4f45ce3ece4053eb4.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-css-layout-and-effects/66ed8ff4f45ce3ece4053eb4.md
@@ -1,0 +1,10 @@
+---
+id: 66ed8ff4f45ce3ece4053eb4
+title: CSS Layout and Effects Quiz
+challengeType: 8
+dashedName: quiz-css-layout-and-effects
+---
+
+# --description--
+
+Answer all of the questions below correctly to pass the quiz.

--- a/curriculum/challenges/english/25-front-end-development/quiz-css-positioning/66ed8ffcf45ce3ece4053eb5.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-css-positioning/66ed8ffcf45ce3ece4053eb5.md
@@ -1,0 +1,10 @@
+---
+id: 66ed8ffcf45ce3ece4053eb5
+title: CSS Positioning Quiz
+challengeType: 8
+dashedName: quiz-css-positioning
+---
+
+# --description--
+
+Answer all of the questions below correctly to pass the quiz.

--- a/curriculum/challenges/english/25-front-end-development/quiz-css-pseudo-classes/66ed9002f45ce3ece4053eb6.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-css-pseudo-classes/66ed9002f45ce3ece4053eb6.md
@@ -1,0 +1,10 @@
+---
+id: 66ed9002f45ce3ece4053eb6
+title: CSS Pseudo-classes Quiz
+challengeType: 8
+dashedName: quiz-css-pseudo-classes
+---
+
+# --description--
+
+Answer all of the questions below correctly to pass the quiz.

--- a/curriculum/challenges/english/25-front-end-development/quiz-css-relative-and-absolute-units/66ed9009f45ce3ece4053eb7.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-css-relative-and-absolute-units/66ed9009f45ce3ece4053eb7.md
@@ -1,0 +1,10 @@
+---
+id: 66ed9009f45ce3ece4053eb7
+title: CSS Relative and Absolute Units Quiz
+challengeType: 8
+dashedName: quiz-css-relative-and-absolute-units
+---
+
+# --description--
+
+Answer all of the questions below correctly to pass the quiz.

--- a/curriculum/challenges/english/25-front-end-development/quiz-css-typography/66ed9010f45ce3ece4053eb8.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-css-typography/66ed9010f45ce3ece4053eb8.md
@@ -1,0 +1,10 @@
+---
+id: 66ed9010f45ce3ece4053eb8
+title: CSS Typography Quiz
+challengeType: 8
+dashedName: quiz-css-typography
+---
+
+# --description--
+
+Answer all of the questions below correctly to pass the quiz.

--- a/curriculum/challenges/english/25-front-end-development/quiz-css-variables/66ed9018f45ce3ece4053eb9.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-css-variables/66ed9018f45ce3ece4053eb9.md
@@ -1,0 +1,10 @@
+---
+id: 66ed9018f45ce3ece4053eb9
+title: CSS Variables Quiz
+challengeType: 8
+dashedName: quiz-css-variables
+---
+
+# --description--
+
+Answer all of the questions below correctly to pass the quiz.

--- a/curriculum/challenges/english/25-front-end-development/quiz-design-fundamentals/66ed901ff45ce3ece4053eba.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-design-fundamentals/66ed901ff45ce3ece4053eba.md
@@ -1,0 +1,10 @@
+---
+id: 66ed901ff45ce3ece4053eba
+title: Design Fundamentals Quiz
+challengeType: 8
+dashedName: quiz-design-fundamentals
+---
+
+# --description--
+
+Answer all of the questions below correctly to pass the quiz.

--- a/curriculum/challenges/english/25-front-end-development/quiz-html-accessibility/66ed9026f45ce3ece4053ebb.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-html-accessibility/66ed9026f45ce3ece4053ebb.md
@@ -1,0 +1,10 @@
+---
+id: 66ed9026f45ce3ece4053ebb
+title: HTML Accessibility Quiz
+challengeType: 8
+dashedName: quiz-html-accessibility
+---
+
+# --description--
+
+Answer all of the questions below correctly to pass the quiz.

--- a/curriculum/challenges/english/25-front-end-development/quiz-html-tables-and-forms/66ed902df45ce3ece4053ebc.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-html-tables-and-forms/66ed902df45ce3ece4053ebc.md
@@ -1,0 +1,10 @@
+---
+id: 66ed902df45ce3ece4053ebc
+title: HTML Tables and Forms Quiz
+challengeType: 8
+dashedName: quiz-html-tables-and-forms
+---
+
+# --description--
+
+Answer all of the questions below correctly to pass the quiz.

--- a/curriculum/challenges/english/25-front-end-development/quiz-responsive-web-design/66ed9034f45ce3ece4053ebd.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-responsive-web-design/66ed9034f45ce3ece4053ebd.md
@@ -1,0 +1,10 @@
+---
+id: 66ed9034f45ce3ece4053ebd
+title: Responsive Web Design Quiz
+challengeType: 8
+dashedName: quiz-responsive-web-design
+---
+
+# --description--
+
+Answer all of the questions below correctly to pass the quiz.

--- a/curriculum/challenges/english/25-front-end-development/quiz-semantic-html/66ed903cf45ce3ece4053ebe.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-semantic-html/66ed903cf45ce3ece4053ebe.md
@@ -1,0 +1,10 @@
+---
+id: 66ed903cf45ce3ece4053ebe
+title: Semantic HTML Quiz
+challengeType: 8
+dashedName: quiz-semantic-html
+---
+
+# --description--
+
+Answer all of the questions below correctly to pass the quiz.

--- a/curriculum/challenges/english/25-front-end-development/quiz-styling-forms/66ed9043f45ce3ece4053ebf.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-styling-forms/66ed9043f45ce3ece4053ebf.md
@@ -1,0 +1,10 @@
+---
+id: 66ed9043f45ce3ece4053ebf
+title: Styling Forms Quiz
+challengeType: 8
+dashedName: quiz-styling-forms
+---
+
+# --description--
+
+Answer all of the questions below correctly to pass the quiz.


### PR DESCRIPTION
This adds the boilerplate files for the HTML and CSS quizzes - it should be 21 quiz blocks and challenges. It will make it easier to add the quiz questions.

a couple notes: I used a temporary show.tsx file so this builds. Once #56058 is in, I can update this - or if this gets in first, I can update that. Also, that PR has the first quiz on it, so I didn't add that here.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
