### PR TITLE
fix(curriculum): approximate lab-date-conversion test

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-date-conversion/66f686b8ebdb982fa8e14330.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-date-conversion/66f686b8ebdb982fa8e14330.md
@@ -40,13 +40,16 @@ const currentDateOnly = new Date(currentDate.getFullYear(), currentDate.getMonth
 assert.equal(currentDateOnly.toString(), expectedDateOnly.toString());
 ```
 
-You should have a variable named `currentDateFormat` that holds the current date in the format `Current Date and Time: [current date]`.
+You should have a variable named `currentDateFormat` that holds the current date in the format `Current Date and Time: <ddd> <MMM> <dd> <yyyy> <HH>:<mm>:<ss> <TIMEZONE>`.
 
 ```js
 const expectedDate = new Date();
-const expectedDateFormat = `Current Date and Time: ${expectedDate}`;
+const expectedDateString = `Current Date and Time: `;
+assert.include(currentDateFormat, expectedDateString);
 
-assert.equal(currentDateFormat, expectedDateFormat);
+const currentTimestamp = new Date(currentDateFormat.replace(expectedDateString, '')).getTime();
+const expectedTimestamp = expectedDate.getTime();
+assert.approximately(currentTimestamp, expectedTimestamp, 1000);
 ```
 
 You should log the value of `currentDateFormat` to the console.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Fixes failures like: https://github.com/freeCodeCamp/freeCodeCamp/actions/runs/11147183576/job/30981942175

```bash
      Test text: <p>You should have a variable named <code>currentDateFormat</code> that holds the current date in the format <code>Current Date and Time: [current date]</code>.</p>
      + expected - actual

      -Current Date and Time: Wed Oct 02 2024 16:42:29 GMT+0000 (Coordinated Universal Time)
      +Current Date and Time: Wed Oct 02 2024 16:42:30 GMT+0000 (Coordinated Universal Time)
      
  AssertionError: expected 'Current Date and Time: Wed Oct 02 202…' to equal 'Current Date and Time: Wed Oct 02 202…'
```

Also, I adjusted the test string, because I would interpret the string as saying the requirement is the literal characters `[` and `]` around the current date. Instead, I replace the `[current date]` with standardized representation for dates. _Feel free to change_