### PR TITLE
refactor(api): always use HOST=0.0.0.0 with docker compose

### DIFF
--- a/.github/workflows/e2e-with-new-api.yml
+++ b/.github/workflows/e2e-with-new-api.yml
@@ -147,7 +147,6 @@ jobs:
       - name: Set freeCodeCamp Environment Variables (needed by api)
         run: |
           cp sample.env .env
-          echo 'HOST=0.0.0.0' >> .env
 
       - name: Install playwright dependencies
         run: npx playwright install --with-deps

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,5 +34,6 @@ services:
       # container, so we have to override these variables.
       - MONGOHQ_URL=mongodb://mongo:27017/freecodecamp?directConnection=true
       - MAILHOG_HOST=mailhog
+      - HOST=0.0.0.0
     ports:
       - '3000:3000'


### PR DESCRIPTION
Because otherwise I will forget and wonder why I can't connect to the server.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
