### PR TITLE
chore(curriculum): add blockLayout when missing from meta

### DIFF
--- a/client/src/templates/Introduction/components/block.test.tsx
+++ b/client/src/templates/Introduction/components/block.test.tsx
@@ -13,7 +13,7 @@ import {
   BilibiliIds
 } from '../../../redux/prop-types';
 import { isAuditedSuperBlock } from '../../../../../shared/utils/is-audited';
-import { BlockTypes } from '../../../../../shared/config/blocks';
+import { BlockLayouts, BlockTypes } from '../../../../../shared/config/blocks';
 import Block from './block';
 
 jest.mock('../../../../../shared/utils/is-audited', () => ({
@@ -22,10 +22,12 @@ jest.mock('../../../../../shared/utils/is-audited', () => ({
 
 const defaultProps = {
   block: 'test-block',
+  blockType: null,
   challenges: [
     {
       block: 'testblock',
       blockType: BlockTypes.lab,
+      blockLayout: BlockLayouts.ChallengeGrid,
       certification: 'mockCertification',
       challengeOrder: 1,
       challengeType: 0,

--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -461,7 +461,7 @@ class Block extends Component<BlockProps> {
     return (
       <>
         {blockRenderer()}
-        {isGridBlock && !isProjectBlock ? null : <Spacer size='m' />}
+        {(!isGridBlock || isProjectBlock) && <Spacer size='m' />}
       </>
     );
   }

--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -444,23 +444,19 @@ class Block extends Component<BlockProps> {
       </ScrollableAnchor>
     );
 
-    const blockRenderer = () => {
-      const blockLayout = challenges[0].blockLayout;
-
-      if (blockLayout === BlockLayouts.ChallengeGrid) return ChallengeGridBlock;
-      if (blockLayout === BlockLayouts.ChallengeList) return ChallengeListBlock;
-      if (blockLayout === BlockLayouts.Link) return LinkBlock;
-      if (blockLayout === BlockLayouts.ProjectList) return ProjectListBlock;
-      if (blockLayout === BlockLayouts.LegacyLink) return LegacyLinkBlock;
-      if (blockLayout === BlockLayouts.LegacyChallengeList)
-        return LegacyChallengeListBlock;
-      if (blockLayout === BlockLayouts.LegacyChallengeGrid)
-        return LegacyChallengeGridBlock;
+    const layoutToComponent = {
+      [BlockLayouts.ChallengeGrid]: ChallengeGridBlock,
+      [BlockLayouts.ChallengeList]: ChallengeListBlock,
+      [BlockLayouts.Link]: LinkBlock,
+      [BlockLayouts.ProjectList]: ProjectListBlock,
+      [BlockLayouts.LegacyLink]: LegacyLinkBlock,
+      [BlockLayouts.LegacyChallengeList]: LegacyChallengeListBlock,
+      [BlockLayouts.LegacyChallengeGrid]: LegacyChallengeGridBlock
     };
 
     return (
       <>
-        {blockRenderer()}
+        {layoutToComponent[challenges[0].blockLayout]}
         {(!isGridBlock || isProjectBlock) && <Spacer size='m' />}
       </>
     );

--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -447,16 +447,6 @@ class Block extends Component<BlockProps> {
     const blockRenderer = () => {
       const blockLayout = challenges[0].blockLayout;
 
-      // `blockLayout` property isn't available in all challenges
-      if (!blockLayout) {
-        if (isProjectBlock)
-          return isGridBlock ? LegacyLinkBlock : ProjectListBlock;
-        return isGridBlock
-          ? LegacyChallengeGridBlock
-          : LegacyChallengeListBlock;
-      }
-
-      // blockLayout is only being used in new certs at the moment, so I made some new components for them for now to not interfere with the existing ones
       if (blockLayout === BlockLayouts.ChallengeGrid) return ChallengeGridBlock;
       if (blockLayout === BlockLayouts.ChallengeList) return ChallengeListBlock;
       if (blockLayout === BlockLayouts.Link) return LinkBlock;

--- a/curriculum/challenges/_meta/a2-english-for-developers-certification-exam/meta.json
+++ b/curriculum/challenges/_meta/a2-english-for-developers-certification-exam/meta.json
@@ -10,5 +10,6 @@
       "id": "6721db5d9f0c116e6a0fe25a",
       "title": "A2 English for Developers Certification Exam"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/a2-english-for-developers-certification-exam/meta.json
+++ b/curriculum/challenges/_meta/a2-english-for-developers-certification-exam/meta.json
@@ -11,5 +11,5 @@
       "title": "A2 English for Developers Certification Exam"
     }
   ],
-  "blockLayout": "legacy-challenge-grid"
+  "blockLayout": "project-list"
 }

--- a/curriculum/challenges/_meta/add-logic-to-c-sharp-console-applications/meta.json
+++ b/curriculum/challenges/_meta/add-logic-to-c-sharp-console-applications/meta.json
@@ -38,5 +38,6 @@
       "id": "647f882207d29547b3bee1c0",
       "title": "Trophy - Add Logic to C# Console Applications"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/advanced-node-and-express/meta.json
+++ b/curriculum/challenges/_meta/advanced-node-and-express/meta.json
@@ -94,5 +94,6 @@
       "id": "589fc832f9fc0f352b528e79",
       "title": "Send and Display Chat Messages"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/algorithms/meta.json
+++ b/curriculum/challenges/_meta/algorithms/meta.json
@@ -46,5 +46,6 @@
       "id": "61abc7ebf3029b56226de5b6",
       "title": "Implement Binary Search"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/applied-accessibility/meta.json
+++ b/curriculum/challenges/_meta/applied-accessibility/meta.json
@@ -94,5 +94,6 @@
       "id": "587d7790367417b2b2512ab1",
       "title": "Use tabindex to Specify the Order of Keyboard Focus for Several Elements"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/applied-visual-design/meta.json
+++ b/curriculum/challenges/_meta/applied-visual-design/meta.json
@@ -214,5 +214,6 @@
       "id": "587d78a9367417b2b2512aea",
       "title": "Make Motion More Natural Using a Bezier Curve"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/back-end-development-and-apis-projects/meta.json
+++ b/curriculum/challenges/_meta/back-end-development-and-apis-projects/meta.json
@@ -26,5 +26,6 @@
       "id": "bd7158d8c443edefaeb5bd0f",
       "title": "File Metadata Microservice"
     }
-  ]
+  ],
+  "blockLayout": "project-list"
 }

--- a/curriculum/challenges/_meta/basic-algorithm-scripting/meta.json
+++ b/curriculum/challenges/_meta/basic-algorithm-scripting/meta.json
@@ -70,5 +70,6 @@
       "id": "a9bd25c716030ec90084d8a1",
       "title": "Chunky Monkey"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/basic-css/meta.json
+++ b/curriculum/challenges/_meta/basic-css/meta.json
@@ -182,5 +182,6 @@
       "id": "5a9d72ad424fe3d0e10cad16",
       "title": "Use a media query to change a variable"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/basic-data-structures/meta.json
+++ b/curriculum/challenges/_meta/basic-data-structures/meta.json
@@ -86,5 +86,6 @@
       "id": "587d7b7d367417b2b2512b1f",
       "title": "Modify an Array Stored in an Object"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/basic-html-and-html5/meta.json
+++ b/curriculum/challenges/_meta/basic-html-and-html5/meta.json
@@ -118,5 +118,6 @@
       "id": "587d78aa367417b2b2512aec",
       "title": "Define the Head and Body of an HTML Document"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/basic-javascript/meta.json
+++ b/curriculum/challenges/_meta/basic-javascript/meta.json
@@ -458,5 +458,6 @@
       "id": "5cc0bd7a49b71cb96132e54c",
       "title": "Use Recursion to Create a Range of Numbers"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/basic-node-and-express/meta.json
+++ b/curriculum/challenges/_meta/basic-node-and-express/meta.json
@@ -54,5 +54,6 @@
       "id": "587d7fb2367417b2b2512bf8",
       "title": "Get Data from POST Requests"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/bootstrap/meta.json
+++ b/curriculum/challenges/_meta/bootstrap/meta.json
@@ -135,5 +135,6 @@
       "id": "bad87fee1348bd9aec908857",
       "title": "Use Comments to Clarify Code"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/build-a-budget-app-project/meta.json
+++ b/curriculum/challenges/_meta/build-a-budget-app-project/meta.json
@@ -1,7 +1,7 @@
 {
   "name": "Build a Budget App Project",
   "isUpcomingChange": false,
-  "usesMultifileEditor": true,  
+  "usesMultifileEditor": true,
   "dashedName": "build-a-budget-app-project",
   "order": 13,
   "superBlock": "scientific-computing-with-python",
@@ -11,5 +11,6 @@
       "title": "Build a Budget App Project"
     }
   ],
-  "helpCategory": "Python"
+  "helpCategory": "Python",
+  "blockLayout": "legacy-link"
 }

--- a/curriculum/challenges/_meta/build-a-cash-register-project/meta.json
+++ b/curriculum/challenges/_meta/build-a-cash-register-project/meta.json
@@ -11,5 +11,6 @@
       "id": "657bdcc3a322aae1eac38392",
       "title": "Build a Cash Register"
     }
-  ]
+  ],
+  "blockLayout": "legacy-link"
 }

--- a/curriculum/challenges/_meta/build-a-celestial-bodies-database-project/meta.json
+++ b/curriculum/challenges/_meta/build-a-celestial-bodies-database-project/meta.json
@@ -10,5 +10,6 @@
       "id": "5f1a4ef5d5d6b5ab580fc6ae",
       "title": "Build a Celestial Bodies Database"
     }
-  ]
+  ],
+  "blockLayout": "project-list"
 }

--- a/curriculum/challenges/_meta/build-a-data-graph-explorer-project/meta.json
+++ b/curriculum/challenges/_meta/build-a-data-graph-explorer-project/meta.json
@@ -10,5 +10,6 @@
       "id": "63d8402e39c73468b059cd43",
       "title": "Build a Data Graph Explorer"
     }
