### PR TITLE
fix(curriculum): typo in HTML quiz

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/quiz-basic-html/66df3b712c41c499e9d31e5b.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-basic-html/66df3b712c41c499e9d31e5b.md
@@ -121,7 +121,7 @@ Boolean attributes must always have a value assigned to them, while regular attr
 
 #### --answer--
 
-A boolean attribute in can be present or absent, indicating `true` or `false`, while a regular attribute always has a specified value.
+A boolean attribute can be present or absent, indicating `true` or `false`, while a regular attribute always has a specified value.
 
 ### --question--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #56277

<!-- Feel free to add any additional description of changes below this line -->
Fix: Correct typo in contributing guidelines (#56277)

Corrected a minor typographical error in the contributing guidelines.

**Changes Made:**
- Removed the word "in" from the sentence "A boolean attribute in can be
  present or absent" to make it read "A boolean attribute can be present
  or absent".
