### PR TITLE
feat(client/curriclum): fsd block layout

### DIFF
--- a/client/src/templates/Introduction/components/block-header.tsx
+++ b/client/src/templates/Introduction/components/block-header.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { BlockTypes } from '../../../../../shared/config/blocks';
+import { ProgressBar } from '../../../components/Progress/progress-bar';
+import DropDown from '../../../assets/icons/dropdown';
+import CheckMark from './check-mark';
+import BlockLabel from './block-label';
+
+interface BlockHeaderProps {
+  blockDashed: string;
+  blockTitle: string;
+  blockType: BlockTypes | null;
+  courseCompletionStatus: string;
+  completedCount: number;
+  handleClick: () => void;
+  isCompleted: boolean;
+  isExpanded: boolean;
+  percentageCompleted: number;
+}
+
+function BlockHeader({
+  blockDashed,
+  blockTitle,
+  blockType,
+  completedCount,
+  courseCompletionStatus,
+  handleClick,
+  isCompleted,
+  isExpanded,
+  percentageCompleted
+}: BlockHeaderProps): JSX.Element {
+  return (
+    <h3 className='block-grid-title'>
+      <button
+        aria-expanded={isExpanded ? 'true' : 'false'}
+        aria-controls={`${blockDashed}-panel`}
+        className='block-header'
+        onClick={handleClick}
+      >
+        <span className='block-header-button-text map-title'>
+          <CheckMark isCompleted={isCompleted} />
+          <span>
+            {blockTitle}
+            <span className='sr-only'>, {courseCompletionStatus}</span>
+          </span>
+          {blockType && <BlockLabel blockType={blockType} />}
+          <DropDown />
+        </span>
+        {!isExpanded && !isCompleted && completedCount > 0 && (
+          <div aria-hidden='true' className='progress-wrapper'>
+            <div>
+              <ProgressBar now={percentageCompleted} />
+            </div>
+            <span>{`${percentageCompleted}%`}</span>
+          </div>
+        )}
+      </button>
+    </h3>
+  );
+}
+
+export default BlockHeader;