-  ]
+  ],
+  "blockLayout": "project-list"
 }

--- a/curriculum/challenges/_meta/build-a-financial-calculator-project/meta.json
+++ b/curriculum/challenges/_meta/build-a-financial-calculator-project/meta.json
@@ -10,5 +10,6 @@
       "id": "63d8401e39c73468b059cd42",
       "title": "Build a Financial Calculator"
     }
-  ]
+  ],
+  "blockLayout": "project-list"
 }

--- a/curriculum/challenges/_meta/build-a-graphing-calculator-project/meta.json
+++ b/curriculum/challenges/_meta/build-a-graphing-calculator-project/meta.json
@@ -10,5 +10,6 @@
       "id": "63d83ffd39c73468b059cd40",
       "title": "Build a Graphing Calculator"
     }
-  ]
+  ],
+  "blockLayout": "project-list"
 }

--- a/curriculum/challenges/_meta/build-a-multi-function-calculator-project/meta.json
+++ b/curriculum/challenges/_meta/build-a-multi-function-calculator-project/meta.json
@@ -10,5 +10,6 @@
       "id": "63d83ff239c73468b059cd3f",
       "title": "Build a Multi-Function Calculator"
     }
-  ]
+  ],
+  "blockLayout": "project-list"
 }

--- a/curriculum/challenges/_meta/build-a-number-guessing-game-project/meta.json
+++ b/curriculum/challenges/_meta/build-a-number-guessing-game-project/meta.json
@@ -10,5 +10,6 @@
       "id": "602da04c22201c65d2a019f4",
       "title": "Build a Number Guessing Game"
     }
-  ]
+  ],
+  "blockLayout": "project-list"
 }

--- a/curriculum/challenges/_meta/build-a-palindrome-checker-project/meta.json
+++ b/curriculum/challenges/_meta/build-a-palindrome-checker-project/meta.json
@@ -11,5 +11,6 @@
       "id": "657bdc55a322aae1eac3838f",
       "title": "Build a Palindrome Checker"
     }
-  ]
+  ],
+  "blockLayout": "legacy-link"
 }

--- a/curriculum/challenges/_meta/build-a-periodic-table-database-project/meta.json
+++ b/curriculum/challenges/_meta/build-a-periodic-table-database-project/meta.json
@@ -10,5 +10,6 @@
       "id": "602d9ff222201c65d2a019f2",
       "title": "Build a Periodic Table Database"
     }
-  ]
+  ],
+  "blockLayout": "project-list"
 }

--- a/curriculum/challenges/_meta/build-a-personal-portfolio-webpage-project/meta.json
+++ b/curriculum/challenges/_meta/build-a-personal-portfolio-webpage-project/meta.json
@@ -11,5 +11,6 @@
       "id": "bd7158d8c242eddfaeb5bd13",
       "title": "Build a Personal Portfolio Webpage"
     }
-  ]
+  ],
+  "blockLayout": "legacy-link"
 }

--- a/curriculum/challenges/_meta/build-a-pokemon-search-app-project/meta.json
+++ b/curriculum/challenges/_meta/build-a-pokemon-search-app-project/meta.json
@@ -11,5 +11,6 @@
       "id": "6555c1d3e11a1574434cf8b5",
       "title": "Build a Pokémon Search App Project"
     }
-  ]
+  ],
+  "blockLayout": "legacy-link"
 }

--- a/curriculum/challenges/_meta/build-a-polygon-area-calculator-project/meta.json
+++ b/curriculum/challenges/_meta/build-a-polygon-area-calculator-project/meta.json
@@ -11,5 +11,6 @@
       "title": "Build a Polygon Area Calculator Project"
     }
   ],
-  "helpCategory": "Python"
+  "helpCategory": "Python",
+  "blockLayout": "legacy-link"
 }

--- a/curriculum/challenges/_meta/build-a-probability-calculator-project/meta.json
+++ b/curriculum/challenges/_meta/build-a-probability-calculator-project/meta.json
@@ -11,5 +11,6 @@
       "title": "Build a Probability Calculator Project"
     }
   ],
-  "helpCategory": "Python"
+  "helpCategory": "Python",
+  "blockLayout": "legacy-link"
 }

--- a/curriculum/challenges/_meta/build-a-product-landing-page-project/meta.json
+++ b/curriculum/challenges/_meta/build-a-product-landing-page-project/meta.json
@@ -11,5 +11,6 @@
       "id": "587d78af367417b2b2512b04",
       "title": "Build a Product Landing Page"
     }
-  ]
+  ],
+  "blockLayout": "legacy-link"
 }

--- a/curriculum/challenges/_meta/build-a-roman-numeral-converter-project/meta.json
+++ b/curriculum/challenges/_meta/build-a-roman-numeral-converter-project/meta.json
@@ -11,5 +11,6 @@
       "id": "657bdc8ba322aae1eac38390",
       "title": "Build a Roman Numeral Converter"
     }
-  ]
+  ],
+  "blockLayout": "legacy-link"
 }

--- a/curriculum/challenges/_meta/build-a-salon-appointment-scheduler-project/meta.json
+++ b/curriculum/challenges/_meta/build-a-salon-appointment-scheduler-project/meta.json
@@ -10,5 +10,6 @@
       "id": "5f87ac112ae598023a42df1a",
       "title": "Build a Salon Appointment Scheduler"
     }
-  ]
+  ],
+  "blockLayout": "project-list"
 }

--- a/curriculum/challenges/_meta/build-a-survey-form-project/meta.json
+++ b/curriculum/challenges/_meta/build-a-survey-form-project/meta.json
@@ -11,5 +11,6 @@
       "id": "587d78af367417b2b2512b03",
       "title": "Build a Survey Form"
     }
-  ]
+  ],
+  "blockLayout": "legacy-link"
 }

--- a/curriculum/challenges/_meta/build-a-technical-documentation-page-project/meta.json
+++ b/curriculum/challenges/_meta/build-a-technical-documentation-page-project/meta.json
@@ -11,5 +11,6 @@
       "id": "587d78b0367417b2b2512b05",
       "title": "Build a Technical Documentation Page"
     }
-  ]
+  ],
+  "blockLayout": "legacy-link"
 }

--- a/curriculum/challenges/_meta/build-a-telephone-number-validator-project/meta.json
+++ b/curriculum/challenges/_meta/build-a-telephone-number-validator-project/meta.json
@@ -11,5 +11,6 @@
       "id": "657bdcb9a322aae1eac38391",
       "title": "Build a Telephone Number Validator"
     }
-  ]
+  ],
+  "blockLayout": "legacy-link"
 }

--- a/curriculum/challenges/_meta/build-a-time-calculator-project/meta.json
+++ b/curriculum/challenges/_meta/build-a-time-calculator-project/meta.json
@@ -11,5 +11,6 @@
       "title": "Build a Time Calculator Project"
     }
   ],
-  "helpCategory": "Python"
+  "helpCategory": "Python",
+  "blockLayout": "legacy-link"
 }

--- a/curriculum/challenges/_meta/build-a-tribute-page-project/meta.json
+++ b/curriculum/challenges/_meta/build-a-tribute-page-project/meta.json
@@ -11,5 +11,6 @@
       "id": "bd7158d8c442eddfaeb5bd18",
       "title": "Build a Tribute Page"
     }
-  ]
+  ],
+  "blockLayout": "legacy-link"
 }

--- a/curriculum/challenges/_meta/build-a-world-cup-database-project/meta.json
+++ b/curriculum/challenges/_meta/build-a-world-cup-database-project/meta.json
@@ -10,5 +10,6 @@
       "id": "5f9771307d4d22b9d2b75a94",
       "title": "Build a World Cup Database"
     }
-  ]
+  ],
+  "blockLayout": "project-list"
 }

--- a/curriculum/challenges/_meta/build-an-arithmetic-formatter-project/meta.json
+++ b/curriculum/challenges/_meta/build-an-arithmetic-formatter-project/meta.json
@@ -11,5 +11,6 @@
       "title": "Build an Arithmetic Formatter Project"
     }
   ],
-  "helpCategory": "Python"
+  "helpCategory": "Python",
+  "blockLayout": "legacy-link"
 }

--- a/curriculum/challenges/_meta/build-three-math-games-project/meta.json
+++ b/curriculum/challenges/_meta/build-three-math-games-project/meta.json
@@ -10,5 +10,6 @@
       "id": "63d8401039c73468b059cd41",
       "title": "Build Three Math Games"
     }
-  ]
+  ],
+  "blockLayout": "project-list"
 }

--- a/curriculum/challenges/_meta/college-algebra-with-python-conclusion/meta.json
+++ b/curriculum/challenges/_meta/college-algebra-with-python-conclusion/meta.json
@@ -14,5 +14,6 @@
       "id": "6363d2959078df117ce4c408",
       "title": "More Resources in Colab"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/create-and-run-simple-c-sharp-console-applications/meta.json
+++ b/curriculum/challenges/_meta/create-and-run-simple-c-sharp-console-applications/meta.json
@@ -38,5 +38,6 @@
       "id": "647f87dc07d29547b3bee1bf",
       "title": "Trophy - Create and Run Simple C# Console Applications"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/create-methods-in-c-sharp-console-applications/meta.json
+++ b/curriculum/challenges/_meta/create-methods-in-c-sharp-console-applications/meta.json
@@ -30,5 +30,6 @@
       "id": "647f877f07d29547b3bee1be",
       "title": "Trophy - Create Methods in C# Console Applications"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/css-flexbox/meta.json
+++ b/curriculum/challenges/_meta/css-flexbox/meta.json
@@ -74,5 +74,6 @@
       "id": "587d78af367417b2b2512b00",
       "title": "Use the align-self Property"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/css-grid/meta.json
