### PR TITLE
fix(client): render hint for failed test (not console logs) in editor

### DIFF
--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -27,6 +27,7 @@ import {
 } from '../../../redux/selectors';
 import {
   ChallengeFiles,
+  ChallengeTest,
   Dimensions,
   FileKey,
   ResizeProps,
@@ -51,7 +52,6 @@ import {
   attemptsSelector,
   canFocusEditorSelector,
   challengeMetaSelector,
-  consoleOutputSelector,
   challengeTestsSelector,
   isResettingSelector,
   isProjectPreviewModalOpenSelector,
@@ -93,7 +93,6 @@ export interface EditorProps {
   isUsingKeyboardInTablist: boolean;
   openHelpModal: () => void;
   openResetModal: () => void;
-  output: string[];
   resizeProps: ResizeProps;
   saveChallenge: () => void;
   sendRenderTime: (renderTime: number) => void;
@@ -135,7 +134,6 @@ const mapStateToProps = createSelector(
   attemptsSelector,
   canFocusEditorSelector,
   challengeMetaSelector,
-  consoleOutputSelector,
   isDonationModalOpenSelector,
   isProjectPreviewModalOpenSelector,
   isResettingSelector,
@@ -147,7 +145,6 @@ const mapStateToProps = createSelector(
     attempts: number,
     canFocus: boolean,
     { challengeType }: { challengeType: number },
-    output: string[],
     open,
     previewOpen: boolean,
     isResetting: boolean,
@@ -162,7 +159,6 @@ const mapStateToProps = createSelector(
     previewOpen,
     isResetting,
     isSignedIn,
-    output,
     theme,
     tests,
     isChallengeCompleted
@@ -1280,6 +1276,12 @@ const Editor = (props: EditorProps): JSX.Element => {
         ? 'vs-custom'
         : editorSystemTheme;
 
+  const isFailedChallengeTest = (test: Test): test is ChallengeTest =>
+    !!test.err && 'text' in test;
+  const firstFailedTest = props.tests.find<ChallengeTest>(test =>
+    isFailedChallengeTest(test)
+  );
+
   return (
     <Suspense fallback={<Loader loaderDelay={600} />}>
       <span className='notranslate'>
@@ -1297,7 +1299,7 @@ const Editor = (props: EditorProps): JSX.Element => {
             openHelpModal={props.openHelpModal}
             openResetModal={props.openResetModal}
             tryToExecuteChallenge={tryToExecuteChallenge}
-            hint={props.output[1]}
+            hint={firstFailedTest?.text}
             testsLength={props.tests.length}
             attempts={attemptsRef.current}
             challengeIsCompleted={challengeIsComplete()}


### PR DESCRIPTION
Most of the time the hint and the second log are the same thing, but not if the learner's code calls console.log twice. Then it's the value of the second call.

This means we cannot use the output as a proxy for the hints.
Fortunately, the hints are directly accessible.

As a side benefit, this fixes a bug (introduced in https://github.com/freeCodeCamp/freeCodeCamp/pull/55874) where the number of the test was
appearing in the hint (e.g. if it's the 5th test 5 would appear).

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->
