### PR TITLE
feat(client/curriculum): add generic challenge and first review block

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -1727,7 +1727,10 @@
         "intro": ["For this lab, you will create a video compilation web page."]
       },
       "bzfv": { "title": "8", "intro": [] },
-      "snuv": { "title": "9", "intro": [] },
+      "review-basic-html": {
+        "title": "Basic HTML Review",
+        "intro": ["Review the basic HTML topics."]
+      },
       "quiz-basic-html": {
         "title": "Basic HTML Quiz",
         "intro": [

--- a/client/src/pages/learn/front-end-development/review-basic-html/index.md
+++ b/client/src/pages/learn/front-end-development/review-basic-html/index.md
@@ -1,0 +1,9 @@
+---
+title: Introduction to the Basic HTML Review
+block: review-basic-html
+superBlock: front-end-development
+---
+
+## Introduction to the Basic HTML Review
+
+Review the basic HTML topics.

--- a/client/src/templates/Challenges/generic/show.tsx
+++ b/client/src/templates/Challenges/generic/show.tsx
@@ -1,7 +1,6 @@
 import { graphql } from 'gatsby';
 import React, { useEffect, useRef, useState } from 'react';
 import Helmet from 'react-helmet';
-// import { ObserveKeys } from 'react-hotkeys';
 import { useTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
@@ -10,11 +9,9 @@ import { createSelector } from 'reselect';
 import { Container, Col, Row, Button } from '@freecodecamp/ui';
 
 // Local Utilities
-// import { shuffleArray } from '../../../../../shared/utils/shuffle-array';
 import Spacer from '../../../components/helpers/spacer';
 import LearnLayout from '../../../components/layouts/learn';
 import { ChallengeNode, ChallengeMeta, Test } from '../../../redux/prop-types';
-// import { challengeTypes } from '../../../../../shared/config/challenge-types';
 import ChallengeDescription from '../components/challenge-description';
 import Hotkeys from '../components/hotkeys';
 import ChallengeTitle from '../components/challenge-title';
@@ -29,9 +26,6 @@ import {
   initTests
 } from '../redux/actions';
 import { isChallengeCompletedSelector } from '../redux/selectors';
-// import PrismFormatted from '../components/prism-formatted';
-
-// import './show.css';
 
 // Redux Setup
 const mapStateToProps = createSelector(
@@ -80,8 +74,6 @@ const ShowGeneric = ({
         fields: { tests },
         helpCategory,
         instructions,
-        // questions,
-        // quizzes,
         title,
         translationPending,
         superBlock,
@@ -103,36 +95,6 @@ const ShowGeneric = ({
   const blockNameTitle = `${t(
     `intro:${superBlock}.blocks.${block}.title`
   )} - ${title}`;
-
-  // Initialize the data passed to `useQuiz`
-  // const [initialQuizData] = useState(
-  //   quiz.map(question => {
-  //     const distractors = question.distractors.map((distractor, index) => {
-  //       return {
-  //         label: (
-  //           <PrismFormatted className='quiz-answer-label' text={distractor} />
-  //         ),
-  //         value: index + 1
-  //       };
-  //     });
-
-  //     const answer = {
-  //       label: (
-  //         <PrismFormatted
-  //           className='quiz-answer-label'
-  //           text={question.answer}
-  //         />
-  //       ),
-  //       value: 4
-  //     };
-
-  //     return {
-  //       question: <PrismFormatted text={question.text} />,
-  //       answers: shuffleArray([...distractors, answer]),
-  //       correctAnswer: answer.value
-  //     };
-  //   })
-  // );
 
   useEffect(() => {
     initTests(tests);
@@ -188,12 +150,11 @@ const ShowGeneric = ({
     setAllAssignmentsCompleted(totalAssignments === newAssignmentsCompleted);
   };
 
-  // Submit
+  // submit
   const handleSubmit = () => {
-    // if all correct, open completion modal
-
-    openCompletionModal();
-    // else, show feedback
+    if (assignments.length > 0 && allAssignmentsCompleted) {
+      openCompletionModal();
+    }
   };
 
   return (

--- a/client/src/templates/Challenges/generic/show.tsx
+++ b/client/src/templates/Challenges/generic/show.tsx
@@ -137,24 +137,19 @@ const ShowGeneric = ({
   };
 
   // assignments
-  const [allAssignmentsCompleted, setAllAssignmentsCompleted] = useState(false);
   const [assignmentsCompleted, setAssignmentsCompleted] = useState(0);
+  const allAssignmentCompleted = assignmentsCompleted === assignments.length;
 
   const handleAssignmentChange = (
-    event: React.ChangeEvent<HTMLInputElement>,
-    totalAssignments: number
+    event: React.ChangeEvent<HTMLInputElement>
   ) => {
-    const newAssignmentsCompleted = event.target.checked
-      ? assignmentsCompleted + 1
-      : assignmentsCompleted - 1;
-
-    setAssignmentsCompleted(newAssignmentsCompleted);
-    setAllAssignmentsCompleted(totalAssignments === newAssignmentsCompleted);
+    const isCompleted = event.target.checked; // extract value before target is nullified
+    setAssignmentsCompleted(a => (isCompleted ? a + 1 : a - 1));
   };
 
   // submit
   const handleSubmit = () => {
-    if (assignments.length > 0 && allAssignmentsCompleted) {
+    if (assignments.length == 0 || allAssignmentsCompleted) {
       openCompletionModal();
     }
   };

--- a/client/src/templates/Challenges/generic/show.tsx
+++ b/client/src/templates/Challenges/generic/show.tsx
@@ -1,0 +1,308 @@
+import { graphql } from 'gatsby';
+import React, { useEffect, useRef, useState } from 'react';
+import Helmet from 'react-helmet';
+// import { ObserveKeys } from 'react-hotkeys';
+import { useTranslation } from 'react-i18next';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import type { Dispatch } from 'redux';
+import { createSelector } from 'reselect';
+import { Container, Col, Row, Button } from '@freecodecamp/ui';
+
+// Local Utilities
+// import { shuffleArray } from '../../../../../shared/utils/shuffle-array';
+import Spacer from '../../../components/helpers/spacer';
+import LearnLayout from '../../../components/layouts/learn';
+import { ChallengeNode, ChallengeMeta, Test } from '../../../redux/prop-types';
+// import { challengeTypes } from '../../../../../shared/config/challenge-types';
+import ChallengeDescription from '../components/challenge-description';
+import Hotkeys from '../components/hotkeys';
+import ChallengeTitle from '../components/challenge-title';
+import VideoPlayer from '../components/video-player';
+import CompletionModal from '../components/completion-modal';
+import Assignments from '../components/assignments';
+import {
+  challengeMounted,
+  updateChallengeMeta,
+  openModal,
+  updateSolutionFormValues,
+  initTests
+} from '../redux/actions';
+import { isChallengeCompletedSelector } from '../redux/selectors';
+// import PrismFormatted from '../components/prism-formatted';
+
+// import './show.css';
+
+// Redux Setup
+const mapStateToProps = createSelector(
+  isChallengeCompletedSelector,
+  (isChallengeCompleted: boolean) => ({
+    isChallengeCompleted
+  })
+);
+const mapDispatchToProps = (dispatch: Dispatch) =>
+  bindActionCreators(
+    {
+      initTests,
+      updateChallengeMeta,
+      challengeMounted,
+      updateSolutionFormValues,
+      openCompletionModal: () => openModal('completion')
+    },
+    dispatch
+  );
+
+// Types
+interface ShowQuizProps {
+  challengeMounted: (arg0: string) => void;
+  data: { challengeNode: ChallengeNode };
+  description: string;
+  initTests: (xs: Test[]) => void;
+  isChallengeCompleted: boolean;
+  openCompletionModal: () => void;
+  pageContext: {
+    challengeMeta: ChallengeMeta;
+  };
+  updateChallengeMeta: (arg0: ChallengeMeta) => void;
+  updateSolutionFormValues: () => void;
+}
+
+const ShowGeneric = ({
+  challengeMounted,
+  data: {
+    challengeNode: {
+      challenge: {
+        assignments,
+        bilibiliIds,
+        block,
+        description,
+        challengeType,
+        fields: { tests },
+        helpCategory,
+        instructions,
+        // questions,
+        // quizzes,
+        title,
+        translationPending,
+        superBlock,
+        videoId,
+        videoLocaleIds
+      }
+    }
+  },
+  pageContext: { challengeMeta },
+  initTests,
+  updateChallengeMeta,
+  openCompletionModal,
+  isChallengeCompleted
+}: ShowQuizProps) => {
+  const { t } = useTranslation();
+  const { nextChallengePath, prevChallengePath } = challengeMeta;
+  const container = useRef<HTMLElement | null>(null);
+
+  const blockNameTitle = `${t(
+    `intro:${superBlock}.blocks.${block}.title`
+  )} - ${title}`;
+
+  // Initialize the data passed to `useQuiz`
+  // const [initialQuizData] = useState(
+  //   quiz.map(question => {
+  //     const distractors = question.distractors.map((distractor, index) => {
+  //       return {
+  //         label: (
+  //           <PrismFormatted className='quiz-answer-label' text={distractor} />
+  //         ),
+  //         value: index + 1
+  //       };
+  //     });
+
+  //     const answer = {
+  //       label: (
+  //         <PrismFormatted
+  //           className='quiz-answer-label'
+  //           text={question.answer}
+  //         />
+  //       ),
+  //       value: 4
+  //     };
+
+  //     return {
+  //       question: <PrismFormatted text={question.text} />,
+  //       answers: shuffleArray([...distractors, answer]),
+  //       correctAnswer: answer.value
+  //     };
+  //   })
+  // );
+
+  useEffect(() => {
+    initTests(tests);
+    updateChallengeMeta({
+      ...challengeMeta,
+      title,
+      challengeType,
+      helpCategory
+    });
+    challengeMounted(challengeMeta.id);
+    container.current?.focus();
+    // This effect should be run once on mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    updateChallengeMeta({
+      ...challengeMeta,
+      title,
+      challengeType,
+      helpCategory
+    });
+    challengeMounted(challengeMeta.id);
+  }, [
+    title,
+    challengeMeta,
+    challengeType,
+    helpCategory,
+    challengeMounted,
+    updateChallengeMeta
+  ]);
+
+  // video
+  const [videoIsLoaded, setVideoIsLoaded] = useState(false);
+
+  const handleVideoIsLoaded = () => {
+    setVideoIsLoaded(true);
+  };
+
+  // assignments
+  const [allAssignmentsCompleted, setAllAssignmentsCompleted] = useState(false);
+  const [assignmentsCompleted, setAssignmentsCompleted] = useState(0);
+
+  const handleAssignmentChange = (
+    event: React.ChangeEvent<HTMLInputElement>,
+    totalAssignments: number
+  ) => {
+    const newAssignmentsCompleted = event.target.checked
+      ? assignmentsCompleted + 1
+      : assignmentsCompleted - 1;
+
+    setAssignmentsCompleted(newAssignmentsCompleted);
+    setAllAssignmentsCompleted(totalAssignments === newAssignmentsCompleted);
+  };
+
+  // Submit
+  const handleSubmit = () => {
+    // if all correct, open completion modal
+
+    openCompletionModal();
+    // else, show feedback
+  };
+
+  return (
+    <Hotkeys
+      executeChallenge={handleSubmit}
+      containerRef={container}
+      nextChallengePath={nextChallengePath}
+      prevChallengePath={prevChallengePath}
+    >
+      <LearnLayout>
+        <Helmet
+          title={`${blockNameTitle} | ${t('learn.learn')} | freeCodeCamp.org`}
+        />
+        <Container>
+          <Row>
+            <Spacer size='medium' />
+            <ChallengeTitle
+              isCompleted={isChallengeCompleted}
+              translationPending={translationPending}
+            >
+              {title}
+            </ChallengeTitle>
+
+            <Col md={8} mdOffset={2} sm={10} smOffset={1} xs={12}>
+              {description && (
+                <ChallengeDescription description={description} />
+              )}
+            </Col>
+
+            <Col lg={10} lgOffset={1} md={10} mdOffset={1}>
+              {videoId && (
+                <VideoPlayer
+                  bilibiliIds={bilibiliIds}
+                  onVideoLoad={handleVideoIsLoaded}
+                  title={title}
+                  videoId={videoId}
+                  videoIsLoaded={videoIsLoaded}
+                  videoLocaleIds={videoLocaleIds}
+                />
+              )}
+            </Col>
+
+            <Col md={8} mdOffset={2} sm={10} smOffset={1} xs={12}>
+              {instructions && (
+                <ChallengeDescription description={instructions} />
+              )}
+
+              <Spacer size='medium' />
+
+              {assignments.length > 0 && (
+                <Assignments
+                  assignments={assignments}
+                  allAssignmentsCompleted={allAssignmentsCompleted}
+                  handleAssignmentChange={handleAssignmentChange}
+                />
+              )}
+
+              <Button block={true} variant='primary' onClick={handleSubmit}>
+                {t('buttons.check-answer')}
+              </Button>
+
+              <Spacer size='large' />
+            </Col>
+            <CompletionModal />
+          </Row>
+        </Container>
+      </LearnLayout>
+    </Hotkeys>
+  );
+};
+
+ShowGeneric.displayName = 'ShowGeneric';
+
+export default connect(mapStateToProps, mapDispatchToProps)(ShowGeneric);
+
+export const query = graphql`
+  query GenericChallenge($id: String!) {
+    challengeNode(id: { eq: $id }) {
+      challenge {
+        assignments
+        bilibiliIds {
+          aid
+          bvid
+          cid
+        }
+        block
+        challengeType
+        description
+        helpCategory
+        instructions
+        fields {
+          blockName
+          slug
+          tests {
+            text
+            testString
+          }
+        }
+        superBlock
+        title
+        translationPending
+        videoId
+        videoId
+        videoLocaleIds {
+          espanol
+          italian
+          portuguese
+        }
+      }
+    }
+  }
+`;

--- a/client/src/templates/Challenges/generic/show.tsx
+++ b/client/src/templates/Challenges/generic/show.tsx
@@ -3,9 +3,6 @@ import React, { useEffect, useRef, useState } from 'react';
 import Helmet from 'react-helmet';
 import { useTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
-import type { Dispatch } from 'redux';
-import { createSelector } from 'reselect';
 import { Container, Col, Row, Button } from '@freecodecamp/ui';
 
 // Local Utilities
@@ -29,23 +26,17 @@ import { isChallengeCompletedSelector } from '../redux/selectors';
 import { BlockTypes } from '../../../../../shared/config/blocks';
 
 // Redux Setup
-const mapStateToProps = createSelector(
-  isChallengeCompletedSelector,
-  (isChallengeCompleted: boolean) => ({
-    isChallengeCompleted
-  })
-);
-const mapDispatchToProps = (dispatch: Dispatch) =>
-  bindActionCreators(
-    {
-      initTests,
-      updateChallengeMeta,
-      challengeMounted,
-      updateSolutionFormValues,
-      openCompletionModal: () => openModal('completion')
-    },
-    dispatch
-  );
+const mapStateToProps = (state: unknown) => ({
+  isChallengeCompleted: isChallengeCompletedSelector(state) as boolean
+});
+
+const mapDispatchToProps = {
+  initTests,
+  updateChallengeMeta,
+  challengeMounted,
+  updateSolutionFormValues,
+  openCompletionModal: () => openModal('completion')
+};
 
 // Types
 interface ShowQuizProps {
@@ -138,7 +129,7 @@ const ShowGeneric = ({
 
   // assignments
   const [assignmentsCompleted, setAssignmentsCompleted] = useState(0);
-  const allAssignmentCompleted = assignmentsCompleted === assignments.length;
+  const allAssignmentsCompleted = assignmentsCompleted === assignments.length;
 
   const handleAssignmentChange = (
     event: React.ChangeEvent<HTMLInputElement>

--- a/client/src/templates/Challenges/generic/show.tsx
+++ b/client/src/templates/Challenges/generic/show.tsx
@@ -26,6 +26,7 @@ import {
   initTests
 } from '../redux/actions';
 import { isChallengeCompletedSelector } from '../redux/selectors';
+import { BlockTypes } from '../../../../../shared/config/blocks';
 
 // Redux Setup
 const mapStateToProps = createSelector(
@@ -69,6 +70,7 @@ const ShowGeneric = ({
         assignments,
         bilibiliIds,
         block,
+        blockType,
         description,
         challengeType,
         fields: { tests },
@@ -213,7 +215,9 @@ const ShowGeneric = ({
               )}
 
               <Button block={true} variant='primary' onClick={handleSubmit}>
-                {t('buttons.submit')}
+                {blockType === BlockTypes.review
+                  ? t('buttons.submit')
+                  : t('buttons.check-answer')}
               </Button>
 
               <Spacer size='large' />
@@ -241,6 +245,7 @@ export const query = graphql`
           cid
         }
         block
+        blockType
         challengeType
         description
         helpCategory

--- a/client/src/templates/Challenges/generic/show.tsx
+++ b/client/src/templates/Challenges/generic/show.tsx
@@ -213,7 +213,7 @@ const ShowGeneric = ({
               )}
 
               <Button block={true} variant='primary' onClick={handleSubmit}>
-                {t('buttons.check-answer')}
+                {t('buttons.submit')}
               </Button>
 
               <Spacer size='large' />

--- a/client/utils/gatsby/challenge-page-creator.js
+++ b/client/utils/gatsby/challenge-page-creator.js
@@ -61,6 +61,11 @@ const fillInTheBlank = path.resolve(
   '../../src/templates/Challenges/fill-in-the-blank/show.tsx'
 );
 
+const generic = path.resolve(
+  __dirname,
+  '../../src/templates/Challenges/generic/show.tsx'
+);
+
 const views = {
   backend,
   classic,
@@ -73,8 +78,8 @@ const views = {
   exam,
   msTrophy,
   dialogue,
-  fillInTheBlank
-  // quiz: Quiz
+  fillInTheBlank,
+  generic
 };
 
 function getIsFirstStepInBlock(id, edges) {

--- a/curriculum/challenges/_meta/review-basic-html/meta.json
+++ b/curriculum/challenges/_meta/review-basic-html/meta.json
@@ -1,11 +1,10 @@
 {
   "name": "Basic HTML Review",
   "isUpcomingChange": true,
-  "usesMultifileEditor": true,
-  "hasEditableBoundaries": true,
   "dashedName": "review-basic-html",
   "order": 9,
   "superBlock": "front-end-development",
   "challengeOrder": [{ "id": "67072fc183c7ca6c588feb4d", "title": "Basic HTML Review" }],
-  "helpCategory": "HTML-CSS"
+  "helpCategory": "HTML-CSS",
+  "blockType": "review"
 }

--- a/curriculum/challenges/_meta/review-basic-html/meta.json
+++ b/curriculum/challenges/_meta/review-basic-html/meta.json
@@ -1,0 +1,11 @@
+{
+  "name": "Basic HTML Review",
+  "isUpcomingChange": true,
+  "usesMultifileEditor": true,
+  "hasEditableBoundaries": true,
+  "dashedName": "review-basic-html",
+  "order": 9,
+  "superBlock": "front-end-development",
+  "challengeOrder": [{ "id": "67072fc183c7ca6c588feb4d", "title": "Basic HTML Review" }],
+  "helpCategory": "HTML-CSS"
+}

--- a/curriculum/challenges/english/25-front-end-development/review-basic-html/67072fc183c7ca6c588feb4d.md
+++ b/curriculum/challenges/english/25-front-end-development/review-basic-html/67072fc183c7ca6c588feb4d.md
@@ -7,6 +7,8 @@ dashedName: basic-html-review
 
 # --description--
 
+Review the concepts below to prepare for the upcoming quiz.
+
 ## HTML Basics
 
 - **Role of HTML**: Foundation of web structure.

--- a/curriculum/challenges/english/25-front-end-development/review-basic-html/67072fc183c7ca6c588feb4d.md
+++ b/curriculum/challenges/english/25-front-end-development/review-basic-html/67072fc183c7ca6c588feb4d.md
@@ -1,37 +1,59 @@
 ---
 id: 67072fc183c7ca6c588feb4d
 title: Basic HTML Review
-challengeType: 15
+challengeType: 24
 dashedName: basic-html-review
 ---
 
 # --description--
 
-# Basic HTML Review Topics
+## HTML Basics
 
-- Role of HTML on the web
-- Block-level vs. inline elements (divs and spans)
-- Attributes and their usage
-- IDs and classes
-- HTML entities and special characters
-- `<link>` element and external stylesheets
-- `<script>` element and external JavaScript files
-- HTML boilerplate structure
-- UTF-8 character encoding
-- Meta tags (description) and SEO
-- Open Graph tags and social media sharing
-- Replaced elements (e.g., images, videos, iframes)
-- Optimizing media assets
-- Image formats and licenses
-- SVGs and their usage
-- HTML audio and video elements
-- Embedding videos using `<iframe>`
-- Target attribute types
-- Absolute vs. relative paths
-- Path syntax (slashes, single dot, double dot)
-- Link states (link, visited, hover, active)
-- Inline vs. block-level links
+- **Role of HTML**: Foundation of web structure.
+- **Block-level vs. inline elements**: Understanding `div` and `span`.
+- **Attributes**: Adding metadata and behavior to elements.
+
+## Identifiers and Grouping
+
+- **IDs**: Unique element identifiers.
+- **Classes**: Grouping elements for styling and behavior.
+
+## Special Characters and Linking
+
+- **HTML entities**: Using special characters like `&amp;` and `&lt;`.
+- **`<link>` element**: Linking to external stylesheets.
+- **`<script>` element**: Embedding external JavaScript files.
+
+## Boilerplate and Encoding
+
+- **HTML boilerplate**: Basic structure of a webpage.
+- **UTF-8 character encoding**: Ensuring universal character display.
+
+## SEO and Social Sharing
+
+- **Meta tags (`description`)**: How it impacts SEO.
+- **Open Graph tags**: Enhancing social media sharing.
+
+## Media Elements and Optimization
+
+- **Replaced elements**: Embedded content (e.g., images, iframes).
+- **Optimizing media**: Techniques to improve media performance.
+- **Image formats and licenses**: Understanding usage rights and types.
+- **SVGs**: Scalable vector graphics for sharp visuals.
+
+## Multimedia Integration
+
+- **HTML audio and video elements**: Embedding multimedia.
+- **Embedding with `<iframe>`**: Integrating external video content.
+
+## Paths and Link Behavior
+
+- **Target attribute types**: Controlling link behavior.
+- **Absolute vs. relative paths**: Navigating directories.
+- **Path syntax**: Understanding `/`, `./`, `../` for file navigation.
+- **Link states**: Managing different link interactions (hover, active).
+- **Inline vs. block-level links**: Layout and behavior differences.
 
 # --assignment--
 
-Read the review page
+Review the Basic HTML topics and concepts.

--- a/curriculum/challenges/english/25-front-end-development/review-basic-html/67072fc183c7ca6c588feb4d.md
+++ b/curriculum/challenges/english/25-front-end-development/review-basic-html/67072fc183c7ca6c588feb4d.md
@@ -1,0 +1,37 @@
+---
+id: 67072fc183c7ca6c588feb4d
+title: Basic HTML Review
+challengeType: 15
+dashedName: basic-html-review
+---
+
+# --description--
+
+# Basic HTML Review Topics
+
+- Role of HTML on the web
+- Block-level vs. inline elements (divs and spans)
+- Attributes and their usage
+- IDs and classes
+- HTML entities and special characters
+- `<link>` element and external stylesheets
+- `<script>` element and external JavaScript files
+- HTML boilerplate structure
+- UTF-8 character encoding
+- Meta tags (description) and SEO
+- Open Graph tags and social media sharing
+- Replaced elements (e.g., images, videos, iframes)
+- Optimizing media assets
+- Image formats and licenses
+- SVGs and their usage
+- HTML audio and video elements
+- Embedding videos using `<iframe>`
+- Target attribute types
+- Absolute vs. relative paths
+- Path syntax (slashes, single dot, double dot)
+- Link states (link, visited, hover, active)
+- Inline vs. block-level links
+
+# --assignment--
+
+Read the review page

--- a/curriculum/schema/__snapshots__/challenge-schema.test.js.snap
+++ b/curriculum/schema/__snapshots__/challenge-schema.test.js.snap
@@ -143,7 +143,7 @@ const schema = Joi.object()
     }),
     challengeOrder: Joi.number(),
     certification: Joi.string().regex(slugWithSlashRE),
-    challengeType: Joi.number().min(0).max(23).required(),
+    challengeType: Joi.number().min(0).max(24).required(),
     checksum: Joi.number(),
     // TODO: require this only for normal challenges, not certs
     dashedName: Joi.string().regex(slugRE),

--- a/curriculum/schema/challenge-schema.js
+++ b/curriculum/schema/challenge-schema.js
@@ -140,7 +140,7 @@ const schema = Joi.object()
     }),
     challengeOrder: Joi.number(),
     certification: Joi.string().regex(slugWithSlashRE),
-    challengeType: Joi.number().min(0).max(23).required(),
+    challengeType: Joi.number().min(0).max(24).required(),
     checksum: Joi.number(),
     // TODO: require this only for normal challenges, not certs
     dashedName: Joi.string().regex(slugRE),

--- a/curriculum/schema/meta-schema.js
+++ b/curriculum/schema/meta-schema.js
@@ -6,12 +6,19 @@ const slugWithSlashRE = new RegExp('^[a-z0-9-/]+$');
 const schema = Joi.object()
   .keys({
     name: Joi.string().required(),
-    blockType: Joi.valid('workshop', 'lab', 'lecture', 'quiz', 'exam'),
     blockLayout: Joi.valid(
       'challenge-list',
       'challenge-grid',
       'link',
       'project-list'
+    ),
+    blockType: Joi.valid(
+      'workshop',
+      'lab',
+      'lecture',
+      'review',
+      'quiz',
+      'exam'
     ),
     isUpcomingChange: Joi.boolean().required(),
     dashedName: Joi.string().regex(slugRE).required(),

--- a/shared/config/challenge-types.ts
+++ b/shared/config/challenge-types.ts
@@ -23,6 +23,7 @@ const python = 20;
 const dialogue = 21;
 const fillInTheBlank = 22;
 const multifilePythonCertProject = 23;
+const generic = 24;
 
 export const challengeTypes = {
   html,
@@ -49,7 +50,8 @@ export const challengeTypes = {
   python,
   dialogue,
   fillInTheBlank,
-  multifilePythonCertProject
+  multifilePythonCertProject,
+  generic
 };
 
 export const hasNoSolution = (challengeType: number): boolean => {
@@ -71,7 +73,8 @@ export const hasNoSolution = (challengeType: number): boolean => {
     msTrophy,
     multipleChoice,
     dialogue,
-    fillInTheBlank
+    fillInTheBlank,
+    generic
   ];
 
   return noSolutions.includes(challengeType);
@@ -101,7 +104,8 @@ export const viewTypes = {
   [python]: 'modern',
   [dialogue]: 'dialogue',
   [fillInTheBlank]: 'fillInTheBlank',
-  [multifilePythonCertProject]: 'classic'
+  [multifilePythonCertProject]: 'classic',
+  [generic]: 'generic'
 };
 
 // determine the type of submit function to use for the challenge on completion
@@ -132,5 +136,6 @@ export const submitTypes = {
   [python]: 'tests',
   [dialogue]: 'tests',
   [fillInTheBlank]: 'tests',
-  [multifilePythonCertProject]: 'tests'
+  [multifilePythonCertProject]: 'tests',
+  [generic]: 'tests'
 };


### PR DESCRIPTION
I've been talking about this for a bit. This adds a generic challenge type to, hopefully, eventually use for many of the various challenge types we have. The idea is that it will render whatever is in the markdown. Right now, it only handles videos and assignments.

This also adds the first review page, which is just a chunk of text with an assignment box. None of the existing challenge types allowed that, so I made this new one.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
