### PR TITLE
Update 66c64ad16796c7f2419b45c5.md

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-shopping-list/66c64ad16796c7f2419b45c5.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-shopping-list/66c64ad16796c7f2419b45c5.md
@@ -32,7 +32,8 @@ console.log("It will be nice to have some fruit to eat.");
 
 shoppingList.push("Apples");
 
-function getShoppingListMsg(){
+// Corrected function declaration with a space
+function getShoppingListMsg() {
   return `Current Shopping List: ${shoppingList}`;
 }
 
@@ -40,6 +41,10 @@ console.log(getShoppingListMsg());
 
 shoppingList.push("Grapes");
 console.log(getShoppingListMsg());
+
+// The message logging for cooking oil
+console.log("It looks like we need to get some cooking oil.");
+
 
 --fcc-editable-region--
 


### PR DESCRIPTION
fix: add missing space in function declaration and log cooking oil message

Corrected the function declaration for `getShoppingListMsg()` to include a space between the function name and the parenthesis. Added a console log to indicate the need for cooking oil. Closes #56500.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ ] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->


This commit fixes the function declaration for `getShoppingListMsg()` in the shopping list workshop project by adding the missing space between the function name and the opening parenthesis. Additionally, the code now includes a `console.log` statement to log the message indicating the need for cooking oil.

