### PR TITLE
feat: check for unclosed code blocks

### DIFF
--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657ddcd61f516cacdc7a04ca.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657ddcd61f516cacdc7a04ca.md
@@ -95,3 +95,4 @@ Rentals are usually stationary services, not something that stops.
     }
   ]
 }
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657e4e3b02a2128049c344c8.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657e4e3b02a2128049c344c8.md
@@ -78,3 +78,4 @@ Refers to the act of being introduced to someone for the first time.
     }
   ]
 }
+```

--- a/tools/scripts/lint/linter/fenced-code-block.js
+++ b/tools/scripts/lint/linter/fenced-code-block.js
@@ -1,0 +1,17 @@
+module.exports = {
+  names: ['closed-code-blocks'],
+  description: 'Code blocks must have closing triple backticks',
+  tags: ['code'],
+  function: function rule(params, onError) {
+    params.parsers.micromark.tokens
+      .filter(token => token.type === 'codeFenced')
+      .forEach(token => {
+        if (token.text.trim().slice(-3) !== '```') {
+          onError({
+            lineNumber: token.endLine,
+            detail: `Code blocks must have closing triple backticks.`
+          });
+        }
+      });
+  }
+};

--- a/tools/scripts/lint/linter/index.js
+++ b/tools/scripts/lint/linter/index.js
@@ -2,13 +2,14 @@ const markdownlint = require('markdownlint');
 
 const lintPrism = require('./markdown-prism');
 const lintYAML = require('./markdown-yaml');
+const fencedCodeBlock = require('./fenced-code-block');
 
 function linter(rules) {
   const lint = (file, next) => {
     const options = {
       files: [file.path],
       config: rules,
-      customRules: [lintYAML, lintPrism]
+      customRules: [lintYAML, lintPrism, fencedCodeBlock]
     };
     markdownlint(options, function callback(err, result) {
       const resultString = (result || '').toString();


### PR DESCRIPTION
- **feat: check fenced code blocks are closed**
- **fix(curriculum): fix files with missing backticks**

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This should prevent issues like https://github.com/freeCodeCamp/freeCodeCamp/actions/runs/11363098133/job/31606309828?pr=56574 where the translated .md file has a mangled final code block. i.e. what Tom fixed here: https://github.com/freeCodeCamp/freeCodeCamp/pull/56690

<!-- Feel free to add any additional description of changes below this line -->
