### PR TITLE
feat(ui): display console error when wrong files are source

### DIFF
--- a/client/src/templates/Challenges/utils/frame.ts
+++ b/client/src/templates/Challenges/utils/frame.ts
@@ -305,6 +305,48 @@ const initMainFrame =
   (frameContext: Context) => {
     waitForFrame(frameContext)
       .then(async () => {
+        const linkElements = Array.from(
+          frameContext.document!.querySelectorAll('script[src], link[href]')
+        );
+
+        const errors = linkElements.map(async elem => {
+          const urlAddr =
+            elem.tagName === 'SCRIPT'
+              ? (elem as HTMLScriptElement).src
+              : (elem as HTMLLinkElement).href;
+
+          try {
+            const response = await fetch(urlAddr, {
+              mode: 'cors'
+            });
+            // Failed to fetch external resource
+            if (!response.ok) {
+              return `Cannot retrieve ${urlAddr}, link status code: ${response.status}`;
+            }
+            const text = await response.text();
+            if (text.trim().includes('<!DOCTYPE html><html id="__fcc-html')) {
+              // Received a 404 page from FreeCodeCamp
+              const resourceAddress = urlAddr.substring(
+                urlAddr.lastIndexOf('/') + 1
+              );
+              return `${resourceAddress} does not exist. Only files that can be sourced are styles.css, script.js, or remote files`;
+            }
+          } catch {
+            // Received an error
+            const resourceAddress = urlAddr.substring(
+              urlAddr.lastIndexOf('/') + 1
+            );
+            return `${resourceAddress} does not exist. Only files that can be sourced are styles.css, script.js, or remote files`;
+          }
+        });
+
+        return (await Promise.all(errors)).filter(Boolean).join('\n');
+      })
+      .then(async importResult => {
+        if (importResult) {
+          proxyLogger && proxyLogger(importResult);
+        }
+
         // Overwriting the onerror added by createHeader to catch any errors thrown
         // after the frame is ready. It has to be overwritten, as proxyLogger cannot
         // be added as part of createHeader.

--- a/client/src/templates/Challenges/utils/frame.ts
+++ b/client/src/templates/Challenges/utils/frame.ts
@@ -321,7 +321,10 @@ const initMainFrame =
             });
             // Failed to fetch external resource
             if (!response.ok) {
-              return `Cannot retrieve ${urlAddr}, link status code: ${response.status}`;
+              const resourceAddress = urlAddr.substring(
+                urlAddr.lastIndexOf('/') + 1
+              );
+              return `${resourceAddress} does not exist. Only files that can be sourced are styles.css, script.js, or remote files`;
             }
             const text = await response.text();
             if (text.trim().includes('<!DOCTYPE html><html id="__fcc-html')) {

--- a/e2e/output.spec.ts
+++ b/e2e/output.spec.ts
@@ -177,26 +177,6 @@ test.describe('Challenge Output Component Tests', () => {
     ).toHaveText(outputTexts.empty);
   });
 
-  test('Displays a warning when the wrong source files are added', async function ({
-    page
-  }) {
-    await page.goto(
-      '/learn/2022/responsive-web-design/learn-basic-css-by-building-a-cafe-menu/step-2'
-    );
-    const editor = getEditors(page);
-    await editor.fill(
-      '<link rel="stylesheet" type="text/css"  href="coolstyle.css">'
-    );
-
-    await expect(
-      page.getByRole('region', {
-        name: translations.learn['editor-tabs'].console
-      })
-    ).toContainText(
-      'coolstyle.css does not exist. Only files that can be sourced are styles.css, script.js, or remote files'
-    );
-  });
-
   test('should contain final output after test pass', async ({
     page,
     isMobile

--- a/e2e/output.spec.ts
+++ b/e2e/output.spec.ts
@@ -177,6 +177,26 @@ test.describe('Challenge Output Component Tests', () => {
     ).toHaveText(outputTexts.empty);
   });
 
+  test('Displays a warning when the wrong source files are added', async function ({
+    page
+  }) {
+    await page.goto(
+      '/learn/2022/responsive-web-design/learn-basic-css-by-building-a-cafe-menu/step-2'
+    );
+    const editor = getEditors(page);
+    await editor.fill(
+      '<link rel="stylesheet" type="text/css"  href="coolstyle.css">'
+    );
+
+    await expect(
+      page.getByRole('region', {
+        name: translations.learn['editor-tabs'].console
+      })
+    ).toContainText(
+      'coolstyle.css does not exist. Only files that can be sourced are styles.css, script.js, or remote files'
+    );
+  });
+
   test('should contain final output after test pass', async ({
     page,
     isMobile

--- a/e2e/tool-panel.spec.ts
+++ b/e2e/tool-panel.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test';
 import translations from '../client/i18n/locales/english/translations.json';
+import { getEditors } from './utils/editor';
 
 test.describe('Tool Panel', () => {
   test.beforeEach(async ({ page }) => {
@@ -28,6 +29,33 @@ test.describe('Tool Panel', () => {
 
     await expect(page.getByTestId('output-text')).toContainText(
       translations.learn['running-tests']
+    );
+  });
+
+  test('Displays a warning when the wrong source files are added', async function ({
+    page,
+    isMobile
+  }) {
+    await page.goto(
+      '/learn/2022/responsive-web-design/learn-basic-css-by-building-a-cafe-menu/step-2'
+    );
+    const editor = getEditors(page);
+    await editor.fill(
+      '<link rel="stylesheet" type="text/css"  href="coolstyle.css">'
+    );
+
+    if (isMobile) {
+      await page
+        .getByRole('tab', {
+          name: 'Console'
+        })
+        .click();
+    } else {
+      await page.getByText('Console').click();
+    }
+
+    await expect(page.getByTestId('output-text')).toContainText(
+      'coolstyle.css does not exist. Only files that can be sourced are styles.css, script.js, or remote files'
     );
   });
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #49492

<!-- Feel free to add any additional description of changes below this line -->
I did my best to pick up from the old attempt to solve this problem and apply everything needed so it would work and meet our standards. A really big issue when setting this up is that every resource would give a 200 instead of a 404. For hours I tried to figure out why, until I finally found that our Gatsby 404 page was being picked up instead of getting a notification about the actual missing resource. I decided the best thing to do was test if the linked resource was one of our pages which would be completely unexpected if a stylesheet or script was loaded. 