### PR TITLE
fix(scripts): remove env-exam call

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "preseed": "npm-run-all create:shared",
     "playwright:install-build-tools": "npx playwright install --with-deps",
     "rename-challenges": "ts-node tools/challenge-helper-scripts/rename-challenge-files.ts",
-    "seed": "pnpm seed:surveys && pnpm seed:exams && pnpm seed:env-exam && DEBUG=fcc:* node ./tools/scripts/seed/seed-demo-user",
+    "seed": "pnpm seed:surveys && pnpm seed:exams && DEBUG=fcc:* node ./tools/scripts/seed/seed-demo-user",
     "seed:certified-user": "pnpm seed:surveys && pnpm seed:exams && pnpm seed:ms-username && DEBUG=fcc:* node ./tools/scripts/seed/seed-demo-user --certified-user",
     "seed:exams": "DEBUG=fcc:* node tools/scripts/seed-exams/create-exams",
     "seed:env-exam": "cd api && pnpm run seed:env-exam",


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

I'm not sure why we added the `env-exams` call to the top-level seed script, but this is creating issues for contributors trying to set the app up locally.

The new API is not in use, and uses Prisma which adds additional (undocumented) challenges with a local Mongo instance.