### PR TITLE
fix: tests throwing on hidden MacOS DS_Store directory

### DIFF
--- a/curriculum/get-challenges.js
+++ b/curriculum/get-challenges.js
@@ -222,7 +222,10 @@ async function buildBlocks({ basename: blockName }, curriculum, superBlock) {
 
 async function buildSuperBlocks({ path, fullPath }, curriculum) {
   const superBlock = getSuperBlockFromDir(getBaseDir(path));
-  curriculum[superBlock] = { blocks: {} };
+
+  if (superBlock) {
+    curriculum[superBlock] = { blocks: {} };
+  }
 
   const cb = (file, curriculum) => buildBlocks(file, curriculum, superBlock);
   return walk(fullPath, curriculum, { depth: 1, type: 'directories' }, cb);

--- a/curriculum/utils.js
+++ b/curriculum/utils.js
@@ -90,8 +90,12 @@ const directoryToSuperblock = {
 };
 
 function getSuperBlockFromDir(dir) {
+  if (dir === '.DS_Store') return null;
+
   const superBlock = directoryToSuperblock[dir];
-  if (!superBlock) return null;
+
+  if (!superBlock) throw Error(`${dir} does not map to a superblock`);
+
   return directoryToSuperblock[dir];
 }
 

--- a/curriculum/utils.js
+++ b/curriculum/utils.js
@@ -91,7 +91,7 @@ const directoryToSuperblock = {
 
 function getSuperBlockFromDir(dir) {
   const superBlock = directoryToSuperblock[dir];
-  if (!superBlock) throw Error(`${dir} does not map to a superblock`);
+  if (!superBlock) return null;
   return directoryToSuperblock[dir];
 }
 

--- a/curriculum/utils.test.ts
+++ b/curriculum/utils.test.ts
@@ -140,18 +140,12 @@ describe('getSuperBlockFromPath', () => {
     path.join(__dirname, './challenges/english')
   );
 
-  it('handles all the directories in ./challenges/english', () => {
-    expect.assertions(25);
-
-    for (const directory of directories) {
-      expect(() => getSuperBlockFromDir(directory)).not.toThrow();
-    }
-  });
-
   it("returns valid superblocks (or 'certifications') for all valid arguments", () => {
     expect.assertions(25);
 
-    const superBlockPaths = directories.filter(x => x !== '00-certifications');
+    const superBlockPaths = directories.filter(
+      x => x !== '00-certifications' && x !== '.DS_Store'
+    );
 
     for (const directory of superBlockPaths) {
       expect(Object.values(SuperBlocks)).toContain(
@@ -166,16 +160,21 @@ describe('getSuperBlockFromPath', () => {
 
     const superBlocks = new Set();
     for (const directory of directories) {
-      superBlocks.add(getSuperBlockFromDir(directory));
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const superBlock = getSuperBlockFromDir(directory);
+
+      if (superBlock) {
+        superBlocks.add(superBlock);
+      }
     }
 
     // + 1 for 'certifications'
     expect(superBlocks.size).toBe(Object.values(SuperBlocks).length + 1);
   });
 
-  it('throws if a directory is unknown', () => {
+  it('returns null if a directory is unknown', () => {
     expect.assertions(1);
 
-    expect(() => getSuperBlockFromDir('unknown')).toThrow();
+    expect(getSuperBlockFromDir('unknown')).toBe(null);
   });
 });

--- a/curriculum/utils.test.ts
+++ b/curriculum/utils.test.ts
@@ -172,9 +172,15 @@ describe('getSuperBlockFromPath', () => {
     expect(superBlocks.size).toBe(Object.values(SuperBlocks).length + 1);
   });
 
-  it('returns null if a directory is unknown', () => {
+  it('returns null when the directory is .DS_Store for Mac Devices', () => {
     expect.assertions(1);
 
-    expect(getSuperBlockFromDir('unknown')).toBe(null);
+    expect(getSuperBlockFromDir('.DS_Store')).toBeNull();
+  });
+
+  it('throws if a directory is unknown', () => {
+    expect.assertions(1);
+
+    expect(() => getSuperBlockFromDir('unknown')).toThrow();
   });
 });

--- a/tools/scripts/build/build-external-curricula-data.test.ts
+++ b/tools/scripts/build/build-external-curricula-data.test.ts
@@ -62,7 +62,11 @@ describe('external curriculum data build', () => {
     ).map(file => file.path);
 
     fileArray
-      .filter(fileInArray => fileInArray !== 'available-superblocks.json')
+      .filter(
+        fileInArray =>
+          fileInArray !== 'available-superblocks.json' &&
+          fileInArray !== '.DS_Store'
+      )
       .forEach(fileInArray => {
         const fileContent = fs.readFileSync(
           `${clientStaticPath}/curriculum-data/${VERSION}/${fileInArray}`,


### PR DESCRIPTION
MacOS will regularly have a directory that interferes with the superblock directory causing the tests to fail. 

I decided to return `null` instead of throwing an error would suffice when getting the superblocks. The tests seem to be able to check if a superblock is missing. 


Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
