### PR TITLE
fix(curriculum): use "an" with HTML heading tags

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/inherit-styles-from-the-body-element.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/inherit-styles-from-the-body-element.md
@@ -15,7 +15,7 @@ Remember, you can style your `body` element just like any other HTML element, an
 
 # --instructions--
 
-First, create a `h1` element with the text `Hello World`
+First, create an `h1` element with the text `Hello World`.
 
 Then, let's give all elements on your page the color of `green` by adding `color: green;` to your `body` element's style declaration.
 

--- a/curriculum/challenges/english/03-front-end-development-libraries/bootstrap/label-bootstrap-wells.md
+++ b/curriculum/challenges/english/03-front-end-development-libraries/bootstrap/label-bootstrap-wells.md
@@ -10,9 +10,9 @@ dashedName: label-bootstrap-wells
 
 For the sake of clarity, let's label both of our wells with their ids.
 
-Above your left-well, inside its `col-xs-6` `div` element, add a `h4` element with the text `#left-well`.
+Above your left-well, inside its `col-xs-6` `div` element, add an `h4` element with the text `#left-well`.
 
-Above your right-well, inside its `col-xs-6` `div` element, add a `h4` element with the text `#right-well`.
+Above your right-well, inside its `col-xs-6` `div` element, add an `h4` element with the text `#right-well`.
 
 # --hints--
 

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-typography-by-building-a-nutrition-label/615f51e4e5b24a6e80eccce1.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-typography-by-building-a-nutrition-label/615f51e4e5b24a6e80eccce1.md
@@ -7,7 +7,7 @@ dashedName: step-30
 
 # --description--
 
-Within your `.calories-info` element, create a `div` element. Give that `div` element a `class` attribute set to `left-container`. Within the newly created `div` element, create a `h2` element with the text `Amount per serving`. Give the `h2` element a `class` attribute set to `bold small-text`.
+Within your `.calories-info` element, create a `div` element. Give that `div` element a `class` attribute set to `left-container`. Within the newly created `div` element, create an `h2` element with the text `Amount per serving`. Give the `h2` element a `class` attribute set to `bold small-text`.
 
 # --hints--
 

--- a/curriculum/challenges/english/16-the-odin-project/top-build-a-recipe-project/top-build-a-recipe-project.md
+++ b/curriculum/challenges/english/16-the-odin-project/top-build-a-recipe-project/top-build-a-recipe-project.md
@@ -51,7 +51,7 @@ You should have a `title` element within the `head` element that contains the te
 assert(document.querySelectorAll('HEAD > TITLE')[0].innerText == 'The Odin Recipes');
 ```
 
-You should have a `h1` element within your `body` element that contains the text
+You should have an `h1` element within your `body` element that contains the text
 `Creamy Chocolate Fudge`.
 
 ```js

--- a/curriculum/challenges/english/25-front-end-development/lab-contact-form/66f26c32ec6f90df01a44f60.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-contact-form/66f26c32ec6f90df01a44f60.md
@@ -18,7 +18,7 @@ demoType: onClick
 
 3. Within the `form` element, you should have the following elements and input fields:
 
-   - A `h2` element with some text.
+   - An `h2` element with some text.
    - A text input field for the name with the `type` set to `text` and `id`, `name`, `required` attributes.
    - An email input field with the `type` set to `email` and `id`, `name`, `required` attributes.
    - A textarea for the message with `id`, `name`, and the `required` attribute.

--- a/curriculum/challenges/english/25-front-end-development/lab-event-hub/66ebd4ae2812430bb883c787.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-event-hub/66ebd4ae2812430bb883c787.md
@@ -15,7 +15,7 @@ Fulfill the user stories below and get all the tests to pass to complete the lab
 **User Stories:**
 
 1. You should have a `header` element.
-1. Inside the `header` element, you should have a `h1` element that contains the text `Event Hub`, and a `nav` element.
+1. Inside the `header` element, you should have an `h1` element that contains the text `Event Hub`, and a `nav` element.
 1. Inside the `nav` element, you should have an unordered list of two items containing links to different sections of the page. The first item should have the text `Upcoming Events`, and the second item should have the text `Past Events`.
 1. Each link should be represented by an `a` element with an `href` attribute that links to the corresponding section of the page, `#upcoming-events` and `#past-events` respectively.
 1. You should have a `main` element that contains the different sections of the page.
@@ -25,7 +25,7 @@ Fulfill the user stories below and get all the tests to pass to complete the lab
    
    - An `h2` element with the text `Upcoming Events`.
    - Two `article` elements. Each article should represent an event, and it should have :
-      - A `h3` element for the event title.
+      - An `h3` element for the event title.
       - A `p` element for the event description. You can add a date at the bottom if you like.
 
 1. The second `section` element should have an `id` attribute with the value `past-events`.
@@ -56,7 +56,7 @@ Your `header` element should come after the opening `body` tag.
 assert.equal(document.querySelector("body")?.firstElementChild?.tagName, "HEADER");
 ```
 
-Inside the `header` element, you should have a `h1` element that contains the text `Event Hub`.
+Inside the `header` element, you should have an `h1` element that contains the text `Event Hub`.
 
 ```js
 const h1Element = document.querySelector('header h1');

--- a/curriculum/challenges/english/25-front-end-development/workshop-nutritional-label/615f51e4e5b24a6e80eccce1.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-nutritional-label/615f51e4e5b24a6e80eccce1.md
@@ -7,7 +7,7 @@ dashedName: step-30
 
 # --description--
 
-Within your `.calories-info` element, create a `div` element. Give that `div` element a `class` attribute set to `left-container`. Within the newly created `div` element, create a `h2` element with the text `Amount per serving`. Give the `h2` element a `class` attribute set to `bold small-text`.
+Within your `.calories-info` element, create a `div` element. Give that `div` element a `class` attribute set to `left-container`. Within the newly created `div` element, create an `h2` element with the text `Amount per serving`. Give the `h2` element a `class` attribute set to `bold small-text`.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

I found a couple of instances in the FSD content where "a" is used with HTML heading tags, so I just went through the entire code base and fixed all of them.

<!-- Feel free to add any additional description of changes below this line -->
