### PR TITLE
chore(.github): optimise workflow usage

### DIFF
--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -14,6 +14,10 @@ on:
       - 'next-**'
       - 'e2e-**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-client:
     name: Build Client

--- a/.github/workflows/e2e-third-party.yml
+++ b/.github/workflows/e2e-third-party.yml
@@ -11,6 +11,10 @@ on:
   # to test this ad-hoc
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   do-everything:
     name: Build & Test

--- a/.github/workflows/e2e-with-new-api.yml
+++ b/.github/workflows/e2e-with-new-api.yml
@@ -13,6 +13,10 @@ on:
       - 'next-**'
       - 'e2e-**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-client:
     name: Build Client

--- a/.github/workflows/github-labeler.yaml
+++ b/.github/workflows/github-labeler.yaml
@@ -5,6 +5,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   triage:
     permissions:

--- a/.github/workflows/i18n-validate-builds.yml
+++ b/.github/workflows/i18n-validate-builds.yml
@@ -4,6 +4,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ci:
     name: Validate i18n Builds

--- a/.github/workflows/i18n-validate-prs.yml
+++ b/.github/workflows/i18n-validate-prs.yml
@@ -4,6 +4,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ci:
     name: Validate i18n Builds

--- a/.github/workflows/node.js-tests.yml
+++ b/.github/workflows/node.js-tests.yml
@@ -15,6 +15,10 @@ on:
   merge_group:
     types: [checks_requested]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/temporary-container-checks.yml
+++ b/.github/workflows/temporary-container-checks.yml
@@ -16,6 +16,10 @@ on:
       - 'next-**'
       - 'e2e-**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-client:
     name: Build Client (Container)

--- a/.github/workflows/temporary-container-checks.yml
+++ b/.github/workflows/temporary-container-checks.yml
@@ -1,6 +1,6 @@
 # TODO: remove this workflow once we use containers in the other workflows. This
 # workflow is intended to prevent regressions until that has been achieved.
-name: CI - E2E - Containers
+name: CI - E2E - Containers - Temp
 on:
   workflow_dispatch:
   workflow_run:


### PR DESCRIPTION
Prevents multiple of the same job on the same pull request

### Before this PR:
1. Open PR 100
    - Action 1 starts to run or is queued
2. Immediately push new commit to PR 100
    - Action 2 starts to run or is queued
3. Action 1 finishes
4. Action 2 finishes

### After this PR:

1. Open PR 100
    - Action 1 starts to run or is queued
2. Immediately push new commit to PR 100
    - Action 1 is cancelled [^1]
    - Action 2 starts to run or is queued
3. Action 2 finishes

[^1]: Technically, action 2 starts before action 1 is cancelled, because action 2 causes action 1 to cancel. https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs