### PR TITLE
chore(api): add request/response shadow dev tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -210,3 +210,6 @@ curriculum/build
 ### Playwright ###
 
 /playwright
+
+### Shadow Testing Log Files Folder ###
+api/logs/

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -27,6 +27,8 @@ import bouncer from './plugins/bouncer';
 import errorHandling from './plugins/error-handling';
 import csrf from './plugins/csrf';
 import notFound from './plugins/not-found';
+import shadowCapture from './plugins/shadow-capture';
+
 import * as publicRoutes from './routes/public';
 import * as protectedRoutes from './routes/protected';
 
@@ -35,6 +37,7 @@ import {
   EMAIL_PROVIDER,
   FCC_ENABLE_DEV_LOGIN_MODE,
   FCC_ENABLE_SWAGGER_UI,
+  FCC_ENABLE_SHADOW_CAPTURE,
   FREECODECAMP_NODE_ENV
 } from './utils/env';
 import { isObjectID } from './utils/validation';
@@ -125,6 +128,10 @@ export const build = async (
       }
     });
     fastify.log.info(`Swagger UI available at ${API_LOCATION}/documentation`);
+  }
+
+  if (FCC_ENABLE_SHADOW_CAPTURE) {
+    void fastify.register(shadowCapture);
   }
 
   void fastify.register(auth);

--- a/api/src/plugins/shadow-capture.ts
+++ b/api/src/plugins/shadow-capture.ts
@@ -1,0 +1,131 @@
+import { randomUUID } from 'crypto';
+import { appendFileSync } from 'fs';
+import type { FastifyPluginCallback } from 'fastify';
+
+import fp from 'fastify-plugin';
+import { FastifyReply } from 'fastify/types/reply';
+import { FastifyRequest } from 'fastify/types/request';
+
+let REQUEST_BUFFER: unknown[] = [];
+let RESPONSE_BUFFER: unknown[] = [];
+
+/**
+ * Plugin for capturing requests and responses to allow shadow testing.
+ *
+ * @param fastify The Fastify instance.
+ * @param _options Options passed to the plugin via `fastify.register(plugin, options)`.
+ * @param done Callback to signal that the logic has completed.
+ */
+const shadowCapture: FastifyPluginCallback = (fastify, _options, done) => {
+  fastify.addHook('onRequest', (req, rep, done) => {
+    // Attach timestamp at beginning of lifecycle
+    // @ts-expect-error TODO
+    req.__timestamp = Date.now();
+
+    // Give request and response same id to match.
+    const id = randomUUID();
+    // @ts-expect-error TODO
+    req.__id = id;
+    // @ts-expect-error TODO
+    rep.__id = id;
+    done();
+  });
+
+  // Body is only included after `Parsing` lifecycle
+  fastify.addHook('preValidation', (req, rep, done) => {
+    captureRequest(req);
+    done();
+  });
+
+  fastify.addHook('onResponse', (req, rep, done) => {
+    captureReply(rep);
+    done();
+  });
+
+  done();
+};
+
+/* eslint-disable @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-return */
+function captureRequest(req: FastifyRequest) {
+  const savedRequest = {
+    // @ts-expect-error TODO
+    id: req.__id,
+    // @ts-expect-error TODO
+    timestamp: req.__timestamp,
+    url: req.url,
+    headers: omit(req.headers, 'cookie'),
+    cookies: include(req.cookies, '_csrf', 'csrf_token', 'jwt_access_token'),
+    user: req.user,
+    body: req.body
+  };
+
+  if (REQUEST_BUFFER.length > 10) {
+    appendFileSync(
+      'request-capture.jsonl',
+      REQUEST_BUFFER.map(rb => JSON.stringify(rb)).join('\n') + '\n'
+    );
+    REQUEST_BUFFER = [savedRequest];
+  } else {
+    REQUEST_BUFFER.push(savedRequest);
+  }
+}
+
+function captureReply(rep: FastifyReply) {
+  const savedReply = {
+    // @ts-expect-error TODO
+    id: rep.__id,
+    // @ts-expect-error TODO
+    headers: rep.raw._header,
+    // @ts-expect-error TODO
+    contentLength: rep.raw._contentLength,
+    timestamp: Date.now()
+  };
+
+  if (RESPONSE_BUFFER.length > 10) {
+    appendFileSync(
+      'response-capture.jsonl',
+      RESPONSE_BUFFER.map(rb => JSON.stringify(rb)).join('\n') + '\n'
+    );
+    RESPONSE_BUFFER = [savedReply];
+  } else {
+    RESPONSE_BUFFER.push(savedReply);
+  }
+}
+
+/**
+ * Returns a subset of the given object with the values or properties given removed.
+ * @param obj - An array or an object literal.
+ * @param vals - Items or properties to exclude from `obj`.
+ * @returns Subset of `obj`.
+ */
+function omit(obj: object, ...vals: unknown[]) {
+  if (Array.isArray(obj)) {
+    return obj.filter(o => !vals.includes(o));
+  } else {
+    return (
+      Object.keys(obj)
+        .filter(k => {
+          return !vals.includes(k);
+        })
+        // @ts-expect-error TODO
+        .reduce((acc, curr) => ({ ...acc, [curr]: obj[curr] }), {})
+    );
+  }
+}
+
+function include(obj: object, ...vals: unknown[]) {
+  if (Array.isArray(obj)) {
+    return obj.filter(o => vals.includes(o));
+  } else {
+    return (
+      Object.keys(obj)
+        .filter(k => {
+          return vals.includes(k);
+        })
+        // @ts-expect-error TODO
+        .reduce((acc, curr) => ({ ...acc, [curr]: obj[curr] }), {})
+    );
+  }
+}
+
+export default fp(shadowCapture);

--- a/api/src/utils/env.ts
+++ b/api/src/utils/env.ts
@@ -125,6 +125,8 @@ export const FCC_ENABLE_SWAGGER_UI =
   process.env.FCC_ENABLE_SWAGGER_UI === 'true';
 export const FCC_ENABLE_DEV_LOGIN_MODE =
   process.env.FCC_ENABLE_DEV_LOGIN_MODE === 'true';
+export const FCC_ENABLE_SHADOW_CAPTURE =
+  process.env.FCC_ENABLE_SHADOW_CAPTURE === 'true';
 export const SENTRY_DSN =
   process.env.SENTRY_DSN === 'dsn_from_sentry_dashboard'
     ? ''

--- a/sample.env
+++ b/sample.env
@@ -68,6 +68,7 @@ NODE_ENV=development
 PORT=3000
 FCC_ENABLE_SWAGGER_UI=true
 FCC_ENABLE_DEV_LOGIN_MODE=true
+FCC_ENABLE_SHADOW_CAPTURE=false
 
 # Email
 # use ses in production


### PR DESCRIPTION
To test, set `FCC_ENABLE_SHADOW_CAPTURE=true` in the `.env` file. Then, make at least 11 requests to the api. A `api/logs/` directory should be populated with `jsonl` files.

Eventually, we can build out tooling for using the `jsonl` files such as:
- Set the database to the same state as needed when the original request came in
- Compare database states before/after same request
- Re-running the requests at the same rate they were originally made
- Re-running the requests as fast as possible
- Compare relative handler times