### PR TITLE
fix(api): delete user's exam attempts with account

### DIFF
--- a/api/__mocks__/env-exam.ts
+++ b/api/__mocks__/env-exam.ts
@@ -343,9 +343,7 @@ export const exam: EnvExam = {
 };
 
 export async function seedEnvExam() {
-  await fastifyTestInstance.prisma.envExamAttempt.deleteMany({});
-  await fastifyTestInstance.prisma.envGeneratedExam.deleteMany({});
-  await fastifyTestInstance.prisma.envExam.deleteMany({});
+  await clearEnvExam();
 
   await fastifyTestInstance.prisma.envExam.create({
     data: exam
@@ -368,4 +366,16 @@ export async function seedEnvExam() {
   //     //
   //   }
   // }
+}
+
+export async function clearEnvExam() {
+  await fastifyTestInstance.prisma.envExamAttempt.deleteMany({});
+  await fastifyTestInstance.prisma.envGeneratedExam.deleteMany({});
+  await fastifyTestInstance.prisma.envExam.deleteMany({});
+}
+
+export async function seedEnvExamAttempt() {
+  await fastifyTestInstance.prisma.envExamAttempt.create({
+    data: examAttempt
+  });
 }

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -277,7 +277,7 @@ model EnvExamAttempt {
   needsRetake        Boolean
 
   // Relations
-  user          user             @relation(fields: [userId], references: [id])
+  user          user             @relation(fields: [userId], references: [id], onDelete: Cascade)
   exam          EnvExam          @relation(fields: [examId], references: [id])
   generatedExam EnvGeneratedExam @relation(fields: [generatedExamId], references: [id])
 }

--- a/api/src/exam-environment/routes/exam-environment.test.ts
+++ b/api/src/exam-environment/routes/exam-environment.test.ts
@@ -42,6 +42,10 @@ describe('/exam-environment/', () => {
         res.body.examEnvironmentAuthorizationToken;
     });
 
+    afterAll(async () => {
+      await mock.clearEnvExam();
+    });
+
     describe('POST /exam-environment/exam/attempt', () => {
       afterEach(async () => {
         await fastifyTestInstance.prisma.envExamAttempt.deleteMany();

--- a/api/src/routes/protected/user.test.ts
+++ b/api/src/routes/protected/user.test.ts
@@ -16,6 +16,11 @@ import {
   createSuperRequest
 } from '../../../jest.utils';
 import { JWT_SECRET } from '../../utils/env';
+import {
+  clearEnvExam,
+  seedEnvExam,
+  seedEnvExamAttempt
+} from '../../../__mocks__/env-exam';
 import { getMsTranscriptApiUrl } from './user';
 
 const mockedFetch = jest.fn();
@@ -336,6 +341,10 @@ describe('userRoutes', () => {
     });
 
     describe('/account/delete', () => {
+      beforeEach(async () => {
+        await seedEnvExam();
+        await seedEnvExamAttempt();
+      });
       afterEach(async () => {
         await fastifyTestInstance.prisma.userToken.deleteMany({
           where: { OR: [{ userId: defaultUserId }, { userId: otherUserId }] }
@@ -343,6 +352,7 @@ describe('userRoutes', () => {
         await fastifyTestInstance.prisma.msUsername.deleteMany({
           where: { OR: [{ userId: defaultUserId }, { userId: otherUserId }] }
         });
+        await clearEnvExam();
       });
 
       test('POST returns 200 status code with empty object', async () => {
@@ -397,6 +407,18 @@ describe('userRoutes', () => {
           ])
         );
         expect(setCookie).toHaveLength(3);
+      });
+
+      test("POST deletes all the user's exam attempts", async () => {
+        const examAttempts =
+          await fastifyTestInstance.prisma.envExamAttempt.findMany();
+        expect(examAttempts).toHaveLength(1);
+
+        await superPost('/account/delete');
+
+        const examAttemptsAfter =
+          await fastifyTestInstance.prisma.envExamAttempt.findMany();
+        expect(examAttemptsAfter).toHaveLength(0);
       });
     });
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Without this, Prisma attempts to delete the user, sees that this would break referential integrity and throws an error.

The other way to avoid the issue was to make the relation optional, i.e. allow exam attempts to exist without a corresponding user, but @ShaunSHamilton confirmed that this is not what's desired.

<!-- Feel free to add any additional description of changes below this line -->
