### PR TITLE
fix: rdb challenge text color

### DIFF
--- a/client/src/templates/Challenges/codeally/show.tsx
+++ b/client/src/templates/Challenges/codeally/show.tsx
@@ -338,20 +338,19 @@ class ShowCodeAlly extends Component<ShowCodeAllyProps> {
                     </>
                   )}
                 <Alert variant='info'>
-                  <p>
-                    <Trans
-                      values={{ course: title }}
-                      i18nKey='learn.gitpod.continue-project'
+                  <Trans
+                    values={{ course: title }}
+                    i18nKey='learn.gitpod.continue-project'
+                  >
+                    <a
+                      href='https://gitpod.io/workspaces'
+                      rel='noopener noreferrer'
+                      target='_blank'
                     >
-                      <a
-                        href='https://gitpod.io/workspaces'
-                        rel='noopener noreferrer'
-                        target='_blank'
-                      >
-                        placeholder
-                      </a>
-                    </Trans>
-                  </p>
+                      placeholder
+                    </a>
+                  </Trans>
+                  <Spacer size='m' />
                   <Trans i18nKey='learn.gitpod.learn-more'>
                     <a
                       href='https://forum.freecodecamp.org/t/using-gitpod-in-the-curriculum/668669'


### PR DESCRIPTION
Not sure if this has always been there - go to an [RDB challenge](https://www.freecodecamp.org/learn/relational-database/learn-bash-by-building-a-boilerplate/build-a-boilerplate). Notice the alert with the blue background - in light mode, the first sentence is black - in dark mode, it's white and you can't read it. This makes it blue for both modes. Perhaps there's a bigger underlying CSS issue that's causing this. Storybook is showing that it should keep paragraph text blue.

Checklist:

Before:
<img width="700" alt="Screenshot 2024-10-31 at 11 41 29 AM" src="https://github.com/user-attachments/assets/fcc74c86-f844-4311-b03f-71420bc1f71f">

After:
<img width="722" alt="Screenshot 2024-10-31 at 11 41 22 AM" src="https://github.com/user-attachments/assets/5ee32b8d-a2cd-4dbd-9263-0e9504c578fc">

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
