### PR TITLE
fix(client-plugins): default description, instructions, and seed to empty string 

### DIFF
--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66a909dc2e382527ead44c23.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66a909dc2e382527ead44c23.md
@@ -7,7 +7,7 @@ dashedName: task-1
 
 <!-- (Audio) Bob: Hey Lisa, do you have a minute?  -->
 
-# --description--
+# --instructions--
 
 Listen to the audio and answer the question below.
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66a909dc2e382527ead44c23.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66a909dc2e382527ead44c23.md
@@ -4,9 +4,10 @@ title: Task 1
 challengeType: 19
 dashedName: task-1
 ---
+
 <!-- (Audio) Bob: Hey Lisa, do you have a minute?  -->
 
-# --instructions--
+# --description--
 
 Listen to the audio and answer the question below.
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66a90bbd872bca2a1b7e63a9.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66a90bbd872bca2a1b7e63a9.md
@@ -7,7 +7,7 @@ dashedName: task-2
 
 <!-- (Audio) Bob: Hey Lisa, do you have a minute?  -->
 
-# --description--
+# --instructions--
 
 Listen to the audio and complete the sentence below.
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66a90bbd872bca2a1b7e63a9.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66a90bbd872bca2a1b7e63a9.md
@@ -7,7 +7,7 @@ dashedName: task-2
 
 <!-- (Audio) Bob: Hey Lisa, do you have a minute?  -->
 
-# --instructions--
+# --description--
 
 Listen to the audio and complete the sentence below.
 

--- a/curriculum/get-challenges.js
+++ b/curriculum/get-challenges.js
@@ -292,7 +292,6 @@ function generateChallengeCreator(lang, englishPath, i18nPath) {
 
     if (!challenge.description) challenge.description = '';
     if (!challenge.instructions) challenge.instructions = '';
-    if (!challenge.seed) challenge.seed = '';
 
     // const superOrder = getSuperOrder(meta.superBlock);
     // NOTE: Use this version when a super block is in beta.

--- a/curriculum/get-challenges.js
+++ b/curriculum/get-challenges.js
@@ -289,6 +289,11 @@ function generateChallengeCreator(lang, englishPath, i18nPath) {
     challenge.blockType = meta.blockType;
     challenge.hasEditableBoundaries = !!meta.hasEditableBoundaries;
     challenge.order = meta.order;
+
+    if (!challenge.description) challenge.description = '';
+    if (!challenge.instructions) challenge.instructions = '';
+    if (!challenge.seed) challenge.seed = '';
+
     // const superOrder = getSuperOrder(meta.superBlock);
     // NOTE: Use this version when a super block is in beta.
     const superOrder = getSuperOrder(meta.superBlock, {

--- a/tools/client-plugins/gatsby-source-challenges/create-challenge-nodes.js
+++ b/tools/client-plugins/gatsby-source-challenges/create-challenge-nodes.js
@@ -7,27 +7,10 @@ function createChallengeNode(
   reporter,
   { isReloading } = { isReloading: false }
 ) {
-  // challengeType 11 is for video challenges (they only have instructions)
-  // challengeType 7 is for certificates (they only have tests)
-  // challengeType 12 is for CodeAlly/CodeRoad challenge
+  if (!challenge.description) challenge.description = '';
+  if (!challenge.instructions) challenge.instructions = '';
+  if (!challenge.seed) challenge.seed = '';
 
-  // TODO: either handle empty descriptions inside Gatsby OR ensure that
-  // description defaults to '' when creating challenges.
-  // ditto for seeds and instructions.
-  // create-md should, then, not create empty seed, description or instruction
-  // sections.
-  if (
-    typeof challenge.description !== 'string' &&
-    challenge.challengeType !== 11 &&
-    challenge.challengeType !== 7 &&
-    challenge.challengeType !== 12
-  ) {
-    reporter.warn(`
-
-    ${challenge.block} ${challenge.title} has a description that will break things!
-
-    `);
-  }
   const contentDigest = crypto
     .createHash('md5')
     .update(JSON.stringify(challenge))

--- a/tools/client-plugins/gatsby-source-challenges/create-challenge-nodes.js
+++ b/tools/client-plugins/gatsby-source-challenges/create-challenge-nodes.js
@@ -7,10 +7,6 @@ function createChallengeNode(
   reporter,
   { isReloading } = { isReloading: false }
 ) {
-  if (!challenge.description) challenge.description = '';
-  if (!challenge.instructions) challenge.instructions = '';
-  if (!challenge.seed) challenge.seed = '';
-
   const contentDigest = crypto
     .createHash('md5')
     .update(JSON.stringify(challenge))

--- a/tools/client-plugins/gatsby-source-challenges/create-challenge-nodes.js
+++ b/tools/client-plugins/gatsby-source-challenges/create-challenge-nodes.js
@@ -24,7 +24,7 @@ function createChallengeNode(
   ) {
     reporter.warn(`
 
-    ${challenge.title} has a description that will break things!
+    ${challenge.block} ${challenge.title} has a description that will break things!
 
     `);
   }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

I got some warning messages in the terminal regarding potentially broken curriculum files, but the challenge titles were just "Task 1" and "Task 2", so I couldn't tell which files they are.

This PR:
- Includes block name in the message to help make it clearer
- Fixes the curriculum files in question

<details>
  <summary>Screenshot</summary>

  | Before | After |
  | --- | --- |
  | <img width="381" alt="Screenshot 2024-10-15 at 03 03 21" src="https://github.com/user-attachments/assets/4891e3ff-97b1-4700-af9a-a7ca45ec5006"> | <img width="657" alt="Screenshot 2024-10-15 at 03 08 14" src="https://github.com/user-attachments/assets/2f3985e2-ed6b-4a12-82cf-4c97d288f430"> |
</details>
<!-- Feel free to add any additional description of changes below this line -->
