### PR TITLE
fix(curriculum): update Redux store listener to not allow direct calls

### DIFF
--- a/curriculum/challenges/english/03-front-end-development-libraries/redux/register-a-store-listener.md
+++ b/curriculum/challenges/english/03-front-end-development-libraries/redux/register-a-store-listener.md
@@ -42,6 +42,12 @@ assert.match(code,/(\s*function\s*)|(\s*\(\s*\)\s*=>)/gm);
 assert.notMatch(code,/store\.subscribe\(.+\(\)\)/)
 ```
 
+The function passed to `store.subscribe` should not be called.
+
+```js
+assert.notMatch(code,/store\.subscribe\(.+\(\)\)/)
+```
+
 The callback to `store.subscribe` should also increment the global `count` variable as the store is updated.
 
 ```js

--- a/curriculum/challenges/english/03-front-end-development-libraries/redux/register-a-store-listener.md
+++ b/curriculum/challenges/english/03-front-end-development-libraries/redux/register-a-store-listener.md
@@ -32,19 +32,19 @@ assert(
 There should be a listener function subscribed to the store using `store.subscribe`.
 
 ```js
-assert.match(code,/store\s*\.\s*subscribe\(/gm);
+assert.match(code, /store\s*\.\s*subscribe\(/gm);
 ```
 
 The `store.subscribe` should receive a function.
 
 ```js
-assert.match(code,/(\s*function\s*)|(\s*\(\s*\)\s*=>)/gm);
+assert.match(code, /(\s*function\s*)|(\s*\(\s*\)\s*=>)/gm);
 ```
 
 The function passed to `store.subscribe` should not be called.
 
 ```js
-assert.notMatch(code,/store\.subscribe\(.+\(\)\)/)
+assert.notMatch(code, /store\.subscribe\(.+\(\)\)/);
 ```
 
 The callback to `store.subscribe` should also increment the global `count` variable as the store is updated.

--- a/curriculum/challenges/english/03-front-end-development-libraries/redux/register-a-store-listener.md
+++ b/curriculum/challenges/english/03-front-end-development-libraries/redux/register-a-store-listener.md
@@ -32,19 +32,20 @@ assert(
 There should be a listener function subscribed to the store using `store.subscribe`.
 
 ```js
-(getUserInput) => assert(getUserInput('index').match(/store\s*\.\s*subscribe\(/gm));
+assert.match(code,/store\s*\.\s*subscribe\(/gm);
 ```
 
 The `store.subscribe` should receive a function.
 
 ```js
-(getUserInput) => assert(getUserInput('index').match(/(\s*function\s*)|(\s*\(\s*\)\s*=>)/gm)) 
+assert.match(code,/(\s*function\s*)|(\s*\(\s*\)\s*=>)/gm);
+assert.notMatch(code,/store\.subscribe\(.+\(\)\)/)
 ```
 
 The callback to `store.subscribe` should also increment the global `count` variable as the store is updated.
 
 ```js
-assert(store.getState() === count);
+assert.strictEqual(store.getState(), count);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/03-front-end-development-libraries/redux/register-a-store-listener.md
+++ b/curriculum/challenges/english/03-front-end-development-libraries/redux/register-a-store-listener.md
@@ -39,7 +39,6 @@ The `store.subscribe` should receive a function.
 
 ```js
 assert.match(code,/(\s*function\s*)|(\s*\(\s*\)\s*=>)/gm);
-assert.notMatch(code,/store\.subscribe\(.+\(\)\)/)
 ```
 
 The function passed to `store.subscribe` should not be called.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #50865

<!-- Feel free to add any additional description of changes below this line -->
I updated the assertions to be easier to read and made sure that campers could not directly their function in `store.subscribe`. 

It would probably be cleaner if we had SinonJS, but it is outside the scope of this PR. 