### PR TITLE
fix(api): increase max message size for sentry

### DIFF
--- a/api/src/plugins/error-handling.ts
+++ b/api/src/plugins/error-handling.ts
@@ -15,6 +15,7 @@ import { getRedirectParams } from '../utils/redirection';
 const errorHandling: FastifyPluginCallback = (fastify, _options, done) => {
   void fastify.register(fastifySentry, {
     dsn: SENTRY_DSN,
+    maxValueLength: 8192, // the default is 250, which is too small.
     // No need to initialize if DSN is not provided (e.g. in development and
     // test environments)
     skipInit: !SENTRY_DSN,


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

As an example: 

```
Invalid `fastify.prisma.user.delete()` invocation in
/home/node/fcc/api/src/routes/protected/user.js:78:41

  75 await fastify.prisma.survey.deleteMany({
  76     where: { userId: req.user.id }
  77 });
→ 78 await fastify.prisma.user.delete(
The cha...
```

the error was cut off _just_ before it could tell me what was wrong.

<!-- Feel free to add any additional description of changes below this line -->
