### PR TITLE
refactor: CURRICULUM_LOCALE fallback to English

### DIFF
--- a/curriculum/get-challenges.js
+++ b/curriculum/get-challenges.js
@@ -27,11 +27,10 @@ const META_DIR = path.resolve(ENGLISH_CHALLENGES_DIR, '_meta');
 
 // This is to allow English to build without having to download the i18n files.
 // It fails when trying to resolve the i18n-curriculum path if they don't exist.
+const curriculumLocale = process.env.CURRICULUM_LOCALE ?? 'english';
 const I18N_CURRICULUM_DIR = path.resolve(
   __dirname,
-  process.env.CURRICULUM_LOCALE === 'english'
-    ? '.'
-    : 'i18n-curriculum/curriculum'
+  curriculumLocale === 'english' ? '.' : 'i18n-curriculum/curriculum'
 );
 
 const I18N_CHALLENGES_DIR = path.resolve(I18N_CURRICULUM_DIR, 'challenges');


### PR DESCRIPTION
Otherwise build:curriculum will assume that it needs the i18n-curriculum
submodule and fail if it is missing.

Ref: https://github.com/freeCodeCamp/freeCodeCamp/actions/runs/11176885391/job/31071198234

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