+++ b/curriculum/challenges/_meta/css-grid/meta.json
@@ -94,5 +94,6 @@
       "id": "5a94fe8569fb03452672e464",
       "title": "Create Grids within Grids"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/d3-dashboard/meta.json
+++ b/curriculum/challenges/_meta/d3-dashboard/meta.json
@@ -597,5 +597,5 @@
       "title": "Step 146"
     }
   ],
-  "blockLayout": "legacy-challenge-list"
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/d3-dashboard/meta.json
+++ b/curriculum/challenges/_meta/d3-dashboard/meta.json
@@ -596,5 +596,6 @@
       "id": "5d8a4cfbe6b6180ed9a1ca72",
       "title": "Step 146"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/data-analysis-with-python-course/meta.json
+++ b/curriculum/challenges/_meta/data-analysis-with-python-course/meta.json
@@ -118,5 +118,6 @@
       "id": "5e9a093a74c4063ca6f7c167",
       "title": "Python Iteration and Modules"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/data-analysis-with-python-projects/meta.json
+++ b/curriculum/challenges/_meta/data-analysis-with-python-projects/meta.json
@@ -26,5 +26,6 @@
       "id": "5e4f5c4b570f7e3a4949899f",
       "title": "Sea Level Predictor"
     }
-  ]
+  ],
+  "blockLayout": "project-list"
 }

--- a/curriculum/challenges/_meta/data-structures/meta.json
+++ b/curriculum/challenges/_meta/data-structures/meta.json
@@ -190,5 +190,6 @@
       "id": "587d825d367417b2b2512c96",
       "title": "Depth-First Search"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/data-visualization-projects/meta.json
+++ b/curriculum/challenges/_meta/data-visualization-projects/meta.json
@@ -26,5 +26,6 @@
       "id": "587d7fa6367417b2b2512bc0",
       "title": "Visualize Data with a Treemap Diagram"
     }
-  ]
+  ],
+  "blockLayout": "project-list"
 }

--- a/curriculum/challenges/_meta/data-visualization-with-d3/meta.json
+++ b/curriculum/challenges/_meta/data-visualization-with-d3/meta.json
@@ -127,5 +127,6 @@
       "id": "587d7fad367417b2b2512bdf",
       "title": "Add Axes to a Visualization"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/debug-c-sharp-console-applications/meta.json
+++ b/curriculum/challenges/_meta/debug-c-sharp-console-applications/meta.json
@@ -34,5 +34,6 @@
       "id": "647f86ff07d29547b3bee1bd",
       "title": "Trophy - Debug C# Console Applications"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/debugging/meta.json
+++ b/curriculum/challenges/_meta/debugging/meta.json
@@ -54,5 +54,6 @@
       "id": "587d7b86367417b2b2512b3d",
       "title": "Prevent Infinite Loops with a Valid Terminal Condition"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/es6/meta.json
+++ b/curriculum/challenges/_meta/es6/meta.json
@@ -122,5 +122,6 @@
       "id": "5cdafbe72913098997531682",
       "title": "Handle a Rejected Promise with catch"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/foundational-c-sharp-with-microsoft-certification-exam/meta.json
+++ b/curriculum/challenges/_meta/foundational-c-sharp-with-microsoft-certification-exam/meta.json
@@ -10,5 +10,6 @@
       "id": "647e22d18acb466c97ccbef8",
       "title": "Foundational C# with Microsoft Certification Exam"
     }
-  ]
+  ],
+  "blockLayout": "project-list"
 }

--- a/curriculum/challenges/_meta/front-end-development-libraries-projects/meta.json
+++ b/curriculum/challenges/_meta/front-end-development-libraries-projects/meta.json
@@ -26,5 +26,6 @@
       "id": "bd7158d8c442eddfaeb5bd0f",
       "title": "Build a 25 + 5 Clock"
     }
-  ]
+  ],
+  "blockLayout": "project-list"
 }

--- a/curriculum/challenges/_meta/functional-programming/meta.json
+++ b/curriculum/challenges/_meta/functional-programming/meta.json
@@ -102,5 +102,6 @@
       "id": "587d7dab367417b2b2512b70",
       "title": "Introduction to Currying and Partial Application"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/how-neural-networks-work/meta.json
+++ b/curriculum/challenges/_meta/how-neural-networks-work/meta.json
@@ -22,5 +22,6 @@
       "id": "5e9a0e9ef99a403d019610cd",
       "title": "How Convolutional Neural Networks work"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/information-security-projects/meta.json
+++ b/curriculum/challenges/_meta/information-security-projects/meta.json
@@ -26,5 +26,6 @@
       "id": "5e601c775ac9d0ecd8b94aff",
       "title": "Secure Real Time Multiplayer Game"
     }
-  ]
+  ],
+  "blockLayout": "project-list"
 }

--- a/curriculum/challenges/_meta/information-security-with-helmetjs/meta.json
+++ b/curriculum/challenges/_meta/information-security-with-helmetjs/meta.json
@@ -62,5 +62,6 @@
       "id": "58a25bcff9fc0f352b528e7e",
       "title": "Hash and Compare Passwords Synchronously"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/intermediate-algorithm-scripting/meta.json
+++ b/curriculum/challenges/_meta/intermediate-algorithm-scripting/meta.json
@@ -90,5 +90,6 @@
       "id": "af4afb223120f7348cdfc9fd",
       "title": "Map the Debris"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/javascript-algorithms-and-data-structures-projects/meta.json
+++ b/curriculum/challenges/_meta/javascript-algorithms-and-data-structures-projects/meta.json
@@ -26,5 +26,6 @@
       "id": "aa2e6f85cab2ab736c9a9b24",
       "title": "Cash Register"
     }
-  ]
+  ],
+  "blockLayout": "project-list"
 }

--- a/curriculum/challenges/_meta/jquery/meta.json
+++ b/curriculum/challenges/_meta/jquery/meta.json
@@ -86,5 +86,6 @@
       "id": "bad87fee1348bd9aecb08826",
       "title": "Use jQuery to Modify the Entire Page"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/json-apis-and-ajax/meta.json
+++ b/curriculum/challenges/_meta/json-apis-and-ajax/meta.json
@@ -51,5 +51,6 @@
       "id": "587d7faf367417b2b2512be9",
       "title": "Post Data with the JavaScript XMLHttpRequest Method"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/learn-about-adverbial-phrases/meta.json
+++ b/curriculum/challenges/_meta/learn-about-adverbial-phrases/meta.json
@@ -10,5 +10,6 @@
       "title": "Dialogue 1: I'm Tom"
     }
   ],
-  "helpCategory": "English"
+  "helpCategory": "English",
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/learn-about-speculation-and-requests/meta.json
+++ b/curriculum/challenges/_meta/learn-about-speculation-and-requests/meta.json
@@ -10,5 +10,6 @@
       "title": "Dialogue 1: I'm Tom"
     }
   ],
-  "helpCategory": "English"
+  "helpCategory": "English",
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/learn-accessibility-by-building-a-quiz/meta.json
+++ b/curriculum/challenges/_meta/learn-accessibility-by-building-a-quiz/meta.json
@@ -276,5 +276,6 @@
       "id": "6148e41c728f65138addf9cc",
       "title": "Step 67"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-advanced-array-methods-by-building-a-statistics-calculator/meta.json
+++ b/curriculum/challenges/_meta/learn-advanced-array-methods-by-building-a-statistics-calculator/meta.json
@@ -244,5 +244,6 @@
       "id": "635302be760d6031d11a06cd",
       "title": "Step 59"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-advanced-bash-by-building-a-kitty-ipsum-translator/meta.json
+++ b/curriculum/challenges/_meta/learn-advanced-bash-by-building-a-kitty-ipsum-translator/meta.json
@@ -10,5 +10,6 @@
       "id": "602da0de22201c65d2a019f6",
       "title": "Build a Kitty Ipsum Translator"
     }
-  ]
+  ],
+  "blockLayout": "project-list"
 }

--- a/curriculum/challenges/_meta/learn-algorithm-design-by-building-a-shortest-path-algorithm/meta.json
+++ b/curriculum/challenges/_meta/learn-algorithm-design-by-building-a-shortest-path-algorithm/meta.json
@@ -244,5 +244,6 @@
       "title": "Step 59"
     }
   ],
-  "helpCategory": "Python"
+  "helpCategory": "Python",
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-applications-of-linear-systems/meta.json
+++ b/curriculum/challenges/_meta/learn-applications-of-linear-systems/meta.json
@@ -14,5 +14,6 @@
       "id": "6363d23a9078df117ce4c3ff",
       "title": "Applications of Linear Systems: Extra"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/learn-asynchronous-programming-by-building-an-fcc-forum-leaderboard/meta.json
+++ b/curriculum/challenges/_meta/learn-asynchronous-programming-by-building-an-fcc-forum-leaderboard/meta.json
@@ -228,5 +228,6 @@
       "id": "64649b108df035051cb2ba2d",
       "title": "Step 55"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-bash-and-sql-by-building-a-bike-rental-shop/meta.json
+++ b/curriculum/challenges/_meta/learn-bash-and-sql-by-building-a-bike-rental-shop/meta.json
@@ -10,5 +10,6 @@
       "id": "5f5b969a05380d2179fe6e18",
       "title": "Build a Bike Rental Shop"
     }
-  ]
+  ],
+  "blockLayout": "project-list"
 }

--- a/curriculum/challenges/_meta/learn-bash-by-building-a-boilerplate/meta.json
+++ b/curriculum/challenges/_meta/learn-bash-by-building-a-boilerplate/meta.json
@@ -10,5 +10,6 @@
       "id": "5ea8adfab628f68d805bfc5e",
       "title": "Build a Boilerplate"
     }
-  ]
+  ],
+  "blockLayout": "project-list"
 }