--- a/client/src/templates/Introduction/components/block-header.tsx
+++ b/client/src/templates/Introduction/components/block-header.tsx
@@ -38,11 +38,11 @@ function BlockHeader({
       >
         <span className='block-header-button-text map-title'>
           <CheckMark isCompleted={isCompleted} />
+          {blockType && <BlockLabel blockType={blockType} />}
           <span>
             {blockTitle}
             <span className='sr-only'>, {courseCompletionStatus}</span>
           </span>
-          {blockType && <BlockLabel blockType={blockType} />}
           <DropDown />
         </span>
         {!isExpanded && !isCompleted && completedCount > 0 && (

--- a/client/src/templates/Introduction/components/block-intros.test.tsx
+++ b/client/src/templates/Introduction/components/block-intros.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
-
-import { BlockIntros } from './block';
+import BlockIntros from './block-intros';
 
 const arrString = ['first paragraph', 'second paragraph'];
 

--- a/client/src/templates/Introduction/components/block-intros.tsx
+++ b/client/src/templates/Introduction/components/block-intros.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+function BlockIntros({ intros }: { intros: string[] }): JSX.Element {
+  return (
+    <div className='block-description'>
+      {intros.map((title, i) => (
+        <p dangerouslySetInnerHTML={{ __html: title }} key={i} />
+      ))}
+    </div>
+  );
+}
+
+export default BlockIntros;

--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -10,10 +10,10 @@ import { SuperBlocks } from '../../../../../shared/config/curriculum';
 import envData from '../../../../config/env.json';
 import { isAuditedSuperBlock } from '../../../../../shared/utils/is-audited';
 import Caret from '../../../assets/icons/caret';
-import DropDown from '../../../assets/icons/dropdown';
+// import DropDown from '../../../assets/icons/dropdown';
 import GreenNotCompleted from '../../../assets/icons/green-not-completed';
 import GreenPass from '../../../assets/icons/green-pass';
-import { ProgressBar } from '../../../components/Progress/progress-bar';
+// import { ProgressBar } from '../../../components/Progress/progress-bar';
 import { Link, Spacer } from '../../../components/helpers';
 import { completedChallengesSelector } from '../../../redux/selectors';
 import { ChallengeNode, CompletedChallenge } from '../../../redux/prop-types';
@@ -23,6 +23,7 @@ import { isGridBased, isProjectBased } from '../../../utils/curriculum-layout';
 import { BlockLayouts, BlockTypes } from '../../../../../shared/config/blocks';
 import Challenges from './challenges';
 import BlockLabel from './block-label';
+import BlockHeader from './block-header';
 
 import '../intro.css';
 
@@ -83,11 +84,11 @@ class Block extends Component<BlockProps> {
     this.handleBlockClick = this.handleBlockClick.bind(this);
   }
 
-  handleBlockClick(): void {
+  handleBlockClick = (): void => {
     const { block, toggleBlock } = this.props;
     void playTone('block-toggle');
     toggleBlock(block);
-  }
+  };
 
   render(): JSX.Element {
     const {
@@ -142,14 +143,24 @@ class Block extends Component<BlockProps> {
       (completedCount / challengesWithCompleted.length) * 100
     );
 
-    const progressBarRender = (
-      <div aria-hidden='true' className='progress-wrapper'>
-        <div>
-          <ProgressBar now={percentageCompleted} />
-        </div>
-        <span>{`${percentageCompleted}%`}</span>
-      </div>
-    );
+    // const progressBarRender = (
+    //   <div aria-hidden='true' className='progress-wrapper'>
+    //     <div>
+    //       <ProgressBar now={percentageCompleted} />
+    //     </div>
+    //     <span>{`${percentageCompleted}%`}</span>
+    //   </div>
+    // );
+
+    const courseCompletionStatus = () => {
+      if (completedCount === 0) {
+        return t('learn.not-started');
+      }
+      if (completedCount === challengesWithCompleted.length) {
+        return t('learn.completed');
+      }
+      return `${percentageCompleted}% ${t('learn.completed')}`;
+    };
 
     /**
      * ChallengeListBlock displays challenges in a list.
@@ -247,16 +258,6 @@ class Block extends Component<BlockProps> {
       </>
     );
 
-    const courseCompletionStatus = () => {
-      if (completedCount === 0) {
-        return t('learn.not-started');
-      }
-      if (completedCount === challengesWithCompleted.length) {
-        return t('learn.completed');
-      }
-      return `${percentageCompleted}% ${t('learn.completed')}`;
-    };
-
     /**
      * ChallengeGridBlock displays challenges in a grid.
      * This layout is used for step-based blocks.
@@ -267,32 +268,17 @@ class Block extends Component<BlockProps> {
         {' '}
         <ScrollableAnchor id={block}>
           <div className={`block block-grid ${isExpanded ? 'open' : ''}`}>
-            <h3 className='block-grid-title'>
-              <button
-                aria-expanded={isExpanded ? 'true' : 'false'}
-                aria-controls={`${block}-panel`}
-                className='block-header'
-                onClick={() => {
-                  this.handleBlockClick();
-                }}
-              >
-                <span className='block-header-button-text map-title'>
-                  <CheckMark isCompleted={isBlockCompleted} />
-                  <span>
-                    {blockTitle}
-                    <span className='sr-only'>
-                      , {courseCompletionStatus()}
-                    </span>
-                  </span>
-                  {blockType && <BlockLabel blockType={blockType} />}
-                  <DropDown />
-                </span>
-                {!isExpanded &&
-                  !isBlockCompleted &&
-                  completedCount > 0 &&
-                  progressBarRender}
-              </button>
-            </h3>
+            <BlockHeader
+              blockDashed={block}
+              blockTitle={blockTitle}
+              blockType={blockType}
+              completedCount={completedCount}
+              courseCompletionStatus={courseCompletionStatus()}
+              handleClick={this.handleBlockClick}
+              isCompleted={isBlockCompleted}
+              isExpanded={isExpanded}
+              percentageCompleted={percentageCompleted}
+            />
             {!isAudited && (
               <div className='tags-wrapper'>
                 <Link
@@ -366,6 +352,82 @@ class Block extends Component<BlockProps> {
       </ScrollableAnchor>
     );
 
+    // used with blockLayout = 'challenge-list'
+    const NewChallengeListBlock = (
+      <>
+        {' '}
+        <ScrollableAnchor id={block}>
+          <div className={`block block-grid ${isExpanded ? 'open' : ''}`}>
+            <BlockHeader
+              blockDashed={block}
+              blockTitle={blockTitle}
+              blockType={blockType}
+              completedCount={completedCount}
+              courseCompletionStatus={courseCompletionStatus()}
+              handleClick={this.handleBlockClick}
+              isCompleted={isBlockCompleted}
+              isExpanded={isExpanded}
+              percentageCompleted={percentageCompleted}
+            />
+            {!isAudited && (
+              <div className='tags-wrapper'>
+                <Link
+                  className='cert-tag'
+                  to={t('links:help-translate-link-url')}
+                >
+                  {t('misc.translation-pending')}
+                </Link>
+              </div>
+            )}
+
+            {isExpanded && (
+              <div id={`${block}-panel`}>
+                <BlockIntros intros={blockIntroArr} />
+                <Challenges
+                  challengesWithCompleted={challengesWithCompleted}
+                  isProjectBlock={isProjectBlock}
+                />
+              </div>
+            )}
+          </div>
+        </ScrollableAnchor>
+      </>
+    );
+
+    // used with blockLayout = 'link'
+    const NewLinkBlock = (
+      <ScrollableAnchor id={block}>
+        <div className='block block-grid grid-project-block'>
+          <div className='tags-wrapper'>
+            {!isAudited && (
+              <Link
+                className='cert-tag'
+                to={t('links:help-translate-link-url')}
+              >
+                {t('misc.translation-pending')}{' '}
+              </Link>
+            )}
+          </div>
+          <div className='title-wrapper map-title'>
+            <h3 className='block-grid-title'>
+              <Link
+                className='block-header'
+                onClick={() => {
+                  this.handleBlockClick();
+                }}
+                to={challengesWithCompleted[0].fields.slug}
+              >
+                <CheckMark isCompleted={isBlockCompleted} />
+                {blockTitle}
+                {blockType && <BlockLabel blockType={blockType} />}
+              </Link>
+            </h3>
+          </div>
+          <BlockIntros intros={blockIntroArr} />
+        </div>
+      </ScrollableAnchor>
+    );
+
     const blockRenderer = () => {
       const blockLayout = challenges[0].blockLayout;
 
@@ -375,9 +437,11 @@ class Block extends Component<BlockProps> {
         return isGridBlock ? ChallengeGridBlock : ChallengeListBlock;
       }
 
+      // blockLayout is only being used in new certs at the moment, so I made some new components for them for now to not interfere with the existing ones
       if (blockLayout === BlockLayouts.ChallengeGrid) return ChallengeGridBlock;
-      if (blockLayout === BlockLayouts.ChallengeList) return ChallengeListBlock;
-      if (blockLayout === BlockLayouts.Link) return LinkBlock;
+      if (blockLayout === BlockLayouts.ChallengeList)
+        return NewChallengeListBlock;
+      if (blockLayout === BlockLayouts.Link) return NewLinkBlock;
       if (blockLayout === BlockLayouts.ProjectList) return ProjectListBlock;
     };
 

--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -10,10 +10,6 @@ import { SuperBlocks } from '../../../../../shared/config/curriculum';
 import envData from '../../../../config/env.json';
 import { isAuditedSuperBlock } from '../../../../../shared/utils/is-audited';
 import Caret from '../../../assets/icons/caret';
-// import DropDown from '../../../assets/icons/dropdown';
-import GreenNotCompleted from '../../../assets/icons/green-not-completed';
-import GreenPass from '../../../assets/icons/green-pass';
-// import { ProgressBar } from '../../../components/Progress/progress-bar';
 import { Link, Spacer } from '../../../components/helpers';
 import { completedChallengesSelector } from '../../../redux/selectors';
 import { ChallengeNode, CompletedChallenge } from '../../../redux/prop-types';
@@ -21,8 +17,10 @@ import { playTone } from '../../../utils/tone';
 import { makeExpandedBlockSelector, toggleBlock } from '../redux';
 import { isGridBased, isProjectBased } from '../../../utils/curriculum-layout';
 import { BlockLayouts, BlockTypes } from '../../../../../shared/config/blocks';
+import CheckMark from './check-mark';
 import Challenges from './challenges';
 import BlockLabel from './block-label';
+import BlockIntros from './block-intros';
 import BlockHeader from './block-header';
 
 import '../intro.css';
@@ -56,24 +54,6 @@ interface BlockProps {
   superBlock: SuperBlocks;
   t: TFunction;
   toggleBlock: typeof toggleBlock;
-}
-
-export const BlockIntros = ({ intros }: { intros: string[] }): JSX.Element => {
-  return (
-    <div className='block-description'>
-      {intros.map((title, i) => (
-        <p dangerouslySetInnerHTML={{ __html: title }} key={i} />
-      ))}
-    </div>
-  );
-};
-
-function CheckMark({ isCompleted }: { isCompleted: boolean }): JSX.Element {
-  return isCompleted ? (
-    <GreenPass hushScreenReaderText />
-  ) : (
-    <GreenNotCompleted hushScreenReaderText />
-  );
 }
 
 class Block extends Component<BlockProps> {
@@ -143,15 +123,6 @@ class Block extends Component<BlockProps> {
       (completedCount / challengesWithCompleted.length) * 100
     );
 
-    // const progressBarRender = (
-    //   <div aria-hidden='true' className='progress-wrapper'>
-    //     <div>
-    //       <ProgressBar now={percentageCompleted} />
-    //     </div>
-    //     <span>{`${percentageCompleted}%`}</span>
-    //   </div>
-    // );
-
     const courseCompletionStatus = () => {
       if (completedCount === 0) {
         return t('learn.not-started');
@@ -163,11 +134,11 @@ class Block extends Component<BlockProps> {
     };
 
     /**
-     * ChallengeListBlock displays challenges in a list.
+     * LegacyChallengeListBlock displays challenges in a list.
      * This layout is used in backend blocks, The Odin Project blocks, and blocks in legacy certification.
      * Example: https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/#basic-javascript
      */
-    const ChallengeListBlock = (
+    const LegacyChallengeListBlock = (
       <>
         {' '}
         <ScrollableAnchor id={block}>
@@ -306,11 +277,11 @@ class Block extends Component<BlockProps> {
     );
 
     /**
-     * LinkBlock displays the block as a single link.
+     * LegacyLinkBlock displays the block as a single link.
      * This layout is used if the block has a single challenge.
      * Example: https://www.freecodecamp.org/learn/2022/responsive-web-design/#build-a-survey-form-project
      */
-    const LinkBlock = (
+    const LegacyLinkBlock = (
       <ScrollableAnchor id={block}>
         <div className='block block-grid grid-project-block'>
           <div className='tags-wrapper'>
@@ -352,52 +323,57 @@ class Block extends Component<BlockProps> {
       </ScrollableAnchor>
     );
 
-    // used with blockLayout = 'challenge-list'
-    const NewChallengeListBlock = (
-      <>
-        {' '}
-        <ScrollableAnchor id={block}>
-          <div className={`block block-grid ${isExpanded ? 'open' : ''}`}>
-            <BlockHeader
-              blockDashed={block}
-              blockTitle={blockTitle}
-              blockType={blockType}
-              completedCount={completedCount}
-              courseCompletionStatus={courseCompletionStatus()}
-              handleClick={this.handleBlockClick}
-              isCompleted={isBlockCompleted}
-              isExpanded={isExpanded}
-              percentageCompleted={percentageCompleted}
-            />
-            {!isAudited && (
-              <div className='tags-wrapper'>
-                <Link
-                  className='cert-tag'
-                  to={t('links:help-translate-link-url')}
-                >
-                  {t('misc.translation-pending')}
-                </Link>
-              </div>
-            )}
-
-            {isExpanded && (
-              <div id={`${block}-panel`}>
-                <BlockIntros intros={blockIntroArr} />
-                <Challenges
-                  challengesWithCompleted={challengesWithCompleted}
-                  isProjectBlock={isProjectBlock}
-                />
-              </div>
-            )}
-          </div>
-        </ScrollableAnchor>
-      </>
+    /**
+     * ChallengeListBlock displays challenges in a list.
+     * Created for the new Full Stack Developer Certification,
+     * so we can play with it without affecting the existing block layouts.
+     */
+    const ChallengeListBlock = (
+      <ScrollableAnchor id={block}>
+        <div className={`block block-grid ${isExpanded ? 'open' : ''}`}>
+          <BlockHeader
+            blockDashed={block}
+            blockTitle={blockTitle}
+            blockType={blockType}
+            completedCount={completedCount}
+            courseCompletionStatus={courseCompletionStatus()}
+            handleClick={this.handleBlockClick}
+            isCompleted={isBlockCompleted}
+            isExpanded={isExpanded}
+            percentageCompleted={percentageCompleted}
+          />
+          {!isAudited && (
+            <div className='tags-wrapper'>
+              <Link
+                className='cert-tag'
+                to={t('links:help-translate-link-url')}
+              >
+                {t('misc.translation-pending')}
+              </Link>
+            </div>
+          )}
+          {isExpanded && (
+            <div id={`${block}-panel`}>
+              <BlockIntros intros={blockIntroArr} />
+              <Challenges
+                challengesWithCompleted={challengesWithCompleted}
+                isProjectBlock={isProjectBlock}
+              />
+            </div>
+          )}
+        </div>
+      </ScrollableAnchor>
     );
 
-    // used with blockLayout = 'link'
-    const NewLinkBlock = (
+    /**
+     * LinkBlock displays the block as a single link.
+     * This layout is used if the block has a single challenge.
+     * Created for the new Full Stack Developer Certification,
+     * so we can play with it without affecting the existing block layouts.
+     */
+    const LinkBlock = (
       <ScrollableAnchor id={block}>
-        <div className='block block-grid grid-project-block'>
+        <div className='block block-grid grid-project-block grid-project-block-no-margin'>
           <div className='tags-wrapper'>
             {!isAudited && (
               <Link
@@ -433,16 +409,19 @@ class Block extends Component<BlockProps> {
 
       // `blockLayout` property isn't available in all challenges
       if (!blockLayout) {
-        if (isProjectBlock) return isGridBlock ? LinkBlock : ProjectListBlock;
-        return isGridBlock ? ChallengeGridBlock : ChallengeListBlock;
+        if (isProjectBlock)
+          return isGridBlock ? LegacyLinkBlock : ProjectListBlock;
+        return isGridBlock ? ChallengeGridBlock : LegacyChallengeListBlock;
       }
 
       // blockLayout is only being used in new certs at the moment, so I made some new components for them for now to not interfere with the existing ones
       if (blockLayout === BlockLayouts.ChallengeGrid) return ChallengeGridBlock;
-      if (blockLayout === BlockLayouts.ChallengeList)
-        return NewChallengeListBlock;
-      if (blockLayout === BlockLayouts.Link) return NewLinkBlock;
+      if (blockLayout === BlockLayouts.ChallengeList) return ChallengeListBlock;
+      if (blockLayout === BlockLayouts.Link) return LinkBlock;
       if (blockLayout === BlockLayouts.ProjectList) return ProjectListBlock;
+      if (blockLayout === BlockLayouts.LegacyLink) return LegacyLinkBlock;
+      if (blockLayout === BlockLayouts.LegacyChallengeList)
+        return LegacyChallengeListBlock;
     };
 
     return (

--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -394,8 +394,8 @@ class Block extends Component<BlockProps> {
                 to={challengesWithCompleted[0].fields.slug}
               >
                 <CheckMark isCompleted={isBlockCompleted} />
-                {blockTitle}
                 {blockType && <BlockLabel blockType={blockType} />}
+                {blockTitle}
               </Link>
             </h3>
           </div>

--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -268,7 +268,6 @@ class Block extends Component<BlockProps> {
         <ScrollableAnchor id={block}>
           <div className={`block block-grid ${isExpanded ? 'open' : ''}`}>
             <h3 className='block-grid-title'>
-              {blockType && <BlockLabel blockType={blockType} />}
               <button
                 aria-expanded={isExpanded ? 'true' : 'false'}
                 aria-controls={`${block}-panel`}
@@ -285,6 +284,7 @@ class Block extends Component<BlockProps> {
                       , {courseCompletionStatus()}
                     </span>
                   </span>
+                  {blockType && <BlockLabel blockType={blockType} />}
                   <DropDown />
                 </span>
                 {!isExpanded &&

--- a/client/src/templates/Introduction/components/check-mark.tsx
+++ b/client/src/templates/Introduction/components/check-mark.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import GreenNotCompleted from '../../../assets/icons/green-not-completed';
+import GreenPass from '../../../assets/icons/green-pass';
+
+function CheckMark({ isCompleted }: { isCompleted: boolean }): JSX.Element {
+  return isCompleted ? (
+    <GreenPass hushScreenReaderText />
+  ) : (
+    <GreenNotCompleted hushScreenReaderText />
+  );
+}
+
+export default CheckMark;

--- a/client/src/templates/Introduction/intro.css
+++ b/client/src/templates/Introduction/intro.css
@@ -12,7 +12,6 @@
 }
 
 .block-label {
-  margin: 0 10px 0 0;
   align-self: center;
   height: fit-content;
   padding: 2px 6px 3px;

--- a/client/src/templates/Introduction/intro.css
+++ b/client/src/templates/Introduction/intro.css
@@ -563,6 +563,12 @@ a.map-grid-item.challenge-completed {
   position: relative;
 }
 
+.grid-project-block {
+  margin-bottom: 0;
+  padding: 18px 15px;
+  position: relative;
+}
+
 .block-grid.grid-project-block:hover {
   cursor: pointer;
   background: var(--tertiary-background);

--- a/client/src/templates/Introduction/intro.css
+++ b/client/src/templates/Introduction/intro.css
@@ -15,9 +15,16 @@
   margin: 0 10px 0 0;
   align-self: center;
   height: fit-content;
-  padding: 4px 10px;
-  background-color: var(--secondary-background);
+  padding: 2px 6px 3px 6px;
+  font-size: 0.9rem;
   border: 1px solid;
+  border-radius: 10px;
+  position: relative;
+  top: 1px;
+}
+
+.block-header:hover .block-label {
+  background-color: var(--tertiary-background);
 }
 
 .block-label-lecture {

--- a/client/src/templates/Introduction/intro.css
+++ b/client/src/templates/Introduction/intro.css
@@ -15,7 +15,7 @@
   margin: 0 10px 0 0;
   align-self: center;
   height: fit-content;
-  padding: 2px 6px 3px 6px;
+  padding: 2px 6px 3px;
   font-size: 0.9rem;
   border: 1px solid;
   border-radius: 10px;
@@ -563,10 +563,8 @@ a.map-grid-item.challenge-completed {
   position: relative;
 }
 
-.grid-project-block {
+.grid-project-block-no-margin {
   margin-bottom: 0;
-  padding: 18px 15px;
-  position: relative;
 }
 
 .block-grid.grid-project-block:hover {

--- a/client/src/templates/Introduction/intro.css
+++ b/client/src/templates/Introduction/intro.css
@@ -14,10 +14,9 @@
 .block-label {
   align-self: center;
   height: fit-content;
-  padding: 2px 6px 3px;
-  font-size: 0.9rem;
+  padding: 1px 6px 2px;
+  font-size: 0.85rem;
   border: 1px solid;
-  border-radius: 10px;
   position: relative;
   top: 1px;
 }

--- a/curriculum/challenges/_meta/front-end-development-certification-exam/meta.json
+++ b/curriculum/challenges/_meta/front-end-development-certification-exam/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Front End Development Certification Exam",
   "blockType": "exam",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "dashedName": "front-end-development-certification-exam",
   "helpCategory": "HTML-CSS",

--- a/curriculum/challenges/_meta/lab-availability-table/meta.json
+++ b/curriculum/challenges/_meta/lab-availability-table/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Build an Availability Table",
   "blockType": "lab",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "lab-availability-table",

--- a/curriculum/challenges/_meta/lab-book-catalog-table/meta.json
+++ b/curriculum/challenges/_meta/lab-book-catalog-table/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Build a Book Catalog Table",
   "blockType": "lab",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "lab-book-catalog-table",

--- a/curriculum/challenges/_meta/lab-book-inventory-app/meta.json
+++ b/curriculum/challenges/_meta/lab-book-inventory-app/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Build a Book Inventory App",
   "blockType": "lab",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "lab-book-inventory-app",

--- a/curriculum/challenges/_meta/lab-bookmark-manager-app/meta.json
+++ b/curriculum/challenges/_meta/lab-bookmark-manager-app/meta.json
@@ -1,8 +1,9 @@
 {
   "name": "Build a Bookmark Manager App",
+  "blockType": "lab",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
-  "blockType": "lab",
   "dashedName": "lab-bookmark-manager-app",
   "order": 229,
   "superBlock": "front-end-development",

--- a/curriculum/challenges/_meta/lab-business-card/meta.json
+++ b/curriculum/challenges/_meta/lab-business-card/meta.json
@@ -1,12 +1,13 @@
 {
   "name": "Design a Business Card",
+  "blockType": "lab",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "lab-business-card",
   "order": 38,
   "superBlock": "front-end-development",
   "challengeOrder": [{ "id": "6690e10ebe2181212abc9652", "title": "Design a Business Card" }],
-  "helpCategory": "HTML-CSS",
-  "blockType": "lab"
+  "helpCategory": "HTML-CSS"
 }
 

--- a/curriculum/challenges/_meta/lab-cash-register/meta.json
+++ b/curriculum/challenges/_meta/lab-cash-register/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Build a Cash Register",
   "blockType": "lab",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "lab-cash-register",

--- a/curriculum/challenges/_meta/lab-celestial-bodies-database/meta.json
+++ b/curriculum/challenges/_meta/lab-celestial-bodies-database/meta.json
@@ -1,10 +1,11 @@
 {
   "name": "Build a Celestial Bodies Database",
+  "blockType": "lab",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "dashedName": "lab-celestial-bodies-database",
   "order": 337,
   "superBlock": "front-end-development",
   "challengeOrder": [{ "id": "5f1a4ef5d5d6b5ab580fc6ae", "title": "Build a Celestial Bodies Database" }],
-  "helpCategory": "Backend Development",
-  "blockType": "lab"
+  "helpCategory": "Backend Development"
 }

--- a/curriculum/challenges/_meta/lab-checkout-page/meta.json
+++ b/curriculum/challenges/_meta/lab-checkout-page/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Build a Checkout Page",
   "blockType": "lab",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "lab-checkout-page",

--- a/curriculum/challenges/_meta/lab-confidential-email-page/meta.json
+++ b/curriculum/challenges/_meta/lab-confidential-email-page/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Build a Confidential Email Page",
   "blockType": "lab",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "lab-confidential-email-page",

--- a/curriculum/challenges/_meta/lab-contact-form/meta.json
+++ b/curriculum/challenges/_meta/lab-contact-form/meta.json
@@ -1,11 +1,12 @@
 {
   "name": "Design a Contact Form",
+  "blockType": "lab",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "lab-contact-form",
   "order": 70,
   "superBlock": "front-end-development",
   "challengeOrder": [{ "id": "66f26c32ec6f90df01a44f60", "title": "Design a Contact Form" }],
-  "helpCategory": "HTML-CSS",
-  "blockType": "lab"
+  "helpCategory": "HTML-CSS"
 }

--- a/curriculum/challenges/_meta/lab-date-conversion/meta.json
+++ b/curriculum/challenges/_meta/lab-date-conversion/meta.json
@@ -1,11 +1,12 @@
 {
   "name": "Build a Date Conversion Program",
+  "blockType": "lab",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "lab-date-conversion",
   "order": 219,
   "superBlock": "front-end-development",
   "challengeOrder": [{ "id": "66f686b8ebdb982fa8e14330", "title": "Build a Date Conversion Program" }],
-  "helpCategory": "JavaScript",
-  "blockType": "lab"
+  "helpCategory": "JavaScript"
 }

--- a/curriculum/challenges/_meta/lab-depth-first-search/meta.json
+++ b/curriculum/challenges/_meta/lab-depth-first-search/meta.json
@@ -1,8 +1,9 @@
 {
   "name": "Implement the Depth-First Search Algorithm",
+  "blockType": "lab",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
-  "blockType": "lab",
   "dashedName": "lab-depth-first-search",
   "order": 269,
   "superBlock": "front-end-development",

--- a/curriculum/challenges/_meta/lab-email-masker/meta.json
+++ b/curriculum/challenges/_meta/lab-email-masker/meta.json
@@ -1,11 +1,12 @@
 {
   "name": "Build an Email Masker",
+  "blockType": "lab",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "lab-email-masker",
   "order": 153,
   "superBlock": "front-end-development",
   "challengeOrder": [{ "id": "66b205e6eacba4c4e54ea434", "title": "Build an Email Masker" }],
-  "helpCategory": "JavaScript",
-  "blockType": "lab"
+  "helpCategory": "JavaScript"
 }

--- a/curriculum/challenges/_meta/lab-event-flyer-page/meta.json
+++ b/curriculum/challenges/_meta/lab-event-flyer-page/meta.json
@@ -1,11 +1,12 @@
 {
   "name": "Build an Event Flyer Page",
+  "blockType": "lab",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "lab-event-flyer-page",
   "order": 55,
   "superBlock": "front-end-development",
   "challengeOrder": [{ "id": "66e45c8140f9fda5c105ae26", "title": "Build an Event Flyer Page" }],
-  "helpCategory": "HTML-CSS",
-  "blockType": "lab"
+  "helpCategory": "HTML-CSS"
 }

--- a/curriculum/challenges/_meta/lab-event-hub/meta.json
+++ b/curriculum/challenges/_meta/lab-event-hub/meta.json
@@ -1,11 +1,12 @@
 {
   "name": "Build an Event Hub",
+  "blockType": "lab",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "lab-event-hub",
   "order": 13,
   "superBlock": "front-end-development",
   "challengeOrder": [{ "id": "66ebd4ae2812430bb883c787", "title": "Build an Event Hub" }],
-  "helpCategory": "HTML-CSS",
-  "blockType": "lab"
+  "helpCategory": "HTML-CSS"
 }

--- a/curriculum/challenges/_meta/lab-exercise-tracker/meta.json
+++ b/curriculum/challenges/_meta/lab-exercise-tracker/meta.json
@@ -1,10 +1,11 @@
 {
   "name": "Build an Exercise Tracker",
+  "blockType": "lab",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "dashedName": "lab-exercise-tracker",
   "order": 375,
   "superBlock": "front-end-development",
   "challengeOrder": [{ "id": "5a8b073d06fa14fcfde687aa", "title": "Build an Exercise Tracker" }],
-  "helpCategory": "Backend Development",
-  "blockType": "lab"
+  "helpCategory": "Backend Development"
 }

--- a/curriculum/challenges/_meta/lab-factorial-calculator/meta.json
+++ b/curriculum/challenges/_meta/lab-factorial-calculator/meta.json
@@ -1,8 +1,9 @@
 {
   "name": "Build a Factorial Calculator ",
+  "blockType": "lab",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
-  "blockType": "lab",
   "dashedName": "lab-factorial-calculator",
   "order": 167,
   "superBlock": "front-end-development",

--- a/curriculum/challenges/_meta/lab-favorite-icon-toggler/meta.json
+++ b/curriculum/challenges/_meta/lab-favorite-icon-toggler/meta.json
@@ -1,8 +1,9 @@
 {
   "name": "Build a Favorite Icon Toggler",
+  "blockType": "lab",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
-  "blockType": "lab",
   "dashedName": "lab-favorite-icon-toggler",
   "order": 190,
   "superBlock": "front-end-development",

--- a/curriculum/challenges/_meta/lab-file-metadata-microservice/meta.json
+++ b/curriculum/challenges/_meta/lab-file-metadata-microservice/meta.json
@@ -1,5 +1,7 @@
 {
   "name": "Build a File Metadata Microservice",
+  "blockType": "lab",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
@@ -7,6 +9,5 @@
   "order": 376,
   "superBlock": "front-end-development",
   "challengeOrder": [{ "id": "bd7158d8c443edefaeb5bd0f", "title": "Build a File Metadata Microservice" }],
-  "helpCategory": "Backend Development",
-  "blockType": "lab"
+  "helpCategory": "Backend Development"
 }

--- a/curriculum/challenges/_meta/lab-football-team-cards/meta.json
+++ b/curriculum/challenges/_meta/lab-football-team-cards/meta.json
@@ -1,11 +1,12 @@
 {
   "name": "Build a Set of Football Team Cards",
+  "blockType": "lab",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "lab-football-team-cards",
   "order": 200,
   "superBlock": "front-end-development",
   "challengeOrder": [{ "id": "66e7ee20b79186306fc12da5", "title": "Build a Set of Football Team Cards" }],
-  "helpCategory": "JavaScript",
-  "blockType": "lab"
+  "helpCategory": "JavaScript"
 }

--- a/curriculum/challenges/_meta/lab-fortune-teller/meta.json
+++ b/curriculum/challenges/_meta/lab-fortune-teller/meta.json
@@ -1,8 +1,9 @@
 {
   "name": "Build a Fortune Teller App",
+  "blockType": "lab",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
-  "blockType": "lab",
   "dashedName": "lab-fortune-teller",
   "order": 143,
   "superBlock": "front-end-development",

--- a/curriculum/challenges/_meta/lab-gradebook-app/meta.json
+++ b/curriculum/challenges/_meta/lab-gradebook-app/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Build a Gradebook App",
   "blockType": "lab",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "lab-gradebook-app",

--- a/curriculum/challenges/_meta/lab-hash-table-class/meta.json
+++ b/curriculum/challenges/_meta/lab-hash-table-class/meta.json
@@ -1,8 +1,9 @@
 {
   "name": "Build a Hash Table Class",
+  "blockType": "lab",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
-  "blockType": "lab",
   "dashedName": "lab-hash-table-class",
   "order": 265,
   "superBlock": "front-end-development",

--- a/curriculum/challenges/_meta/lab-house-painting/meta.json
+++ b/curriculum/challenges/_meta/lab-house-painting/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Build a House Painting",
   "blockType": "lab",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "lab-house-painting",

--- a/curriculum/challenges/_meta/lab-inventory-management-program/meta.json
+++ b/curriculum/challenges/_meta/lab-inventory-management-program/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Build an Inventory Management Program",
   "blockType": "lab",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "lab-inventory-management-program",

--- a/curriculum/challenges/_meta/lab-javascript-trivia-bot/meta.json
+++ b/curriculum/challenges/_meta/lab-javascript-trivia-bot/meta.json
@@ -1,11 +1,12 @@
 {
   "name": "Build a JavaScript Trivia Bot",
+  "blockType": "lab",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "lab-javascript-trivia-bot",
   "order": 132,
   "superBlock": "front-end-development",
   "challengeOrder": [{ "id": "66ed41f912d0bb1dc62da5dd", "title": "Build a JavaScript Trivia Bot" }],
-  "helpCategory": "JavaScript",
-  "blockType": "lab"
+  "helpCategory": "JavaScript"
 }

--- a/curriculum/challenges/_meta/lab-job-application-form/meta.json
+++ b/curriculum/challenges/_meta/lab-job-application-form/meta.json
@@ -1,11 +1,12 @@
 {
   "name": "Build a Job Application Form",
+  "blockType": "lab",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "lab-job-application-form",
   "order": 60,
   "superBlock": "front-end-development",
   "challengeOrder": [{ "id": "66faac4139dbbd5dd632c860", "title": "Build a Job Application Form" }],
-  "helpCategory": "HTML-CSS",
-  "blockType": "lab"
+  "helpCategory": "HTML-CSS"
 }

--- a/curriculum/challenges/_meta/lab-leap-year-calculator/meta.json
+++ b/curriculum/challenges/_meta/lab-leap-year-calculator/meta.json
@@ -1,8 +1,9 @@
 {
   "name": "Build a Leap Year Calculator ",
+  "blockType": "lab",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
-  "blockType": "lab",
   "dashedName": "lab-leap-year-calculator",
   "order": 155,
   "superBlock": "front-end-development",

--- a/curriculum/challenges/_meta/lab-lightbox-viewer/meta.json
+++ b/curriculum/challenges/_meta/lab-lightbox-viewer/meta.json
@@ -1,11 +1,12 @@
 {
   "name": "Build a Lightbox Viewer",
+  "blockType": "lab",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "lab-lightbox-viewer",
   "order": 197,
   "superBlock": "front-end-development",
   "challengeOrder": [{ "id": "66db57ad34c7089b9b41bfd6", "title": "Build a Lightbox Viewer" }],
-  "helpCategory": "HTML-CSS",
-  "blockType": "lab"
+  "helpCategory": "HTML-CSS"
 }

--- a/curriculum/challenges/_meta/lab-linked-list-class/meta.json
+++ b/curriculum/challenges/_meta/lab-linked-list-class/meta.json
@@ -1,8 +1,9 @@
 {
   "name": "Build a Linked List Class",
+  "blockType": "lab",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
-  "blockType": "lab",
   "dashedName": "lab-linked-list-class",
   "order": 264,
   "superBlock": "front-end-development",

--- a/curriculum/challenges/_meta/lab-lunch-picker-program/meta.json
+++ b/curriculum/challenges/_meta/lab-lunch-picker-program/meta.json
@@ -1,11 +1,12 @@
 {
   "name": "Build a Lunch Picker Program",
+  "blockType": "lab",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "lab-lunch-picker-program",
   "order": 160,
   "superBlock": "front-end-development",
   "challengeOrder": [{ "id": "66db529d37ad966480ebb633", "title": "Build a Lunch Picker Program" }],
-  "helpCategory": "JavaScript",
-  "blockType": "lab"
+  "helpCategory": "JavaScript"
 }

--- a/curriculum/challenges/_meta/lab-moon-orbit/meta.json
+++ b/curriculum/challenges/_meta/lab-moon-orbit/meta.json
@@ -1,5 +1,7 @@
 {
   "name": "Build a Moon Orbit",
+  "blockType": "lab",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": false,
@@ -7,6 +9,5 @@
   "order": 122,
   "superBlock": "front-end-development",
   "challengeOrder": [{ "id": "66a37f37ef5823a313de8c26", "title": "Build a Moon Orbit" }],
-  "helpCategory": "HTML-CSS",
-  "blockType": "lab"
+  "helpCategory": "HTML-CSS"
 }

--- a/curriculum/challenges/_meta/lab-newspaper-article/meta.json
+++ b/curriculum/challenges/_meta/lab-newspaper-article/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Build a Newspaper Article",
   "blockType": "lab",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "lab-newspaper-article",

--- a/curriculum/challenges/_meta/lab-nth-fibonacci-number-generator/meta.json
+++ b/curriculum/challenges/_meta/lab-nth-fibonacci-number-generator/meta.json
@@ -1,11 +1,12 @@
 {
   "name": "Build the nth Fibonacci number generator",
+  "blockType": "lab",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "lab-nth-fibonacci-number-generator",
   "order": 273,
   "superBlock": "front-end-development",
   "challengeOrder": [{ "id": "66d9af3897e7d75a895b72c2", "title": "Build the nth Fibonacci number generator" }],
-  "helpCategory": "JavaScript",
-  "blockType": "lab"
+  "helpCategory": "JavaScript"
 }

--- a/curriculum/challenges/_meta/lab-number-guessing-game/meta.json
+++ b/curriculum/challenges/_meta/lab-number-guessing-game/meta.json
@@ -1,10 +1,11 @@
 {
   "name": "Build a Number Guessing Game",
+  "blockType": "lab",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "dashedName": "lab-number-guessing-game",
   "order": 360,
   "superBlock": "front-end-development",
   "challengeOrder": [{ "id": "602da04c22201c65d2a019f4", "title": "Build a Number Guessing Game" }],
-  "helpCategory": "Backend Development",
-  "blockType": "lab"
+  "helpCategory": "Backend Development"
 }

--- a/curriculum/challenges/_meta/lab-page-of-playing-cards/meta.json
+++ b/curriculum/challenges/_meta/lab-page-of-playing-cards/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Build a Page of Playing Cards",
   "blockType": "lab",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "lab-page-of-playing-cards",

--- a/curriculum/challenges/_meta/lab-palindrome-checker/meta.json
+++ b/curriculum/challenges/_meta/lab-palindrome-checker/meta.json
@@ -1,11 +1,12 @@
 {
   "name": "Build a Palindrome Checker",
+  "blockType": "lab",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "lab-palindrome-checker",
   "order": 199,
   "superBlock": "front-end-development",
   "challengeOrder": [{ "id": "657bdc55a322aae1eac3838f", "title": "Build a Palindrome Checker" }],
-  "helpCategory": "JavaScript",
-  "blockType": "lab"
+  "helpCategory": "JavaScript"
 }

--- a/curriculum/challenges/_meta/lab-periodic-table-database/meta.json
+++ b/curriculum/challenges/_meta/lab-periodic-table-database/meta.json
@@ -1,10 +1,11 @@
 {
   "name": "Build a Periodic Table Database",
+  "blockType": "lab",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "dashedName": "lab-periodic-table-database",
   "order": 359,
   "superBlock": "front-end-development",
   "challengeOrder": [{ "id": "602d9ff222201c65d2a019f2", "title": "Build a Periodic Table Database" }],
-  "helpCategory": "Backend Development",
-  "blockType": "lab"
+  "helpCategory": "Backend Development"
 }

--- a/curriculum/challenges/_meta/lab-personal-portfolio/meta.json
+++ b/curriculum/challenges/_meta/lab-personal-portfolio/meta.json
@@ -1,11 +1,12 @@
 {
   "name": "Build a Personal Portfolio",
+  "blockType": "lab",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "lab-personal-portfolio",
   "order": 124,
   "superBlock": "front-end-development",
   "challengeOrder": [{ "id": "bd7158d8c242eddfaeb5bd13", "title": "Build a Personal Portfolio" }],
-  "helpCategory": "HTML-CSS",
-  "blockType": "lab"
+  "helpCategory": "HTML-CSS"
 }

--- a/curriculum/challenges/_meta/lab-pokemon-search-app/meta.json
+++ b/curriculum/challenges/_meta/lab-pokemon-search-app/meta.json
@@ -1,11 +1,12 @@
 {
   "name": "Build a Pokémon Search App",
+  "blockType": "lab",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "lab-pokemon-search-app",
   "order": 280,
   "superBlock": "front-end-development",
   "challengeOrder": [{ "id": "6555c1d3e11a1574434cf8b5", "title": "Build a Pokémon Search App" }],
-  "helpCategory": "JavaScript",
-  "blockType": "lab"
+  "helpCategory": "JavaScript"
 }

--- a/curriculum/challenges/_meta/lab-product-landing-page/meta.json
+++ b/curriculum/challenges/_meta/lab-product-landing-page/meta.json
@@ -1,11 +1,12 @@
 {
   "name": "Build a Product Landing Page",
+  "blockType": "lab",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "lab-product-landing-page",
   "order": 117,
   "superBlock": "front-end-development",
   "challengeOrder": [{ "id": "587d78af367417b2b2512b04", "title": "Build a Product Landing Page" }],
-  "helpCategory": "HTML-CSS",
-  "blockType": "lab"
+  "helpCategory": "HTML-CSS"
 }

--- a/curriculum/challenges/_meta/lab-pyramid-generator/meta.json
+++ b/curriculum/challenges/_meta/lab-pyramid-generator/meta.json
@@ -1,11 +1,12 @@
 {
   "name": "Build a Pyramid Generator",
+  "blockType": "lab",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "lab-pyramid-generator",
   "order": 175,
   "superBlock": "front-end-development",
   "challengeOrder": [{ "id": "66f2836c459cfb16ae76f24f", "title": "Build a Pyramid Generator" }],
-  "helpCategory": "JavaScript",
-  "blockType": "lab"
+  "helpCategory": "JavaScript"
 }

--- a/curriculum/challenges/_meta/lab-quicksort-algorithm/meta.json
+++ b/curriculum/challenges/_meta/lab-quicksort-algorithm/meta.json
@@ -1,11 +1,12 @@
 {
   "name": "Build the Quicksort Algorithm",
+  "blockType": "lab",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "lab-quicksort-algorithm",
   "order": 239,
   "superBlock": "front-end-development",
   "challengeOrder": [{ "id": "587d825a367417b2b2512c89", "title": "Build the Quicksort Algorithm" }],
-  "helpCategory": "JavaScript",
-  "blockType": "lab"
+  "helpCategory": "JavaScript"
 }

--- a/curriculum/challenges/_meta/lab-quiz-game/meta.json
+++ b/curriculum/challenges/_meta/lab-quiz-game/meta.json
@@ -1,11 +1,12 @@
 {
   "name": "Build a Quiz Game",
+  "blockType": "lab",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "lab-quiz-game",
   "order": 166,
   "superBlock": "front-end-development",
   "challengeOrder": [{ "id": "66f17db06803d11a1bd19a20", "title": "Build a Quiz Game" }],
-  "helpCategory": "JavaScript",
-  "blockType": "lab"
+  "helpCategory": "JavaScript"
 }

--- a/curriculum/challenges/_meta/lab-random-background-color-changer/meta.json
+++ b/curriculum/challenges/_meta/lab-random-background-color-changer/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Debug a Random Background Color Changer",
+  "blockLayout": "link",
   "blockType": "lab",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,

--- a/curriculum/challenges/_meta/lab-real-time-counter/meta.json
+++ b/curriculum/challenges/_meta/lab-real-time-counter/meta.json
@@ -1,8 +1,9 @@
 {
   "name": "Build a Real Time Counter",
+  "blockType": "lab",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
-  "blockType": "lab",
   "dashedName": "lab-real-time-counter",
   "order": 195,
   "superBlock": "front-end-development",

--- a/curriculum/challenges/_meta/lab-recipe-page/meta.json
+++ b/curriculum/challenges/_meta/lab-recipe-page/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Build a Recipe Page",
   "blockType": "lab",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "lab-recipe-page",

--- a/curriculum/challenges/_meta/lab-regex-sandbox/meta.json
+++ b/curriculum/challenges/_meta/lab-regex-sandbox/meta.json
@@ -1,11 +1,12 @@
 {
   "name": "Build a RegEx Sandbox",
+  "blockType": "lab",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "lab-regex-sandbox",
   "order": 210,
   "superBlock": "front-end-development",
   "challengeOrder": [{ "id": "66e028680eca7d21db7e1aee", "title": "Build a RegEx Sandbox" }],
-  "helpCategory": "JavaScript",
-  "blockType": "lab"
+  "helpCategory": "JavaScript"
 }

--- a/curriculum/challenges/_meta/lab-request-header-parser-microservice/meta.json
+++ b/curriculum/challenges/_meta/lab-request-header-parser-microservice/meta.json
@@ -1,10 +1,11 @@
 {
   "name": "Build a Request Header Parser Microservice",
+  "blockType": "lab",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "dashedName": "lab-request-header-parser-microservice",
   "order": 373,
   "superBlock": "front-end-development",
   "challengeOrder": [{ "id": "bd7158d8c443edefaeb5bdff", "title": "Build a Request Header Parser Microservice" }],
-  "helpCategory": "Backend Development",
-  "blockType": "lab"
+  "helpCategory": "Backend Development"
 }

--- a/curriculum/challenges/_meta/lab-roman-numeral-converter/meta.json
+++ b/curriculum/challenges/_meta/lab-roman-numeral-converter/meta.json
@@ -1,11 +1,12 @@
 {
   "name": "Build a Roman Numeral Converter",
+  "blockType": "lab",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "lab-roman-numeral-converter",
   "order": 244,
   "superBlock": "front-end-development",
   "challengeOrder": [{ "id": "657bdc8ba322aae1eac38390", "title": "Build a Roman Numeral Converter" }],
-  "helpCategory": "JavaScript",
-  "blockType": "lab"
+  "helpCategory": "JavaScript"
 }

--- a/curriculum/challenges/_meta/lab-salon-appointment-scheduler/meta.json
+++ b/curriculum/challenges/_meta/lab-salon-appointment-scheduler/meta.json
@@ -1,5 +1,7 @@
 {
   "name": "Build a Salon Appointment Scheduler",
+  "blockType": "lab",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "dashedName": "lab-salon-appointment-scheduler",
   "order": 350,
@@ -10,6 +12,5 @@
       "id": "5f87ac112ae598023a42df1a",
       "title": "Build a Salon Appointment Scheduler"
     }
-  ],
-  "blockType": "lab"
+  ]
 }

--- a/curriculum/challenges/_meta/lab-sentence-maker/meta.json
+++ b/curriculum/challenges/_meta/lab-sentence-maker/meta.json
@@ -1,8 +1,9 @@
 {
   "name": "Build a Sentence Maker",
+  "blockType": "lab",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
-  "blockType": "lab",
   "dashedName": "lab-sentence-maker",
   "order": 154,
   "superBlock": "front-end-development",

--- a/curriculum/challenges/_meta/lab-stack-class/meta.json
+++ b/curriculum/challenges/_meta/lab-stack-class/meta.json
@@ -1,8 +1,9 @@
 {
   "name": "Build a Stack Class",
+  "blockType": "lab",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
-  "blockType": "lab",
   "dashedName": "lab-stack-class",
   "order": 263,
   "superBlock": "front-end-development",

--- a/curriculum/challenges/_meta/lab-stylized-to-do-list/meta.json
+++ b/curriculum/challenges/_meta/lab-stylized-to-do-list/meta.json
@@ -1,8 +1,9 @@
 {
   "name": "Build a Stylized To-Do List",
+  "blockType": "lab",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
-  "blockType": "lab",
   "dashedName": "lab-stylized-to-do-list",
   "order": 43,
   "superBlock": "front-end-development",

--- a/curriculum/challenges/_meta/lab-survey-form/meta.json
+++ b/curriculum/challenges/_meta/lab-survey-form/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Build a Survey Form",
   "blockType": "lab",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "lab-survey-form",

--- a/curriculum/challenges/_meta/lab-technical-documentation-page/meta.json
+++ b/curriculum/challenges/_meta/lab-technical-documentation-page/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Build a Technical Documentation Page",
   "blockType": "lab",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "lab-technical-documentation-page",

--- a/curriculum/challenges/_meta/lab-telephone-number-validator/meta.json
+++ b/curriculum/challenges/_meta/lab-telephone-number-validator/meta.json
@@ -1,8 +1,9 @@
 {
     "name": "Build a Telephone Number Validator",
+    "blockType": "lab",
+    "blockLayout": "link",
     "isUpcomingChange": true,
     "usesMultifileEditor": true,
-    "blockType": "lab",
     "dashedName": "lab-telephone-number-validator",
     "order": 246,
     "superBlock": "front-end-development",

--- a/curriculum/challenges/_meta/lab-timestamp-microservice/meta.json
+++ b/curriculum/challenges/_meta/lab-timestamp-microservice/meta.json
@@ -1,10 +1,11 @@
 {
   "name": "Build a Timestamp Microservice",
+  "blockType": "lab",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "dashedName": "lab-timestamp-microservice",
   "order": 372,
   "superBlock": "front-end-development",
   "challengeOrder": [{ "id": "bd7158d8c443edefaeb5bdef", "title": "Build a Timestamp Microservice" }],
-  "helpCategory": "Backend Development",
-  "blockType": "lab"
+  "helpCategory": "Backend Development"
 }

--- a/curriculum/challenges/_meta/lab-travel-agency-page/meta.json
+++ b/curriculum/challenges/_meta/lab-travel-agency-page/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Build a Travel Agency Page",
   "blockType": "lab",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "lab-travel-agency-page",

--- a/curriculum/challenges/_meta/lab-tribute-page/meta.json
+++ b/curriculum/challenges/_meta/lab-tribute-page/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Build a Tribute Page",
   "blockType": "lab",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "lab-tribute-page",

--- a/curriculum/challenges/_meta/lab-url-shortener-microservice/meta.json
+++ b/curriculum/challenges/_meta/lab-url-shortener-microservice/meta.json
@@ -1,10 +1,11 @@
 {
     "name": "Build a URL Shortener Microservice",
+    "blockType": "lab",
+    "blockLayout": "link",
     "isUpcomingChange": true,
     "dashedName": "lab-url-shortener-microservice",
     "order": 374,
     "superBlock": "front-end-development",
     "challengeOrder": [{ "id": "bd7158d8c443edefaeb5bd0e", "title": "Build a URL Shortener Microservice" }],
-    "helpCategory": "Backend Development",
-    "blockType": "lab"
+    "helpCategory": "Backend Development"
   }

--- a/curriculum/challenges/_meta/lab-video-compilation-page/meta.json
+++ b/curriculum/challenges/_meta/lab-video-compilation-page/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Build a Video Compilation Page",
   "blockType": "lab",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "lab-video-compilation-page",

--- a/curriculum/challenges/_meta/lab-world-cup-database/meta.json
+++ b/curriculum/challenges/_meta/lab-world-cup-database/meta.json
@@ -1,5 +1,7 @@
 {
   "name": "Build a World Cup Database",
+  "blockType": "lab",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
@@ -7,6 +9,5 @@
   "order": 347,
   "superBlock": "front-end-development",
   "challengeOrder": [{ "id": "5f9771307d4d22b9d2b75a94", "title": "Build a World Cup Database" }],
-  "helpCategory": "Backend Development",
-  "blockType": "lab"
+  "helpCategory": "Backend Development"
 }

--- a/curriculum/challenges/_meta/lecture-html-fundamentals/meta.json
+++ b/curriculum/challenges/_meta/lecture-html-fundamentals/meta.json
@@ -1,11 +1,12 @@
 {
   "name": "HTML Fundamentals",
+  "blockType": "lecture",
+  "blockLayout": "challenge-list",
   "isUpcomingChange": true,
   "dashedName": "lecture-html-fundamentals",
   "order": 4,
   "superBlock": "front-end-development",
   "helpCategory": "HTML-CSS",
-  "blockType": "lecture",
   "challengeOrder": [
     {
       "id": "670803abcb3e980233da4768",

--- a/curriculum/challenges/_meta/lecture-what-is-html/meta.json
+++ b/curriculum/challenges/_meta/lecture-what-is-html/meta.json
@@ -4,7 +4,8 @@
   "dashedName": "lecture-what-is-html",
   "order": 1,
   "superBlock": "front-end-development",
-  "challengeOrder": [{ "id": "66f6db08d55022680a3cfbc9", "title": "What is HTML and what role does it play on the web?" }],
+  "challengeOrder": [{ "id": "66f6db08d55022680a3cfbc9", "title": "What Is HTML, and What Role Does It Play on the Web?" }],
   "helpCategory": "HTML-CSS",
-  "blockType": "lecture"
+  "blockType": "lecture",
+  "blockLayout": "challenge-list"
 }

--- a/curriculum/challenges/_meta/quiz-advanced-react/meta.json
+++ b/curriculum/challenges/_meta/quiz-advanced-react/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Advanced React Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "quiz-advanced-react",

--- a/curriculum/challenges/_meta/quiz-asynchronous-javascript/meta.json
+++ b/curriculum/challenges/_meta/quiz-asynchronous-javascript/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Asynchronous JavaScript Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "quiz-asynchronous-javascript",

--- a/curriculum/challenges/_meta/quiz-backend-javascript/meta.json
+++ b/curriculum/challenges/_meta/quiz-backend-javascript/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Backend JavaScript Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "quiz-backend-javascript",

--- a/curriculum/challenges/_meta/quiz-bash-and-sql/meta.json
+++ b/curriculum/challenges/_meta/quiz-bash-and-sql/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Bash and SQL Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "quiz-bash-and-sql",

--- a/curriculum/challenges/_meta/quiz-bash-commands/meta.json
+++ b/curriculum/challenges/_meta/quiz-bash-commands/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Bash Commands Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "quiz-bash-commands",

--- a/curriculum/challenges/_meta/quiz-bash-scripting/meta.json
+++ b/curriculum/challenges/_meta/quiz-bash-scripting/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Bash Scripting Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "quiz-bash-scripting",

--- a/curriculum/challenges/_meta/quiz-basic-css/meta.json
+++ b/curriculum/challenges/_meta/quiz-basic-css/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Basic CSS Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "dashedName": "quiz-basic-css",
   "order": 41,

--- a/curriculum/challenges/_meta/quiz-basic-html/meta.json
+++ b/curriculum/challenges/_meta/quiz-basic-html/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Basic HTML Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "dashedName": "quiz-basic-html",
   "order": 10,

--- a/curriculum/challenges/_meta/quiz-computer-basics/meta.json
+++ b/curriculum/challenges/_meta/quiz-computer-basics/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Computer Basics Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "dashedName": "quiz-computer-basics",
   "order": 35,

--- a/curriculum/challenges/_meta/quiz-css-accessibility/meta.json
+++ b/curriculum/challenges/_meta/quiz-css-accessibility/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "CSS Accessibility Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "dashedName": "quiz-css-accessibility",
   "order": 92,

--- a/curriculum/challenges/_meta/quiz-css-animations/meta.json
+++ b/curriculum/challenges/_meta/quiz-css-animations/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "CSS Animations Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "dashedName": "quiz-css-animations",
   "order": 126,

--- a/curriculum/challenges/_meta/quiz-css-attribute-selectors/meta.json
+++ b/curriculum/challenges/_meta/quiz-css-attribute-selectors/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "CSS Attribute Selectors Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "dashedName": "quiz-css-attribute-selectors",
   "order": 97,

--- a/curriculum/challenges/_meta/quiz-css-backgrounds-and-borders/meta.json
+++ b/curriculum/challenges/_meta/quiz-css-backgrounds-and-borders/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "CSS Backgrounds and Borders Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "dashedName": "quiz-css-backgrounds-and-borders",
   "order": 47,

--- a/curriculum/challenges/_meta/quiz-css-colors/meta.json
+++ b/curriculum/challenges/_meta/quiz-css-colors/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "CSS Colors Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "dashedName": "quiz-css-colors",
   "order": 67,

--- a/curriculum/challenges/_meta/quiz-css-flexbox/meta.json
+++ b/curriculum/challenges/_meta/quiz-css-flexbox/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "CSS Flexbox Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "dashedName": "quiz-css-flexbox",
   "order": 82,

--- a/curriculum/challenges/_meta/quiz-css-grid/meta.json
+++ b/curriculum/challenges/_meta/quiz-css-grid/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "CSS Grid Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "dashedName": "quiz-css-grid",
   "order": 119,

--- a/curriculum/challenges/_meta/quiz-css-layout-and-effects/meta.json
+++ b/curriculum/challenges/_meta/quiz-css-layout-and-effects/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "CSS Layout and Effects Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "dashedName": "quiz-css-layout-and-effects",
   "order": 77,

--- a/curriculum/challenges/_meta/quiz-css-libraries-and-frameworks/meta.json
+++ b/curriculum/challenges/_meta/quiz-css-libraries-and-frameworks/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "CSS Libraries and Frameworks Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "quiz-css-libraries-and-frameworks",

--- a/curriculum/challenges/_meta/quiz-css-positioning/meta.json
+++ b/curriculum/challenges/_meta/quiz-css-positioning/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "CSS Positioning Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "dashedName": "quiz-css-positioning",
   "order": 102,

--- a/curriculum/challenges/_meta/quiz-css-pseudo-classes/meta.json
+++ b/curriculum/challenges/_meta/quiz-css-pseudo-classes/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "CSS Pseudo-classes Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "dashedName": "quiz-css-pseudo-classes",
   "order": 62,

--- a/curriculum/challenges/_meta/quiz-css-relative-and-absolute-units/meta.json
+++ b/curriculum/challenges/_meta/quiz-css-relative-and-absolute-units/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "CSS Relative and Absolute Units Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "dashedName": "quiz-css-relative-and-absolute-units",
   "order": 57,

--- a/curriculum/challenges/_meta/quiz-css-typography/meta.json
+++ b/curriculum/challenges/_meta/quiz-css-typography/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "CSS Typography Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "dashedName": "quiz-css-typography",
   "order": 87,

--- a/curriculum/challenges/_meta/quiz-css-variables/meta.json
+++ b/curriculum/challenges/_meta/quiz-css-variables/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "CSS Variables Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "dashedName": "quiz-css-variables",
   "order": 112,

--- a/curriculum/challenges/_meta/quiz-debugging-javascript/meta.json
+++ b/curriculum/challenges/_meta/quiz-debugging-javascript/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Debugging JavaScript Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "quiz-debugging-javascript",

--- a/curriculum/challenges/_meta/quiz-design-fundamentals/meta.json
+++ b/curriculum/challenges/_meta/quiz-design-fundamentals/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Design Fundamentals Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "dashedName": "quiz-design-fundamentals",
   "order": 52,

--- a/curriculum/challenges/_meta/quiz-dom-manipulation-and-click-event-with-javascript/meta.json
+++ b/curriculum/challenges/_meta/quiz-dom-manipulation-and-click-event-with-javascript/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "DOM Manipulation and Click Events with JavaScript Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "quiz-dom-manipulation-and-click-event-with-javascript",

--- a/curriculum/challenges/_meta/quiz-dynamic-programming/meta.json
+++ b/curriculum/challenges/_meta/quiz-dynamic-programming/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Dynamic Programming Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "quiz-dynamic-programming",

--- a/curriculum/challenges/_meta/quiz-form-validation-with-javascript/meta.json
+++ b/curriculum/challenges/_meta/quiz-form-validation-with-javascript/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Form Validation with JavaScript Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "quiz-form-validation-with-javascript",

--- a/curriculum/challenges/_meta/quiz-git/meta.json
+++ b/curriculum/challenges/_meta/quiz-git/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Git Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "quiz-git",

--- a/curriculum/challenges/_meta/quiz-graphs-and-trees/meta.json
+++ b/curriculum/challenges/_meta/quiz-graphs-and-trees/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Graphs and Trees Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "quiz-graphs-and-trees",

--- a/curriculum/challenges/_meta/quiz-html-accessibility/meta.json
+++ b/curriculum/challenges/_meta/quiz-html-accessibility/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "HTML Accessibility Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "dashedName": "quiz-html-accessibility",
   "order": 28,

--- a/curriculum/challenges/_meta/quiz-html-tables-and-forms/meta.json
+++ b/curriculum/challenges/_meta/quiz-html-tables-and-forms/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "HTML Tables and Forms Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "dashedName": "quiz-html-tables-and-forms",
   "order": 24,

--- a/curriculum/challenges/_meta/quiz-javascript-arrays/meta.json
+++ b/curriculum/challenges/_meta/quiz-javascript-arrays/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "JavaScript Arrays Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "quiz-javascript-arrays",

--- a/curriculum/challenges/_meta/quiz-javascript-audio-and-video/meta.json
+++ b/curriculum/challenges/_meta/quiz-javascript-audio-and-video/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "JavaScript Audio and Video Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "quiz-javascript-audio-and-video",

--- a/curriculum/challenges/_meta/quiz-javascript-comparisons-and-conditionals/meta.json
+++ b/curriculum/challenges/_meta/quiz-javascript-comparisons-and-conditionals/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "JavaScript Comparisons and Conditionals Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "quiz-javascript-comparisons-and-conditionals",

--- a/curriculum/challenges/_meta/quiz-javascript-data-structures/meta.json
+++ b/curriculum/challenges/_meta/quiz-javascript-data-structures/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "JavaScript Data Structures Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "quiz-javascript-data-structures",

--- a/curriculum/challenges/_meta/quiz-javascript-dates/meta.json
+++ b/curriculum/challenges/_meta/quiz-javascript-dates/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "JavaScript Dates Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "quiz-javascript-dates",

--- a/curriculum/challenges/_meta/quiz-javascript-events/meta.json
+++ b/curriculum/challenges/_meta/quiz-javascript-events/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "JavaScript Events Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "quiz-javascript-events",

--- a/curriculum/challenges/_meta/quiz-javascript-functional-programming/meta.json
+++ b/curriculum/challenges/_meta/quiz-javascript-functional-programming/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "JavaScript Functional Programming Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "quiz-javascript-functional-programming",

--- a/curriculum/challenges/_meta/quiz-javascript-functions/meta.json
+++ b/curriculum/challenges/_meta/quiz-javascript-functions/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "JavaScript Functions Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "quiz-javascript-functions",

--- a/curriculum/challenges/_meta/quiz-javascript-fundamentals/meta.json
+++ b/curriculum/challenges/_meta/quiz-javascript-fundamentals/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "JavaScript Fundamentals Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "quiz-javascript-fundamentals",

--- a/curriculum/challenges/_meta/quiz-javascript-higher-order-functions/meta.json
+++ b/curriculum/challenges/_meta/quiz-javascript-higher-order-functions/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "JavaScript Higher Order Functions Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "quiz-javascript-higher-order-functions",

--- a/curriculum/challenges/_meta/quiz-javascript-loops/meta.json
+++ b/curriculum/challenges/_meta/quiz-javascript-loops/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "JavaScript Loops Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "quiz-javascript-loops",

--- a/curriculum/challenges/_meta/quiz-javascript-math/meta.json
+++ b/curriculum/challenges/_meta/quiz-javascript-math/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "JavaScript Math Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "quiz-javascript-math",

--- a/curriculum/challenges/_meta/quiz-javascript-object-oriented-programming/meta.json
+++ b/curriculum/challenges/_meta/quiz-javascript-object-oriented-programming/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "JavaScript Object Oriented Programming Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "quiz-javascript-object-oriented-programming",

--- a/curriculum/challenges/_meta/quiz-javascript-objects/meta.json
+++ b/curriculum/challenges/_meta/quiz-javascript-objects/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "JavaScript Objects Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "quiz-javascript-objects",

--- a/curriculum/challenges/_meta/quiz-javascript-problem-solving-and-algorithmic-thinking/meta.json
+++ b/curriculum/challenges/_meta/quiz-javascript-problem-solving-and-algorithmic-thinking/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "JavaScript Problem Solving and Algorithmic Thinking Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "quiz-javascript-problem-solving-and-algorithmic-thinking",

--- a/curriculum/challenges/_meta/quiz-javascript-regular-expressions/meta.json
+++ b/curriculum/challenges/_meta/quiz-javascript-regular-expressions/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "JavaScript Regular Expressions Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "quiz-javascript-regular-expressions",

--- a/curriculum/challenges/_meta/quiz-javascript-strings/meta.json
+++ b/curriculum/challenges/_meta/quiz-javascript-strings/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "JavaScript Strings Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "quiz-javascript-strings",

--- a/curriculum/challenges/_meta/quiz-javascript-variables-and-data-types/meta.json
+++ b/curriculum/challenges/_meta/quiz-javascript-variables-and-data-types/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "JavaScript Variables and Data Types Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "quiz-javascript-variables-and-data-types",

--- a/curriculum/challenges/_meta/quiz-local-storage-and-crud/meta.json
+++ b/curriculum/challenges/_meta/quiz-local-storage-and-crud/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Local Storage and CRUD Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "quiz-local-storage-and-crud",

--- a/curriculum/challenges/_meta/quiz-nano/meta.json
+++ b/curriculum/challenges/_meta/quiz-nano/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Nano Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "quiz-nano",

--- a/curriculum/challenges/_meta/quiz-react-basics/meta.json
+++ b/curriculum/challenges/_meta/quiz-react-basics/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "React Basics Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "quiz-react-basics",

--- a/curriculum/challenges/_meta/quiz-react-state-and-hooks/meta.json
+++ b/curriculum/challenges/_meta/quiz-react-state-and-hooks/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "React State and Hooks Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "quiz-react-state-and-hooks",

--- a/curriculum/challenges/_meta/quiz-recursion/meta.json
+++ b/curriculum/challenges/_meta/quiz-recursion/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Recursion Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "quiz-recursion",

--- a/curriculum/challenges/_meta/quiz-relational-database/meta.json
+++ b/curriculum/challenges/_meta/quiz-relational-database/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Relational Database Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "quiz-relational-database",

--- a/curriculum/challenges/_meta/quiz-responsive-web-design/meta.json
+++ b/curriculum/challenges/_meta/quiz-responsive-web-design/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Responsive Web Design Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "dashedName": "quiz-responsive-web-design",
   "order": 107,

--- a/curriculum/challenges/_meta/quiz-searching-and-sorting-algorithms/meta.json
+++ b/curriculum/challenges/_meta/quiz-searching-and-sorting-algorithms/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Searching and Sorting Algorithms Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "quiz-searching-and-sorting-algorithms",

--- a/curriculum/challenges/_meta/quiz-security-and-privacy/meta.json
+++ b/curriculum/challenges/_meta/quiz-security-and-privacy/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Security and Privacy Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "quiz-security-and-privacy",

--- a/curriculum/challenges/_meta/quiz-semantic-html/meta.json
+++ b/curriculum/challenges/_meta/quiz-semantic-html/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Semantic HTML Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "dashedName": "quiz-semantic-html",
   "order": 15,

--- a/curriculum/challenges/_meta/quiz-styling-forms/meta.json
+++ b/curriculum/challenges/_meta/quiz-styling-forms/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Styling Forms Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "dashedName": "quiz-styling-forms",
   "order": 72,

--- a/curriculum/challenges/_meta/quiz-testing/meta.json
+++ b/curriculum/challenges/_meta/quiz-testing/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Testing Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "quiz-testing",

--- a/curriculum/challenges/_meta/quiz-tooling-and-deployment/meta.json
+++ b/curriculum/challenges/_meta/quiz-tooling-and-deployment/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Tooling and Deployment Quiz",
   "isUpcomingChange": true,
+  "blockLayout": "link",
   "usesMultifileEditor": true,
   "dashedName": "quiz-tooling-and-deployment",
   "order": 383,

--- a/curriculum/challenges/_meta/quiz-typescript/meta.json
+++ b/curriculum/challenges/_meta/quiz-typescript/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "TypeScript Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "quiz-typescript",

--- a/curriculum/challenges/_meta/quiz-web-performance/meta.json
+++ b/curriculum/challenges/_meta/quiz-web-performance/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Web Performance Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "quiz-web-performance",

--- a/curriculum/challenges/_meta/quiz-web-standards/meta.json
+++ b/curriculum/challenges/_meta/quiz-web-standards/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Web Standards Quiz",
   "blockType": "quiz",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "quiz-web-standards",

--- a/curriculum/challenges/_meta/review-basic-html/meta.json
+++ b/curriculum/challenges/_meta/review-basic-html/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Basic HTML Review",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "dashedName": "review-basic-html",
   "order": 9,

--- a/curriculum/challenges/_meta/workshop-balance-sheet/meta.json
+++ b/curriculum/challenges/_meta/workshop-balance-sheet/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Build a Balance Sheet",
   "blockType": "workshop",
+  "blockLayout": "challenge-grid",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,

--- a/curriculum/challenges/_meta/workshop-bash-boilerplate/meta.json
+++ b/curriculum/challenges/_meta/workshop-bash-boilerplate/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Build a Boilerplate",
   "blockType": "workshop",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": false,
   "hasEditableBoundaries": false,

--- a/curriculum/challenges/_meta/workshop-bash-five-programs/meta.json
+++ b/curriculum/challenges/_meta/workshop-bash-five-programs/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Build Five Programs",
   "blockType": "workshop",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": false,
   "hasEditableBoundaries": false,

--- a/curriculum/challenges/_meta/workshop-bike-rental-shop/meta.json
+++ b/curriculum/challenges/_meta/workshop-bike-rental-shop/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Build a Bike Rental Shop",
   "blockType": "workshop",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": false,
   "hasEditableBoundaries": false,

--- a/curriculum/challenges/_meta/workshop-blog-page/meta.json
+++ b/curriculum/challenges/_meta/workshop-blog-page/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Build a Cat Blog Page",
   "blockType": "workshop",
+  "blockLayout": "challenge-grid",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,

--- a/curriculum/challenges/_meta/workshop-cafe-menu/meta.json
+++ b/curriculum/challenges/_meta/workshop-cafe-menu/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Design a Cafe Menu",
   "blockType": "workshop",
+  "blockLayout": "challenge-grid",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,

--- a/curriculum/challenges/_meta/workshop-calculator/meta.json
+++ b/curriculum/challenges/_meta/workshop-calculator/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Build a Calculator",
   "blockType": "workshop",
+  "blockLayout": "challenge-grid",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,

--- a/curriculum/challenges/_meta/workshop-castle/meta.json
+++ b/curriculum/challenges/_meta/workshop-castle/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Build a Castle",
   "blockType": "workshop",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": false,
   "hasEditableBoundaries": false,

--- a/curriculum/challenges/_meta/workshop-cat-photo-app/meta.json
+++ b/curriculum/challenges/_meta/workshop-cat-photo-app/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Build a Cat Photo App",
   "blockType": "workshop",
+  "blockLayout": "challenge-grid",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,

--- a/curriculum/challenges/_meta/workshop-city-skyline/meta.json
+++ b/curriculum/challenges/_meta/workshop-city-skyline/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Build a City Skyline",
   "blockType": "workshop",
+  "blockLayout": "challenge-grid",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,

--- a/curriculum/challenges/_meta/workshop-final-exams-table/meta.json
+++ b/curriculum/challenges/_meta/workshop-final-exams-table/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Build a Final Exams Table",
   "blockType": "workshop",
+  "blockLayout": "challenge-grid",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,

--- a/curriculum/challenges/_meta/workshop-flexbox-photo-gallery/meta.json
+++ b/curriculum/challenges/_meta/workshop-flexbox-photo-gallery/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Build a Flexbox Photo Gallery",
   "blockType": "workshop",
+  "blockLayout": "challenge-grid",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,

--- a/curriculum/challenges/_meta/workshop-greeting-bot/meta.json
+++ b/curriculum/challenges/_meta/workshop-greeting-bot/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Build a Greeting Bot",
   "blockType": "workshop",
+  "blockLayout": "challenge-grid",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,

--- a/curriculum/challenges/_meta/workshop-hotel-feedback-form/meta.json
+++ b/curriculum/challenges/_meta/workshop-hotel-feedback-form/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Build a Hotel Feedback Form",
   "blockType": "workshop",
+  "blockLayout": "challenge-grid",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,

--- a/curriculum/challenges/_meta/workshop-kitty-ipsum-translator/meta.json
+++ b/curriculum/challenges/_meta/workshop-kitty-ipsum-translator/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Build a Kitty Ipsum Translator",
   "blockType": "workshop",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": false,
   "hasEditableBoundaries": false,

--- a/curriculum/challenges/_meta/workshop-loan-qualification-checker/meta.json
+++ b/curriculum/challenges/_meta/workshop-loan-qualification-checker/meta.json
@@ -1,9 +1,10 @@
 {
   "name": "Build a Loan Qualification Checker",
+  "blockType": "workshop",
+  "blockLayout": "challenge-grid",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
-  "blockType": "workshop",
   "dashedName": "workshop-loan-qualification-checker",
   "order": 154,
   "superBlock": "front-end-development",

--- a/curriculum/challenges/_meta/workshop-mario-database/meta.json
+++ b/curriculum/challenges/_meta/workshop-mario-database/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Build a Mario Database",
   "blockType": "workshop",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": false,
   "hasEditableBoundaries": false,

--- a/curriculum/challenges/_meta/workshop-mathbot/meta.json
+++ b/curriculum/challenges/_meta/workshop-mathbot/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Build a Mathbot",
   "blockType": "workshop",
+  "blockLayout": "challenge-grid",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,

--- a/curriculum/challenges/_meta/workshop-node-and-express/meta.json
+++ b/curriculum/challenges/_meta/workshop-node-and-express/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Basic Node and Express",
   "blockType": "workshop",
+  "blockLayout": "challenge-list",
   "isUpcomingChange": true,
   "usesMultifileEditor": false,
   "hasEditableBoundaries": false,

--- a/curriculum/challenges/_meta/workshop-npm-packages/meta.json
+++ b/curriculum/challenges/_meta/workshop-npm-packages/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Managing Packages with npm",
   "blockType": "workshop",
+  "blockLayout": "challenge-list",
   "isUpcomingChange": true,
   "usesMultifileEditor": false,
   "hasEditableBoundaries": false,

--- a/curriculum/challenges/_meta/workshop-nutritional-label/meta.json
+++ b/curriculum/challenges/_meta/workshop-nutritional-label/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Build a Nutritional Label",
   "blockType": "workshop",
+  "blockLayout": "challenge-grid",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,

--- a/curriculum/challenges/_meta/workshop-piano/meta.json
+++ b/curriculum/challenges/_meta/workshop-piano/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Design a Piano",
   "blockType": "workshop",
+  "blockLayout": "challenge-grid",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,

--- a/curriculum/challenges/_meta/workshop-recipe-tracker/meta.json
+++ b/curriculum/challenges/_meta/workshop-recipe-tracker/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Build a Recipe Tracker",
+  "blockLayout": "challenge-grid",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,

--- a/curriculum/challenges/_meta/workshop-rothko-painting/meta.json
+++ b/curriculum/challenges/_meta/workshop-rothko-painting/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Design a Rothko Painting",
   "blockType": "workshop",
+  "blockLayout": "challenge-grid",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,

--- a/curriculum/challenges/_meta/workshop-rps-game/meta.json
+++ b/curriculum/challenges/_meta/workshop-rps-game/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Build a Rock, Paper, Scissors Game",
   "blockType": "workshop",
+  "blockLayout": "challenge-grid",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,

--- a/curriculum/challenges/_meta/workshop-sentence-analyzer/meta.json
+++ b/curriculum/challenges/_meta/workshop-sentence-analyzer/meta.json
@@ -1,5 +1,7 @@
 {
   "name": "Build a Sentence Analyzer",
+  "blockType": "workshop",
+  "blockLayout": "challenge-grid",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
@@ -40,6 +42,5 @@
       "title": "Step 8"
     }
   ],
-  "helpCategory": "JavaScript",
-  "blockType": "workshop"
+  "helpCategory": "JavaScript"
 }

--- a/curriculum/challenges/_meta/workshop-shopping-list/meta.json
+++ b/curriculum/challenges/_meta/workshop-shopping-list/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Build a Shopping List",
   "blockType": "workshop",
+  "blockLayout": "challenge-grid",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,

--- a/curriculum/challenges/_meta/workshop-sql-reference-object/meta.json
+++ b/curriculum/challenges/_meta/workshop-sql-reference-object/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Build an SQL Reference Object",
   "blockType": "workshop",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": false,
   "hasEditableBoundaries": false,

--- a/curriculum/challenges/_meta/workshop-sql-student-database-part-1/meta.json
+++ b/curriculum/challenges/_meta/workshop-sql-student-database-part-1/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Build a Student Database: Part 1",
   "blockType": "workshop",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": false,
   "hasEditableBoundaries": false,

--- a/curriculum/challenges/_meta/workshop-sql-student-database-part-2/meta.json
+++ b/curriculum/challenges/_meta/workshop-sql-student-database-part-2/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Build a Student Database: Part 2",
   "blockType": "workshop",
+  "blockLayout": "link",
   "isUpcomingChange": true,
   "usesMultifileEditor": false,
   "hasEditableBoundaries": false,

--- a/curriculum/challenges/_meta/workshop-teacher-chatbot/meta.json
+++ b/curriculum/challenges/_meta/workshop-teacher-chatbot/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Build a Teacher Chatbot",
   "blockType": "workshop",
+  "blockLayout": "challenge-grid",
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,

--- a/curriculum/challenges/english/25-front-end-development/lecture-what-is-html/66f6db08d55022680a3cfbc9.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-what-is-html/66f6db08d55022680a3cfbc9.md
@@ -1,9 +1,9 @@
 ---
 id: 66f6db08d55022680a3cfbc9
-title: What Is HTML and What Role Does It Play on the Web?
+title: What Is HTML, and What Role Does It Play on the Web?
 challengeType: 11
 videoId: Me-GFJKL-9E
-dashedName: what-is-html-and-what-role-does-it-play-on-the-web
+dashedName: what-is-html
 ---
 
 # --description--

--- a/curriculum/schema/__snapshots__/challenge-schema.test.js.snap
+++ b/curriculum/schema/__snapshots__/challenge-schema.test.js.snap
@@ -138,7 +138,9 @@ const schema = Joi.object()
         'challenge-list',
         'challenge-grid',
         'link',
-        'project-list'
+        'project-list',
+        'legacy-challenge-list',
+        'legacy-link'
       )
     }),
     challengeOrder: Joi.number(),

--- a/curriculum/schema/challenge-schema.js
+++ b/curriculum/schema/challenge-schema.js
@@ -135,7 +135,9 @@ const schema = Joi.object()
         'challenge-list',
         'challenge-grid',
         'link',
-        'project-list'
+        'project-list',
+        'legacy-challenge-list',
+        'legacy-link'
       )
     }),
     challengeOrder: Joi.number(),

--- a/curriculum/schema/meta-schema.js
+++ b/curriculum/schema/meta-schema.js
@@ -10,7 +10,9 @@ const schema = Joi.object()
       'challenge-list',
       'challenge-grid',
       'link',
-      'project-list'
+      'project-list',
+      'legacy-challenge-list',
+      'legacy-link'
     ),
     blockType: Joi.valid(
       'workshop',

--- a/shared/config/blocks.ts
+++ b/shared/config/blocks.ts
@@ -9,11 +9,18 @@ export enum BlockTypes {
 
 export enum BlockLayouts {
   /**
+   * These two are for the new Full Stack Developer Certification,
+   * so we can play with them without affecting the existing block layouts
+   */
+  ChallengeList = 'challenge-list',
+  Link = 'link',
+
+  /**
    * ChallengeList displays challenges in a list.
    * This layout is used in backend blocks, The Odin Project blocks, and blocks in legacy certification.
    * Example: https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/#basic-javascript
    */
-  ChallengeList = 'challenge-list',
+  LegacyChallengeList = 'legacy-challenge-list',
 
   /**
    * ChallengeGrid displays challenges in a grid.
@@ -27,7 +34,7 @@ export enum BlockLayouts {
    * This layout is used if the block has a single challenge.
    * Example: https://www.freecodecamp.org/learn/2022/responsive-web-design/#build-a-survey-form-project
    */
-  Link = 'link',
+  LegacyLink = 'legacy-link',
 
   /**
    * ProjectList displays a list of certification projects.


### PR DESCRIPTION
This is an attempt to make the blocks look a little better on the superblock page. There's a long way to go, but it also should make it easier to make changes in the future.

It changes the existing `challenge-list` and `link` block layouts to `legacy-challenge-list` and `legacy-link` - and adds two new layouts of the original names. This is so I could make changes to the block layouts without affecting the existing layouts.

Extracts a few things from block.tsx into their own components.

Updates all the full stack meta.json files to include a blockLayout.

Some other misc changes might have snuck in there.


Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
