### PR TITLE
fix(client): add instructions to challenge view components

### DIFF
--- a/client/src/templates/Challenges/dialogue/show.tsx
+++ b/client/src/templates/Challenges/dialogue/show.tsx
@@ -197,6 +197,7 @@ class ShowDialogue extends Component<ShowDialogueProps, ShowDialogueState> {
           challenge: {
             title,
             description,
+            instructions,
             superBlock,
             block,
             fields: { blockName },
@@ -255,6 +256,15 @@ class ShowDialogue extends Component<ShowDialogueProps, ShowDialogueState> {
 
               <Col md={8} mdOffset={2} sm={10} smOffset={1} xs={12}>
                 <Spacer size='medium' />
+                {instructions && (
+                  <>
+                    <PrismFormatted
+                      className={'line-numbers'}
+                      text={instructions}
+                    />
+                    <Spacer size='medium' />
+                  </>
+                )}
                 <ObserveKeys>
                   <Assignments
                     assignments={assignments}
@@ -302,6 +312,7 @@ export const query = graphql`
         videoId
         title
         description
+        instructions
         challengeType
         helpCategory
         superBlock

--- a/client/src/templates/Challenges/odin/show.tsx
+++ b/client/src/templates/Challenges/odin/show.tsx
@@ -230,6 +230,7 @@ class ShowOdin extends Component<ShowOdinProps, ShowOdinState> {
           challenge: {
             title,
             description,
+            instructions,
             superBlock,
             block,
             videoId,
@@ -310,6 +311,13 @@ class ShowOdin extends Component<ShowOdinProps, ShowOdinState> {
               )}
 
               <Col md={8} mdOffset={2} sm={10} smOffset={1} xs={12}>
+                {instructions && (
+                  <PrismFormatted
+                    className={'line-numbers'}
+                    text={instructions}
+                  />
+                )}
+
                 <ObserveKeys>
                   {assignments.length > 0 && (
                     <Assignments
@@ -389,6 +397,7 @@ export const query = graphql`
         }
         title
         description
+        instructions
         challengeType
         helpCategory
         superBlock


### PR DESCRIPTION
This adds the instructions to the odin (challenge-type 15 & 19) and dialogue (challenge-type 21) view components. None of those challenges have instructions at the moment. Adding this so the English team can put something like "Watch the video and complete the task below" between the video and tasks.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
