### PR TITLE
fix(curriculum): description for working with links lecture block

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -1736,7 +1736,9 @@
       },
       "lecture-working-with-links": {
         "title": "Working with Links",
-        "intro": ["Learn about using links in HTML with these lecture videos."]
+        "intro": [
+          "In these lecture videos, you will learn about the different <code>target</code> attribute values, absolute and relative links and the different links states."
+        ]
       },
       "review-basic-html": {
         "title": "Basic HTML Review",


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #56865

<!-- Feel free to add any additional description of changes below this line -->

### Description of Changes:
Updated the description for the "Working with Links" lecture intro text.
- **Previous Code:**
  ```json
  "intro": ["Learn about using links in HTML with these lecture videos."]

- **Updated code:**
```json
"intro": [
  "In these lecture videos, you will learn about the different <code>target</code> attribute values, absolute and relative links and the different links states."
]