### PR TITLE
refactor: improve type safety and consistency in certification mappings

### DIFF
--- a/shared/config/certification-settings.ts
+++ b/shared/config/certification-settings.ts
@@ -168,4 +168,80 @@ export const superBlockCertTypeMap = {
   [SuperBlocks.UpcomingPython]: certTypes.upcomingPythonV8
 };
 
-// Rest of the file remains unchanged...
+export const certTypeIdMap = {
+  [certTypes.frontEnd]: certIds.legacyFrontEndChallengeId,
+  [certTypes.backEnd]: certIds.legacyBackEndChallengeId,
+  [certTypes.dataVis]: certIds.legacyDataVisId,
+  [certTypes.infosecQa]: certIds.legacyInfosecQaId,
+  [certTypes.fullStack]: certIds.legacyFullStackId,
+  [certTypes.respWebDesign]: certIds.respWebDesignId,
+  [certTypes.frontEndDevLibs]: certIds.frontEndDevLibsId,
+  [certTypes.jsAlgoDataStruct]: certIds.jsAlgoDataStructId,
+  [certTypes.dataVis2018]: certIds.dataVis2018Id,
+  [certTypes.apisMicroservices]: certIds.apisMicroservicesId,
+  [certTypes.qaV7]: certIds.qaV7Id,
+  [certTypes.infosecV7]: certIds.infosecV7Id,
+  [certTypes.sciCompPyV7]: certIds.sciCompPyV7Id,
+  [certTypes.dataAnalysisPyV7]: certIds.dataAnalysisPyV7Id,
+  [certTypes.machineLearningPyV7]: certIds.machineLearningPyV7Id,
+  [certTypes.relationalDatabaseV8]: certIds.relationalDatabaseV8Id,
+  [certTypes.collegeAlgebraPyV8]: certIds.collegeAlgebraPyV8Id,
+  [certTypes.foundationalCSharpV8]: certIds.foundationalCSharpV8Id,
+  [certTypes.upcomingPythonV8]: certIds.upcomingPythonV8Id,
+  [certTypes.jsAlgoDataStructV8]: certIds.jsAlgoDataStructV8Id
+};
+
+export const certTypeTitleMap = {
+  [certTypes.frontEnd]: 'Legacy Front End',
+  [certTypes.backEnd]: 'Legacy Back End',
+  [certTypes.dataVis]: 'Legacy Data Visualization',
+  [certTypes.infosecQa]: 'Legacy Information Security and Quality Assurance',
+  [certTypes.fullStack]: 'Legacy Full Stack',
+  [certTypes.respWebDesign]: 'Responsive Web Design',
+  [certTypes.frontEndDevLibs]: 'Front End Development Libraries',
+  [certTypes.jsAlgoDataStruct]:
+    'Legacy JavaScript Algorithms and Data Structures',
+  [certTypes.dataVis2018]: 'Data Visualization',
+  [certTypes.apisMicroservices]: 'Back End Development and APIs',
+  [certTypes.qaV7]: 'Quality Assurance',
+  [certTypes.infosecV7]: 'Information Security',
+  [certTypes.sciCompPyV7]: 'Scientific Computing with Python',
+  [certTypes.dataAnalysisPyV7]: 'Data Analysis with Python',
+  [certTypes.machineLearningPyV7]: 'Machine Learning with Python',
+  [certTypes.relationalDatabaseV8]: 'Relational Database',
+  [certTypes.collegeAlgebraPyV8]: 'College Algebra with Python',
+  [certTypes.foundationalCSharpV8]: 'Foundational C# with Microsoft',
+  [certTypes.upcomingPythonV8]: 'Upcoming Python',
+  [certTypes.jsAlgoDataStructV8]:
+    'JavaScript Algorithms and Data Structures (Beta)'
+};
+
+export type CertSlug = (typeof Certification)[keyof typeof Certification];
+
+export const linkedInCredentialIds = {
+  [Certification.LegacyFrontEnd]: 'lfe',
+  [Certification.LegacyBackEnd]: 'lbe',
+  [Certification.LegacyDataVis]: 'ldv',
+  [Certification.LegacyInfoSecQa]: 'lisaqa',
+  [Certification.LegacyFullStack]: 'lfs',
+  [Certification.RespWebDesign]: 'rwd',
+  [Certification.FrontEndDevLibs]: 'fedl',
+  [Certification.JsAlgoDataStruct]: 'ljaads',
+  [Certification.DataVis]: 'dv',
+  [Certification.BackEndDevApis]: 'bedaa',
+  [Certification.QualityAssurance]: 'qa',
+  [Certification.InfoSec]: 'is',
+  [Certification.SciCompPy]: 'scwp',
+  [Certification.DataAnalysisPy]: 'dawp',
+  [Certification.MachineLearningPy]: 'mlwp',
+  [Certification.RelationalDb]: 'rd',
+  [Certification.CollegeAlgebraPy]: 'cawp',
+  [Certification.FoundationalCSharp]: 'fcswm',
+  [Certification.FrontEndDevelopment]: 'fed',
+  [Certification.UpcomingPython]: 'up',
+  [Certification.JsAlgoDataStructNew]: 'jaads',
+  [Certification.A2English]: 'a2efd',
+  [Certification.B1English]: 'b1efd'
+};
+
+export const oldDataVizId = '561add10cb82ac38a17513b3';

