### PR TITLE
fix(client): donation alert text color

### DIFF
--- a/client/src/components/layouts/global.css
+++ b/client/src/components/layouts/global.css
@@ -633,6 +633,11 @@ pre code {
     );
 }
 
+.university-alert p,
+.annual-donation-alert p {
+  color: inherit;
+}
+
 /* gatsby 404 */
 #search {
   background-color: var(--quaternary-background);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

The latest version of @freecodecamp/ui has a change in the default text color of `p` elements (https://github.com/freeCodeCamp/ui/pull/303/files#diff-5e64d0cc9c46937489d71595a4efb9d03f22574a0e83ca8b132a8833e03e6c60R43). This CSS rule appears to override the donation alert text color in /learn. 

This PR is to fix the issue.

## Screenshot

| Before | After |
| --- | --- |
| <img width="785" alt="Screenshot 2024-09-24 at 04 05 05" src="https://github.com/user-attachments/assets/ab03b7e4-8a9b-4235-8627-dcc6dd2828b8"> | <img width="783" alt="Screenshot 2024-09-24 at 04 07 18" src="https://github.com/user-attachments/assets/a5773de8-9299-4cff-a02a-374aa1921d03"> |

<!-- Feel free to add any additional description of changes below this line -->
