### PR TITLE
feat(api): send version header

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -28,6 +28,7 @@ import errorHandling from './plugins/error-handling';
 import csrf from './plugins/csrf';
 import notFound from './plugins/not-found';
 import shadowCapture from './plugins/shadow-capture';
+import versioner from './plugins/versioner';
 
 import * as publicRoutes from './routes/public';
 import * as protectedRoutes from './routes/protected';
@@ -138,6 +139,7 @@ export const build = async (
   void fastify.register(notFound);
   void fastify.register(prismaPlugin);
   void fastify.register(bouncer);
+  void fastify.register(versioner);
 
   // Routes requiring authentication:
   void fastify.register(async function (fastify, _opts) {

--- a/api/src/plugins/versioner.ts
+++ b/api/src/plugins/versioner.ts
@@ -1,0 +1,37 @@
+import { FastifyPluginCallback } from 'fastify';
+import fp from 'fastify-plugin';
+
+import { version } from '../../package.json';
+
+/**
+ * Plugin which sets the api version in a response header.
+ *
+ * @param fastify The Fastify instance.
+ * @param _options Options passed to the plugin via `fastify.register(plugin, options)`.
+ * @param done Callback to signal that the logic has completed.
+ */
+const versioner: FastifyPluginCallback = (fastify, _options, done) => {
+  fastify.addHook('onRequest', (req, rep, done) => {
+    // TODO: Handle client expected api version?
+    //       Maybe send to correct version of the API?
+    // const requestedVersion = req.headers['version'];
+    // if (typeof requestedVersion === "string") {
+    //   const [expectedMajor] = requestedVersion.split('.');
+    //   const [currentMajor] = version.split('.');
+    //   if (expectedMajor !== currentMajor) {
+    //     void rep.code(400)
+    //     return rep.send({
+    //       code: 'ERR_UNSUPPORTED_VERSION',
+    //       message: `Client requested version ${requestedVersion} but server is version ${version}`
+    //     });
+    //   }
+    // }
+
+    // Set header to send to client of current version
+    void rep.header('Version', version);
+    done();
+  });
+  done();
+};
+
+export default fp(versioner);


### PR DESCRIPTION
**NOTE**: This PR is here to discuss ideas.

---

**Options:**

1) `/v2/<endpoint>`
2) `Version` header

`1` is common-place, but does not help the situation we have with the exam environment client, necessarily. That is, with any (major) change to the endpoint, we want to be able to completely prevent the client from continuing without an update. So, there will be no "support" period for older versions.

I do not know if we ever plan to support multiple versions of the api at the same time. If we **DO**, then `/v2/<endpoint>` is the obvious choice. But, then, we must come up with another solution for situations like the exam environment client which **may not** use older versions of **certain** endpoints.

At the end of the day, this might come back to the point previously raised about the `/exam-environment/` endpoints being orthogonal to the main api. That is, the reason it lives in its own directory; it might make more sense as its own service.

<details>
  <summary>Expanded Explanation</summary>

The requirement for the Exam Environment app will look something like:

```rust
fn main() {
    let login_result = login();
    match login_result {
        Ok(user) => navigate_to_landing(user),
        Err(ApiErrors::UnsupportedVersion(current_api_version) => {
            navigate_to_error_page("This app needs to be updated to work with freeCodeCamp API v{current_api_version}");
        }
    }
}

fn login() -> Result<User> {
    let expected_api_version = "1.0.1";
    return auth_user(expected_api_version);
}
    
```

In practice, we _could_ just support only one `/v<X>/exam-environment/<sub_path>`, and support multiple other versions of other routes. However, that sounds more confusing than soluble (_adjective form of "solution"_ 🤫). Unless I am missing something, I have never seen another API support:

```
/v1/a
/v2/a
!/v1/b
/v2/b
```

In all actuality, we do not **need** this _now_. The app has the capability to auto-update, and prevent use if there is an updated version of the app. So, in theory, if we cut a breaking change of the api's endpoints, then we just need to cut a new release of the app, and the problem can be considered _"solved"_.

That said, this discussion could still be useful because:
a) We definitely want versioning
b) For some endpoints, we will just NOT want to support the previous version for the same length of time as other endpoints

**FAQ**

- Would this not have been better suit as an issue?
  - Maybe. 🤫 

</details>