### PR TITLE
fix(curriculum): replace placeholder link with actual cdn link 

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-recipe-page/668f08ea07b99b1f4a91acab.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-recipe-page/668f08ea07b99b1f4a91acab.md
@@ -174,7 +174,7 @@ assert.isAbove($('img')[0].alt.length, 0);
   <p>Welcome to the ultimate guide for making mini chocolate chip cookies! These bite-sized treats are perfect for
     satisfying your sweet tooth without overindulging. Follow this simple recipe to create delicious,
     crispy-on-the-outside, chewy-on-the-inside mini chocolate chip cookies that everyone will love.</p>
-    <img src="https://cdn.freecodecamp.org/curriculum/labs/recipe.jpg" alt="Ingredients for baking: three eggs, a bowl of flour, a glass of milk, and a whisk arranged on a wooden table.">
+  <img src="https://cdn.freecodecamp.org/curriculum/labs/recipe.jpg" alt="Ingredients for baking: three eggs, a bowl of flour, a glass of milk, and a whisk arranged on a wooden table.">
   <h2>Ingredients</h2>
   <ul>
     <li>1 cup all-purpose flour</li>

--- a/curriculum/challenges/english/25-front-end-development/lab-recipe-page/668f08ea07b99b1f4a91acab.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-recipe-page/668f08ea07b99b1f4a91acab.md
@@ -174,7 +174,7 @@ assert.isAbove($('img')[0].alt.length, 0);
   <p>Welcome to the ultimate guide for making mini chocolate chip cookies! These bite-sized treats are perfect for
     satisfying your sweet tooth without overindulging. Follow this simple recipe to create delicious,
     crispy-on-the-outside, chewy-on-the-inside mini chocolate chip cookies that everyone will love.</p>
-    <img src="https://cdn.freecodecamp.org/curriculum/labs/recipe.jpg" alt=""Ingredients for baking: three eggs, a bowl of flour, a glass of milk, and a whisk arranged on a wooden table."">">
+    <img src="https://cdn.freecodecamp.org/curriculum/labs/recipe.jpg" alt="Ingredients for baking: three eggs, a bowl of flour, a glass of milk, and a whisk arranged on a wooden table.">
   <h2>Ingredients</h2>
   <ul>
     <li>1 cup all-purpose flour</li>

--- a/curriculum/challenges/english/25-front-end-development/lab-recipe-page/668f08ea07b99b1f4a91acab.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-recipe-page/668f08ea07b99b1f4a91acab.md
@@ -174,7 +174,7 @@ assert.isAbove($('img')[0].alt.length, 0);
   <p>Welcome to the ultimate guide for making mini chocolate chip cookies! These bite-sized treats are perfect for
     satisfying your sweet tooth without overindulging. Follow this simple recipe to create delicious,
     crispy-on-the-outside, chewy-on-the-inside mini chocolate chip cookies that everyone will love.</p>
-  <img src="cookies-image.jpg" alt="a tray of chocolate chip cookies">
+    <img src="https://cdn.freecodecamp.org/curriculum/labs/recipe.jpg" alt=""Ingredients for baking: three eggs, a bowl of flour, a glass of milk, and a whisk arranged on a wooden table."">">
   <h2>Ingredients</h2>
   <ul>
     <li>1 cup all-purpose flour</li>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #56343


<!-- Feel free to add any additional description of changes below this line -->

Screenshots : 

before : 
![image](https://github.com/user-attachments/assets/b6b68e63-1bd1-4760-b761-0e4af17e8760)
after:
![image](https://github.com/user-attachments/assets/925129f9-03b7-41d0-9e4f-790cfe0f2fdd)

This PR addresses issue #56343 by fixing the broken image link in the demo project for the recipe lab. The placeholder image URL has been replaced with the actual CDN link to ensure that the image displays correctly.

**Changes Made:**
- Updated the image source in the HTML file.

Please review and let me know if any further changes are needed. Thank you!

