### PR TITLE
feat(tools): autoclose specific python file prs

### DIFF
--- a/.github/workflows/github-autoclose.yml
+++ b/.github/workflows/github-autoclose.yml
@@ -21,7 +21,12 @@ jobs:
             });
             if (
               files.data.length !== 1 ||
-              files.data[0].filename !== ".gitignore"
+              (files.data[0].filename !== ".gitignore" &&
+              // We've had four PRs make this same (irrelevant) change already.
+                !(files.data[0].filename === "664ef4623946e65e18d59764.md" &&
+                  files.data[0].patch.includes("return re.sub('(?<!\d)1', '', equation_string.strip('+'))")
+                )
+              )
             ) {
               return;
             }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

We've had three or four PRs that make this exact same (unwanted, irrelevant) change to the same file.

This change is temporary and should be reverted after Hacktoberfest.

Would not mind some extra eyes on the conditional logic.