### PR TITLE
fix(curriculum): excessive blank lines in seed

### DIFF
--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-data-structures-by-building-the-merge-sort-algorithm/6577254891048c8f2c19e961.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-data-structures-by-building-the-merge-sort-algorithm/6577254891048c8f2c19e961.md
@@ -30,7 +30,6 @@ You should call `merge_sort()` again after the previous function call.
 ## --seed-contents--
 
 ```py
-    
 --fcc-editable-region--
 def merge_sort(array):
     middle_point = len(array) // 2

--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-lambda-functions-by-building-an-expense-tracker/65821fcc010c3245718f2a06.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-lambda-functions-by-building-an-expense-tracker/65821fcc010c3245718f2a06.md
@@ -29,7 +29,7 @@ You should not have `pass` in your function.
 
 ## --seed-contents--
 
-```py    
+```py
 --fcc-editable-region--
 def add_expense(expenses, amount, category):
     pass

--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-the-bisection-method-by-finding-the-square-root-of-a-number/65ef190c6b51e9b5a5f7ed29.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-the-bisection-method-by-finding-the-square-root-of-a-number/65ef190c6b51e9b5a5f7ed29.md
@@ -28,7 +28,6 @@ Your function should have these parameters: `square_target`, `tolerance = 1e-7`,
 ## --seed-contents--
 
 ```py
-
 --fcc-editable-region--
 def square_root_bisection():
     pass

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-modern-javascript-methods-by-building-football-team-cards/63f28972973504e7bb58b0b3.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-modern-javascript-methods-by-building-football-team-cards/63f28972973504e7bb58b0b3.md
@@ -480,6 +480,4 @@ const setPlayerCards = (arr = players) => {
 
 --fcc-editable-region--
 
-
-
 ```

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-modern-javascript-methods-by-building-football-team-cards/63f28ef082d771e8bf71f94a.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-modern-javascript-methods-by-building-football-team-cards/63f28ef082d771e8bf71f94a.md
@@ -470,6 +470,4 @@ playersDropdownList.addEventListener("change", () => {
 
 --fcc-editable-region--
 
-
-
 ```


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

- - -
- Nothing more than nitpicking excessive blank space in seed code. Annoying example of leading blank line can be found at https://www.freecodecamp.org/learn/scientific-computing-with-python/learn-the-bisection-method-by-finding-the-square-root-of-a-number/step-2, where there's one line before the editable region.
- Trailing blank line is less sticking out. One might argue it also fits into practice of keeping blank line at the end of file. Nevertheless having multiple blank lines at the end of seed is not needed.