### PR TITLE
fix(curriculum): clarify usage of getElementById in Step 103

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-recursion-by-building-a-decimal-to-binary-converter/6464ad3c9b2e6cf58224cfa9.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-recursion-by-building-a-decimal-to-binary-converter/6464ad3c9b2e6cf58224cfa9.md
@@ -11,6 +11,8 @@ You have set the `id` attribute for your paragraph elements to the `obj.inputVal
 
 Now, use `getElementById` to select the element with that attribute value, again using the `obj.inputVal` property.
 
+**Note:** In JavaScript, `getElementById()` can accept non-string values, including integers. It will automatically convert these values to strings when looking for the corresponding element in the DOM. This means you can pass `obj.inputVal` directly without needing to convert it to a string.
+
 # --hints--
 
 You should use the `.getElementById()` method to target the element where the `id` attribute matches the value of `inputVal` for the current object.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #56587 

<!-- Feel free to add any additional description of changes below this line -->

Updated Step 103 to clarify that getElementById can accept non-string values, including integers, and will convert them automatically to strings.