### PR TITLE
fix(curriculum): add demoType to workshops

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-book-inventory-app/66a207974c806a19d6607073.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-book-inventory-app/66a207974c806a19d6607073.md
@@ -3,6 +3,7 @@ id: 66a207974c806a19d6607073
 title: Build a Book Inventory App
 challengeType: 14
 dashedName: build-a-book-inventory-app
+demoType: onClick
 ---
 
 # --description--

--- a/curriculum/challenges/english/25-front-end-development/lab-random-background-color-changer/66b62d0ad68488dd76228d6c.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-random-background-color-changer/66b62d0ad68488dd76228d6c.md
@@ -3,6 +3,7 @@ id: 66b62d0ad68488dd76228d6c
 title: Debug a Random Background Color Changer
 challengeType: 14
 dashedName: debug-a-random-background-color-changer
+demoType: onClick
 ---
 
 # --description--

--- a/curriculum/challenges/english/25-front-end-development/lab-travel-agency-page/669e2f60e83c011754f711f9.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-travel-agency-page/669e2f60e83c011754f711f9.md
@@ -3,6 +3,7 @@ id: 669e2f60e83c011754f711f9
 title: Build a Travel Agency Page
 challengeType: 14
 dashedName: build-a-travel-agency-page
+demoType: onClick
 ---
 
 # --description--

--- a/curriculum/challenges/english/25-front-end-development/lab-video-compilation-page/669e81368e52b3a5c35a2dc5.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-video-compilation-page/669e81368e52b3a5c35a2dc5.md
@@ -3,6 +3,7 @@ id: 669e81368e52b3a5c35a2dc5
 title: Build a Video Compilation Page
 challengeType: 14
 dashedName: build-a-video-compilation-page
+demoType: onClick
 ---
 
 # --description--

--- a/curriculum/challenges/english/25-front-end-development/workshop-blog-page/669aff9f5488f1bea056416d.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-blog-page/669aff9f5488f1bea056416d.md
@@ -3,6 +3,7 @@ id: 669aff9f5488f1bea056416d
 title: Step 1
 challengeType: 0
 dashedName: step-1
+demoType: onLoad
 ---
 
 # --description--

--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-photo-app/66731cd027ef3acb155669f5.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-photo-app/66731cd027ef3acb155669f5.md
@@ -3,6 +3,7 @@ id: 66731cd027ef3acb155669f5
 title: Step 1
 challengeType: 0
 dashedName: step-1
+demoType: onLoad
 ---
 
 # --description--

--- a/curriculum/challenges/english/25-front-end-development/workshop-final-exams-table/66a98f42c7c06903e5f8dd07.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-final-exams-table/66a98f42c7c06903e5f8dd07.md
@@ -3,6 +3,7 @@ id: 66a98f42c7c06903e5f8dd07
 title: Step 1
 challengeType: 0
 dashedName: step-1
+demoType: onLoad
 ---
 
 # --description--

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a8290a27c2c625e2355042.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a8290a27c2c625e2355042.md
@@ -3,6 +3,7 @@ id: 66a8290a27c2c625e2355042
 title: Step 1
 challengeType: 0
 dashedName: step-1
+demoType: onLoad
 ---
 
 # --description--


### PR DESCRIPTION
The opens the "preview of what you will build" on step one of the workshops with a UI (that don't already have this set).

Also, add the demoType to labs with UI's that were missing it.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
