### PR TITLE
fix(api): cookie values for swagger ui

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -25,7 +25,7 @@ import security from './plugins/security';
 import auth from './plugins/auth';
 import bouncer from './plugins/bouncer';
 import errorHandling from './plugins/error-handling';
-import csrf, { CSRF_COOKIE, CSRF_HEADER } from './plugins/csrf';
+import csrf from './plugins/csrf';
 import notFound from './plugins/not-found';
 import * as publicRoutes from './routes/public';
 import * as protectedRoutes from './routes/protected';
@@ -115,11 +115,11 @@ export const build = async (
         requestInterceptor: req => {
           const csrfTokenCookie = document.cookie
             .split(';')
-            .find(str => str.includes(CSRF_COOKIE));
+            .find(str => str.includes('csrf_token'));
           const [_key, csrfToken] = csrfTokenCookie?.split('=') ?? [];
 
           // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-          if (csrfToken) req.headers[CSRF_HEADER] = csrfToken.trim();
+          if (csrfToken) req.headers['csrf-token'] = csrfToken.trim();
           return req;
         }
       }


### PR DESCRIPTION
The code in uiConfig is provided to the browser as is. This means that
anything relying on imports will not work, since the imported modules
are not exposed to the browser.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->
<!-- Feel free to add any additional description of changes below this line -->