--- a/curriculum/challenges/_meta/learn-bash-scripting-by-building-five-programs/meta.json
+++ b/curriculum/challenges/_meta/learn-bash-scripting-by-building-five-programs/meta.json
@@ -10,5 +10,6 @@
       "id": "5f5904ac738bc2fa9efecf5a",
       "title": "Build Five Programs"
     }
-  ]
+  ],
+  "blockLayout": "project-list"
 }

--- a/curriculum/challenges/_meta/learn-basic-algorithmic-thinking-by-building-a-number-sorter/meta.json
+++ b/curriculum/challenges/_meta/learn-basic-algorithmic-thinking-by-building-a-number-sorter/meta.json
@@ -188,5 +188,6 @@
       "id": "64113249bab9952fb2ce4469",
       "title": "Step 45"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-basic-css-by-building-a-cafe-menu/meta.json
+++ b/curriculum/challenges/_meta/learn-basic-css-by-building-a-cafe-menu/meta.json
@@ -372,5 +372,6 @@
       "id": "5f47fe7e31980053a8d4403b",
       "title": "Step 91"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-basic-debugging-by-building-a-random-background-color-changer/meta.json
+++ b/curriculum/challenges/_meta/learn-basic-debugging-by-building-a-random-background-color-changer/meta.json
@@ -40,5 +40,6 @@
       "title": "Step 8"
     }
   ],
-  "helpCategory": "JavaScript"
+  "helpCategory": "JavaScript",
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-basic-javascript-by-building-a-role-playing-game/meta.json
+++ b/curriculum/challenges/_meta/learn-basic-javascript-by-building-a-role-playing-game/meta.json
@@ -700,5 +700,6 @@
       "id": "62aa2ba9cd881355a6f0a5a8",
       "title": "Step 173"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-basic-oop-by-building-a-shopping-cart/meta.json
+++ b/curriculum/challenges/_meta/learn-basic-oop-by-building-a-shopping-cart/meta.json
@@ -248,5 +248,6 @@
       "id": "63f03b1ed5ab15420c057463",
       "title": "Step 60"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-basic-string-and-array-methods-by-building-a-music-player/meta.json
+++ b/curriculum/challenges/_meta/learn-basic-string-and-array-methods-by-building-a-music-player/meta.json
@@ -404,5 +404,6 @@
       "title": "Step 99"
     }
   ],
-  "helpCategory": "JavaScript"
+  "helpCategory": "JavaScript",
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-business-applications-of-college-algebra/meta.json
+++ b/curriculum/challenges/_meta/learn-business-applications-of-college-algebra/meta.json
@@ -14,5 +14,6 @@
       "id": "63dbd0375d93712ff177d969",
       "title": "Business Applications of College Algebra: Extra"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/learn-classes-and-objects-by-building-a-sudoku-solver/meta.json
+++ b/curriculum/challenges/_meta/learn-classes-and-objects-by-building-a-sudoku-solver/meta.json
@@ -320,5 +320,6 @@
       "title": "Step 78"
     }
   ],
-  "helpCategory": "Python"
+  "helpCategory": "Python",
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-common-factors-and-square-roots/meta.json
+++ b/curriculum/challenges/_meta/learn-common-factors-and-square-roots/meta.json
@@ -10,5 +10,6 @@
       "id": "6331d251b51aeedd1a2bd648",
       "title": "Factoring"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/learn-common-phrasal-verbs-and-idioms/meta.json
+++ b/curriculum/challenges/_meta/learn-common-phrasal-verbs-and-idioms/meta.json
@@ -10,5 +10,6 @@
       "title": "Dialogue 1: I'm Tom"
     }
   ],
-  "helpCategory": "English"
+  "helpCategory": "English",
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/learn-conversation-starters-in-the-break-room/meta.json
+++ b/curriculum/challenges/_meta/learn-conversation-starters-in-the-break-room/meta.json
@@ -534,5 +534,6 @@
       "title": "Task 127"
     }
   ],
-  "helpCategory": "English"
+  "helpCategory": "English",
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-css-animation-by-building-a-ferris-wheel/meta.json
+++ b/curriculum/challenges/_meta/learn-css-animation-by-building-a-ferris-wheel/meta.json
@@ -124,5 +124,6 @@
       "id": "6169b284950e171d8d0bb16a",
       "title": "Step 29"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-css-colors-by-building-a-set-of-colored-markers/meta.json
+++ b/curriculum/challenges/_meta/learn-css-colors-by-building-a-set-of-colored-markers/meta.json
@@ -384,5 +384,6 @@
       "id": "61b31cd7b0c76bfc076b4719",
       "title": "Step 94"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-css-flexbox-by-building-a-photo-gallery/meta.json
+++ b/curriculum/challenges/_meta/learn-css-flexbox-by-building-a-photo-gallery/meta.json
@@ -104,5 +104,6 @@
       "id": "6153a3ebb4f7f05b8401b716",
       "title": "Step 24"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-css-grid-by-building-a-magazine/meta.json
+++ b/curriculum/challenges/_meta/learn-css-grid-by-building-a-magazine/meta.json
@@ -328,5 +328,6 @@
       "id": "6148f6f7d8914c78e93136ca",
       "title": "Step 80"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-css-transforms-by-building-a-penguin/meta.json
+++ b/curriculum/challenges/_meta/learn-css-transforms-by-building-a-penguin/meta.json
@@ -424,5 +424,6 @@
       "id": "619d3711d04d623000013e9e",
       "title": "Step 104"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-css-variables-by-building-a-city-skyline/meta.json
+++ b/curriculum/challenges/_meta/learn-css-variables-by-building-a-city-skyline/meta.json
@@ -480,5 +480,6 @@
       "id": "5d822fd413a79914d39e993e",
       "title": "Step 118"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-data-structures-by-building-the-merge-sort-algorithm/meta.json
+++ b/curriculum/challenges/_meta/learn-data-structures-by-building-the-merge-sort-algorithm/meta.json
@@ -140,5 +140,6 @@
       "title": "Step 33"
     }
   ],
-  "helpCategory": "Python"
+  "helpCategory": "Python",
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-determiners-and-advanced-use-of-articles/meta.json
+++ b/curriculum/challenges/_meta/learn-determiners-and-advanced-use-of-articles/meta.json
@@ -10,5 +10,6 @@
       "title": "Dialogue 1: I'm Tom"
     }
   ],
-  "helpCategory": "English"
+  "helpCategory": "English",
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/learn-encapsulation-by-building-a-projectile-trajectory-calculator/meta.json
+++ b/curriculum/challenges/_meta/learn-encapsulation-by-building-a-projectile-trajectory-calculator/meta.json
@@ -104,5 +104,6 @@
       "title": "Step 24"
     }
   ],
-  "helpCategory": "Python"
+  "helpCategory": "Python",
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-exponents-and-logarithms/meta.json
+++ b/curriculum/challenges/_meta/learn-exponents-and-logarithms/meta.json
@@ -10,5 +10,6 @@
       "id": "6363d2769078df117ce4c406",
       "title": "Exponents and Logarithms"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/learn-fetch-and-promises-by-building-an-fcc-authors-page/meta.json
+++ b/curriculum/challenges/_meta/learn-fetch-and-promises-by-building-an-fcc-authors-page/meta.json
@@ -124,5 +124,6 @@
       "id": "641dab13c1b6f14b9828e6b1",
       "title": "Step 29"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-form-validation-by-building-a-calorie-counter/meta.json
+++ b/curriculum/challenges/_meta/learn-form-validation-by-building-a-calorie-counter/meta.json
@@ -396,5 +396,6 @@
       "id": "63c9f2bff625af342023512c",
       "title": "Step 97"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-fractions-and-decimals/meta.json
+++ b/curriculum/challenges/_meta/learn-fractions-and-decimals/meta.json
@@ -14,5 +14,6 @@
       "id": "6331d260b51aeedd1a2bd64a",
       "title": "Fractions and Decimals: Extra"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/learn-functional-programming-by-building-a-spreadsheet/meta.json
+++ b/curriculum/challenges/_meta/learn-functional-programming-by-building-a-spreadsheet/meta.json
@@ -428,5 +428,6 @@
       "id": "646d4b3d80ea98d824c8a4f9",
       "title": "Step 105"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-functions-and-graphing/meta.json
+++ b/curriculum/challenges/_meta/learn-functions-and-graphing/meta.json
@@ -18,5 +18,6 @@
       "id": "63e1798f811fda1bc546bba0",
       "title": "Functions and Graphing: Extra"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/learn-future-continuous-while-describing-actions/meta.json
+++ b/curriculum/challenges/_meta/learn-future-continuous-while-describing-actions/meta.json
@@ -10,5 +10,6 @@
       "title": "Dialogue 1: I'm Tom"
     }
   ],
-  "helpCategory": "English"
+  "helpCategory": "English",
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/learn-git-by-building-an-sql-reference-object/meta.json
+++ b/curriculum/challenges/_meta/learn-git-by-building-an-sql-reference-object/meta.json
@@ -10,5 +10,6 @@
       "id": "5fa323cdaf6a73463d590659",
       "title": "Build an SQL Reference Object"
     }
-  ]
+  ],
+  "blockLayout": "project-list"
 }

--- a/curriculum/challenges/_meta/learn-greetings-in-your-first-day-at-the-office/meta.json
+++ b/curriculum/challenges/_meta/learn-greetings-in-your-first-day-at-the-office/meta.json
@@ -690,5 +690,6 @@
       "title": "Task 166"
     }
   ],
-  "helpCategory": "English"
+  "helpCategory": "English",
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-how-to-analyze-code-documentation/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-analyze-code-documentation/meta.json
@@ -118,5 +118,6 @@
       "title": "Task 25"
     }
   ],
-  "helpCategory": "English"
+  "helpCategory": "English",
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-how-to-ask-and-share-about-educational-and-professional-background/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-ask-and-share-about-educational-and-professional-background/meta.json
@@ -394,5 +394,6 @@
       "title": "Task 92"
     }
   ],
