### PR TITLE
fix(curriculum) : Add validation for trailing spaces in cat image src…

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5efada803cbd2bbdab94e332.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5efada803cbd2bbdab94e332.md
@@ -43,6 +43,16 @@ The third image should have a `src` attribute set to `https://cdn.freecodecamp.o
 ```js
 const catsImg = document.querySelectorAll('figure > img')[1];
 assert(
+  catsImg && 
+  catsImg.getAttribute('src').trim() === 'https://cdn.freecodecamp.org/curriculum/cat-photo-app/cats.jpg'
+);
+```
+
+Ensure there are no trailing spaces in the `src` attribute.
+
+```js
+const catsImg = document.querySelectorAll('figure > img')[1];
+assert(
   catsImg &&
     catsImg.getAttribute('src').toLowerCase() === 'https://cdn.freecodecamp.org/curriculum/cat-photo-app/cats.jpg'
 );


### PR DESCRIPTION
… attribute (#56255)

fix(curriculum) : test case added in cat photo app. Update curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5efada803cbd2bbdab94e332.md

Implemented a test to check for trailing spaces in the `src` attribute of the cat image in the "learn HTML by building a cat photo app" challenge. If a user adds a trailing space (e.g., 'https://cdn.freecodecamp.org/curriculum/cat-photo-app/cats.jpg '), the image still displays in the UI, but the test fails. This could cause confusion, as the image appears correct to the user, even though the test is broken. This validation prevents such misunderstandings by ensuring consistent behavior between the UI and the tests.

Signed-off-by: Habeb Nawatha <habeb.naw@outlook.com>
Reviewed-by: Sameeh Jubran <sameeh.j@gmail.com>

Checklist:


- [ x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ x] My pull request targets the `main` branch of freeCodeCamp.
- [ x] I have tested these changes either locally on my machine, or GitPod.


Closes #56255