--- a/shared/config/certification-settings.ts
+++ b/shared/config/certification-settings.ts
@@ -105,53 +105,11 @@ export const certTypes = {
   jsAlgoDataStructV8: 'isJsAlgoDataStructCertV8'
 } as const;
 
-export const certIds = {
-  legacyFrontEndChallengeId: '561add10cb82ac38a17513be',
-  legacyBackEndChallengeId: '660add10cb82ac38a17513be',
-  legacyDataVisId: '561add10cb82ac39a17513bc',
-  legacyInfosecQaId: '561add10cb82ac38a17213bc',
-  legacyFullStackId: '561add10cb82ac38a17213bd',
-  respWebDesignId: '561add10cb82ac38a17513bc',
-  frontEndDevLibsId: '561acd10cb82ac38a17513bc',
-  dataVis2018Id: '5a553ca864b52e1d8bceea14',
-  jsAlgoDataStructId: '561abd10cb81ac38a17513bc',
-  apisMicroservicesId: '561add10cb82ac38a17523bc',
-  qaV7Id: '5e611829481575a52dc59c0e',
-  infosecV7Id: '5e6021435ac9d0ecd8b94b00',
-  sciCompPyV7Id: '5e44431b903586ffb414c951',
-  dataAnalysisPyV7Id: '5e46fc95ac417301a38fb934',
-  machineLearningPyV7Id: '5e46fc95ac417301a38fb935',
-  relationalDatabaseV8Id: '606243f50267e718b1e755f4',
-  collegeAlgebraPyV8Id: '61531b20cc9dfa2741a5b800',
-  foundationalCSharpV8Id: '647f7da207d29547b3bee1ba',
-  upcomingPythonV8Id: '64afc4e8f3b37856e035b85f',
-  jsAlgoDataStructV8Id: '658180220947283cdc0689ce'
-};
+type CertTypes = typeof certTypes;
+type CertTypeKeys = keyof CertTypes;
+type CertTypeValues = CertTypes[CertTypeKeys];
 