-  "helpCategory": "English"
+  "helpCategory": "English",
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-how-to-ask-for-clarification-on-code-understanding/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-ask-for-clarification-on-code-understanding/meta.json
@@ -190,5 +190,6 @@
       "title": "Task 43"
     }
   ],
-  "helpCategory": "English"
+  "helpCategory": "English",
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-how-to-clarify-information-in-different-interactions/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-clarify-information-in-different-interactions/meta.json
@@ -370,5 +370,6 @@
       "title": "Task 86"
     }
   ],
-  "helpCategory": "English"
+  "helpCategory": "English",
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-how-to-clarify-misunderstandings/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-clarify-misunderstandings/meta.json
@@ -10,5 +10,6 @@
       "title": "Dialogue 1: I'm Tom"
     }
   ],
-  "helpCategory": "English"
+  "helpCategory": "English",
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/learn-how-to-describe-places-and-events/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-describe-places-and-events/meta.json
@@ -626,5 +626,6 @@
       "title": "Task 151"
     }
   ],
-  "helpCategory": "English"
+  "helpCategory": "English",
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/learn-how-to-describe-your-current-project/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-describe-your-current-project/meta.json
@@ -258,5 +258,6 @@
       "title": "Task 58"
     }
   ],
-  "helpCategory": "English"
+  "helpCategory": "English",
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-how-to-discuss-popular-trends-in-technology/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-discuss-popular-trends-in-technology/meta.json
@@ -446,5 +446,6 @@
       "title": "Task 105"
     }
   ],
-  "helpCategory": "English"
+  "helpCategory": "English",
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-how-to-discuss-roles-and-responsibilies/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-discuss-roles-and-responsibilies/meta.json
@@ -450,5 +450,6 @@
       "title": "Task 106"
     }
   ],
-  "helpCategory": "English"
+  "helpCategory": "English",
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-how-to-discuss-tech-trends-and-updates/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-discuss-tech-trends-and-updates/meta.json
@@ -226,5 +226,6 @@
       "title": "Task 52"
     }
   ],
-  "helpCategory": "English"
+  "helpCategory": "English",
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-how-to-discuss-your-morning-or-evening-routine/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-discuss-your-morning-or-evening-routine/meta.json
@@ -418,5 +418,6 @@
       "title": "Task 98"
     }
   ],
-  "helpCategory": "English"
+  "helpCategory": "English",
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-how-to-document-code-for-a-project/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-document-code-for-a-project/meta.json
@@ -210,5 +210,6 @@
       "title": "Task 48"
     }
   ],
-  "helpCategory": "English"
+  "helpCategory": "English",
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-how-to-express-agreement-or-disagreement/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-express-agreement-or-disagreement/meta.json
@@ -154,5 +154,6 @@
       "title": "Task 34"
     }
   ],
-  "helpCategory": "English"
+  "helpCategory": "English",
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-how-to-express-agreement/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-express-agreement/meta.json
@@ -10,5 +10,6 @@
       "title": "Dialogue 1: I'm Tom"
     }
   ],
-  "helpCategory": "English"
+  "helpCategory": "English",
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/learn-how-to-express-concerns/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-express-concerns/meta.json
@@ -10,5 +10,6 @@
       "title": "Dialogue 1: I'm Tom"
     }
   ],
-  "helpCategory": "English"
+  "helpCategory": "English",
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/learn-how-to-express-decisions-based-on-comparisons/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-express-decisions-based-on-comparisons/meta.json
@@ -10,5 +10,6 @@
       "title": "Dialogue 1: I'm Tom"
     }
   ],
-  "helpCategory": "English"
+  "helpCategory": "English",
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/learn-how-to-express-disagreement/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-express-disagreement/meta.json
@@ -10,5 +10,6 @@
       "title": "Dialogue 1: I'm Tom"
     }
   ],
-  "helpCategory": "English"
+  "helpCategory": "English",
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/learn-how-to-graph-systems-of-equations/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-graph-systems-of-equations/meta.json
@@ -14,5 +14,6 @@
       "id": "6331d276b51aeedd1a2bd64d",
       "title": "Graphing Systems of Equations: Extra"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/learn-how-to-have-a-conversation-about-preferences-and-motivations/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-have-a-conversation-about-preferences-and-motivations/meta.json
@@ -590,5 +590,6 @@
       "title": "Task 141"
     }
   ],
-  "helpCategory": "English"
+  "helpCategory": "English",
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-how-to-help-a-coworker-troubleshoot-on-github/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-help-a-coworker-troubleshoot-on-github/meta.json
@@ -262,5 +262,6 @@
       "title": "Task 61"
     }
   ],
-  "helpCategory": "English"
+  "helpCategory": "English",
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-how-to-manage-a-conversation/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-manage-a-conversation/meta.json
@@ -10,5 +10,6 @@
       "title": "Dialogue 1: I'm Tom"
     }
   ],
-  "helpCategory": "English"
+  "helpCategory": "English",
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/learn-how-to-offer-technical-support-and-guidance/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-offer-technical-support-and-guidance/meta.json
@@ -282,5 +282,6 @@
       "title": "Task 66"
     }
   ],
-  "helpCategory": "English"
+  "helpCategory": "English",
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-how-to-plan-future-events/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-plan-future-events/meta.json
@@ -10,5 +10,6 @@
       "title": "Dialogue 1: I'm Tom"
     }
   ],
-  "helpCategory": "English"
+  "helpCategory": "English",
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/learn-how-to-provide-explanations-when-helping-others/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-provide-explanations-when-helping-others/meta.json
@@ -182,5 +182,6 @@
       "title": "Task 41"
     }
   ],
-  "helpCategory": "English"
+  "helpCategory": "English",
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-how-to-read-and-understand-code-documentation/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-read-and-understand-code-documentation/meta.json
@@ -162,5 +162,6 @@
       "title": "Task 36"
     }
   ],
-  "helpCategory": "English"
+  "helpCategory": "English",
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-how-to-request-and-receive-guidance/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-request-and-receive-guidance/meta.json
@@ -270,5 +270,6 @@
       "title": "Task 63"
     }
   ],
-  "helpCategory": "English"
+  "helpCategory": "English",
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-how-to-share-feedback/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-share-feedback/meta.json
@@ -10,5 +10,6 @@
       "title": "Dialogue 1: I'm Tom"
     }
   ],
-  "helpCategory": "English"
+  "helpCategory": "English",
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/learn-how-to-share-progress-and-accomplishments/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-share-progress-and-accomplishments/meta.json
@@ -178,5 +178,6 @@
       "title": "Task 40"
     }
   ],
-  "helpCategory": "English"
+  "helpCategory": "English",
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-how-to-share-your-opinion/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-share-your-opinion/meta.json
@@ -10,5 +10,6 @@
       "title": "Dialogue 1: I'm Tom"
     }
   ],
-  "helpCategory": "English"
+  "helpCategory": "English",
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/learn-how-to-share-your-progress-in-weekly-stand-up-meetings/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-share-your-progress-in-weekly-stand-up-meetings/meta.json
@@ -254,5 +254,6 @@
       "title": "Task 59"
     }
   ],
-  "helpCategory": "English"
+  "helpCategory": "English",
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-how-to-solve-for-x/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-solve-for-x/meta.json
@@ -14,5 +14,6 @@
       "id": "6331d233b51aeedd1a2bd645",
       "title": "How to Solve for X: Extra"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/learn-how-to-solve-systems-of-equations/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-solve-systems-of-equations/meta.json
@@ -14,5 +14,6 @@
       "id": "6331d2a9b51aeedd1a2bd654",
       "title": "Solving Systems of Equations: Extra"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/learn-how-to-talk-about-a-typical-workday-and-tasks/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-talk-about-a-typical-workday-and-tasks/meta.json
@@ -305,7 +305,7 @@
       "id": "657e4bdba35dc68e1977e5d5",
       "title": "Dialogue 4: James Explains Compliance"
     },
-        {
+    {
       "id": "657e50dd1f6ff2a9873f9ff0",
       "title": "Task 72"
     },
@@ -542,5 +542,6 @@
       "title": "Task 129"
     }
   ],
-  "helpCategory": "English"
+  "helpCategory": "English",
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-how-to-talk-about-hobbies-and-interests/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-talk-about-hobbies-and-interests/meta.json
@@ -446,5 +446,6 @@
       "title": "Task 105"
     }
   ],
-  "helpCategory": "English"
+  "helpCategory": "English",
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-how-to-talk-about-numbers-with-a-coworker/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-talk-about-numbers-with-a-coworker/meta.json
@@ -10,5 +10,6 @@
       "title": "Dialogue 1: I'm Tom"
     }
   ],
-  "helpCategory": "English"
+  "helpCategory": "English",
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/learn-how-to-talk-about-past-activities/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-talk-about-past-activities/meta.json
@@ -10,5 +10,6 @@
       "title": "Dialogue 1: I'm Tom"
     }
   ],
-  "helpCategory": "English"
+  "helpCategory": "English",
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/learn-how-to-talk-about-past-experiences/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-talk-about-past-experiences/meta.json
@@ -10,5 +10,6 @@
       "title": "Dialogue 1: I'm Tom"
     }
   ],
-  "helpCategory": "English"
+  "helpCategory": "English",
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/meta.json
@@ -142,5 +142,6 @@
       "title": "Task 31"
     }
   ],
-  "helpCategory": "English"
+  "helpCategory": "English",
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-how-to-use-adjectives-in-conversations/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-use-adjectives-in-conversations/meta.json
@@ -10,5 +10,6 @@
       "title": "Dialogue 1: I'm Tom"
     }
   ],
-  "helpCategory": "English"
+  "helpCategory": "English",
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/learn-how-to-use-basic-programming-vocabulary-in-conversations/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-use-basic-programming-vocabulary-in-conversations/meta.json
@@ -330,5 +330,6 @@
       "title": "Task 78"
     }
   ],
