### PR TITLE
fix(curriculum): match literal dot

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-calculator/66cdf76685e4cb5a8726e27b.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-calculator/66cdf76685e4cb5a8726e27b.md
@@ -18,13 +18,13 @@ Below that `console.log`, add another `console.log` that calls the `calculateSum
 You should have a `console.log` that calls the `calculateSum` function with the arguments `10` and `10`.
 
 ```js
-assert.match(code, /console.log\(calculateSum\(10\s*,\s*10\)\)/);
+assert.match(code, /console\.log\(calculateSum\(10\s*,\s*10\)\)/);
 ```
 
 You should have a `console.log` that calls the `calculateSum` function with the arguments `5` and `5`.
 
 ```js
-assert.match(code, /console.log\(calculateSum\(5\s*,\s*5\)\)/);
+assert.match(code, /console\.log\(calculateSum\(5\s*,\s*5\)\)/);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-photo-app/66984ec64a3652522e81c678.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-photo-app/66984ec64a3652522e81c678.md
@@ -46,7 +46,7 @@ After nesting the anchor (`a`) element, the only `p` element content visible in 
 
 ```js
 const pText = document.querySelectorAll('footer > p')[0].innerText.toLowerCase().replace(/\s+/g, ' ');
-assert.match(pText, /^no copyright - freecodecamp.org$/);
+assert.match(pText, /^no copyright - freecodecamp\.org$/);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-teacher-chatbot/66b59829dba144ff1351220f.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-teacher-chatbot/66b59829dba144ff1351220f.md
@@ -47,7 +47,7 @@ assert.equal(greeting, "My name is teacherBot.");
 You should have a `console` statement that logs the `greeting` variable to the console.
 
 ```js
-assert.match(code, /console.log\(.*greeting.*\)/);
+assert.match(code, /console\.log\(.*greeting.*\)/);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-teacher-chatbot/66b6e80d6c3f0b329c360283.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-teacher-chatbot/66b6e80d6c3f0b329c360283.md
@@ -18,7 +18,7 @@ Remember to replace `[subject]` with the `subject` variable and use proper templ
 Your `console` statement should output the message `Here is an example of accessing the first letter in the word [subject].`. 
 
 ```js
-assert.match(code, /console.log\(`Here\s+is\s+an\s+example\s+of\s+accessing\s+the\s+first\s+letter\s+in\s+the\s+word\s+\${subject}\.`\);?/);
+assert.match(code, /console\.log\(`Here\s+is\s+an\s+example\s+of\s+accessing\s+the\s+first\s+letter\s+in\s+the\s+word\s+\${subject}\.`\);?/);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-teacher-chatbot/66b6efddeca35833cd6f0b03.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-teacher-chatbot/66b6efddeca35833cd6f0b03.md
@@ -26,7 +26,7 @@ Inside the `console` statement, output the first letter of the `subject` variabl
 Your `console` statement should output the first letter of the `subject` variable using bracket notation and index `0`.
 
 ```js
-assert.match(code, /console.log\(subject\[0\]\);?/);
+assert.match(code, /console\.log\(subject\[0\]\);?/);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-teacher-chatbot/66b6f586767a1534f3097353.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-teacher-chatbot/66b6f586767a1534f3097353.md
@@ -18,13 +18,13 @@ Then add another `console` statement that outputs the second letter of the `subj
 Your `console` statement should output the message `Here is an example of accessing the second letter in the word [subject].`. 
 
 ```js
-assert.match(code, /console.log\(`Here\s+is\s+an\s+example\s+of\s+accessing\s+the\s+second\s+letter\s+in\s+the\s+word\s+\$\{subject\}\.`\);?/);
+assert.match(code, /console\.log\(`Here\s+is\s+an\s+example\s+of\s+accessing\s+the\s+second\s+letter\s+in\s+the\s+word\s+\$\{subject\}\.`\);?/);
 ```
 
 You should have another `console` statement that outputs the second letter of the `subject` variable using bracket notation index `1`.
 
 ```js
-assert.match(code, /console.log\(subject\[1\]\);?/);
+assert.match(code, /console\.log\(subject\[1\]\);?/);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-teacher-chatbot/66b6f80fca500635d1e8af8d.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-teacher-chatbot/66b6f80fca500635d1e8af8d.md
@@ -18,7 +18,7 @@ Remember to replace `[subject]` with the actual value of the `subject` variable 
 Your `console` statement should output the message `Here is an example of accessing the last letter in the word [subject].` Remember to use the correct template literal syntax.
 
 ```js
-assert.match(code, /console.log\(`Here\s+is\s+an\s+example\s+of\s+accessing\s+the\s+last\s+letter\s+in\s+the\s+word\s+\${subject}\.`\);?/);
+assert.match(code, /console\.log\(`Here\s+is\s+an\s+example\s+of\s+accessing\s+the\s+last\s+letter\s+in\s+the\s+word\s+\${subject}\.`\);?/);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-teacher-chatbot/66b6fdb76441c738719039fa.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-teacher-chatbot/66b6fdb76441c738719039fa.md
@@ -39,7 +39,7 @@ assert.strictEqual(lastCharacter, subject[subject.length - 1]);
 You should log the value of the `lastCharacter` variable to the `console`.
 
 ```js
-assert.match(code, /console.log\(lastCharacter\)/);
+assert.match(code, /console\.log\(lastCharacter\)/);
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

- - -
- Few cases of regex matching _any_ character, when it should be literal dot.