### PR TITLE
fix(tests): wait for api to respond during e2e tests

### DIFF
--- a/e2e/academic-honesty.spec.ts
+++ b/e2e/academic-honesty.spec.ts
@@ -65,6 +65,7 @@ test.describe('When the user has not accepted the Academic Honesty Policy', () =
       name: translations.buttons['agree-honesty']
     });
     await agreeButton.click();
+    await alertToBeVisible(page, translations.buttons['accepted-honesty']);
 
     await page.reload();
 

--- a/e2e/challenge-reset-modal.spec.ts
+++ b/e2e/challenge-reset-modal.spec.ts
@@ -4,6 +4,7 @@ import { test, expect, Page } from '@playwright/test';
 
 import translations from '../client/i18n/locales/english/translations.json';
 import { clearEditor, focusEditor, getEditors } from './utils/editor';
+import { alertToBeVisible } from './utils/alerts';
 
 const expectToRenderResetModal = async (page: Page) => {
   await expect(
@@ -241,6 +242,7 @@ test.describe('Signed in user', () => {
     await clearEditor({ page, browserName });
     await getEditors(page).fill(savedText);
     await page.keyboard.press('Control+S');
+    await alertToBeVisible(page, translations.flash['code-saved']);
 
     await page.reload();
 
@@ -281,6 +283,7 @@ test.describe('Signed in user', () => {
     await clearEditor({ page, browserName });
     await getEditors(page).fill(savedText);
     await page.keyboard.press('Control+S');
+    await alertToBeVisible(page, translations.flash['code-saved']);
 
     // This second edit should be reset
     await focusEditor({ page, isMobile });


### PR DESCRIPTION
- **fix(tests): wait for server to accept honesty**
- **fix(tests): wait for code to be saved**

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Some of our tests are flaky because they have hidden race conditions. They were implicitly assuming that since a request has been made, it will have finished by the time the effect of the request is checked. This generally isn't much of a problem when the two servers are on the same machine, but it's pretty bad when they're not.

Related to https://github.com/freeCodeCamp/freeCodeCamp/pull/56728

<!-- Feel free to add any additional description of changes below this line -->
