### PR TITLE
fix: Allow f-string implementation to pass tests

### DIFF
--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-list-comprehension-by-building-a-case-converter-program/657efa642593c5746acc5c81.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-list-comprehension-by-building-a-case-converter-program/657efa642593c5746acc5c81.md
@@ -22,7 +22,10 @@ You should assign the modified character to a variable named `converted_characte
         const convert_to_snake_case = __helpers.python.getDef("\n" + transformedCode, "convert_to_snake_case");
         const { function_body } = convert_to_snake_case;
 
-        assert.match(function_body, / +converted_character\s*=\s*("|')_\1\s*\+\s*char\.lower\s*\(\s*\)/);
+        const StrictRegexPattern = / +converted_character\s*=\s*("|')_\1\s*\+\s*char\.lower\s*\(\s*\)/;
+        const FStringPattern = /converted_character\s*=\s*f("|')_\{char\.lower\(\)\}\1/;
+        
+        assert.match(function_body, new RegExp(`${StrictRegexPattern.source}|${FStringPattern.source}`));
     }
 })
 ```


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #56836 

<!-- Feel free to add any additional description of changes below this line -->
