### PR TITLE
fix(curriculum): stop testing translated comments

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f4f79e2a82a4e92290f44.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f4f79e2a82a4e92290f44.md
@@ -23,7 +23,7 @@ assert.match(stripped, /for\s*\(\s*let\s+i\s*=\s*1;\s*i\s*<=\s*count;\s*i\+\+\s*
 You should not remove your single-line comment.
 
 ```js
-assert.match(code, /\/\/\sTODO:/);
+assert.match(code, /\/\//);
 ```
 
 You should not uncomment your `while` loop.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Comments are translated, so the learners will see different things in different languages. Tests should not rely on the comments, since then learners code may fail even though they've done everything correctly.

Ref: https://github.com/freeCodeCamp/freeCodeCamp/actions/runs/11488087606/job/31977366761

<!-- Feel free to add any additional description of changes below this line -->
