### PR TITLE
fix(client): add doctype to preview iframe

### DIFF
--- a/client/src/templates/Challenges/utils/frame.ts
+++ b/client/src/templates/Challenges/utils/frame.ts
@@ -372,7 +372,7 @@ function writeToFrame(content: string, frame?: FrameDocument) {
   // to be null at this point.
   if (frame) {
     frame.open();
-    frame.write(content);
+    frame.write('<!DOCTYPE html>' + content);
     frame.close();
   }
 }

--- a/client/src/templates/Challenges/utils/frame.ts
+++ b/client/src/templates/Challenges/utils/frame.ts
@@ -378,12 +378,8 @@ function writeToFrame(content: string, frame?: FrameDocument) {
 }
 
 const writeContentToFrame = (frameContext: Context) => {
-  let doctype = '';
-
-  if (frameContext.sources.contents) {
-    doctype =
-      frameContext.sources.contents.match(/^<!DOCTYPE html>/i)?.[0] || '';
-  }
+  const doctype =
+    frameContext.sources.contents?.match(/^<!DOCTYPE html>/i)?.[0] || '';
 
   writeToFrame(
     doctype + createHeader(frameContext.element.id) + frameContext.build,

--- a/client/src/templates/Challenges/utils/frame.ts
+++ b/client/src/templates/Challenges/utils/frame.ts
@@ -372,14 +372,21 @@ function writeToFrame(content: string, frame?: FrameDocument) {
   // to be null at this point.
   if (frame) {
     frame.open();
-    frame.write('<!DOCTYPE html>' + content);
+    frame.write(content);
     frame.close();
   }
 }
 
 const writeContentToFrame = (frameContext: Context) => {
+  let doctype = '';
+
+  if (frameContext.sources.contents) {
+    doctype =
+      frameContext.sources.contents.match(/^<!DOCTYPE html>/i)?.[0] || '';
+  }
+
   writeToFrame(
-    createHeader(frameContext.element.id) + frameContext.build,
+    doctype + createHeader(frameContext.element.id) + frameContext.build,
     frameContext.document
   );
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #56660

The preview iframe is running in quirks mode because it's missing the doctype. Example of incorrect output can be found in the issue.

I tried a few things that didn't work, so I ended up adding it to the frame.write(). It's a simple solution and seems to work just fine.
