### PR TITLE
fix(curriculum): pyramid project step 110 test

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f4f79e2a82a4e92290f44.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f4f79e2a82a4e92290f44.md
@@ -23,7 +23,7 @@ assert.match(stripped, /for\s*\(\s*let\s+i\s*=\s*1;\s*i\s*<=\s*count;\s*i\+\+\s*
 You should not remove your single-line comment.
 
 ```js
-assert.match(code, /\/\/\sTODO:/);
+assert.match(code, /\/\//);
 ```
 
 You should not uncomment your `while` loop.


### PR DESCRIPTION
This came about because [the submodule update is failing the Chinese curriculum tests.](https://github.com/freeCodeCamp/freeCodeCamp/actions/runs/11488087606/job/31977366761?pr=56797)

[This step has a tests that makes sure you don't delete a comment.](https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures-v8/learn-introductory-javascript-by-building-a-pyramid-generator/step-110) Delete the inline comment and uncomment the first `for` loop to see the test. The test is the one in this PR: `assert.match(code, /\/\/\sTODO:/);`. [That comment is being translated](https://github.com/freeCodeCamp/i18n-curriculum/blob/main/curriculum/dictionaries/japanese/comments.json#L112) and making the test fail. Note that the translated comment still has the `TODO`, but the colon there isn't the same, so it doesn't pass. The solution I added here was to just test for the two forward slashes that are used for comments (`//`) instead of including the TODO or anything else in there which can get translated.

Here is [the step where users add that comment.](https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures-v8/learn-introductory-javascript-by-building-a-pyramid-generator/step-76) Since they can add any comment they want, I think it's fine to translate the comment - but the alternate option would be to move that comment to the "comments not to translate" file.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
