### PR TITLE
fix(client): python duplicated input

### DIFF
--- a/tools/client-plugins/browser-scripts/python-worker.ts
+++ b/tools/client-plugins/browser-scripts/python-worker.ts
@@ -101,6 +101,10 @@ function initRunPython() {
     };
   }
 
+  function __interruptExecution() {
+    postMessage({ type: 'reset' });
+  }
+
   // I tried setting jsglobals here, to provide 'input' and 'print' to python,
   // without having to modify the global window object. However, it didn't work
   // because pyodide needs access to that object. Instead, I used
@@ -109,7 +113,8 @@ function initRunPython() {
   // Make print available to python
   pyodide.registerJsModule('jscustom', {
     print,
-    input
+    input,
+    __interruptExecution
   });
   // Create fresh globals each time user code is run.
   // eslint-disable-next-line @typescript-eslint/no-unsafe-call
@@ -118,20 +123,29 @@ function initRunPython() {
   // have this set by default.
   // eslint-disable-next-line @typescript-eslint/no-unsafe-call
   globals.set('__name__', '__main__');
+
   // The runPython helper is a shortcut for running python code with our
   // custom globals.
   const runPython = (pyCode: string) =>
     pyodide!.runPython(pyCode, { globals }) as unknown;
+
   runPython(`
+  from pyodide.ffi import JsException
+
   import jscustom
   from jscustom import print
   from jscustom import input
+
   def __wrap(func):
     def fn(*args):
-      data = func(*args)
-      if data.type == 'cancel':
-        raise KeyboardInterrupt(data.value)
-      return data.value
+      try:
+        data = func(*args)
+        if data.type == 'cancel':
+          raise KeyboardInterrupt(data.value)
+        return data.value
+      except JsException:
+        jscustom.__interruptExecution()
+        raise
     return fn
   input = __wrap(input)
   `);


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Closes #53741

- - -
- When `jscustom.input` time outs `pyodide.ffi.JsException` is raised. Or breaks in different ways too, I guess, locally I was getting different specific error than in production.
- I'm not sure how to force keyboard interrupt in the fCC's terminal, `Ctrl + C` doesn't seem to do anything for me. I'm right now assuming, it still would be `pyodide.ffi.JsException` raised in such case, as it happens in the JS _code_.
- I've tried to use custom `signal.SIGINT` handler, to handle all `KeyboardInterrupt`s. It was only partially working, as it actually required the literal keyboard interrupt, not `KeyboardInterrupt` raised by code. In the latter case handler would not be executed.
- _interrupt_ is not very precise right now. Execution still continues further, once terminal is cleared.

What happens step-by-step:
1. `input` time outs, `pyodide.ffi.JsException` is raised.
1. Exception is handled by the code wrapped around `input` function. `jscustom.__interruptExecution` sends `reset` message.
1. Terminal is reset. No duplicated inputs.
1. Exception is re-raised to be handled (or not) by user code.