### PR TITLE
fix: aa test supporting copy and background

### DIFF
--- a/client/src/components/landing/components/landing-top-b.tsx
+++ b/client/src/components/landing/components/landing-top-b.tsx
@@ -63,8 +63,9 @@ function LandingTop(): JSX.Element {
               id='content-start'
               className='mega-heading'
               data-test-label='landing-header'
+              data-playwright-test-label='landing-big-heading-1'
             >
-              {t('landing.big-heading-1-b')}
+              {t('landing.big-heading-1')}
             </h1>
             <p
               className='mega-heading'
@@ -77,12 +78,6 @@ function LandingTop(): JSX.Element {
               data-playwright-test-label='landing-big-heading-3'
             >
               {t('landing.big-heading-3')}
-            </p>
-            <p
-              className='mega-heading gradient-foreground'
-              data-playwright-test-label='landing-big-heading-4'
-            >
-              {t('landing.big-heading-4')}
             </p>
             <LogoRow />
             <Spacer size='m' />

--- a/client/src/components/landing/landing.css
+++ b/client/src/components/landing/landing.css
@@ -219,7 +219,7 @@ figcaption.caption {
 
 /* AB testing styles */
 .landing-page-b .mega-heading {
-  font-size: 2.5rem;
+  font-size: 2.2rem;
   margin: 0px 0px 2rem;
   font-weight: 700;
   line-height: 2rem;

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -69,7 +69,7 @@ function IndexPage({
       'show-benefits',
       false
     );
-
+    growthbook.getFeatureValue('landing-aa-test', false);
     return (
       <>
         <SEO title={t('metaTags:title')} />

--- a/e2e/landing.spec.ts
+++ b/e2e/landing.spec.ts
@@ -49,28 +49,7 @@ test.describe('Landing Top - Variation B', () => {
     await goToLandingPage(page);
   });
 
-  test('The component Landing-top renders correctly', async ({ page }) => {
-    await expect(
-      page
-        .getByRole('heading', { level: 1 })
-        .filter({ hasText: `${translations.landing['big-heading-1-b']}` })
-    ).toBeVisible();
-
-    const landingHeading2 = page.getByTestId('landing-big-heading-2');
-    await expect(landingHeading2).toHaveText(
-      translations.landing['big-heading-2']
-    );
-
-    const landingHeading3 = page.getByTestId('landing-big-heading-3');
-    await expect(landingHeading3).toHaveText(
-      translations.landing['big-heading-3']
-    );
-
-    const landingHeading4 = page.getByTestId('landing-big-heading-4');
-    await expect(landingHeading4).toHaveText(
-      translations.landing['big-heading-4']
-    );
-
+  test('The supporting copy renders correctly', async ({ page }) => {
     const landingH2Heading = page.getByTestId('landing-h2-heading-b');
     await expect(landingH2Heading).toHaveText(
       translations.landing['h2-heading-b'].replace(/<\/?strong>/g, '')
@@ -99,22 +78,7 @@ test.describe('Landing Top - Variation A', () => {
     await goToLandingPage(page);
   });
 
-  test('The component Landing-top renders correctly', async ({ page }) => {
-    const landingHeading1 = page.getByTestId('landing-big-heading-1');
-    await expect(landingHeading1).toHaveText(
-      translations.landing['big-heading-1']
-    );
-
-    const landingHeading2 = page.getByTestId('landing-big-heading-2');
-    await expect(landingHeading2).toHaveText(
-      translations.landing['big-heading-2']
-    );
-
-    const landingHeading3 = page.getByTestId('landing-big-heading-3');
-    await expect(landingHeading3).toHaveText(
-      translations.landing['big-heading-3']
-    );
-
+  test('The supporting copy renders correctly', async ({ page }) => {
     const landingH2Heading = page.getByTestId('landing-h2-heading');
     await expect(landingH2Heading).toHaveText(
       translations.landing['h2-heading']
@@ -147,6 +111,23 @@ test.describe('Landing Page', () => {
     for (const cta of await ctas.all()) {
       await expect(cta).toBeVisible();
     }
+  });
+
+  test('The headline renders correctly', async ({ page }) => {
+    const landingHeading1 = page.getByTestId('landing-big-heading-1');
+    await expect(landingHeading1).toHaveText(
+      translations.landing['big-heading-1']
+    );
+
+    const landingHeading2 = page.getByTestId('landing-big-heading-2');
+    await expect(landingHeading2).toHaveText(
+      translations.landing['big-heading-2']
+    );
+
+    const landingHeading3 = page.getByTestId('landing-big-heading-3');
+    await expect(landingHeading3).toHaveText(
+      translations.landing['big-heading-3']
+    );
   });
 
   test('Hero image should have an alt and a description', async ({


### PR DESCRIPTION
Reducing the domain of the ab test in the previous pr did not change the results dramatically.
With this pr, I am only testing the changes in the supporting copy and the background. 
I also added an aa test to check the validity of the test.

![Screenshot 2024-11-01 at 12 04 21 PM](https://github.com/user-attachments/assets/8497e9d5-2c2a-4626-baab-6a20616a350e)

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

ref: #54656

<!-- Feel free to add any additional description of changes below this line -->
