### PR TITLE
fix(client/ui): lab demo button

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -397,6 +397,7 @@
     "running-tests": "// running tests",
     "tests-completed": "// tests completed",
     "console-output": "// console output",
+    "example-app": "Build an app that is functionally similar to <0>this example project</0>.",
     "syntax-error": "Your code raised an error before any tests could run. Please fix it and try again.",
     "indentation-error": "Your code has an indentation error. You may need to add <code>pass</code> on a new line to form a valid block of code.",
     "sign-in-save": "Sign in to save your progress",

--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -397,7 +397,7 @@
     "running-tests": "// running tests",
     "tests-completed": "// tests completed",
     "console-output": "// console output",
-    "example-app": "Build an app that is functionally similar to <0>this example project</0>.",
+    "example-app": "Build an app that is functionally similar to <0>this example project</0>. Try not to copy the example project, give it your own personal style.",
     "syntax-error": "Your code raised an error before any tests could run. Please fix it and try again.",
     "indentation-error": "Your code has an indentation error. You may need to add <code>pass</code> on a new line to form a valid block of code.",
     "sign-in-save": "Sign in to save your progress",

--- a/client/src/templates/Challenges/components/side-panel.css
+++ b/client/src/templates/Challenges/components/side-panel.css
@@ -18,3 +18,14 @@
   height: auto;
   overflow-y: none;
 }
+
+.example-app-link {
+  text-decoration: underline;
+}
+
+.example-app-link:hover,
+.example-app-link:active,
+.example-app-link:focus {
+  text-decoration: none;
+  background-color: var(--tertiary-background);
+}

--- a/client/src/templates/Challenges/components/side-panel.tsx
+++ b/client/src/templates/Challenges/components/side-panel.tsx
@@ -1,15 +1,13 @@
 import React, { useEffect, ReactElement, ReactNode } from 'react';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
-import { useTranslation } from 'react-i18next';
-import { Button } from '@freecodecamp/ui';
+import { Trans } from 'react-i18next';
 
 import { Test } from '../../../redux/prop-types';
 import { SuperBlocks } from '../../../../../shared/config/curriculum';
 import { initializeMathJax } from '../../../utils/math-jax';
 import { challengeTestsSelector } from '../redux/selectors';
 import { openModal } from '../redux/actions';
-import { Spacer } from '../../../components/helpers';
 import TestSuite from './test-suite';
 
 import './side-panel.css';
