### PR TITLE
fix: rewrite test in direct comparison with strings

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-modern-javascript-methods-by-building-football-team-cards/63e95e39860dc5b01ebe9be0.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-modern-javascript-methods-by-building-football-team-cards/63e95e39860dc5b01ebe9be0.md
@@ -16,7 +16,16 @@ Before the `${name}` expression, add a new embedded expression. Inside that expr
 You should use a ternary operator to check if `isCaptain` is true and return `"(Captain)"` or return an empty string.
 
 ```js
-assert.match(code, /\s*<h2\s*>\s*\$\{isCaptain(\s*===\s*true)?\s*\?\s*('|"|`)\(Captain\)\2\s*:\s*('|"|`)\3\}\s*\${\s*name\s*}\s*<\/h2>\s*/)
+const players = [
+  { name: "First", isCaptain: true },
+  { name: "Second", isCaptain: false },
+];
+
+playerCards.innerHTML = "";
+setPlayerCards(players);
+
+assert.ok(playerCards.innerHTML.includes("<h2>(Captain) First</h2>"));
+assert.ok(playerCards.innerHTML.includes("<h2>Second</h2>"));
 ```
 
 # --seed--
@@ -452,7 +461,7 @@ const setPlayerCards = (arr = players) => {
 
   playerCards.innerHTML += arr.map(
     ({ name, position, number, isCaptain, nickname }) => {
-      `
+      return `
         <div class="player-card">
           <h2>${name}</h2>
         </div>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Closes #56666

<hr>

Instead of regex match, I made a direct comparison with next solutions:

```js
const isTestOk =
  [
    "<h2>${isCaptain ? '(Captain) ' : ''}${name}</h2>",
    '<h2>${isCaptain ? "(Captain) " : ""}${name}</h2>',

    "<h2>${isCaptain == true ? '(Captain) ' : ''}${name}</h2>",
    "<h2>${isCaptain === true ? '(Captain) ' : ''}${name}</h2>",

    '<h2>${isCaptain == true ? "(Captain) " : ""}${name}</h2>',
    '<h2>${isCaptain === true ? "(Captain) " : ""}${name}</h2>',
  ].includes(title);
```