### PR TITLE
fix(curriculum): add more buffer time lab data conversion

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-date-conversion/66f686b8ebdb982fa8e14330.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-date-conversion/66f686b8ebdb982fa8e14330.md
@@ -48,7 +48,7 @@ assert.include(currentDateFormat, expectedDateString);
 
 const currentTimestamp = new Date(currentDateFormat.replace(expectedDateString, '')).getTime();
 const expectedTimestamp = new Date().getTime();
-assert.approximately(currentTimestamp, expectedTimestamp, 1100);
+assert.approximately(currentTimestamp, expectedTimestamp, 2000);
 ```
 
 You should log the value of `currentDateFormat` to the console.

--- a/curriculum/challenges/english/25-front-end-development/lab-date-conversion/66f686b8ebdb982fa8e14330.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-date-conversion/66f686b8ebdb982fa8e14330.md
@@ -43,12 +43,11 @@ assert.equal(currentDateOnly.toString(), expectedDateOnly.toString());
 You should have a variable named `currentDateFormat` that holds the current date in the format `Current Date and Time: <ddd> <MMM> <dd> <yyyy> <HH>:<mm>:<ss> <TIMEZONE>`.
 
 ```js
-const expectedDate = new Date();
 const expectedDateString = `Current Date and Time: `;
 assert.include(currentDateFormat, expectedDateString);
 
 const currentTimestamp = new Date(currentDateFormat.replace(expectedDateString, '')).getTime();
-const expectedTimestamp = expectedDate.getTime();
+const expectedTimestamp = new Date().getTime();
 assert.approximately(currentTimestamp, expectedTimestamp, 1100);
 ```
 

--- a/curriculum/challenges/english/25-front-end-development/lab-date-conversion/66f686b8ebdb982fa8e14330.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-date-conversion/66f686b8ebdb982fa8e14330.md
@@ -49,7 +49,7 @@ assert.include(currentDateFormat, expectedDateString);
 
 const currentTimestamp = new Date(currentDateFormat.replace(expectedDateString, '')).getTime();
 const expectedTimestamp = expectedDate.getTime();
-assert.approximately(currentTimestamp, expectedTimestamp, 1000);
+assert.approximately(currentTimestamp, expectedTimestamp, 1100);
 ```
 
 You should log the value of `currentDateFormat` to the console.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #56605

<!-- Feel free to add any additional description of changes below this line -->
An extra one hundred milliseconds should be enough to make sure the tests pass as the values were off by 20 milliseconds in the example. 