### PR TITLE
fix(curriculum): use double quotations in console.log statement

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-greeting-bot/66ad8294a0ad902f1b31b612.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-greeting-bot/66ad8294a0ad902f1b31b612.md
@@ -16,7 +16,7 @@ Remember that you learned about `console.log()` and strings in the previous lect
 Here is a reminder of how to use `console.log()` with strings:
 
 ```js
-console.log('Hello, World!');
+console.log("Hello, World!");
 ```
 
 Add a `console.log()` statement that outputs the string `"Hi there!"` to the console. Don't forget your quotes around the message! 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #56509 

<!-- Feel free to add any additional description of changes below this line -->

The single quotes have been changed to double quotes in the console.log statement as mentioned in the issue .
