### PR TITLE
fix(curriculum): replace asterisks with "(required)" for accessibility

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a84111965a0c46df6bbd0a.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a84111965a0c46df6bbd0a.md
@@ -16,7 +16,7 @@ In the previous lecture videos, you learned how to associate a `label` element w
 
 The `for` attribute on the `label` element should match the `id` attribute on the `input` element. This is known as an explicit association.
 
-Below your `legend` element, add a `label` element with the text of `Name*:`. For the `for` attribute, set it to the value of `"full-name"`.
+Below your `legend` element, add a `label` element with the text of `Name (required):`. For the `for` attribute, set it to the value of `"full-name"`.
 
 Then below your `legend` element, add an `input` element with no attributes. In the next steps, you will add the necessary attributes. 
 
@@ -47,11 +47,11 @@ const label = document.querySelector('fieldset label');
 assert.strictEqual(label.getAttribute('for'), 'full-name');
 ```
 
-Your `label` element should have the text of `Name*:`.
+Your `label` element should have the text of `Name (required):`.
 
 ```js
 const label = document.querySelector('fieldset label');
-assert.strictEqual(label.innerText, 'Name*:');
+assert.strictEqual(label.innerText, 'Name (required):');
 ```
 
 You should have an `input` element.

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a930b20f589b6664c51cb0.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a930b20f589b6664c51cb0.md
@@ -70,7 +70,7 @@ assert.strictEqual(input.getAttribute('id'), 'full-name');
       <form method="POST" action="https://hotel-feedback.freecodecamp.org">
         <fieldset>
           <legend>Personal Information</legend>
-          <label for="full-name">Name*:</label>
+          <label for="full-name">Name (required):</label>
         --fcc-editable-region--
           <input>
         --fcc-editable-region--

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a93730719e1f68410cce54.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a93730719e1f68410cce54.md
@@ -61,7 +61,7 @@ assert.strictEqual(input.getAttribute('name'), 'name');
       <form method="POST" action="https://hotel-feedback.freecodecamp.org">
         <fieldset>
           <legend>Personal Information</legend>
-          <label for="full-name">Name*:</label>
+          <label for="full-name">Name (required):</label>
 --fcc-editable-region--
           <input type="text" id="full-name">
 --fcc-editable-region--

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a937e74920ba68ebe5e86d.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a937e74920ba68ebe5e86d.md
@@ -60,7 +60,7 @@ assert.isNotNull(document.querySelector('fieldset input[required]'));
       <form method="POST" action="https://hotel-feedback.freecodecamp.org">
         <fieldset>
           <legend>Personal Information</legend>
-          <label for="full-name">Name*:</label>
+          <label for="full-name">Name (required):</label>
 --fcc-editable-region--
           <input type="text" id="full-name" name="name">
 --fcc-editable-region--

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a93bbe65a26169dbf3bc39.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a93bbe65a26169dbf3bc39.md
@@ -9,7 +9,7 @@ dashedName: step-13
 
 Your hotel feedback form should also collect an email address from the user. 
 
-Start by adding a new `label` element with the text `Email address*:` to the form. Your `label` element should have a `for` attribute set to the value of `"email"`.
+Start by adding a new `label` element with the text `Email address (required):` to the form. Your `label` element should have a `for` attribute set to the value of `"email"`.
 
 # --hints--
 
@@ -19,10 +19,10 @@ You should have a `label` element.
 assert.strictEqual(document.querySelectorAll('fieldset label').length, 2);
 ```
 
-Your `label` element should have the text `Email*:`.
+Your `label` element should have the text `Email address (required):`.
 
 ```js
-assert.strictEqual(document.querySelector('fieldset label:nth-of-type(2)').innerText, 'Email address*:');
+assert.strictEqual(document.querySelector('fieldset label:nth-of-type(2)').innerText, 'Email address (required):');
 ```
 
 Your `label` element should have a `for` attribute set to the value of `"email"`.
