### PR TITLE
feat(api): remove pm2 from container

### DIFF
--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -52,7 +52,6 @@ RUN pnpm install --prod --ignore-scripts -F=shared -F=api --frozen-lockfile
 RUN cd api && npx prisma@$(jq -r '.devDependencies.prisma' < package.json) generate
 
 FROM node:20-bookworm
-RUN npm i -g pm2@4
 USER node
 WORKDIR /home/node/fcc
 COPY --from=builder --chown=node:node /home/node/build/api/dist/ ./
@@ -63,4 +62,4 @@ COPY --from=deps --chown=node:node /home/node/build/node_modules/ node_modules/
 COPY --from=deps --chown=node:node /home/node/build/shared/node_modules/ shared/node_modules/
 COPY --from=deps --chown=node:node /home/node/build/api/node_modules/ api/node_modules/
 
-CMD ["pm2-runtime", "start", "-i", "0","api/src/server.js"]
+CMD ["node", "api/src/server.js"]


### PR DESCRIPTION
Running a single instance of the app in the container means it takes less resources to run and is cheaper to test.

When we get to performance testing, we can add it back and see how it does under load.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
