### PR TITLE
fix(api): specify openapi version

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -106,6 +106,7 @@ export const build = async (
   if (FCC_ENABLE_SWAGGER_UI) {
     void fastify.register(fastifySwagger, {
       openapi: {
+        openapi: '3.1.0',
         info: {
           title: 'freeCodeCamp API',
           version: '1.0.0' // API version


### PR DESCRIPTION
3.1.0 brings back null as an property type. Our schema conforms to this spec, not 3.0.3 (since it handles nullable properties differently).

This doesn't change any functionality, it just removes a spurious warning that shows up when looking at the swagger documentation.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->