-  "helpCategory": "English"
+  "helpCategory": "English",
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-how-to-use-code-related-concepts-and-terms/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-use-code-related-concepts-and-terms/meta.json
@@ -222,5 +222,6 @@
       "title": "Task 51"
     }
   ],
-  "helpCategory": "English"
+  "helpCategory": "English",
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-how-to-use-conditionals/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-use-conditionals/meta.json
@@ -10,5 +10,6 @@
       "title": "Dialogue 1: I'm Tom"
     }
   ],
-  "helpCategory": "English"
+  "helpCategory": "English",
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/learn-how-to-use-modal-verbs/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-use-modal-verbs/meta.json
@@ -10,5 +10,6 @@
       "title": "Dialogue 1: I'm Tom"
     }
   ],
-  "helpCategory": "English"
+  "helpCategory": "English",
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/learn-how-to-use-prepositions-according-to-context/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-use-prepositions-according-to-context/meta.json
@@ -10,5 +10,6 @@
       "title": "Dialogue 1: I'm Tom"
     }
   ],
-  "helpCategory": "English"
+  "helpCategory": "English",
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/learn-how-to-use-reported-speech/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-use-reported-speech/meta.json
@@ -10,5 +10,6 @@
       "title": "Dialogue 1: I'm Tom"
     }
   ],
-  "helpCategory": "English"
+  "helpCategory": "English",
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/learn-how-to-work-with-numbers-and-strings-by-implementing-the-luhn-algorithm/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-work-with-numbers-and-strings-by-implementing-the-luhn-algorithm/meta.json
@@ -148,5 +148,6 @@
       "title": "Step 35"
     }
   ],
-  "helpCategory": "Python"
+  "helpCategory": "Python",
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-html-by-building-a-cat-photo-app/meta.json
+++ b/curriculum/challenges/_meta/learn-html-by-building-a-cat-photo-app/meta.json
@@ -292,5 +292,6 @@
       "id": "62bb4009e3458a128ff57d5d",
       "title": "Step 71"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-html-forms-by-building-a-registration-form/meta.json
+++ b/curriculum/challenges/_meta/learn-html-forms-by-building-a-registration-form/meta.json
@@ -268,5 +268,6 @@
       "id": "6537e0be715fcb57d31ba8c3",
       "title": "Step 65"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-interfaces-by-building-an-equation-solver/meta.json
+++ b/curriculum/challenges/_meta/learn-interfaces-by-building-an-equation-solver/meta.json
@@ -276,5 +276,6 @@
       "title": "Step 67"
     }
   ],
-  "helpCategory": "Python"
+  "helpCategory": "Python",
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-intermediate-css-by-building-a-cat-painting/meta.json
+++ b/curriculum/challenges/_meta/learn-intermediate-css-by-building-a-cat-painting/meta.json
@@ -336,5 +336,6 @@
       "title": "Step 82"
     }
   ],
-  "helpCategory": "HTML-CSS"
+  "helpCategory": "HTML-CSS",
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-intermediate-oop-by-building-a-platformer-game/meta.json
+++ b/curriculum/challenges/_meta/learn-intermediate-oop-by-building-a-platformer-game/meta.json
@@ -478,5 +478,6 @@
       "id": "650757918a9e97418dc3d71a",
       "title": "Step 117"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-introductions-in-an-online-team-meeting/meta.json
+++ b/curriculum/challenges/_meta/learn-introductions-in-an-online-team-meeting/meta.json
@@ -438,5 +438,6 @@
       "title": "Task 103"
     }
   ],
-  "helpCategory": "English"
+  "helpCategory": "English",
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-introductory-javascript-by-building-a-pyramid-generator/meta.json
+++ b/curriculum/challenges/_meta/learn-introductory-javascript-by-building-a-pyramid-generator/meta.json
@@ -480,5 +480,6 @@
       "title": "Step 118"
     }
   ],
-  "helpCategory": "JavaScript"
+  "helpCategory": "JavaScript",
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-lambda-functions-by-building-an-expense-tracker/meta.json
+++ b/curriculum/challenges/_meta/learn-lambda-functions-by-building-an-expense-tracker/meta.json
@@ -216,5 +216,6 @@
       "title": "Step 52"
     }
   ],
-  "helpCategory": "Python"
+  "helpCategory": "Python",
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-linear-functions/meta.json
+++ b/curriculum/challenges/_meta/learn-linear-functions/meta.json
@@ -18,5 +18,6 @@
       "id": "6331d283b51aeedd1a2bd64f",
       "title": "Linear Functions: Extra"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/learn-list-comprehension-by-building-a-case-converter-program/meta.json
+++ b/curriculum/challenges/_meta/learn-list-comprehension-by-building-a-case-converter-program/meta.json
@@ -100,5 +100,6 @@
       "title": "Step 23"
     }
   ],
-  "helpCategory": "Python"
+  "helpCategory": "Python",
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-localstorage-by-building-a-todo-app/meta.json
+++ b/curriculum/challenges/_meta/learn-localstorage-by-building-a-todo-app/meta.json
@@ -280,5 +280,6 @@
       "title": "Step 68"
     }
   ],
-  "helpCategory": "JavaScript"
+  "helpCategory": "JavaScript",
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-modern-javascript-methods-by-building-football-team-cards/meta.json
+++ b/curriculum/challenges/_meta/learn-modern-javascript-methods-by-building-football-team-cards/meta.json
@@ -188,5 +188,6 @@
       "id": "63f2ab4f6c52c5eec6d68de4",
       "title": "Step 45"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-more-about-css-pseudo-selectors-by-building-a-balance-sheet/meta.json
+++ b/curriculum/challenges/_meta/learn-more-about-css-pseudo-selectors-by-building-a-balance-sheet/meta.json
@@ -272,5 +272,6 @@
       "id": "6201a59be346d399c21d10b1",
       "title": "Step 66"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-nano-by-building-a-castle/meta.json
+++ b/curriculum/challenges/_meta/learn-nano-by-building-a-castle/meta.json
@@ -10,5 +10,6 @@
       "id": "5f32db63eb37f7e17323f459",
       "title": "Build a Castle"
     }
-  ]
+  ],
+  "blockLayout": "project-list"
 }

--- a/curriculum/challenges/_meta/learn-parent-graphs-and-polynomials/meta.json
+++ b/curriculum/challenges/_meta/learn-parent-graphs-and-polynomials/meta.json
@@ -14,5 +14,6 @@
       "id": "6363d25c9078df117ce4c403",
       "title": "Parent Graphs and Polynomials: Extra"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/learn-present-perfect-while-talking-about-accessibility/meta.json
+++ b/curriculum/challenges/_meta/learn-present-perfect-while-talking-about-accessibility/meta.json
@@ -10,5 +10,6 @@
       "title": "Dialogue 1: I'm Tom"
     }
   ],
-  "helpCategory": "English"
+  "helpCategory": "English",
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/learn-python-by-building-a-blackjack-game/meta.json
+++ b/curriculum/challenges/_meta/learn-python-by-building-a-blackjack-game/meta.json
@@ -29,5 +29,5 @@
       "title": "Step 5"
     }
   ],
-  "blockLayout": "legacy-challenge-list"
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-python-by-building-a-blackjack-game/meta.json
+++ b/curriculum/challenges/_meta/learn-python-by-building-a-blackjack-game/meta.json
@@ -28,5 +28,6 @@
       "id": "65df3afd233057f6a620a860",
       "title": "Step 5"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/learn-quadratic-equations/meta.json
+++ b/curriculum/challenges/_meta/learn-quadratic-equations/meta.json
@@ -10,5 +10,6 @@
       "id": "6363d2429078df117ce4c400",
       "title": "Quadratics"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/learn-ratios-and-proportions/meta.json
+++ b/curriculum/challenges/_meta/learn-ratios-and-proportions/meta.json
@@ -18,5 +18,6 @@
       "id": "6331d298b51aeedd1a2bd652",
       "title": "Ratios and Proportions: Extra"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/learn-recursion-by-building-a-decimal-to-binary-converter/meta.json
+++ b/curriculum/challenges/_meta/learn-recursion-by-building-a-decimal-to-binary-converter/meta.json
@@ -440,5 +440,6 @@
       "id": "6464c6d6698a8027f8c9d6be",
       "title": "Step 108"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-recursion-by-solving-the-tower-of-hanoi-puzzle/meta.json
+++ b/curriculum/challenges/_meta/learn-recursion-by-solving-the-tower-of-hanoi-puzzle/meta.json
@@ -228,5 +228,6 @@
       "title": "Step 55"
     }
   ],
-  "helpCategory": "Python"
+  "helpCategory": "Python",
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-regular-expressions-by-building-a-password-generator/meta.json
+++ b/curriculum/challenges/_meta/learn-regular-expressions-by-building-a-password-generator/meta.json
@@ -296,5 +296,6 @@
       "title": "Step 72"
     }
   ],
-  "helpCategory": "Python"
+  "helpCategory": "Python",
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-regular-expressions-by-building-a-spam-filter/meta.json
+++ b/curriculum/challenges/_meta/learn-regular-expressions-by-building-a-spam-filter/meta.json
@@ -152,5 +152,6 @@
       "id": "642349b5b7bae31af21cd5f8",
       "title": "Step 36"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-relational-databases-by-building-a-mario-database/meta.json
+++ b/curriculum/challenges/_meta/learn-relational-databases-by-building-a-mario-database/meta.json
@@ -10,5 +10,6 @@
       "id": "5f2c289f164c29556da632fd",
       "title": "Build a Mario Database"
     }
-  ]
+  ],
+  "blockLayout": "project-list"
 }

