### PR TITLE
fix(learn): fixed console panel overlaping with preview

### DIFF
--- a/client/src/templates/Challenges/components/preview.css
+++ b/client/src/templates/Challenges/components/preview.css
@@ -1,7 +1,6 @@
 .challenge-preview,
 .challenge-preview-frame {
   height: 100%;
-  min-height: 70vh;
   width: 100%;
   padding: 0;
   margin: 0;


### PR DESCRIPTION


Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] I have tested these changes either locally on my machine, or GitPod.
- [x] My pull request targets the `main` branch of freeCodeCamp.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #57028

<!-- Feel free to add any additional description of changes below this line -->


## Description
Fixes #57028

Removed `min-height: 70vh` from the preview panel CSS to prevent overlap between the console and preview panels in step-based challenges.



> css:client/src/templates/Challenges/components/preview.css
```

// Removed the fixed minimum height constraint that was causing the overlap
.challenge-preview,
.challenge-preview-frame {
height: 100%;
width: 100%;
padding: 0;
margin: 0;
border: none;
background-color: white;
}
```
