### PR TITLE
fix: reset username change spec test

### DIFF
--- a/e2e/username-change.spec.ts
+++ b/e2e/username-change.spec.ts
@@ -1,6 +1,12 @@
+import { execSync } from 'child_process';
 import { test, expect } from '@playwright/test';
 import translations from '../client/i18n/locales/english/translations.json';
 test.use({ storageState: 'playwright/.auth/certified-user.json' });
+
+test.afterAll(() => {
+  // change the name back to the original
+  execSync('node ./tools/scripts/seed/seed-demo-user --certified-user');
+});
 
 const settingsObject = {
   usernamePlaceholder: '{{username}}',
@@ -16,11 +22,10 @@ const settingsObject = {
   errorCode: '404'
 };
 
-let currentUsername = 'certifieduser';
-
 test.describe('Username Settings Validation', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto(`/${currentUsername}`);
+    execSync('node ./tools/scripts/seed/seed-demo-user --certified-user');
+    await page.goto(`/certifieduser`);
 
     if (!process.env.CI) {
       await page
@@ -108,7 +113,6 @@ test.describe('Username Settings Validation', () => {
     await expect(
       page.getByRole('alert').filter({ hasText: flashText }).first()
     ).toBeVisible();
-    currentUsername = settingsObject.usernameAvailable;
   });
 
   test('should update username in lowercase and reflect in the UI', async ({
@@ -129,7 +133,6 @@ test.describe('Username Settings Validation', () => {
     await expect(
       page.getByRole('alert').filter({ hasText: flashText }).first()
     ).toBeVisible();
-    currentUsername = settingsObject.usernameUpdateToLowerCase;
   });
 
   test('should update username in uppercase and reflect in the UI', async ({
@@ -150,7 +153,6 @@ test.describe('Username Settings Validation', () => {
     await expect(
       page.getByRole('alert').filter({ hasText: flashText }).first()
     ).toBeVisible();
-    currentUsername = settingsObject.usernameUpdateToUpperCase;
   });
 
   test('should update username by pressing enter', async ({ page }) => {
@@ -171,7 +173,6 @@ test.describe('Username Settings Validation', () => {
     await expect(
       page.getByRole('alert').filter({ hasText: flashText }).first()
     ).toBeVisible();
-    currentUsername = settingsObject.testUser;
   });
 
   test('should not be able to update username to the same username', async ({
@@ -181,7 +182,7 @@ test.describe('Username Settings Validation', () => {
     const saveButton = page.getByRole('button', {
       name: translations.settings.labels.username
     });
-    await inputLabel.fill(settingsObject.testUser);
+    await inputLabel.fill(settingsObject.certifiedUsername);
     await expect(saveButton).toBeDisabled();
   });
 });


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

ref #56828

<!-- Feel free to add any additional description of changes below this line -->

Seems like the username-change spec is also failing sometimes. This should probably fix it.
https://github.com/freeCodeCamp/freeCodeCamp/actions/runs/11452904446/job/31864668658
