### PR TITLE
feat(curriculum): probability calculator test - allow for hat content to be returned in any order

### DIFF
--- a/curriculum/challenges/english/07-scientific-computing-with-python/build-a-probability-calculator-project/probability-calculator.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/build-a-probability-calculator-project/probability-calculator.md
@@ -164,8 +164,8 @@ class UnitTests(unittest.TestCase):
     maxDiff = None
     def test_hat_draw_2(self):
         hat = probability_calculator.Hat(yellow=5,red=1,green=3,blue=9,test=1)
-        actual = hat.draw(20).sort()
-        expected = ['yellow', 'yellow', 'yellow', 'yellow', 'yellow', 'red', 'green', 'green', 'green', 'blue', 'blue', 'blue', 'blue', 'blue', 'blue', 'blue', 'blue', 'blue', 'test'].sort()
+        actual = sorted(hat.draw(20))
+        expected = sorted(['yellow', 'yellow', 'yellow', 'yellow', 'yellow', 'red', 'green', 'green', 'green', 'blue', 'blue', 'blue', 'blue', 'blue', 'blue', 'blue', 'blue', 'blue', 'test'])
         self.assertEqual(actual, expected, 'Expected hat draw to return all items from hat contents.')
         actual = len(hat.contents)
         expected = 0

--- a/curriculum/challenges/english/07-scientific-computing-with-python/build-a-probability-calculator-project/probability-calculator.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/build-a-probability-calculator-project/probability-calculator.md
@@ -164,8 +164,8 @@ class UnitTests(unittest.TestCase):
     maxDiff = None
     def test_hat_draw_2(self):
         hat = probability_calculator.Hat(yellow=5,red=1,green=3,blue=9,test=1)
-        actual = hat.draw(20)
-        expected = ['yellow', 'yellow', 'yellow', 'yellow', 'yellow', 'red', 'green', 'green', 'green', 'blue', 'blue', 'blue', 'blue', 'blue', 'blue', 'blue', 'blue', 'blue', 'test']
+        actual = hat.draw(20).sort()
+        expected = ['yellow', 'yellow', 'yellow', 'yellow', 'yellow', 'red', 'green', 'green', 'green', 'blue', 'blue', 'blue', 'blue', 'blue', 'blue', 'blue', 'blue', 'blue', 'test'].sort()
         self.assertEqual(actual, expected, 'Expected hat draw to return all items from hat contents.')
         actual = len(hat.contents)
         expected = 0


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

I'm proposing this change because I don't think there is any reason to require the balls to be returned in a specific order.