--- a/curriculum/challenges/_meta/learn-responsive-web-design-by-building-a-piano/meta.json
+++ b/curriculum/challenges/_meta/learn-responsive-web-design-by-building-a-piano/meta.json
@@ -140,5 +140,6 @@
       "id": "612ec29c84b9a6718b1f5cec",
       "title": "Step 33"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-simple-and-compound-interest/meta.json
+++ b/curriculum/challenges/_meta/learn-simple-and-compound-interest/meta.json
@@ -14,5 +14,6 @@
       "id": "63dbd1335d93712ff177d96a",
       "title": "Simple and Compound Interest: Extra"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/learn-special-methods-by-building-a-vector-space/meta.json
+++ b/curriculum/challenges/_meta/learn-special-methods-by-building-a-vector-space/meta.json
@@ -316,5 +316,6 @@
       "title": "Step 77"
     }
   ],
-  "helpCategory": "Python"
+  "helpCategory": "Python",
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-sql-by-building-a-student-database-part-1/meta.json
+++ b/curriculum/challenges/_meta/learn-sql-by-building-a-student-database-part-1/meta.json
@@ -10,5 +10,6 @@
       "id": "602da0c222201c65d2a019f5",
       "title": "Build a Student Database: Part 1"
     }
-  ]
+  ],
+  "blockLayout": "project-list"
 }

--- a/curriculum/challenges/_meta/learn-sql-by-building-a-student-database-part-2/meta.json
+++ b/curriculum/challenges/_meta/learn-sql-by-building-a-student-database-part-2/meta.json
@@ -10,5 +10,6 @@
       "id": "618590adb0730ca724e37672",
       "title": "Build a Student Database: Part 2"
     }
-  ]
+  ],
+  "blockLayout": "project-list"
 }

--- a/curriculum/challenges/_meta/learn-string-manipulation-by-building-a-cipher/meta.json
+++ b/curriculum/challenges/_meta/learn-string-manipulation-by-building-a-cipher/meta.json
@@ -392,5 +392,6 @@
       "title": "Step 96"
     }
   ],
-  "helpCategory": "Python"
+  "helpCategory": "Python",
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-the-bisection-method-by-finding-the-square-root-of-a-number/meta.json
+++ b/curriculum/challenges/_meta/learn-the-bisection-method-by-finding-the-square-root-of-a-number/meta.json
@@ -92,5 +92,6 @@
       "title": "Step 21"
     }
   ],
-  "helpCategory": "Python"
+  "helpCategory": "Python",
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-the-css-box-model-by-building-a-rothko-painting/meta.json
+++ b/curriculum/challenges/_meta/learn-the-css-box-model-by-building-a-rothko-painting/meta.json
@@ -188,5 +188,6 @@
       "id": "60a3e3396c7b40068ad69997",
       "title": "Step 45"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-the-date-object-by-building-a-date-formatter/meta.json
+++ b/curriculum/challenges/_meta/learn-the-date-object-by-building-a-date-formatter/meta.json
@@ -116,5 +116,6 @@
       "title": "Step 27"
     }
   ],
-  "helpCategory": "JavaScript"
+  "helpCategory": "JavaScript",
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-tree-traversal-by-building-a-binary-search-tree/meta.json
+++ b/curriculum/challenges/_meta/learn-tree-traversal-by-building-a-binary-search-tree/meta.json
@@ -256,5 +256,6 @@
       "title": "Step 62"
     }
   ],
-  "helpCategory": "Python"
+  "helpCategory": "Python",
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/learn-typography-by-building-a-nutrition-label/meta.json
+++ b/curriculum/challenges/_meta/learn-typography-by-building-a-nutrition-label/meta.json
@@ -280,5 +280,6 @@
       "id": "615f951dff9317a900ef683f",
       "title": "Step 68"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/machine-learning-with-python-projects/meta.json
+++ b/curriculum/challenges/_meta/machine-learning-with-python-projects/meta.json
@@ -26,5 +26,6 @@
       "id": "5e46f8edac417301a38fb931",
       "title": "Neural Network SMS Text Classifier"
     }
-  ]
+  ],
+  "blockLayout": "project-list"
 }

--- a/curriculum/challenges/_meta/managing-packages-with-npm/meta.json
+++ b/curriculum/challenges/_meta/managing-packages-with-npm/meta.json
@@ -46,5 +46,6 @@
       "id": "587d7fb5367417b2b2512c04",
       "title": "Remove a Package from Your Dependencies"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/mongodb-and-mongoose/meta.json
+++ b/curriculum/challenges/_meta/mongodb-and-mongoose/meta.json
@@ -54,5 +54,6 @@
       "id": "587d7fb9367417b2b2512c12",
       "title": "Chain Search Query Helpers to Narrow Search Results"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/numpy/meta.json
+++ b/curriculum/challenges/_meta/numpy/meta.json
@@ -42,5 +42,6 @@
       "id": "5e9a0a8e09c5df3cc3600eda",
       "title": "Loading Data and Advanced Indexing"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/object-oriented-programming/meta.json
+++ b/curriculum/challenges/_meta/object-oriented-programming/meta.json
@@ -110,5 +110,6 @@
       "id": "587d7db2367417b2b2512b8c",
       "title": "Use an IIFE to Create a Module"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/project-euler-problems-1-to-100/meta.json
+++ b/curriculum/challenges/_meta/project-euler-problems-1-to-100/meta.json
@@ -407,5 +407,6 @@
       "id": "5900f3d01000cf542c50fee3",
       "title": "Problem 100: Arranged probability"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/project-euler-problems-101-to-200/meta.json
+++ b/curriculum/challenges/_meta/project-euler-problems-101-to-200/meta.json
@@ -408,5 +408,6 @@
       "id": "5900f4351000cf542c50ff47",
       "title": "Problem 200: Find the 200th prime-proof sqube containing the contiguous sub-string \"200\""
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/project-euler-problems-201-to-300/meta.json
+++ b/curriculum/challenges/_meta/project-euler-problems-201-to-300/meta.json
@@ -407,5 +407,6 @@
       "id": "5900f49a1000cf542c50ffac",
       "title": "Problem 300: Protein folding"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/project-euler-problems-301-to-400/meta.json
+++ b/curriculum/challenges/_meta/project-euler-problems-301-to-400/meta.json
@@ -407,5 +407,6 @@
       "id": "5900f4fe1000cf542c510010",
       "title": "Problem 400: Fibonacci tree game"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/project-euler-problems-401-to-480/meta.json
+++ b/curriculum/challenges/_meta/project-euler-problems-401-to-480/meta.json
@@ -327,5 +327,6 @@
       "id": "5900f54c1000cf542c51005f",
       "title": "Problem 480: The Last Question"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/python-for-everybody/meta.json
+++ b/curriculum/challenges/_meta/python-for-everybody/meta.json
@@ -230,5 +230,6 @@
       "id": "5e7b9f6a0b6c005b0e76f097",
       "title": "Data Visualization: Mailing Lists"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/python-for-penetration-testing/meta.json
+++ b/curriculum/challenges/_meta/python-for-penetration-testing/meta.json
@@ -34,5 +34,6 @@
       "id": "5ea9997bbec2e9bc47e94db4",
       "title": "Developing a Port Scanner"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/quality-assurance-and-testing-with-chai/meta.json
+++ b/curriculum/challenges/_meta/quality-assurance-and-testing-with-chai/meta.json
@@ -106,5 +106,6 @@
       "id": "5f8884f4c46685731aabfc41",
       "title": "Run Functional Tests Using a Headless Browser II"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/quality-assurance-projects/meta.json
+++ b/curriculum/challenges/_meta/quality-assurance-projects/meta.json
@@ -26,5 +26,6 @@
       "id": "5e601c0d5ac9d0ecd8b94afe",
       "title": "American British Translator"
     }
-  ]
+  ],
+  "blockLayout": "project-list"
 }

--- a/curriculum/challenges/_meta/react-and-redux/meta.json
+++ b/curriculum/challenges/_meta/react-and-redux/meta.json
@@ -61,5 +61,6 @@
       "id": "5a24c314108439a4d403614a",
       "title": "Moving Forward From Here"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/react/meta.json
+++ b/curriculum/challenges/_meta/react/meta.json
@@ -203,5 +203,6 @@
       "id": "5a24c314108439a4d403618d",
       "title": "Render React on the Server with renderToString"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/redux/meta.json
+++ b/curriculum/challenges/_meta/redux/meta.json
@@ -82,5 +82,6 @@
       "id": "5a24c314108439a4d403615b",
       "title": "Copy an Object with Object.assign"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/regular-expressions/meta.json
+++ b/curriculum/challenges/_meta/regular-expressions/meta.json
@@ -138,5 +138,6 @@
       "id": "587d7dbb367417b2b2512bac",
       "title": "Remove Whitespace from Start and End"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/responsive-web-design-principles/meta.json
+++ b/curriculum/challenges/_meta/responsive-web-design-principles/meta.json
@@ -22,5 +22,6 @@
       "id": "587d78b1367417b2b2512b0c",
       "title": "Make Typography Responsive"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/review-algorithmic-thinking-by-building-a-dice-game/meta.json
+++ b/curriculum/challenges/_meta/review-algorithmic-thinking-by-building-a-dice-game/meta.json
@@ -64,5 +64,6 @@
       "id": "657e230500602983e01fff6e",
       "title": "Step 14"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/review-dom-manipulation-by-building-a-rock-paper-scissors-game/meta.json
+++ b/curriculum/challenges/_meta/review-dom-manipulation-by-building-a-rock-paper-scissors-game/meta.json
@@ -32,5 +32,6 @@
       "title": "Step 6"
     }
   ],
-  "helpCategory": "JavaScript"
+  "helpCategory": "JavaScript",
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/review-js-fundamentals-by-building-a-gradebook-app/meta.json
+++ b/curriculum/challenges/_meta/review-js-fundamentals-by-building-a-gradebook-app/meta.json
@@ -24,5 +24,6 @@
       "title": "Step 4"
     }
   ],
