### PR TITLE
feat(client): add block labels to front-end blocks

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -534,7 +534,7 @@
       "transcript-label": "Your Microsoft Transcript Link",
       "invalid-transcript": "Your transcript link is not correct, it should have the following form: <1>https://learn.microsoft.com/LOCALE/users/USERNAME/transcript/ID</1> - check the UPPERCASE items in your link are correct."
     },
-    "blockType": {
+    "block-type": {
       "lecture": "Lecture",
       "workshop": "Workshop",
       "lab": "Lab",

--- a/client/src/components/layouts/variables.css
+++ b/client/src/components/layouts/variables.css
@@ -54,6 +54,10 @@
   --success-background: var(--green-dark);
   --danger-color: var(--red-light);
   --danger-background: var(--red-dark);
+  --yellow-background: var(--yellow-dark);
+  --yellow-color: var(--yellow-light);
+  --purple-background: var(--purple-dark);
+  --purple-color: var(--purple-light);
   --love-color: var(--love-light);
   --editor-background: var(--editor-background-dark);
 }
@@ -74,6 +78,10 @@
   --success-background: var(--green-light);
   --danger-color: var(--red-dark);
   --danger-background: var(--red-light);
+  --yellow-background: var(--yellow-light);
+  --yellow-color: var(--yellow-dark);
+  --purple-background: var(--purple-light);
+  --purple-color: var(--purple-dark);
   --love-color: var(--love-dark);
   --editor-background: var(--editor-background-light);
 }

--- a/client/src/templates/Introduction/components/block-label.tsx
+++ b/client/src/templates/Introduction/components/block-label.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { BlockTypes } from '../../../../../shared/config/blocks';
+
+interface BlockLabelProps {
+  blockType: BlockTypes;
+}
+
+function BlockLabel({ blockType }: BlockLabelProps): JSX.Element {
+  const { t } = useTranslation();
+
+  return (
+    <div className={`block-label block-label-${blockType}`}>
+      {t(`learn.block-type.${blockType}`)}
+    </div>
+  );
+}
+
+export default BlockLabel;

--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -20,7 +20,9 @@ import { ChallengeNode, CompletedChallenge } from '../../../redux/prop-types';
 import { playTone } from '../../../utils/tone';
 import { makeExpandedBlockSelector, toggleBlock } from '../redux';
 import { isGridBased, isProjectBased } from '../../../utils/curriculum-layout';
+import { BlockTypes } from '../../../../../shared/config/blocks';
 import Challenges from './challenges';
+import BlockLabel from './block-label';
 
 import '../intro.css';
 
