### PR TITLE
fix(api): allow coderoad and exam env headers

### DIFF
--- a/api/src/plugins/cors.ts
+++ b/api/src/plugins/cors.ts
@@ -24,7 +24,7 @@ const cors: FastifyPluginCallback = (fastify, _options, done) => {
     void reply
       .header(
         'Access-Control-Allow-Headers',
-        'Origin, X-Requested-With, Content-Type, Accept, Csrf-Token'
+        'Origin, X-Requested-With, Content-Type, Accept, Csrf-Token, Coderoad-User-Token, Exam-Environment-Authorization-Token'
       )
       .header('Access-Control-Allow-Credentials', true)
       // These 4 are the only methods we use

--- a/api/src/server.test.ts
+++ b/api/src/server.test.ts
@@ -62,7 +62,7 @@ describe('server', () => {
       const res = await superRequest('/', { method: 'GET' });
       expect(res.headers).toMatchObject({
         'access-control-allow-headers':
-          'Origin, X-Requested-With, Content-Type, Accept, Csrf-Token',
+          'Origin, X-Requested-With, Content-Type, Accept, Csrf-Token, Coderoad-User-Token, Exam-Environment-Authorization-Token',
         'access-control-allow-credentials': 'true',
         'access-control-allow-methods': 'GET, PUT, POST, DELETE'
       });


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

I keep having to change this to test the exam env app. So, I stopped to think "wait... why do I have to do this?".