### PR TITLE
fix(client): ensure source is added to files

### DIFF
--- a/client/src/templates/Challenges/rechallenge/transformers.js
+++ b/client/src/templates/Challenges/rechallenge/transformers.js
@@ -14,7 +14,8 @@ import {
   transformContents,
   transformHeadTailAndContents,
   setExt,
-  compileHeadTail
+  compileHeadTail,
+  createSource
 } from '../../../../../shared/utils/polyvinyl';
 import { WorkerExecutor } from '../utils/worker-executor';
 
@@ -275,6 +276,7 @@ const htmlTransformer = cond([
 ]);
 
 export const getTransformers = loopProtectOptions => [
+  createSource,
   replaceNBSP,
   babelTransformer(loopProtectOptions),
   partial(compileHeadTail, ''),
@@ -282,6 +284,7 @@ export const getTransformers = loopProtectOptions => [
 ];
 
 export const getPythonTransformers = () => [
+  createSource,
   replaceNBSP,
   partial(compileHeadTail, '')
 ];

--- a/shared/utils/polyvinyl.js
+++ b/shared/utils/polyvinyl.js
@@ -20,7 +20,7 @@ const invariant = require('invariant');
 //   contents: String,
 //   history?: [...String],
 // }) => PolyVinyl, throws
-function createPoly({ name, ext, contents, history, ...rest } = {}) {
+function createPoly({ name, ext, contents, history, ...rest }) {
   invariant(typeof name === 'string', 'name must be a string but got %s', name);
 
   invariant(typeof ext === 'string', 'ext must be a string, but was %s', ext);
@@ -147,11 +147,20 @@ function transformHeadTailAndContents(wrap, poly) {
   };
 }
 
+// createSource(poly: PolyVinyl) => PolyVinyl
+function createSource(poly) {
+  return {
+    ...poly,
+    source: poly.source || poly.contents
+  };
+}
+
 module.exports = {
   createPoly,
   isPoly,
   setContent,
   setExt,
+  createSource,
   compileHeadTail,
   regeneratePathAndHistory,
   transformContents,

--- a/shared/utils/polyvinyl.test.js
+++ b/shared/utils/polyvinyl.test.js
@@ -1,0 +1,29 @@
+import polyvinyl from './polyvinyl';
+
+const polyData = {
+  name: 'test',
+  ext: 'js',
+  contents: 'var hello = world;',
+  history: ['test.js']
+};
+
+describe('createSource', () => {
+  it('should return a vinyl object with a source matching the contents', () => {
+    const original = polyvinyl.createPoly(polyData);
+
+    const updated = polyvinyl.createSource(original);
+    expect(original).not.toHaveProperty('source');
+    expect(updated).toHaveProperty('source', 'var hello = world;');
+    expect(updated).toMatchObject(original);
+  });
+
+  it('should not update the source if it already exists', () => {
+    const original = polyvinyl.createPoly({
+      ...polyData,
+      source: 'const hello = world;'
+    });
+
+    const updated = polyvinyl.createSource(original);
+    expect(updated).toStrictEqual(original);
+  });
+});


### PR DESCRIPTION
Before this change the build pipeline would only add sources if at least one transformation (e.g. via Babel) happened during processing. This meant that the learner's source code was not guaranteed to be available for testing.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->
