### PR TITLE
fix(curriculum): typo and hint text wording

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-video-compilation-page/669e81368e52b3a5c35a2dc5.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-video-compilation-page/669e81368e52b3a5c35a2dc5.md
@@ -55,7 +55,7 @@ assert.equal(document.querySelectorAll('section')?.length, 3);
 assert.equal(document.querySelectorAll('section')[0]?.previousElementSibling?.tagName, 'P')
 ```
 
-Each `section` element should contain an `h2` element to give a title to that section as its first child.
+Each `section` element should start with an `h2` element that serves as the title for that section.
 
 ```js
 const sections = $('section');
@@ -195,7 +195,7 @@ assert.isAbove(document.querySelectorAll('iframe')[2]?.width.length, 0)
         <h1>Front End Web Development</h1>
         <p>Front End Web Development involves designing and building user interfaces of websites using HTML, CSS, and
             JavaScript. It focuses on creating visually appealing, interactive, and user-friendly websites. Front End
-            evelopers
+            developers
             ensure accessibility, performance optimization, and
             adherence to web standards, blending creativity with technical expertise.</p>
         <section>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes [#56491](https://github.com/freeCodeCamp/freeCodeCamp/issues/56491)

<!-- Feel free to add any additional description of changes below this line -->

Fixed 'evelopers' typo to 'developers'.

> Front End Web Development involves designing and building user interfaces of websites using HTML, CSS, and
> JavaScript. It focuses on creating visually appealing, interactive, and user-friendly websites. Front End
> evelopers
> ensure accessibility, performance optimization, and
> adherence to web standards, blending creativity with technical expertise.

Hint text wording is fixed to:

> Each `section` element should start with an `h2` element that serves as the title for that section.