@@ -52,7 +50,6 @@ export function SidePanel({
   tests,
   openModal
 }: SidePanelProps): JSX.Element {
-  const { t } = useTranslation();
   useEffect(() => {
     const mathJaxChallenge =
       superBlock === SuperBlocks.RosettaCode ||
@@ -69,12 +66,21 @@ export function SidePanel({
     >
       {challengeTitle}
       {hasDemo && (
-        <>
-          <Button size='small' onClick={() => openModal('projectPreview')}>
-            {t('buttons.show-demo')}
-          </Button>
-          <Spacer size='xSmall' />
-        </>
+        <p>
+          <Trans i18nKey='learn.example-app'>
+            <span
+              className='example-app-link'
+              onClick={() => openModal('projectPreview')}
+              role='button'
+              tabIndex={0}
+              onKeyDown={e => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  openModal('projectPreview');
+                }
+              }}
+            ></span>
+          </Trans>
+        </p>
       )}
       {challengeDescription}
       {toolPanel}

--- a/curriculum/challenges/english/25-front-end-development/lab-availability-table/66b36358ed4f261d64840c24.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-availability-table/66b36358ed4f261d64840c24.md
@@ -8,7 +8,7 @@ demoType: onClick
 
 # --description--
 
-**Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab. 
+Fulfill the user stories below and get all the tests to pass to complete the lab.
 
 **User Stories:**
 

--- a/curriculum/challenges/english/25-front-end-development/lab-book-catalog-table/66ec4c8e9878d8441956516f.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-book-catalog-table/66ec4c8e9878d8441956516f.md
@@ -8,7 +8,7 @@ demoType: onClick
 
 # --description--
 
-**Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab. 
+Fulfill the user stories below and get all the tests to pass to complete the lab.
 
 **User Stories:**
 

--- a/curriculum/challenges/english/25-front-end-development/lab-book-inventory-app/66a207974c806a19d6607073.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-book-inventory-app/66a207974c806a19d6607073.md
@@ -9,7 +9,7 @@ demoType: onClick
 # --description--
 
 
-**Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab. 
+Fulfill the user stories below and get all the tests to pass to complete the lab.
 
 **User Stories:**
 

--- a/curriculum/challenges/english/25-front-end-development/lab-bookmark-manager-app/66def5467aee701733aaf8cc.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-bookmark-manager-app/66def5467aee701733aaf8cc.md
@@ -10,7 +10,7 @@ demoType: onClick
 
 For this lab, all the HTML and CSS has been provided to you. You will use JavaScript to complete the Bookmark Manager app so that it can store a collection of bookmarks in the local storage and read data from it.
 
-**Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab. 
+Fulfill the user stories below and get all the tests to pass to complete the lab.
 
 **User Stories:**
 

--- a/curriculum/challenges/english/25-front-end-development/lab-business-card/6690e10ebe2181212abc9652.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-business-card/6690e10ebe2181212abc9652.md
@@ -8,7 +8,7 @@ demoType: onClick
 
 # --description--
 
-**Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab.
+Fulfill the user stories below and get all the tests to pass to complete the lab.
 
 **User Stories:**
 

--- a/curriculum/challenges/english/25-front-end-development/lab-cash-register/aa2e6f85cab2ab736c9a9b24.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-cash-register/aa2e6f85cab2ab736c9a9b24.md
@@ -7,7 +7,7 @@ dashedName: build-a-cash-register
 
 # --description--
 
-**Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab. 
+Fulfill the user stories below and get all the tests to pass to complete the lab.
 
 **User Stories:**
 

--- a/curriculum/challenges/english/25-front-end-development/lab-checkout-page/66da326c02141df538f29ba5.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-checkout-page/66da326c02141df538f29ba5.md
@@ -8,7 +8,7 @@ demoType: onClick
 
 # --description--
 
-**Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab.
+Fulfill the user stories below and get all the tests to pass to complete the lab.
 
 **User Stories:**
 

--- a/curriculum/challenges/english/25-front-end-development/lab-confidential-email-page/66bba6fff611169359d9d36a.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-confidential-email-page/66bba6fff611169359d9d36a.md
@@ -8,7 +8,7 @@ demoType: onClick
 
 # --description--
 
-**Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab.
+Fulfill the user stories below and get all the tests to pass to complete the lab.
 
 **User Stories:**
 

--- a/curriculum/challenges/english/25-front-end-development/lab-email-masker/66b205e6eacba4c4e54ea434.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-email-masker/66b205e6eacba4c4e54ea434.md
@@ -11,7 +11,7 @@ In this lab, you will mask the username part of an email address with asterisks.
 
 For example, if the email address was `myEmail@email.com`, then the masked email address will be `m*******l@email.com`.
 
-**Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab. 
+Fulfill the user stories below and get all the tests to pass to complete the lab.
 
 **User Stories:**
 

--- a/curriculum/challenges/english/25-front-end-development/lab-event-flyer-page/66e45c8140f9fda5c105ae26.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-event-flyer-page/66e45c8140f9fda5c105ae26.md
@@ -8,7 +8,7 @@ demoType: onClick
 
 # --description--
 
-**Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab.
+Fulfill the user stories below and get all the tests to pass to complete the lab.
 
 **User Stories:**
 

--- a/curriculum/challenges/english/25-front-end-development/lab-event-hub/66ebd4ae2812430bb883c787.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-event-hub/66ebd4ae2812430bb883c787.md
@@ -10,7 +10,7 @@ demoType: onClick
 
 In this lab you will utilize the semantic HTML elements to create the structure of a web page. You'll add content and images to make it look like a real event hub.
 
-**Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab. 
+Fulfill the user stories below and get all the tests to pass to complete the lab.
 
 **User Stories:**
 

--- a/curriculum/challenges/english/25-front-end-development/lab-factorial-calculator/66c07238b01053abaf812065.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-factorial-calculator/66c07238b01053abaf812065.md
@@ -9,7 +9,7 @@ dashedName: build-a-factorial-calculator
 
 A factorial is the product of an integer and all the integers below it. For example, the factorial of `5` is `5 * 4 * 3 * 2 * 1 = 120`. In this lab, you will create a factorial calculator that takes a number from the user and calculates the factorial of that number.
 
-**Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab.
+Fulfill the user stories below and get all the tests to pass to complete the lab.
 
 **User Stories:**
 

--- a/curriculum/challenges/english/25-front-end-development/lab-favorite-icon-toggler/66bf6bacf178eac7b96d4f5e.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-favorite-icon-toggler/66bf6bacf178eac7b96d4f5e.md
@@ -10,7 +10,7 @@ demoType: onClick
 
 In this lab you will use JavaScript click events to toggle the appearance of a favorite icon. When the heart icon is clicked, the appearance of the heart changes from empty to filled, and vice versa.
 
-**Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab. **Do not copy this demo project**.
+Fulfill the user stories below and get all the tests to pass to complete the lab. **Do not copy this demo project**.
 
 **User Stories:**
 

--- a/curriculum/challenges/english/25-front-end-development/lab-football-team-cards/66e7ee20b79186306fc12da5.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-football-team-cards/66e7ee20b79186306fc12da5.md
@@ -10,7 +10,7 @@ demoType: onClick
 
 In this lab, you will build a set of football team cards. The user should be able to use the dropdown menu and filter between the different players based on their positions.
 
-**Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab. 
+Fulfill the user stories below and get all the tests to pass to complete the lab.
 
 **User Stories:**
 

--- a/curriculum/challenges/english/25-front-end-development/lab-fortune-teller/66c06d618d075c7f7f1b890a.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-fortune-teller/66c06d618d075c7f7f1b890a.md
@@ -9,7 +9,7 @@ dashedName: build-a-fortune-teller
 
 In this lab, you will define five fortunes and randomly select one of them to display the fortune to the user.
 
-**Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab. 
+Fulfill the user stories below and get all the tests to pass to complete the lab.
 
 **User Stories:**
 

--- a/curriculum/challenges/english/25-front-end-development/lab-gradebook-app/66bb6a9c2dd58b73cd759034.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-gradebook-app/66bb6a9c2dd58b73cd759034.md
@@ -7,7 +7,7 @@ dashedName: build-a-gradebook-app
 
 # --description--
 
-**Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab. 
+Fulfill the user stories below and get all the tests to pass to complete the lab.
 
 **User Stories:**
 

--- a/curriculum/challenges/english/25-front-end-development/lab-house-painting/66d6a7a3e1aa411e94bf2346.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-house-painting/66d6a7a3e1aa411e94bf2346.md
@@ -10,7 +10,7 @@ demoType: onClick
 
 In this lab, you will use HTML to create the structure of a house. Then, you will use CSS positioning to arrange the elements of your house like windows and doors.
 
-**Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab. 
+Fulfill the user stories below and get all the tests to pass to complete the lab.
 
 **User Stories:**
 

--- a/curriculum/challenges/english/25-front-end-development/lab-inventory-management-program/66d75dd0aa65a71600dc669b.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-inventory-management-program/66d75dd0aa65a71600dc669b.md
@@ -9,7 +9,7 @@ dashedName: build-an-inventory-management-program
 
 In this lab, you will build an inventory management program that will allow you to add, update, find and remove products from the inventory. You will use an array of objects to represent your inventory, where each object will have name and quantity as the keys.
 
-**Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab. 
+Fulfill the user stories below and get all the tests to pass to complete the lab.
 
 **User Stories:**
 

--- a/curriculum/challenges/english/25-front-end-development/lab-javascript-trivia-bot/66ed41f912d0bb1dc62da5dd.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-javascript-trivia-bot/66ed41f912d0bb1dc62da5dd.md
@@ -7,7 +7,7 @@ dashedName: lab-javascript-trivia-bot
 
 # --description--
 
-**Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab.
+Fulfill the user stories below and get all the tests to pass to complete the lab.
 
 **User Stories:**
 

--- a/curriculum/challenges/english/25-front-end-development/lab-leap-year-calculator/66c06fad3475cd92421b9ac2.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-leap-year-calculator/66c06fad3475cd92421b9ac2.md
@@ -9,7 +9,7 @@ dashedName: build-a-leap-year-calculator
 
 A leap year is a year that is divisible by `4`, except for years that are divisible by `100` and not divisible by `400`. For example, `2000` is a leap year, but `1900` is not. Also, a leap year has an extra day in February, which is the 29th day of the month.
 
-**Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab. 
+Fulfill the user stories below and get all the tests to pass to complete the lab.
 
 **User Stories:**
 

--- a/curriculum/challenges/english/25-front-end-development/lab-lightbox-viewer/66db57ad34c7089b9b41bfd6.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-lightbox-viewer/66db57ad34c7089b9b41bfd6.md
@@ -10,7 +10,7 @@ demoType: onClick
 
 A lightbox displays a larger version of an image when clicked and shadows the rest of the page. This project will create a lightbox gallery that displays full-size images when a thumbnail is clicked. For each image, two versions are provided: a thumbnail and a full-size image. The full-size image is the same as the thumbnail, but without the `-thumbnail` suffix.
 
-**Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab. 
+Fulfill the user stories below and get all the tests to pass to complete the lab.
 
 **User Stories:**
 

--- a/curriculum/challenges/english/25-front-end-development/lab-linked-list-class/66dadcf18df3a76104054d95.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-linked-list-class/66dadcf18df3a76104054d95.md
@@ -9,7 +9,7 @@ dashedName: build-a-linked-list-class
 
 In this lab, you'll build a linked list, which is a linear collection of data elements, called <dfn>nodes</dfn>, where each node points to the next node in the linked list. Each node in a linked list contains two key pieces of information: the element itself, and a reference to the next node.
 
-**Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab. 
+Fulfill the user stories below and get all the tests to pass to complete the lab.
 
 **User Stories:**
 

--- a/curriculum/challenges/english/25-front-end-development/lab-moon-orbit/66a37f37ef5823a313de8c26.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-moon-orbit/66a37f37ef5823a313de8c26.md
@@ -10,7 +10,7 @@ demoType: onClick
 
 In this lab, you will create a simple animation of the Moon's orbit around the Earth using HTML and CSS. The Earth will be at the center of the system, and the Moon will orbit around it.
 
-**Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab. 
+Fulfill the user stories below and get all the tests to pass to complete the lab.
 
 **User Stories:**
 

--- a/curriculum/challenges/english/25-front-end-development/lab-newspaper-article/66ba762af611169359d9d369.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-newspaper-article/66ba762af611169359d9d369.md
@@ -8,7 +8,7 @@ demoType: onClick
 
 # --description--
 
-**Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab. 
+Fulfill the user stories below and get all the tests to pass to complete the lab.
 
 **User Stories:**
 

--- a/curriculum/challenges/english/25-front-end-development/lab-nth-fibonacci-number-generator/66d9af3897e7d75a895b72c2.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-nth-fibonacci-number-generator/66d9af3897e7d75a895b72c2.md
@@ -9,7 +9,7 @@ dashedName: lab-nth-fibonacci-number-generator
 
 In this lab you will use a dynamic programming approach to compute and return the `n`-th number from the Fibonacci sequence, in which each number is the sum of the two preceding numbers.
 
-**Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab. 
+Fulfill the user stories below and get all the tests to pass to complete the lab.
 
 **User Stories:**
 

--- a/curriculum/challenges/english/25-front-end-development/lab-page-of-playing-cards/66be24cb4144f955b6bcc550.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-page-of-playing-cards/66be24cb4144f955b6bcc550.md
@@ -8,7 +8,7 @@ demoType: onClick
 
 # --description--
 
-**Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab. 
+Fulfill the user stories below and get all the tests to pass to complete the lab.
 
 **User Stories:**
 

--- a/curriculum/challenges/english/25-front-end-development/lab-palindrome-checker/657bdc55a322aae1eac3838f.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-palindrome-checker/657bdc55a322aae1eac3838f.md
@@ -12,7 +12,7 @@ A <dfn>palindrome</dfn> is a word or phrase that can be read the same way forwar
 
 **Note:** You'll need to remove **all non-alphanumeric characters** (punctuation, spaces and symbols) and turn everything into the same case (lower or upper case) in order to check for palindromes.
 
-**Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab. 
+Fulfill the user stories below and get all the tests to pass to complete the lab.
 
 **User Stories:**
 

--- a/curriculum/challenges/english/25-front-end-development/lab-personal-portfolio/bd7158d8c242eddfaeb5bd13.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-personal-portfolio/bd7158d8c242eddfaeb5bd13.md
@@ -8,7 +8,7 @@ demoType: onClick
 
 # --description--
 
-**Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab. 
+Fulfill the user stories below and get all the tests to pass to complete the lab.
 
 **User Stories:**
 

--- a/curriculum/challenges/english/25-front-end-development/lab-pokemon-search-app/6555c1d3e11a1574434cf8b5.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-pokemon-search-app/6555c1d3e11a1574434cf8b5.md
@@ -10,7 +10,7 @@ demoType: onClick
 
 In this lab, you'll build an app that will search for Pokémon by name or ID and display the results to the user. To retrieve the Pokémon data and images, you'll use freeCodeCamp's <a href="https://pokeapi-proxy.freecodecamp.rocks/" target="_blank" rel="noopener noreferrer nofollow">PokéAPI Proxy</a>.
 
-**Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab. 
+Fulfill the user stories below and get all the tests to pass to complete the lab.
 
 **User Stories:**
 

--- a/curriculum/challenges/english/25-front-end-development/lab-product-landing-page/587d78af367417b2b2512b04.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-product-landing-page/587d78af367417b2b2512b04.md
@@ -8,7 +8,7 @@ demoType: onClick
 
 # --description--
 
-**Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab. 
+Fulfill the user stories below and get all the tests to pass to complete the lab.
 
 **User Stories:**
 

--- a/curriculum/challenges/english/25-front-end-development/lab-pyramid-generator/66f2836c459cfb16ae76f24f.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-pyramid-generator/66f2836c459cfb16ae76f24f.md
@@ -7,7 +7,7 @@ dashedName: lab-pyramid-generator
 
 # --description--
 
-**Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab. 
+Fulfill the user stories below and get all the tests to pass to complete the lab.
 
 **User Stories:**
 

--- a/curriculum/challenges/english/25-front-end-development/lab-quicksort-algorithm/587d825a367417b2b2512c89.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-quicksort-algorithm/587d825a367417b2b2512c89.md
@@ -15,7 +15,7 @@ It can be implemented as follows:
 - Partition the input array into three subarrays containing elements greater than, lesser than, and equal to the pivot value.
 - Recursively call `quicksort` to sort the subarrays.
 
-**Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab. 
+Fulfill the user stories below and get all the tests to pass to complete the lab.
 
 **User Stories:**
 

--- a/curriculum/challenges/english/25-front-end-development/lab-quiz-game/66f17db06803d11a1bd19a20.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-quiz-game/66f17db06803d11a1bd19a20.md
@@ -7,7 +7,7 @@ dashedName: lab-quiz-game
 
 # --description--
 
-**Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab. 
+Fulfill the user stories below and get all the tests to pass to complete the lab.
 
 **User Stories:**
 

--- a/curriculum/challenges/english/25-front-end-development/lab-random-background-color-changer/66b62d0ad68488dd76228d6c.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-random-background-color-changer/66b62d0ad68488dd76228d6c.md
@@ -10,7 +10,7 @@ demoType: onClick
 
 Camperbot is learning JavaScript and has tried to build their own Random Background Color Changer. However, they have made a few mistakes along the way.   
 
-**Objective:** Fulfill the user stories below and get all the tests to pass so the lab is functioning properly.
+Fulfill the user stories below and get all the tests to pass so the lab is functioning properly.
 
 **User Stories:**
 

--- a/curriculum/challenges/english/25-front-end-development/lab-real-time-counter/66bb3e20d3dc5b6d0a21f5dd.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-real-time-counter/66bb3e20d3dc5b6d0a21f5dd.md
@@ -10,7 +10,7 @@ demoType: onClick
 
 In this lab, you will build a real-time character counter by using JavaScript. The character counter will display the number of characters entered in a `textarea` element. The counter will update in real-time as the user types in the `textarea`.
 
-**Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab. **Do not copy this demo project**.
+Fulfill the user stories below and get all the tests to pass to complete the lab. **Do not copy this demo project**.
 
 **User Stories:**
 

--- a/curriculum/challenges/english/25-front-end-development/lab-recipe-page/668f08ea07b99b1f4a91acab.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-recipe-page/668f08ea07b99b1f4a91acab.md
@@ -8,7 +8,7 @@ demoType: onClick
 
 # --description--
 
-**Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab. 
+Fulfill the user stories below and get all the tests to pass to complete the lab.
 
 **User Stories:**
 

--- a/curriculum/challenges/english/25-front-end-development/lab-regex-sandbox/66e028680eca7d21db7e1aee.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-regex-sandbox/66e028680eca7d21db7e1aee.md
@@ -10,7 +10,7 @@ demoType: onClick
 
 For this lab, you start with the CSS and HTML already written for you. You will use JavaScript to enable the regex sandbox to test a regular expression against a string and highlight the results.
  
-**Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab.
+Fulfill the user stories below and get all the tests to pass to complete the lab.
 
 **User Stories:**
 

--- a/curriculum/challenges/english/25-front-end-development/lab-roman-numeral-converter/657bdc8ba322aae1eac38390.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-roman-numeral-converter/657bdc8ba322aae1eac38390.md
@@ -26,7 +26,7 @@ Roman numerals are based on seven symbols and can be written using various combi
 | IV             | 4               |
 | I              | 1               |
 
-**Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab.
+Fulfill the user stories below and get all the tests to pass to complete the lab.
 
 **User Stories:**
 

--- a/curriculum/challenges/english/25-front-end-development/lab-sentence-maker/66c057041df6394ca796bf33.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-sentence-maker/66c057041df6394ca796bf33.md
@@ -9,7 +9,7 @@ dashedName: build-a-sentence-maker
 
 In this lab, you will create two different stories using a sentence template. You will use variables to store different parts of the story and then output the stories to the console.
 
-**Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab. 
+Fulfill the user stories below and get all the tests to pass to complete the lab.
 
 **User Stories:**
 

--- a/curriculum/challenges/english/25-front-end-development/lab-stack-class/587d8250367417b2b2512c5f.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-stack-class/587d8250367417b2b2512c5f.md
@@ -9,7 +9,7 @@ dashedName: build-a-stack-class
 
 A stack is a data structure that stores an ordered collection of elements. It follows the *Last-In-First-Out* principle, where the last element inserted is removed first.
 
-**Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab. 
+Fulfill the user stories below and get all the tests to pass to complete the lab.
 
 **User Stories:**
 

--- a/curriculum/challenges/english/25-front-end-development/lab-stylized-to-do-list/66c051d13a6a20255a963695.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-stylized-to-do-list/66c051d13a6a20255a963695.md
@@ -10,7 +10,7 @@ demoType: onClick
 
 In this lab, you will practice the different styles that can be applied to links when they are hovered over, focused, clicked, and visited.
 
-**Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab.
+Fulfill the user stories below and get all the tests to pass to complete the lab.
 
 **User Stories:**
 

--- a/curriculum/challenges/english/25-front-end-development/lab-survey-form/587d78af367417b2b2512b03.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-survey-form/587d78af367417b2b2512b03.md
@@ -8,7 +8,7 @@ demoType: onClick
 
 # --description--
 
-**Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab. 
+Fulfill the user stories below and get all the tests to pass to complete the lab.
 
 **User Stories:**
 

--- a/curriculum/challenges/english/25-front-end-development/lab-technical-documentation-page/587d78b0367417b2b2512b05.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-technical-documentation-page/587d78b0367417b2b2512b05.md
@@ -8,7 +8,7 @@ dashedName: build-a-technical-documentation-page
 
 # --description--
 
-**Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab.
+Fulfill the user stories below and get all the tests to pass to complete the lab.
 
 **User Stories:**
 

--- a/curriculum/challenges/english/25-front-end-development/lab-telephone-number-validator/657bdcb9a322aae1eac38391.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-telephone-number-validator/657bdcb9a322aae1eac38391.md
@@ -22,7 +22,7 @@ In the US, phone numbers can be formatted in many ways. Here are some examples o
 
 Note that the area code is required. Also, if the country code is provided, you must confirm that the country code is `1`.
 
-**Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab.
+Fulfill the user stories below and get all the tests to pass to complete the lab.
 
 **User Stories:**
 

--- a/curriculum/challenges/english/25-front-end-development/lab-travel-agency-page/669e2f60e83c011754f711f9.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-travel-agency-page/669e2f60e83c011754f711f9.md
@@ -8,7 +8,7 @@ demoType: onClick
 
 # --description--
 
-**Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab. 
+Fulfill the user stories below and get all the tests to pass to complete the lab.
 
 **User Stories:**
 

--- a/curriculum/challenges/english/25-front-end-development/lab-tribute-page/bd7158d8c442eddfaeb5bd18.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-tribute-page/bd7158d8c442eddfaeb5bd18.md
@@ -8,7 +8,7 @@ dashedName: build-a-tribute-page
 
 # --description--
 
-**Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab. 
+Fulfill the user stories below and get all the tests to pass to complete the lab.
 
 **User Stories:**
 

--- a/curriculum/challenges/english/25-front-end-development/lab-video-compilation-page/669e81368e52b3a5c35a2dc5.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-video-compilation-page/669e81368e52b3a5c35a2dc5.md
@@ -9,7 +9,7 @@ demoType: onClick
 # --description--
 
 
-**Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab. 
+Fulfill the user stories below and get all the tests to pass to complete the lab.
 
 **User Stories:**
 


### PR DESCRIPTION
This is an attempt to make the lab demo button look more like the .rocks links on the current cert projects. It's a little tricky because not all the labs have a demo app. The JS algorithm style labs don't, for example. So the button doesn't get displayed there - and some of the labs are pretty much exact copies of the example, while some have a lot of room for creativity. So the text I ended up with was "Build an app that is functionally similar to `<button>`this example project`</button>`. Try not to copy the example project, give it your own personal style."

<details><summary>images</summary>

| Before | After |
|--------|-------|
| <img width="736" alt="Screenshot 2024-09-27 at 10 56 32 AM" src="https://github.com/user-attachments/assets/7a6b76f4-3bc2-497f-b40c-45e077d67c0a"> | <img width="835" alt="Screenshot 2024-09-27 at 2 43 01 PM" src="https://github.com/user-attachments/assets/ff3aa226-a128-4ef6-9745-8e9ecd72f78e"> |

</details>

Not sure if this is the best way to go. I think it's a little better. Could use some more opinions.



Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
