### PR TITLE
fix(curriculum): correct "an checkbox" to "a checkbox"

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a9689b1bf24b7750898a1b.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a9689b1bf24b7750898a1b.md
@@ -33,7 +33,7 @@ You should have a fifth checkbox `input`.
 assert(document.querySelector("fieldset:nth-of-type(3) input:nth-of-type(5)[type='checkbox']"));
 ```   
 
-You should have an checkbox input with an `id` of `"price"`.
+You should have a checkbox input with an `id` of `"price"`.
 
 ```js
 assert.strictEqual(document.querySelectorAll("fieldset:nth-of-type(3) input[type='checkbox']")[4].getAttribute('id'), 'price');

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66ad24c7eb8c121000c603a6.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66ad24c7eb8c121000c603a6.md
@@ -7,7 +7,7 @@ dashedName: step-24
 
 # --description--
 
-To make an checkbox input checked by default, you can add the `checked` attribute.
+To make a checkbox input checked by default, you can add the `checked` attribute.
 
 Here is an example of using the `checked` attribute:
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #56711

<!-- Feel free to add any additional description of changes below this line -->
- Replaced `an` with `a` in two files as suggested.
