### PR TITLE
fix(curriculum): make color percentage requirements clearer

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-variables-by-building-a-city-skyline/5d822fd413a79914d39e9904.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-variables-by-building-a-city-skyline/5d822fd413a79914d39e9904.md
@@ -17,7 +17,9 @@ gradient-type(
 );
 ```
 
-Fill in `.bb3` with a `repeating-linear-gradient`. Use `90deg` for the direction, your `building-color3` for the first two colors, and `window-color3` at `15%` for the third. When you don't specify a distance for a color, it will use the values that makes sense. In this case, the first two colors will default to `0%` and `7.5%` because it starts at `0%`, and `7.5%` is half of the `15%`.
+Fill in `.bb3` with a `repeating-linear-gradient`. Use `90deg` for the direction, your `building-color3` for the first two colors, and `window-color3` at `15%` for the third.
+
+When you don't specify a distance for a color, it will use the values that makes sense. In this case, the first two colors will default to `0%` and `7.5%` because it starts at `0%`, and `7.5%` is half of the `15%`, so you do not need to set them.
 
 # --hints--
 
@@ -31,6 +33,18 @@ You should use `90deg` for the direction in the first argument of `repeating-lin
 
 ```js
 assert.include(new __helpers.CSSHelp(document).getStyle(".bb3")?.getPropVal('background', true), "repeating-linear-gradient(90deg");
+```
+
+You should not set the percentage for the first color.
+
+```js
+assert.notInclude(new __helpers.CSSHelp(document).getStyle(".bb3")?.getPropVal('background', true), "var(--building-color3)0%");
+```
+
+You should not set the percentage for the second color.
+
+```js
+assert.notInclude(new __helpers.CSSHelp(document).getStyle(".bb3")?.getPropVal('background', true), "var(--building-color3)7.5%");
 ```
 
 You should use `--building-color3` for the first two colors.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

- Update text to say you do not need to set the percentage for the first two colors.
- Added two tests that checks that the mention percentages for the first two colors are not set.
- Added a new line to make it easier to read the text.

---

Technically, if you set an incorrect percentage for either of the two first colors, you will still get the wrong hints. But at least this way you are warned if you set them to the two percentages mentioned in the text. I didn't really want to go the regex route, but I guess it's an option.

---

This is a fairly common issue on the forum, as I remember it.

Forum: https://forum.freecodecamp.org/t/aprende-variables-css-construyendo-un-horizonte-de-la-ciudad-paso-60/715410
