### PR TITLE
fix(curriculum): enhance calorie counter step 45 test flexibility and accuracy

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-form-validation-by-building-a-calorie-counter/63c2164c0df38a382062c4af.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-form-validation-by-building-a-calorie-counter/63c2164c0df38a382062c4af.md
@@ -18,19 +18,19 @@ This will return a `NodeList` of all the text inputs in the form. You can then a
 You should pass the string `input[type="text"]` to the `querySelectorAll()` method.
 
 ```js
-assert.match(addEntry.toString(), /entryNumber\s*=\s*targetInputContainer\.querySelectorAll\(\s*'\s*input\s*\[\s*type\s*=\s*"text"\s*]\s*'\s*\)/)
+assert.match(addEntry.toString(), /entryNumber\s*=\s*targetInputContainer\.querySelectorAll\(\s*("|')\s*input\s*\[\s*type\s*=\s*("|')text\2\s*]\s*\1\s*\)/)
 ```
 
 You should access the `length` property of your `querySelectorAll()`.
 
 ```js
-assert.match(addEntry.toString(), /\.querySelectorAll\(\s*'\s*input\s*\[\s*type\s*=\s*"text"\s*]\s*'\s*\)\.length/)
+assert.match(addEntry.toString(), /\.querySelectorAll\(.*\)\.(?=(length))(\1$|\1\s*;)/)
 ```
 
 Your `entryNumber` variable should be the `length` of the `querySelectorAll`.
 
 ```js
-assert.match(addEntry.toString(), /entryNumber\s*=\s*targetInputContainer\.querySelectorAll\(\s*'\s*input\s*\[\s*type\s*=\s*"text"\s*]\s*'\s*\)\.length/)
+assert.match(addEntry.toString(), /entryNumber\s*=\s*targetInputContainer\.querySelectorAll\(\s*("|')\s*input\s*\[\s*type\s*=\s*("|')text\2\s*]\s*\1\s*\)\.(?=(length))(\3$|\3\s*;)/)
 ```
 
 # --seed--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-form-validation-by-building-a-calorie-counter/63c2164c0df38a382062c4af.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-form-validation-by-building-a-calorie-counter/63c2164c0df38a382062c4af.md
@@ -9,7 +9,7 @@ dashedName: step-45
 
 Each entry will have a text input for the entry's name, and a number input for the calories. To get a count of the number of entries, you can query by text inputs. Note that you cannot query by number inputs, as you have an extra number input for the user's calorie budget.
 
-Pass the string `input[type="text"]` to the `querySelectorAll()` method. Remember that you will need to use single quotes for your string, so that you can use double quotes within.
+Pass the string `input[type="text"]` to the `querySelectorAll()` method. Remember that if you use single quotes for your string, you must also use double quotes within it (or vice-versa).
 
 This will return a `NodeList` of all the text inputs in the form. You can then access the `length` property of the `NodeList` to get the number of entries. Do this on the same line.
 


### PR DESCRIPTION
This fix enhances the flexibility and accuracy of the checks done for step 45.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #57090

<!-- Feel free to add any additional description of changes below this line -->
The 3 asserts in this step were all changed as follows:
- the first one was changed to allow single or double outer quotes and single or double inner quotes. 
- the second one was simplified to not repeat the full regex pattern that was in the first and instead to focus on checking the length property is there and is not followed by any other character (like parenthesis). The check optionally allows the presence of semicolon at the end of the line.
- the third check was changed to allow single or double outer quotes and single or double inner quotes plus the length property check was enforced (to not allow any character after the property - like parenthesis - but spaces and/or a final semicolon are accepted)

Thank you for your review.