### PR TITLE
fix(curriculum): fix a typo in js course

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/660880e67dfed9eb6adb7178.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/660880e67dfed9eb6adb7178.md
@@ -7,7 +7,7 @@ dashedName: step-48
 
 # --description--
 
-Before you can begin to build out your `locations` array, you will first need to learn about <df>objects</dfn>. Objects are an important data type in JavaScript. The next few steps will be dedicated to learning about them so you will better understand how to apply them in your project.
+Before you can begin to build out your `locations` array, you will first need to learn about <dfn>objects</dfn>. Objects are an important data type in JavaScript. The next few steps will be dedicated to learning about them so you will better understand how to apply them in your project.
 
 Objects are non primitive data types that store key-value pairs. Non primitive data types are mutable data types that are not `undefined`, `null`, `boolean`, `number`, `string`, or `symbol`. Mutable means that the data can be changed after it is created.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!-- Feel free to add any additional description of changes below this line -->

I was translating this file and noticed that Crowdin shows a broken sentence. After checking the source file, I saw a typo in the HTML tag. This PR fixes the typo.

![image](https://github.com/user-attachments/assets/325730e1-9e0b-41d6-82e3-988bd074da90)

![image](https://github.com/user-attachments/assets/1641dc9a-03f3-4d43-9602-10ab370f1f2c)

(If there is no typo, those two should be one sentence.)