### PR TITLE
fix(curriculum): double quoting strings in code examples

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-teacher-chatbot/66b6efddeca35833cd6f0b03.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-teacher-chatbot/66b6efddeca35833cd6f0b03.md
@@ -10,8 +10,8 @@ dashedName: step-10
 In the previous lecture videos, you learned how to access characters in a string like this:
 
 ```js
-const firstName = 'Jessica';
-// returns 'J'
+const firstName = "Jessica";
+// returns "J"
 firstName[0];
 ```  
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-teacher-chatbot/66b6fdb76441c738719039fa.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-teacher-chatbot/66b6fdb76441c738719039fa.md
@@ -12,7 +12,7 @@ In the lecture videos, you learned how to access the last character in a string 
 ```js
 const firstName = "Jessica";
 
-// returns 'a'
+// returns "a"
 firstName[firstName.length - 1];
 ```
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

- Replaced single-quoted strings with double-quoted strings in the code example.

Closes [#56510](https://github.com/freeCodeCamp/freeCodeCamp/issues/56510)

<!-- Feel free to add any additional description of changes below this line -->