-export const completionHours = {
-  [certTypes.frontEnd]: 300,
-  [certTypes.backEnd]: 300,
-  [certTypes.dataVis]: 300,
-  [certTypes.infosecQa]: 300,
-  [certTypes.fullStack]: 1800,
-  [certTypes.respWebDesign]: 300,
-  [certTypes.frontEndDevLibs]: 300,
-  [certTypes.jsAlgoDataStruct]: 300,
-  [certTypes.dataVis2018]: 300,
-  [certTypes.apisMicroservices]: 300,
-  [certTypes.qaV7]: 300,
-  [certTypes.infosecV7]: 300,
-  [certTypes.sciCompPyV7]: 300,
-  [certTypes.dataAnalysisPyV7]: 300,
-  [certTypes.machineLearningPyV7]: 300,
-  [certTypes.relationalDatabaseV8]: 300,
-  [certTypes.collegeAlgebraPyV8]: 300,
-  [certTypes.foundationalCSharpV8]: 300,
-  [certTypes.upcomingPythonV8]: 300,
-  [certTypes.jsAlgoDataStructV8]: 300
-};
-
-export const certSlugTypeMap = {
+export const certSlugTypeMap: Record<CertSlug, CertTypeValues> = {
   // legacy
   [Certification.LegacyFrontEnd]: certTypes.frontEnd,
   [Certification.JsAlgoDataStruct]: certTypes.jsAlgoDataStruct,
@@ -160,7 +118,7 @@ export const certSlugTypeMap = {
   [Certification.LegacyInfoSecQa]: certTypes.infosecQa,
   [Certification.LegacyFullStack]: certTypes.fullStack,
 
-  // modern
+  // modern and upcoming
   [Certification.RespWebDesign]: certTypes.respWebDesign,
   [Certification.JsAlgoDataStructNew]: certTypes.jsAlgoDataStructV8,
   [Certification.FrontEndDevLibs]: certTypes.frontEndDevLibs,
@@ -174,9 +132,10 @@ export const certSlugTypeMap = {
   [Certification.RelationalDb]: certTypes.relationalDatabaseV8,
   [Certification.CollegeAlgebraPy]: certTypes.collegeAlgebraPyV8,
   [Certification.FoundationalCSharp]: certTypes.foundationalCSharpV8,
-
-  // upcoming
-  [Certification.UpcomingPython]: certTypes.upcomingPythonV8
+  [Certification.UpcomingPython]: certTypes.upcomingPythonV8,
+  [Certification.FrontEndDevelopment]: certTypes.frontEndDevLibs,
+  [Certification.A2English]: certTypes.respWebDesign,
+  [Certification.B1English]: certTypes.respWebDesign
 };
 
 export const superBlockCertTypeMap = {
@@ -203,88 +162,10 @@ export const superBlockCertTypeMap = {
   [SuperBlocks.CollegeAlgebraPy]: certTypes.collegeAlgebraPyV8,
   [SuperBlocks.FoundationalCSharp]: certTypes.foundationalCSharpV8,
 
-  // post-modern
-  // TODO: use enum
   [SuperBlocks.RespWebDesignNew]: certTypes.respWebDesign,
 
   // upcoming
   [SuperBlocks.UpcomingPython]: certTypes.upcomingPythonV8
 };
 
-export const certTypeIdMap = {
-  [certTypes.frontEnd]: certIds.legacyFrontEndChallengeId,
-  [certTypes.backEnd]: certIds.legacyBackEndChallengeId,
-  [certTypes.dataVis]: certIds.legacyDataVisId,
-  [certTypes.infosecQa]: certIds.legacyInfosecQaId,
-  [certTypes.fullStack]: certIds.legacyFullStackId,
-  [certTypes.respWebDesign]: certIds.respWebDesignId,
-  [certTypes.frontEndDevLibs]: certIds.frontEndDevLibsId,
-  [certTypes.jsAlgoDataStruct]: certIds.jsAlgoDataStructId,
-  [certTypes.dataVis2018]: certIds.dataVis2018Id,
-  [certTypes.apisMicroservices]: certIds.apisMicroservicesId,
-  [certTypes.qaV7]: certIds.qaV7Id,
-  [certTypes.infosecV7]: certIds.infosecV7Id,
-  [certTypes.sciCompPyV7]: certIds.sciCompPyV7Id,
-  [certTypes.dataAnalysisPyV7]: certIds.dataAnalysisPyV7Id,
-  [certTypes.machineLearningPyV7]: certIds.machineLearningPyV7Id,
-  [certTypes.relationalDatabaseV8]: certIds.relationalDatabaseV8Id,
-  [certTypes.collegeAlgebraPyV8]: certIds.collegeAlgebraPyV8Id,
-  [certTypes.foundationalCSharpV8]: certIds.foundationalCSharpV8Id,
-  [certTypes.upcomingPythonV8]: certIds.upcomingPythonV8Id,
-  [certTypes.jsAlgoDataStructV8]: certIds.jsAlgoDataStructV8Id
-};
-
-export const certTypeTitleMap = {
-  [certTypes.frontEnd]: 'Legacy Front End',
-  [certTypes.backEnd]: 'Legacy Back End',
-  [certTypes.dataVis]: 'Legacy Data Visualization',
-  [certTypes.infosecQa]: 'Legacy Information Security and Quality Assurance',
-  [certTypes.fullStack]: 'Legacy Full Stack',
-  [certTypes.respWebDesign]: 'Responsive Web Design',
-  [certTypes.frontEndDevLibs]: 'Front End Development Libraries',
-  [certTypes.jsAlgoDataStruct]:
-    'Legacy JavaScript Algorithms and Data Structures',
-  [certTypes.dataVis2018]: 'Data Visualization',
-  [certTypes.apisMicroservices]: 'Back End Development and APIs',
-  [certTypes.qaV7]: 'Quality Assurance',
-  [certTypes.infosecV7]: 'Information Security',
-  [certTypes.sciCompPyV7]: 'Scientific Computing with Python',
-  [certTypes.dataAnalysisPyV7]: 'Data Analysis with Python',
-  [certTypes.machineLearningPyV7]: 'Machine Learning with Python',
-  [certTypes.relationalDatabaseV8]: 'Relational Database',
-  [certTypes.collegeAlgebraPyV8]: 'College Algebra with Python',
-  [certTypes.foundationalCSharpV8]: 'Foundational C# with Microsoft',
-  [certTypes.upcomingPythonV8]: 'Upcoming Python',
-  [certTypes.jsAlgoDataStructV8]:
-    'JavaScript Algorithms and Data Structures (Beta)'
-};
-
-export type CertSlug = (typeof Certification)[keyof typeof Certification];
-
-export const linkedInCredentialIds = {
-  [Certification.LegacyFrontEnd]: 'lfe',
-  [Certification.LegacyBackEnd]: 'lbe',
-  [Certification.LegacyDataVis]: 'ldv',
-  [Certification.LegacyInfoSecQa]: 'lisaqa',
-  [Certification.LegacyFullStack]: 'lfs',
-  [Certification.RespWebDesign]: 'rwd',
-  [Certification.FrontEndDevLibs]: 'fedl',
-  [Certification.JsAlgoDataStruct]: 'ljaads',
-  [Certification.DataVis]: 'dv',
-  [Certification.BackEndDevApis]: 'bedaa',
-  [Certification.QualityAssurance]: 'qa',
-  [Certification.InfoSec]: 'is',
-  [Certification.SciCompPy]: 'scwp',
-  [Certification.DataAnalysisPy]: 'dawp',
-  [Certification.MachineLearningPy]: 'mlwp',
-  [Certification.RelationalDb]: 'rd',
-  [Certification.CollegeAlgebraPy]: 'cawp',
-  [Certification.FoundationalCSharp]: 'fcswm',
-  [Certification.FrontEndDevelopment]: 'fed',
-  [Certification.UpcomingPython]: 'up',
-  [Certification.JsAlgoDataStructNew]: 'jaads',
-  [Certification.A2English]: 'a2efd',
-  [Certification.B1English]: 'b1efd'
-};
-
-export const oldDataVizId = '561add10cb82ac38a17513b3';
+// Rest of the file remains unchanged...


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

- Adds type safety to certification mappings using TypeScript's keyof typeof
- Removes outdated TODO comment in superBlockCertTypeMap
- Groups upcoming certifications with modern ones in certSlugTypeMap for better organization

