### PR TITLE
fix: remove comma from "Hi, there" text in example and closed captions

### DIFF
--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a2a7b05241026c429e3f0.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a2a7b05241026c429e3f0.md
@@ -51,7 +51,7 @@ Watch the video
       "startTime": 1,
       "finishTime": 4.3,
       "dialogue": {
-        "text": "Hi, there. I'm Tom. I'm the new graphic designer.",
+        "text": "Hi there. I'm Tom. I'm the new graphic designer.",
         "align": "left"
       }
     },

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a2b1c7216c026fcd156c7.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a2b1c7216c026fcd156c7.md
@@ -7,12 +7,12 @@ dashedName: task-33
 
 <!--
 AUDIO REFERENCE:
-Tom: Hi, there. I'm Tom.
+Tom: Hi there. I'm Tom.
 -->
 
 # --description--
 
-When greeting someone casually or for the first time, `Hi, there` is a friendly way to say hello. It's often used in informal situations or to greet someone you might not know very well.
+When greeting someone casually or for the first time, `Hi there` is a friendly way to say hello. It's often used in informal situations or to greet someone you might not know very well.
 
 # --fillInTheBlank--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!-- Feel free to add any additional description of changes below this line -->
Someone emailed support with some confusion about the expected answer here because the example in step 33 and the closed captions for that step and for dialogue 2 of "Learn Greetings in Your First Day at the Office" have a comma in the text "Hi, there". However, the expected answer is "Hi there" with no comma.

- Dialogue 2: https://www.freecodecamp.org/learn/a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/dialogue-2-tom-meets-the-coworker-next-to-him
- Step 33: https://www.freecodecamp.org/learn/a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/task-33

I believe the comma is a typo, and there are other examples where similar sentences don't include one.

Edit: Originally the title and description were about removing the comma between "Hi" and a name like "Tom", but that was a mistake.