### PR TITLE
fix: recreate editable boundaries for saved files

### DIFF
--- a/client/src/templates/Challenges/redux/actions.js
+++ b/client/src/templates/Challenges/redux/actions.js
@@ -13,6 +13,8 @@ export const createFiles = createAction(
         challengeFile.contents,
         challengeFile.editableRegionBoundaries
       ),
+      editableRegionBoundaries:
+        challengeFile.editableRegionBoundaries?.slice() ?? [],
       seedEditableRegionBoundaries:
         challengeFile.editableRegionBoundaries?.slice() ?? []
     }))


### PR DESCRIPTION
The create-question-epic assumes they exist, so this makes sure they do.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Ref: https://forum.freecodecamp.org/t/not-being-able-to-create-post/708912/24

<!-- Feel free to add any additional description of changes below this line -->
