### PR TITLE
chore(client): remove unload event from exam/show.tsx

### DIFF
--- a/client/src/templates/Challenges/exam/show.tsx
+++ b/client/src/templates/Challenges/exam/show.tsx
@@ -257,7 +257,6 @@ class ShowExam extends Component<ShowExamProps, ShowExamState> {
           this.props.startExam();
 
           window.addEventListener('beforeunload', this.stopWindowClose);
-          window.addEventListener('unload', this.stopWindowClose);
           window.addEventListener('popstate', this.stopBrowserBack);
         }
       );
@@ -298,7 +297,6 @@ class ShowExam extends Component<ShowExamProps, ShowExamState> {
     });
 
     window.removeEventListener('beforeunload', this.stopWindowClose);
-    window.removeEventListener('unload', this.stopWindowClose);
     window.removeEventListener('popstate', this.stopBrowserBack);
 
     this.props.clearExamResults();


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR removes the `unload` event from `exam/show.tsx` as the event is deprecated.

Ref: https://developer.mozilla.org/en-US/docs/Web/API/Window/unload_event

<!-- Feel free to add any additional description of changes below this line -->