@@ -46,6 +48,7 @@ const mapDispatchToProps = (dispatch: Dispatch) =>
 
 interface BlockProps {
   block: string;
+  blockType: BlockTypes | null;
   challenges: Challenge[];
   completedChallengeIds: string[];
   isExpanded: boolean;
@@ -89,6 +92,7 @@ class Block extends Component<BlockProps> {
   render(): JSX.Element {
     const {
       block,
+      blockType,
       completedChallengeIds,
       challenges,
       isExpanded,
@@ -154,6 +158,7 @@ class Block extends Component<BlockProps> {
           <div className={`block ${isExpanded ? 'open' : ''}`}>
             <div className='block-header'>
               <h3 className='big-block-title'>{blockTitle}</h3>
+              {blockType && <BlockLabel blockType={blockType} />}
               {!isAudited && (
                 <div className='block-cta-wrapper'>
                   <Link
@@ -210,6 +215,7 @@ class Block extends Component<BlockProps> {
           <div className='block'>
             <div className='block-header'>
               <h3 className='big-block-title'>{blockTitle}</h3>
+              {blockType && <BlockLabel blockType={blockType} />}
               {!isAudited && (
                 <div className='block-cta-wrapper'>
                   <Link
@@ -247,6 +253,7 @@ class Block extends Component<BlockProps> {
         <ScrollableAnchor id={block}>
           <div className={`block block-grid ${isExpanded ? 'open' : ''}`}>
             <h3 className='block-grid-title'>
+              {blockType && <BlockLabel blockType={blockType} />}
               <button
                 aria-expanded={isExpanded ? 'true' : 'false'}
                 aria-controls={`${block}-panel`}
@@ -317,6 +324,7 @@ class Block extends Component<BlockProps> {
             )}
           </div>
           <div className='title-wrapper map-title'>
+            {blockType && <BlockLabel blockType={blockType} />}
             <h3 className='block-grid-title'>
               <Link
                 className='block-header'

--- a/client/src/templates/Introduction/intro.css
+++ b/client/src/templates/Introduction/intro.css
@@ -11,6 +11,44 @@
   overflow-wrap: break-word;
 }
 
+.block-label {
+  margin: 0 10px 0 0;
+  align-self: center;
+  height: fit-content;
+  font-weight: bold;
+  padding: 4px 10px;
+}
+
+.block-label-lecture {
+  background-color: var(--yellow-background);
+  color: var(--yellow-color);
+}
+
+.block-label-workshop {
+  background-color: var(--highlight-background);
+  color: var(--highlight-color);
+}
+
+.block-label-lab {
+  background-color: var(--success-background);
+  color: var(--success-color);
+}
+
+.block-label-review {
+  background-color: var(--purple-background);
+  color: var(--purple-color);
+}
+
+.block-label-quiz {
+  background-color: var(--danger-background);
+  color: var(--danger-color);
+}
+
+.block-label-exam {
+  background-color: var(--quaternary-background);
+  color: var(--quaternary-color);
+}
+
 .block-header {
   display: flex;
   justify-content: space-between;

--- a/client/src/templates/Introduction/intro.css
+++ b/client/src/templates/Introduction/intro.css
@@ -15,37 +15,38 @@
   margin: 0 10px 0 0;
   align-self: center;
   height: fit-content;
-  font-weight: bold;
   padding: 4px 10px;
+  background-color: var(--secondary-background);
+  border: 1px solid;
 }
 
 .block-label-lecture {
-  background-color: var(--yellow-background);
+  border-color: var(--yellow-color);
   color: var(--yellow-color);
 }
 
 .block-label-workshop {
-  background-color: var(--highlight-background);
+  border-color: var(--highlight-color);
   color: var(--highlight-color);
 }
 
 .block-label-lab {
-  background-color: var(--success-background);
+  border-color: var(--success-color);
   color: var(--success-color);
 }
 
 .block-label-review {
-  background-color: var(--purple-background);
+  border-color: var(--purple-color);
   color: var(--purple-color);
 }
 
 .block-label-quiz {
-  background-color: var(--danger-background);
+  border-color: var(--danger-color);
   color: var(--danger-color);
 }
 
 .block-label-exam {
-  background-color: var(--quaternary-background);
+  border-color: var(--quaternary-color);
   color: var(--quaternary-color);
 }
 

--- a/client/src/templates/Introduction/super-block-intro.tsx
+++ b/client/src/templates/Introduction/super-block-intro.tsx
@@ -223,14 +223,22 @@ const SuperBlockIntroductionPage = (props: SuperBlockProp) => {
               </h2>
               <Spacer size='medium' />
               <div className='block-ui'>
-                {blocks.map(block => (
-                  <Block
-                    key={block}
-                    block={block}
-                    challenges={challenges.filter(c => c.block === block)}
-                    superBlock={superBlock}
-                  />
-                ))}
+                {blocks.map(block => {
+                  const blockChallenges = challenges.filter(
+                    c => c.block === block
+                  );
+                  const blockType = blockChallenges[0].blockType;
+
+                  return (
+                    <Block
+                      key={block}
+                      block={block}
+                      blockType={blockType}
+                      challenges={blockChallenges}
+                      superBlock={superBlock}
+                    />
+                  );
+                })}
                 {!superblockWithoutCert.includes(superBlock) && (
                   <CertChallenge
                     certification={certification}
@@ -291,6 +299,7 @@ export const query = graphql`
           }
           id
           block
+          blockType
           challengeType
           title
           order


### PR DESCRIPTION
This adds labels to the blocks on the front end superblock page. It only adds the labels when the blocktype exists, which is only on the front end blocks - so nothing in production should be affected. It looks pretty good - the colors could maybe be better, I used what we had in our palette. This is what I came up with, am open to suggestions. cc @ahmaxed - curious if you have any input.

<details><summary>images</summary>

<img width="622" alt="Screenshot 2024-10-10 at 9 40 46 AM" src="https://github.com/user-attachments/assets/8f933a31-611b-47a9-8a31-41df51d2f255">

<img width="625" alt="Screenshot 2024-10-10 at 9 40 39 AM" src="https://github.com/user-attachments/assets/9747565b-0f7c-4af8-b58c-0bc529d52347">

</details>


Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