@@ -54,7 +54,7 @@ assert.strictEqual(document.querySelector('fieldset label[for="email"]').getAttr
       <form method="POST" action="https://hotel-feedback.freecodecamp.org">
         <fieldset>
           <legend>Personal Information</legend>
-          <label for="full-name">Name*:</label>
+          <label for="full-name">Name (required):</label>
           <input type="text" id="full-name" name="name" placeholder="Ex. John Doe" required>
         --fcc-editable-region--
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a93c95bc58e26a8fe95818.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a93c95bc58e26a8fe95818.md
@@ -74,10 +74,10 @@ assert.strictEqual(document.querySelector('input#email').getAttribute('placehold
       <form method="POST" action="https://hotel-feedback.freecodecamp.org">
         <fieldset>
           <legend>Personal Information</legend>
-          <label for="full-name">Name*:</label>
+          <label for="full-name">Name (required):</label>
           <input type="text" id="full-name" name="name" placeholder="Ex. John Doe" required>
         --fcc-editable-region--
-          <label for="email">Email address*:</label>
+          <label for="email">Email address (required):</label>
 
         --fcc-editable-region--
         </fieldset>

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a9401c9d660d6bb15993e2.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a9401c9d660d6bb15993e2.md
@@ -9,7 +9,7 @@ dashedName: step-15
 
 Your hotel feedback form should have an option for users to add their age. 
 
-Start by adding a `label` element with the text `Age(optional):` to the form.
+Start by adding a `label` element with the text `Age (optional):` to the form.
 
 The `for` attribute should be set to `"age"`.
 
@@ -27,10 +27,10 @@ Your `label` element should have a `for` attribute set to `"age"`.
 assert.isNotNull(document.querySelector('label[for="age"]'));
 ```
 
-You `label` element should have the text `Age(optional):`.
+You `label` element should have the text `Age (optional):`.
 
 ```js
-assert.strictEqual(document.querySelector('label[for="age"]').textContent, "Age(optional):");
+assert.strictEqual(document.querySelector('label[for="age"]').textContent, "Age (optional):");
 ```
 
 # --seed--
@@ -56,10 +56,10 @@ assert.strictEqual(document.querySelector('label[for="age"]').textContent, "Age(
       <form method="POST" action="https://hotel-feedback.freecodecamp.org">
         <fieldset>
           <legend>Personal Information</legend>
-          <label for="full-name">Name*:</label>
+          <label for="full-name">Name (required):</label>
           <input type="text" id="full-name" name="name" placeholder="Ex. John Doe" required>
 
-          <label for="email">Email address*:</label>
+          <label for="email">Email address (required):</label>
           <input
             placeholder="example@email.com"
             required

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a9419e2d18476c645ce693.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a9419e2d18476c645ce693.md
@@ -76,10 +76,10 @@ assert.isNotNull(document.querySelector('input[max="100"]'));
       <form method="POST" action="https://hotel-feedback.freecodecamp.org">
         <fieldset>
           <legend>Personal Information</legend>
-          <label for="full-name">Name*:</label>
+          <label for="full-name">Name (required):</label>
           <input type="text" id="full-name" name="name" placeholder="Ex. John Doe" required>
 
-          <label for="email">Email address*:</label>
+          <label for="email">Email address (required):</label>
           <input
             placeholder="example@email.com"
             required
@@ -88,7 +88,7 @@ assert.isNotNull(document.querySelector('input[max="100"]'));
             name="email"
           />
       --fcc-editable-region--
-          <label for="age">Age(optional):</label>
+          <label for="age">Age (optional):</label>
 
       --fcc-editable-region--
         </fieldset>

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a94ea5df66236ebed260e8.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a94ea5df66236ebed260e8.md
@@ -56,10 +56,10 @@ assert.strictEqual(document.querySelectorAll('legend')[1].textContent, 'Was this
       <form method="POST" action="https://hotel-feedback.freecodecamp.org">
         <fieldset>
           <legend>Personal Information</legend>
-          <label for="full-name">Name*:</label>
+          <label for="full-name">Name (required):</label>
           <input type="text" id="full-name" name="name" placeholder="Ex. John Doe" required>
 
-          <label for="email">Email address*:</label>
+          <label for="email">Email address (required):</label>
           <input
             placeholder="example@email.com"
             required
@@ -67,7 +67,7 @@ assert.strictEqual(document.querySelectorAll('legend')[1].textContent, 'Was this
             type="email"
             name="email"
           />
-          <label for="age">Age(optional):</label>
+          <label for="age">Age (optional):</label>
           <input type="number" name="age" id="age" min="3" max="100" />
         </fieldset>
       --fcc-editable-region--

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a9521bc70162712caf118d.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a9521bc70162712caf118d.md
@@ -85,10 +85,10 @@ assert.strictEqual(document.querySelector('fieldset:nth-of-type(2) input[type="r
       <form method="POST" action="https://hotel-feedback.freecodecamp.org">
         <fieldset>
           <legend>Personal Information</legend>
-          <label for="full-name">Name*:</label>
+          <label for="full-name">Name (required):</label>
           <input type="text" id="full-name" name="name" placeholder="Ex. John Doe" required>
 
-          <label for="email">Email address*:</label>
+          <label for="email">Email address (required):</label>
           <input
             placeholder="example@email.com"
             required
@@ -96,7 +96,7 @@ assert.strictEqual(document.querySelector('fieldset:nth-of-type(2) input[type="r
             type="email"
             name="email"
           />
-          <label for="age">Age(optional):</label>
+          <label for="age">Age (optional):</label>
           <input type="number" name="age" id="age" min="3" max="100" />
         </fieldset>
         --fcc-editable-region--

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a954b2bcddba72076c1857.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a954b2bcddba72076c1857.md
@@ -80,10 +80,10 @@ assert.strictEqual(document.querySelector('fieldset:nth-of-type(2) input:nth-of-
       <form method="POST" action="https://hotel-feedback.freecodecamp.org">
         <fieldset>
           <legend>Personal Information</legend>
-          <label for="full-name">Name*:</label>
+          <label for="full-name">Name (required):</label>
           <input type="text" id="full-name" name="name" placeholder="Ex. John Doe" required>
 
-          <label for="email">Email address*:</label>
+          <label for="email">Email address (required):</label>
           <input
             placeholder="example@email.com"
             required
@@ -91,7 +91,7 @@ assert.strictEqual(document.querySelector('fieldset:nth-of-type(2) input:nth-of-
             type="email"
             name="email"
           />
-          <label for="age">Age(optional):</label>
+          <label for="age">Age (optional):</label>
           <input type="number" name="age" id="age" min="3" max="100" />
         </fieldset>
         <fieldset>

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a9577022877d72d8f43b4f.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a9577022877d72d8f43b4f.md
@@ -56,10 +56,10 @@ assert.strictEqual(document.querySelector('fieldset:nth-of-type(3) legend').inne
       <form method="POST" action="https://hotel-feedback.freecodecamp.org">
         <fieldset>
           <legend>Personal Information</legend>
-          <label for="full-name">Name*:</label>
+          <label for="full-name">Name (required):</label>
           <input type="text" id="full-name" name="name" placeholder="Ex. John Doe" required>
 
-          <label for="email">Email address*:</label>
+          <label for="email">Email address (required):</label>
           <input
             placeholder="example@email.com"
             required
@@ -67,7 +67,7 @@ assert.strictEqual(document.querySelector('fieldset:nth-of-type(3) legend').inne
             type="email"
             name="email"
           />
-          <label for="age">Age(optional):</label>
+          <label for="age">Age (optional):</label>
           <input type="number" name="age" id="age" min="3" max="100" />
         </fieldset>
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a95d0eff8168747805f1f3.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a95d0eff8168747805f1f3.md
@@ -95,10 +95,10 @@ assert.strictEqual(document.querySelector("fieldset:nth-of-type(3) input[type='c
       <form method="POST" action="https://hotel-feedback.freecodecamp.org">
         <fieldset>
           <legend>Personal Information</legend>
-          <label for="full-name">Name*:</label>
+          <label for="full-name">Name (required):</label>
           <input type="text" id="full-name" name="name" placeholder="Ex. John Doe" required>
 
-          <label for="email">Email address*:</label>
+          <label for="email">Email address (required):</label>
           <input
             placeholder="example@email.com"
             required
@@ -106,7 +106,7 @@ assert.strictEqual(document.querySelector("fieldset:nth-of-type(3) input[type='c
             type="email"
             name="email"
           />
-          <label for="age">Age(optional):</label>
+          <label for="age">Age (optional):</label>
           <input type="number" name="age" id="age" min="3" max="100" />
         </fieldset>
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a96127422411756204bc1b.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a96127422411756204bc1b.md
@@ -78,10 +78,10 @@ assert.strictEqual(document.querySelector("fieldset:nth-of-type(3) input:nth-of-
       <form method="POST" action="https://hotel-feedback.freecodecamp.org">
         <fieldset>
           <legend>Personal Information</legend>
-          <label for="full-name">Name*:</label>
+          <label for="full-name">Name (required):</label>
           <input type="text" id="full-name" name="name" placeholder="Ex. John Doe" required>
 
-          <label for="email">Email address*:</label>
+          <label for="email">Email address (required):</label>
           <input
             placeholder="example@email.com"
             required
@@ -89,7 +89,7 @@ assert.strictEqual(document.querySelector("fieldset:nth-of-type(3) input:nth-of-
             type="email"
             name="email"
           />
-          <label for="age">Age(optional):</label>
+          <label for="age">Age (optional):</label>
           <input type="number" name="age" id="age" min="3" max="100" />
         </fieldset>
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a962954f4e0d76223b37ed.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a962954f4e0d76223b37ed.md
@@ -112,10 +112,10 @@ assert.strictEqual(document.querySelectorAll("fieldset:nth-of-type(3) input[type
       <form method="POST" action="https://hotel-feedback.freecodecamp.org">
         <fieldset>
           <legend>Personal Information</legend>
-          <label for="full-name">Name*:</label>
+          <label for="full-name">Name (required):</label>
           <input type="text" id="full-name" name="name" placeholder="Ex. John Doe" required>
 
-          <label for="email">Email address*:</label>
+          <label for="email">Email address (required):</label>
           <input
             placeholder="example@email.com"
             required
@@ -123,7 +123,7 @@ assert.strictEqual(document.querySelectorAll("fieldset:nth-of-type(3) input[type
             type="email"
             name="email"
           />
-          <label for="age">Age(optional):</label>
+          <label for="age">Age (optional):</label>
           <input type="number" name="age" id="age" min="3" max="100" />
         </fieldset>
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a9689b1bf24b7750898a1b.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a9689b1bf24b7750898a1b.md
@@ -74,10 +74,10 @@ assert.strictEqual(document.querySelectorAll("fieldset:nth-of-type(3) input[type
       <form method="POST" action="https://hotel-feedback.freecodecamp.org">
         <fieldset>
           <legend>Personal Information</legend>
-          <label for="full-name">Name*:</label>
+          <label for="full-name">Name (required):</label>
           <input type="text" id="full-name" name="name" placeholder="Ex. John Doe" required>
 
-          <label for="email">Email address*:</label>
+          <label for="email">Email address (required):</label>
           <input
             placeholder="example@email.com"
             required
@@ -85,7 +85,7 @@ assert.strictEqual(document.querySelectorAll("fieldset:nth-of-type(3) input[type
             type="email"
             name="email"
           />
-          <label for="age">Age(optional):</label>
+          <label for="age">Age (optional):</label>
           <input type="number" name="age" id="age" min="3" max="100" />
         </fieldset>
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a969951120be7818d8ee49.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a969951120be7818d8ee49.md
@@ -74,10 +74,10 @@ assert.strictEqual(document.querySelectorAll('fieldset:nth-of-type(4) label')[0]
       <form method="POST" action="https://hotel-feedback.freecodecamp.org">
         <fieldset>
           <legend>Personal Information</legend>
-          <label for="full-name">Name*:</label>
+          <label for="full-name">Name (required):</label>
           <input type="text" id="full-name" name="name" placeholder="Ex. John Doe" required>
 
-          <label for="email">Email address*:</label>
+          <label for="email">Email address (required):</label>
           <input
             placeholder="example@email.com"
             required
@@ -85,7 +85,7 @@ assert.strictEqual(document.querySelectorAll('fieldset:nth-of-type(4) label')[0]
             type="email"
             name="email"
           />
-          <label for="age">Age(optional):</label>
+          <label for="age">Age (optional):</label>
           <input type="number" name="age" id="age" min="3" max="100" />
         </fieldset>
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a96b01f33ef178dfca9e42.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a96b01f33ef178dfca9e42.md
@@ -66,10 +66,10 @@ assert(document.querySelector('select[id="service"]'));
       <form method="POST" action="https://hotel-feedback.freecodecamp.org">
         <fieldset>
           <legend>Personal Information</legend>
-          <label for="full-name">Name*:</label>
+          <label for="full-name">Name (required):</label>
           <input type="text" id="full-name" name="name" placeholder="Ex. John Doe" required>
 
-          <label for="email">Email address*:</label>
+          <label for="email">Email address (required):</label>
           <input
             placeholder="example@email.com"
             required
@@ -77,7 +77,7 @@ assert(document.querySelector('select[id="service"]'));
             type="email"
             name="email"
           />
-          <label for="age">Age(optional):</label>
+          <label for="age">Age (optional):</label>
           <input type="number" name="age" id="age" min="3" max="100" />
         </fieldset>
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a972137acd1179fa3fe8a0.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a972137acd1179fa3fe8a0.md
@@ -112,10 +112,10 @@ assert.strictEqual(document.querySelector('option[value="excellent"]').textConte
       <form method="POST" action="https://hotel-feedback.freecodecamp.org">
         <fieldset>
           <legend>Personal Information</legend>
-          <label for="full-name">Name*:</label>
+          <label for="full-name">Name (required):</label>
           <input type="text" id="full-name" name="name" placeholder="Ex. John Doe" required>
 
-          <label for="email">Email address*:</label>
+          <label for="email">Email address (required):</label>
           <input
             placeholder="example@email.com"
             required
@@ -123,7 +123,7 @@ assert.strictEqual(document.querySelector('option[value="excellent"]').textConte
             type="email"
             name="email"
           />
-          <label for="age">Age(optional):</label>
+          <label for="age">Age (optional):</label>
           <input type="number" name="age" id="age" min="3" max="100" />
         </fieldset>
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a975260401487af226b290.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a975260401487af226b290.md
@@ -48,10 +48,10 @@ assert(document.querySelector('option[value="excellent"][selected]'));
       <form method="POST" action="https://hotel-feedback.freecodecamp.org">
         <fieldset>
           <legend>Personal Information</legend>
-          <label for="full-name">Name*:</label>
+          <label for="full-name">Name (required):</label>
           <input type="text" id="full-name" name="name" placeholder="Ex. John Doe" required>
 
-          <label for="email">Email address*:</label>
+          <label for="email">Email address (required):</label>
           <input
             placeholder="example@email.com"
             required
@@ -59,7 +59,7 @@ assert(document.querySelector('option[value="excellent"][selected]'));
             type="email"
             name="email"
           />
-          <label for="age">Age(optional):</label>
+          <label for="age">Age (optional):</label>
           <input type="number" name="age" id="age" min="3" max="100" />
         </fieldset>
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a975c259525b7bc2d5c776.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a975c259525b7bc2d5c776.md
@@ -62,10 +62,10 @@ assert(document.querySelector('select[name="food"]'));
       <form method="POST" action="https://hotel-feedback.freecodecamp.org">
         <fieldset>
           <legend>Personal Information</legend>
-          <label for="full-name">Name*:</label>
+          <label for="full-name">Name (required):</label>
           <input type="text" id="full-name" name="name" placeholder="Ex. John Doe" required>
 
-          <label for="email">Email address*:</label>
+          <label for="email">Email address (required):</label>
           <input
             placeholder="example@email.com"
             required
@@ -73,7 +73,7 @@ assert(document.querySelector('select[name="food"]'));
             type="email"
             name="email"
           />
-          <label for="age">Age(optional):</label>
+          <label for="age">Age (optional):</label>
           <input type="number" name="age" id="age" min="3" max="100" />
         </fieldset>
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a97ca8c4cbae7d0bb6e0ad.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a97ca8c4cbae7d0bb6e0ad.md
@@ -121,10 +121,10 @@ assert(document.querySelector('fieldset:nth-of-type(4) select#food option[value=
       <form method="POST" action="https://hotel-feedback.freecodecamp.org">
         <fieldset>
           <legend>Personal Information</legend>
-          <label for="full-name">Name*:</label>
+          <label for="full-name">Name (required):</label>
           <input type="text" id="full-name" name="name" placeholder="Ex. John Doe" required>
 
-          <label for="email">Email address*:</label>
+          <label for="email">Email address (required):</label>
           <input
             placeholder="example@email.com"
             required
@@ -132,7 +132,7 @@ assert(document.querySelector('fieldset:nth-of-type(4) select#food option[value=
             type="email"
             name="email"
           />
-          <label for="age">Age(optional):</label>
+          <label for="age">Age (optional):</label>
           <input type="number" name="age" id="age" min="3" max="100" />
         </fieldset>
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a97f40ddd40d7deb0618b7.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a97f40ddd40d7deb0618b7.md
@@ -48,10 +48,10 @@ assert.strictEqual(document.querySelector('label[for="comments"]').textContent, 
       <form method="POST" action="https://hotel-feedback.freecodecamp.org">
         <fieldset>
           <legend>Personal Information</legend>
-          <label for="full-name">Name*:</label>
+          <label for="full-name">Name (required):</label>
           <input type="text" id="full-name" name="name" placeholder="Ex. John Doe" required>
 
-          <label for="email">Email address*:</label>
+          <label for="email">Email address (required):</label>
           <input
             placeholder="example@email.com"
             required
@@ -59,7 +59,7 @@ assert.strictEqual(document.querySelector('label[for="comments"]').textContent, 
             type="email"
             name="email"
           />
-          <label for="age">Age(optional):</label>
+          <label for="age">Age (optional):</label>
           <input type="number" name="age" id="age" min="3" max="100" />
         </fieldset>
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a9824ac5d9f77ec304969f.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a9824ac5d9f77ec304969f.md
@@ -52,10 +52,10 @@ assert(document.querySelector('form textarea'));
       <form method="POST" action="https://hotel-feedback.freecodecamp.org">
         <fieldset>
           <legend>Personal Information</legend>
-          <label for="full-name">Name*:</label>
+          <label for="full-name">Name (required):</label>
           <input type="text" id="full-name" name="name" placeholder="Ex. John Doe" required>
 
-          <label for="email">Email address*:</label>
+          <label for="email">Email address (required):</label>
           <input
             placeholder="example@email.com"
             required
@@ -63,7 +63,7 @@ assert(document.querySelector('form textarea'));
             type="email"
             name="email"
           />
-          <label for="age">Age(optional):</label>
+          <label for="age">Age (optional):</label>
           <input type="number" name="age" id="age" min="3" max="100" />
         </fieldset>
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a9836b339fed7f9a8fe35a.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a9836b339fed7f9a8fe35a.md
@@ -60,10 +60,10 @@ assert(document.querySelector('textarea[rows="10"]'));
       <form method="POST" action="https://hotel-feedback.freecodecamp.org">
         <fieldset>
           <legend>Personal Information</legend>
-          <label for="full-name">Name*:</label>
+          <label for="full-name">Name (required):</label>
           <input type="text" id="full-name" name="name" placeholder="Ex. John Doe" required>
 
-          <label for="email">Email address*:</label>
+          <label for="email">Email address (required):</label>
           <input
             placeholder="example@email.com"
             required
@@ -71,7 +71,7 @@ assert(document.querySelector('textarea[rows="10"]'));
             type="email"
             name="email"
           />
-          <label for="age">Age(optional):</label>
+          <label for="age">Age (optional):</label>
           <input type="number" name="age" id="age" min="3" max="100" />
         </fieldset>
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a9843525e9fa8046d709b7.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a9843525e9fa8046d709b7.md
@@ -170,10 +170,10 @@ assert.strictEqual(document.querySelector('button').textContent, 'Submit');
       <form method="POST" action="https://hotel-feedback.freecodecamp.org">
         <fieldset>
           <legend>Personal Information</legend>
-          <label for="full-name">Name*:</label>
+          <label for="full-name">Name (required):</label>
           <input type="text" id="full-name" name="name" placeholder="Ex. John Doe" required>
 
-          <label for="email">Email address*:</label>
+          <label for="email">Email address (required):</label>
           <input
             placeholder="example@email.com"
             required
@@ -181,7 +181,7 @@ assert.strictEqual(document.querySelector('button').textContent, 'Submit');
             type="email"
             name="email"
           />
-          <label for="age">Age(optional):</label>
+          <label for="age">Age (optional):</label>
           <input type="number" name="age" id="age" min="3" max="100" />
         </fieldset>
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a9843525e9fa8046d709b7.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a9843525e9fa8046d709b7.md
@@ -58,10 +58,10 @@ assert.strictEqual(document.querySelector('button').textContent, 'Submit');
       <form method="POST" action="https://hotel-feedback.freecodecamp.org">
         <fieldset>
           <legend>Personal Information</legend>
-          <label for="full-name">Name*:</label>
+          <label for="full-name">Name (required):</label>
           <input type="text" id="full-name" name="name" placeholder="Ex. John Doe" required>
 
-          <label for="email">Email address*:</label>
+          <label for="email">Email address (required):</label>
           <input
             placeholder="example@email.com"
             required
@@ -69,7 +69,7 @@ assert.strictEqual(document.querySelector('button').textContent, 'Submit');
             type="email"
             name="email"
           />
-          <label for="age">Age(optional):</label>
+          <label for="age">Age (optional):</label>
           <input type="number" name="age" id="age" min="3" max="100" />
         </fieldset>
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66ad24c7eb8c121000c603a6.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66ad24c7eb8c121000c603a6.md
@@ -48,10 +48,10 @@ assert(document.querySelector("input#reputation[checked]"));
       <form method="POST" action="https://hotel-feedback.freecodecamp.org">
         <fieldset>
           <legend>Personal Information</legend>
-          <label for="full-name">Name*:</label>
+          <label for="full-name">Name (required):</label>
           <input type="text" id="full-name" name="name" placeholder="Ex. John Doe" required>
 
-          <label for="email">Email address*:</label>
+          <label for="email">Email address (required):</label>
           <input
             placeholder="example@email.com"
             required
@@ -59,7 +59,7 @@ assert(document.querySelector("input#reputation[checked]"));
             type="email"
             name="email"
           />
-          <label for="age">Age(optional):</label>
+          <label for="age">Age (optional):</label>
           <input type="number" name="age" id="age" min="3" max="100" />
         </fieldset>
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #56714 

<!-- Feel free to add any additional description of changes below this line -->
 - Replaced asterisks with `(required)` for accessibility in form labels
