### PR TITLE
fix(curriculum): add line break for note in Odin Specificity F

### DIFF
--- a/curriculum/challenges/english/16-the-odin-project/top-learn-css-specificity/the-cascade-of-css-lesson-f.md
+++ b/curriculum/challenges/english/16-the-odin-project/top-learn-css-specificity/the-cascade-of-css-lesson-f.md
@@ -35,6 +35,7 @@ Here both rule 1 and rule 2 have the same specificity. Rule 1 uses a chaining se
 This example shows the same thing. Even though rule 2 is using a child combinator (`>`), this does not change the specificity value. Both rules still have two classes so they have the same specificity values.
 
 *Note:* Not everything adds to specificity
+
 When comparing selectors, you may come across special symbols for the universal selector (`*`) as well as combinators (`+`, `~`, `>`, and an empty space). These symbols do not add any specificity in and of themselves.
 
 # --questions--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Add a line break to separate the note from the paragraph

Currently
![image](https://github.com/user-attachments/assets/cff24ec9-79b1-4946-83ab-1bcf4055f1d5)

Proposed
![image](https://github.com/user-attachments/assets/ba1912e2-6cee-44c6-b851-2bce98caddbc)

