### PR TITLE
fix(docker compose):  MongoDB container to be fully healthy before running the replica set initialization

### DIFF
--- a/api/tools/docker-compose.yml
+++ b/api/tools/docker-compose.yml
@@ -9,17 +9,29 @@ services:
       - 27017:27017
     volumes:
       - db-data:/data
+    healthcheck:
+      test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
   setup:
     image: mongo
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     restart: on-failure
-    entrypoint: [
-        'bash',
-        '-c',
-        # This will try to initiate the replica set, until it succeeds twice (i.e. until the replica set is already initialized)
-        'mongosh --host db:27017 --eval ''try {rs.initiate();} catch (err) { if(err.codeName !== "AlreadyInitialized") throw err };'''
-      ]
+    command: >
+      mongosh --host db:27017 --eval '
+        try {
+          rs.initiate({
+            _id: "rs0",
+            members: [{ _id: 0, host: "db:27017" }]
+          });
+        } catch (err) {
+          if(err.codeName !== "AlreadyInitialized") throw err;
+        }
+      '
 
 volumes:
   db-data:

--- a/api/tools/docker-compose.yml
+++ b/api/tools/docker-compose.yml
@@ -11,8 +11,7 @@ services:
       - db-data:/data
     healthcheck:
       test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
-      interval: 10s
-      timeout: 5s
+      interval: 2s
       retries: 5
 
   setup:

--- a/api/tools/docker-compose.yml
+++ b/api/tools/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     volumes:
       - db-data:/data
     healthcheck:
-      test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
+      test: ['CMD', 'mongosh', '--eval', "db.adminCommand('ping')"]
       interval: 2s
       retries: 5
 

--- a/api/tools/docker-compose.yml
+++ b/api/tools/docker-compose.yml
@@ -23,10 +23,7 @@ services:
     command: >
       mongosh --host db:27017 --eval '
         try {
-          rs.initiate({
-            _id: "rs0",
-            members: [{ _id: 0, host: "db:27017" }]
-          });
+          rs.initiate();
         } catch (err) {
           if(err.codeName !== "AlreadyInitialized") throw err;
         }

--- a/api/tools/docker-compose.yml
+++ b/api/tools/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       db:
         condition: service_healthy
     restart: on-failure
+    # This will try to initiate the replica set, until it succeeds twice (i.e. until the replica set is already initialized)
     command: >
       mongosh --host db:27017 --eval '
         try {


### PR DESCRIPTION
- Added a healthcheck to the db service to ensure MongoDB is ready
- Changed depends_on to wait for the db service to be healthy
- Replaced the bash entrypoint with a direct command using proper replica set configuration
- Improved the initialization script to properly configure the replica set with an ID and member
- Removed the complex bash entrypoint in favor of a more direct command approach

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
