### PR TITLE
fix(curriculum): Added Hint for Step 49 of Statistics Calculator

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-advanced-array-methods-by-building-a-statistics-calculator/6352fbb93a91a8272f838d42.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-advanced-array-methods-by-building-a-statistics-calculator/6352fbb93a91a8272f838d42.md
@@ -43,6 +43,12 @@ Your `map` callback should use the `**` operator.
 assert.match(code.split("getVariance")[1], /el\s*\*\*\s*2/);
 ```
 
+You are missing the initial value of the `reduce` function.
+
+```js
+assert.match(getVariance.toString(), /\.reduce\(\((\w+),\s+(\w+)\)\s+=>\s+(\w+)\s+\+\s+(\w+)\)/g);
+```
+
 # --seed--
 
 ## --seed-contents--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #56938

<!-- Feel free to add any additional description of changes below this line -->
I have corrected Step 49 of the Statistics Calculator, which now provides a useful hint if the initial value of the `reduce` function is missing.