### PR TITLE
fix: remove trailing hr from ChallengeDescription

### DIFF
--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -392,10 +392,8 @@ function ShowClassic({
         block={block}
         challengeDescription={
           <ChallengeDescription
-            block={block}
             description={description}
             instructions={instructions}
-            superBlock={superBlock}
           />
         }
         challengeTitle={

--- a/client/src/templates/Challenges/components/challenge-description.tsx
+++ b/client/src/templates/Challenges/components/challenge-description.tsx
@@ -3,33 +3,21 @@ import React from 'react';
 import PrismFormatted from './prism-formatted';
 import './challenge-description.css';
 
-type Challenge = {
-  block?: string;
+type Props = {
   description?: string;
   instructions?: string;
-  superBlock?: string;
 };
 
-function ChallengeDescription(challenge: Challenge): JSX.Element {
-  const sbClass = challenge.superBlock ? challenge.superBlock : '';
-  const bClass = challenge.block ? challenge.block : '';
-
-  return (
-    <div
-      className={`challenge-instructions ${sbClass} ${bClass}`}
-      data-playwright-test-label='challenge-description'
-    >
-      {challenge.description && <PrismFormatted text={challenge.description} />}
-      {challenge.instructions && (
-        <>
-          <hr />
-          <PrismFormatted text={challenge.instructions} />
-        </>
-      )}
-      <hr />
-    </div>
-  );
-}
+const ChallengeDescription = ({ description, instructions }: Props) => (
+  <div
+    className={'challenge-instructions'}
+    data-playwright-test-label='challenge-description'
+  >
+    {description && <PrismFormatted text={description} />}
+    {instructions && description && <hr />}
+    {instructions && <PrismFormatted text={instructions} />}
+  </div>
+);
 
 ChallengeDescription.displayName = 'ChallengeDescription';
 

--- a/client/src/templates/Challenges/components/side-panel.tsx
+++ b/client/src/templates/Challenges/components/side-panel.tsx
@@ -8,6 +8,7 @@ import { SuperBlocks } from '../../../../../shared/config/curriculum';
 import { initializeMathJax } from '../../../utils/math-jax';
 import { challengeTestsSelector } from '../redux/selectors';
 import { openModal } from '../redux/actions';
+import { Spacer } from '../../../components/helpers';
 import TestSuite from './test-suite';
 
 import './side-panel.css';
@@ -83,6 +84,7 @@ export function SidePanel({
         </p>
       )}
       {challengeDescription}
+      <Spacer size='medium' />
       {toolPanel}
       <TestSuite tests={tests} />
     </div>

--- a/client/src/templates/Challenges/projects/backend/show.tsx
+++ b/client/src/templates/Challenges/projects/backend/show.tsx
@@ -242,6 +242,7 @@ class BackEnd extends Component<BackEndProps> {
                   description={description}
                   instructions={instructions}
                 />
+                <Spacer size='medium' />
                 <SolutionForm
                   challengeType={challengeType}
                   // eslint-disable-next-line @typescript-eslint/unbound-method

--- a/client/src/templates/Challenges/projects/frontend/show.tsx
+++ b/client/src/templates/Challenges/projects/frontend/show.tsx
@@ -197,6 +197,7 @@ class Project extends Component<ProjectProps> {
                   description={description}
                   instructions={instructions}
                 />
+                <Spacer size='medium' />
                 <SolutionForm
                   challengeType={challengeType}
                   description={description}


### PR DESCRIPTION
The line rule makes sense if we want to separate instructions from
descriptions, but not if there's nothing to separate.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
