### PR TITLE
fix(curriculum): Add missing quote in Python list example

### DIFF
--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-lambda-functions-by-building-an-expense-tracker/66694bfa435cef241f6f9a68.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-lambda-functions-by-building-an-expense-tracker/66694bfa435cef241f6f9a68.md
@@ -18,7 +18,7 @@ empty_list = []
 
 The list is characterized by the square brackets around all the values, and a comma between the values, like: `["A", "happy", "list"]`. If the list does not contain any values, then it is an empty list: `[]`.
 
-A list can contain different data types: `[1, "Up", ["Down", "Twice]]`. That includes all possible data types. It can also contain another list!
+A list can contain different data types: `[1, "Up", ["Down", "Twice"]]`. That includes all possible data types. It can also contain another list!
 
 Create a variable called `my_list` and assign to it an empty list.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #56273 

<!-- Feel free to add any additional description of changes below this line -->

This PR fixes a typo in the Python list example in the lambda functions lesson. 
A missing quotation mark was added to correctly format the nested list example.

