### PR TITLE
fix(curriculum): head content test

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-colors-by-building-a-set-of-colored-markers/616965351e74d4689eb6de30.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-colors-by-building-a-set-of-colored-markers/616965351e74d4689eb6de30.md
@@ -36,11 +36,15 @@ const target = meta?.find(m => m?.getAttribute('name')?.toLowerCase()?.replace(/
 assert.exists(target);
 ```
 
-Your new `meta` element should be inside the `head` element.
+Your two `meta` elements should be inside the `head` element.
 
 ```js
-const metaElementRegex = /<head\s*>(?:.|\r|\n)*?<meta\s+name\s*=\s*('|"|`)\s*viewport\s*\1\s+content\s*=\s*\1\s*width\s*=\s*device-width\s*,\s*initial-scale\s*=\s*1(?:\.0)?\s*\1(?:.|\r|\n)*?<\/head\s*>/i;
-assert.match(code, metaElementRegex);
+const headContentRegex = /(?<=<head\s*>)[\S|\s]*(?=<\/head\s*>)/;
+const headElementContent = code.match(headContentRegex);
+
+const headElement = document.createElement("head");
+headElement.innerHTML = headElementContent;
+assert.strictEqual(headElement.querySelectorAll('meta').length, 2);
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Instead of the pure regex test.

This will also allow using two different types of quotes for the two attribute values, unlike the current regex because of the capture group (the quotes used for the two attribute values must match).

This was motivated by this thread.

https://forum.freecodecamp.org/t/learn-css-colors-by-building-a-set-of-colored-markers-step-5/712331

It is cleaner as well, in my opinion.
