### PR TITLE
Added explanation for getElementById implicit string conversion

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-recursion-by-building-a-decimal-to-binary-converter/6464ad3c9b2e6cf58224cfa9.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-recursion-by-building-a-decimal-to-binary-converter/6464ad3c9b2e6cf58224cfa9.md
@@ -240,7 +240,10 @@ const showAnimation = () => {
 
     setTimeout(() => {
 --fcc-editable-region--
-
+    // Note: getElementById() accepts non-string values like numbers and automatically converts them to strings.
+    // Therefore, both getElementById("idName") and getElementById(idName) work as long as the value can be converted to a string.
+    document.getElementById(obj.inputVal);
+    const actionFrame = document.getElementById(obj.inputVal)
 --fcc-editable-region--
     }, obj.showMsgDelay);
   });


### PR DESCRIPTION
In the earlier steps of the curriculum, `getElementById` was used with explicit string values. In this step, it is important to clarify that `getElementById()` can accept non-string values and implicitly converts them to strings. This PR includes a comment to explain this behavior for better learner understanding.

