### PR TITLE
fix(curriculum): replace jQuery with vanilla js

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-video-compilation-page/669e81368e52b3a5c35a2dc5.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-video-compilation-page/669e81368e52b3a5c35a2dc5.md
@@ -58,33 +58,33 @@ assert.equal(document.querySelectorAll('section')[0]?.previousElementSibling?.ta
 Each `section` element should contain an `h2` element to give a title to that section as its first child.
 
 ```js
-const sections = $('section');
+const sections = document.querySelectorAll('section');
 assert.equal(sections?.length, 3)
-for (let section of sections) {
+sections.forEach((section) => {
     assert.equal(section.children[0]?.tagName, 'H2');
     assert.isAbove(section.children[0]?.innerText.length, 0);
-}
+});
 ```
 
 Each `section` element should contain a `p` element to introduce the video content as its second child.
 
 ```js
-const sections = $('section');
+const sections = document.querySelectorAll('section');
 assert.equal(sections?.length, 3)
-for (let section of sections) {
+sections.forEach((section) => {
     assert.equal(section.children[1]?.tagName, 'P');
     assert.isAbove(section.children[1]?.innerText.length, 0);
-}
+});
 ```
 
 Each `section` element should contain an `iframe` element as its third child.
 
 ```js
-const sections = $('section');
+const sections = document.querySelectorAll('section');
 assert.equal(sections?.length, 3)
-for (let section of sections) {
+sections.forEach((section) => {
     assert.equal(section.children[2]?.tagName, 'IFRAME');
-}
+});
 ```
 
 Your first `iframe` element should have a `src` attribute set to a valid video.

--- a/curriculum/challenges/english/25-front-end-development/lab-video-compilation-page/669e81368e52b3a5c35a2dc5.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-video-compilation-page/669e81368e52b3a5c35a2dc5.md
@@ -60,10 +60,10 @@ Each `section` element should contain an `h2` element to give a title to that se
 ```js
 const sections = document.querySelectorAll('section');
 assert.equal(sections?.length, 3)
-sections.forEach((section) => {
+for (let section of sections) {
     assert.equal(section.children[0]?.tagName, 'H2');
     assert.isAbove(section.children[0]?.innerText.length, 0);
-});
+}
 ```
 
 Each `section` element should contain a `p` element to introduce the video content as its second child.
@@ -71,10 +71,10 @@ Each `section` element should contain a `p` element to introduce the video conte
 ```js
 const sections = document.querySelectorAll('section');
 assert.equal(sections?.length, 3)
-sections.forEach((section) => {
+for (let section of sections) {
     assert.equal(section.children[1]?.tagName, 'P');
     assert.isAbove(section.children[1]?.innerText.length, 0);
-});
+}
 ```
 
 Each `section` element should contain an `iframe` element as its third child.
@@ -82,9 +82,9 @@ Each `section` element should contain an `iframe` element as its third child.
 ```js
 const sections = document.querySelectorAll('section');
 assert.equal(sections?.length, 3)
-sections.forEach((section) => {
+for (let section of sections) {
     assert.equal(section.children[2]?.tagName, 'IFRAME');
-});
+}
 ```
 
 Your first `iframe` element should have a `src` attribute set to a valid video.


### PR DESCRIPTION
Converted the previous JQuery elements to Vanilla JavaScript.


Checklist:
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Closes #56492 

