### PR TITLE
fix(client): review pages

### DIFF
--- a/client/src/templates/Challenges/generic/show.tsx
+++ b/client/src/templates/Challenges/generic/show.tsx
@@ -254,7 +254,7 @@ const ShowGeneric = ({
                 />
               )}
 
-              {!!questions && (
+              {questions.length > 0 && (
                 <MultipleChoiceQuestions
                   questions={questions}
                   selectedOptions={selectedMcqOptions}

--- a/curriculum/get-challenges.js
+++ b/curriculum/get-challenges.js
@@ -324,6 +324,7 @@ function generateChallengeCreator(lang, englishPath, i18nPath) {
 
     if (!challenge.description) challenge.description = '';
     if (!challenge.instructions) challenge.instructions = '';
+    if (!challenge.questions) challenge.questions = [];
 
     // const superOrder = getSuperOrder(meta.superBlock);
     // NOTE: Use this version when a super block is in beta.

--- a/curriculum/schema/challenge-schema.js
+++ b/curriculum/schema/challenge-schema.js
@@ -243,7 +243,7 @@ const schema = Joi.object()
         challengeTypes.theOdinProject
       ],
       then: Joi.array().items(questionJoi).min(1).required(),
-      otherwise: Joi.forbidden()
+      otherwise: Joi.array().length(0)
     }),
     quizzes: Joi.when('challengeType', {
       is: challengeTypes.quiz,


### PR DESCRIPTION
The review pages are giving a runtime error after [commit.](https://github.com/freeCodeCamp/freeCodeCamp/pull/56825/files#diff-08e9eab8f3640452df1f47fa8728d549440cd0d25bf4e282032cefb0652be097R257) This defaults the questions to an empty array.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
