### PR TITLE
fix(client): remove --fcc-expected-- from hints

### DIFF
--- a/client/src/redux/prop-types.ts
+++ b/client/src/redux/prop-types.ts
@@ -270,6 +270,7 @@ export type Dimensions = {
 export type Test = {
   pass?: boolean;
   err?: string;
+  message?: string;
 } & (ChallengeTest | CertTest);
 
 export type ChallengeTest = {

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -27,7 +27,6 @@ import {
 } from '../../../redux/selectors';
 import {
   ChallengeFiles,
-  ChallengeTest,
   Dimensions,
   FileKey,
   ResizeProps,
@@ -150,7 +149,7 @@ const mapStateToProps = createSelector(
     isResetting: boolean,
     isSignedIn: boolean,
     { theme }: { theme: Themes },
-    tests: [{ text: string; testString: string }],
+    tests: [{ text: string; testString: string; message?: string }],
     isChallengeCompleted: boolean
   ) => ({
     attempts,
@@ -1276,11 +1275,7 @@ const Editor = (props: EditorProps): JSX.Element => {
         ? 'vs-custom'
         : editorSystemTheme;
 
-  const isFailedChallengeTest = (test: Test): test is ChallengeTest =>
-    !!test.err && 'text' in test;
-  const firstFailedTest = props.tests.find<ChallengeTest>(test =>
-    isFailedChallengeTest(test)
-  );
+  const firstFailedTest = props.tests.find(test => !!test.err);
 
   return (
     <Suspense fallback={<Loader loaderDelay={600} />}>
@@ -1299,7 +1294,7 @@ const Editor = (props: EditorProps): JSX.Element => {
             openHelpModal={props.openHelpModal}
             openResetModal={props.openResetModal}
             tryToExecuteChallenge={tryToExecuteChallenge}
-            hint={firstFailedTest?.text}
+            hint={firstFailedTest?.message}
             testsLength={props.tests.length}
             attempts={attemptsRef.current}
             challengeIsCompleted={challengeIsComplete()}

--- a/client/src/templates/Challenges/redux/execute-challenge-saga.js
+++ b/client/src/templates/Challenges/redux/execute-challenge-saga.js
@@ -232,8 +232,8 @@ function* executeTests(testRunner, tests, testTimeout = 5000) {
         newTest.stack = stack;
       }
 
-      newTest.message = newTest.message.replace(/<p>/, `<p>${i + 1}. `);
-      yield put(updateConsole(newTest.message));
+      const withIndex = newTest.message.replace(/<p>/, `<p>${i + 1}. `);
+      yield put(updateConsole(withIndex));
     } finally {
       testResults.push(newTest);
     }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

The error was caused by https://github.com/freeCodeCamp/freeCodeCamp/pull/56364 because I used the wrong test property (`text` includes `--fcc-expected--`, but `message` has that replaced with the value).

Closes: https://github.com/freeCodeCamp/freeCodeCamp/issues/56572

<!-- Feel free to add any additional description of changes below this line -->