-  "helpCategory": "JavaScript"
+  "helpCategory": "JavaScript",
+  "blockLayout": "legacy-challenge-grid"
 }

--- a/curriculum/challenges/_meta/rosetta-code-challenges/meta.json
+++ b/curriculum/challenges/_meta/rosetta-code-challenges/meta.json
@@ -647,5 +647,6 @@
       "id": "594810f028c0303b75339ad8",
       "title": "Zig-zag matrix"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/sass/meta.json
+++ b/curriculum/challenges/_meta/sass/meta.json
@@ -42,5 +42,6 @@
       "id": "587d7fa5367417b2b2512bbd",
       "title": "Extend One Set of CSS Styles to Another Element"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/take-home-projects/meta.json
+++ b/curriculum/challenges/_meta/take-home-projects/meta.json
@@ -86,5 +86,6 @@
       "id": "5a5d02bd919fcf9ca8cf46cb",
       "title": "Build a Light-Bright App"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/tensorflow/meta.json
+++ b/curriculum/challenges/_meta/tensorflow/meta.json
@@ -134,5 +134,6 @@
       "id": "5e8f2f13c4cdbe86b5c72da6",
       "title": "Conclusion"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/top-basic-function-projects/meta.json
+++ b/curriculum/challenges/_meta/top-basic-function-projects/meta.json
@@ -22,5 +22,6 @@
       "id": "661e17c6068359c3ccf2f4d8",
       "title": "Basic Functions Exercise D"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/top-build-a-recipe-project/meta.json
+++ b/curriculum/challenges/_meta/top-build-a-recipe-project/meta.json
@@ -10,5 +10,6 @@
       "id": "6391d1a4f7ac71efd0621380",
       "title": "Build a Recipe Page Project"
     }
-  ]
+  ],
+  "blockLayout": "project-list"
 }

--- a/curriculum/challenges/_meta/top-build-a-rock-paper-scissors-game/meta.json
+++ b/curriculum/challenges/_meta/top-build-a-rock-paper-scissors-game/meta.json
@@ -10,5 +10,6 @@
       "id": "66629f407d679d3105e8317f",
       "title": "Build a Rock Paper Scissors Game"
     }
-  ]
+  ],
+  "blockLayout": "project-list"
 }

--- a/curriculum/challenges/_meta/top-introduction-to-flexbox/meta.json
+++ b/curriculum/challenges/_meta/top-introduction-to-flexbox/meta.json
@@ -50,5 +50,6 @@
       "id": "6597b43d854b3fa8e35d66d7",
       "title": "Introduction to Flexbox Question K"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/top-learn-arrays-and-loops/meta.json
+++ b/curriculum/challenges/_meta/top-learn-arrays-and-loops/meta.json
@@ -38,5 +38,6 @@
       "id": "661e275a8602567c118451d8",
       "title": "Learn Arrays and Loops Lesson H"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/top-learn-block-and-inline/meta.json
+++ b/curriculum/challenges/_meta/top-learn-block-and-inline/meta.json
@@ -50,5 +50,6 @@
       "id": "65704486e7b02272663824e9",
       "title": "Learn Block and Inline Lesson K"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/top-learn-css-foundations-projects/meta.json
+++ b/curriculum/challenges/_meta/top-learn-css-foundations-projects/meta.json
@@ -26,5 +26,6 @@
       "id": "63ee3ff8381756f9716727f3",
       "title": "CSS Foundations Exercise E"
     }
-  ]
+  ],
+  "blockLayout": "project-list"
 }

--- a/curriculum/challenges/_meta/top-learn-css-foundations/meta.json
+++ b/curriculum/challenges/_meta/top-learn-css-foundations/meta.json
@@ -38,5 +38,6 @@
       "id": "63ee354c0d8d4841c3a70921",
       "title": "CSS Foundations Lesson H"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/top-learn-css-specificity/meta.json
+++ b/curriculum/challenges/_meta/top-learn-css-specificity/meta.json
@@ -38,5 +38,6 @@
       "id": "648acb0745e79f79650fa2ac",
       "title": "The Cascade of CSS Lesson H"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/top-learn-data-types-and-conditionals/meta.json
+++ b/curriculum/challenges/_meta/top-learn-data-types-and-conditionals/meta.json
@@ -54,5 +54,6 @@
       "id": "65e97293484dd50f720e6ff1",
       "title": "Learn Data Types and Conditionals Lesson L"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/top-learn-function-basics/meta.json
+++ b/curriculum/challenges/_meta/top-learn-function-basics/meta.json
@@ -30,5 +30,6 @@
       "id": "6617aef85b87c334e7ae8017",
       "title": "Learn Function Basics Lesson F"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/top-learn-html-foundations/meta.json
+++ b/curriculum/challenges/_meta/top-learn-html-foundations/meta.json
@@ -38,5 +38,6 @@
       "id": "637633162724a688c04636e4",
       "title": "HTML Foundations Lesson H"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/top-learn-to-solve-problems-and-understand-errors/meta.json
+++ b/curriculum/challenges/_meta/top-learn-to-solve-problems-and-understand-errors/meta.json
@@ -38,5 +38,6 @@
       "id": "66581a7fb1eb228115949301",
       "title": "Learn to Solve Problems and Understand Errors Lesson H"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/top-learn-variables-and-operators/meta.json
+++ b/curriculum/challenges/_meta/top-learn-variables-and-operators/meta.json
@@ -42,5 +42,6 @@
       "id": "65e1b46e500d930ce8ed90ad",
       "title": "Learn Variables and Operators Lesson I"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/top-links-and-images/meta.json
+++ b/curriculum/challenges/_meta/top-links-and-images/meta.json
@@ -38,5 +38,6 @@
       "id": "637f700b72c65bc8e73dfe2f",
       "title": "Links and Images Lesson H"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/top-the-box-model/meta.json
+++ b/curriculum/challenges/_meta/top-the-box-model/meta.json
@@ -58,5 +58,6 @@
       "id": "64a674c27a7d00f97013ed14",
       "title": "The Box Model Lesson M"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/top-working-with-text/meta.json
+++ b/curriculum/challenges/_meta/top-working-with-text/meta.json
@@ -46,5 +46,6 @@
       "id": "637f4e5172c65bc8e73dfe26",
       "title": "Working With Text Lesson J"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/upcoming-python-project/meta.json
+++ b/curriculum/challenges/_meta/upcoming-python-project/meta.json
@@ -18,5 +18,7 @@
     {
       "id": "6703d9382ebd112db6f7788b",
       "title": "Odin Layout"
-    }  
-  ]}
+    }
+  ],
+  "blockLayout": "legacy-challenge-list"
+}

--- a/curriculum/challenges/_meta/work-with-variable-data-in-c-sharp-console-applications/meta.json
+++ b/curriculum/challenges/_meta/work-with-variable-data-in-c-sharp-console-applications/meta.json
@@ -38,5 +38,6 @@
       "id": "647f867a07d29547b3bee1bc",
       "title": "Trophy - Work with Variable Data in C# Console Applications"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/challenges/_meta/write-your-first-code-using-c-sharp/meta.json
+++ b/curriculum/challenges/_meta/write-your-first-code-using-c-sharp/meta.json
@@ -34,5 +34,6 @@
       "id": "647f85d407d29547b3bee1bb",
       "title": "Trophy - Write Your First Code Using C#"
     }
-  ]
+  ],
+  "blockLayout": "legacy-challenge-list"
 }

--- a/curriculum/schema/challenge-schema.js
+++ b/curriculum/schema/challenge-schema.js
@@ -129,18 +129,15 @@ const schema = Joi.object()
       ).required(),
       otherwise: Joi.valid(null)
     }),
-    blockLayout: Joi.when('superBlock', {
-      is: [SuperBlocks.FullStackDeveloper],
-      then: Joi.valid(
-        'challenge-list',
-        'challenge-grid',
-        'link',
-        'project-list',
-        'legacy-challenge-list',
-        'legacy-link',
-        'legacy-challenge-grid'
-      ).required()
-    }),
+    blockLayout: Joi.valid(
+      'challenge-list',
+      'challenge-grid',
+      'link',
+      'project-list',
+      'legacy-challenge-list',
+      'legacy-link',
+      'legacy-challenge-grid'
+    ).required(),
     challengeOrder: Joi.number(),
     chapter: Joi.string().when('superBlock', {
       is: 'full-stack-developer',

--- a/curriculum/schema/meta-schema.js
+++ b/curriculum/schema/meta-schema.js
@@ -14,7 +14,7 @@ const schema = Joi.object()
       'legacy-challenge-list',
       'legacy-link',
       'legacy-challenge-grid'
-    ),
+    ).required(),
     blockType: Joi.valid(
       'workshop',
       'lab',

--- a/tools/scripts/build/external-data-schema.js
+++ b/tools/scripts/build/external-data-schema.js
@@ -24,6 +24,7 @@ const blockSchema = Joi.object({}).keys({
     template: Joi.string().allow(''),
     required: Joi.array(),
     superBlock: Joi.string(),
+    blockLayout: Joi.string(),
     challengeOrder: Joi.array().items(
       Joi.object({}).keys({
         id: Joi.string(),


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Companion to https://github.com/freeCodeCamp/freeCodeCamp/pull/56808. It adds all the layouts according to which combination of `isProjectBased` and `isGridBased` that they have. The rationale being that it's confusing (to me!) to have some block's layout determined by the `blockLayout` properties while some rely on `isProjectBased` and `isGridBased`.

 The logic for how they currently determine `blockLayout` is here

https://github.com/freeCodeCamp/freeCodeCamp/blob/c6c40097c199f934bf8ca1f986a793d8146c2fe6/client/src/templates/Introduction/components/block.tsx#L405-L407

@huyenltnguyen if this seems like a good idea to you, we can cherrypick these commits onto your PR. Or we can wait until yours is in and then look at this.

<!-- Feel free to add any additional description of changes below this line -->
