### PR TITLE
fix(tests): remove typo from test description

### DIFF
--- a/e2e/help-modal.spec.ts
+++ b/e2e/help-modal.spec.ts
@@ -40,7 +40,7 @@ test.describe('Help Modal component', () => {
     ).toBeVisible();
   });
 
-  test('should disable the submit button if the checboxes are not checked', async ({
+  test('should disable the submit button if the checkboxes are not checked', async ({
     page
   }) => {
     await page


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
I wanted to figure out which file to stick a curriculum-based test in and found a typo in the test description in the help-modal tests. 