### PR TITLE
chore(curriculum): remove jquery from Legacy Basic CSS Challenges

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/add-a-negative-margin-to-an-element.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/add-a-negative-margin-to-an-element.md
@@ -24,7 +24,9 @@ Change the `margin` of the blue box to `-15px`, so it fills the entire horizonta
 Your `blue-box` class should give elements `-15px` of `margin`.
 
 ```js
-assert($('.blue-box').css('margin-top') === '-15px');
+const blueBox = document.querySelector('.blue-box');
+const marginTop = window.getComputedStyle(blueBox)["margin-top"]; 
+assert.strictEqual(marginTop,"-15px"); 
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/add-a-negative-margin-to-an-element.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/add-a-negative-margin-to-an-element.md
@@ -26,7 +26,7 @@ Your `blue-box` class should give elements `-15px` of `margin`.
 ```js
 const blueBox = document.querySelector('.blue-box');
 const marginTop = window.getComputedStyle(blueBox)["margin-top"]; 
-assert.strictEqual(marginTop,"-15px"); 
+assert.strictEqual(marginTop, "-15px"); 
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/add-borders-around-your-elements.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/add-borders-around-your-elements.md
@@ -38,35 +38,38 @@ Remember that you can apply multiple classes to an element using its `class` att
 Your `img` element should have the class `smaller-image`.
 
 ```js
-assert($('img').hasClass('smaller-image'));
+assert.isTrue(document.querySelector('img').classList.contains('smaller-image'));
 ```
 
 Your `img` element should have the class `thick-green-border`.
 
 ```js
-assert($('img').hasClass('thick-green-border'));
+assert.isTrue(document.querySelector('img').classList.contains('thick-green-border'));
 ```
 
 Your image should have a border width of `10px`.
 
 ```js
-assert(
-  $('img').hasClass('thick-green-border') &&
-    parseInt($('img').css('border-top-width'), 10) >= 8 &&
-    parseInt($('img').css('border-top-width'), 10) <= 12
-);
+const image = document.querySelector('img'); 
+const imageBorderTopWidth = window.getComputedStyle(image)["border-top-width"]; 
+
+assert.strictEqual(imageBorderTopWidth,"10px")
 ```
 
 Your image should have a border style of `solid`.
 
 ```js
-assert($('img').css('border-right-style') === 'solid');
+const image = document.querySelector('img'); 
+const borderRightStyle = window.getComputedStyle(image)["border-right-style"]; 
+assert.strictEqual(borderRightStyle,'solid');
 ```
 
 The border around your `img` element should be green.
 
 ```js
-assert($('img').css('border-left-color') === 'rgb(0, 128, 0)');
+const image= document.querySelector('img'); 
+const borderLeftColor = window.getComputedStyle(image)["border-left-color"]; 
+assert.strictEqual(borderLeftColor,'rgb(0, 128, 0)');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/add-borders-around-your-elements.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/add-borders-around-your-elements.md
@@ -53,7 +53,7 @@ Your image should have a border width of `10px`.
 const image = document.querySelector('img'); 
 const imageBorderTopWidth = window.getComputedStyle(image)["border-top-width"]; 
 
-assert.strictEqual(imageBorderTopWidth,"10px")
+assert.strictEqual(imageBorderTopWidth, "10px")
 ```
 
 Your image should have a border style of `solid`.
@@ -61,15 +61,15 @@ Your image should have a border style of `solid`.
 ```js
 const image = document.querySelector('img'); 
 const borderRightStyle = window.getComputedStyle(image)["border-right-style"]; 
-assert.strictEqual(borderRightStyle,'solid');
+assert.strictEqual(borderRightStyle, 'solid');
 ```
 
 The border around your `img` element should be green.
 
 ```js
-const image= document.querySelector('img'); 
+const image = document.querySelector('img'); 
 const borderLeftColor = window.getComputedStyle(image)["border-left-color"]; 
-assert.strictEqual(borderLeftColor,'rgb(0, 128, 0)');
+assert.strictEqual(borderLeftColor, 'rgb(0, 128, 0)');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/add-different-margins-to-each-side-of-an-element.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/add-different-margins-to-each-side-of-an-element.md
@@ -22,25 +22,33 @@ Give the blue box a `margin` of `40px` on its top and left side, but only `20px`
 Your `blue-box` class should give the top of elements `40px` of `margin`.
 
 ```js
-assert($('.blue-box').css('margin-top') === '40px');
+const blueBox = document.querySelector('.blue-box');
+const marginTop = window.getComputedStyle(blueBox)['margin-top'];
+assert.strictEqual(marginTop,'40px');
 ```
 
 Your `blue-box` class should give the right of elements `20px` of `margin`.
 
 ```js
-assert($('.blue-box').css('margin-right') === '20px');
+const blueBox = document.querySelector('.blue-box');
+const marginRight = window.getComputedStyle(blueBox)['margin-right'];
+assert.strictEqual(marginRight,'20px');
 ```
 
 Your `blue-box` class should give the bottom of elements `20px` of `margin`.
 
 ```js
-assert($('.blue-box').css('margin-bottom') === '20px');
+const blueBox = document.querySelector('.blue-box');
+const marginBottom = window.getComputedStyle(blueBox)['margin-bottom'];
+assert.strictEqual(marginBottom,'20px');
 ```
 
 Your `blue-box` class should give the left of elements `40px` of `margin`.
 
 ```js
-assert($('.blue-box').css('margin-left') === '40px');
+const blueBox = document.querySelector('.blue-box');
+const marginLeft = window.getComputedStyle(blueBox)['margin-left'];
+assert.strictEqual(marginLeft,'40px');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/add-different-margins-to-each-side-of-an-element.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/add-different-margins-to-each-side-of-an-element.md
@@ -24,7 +24,7 @@ Your `blue-box` class should give the top of elements `40px` of `margin`.
 ```js
 const blueBox = document.querySelector('.blue-box');
 const marginTop = window.getComputedStyle(blueBox)['margin-top'];
-assert.strictEqual(marginTop,'40px');
+assert.strictEqual(marginTop, '40px');
 ```
 
 Your `blue-box` class should give the right of elements `20px` of `margin`.
@@ -32,7 +32,7 @@ Your `blue-box` class should give the right of elements `20px` of `margin`.
 ```js
 const blueBox = document.querySelector('.blue-box');
 const marginRight = window.getComputedStyle(blueBox)['margin-right'];
-assert.strictEqual(marginRight,'20px');
+assert.strictEqual(marginRight, '20px');
 ```
 
 Your `blue-box` class should give the bottom of elements `20px` of `margin`.
@@ -40,7 +40,7 @@ Your `blue-box` class should give the bottom of elements `20px` of `margin`.
 ```js
 const blueBox = document.querySelector('.blue-box');
 const marginBottom = window.getComputedStyle(blueBox)['margin-bottom'];
-assert.strictEqual(marginBottom,'20px');
+assert.strictEqual(marginBottom, '20px');
 ```
 
 Your `blue-box` class should give the left of elements `40px` of `margin`.

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/add-different-padding-to-each-side-of-an-element.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/add-different-padding-to-each-side-of-an-element.md
@@ -22,25 +22,33 @@ Give the blue box a `padding` of `40px` on its top and left side, but only `20px
 Your `blue-box` class should give the top of the elements `40px` of `padding`.
 
 ```js
-assert($('.blue-box').css('padding-top') === '40px');
+const blueBox = document.querySelector('.blue-box');
+const paddingTop = window.getComputedStyle(blueBox)['padding-top'];
+assert.strictEqual(paddingTop,'40px');
 ```
 
 Your `blue-box` class should give the right of the elements `20px` of `padding`.
 
 ```js
-assert($('.blue-box').css('padding-right') === '20px');
+const blueBox = document.querySelector('.blue-box');
+const paddingRight = window.getComputedStyle(blueBox)['padding-right'];
+assert.strictEqual(paddingRight,'20px');
 ```
 
 Your `blue-box` class should give the bottom of the elements `20px` of `padding`.
 
 ```js
-assert($('.blue-box').css('padding-bottom') === '20px');
+const blueBox = document.querySelector('.blue-box');
+const paddingBottom = window.getComputedStyle(blueBox)['padding-bottom'];
+assert.strictEqual(paddingBottom,'20px');
 ```
 
 Your `blue-box` class should give the left of the elements `40px` of `padding`.
 
 ```js
-assert($('.blue-box').css('padding-left') === '40px');
+const blueBox = document.querySelector('.blue-box');
+const paddingLeft = window.getComputedStyle(blueBox)['padding-left'];
+assert.strictEqual(paddingLeft,'40px');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/add-different-padding-to-each-side-of-an-element.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/add-different-padding-to-each-side-of-an-element.md
@@ -24,7 +24,7 @@ Your `blue-box` class should give the top of the elements `40px` of `padding`.
 ```js
 const blueBox = document.querySelector('.blue-box');
 const paddingTop = window.getComputedStyle(blueBox)['padding-top'];
-assert.strictEqual(paddingTop,'40px');
+assert.strictEqual(paddingTop, '40px');
 ```
 
 Your `blue-box` class should give the right of the elements `20px` of `padding`.
@@ -32,7 +32,7 @@ Your `blue-box` class should give the right of the elements `20px` of `padding`.
 ```js
 const blueBox = document.querySelector('.blue-box');
 const paddingRight = window.getComputedStyle(blueBox)['padding-right'];
-assert.strictEqual(paddingRight,'20px');
+assert.strictEqual(paddingRight, '20px');
 ```
 
 Your `blue-box` class should give the bottom of the elements `20px` of `padding`.
@@ -40,7 +40,7 @@ Your `blue-box` class should give the bottom of the elements `20px` of `padding`
 ```js
 const blueBox = document.querySelector('.blue-box');
 const paddingBottom = window.getComputedStyle(blueBox)['padding-bottom'];
-assert.strictEqual(paddingBottom,'20px');
+assert.strictEqual(paddingBottom, '20px');
 ```
 
 Your `blue-box` class should give the left of the elements `40px` of `padding`.
@@ -48,7 +48,7 @@ Your `blue-box` class should give the left of the elements `40px` of `padding`.
 ```js
 const blueBox = document.querySelector('.blue-box');
 const paddingLeft = window.getComputedStyle(blueBox)['padding-left'];
-assert.strictEqual(paddingLeft,'40px');
+assert.strictEqual(paddingLeft, '40px');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/add-rounded-corners-with-border-radius.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/add-rounded-corners-with-border-radius.md
@@ -22,18 +22,23 @@ You can specify a `border-radius` with pixels. Give your cat photo a `border-rad
 Your image element should have the class `thick-green-border`.
 
 ```js
-assert($('img').hasClass('thick-green-border'));
+assert.isTrue(document.querySelector('img').classList.contains('thick-green-border'));
 ```
 
 Your image should have a border radius of `10px`.
 
 ```js
-assert(
-  $('img').css('border-top-left-radius') === '10px' &&
-    $('img').css('border-top-right-radius') === '10px' &&
-    $('img').css('border-bottom-left-radius') === '10px' &&
-    $('img').css('border-bottom-right-radius') === '10px'
-);
+const image = document.querySelector('img');
+const style = window.getComputedStyle(image);  
+const borderTopLeftRadius = style['border-top-left-radius']; 
+const borderTopRightRadius = style['border-top-right-radius'];
+const borderBottomLeftRadius = style['border-bottom-left-radius'];
+const borderBottomRightRadius = style['border-bottom-right-radius'];
+
+assert.strictEqual(borderTopLeftRadius,'10px');
+assert.strictEqual(borderTopRightRadius,'10px');
+assert.strictEqual(borderBottomLeftRadius,'10px');
+assert.strictEqual(borderBottomRightRadius,'10px');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/add-rounded-corners-with-border-radius.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/add-rounded-corners-with-border-radius.md
@@ -35,10 +35,10 @@ const borderTopRightRadius = style['border-top-right-radius'];
 const borderBottomLeftRadius = style['border-bottom-left-radius'];
 const borderBottomRightRadius = style['border-bottom-right-radius'];
 
-assert.strictEqual(borderTopLeftRadius,'10px');
-assert.strictEqual(borderTopRightRadius,'10px');
-assert.strictEqual(borderBottomLeftRadius,'10px');
-assert.strictEqual(borderBottomRightRadius,'10px');
+assert.strictEqual(borderTopLeftRadius, '10px');
+assert.strictEqual(borderTopRightRadius, '10px');
+assert.strictEqual(borderBottomLeftRadius, '10px');
+assert.strictEqual(borderBottomRightRadius, '10px');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/adjust-the-margin-of-an-element.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/adjust-the-margin-of-an-element.md
@@ -24,7 +24,9 @@ Change the `margin` of the blue box to match that of the red box.
 Your `blue-box` class should give elements `20px` of `margin`.
 
 ```js
-assert($('.blue-box').css('margin-top') === '20px');
+const blueBox = document.querySelector('.blue-box');
+const marginTop = window.getComputedStyle(blueBox)['margin-top'];
+assert.strictEqual(marginTop,'20px');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/adjust-the-margin-of-an-element.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/adjust-the-margin-of-an-element.md
@@ -26,7 +26,7 @@ Your `blue-box` class should give elements `20px` of `margin`.
 ```js
 const blueBox = document.querySelector('.blue-box');
 const marginTop = window.getComputedStyle(blueBox)['margin-top'];
-assert.strictEqual(marginTop,'20px');
+assert.strictEqual(marginTop, '20px');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/adjust-the-padding-of-an-element.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/adjust-the-padding-of-an-element.md
@@ -30,7 +30,9 @@ Change the `padding` of your blue box to match that of your red box.
 Your `blue-box` class should give elements `20px` of `padding`.
 
 ```js
-assert($('.blue-box').css('padding-top') === '20px');
+const blueBox = document.querySelector('.blue-box');
+const paddingTop = window.getComputedStyle(blueBox)['padding-top'];
+assert.strictEqual(paddingTop,'20px');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/adjust-the-padding-of-an-element.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/adjust-the-padding-of-an-element.md
@@ -32,7 +32,7 @@ Your `blue-box` class should give elements `20px` of `padding`.
 ```js
 const blueBox = document.querySelector('.blue-box');
 const paddingTop = window.getComputedStyle(blueBox)['padding-top'];
-assert.strictEqual(paddingTop,'20px');
+assert.strictEqual(paddingTop, '20px');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/attach-a-fallback-value-to-a-css-variable.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/attach-a-fallback-value-to-a-css-variable.md
@@ -30,21 +30,13 @@ It looks like there is a problem with the variables supplied to the `.penguin-to
 The fallback value of `black` should be used in the `background` property of the `penguin-top` class.
 
 ```js
-assert(
-  code.match(
-    /.penguin-top\s*?{[\s\S]*background\s*?:\s*?var\(\s*?--pengiun-skin\s*?,\s*?black\s*?\)\s*?;[\s\S]*}[\s\S]*.penguin-bottom\s{/gi
-  )
-);
+assert.match(code,/.penguin-top\s*?{[\s\S]*background\s*?:\s*?var\(\s*?--pengiun-skin\s*?,\s*?black\s*?\)\s*?;[\s\S]*}[\s\S]*.penguin-bottom\s{/gi);
 ```
 
 The fallback value of `black` should be used in `background` property of the `penguin-bottom` class.
 
 ```js
-assert(
-  code.match(
-    /.penguin-bottom\s*?{[\s\S]*background\s*?:\s*?var\(\s*?--pengiun-skin\s*?,\s*?black\s*?\)\s*?;[\s\S]*}/gi
-  )
-);
+assert.match(code,/.penguin-bottom\s*?{[\s\S]*background\s*?:\s*?var\(\s*?--pengiun-skin\s*?,\s*?black\s*?\)\s*?;[\s\S]*}/gi);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/attach-a-fallback-value-to-a-css-variable.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/attach-a-fallback-value-to-a-css-variable.md
@@ -30,13 +30,13 @@ It looks like there is a problem with the variables supplied to the `.penguin-to
 The fallback value of `black` should be used in the `background` property of the `penguin-top` class.
 
 ```js
-assert.match(code,/.penguin-top\s*?{[\s\S]*background\s*?:\s*?var\(\s*?--pengiun-skin\s*?,\s*?black\s*?\)\s*?;[\s\S]*}[\s\S]*.penguin-bottom\s{/gi);
+assert.match(__helpers.removeCssComments(code), /.penguin-top\s*?{[\s\S]*background\s*?:\s*?var\(\s*?--pengiun-skin\s*?,\s*?black\s*?\)\s*?;[\s\S]*}[\s\S]*.penguin-bottom\s{/gi);
 ```
 
 The fallback value of `black` should be used in `background` property of the `penguin-bottom` class.
 
 ```js
-assert.match(code,/.penguin-bottom\s*?{[\s\S]*background\s*?:\s*?var\(\s*?--pengiun-skin\s*?,\s*?black\s*?\)\s*?;[\s\S]*}/gi);
+assert.match(__helpers.removeCssComments(code), /.penguin-bottom\s*?{[\s\S]*background\s*?:\s*?var\(\s*?--pengiun-skin\s*?,\s*?black\s*?\)\s*?;[\s\S]*}/gi);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/change-a-variable-for-a-specific-area.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/change-a-variable-for-a-specific-area.md
@@ -22,17 +22,13 @@ Change the value of `--penguin-belly` to `white` in the `penguin` class.
 The `penguin` class should reassign the `--penguin-belly` variable to `white`.
 
 ```js
-assert(
-  code.match(/\.penguin\s*?{[\s\S]*--penguin-belly\s*?:\s*?white\s*?;[\s\S]*}/gi)
-);
+assert.match(code,/\.penguin\s*?{[\s\S]*--penguin-belly\s*?:\s*?white\s*?;[\s\S]*}/gi);
 ```
 
 The `penguin` class should not contain the `background-color` property.
 
 ```js
-assert(
-  code.match(/^((?!background-color\s*?:\s*?)[\s\S])*$/g)
-);
+assert.match(code,/^((?!background-color\s*?:\s*?)[\s\S])*$/g);
 ``` 
 
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/change-a-variable-for-a-specific-area.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/change-a-variable-for-a-specific-area.md
@@ -22,13 +22,13 @@ Change the value of `--penguin-belly` to `white` in the `penguin` class.
 The `penguin` class should reassign the `--penguin-belly` variable to `white`.
 
 ```js
-assert.match(code,/\.penguin\s*?{[\s\S]*--penguin-belly\s*?:\s*?white\s*?;[\s\S]*}/gi);
+assert.match(__helpers.removeCssComments(code), /\.penguin\s*?{[\s\S]*--penguin-belly\s*?:\s*?white\s*?;[\s\S]*}/gi);
 ```
 
 The `penguin` class should not contain the `background-color` property.
 
 ```js
-assert.match(code,/^((?!background-color\s*?:\s*?)[\s\S])*$/g);
+assert.match(__helpers.removeCssComments(code), /^((?!background-color\s*?:\s*?)[\s\S])*$/g);
 ``` 
 
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/change-the-color-of-text.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/change-the-color-of-text.md
@@ -32,19 +32,19 @@ Change your `h2` element's style so that its text color is red.
 Your `h2` element should have a `style` declaration.
 
 ```js
-assert($('h2').attr('style'));
+assert.exists(document.querySelector('h2').getAttribute('style'));
 ```
 
 Your `h2` element should have color set to `red`.
 
 ```js
-assert($('h2')[0].style.color === 'red');
+assert.strictEqual(document.querySelector('h2').style.color,'red');
 ```
 
 Your `style` declaration should end with a `;` .
 
 ```js
-assert($('h2').attr('style') && $('h2').attr('style').endsWith(';'));
+assert.isTrue(document.querySelector('h2').getAttribute('style').endsWith(';'));
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/change-the-color-of-text.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/change-the-color-of-text.md
@@ -38,7 +38,7 @@ assert.exists(document.querySelector('h2').getAttribute('style'));
 Your `h2` element should have color set to `red`.
 
 ```js
-assert.strictEqual(document.querySelector('h2').style.color,'red');
+assert.strictEqual(document.querySelector('h2').style.color, 'red');
 ```
 
 Your `style` declaration should end with a `;` .

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/change-the-font-size-of-an-element.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/change-the-font-size-of-an-element.md
@@ -26,7 +26,7 @@ Inside the same `<style>` tag that contains your `red-text` class, create an ent
 Between the `style` tags, give the `p` elements `font-size` of `16px`. Browser and Text zoom should be at 100%.
 
 ```js
-assert(code.match(/p\s*{\s*font-size\s*:\s*16\s*px\s*;\s*}/i));
+assert.match(code,/p\s*{\s*font-size\s*:\s*16\s*px\s*;\s*}/i);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/change-the-font-size-of-an-element.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/change-the-font-size-of-an-element.md
@@ -26,7 +26,7 @@ Inside the same `<style>` tag that contains your `red-text` class, create an ent
 Between the `style` tags, give the `p` elements `font-size` of `16px`. Browser and Text zoom should be at 100%.
 
 ```js
-assert.match(code,/p\s*{\s*font-size\s*:\s*16\s*px\s*;\s*}/i);
+assert.match(__helpers.removeCssComments(code), /p\s*{\s*font-size\s*:\s*16\s*px\s*;\s*}/i);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/create-a-custom-css-variable.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/create-a-custom-css-variable.md
@@ -26,9 +26,7 @@ In the `penguin` class, create a variable name `--penguin-skin` and give it a va
 `penguin` class should declare the `--penguin-skin` variable and assign it to `gray`.
 
 ```js
-assert(
-  code.match(/\.penguin\s*\{[^{}]*?--penguin-skin\s*:\s*gr[ae]y\s*;[^{}]*?\}/gi)
-);
+assert.match(code,/\.penguin\s*\{[^{}]*?--penguin-skin\s*:\s*gr[ae]y\s*;[^{}]*?\}/gi);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/create-a-custom-css-variable.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/create-a-custom-css-variable.md
@@ -26,7 +26,7 @@ In the `penguin` class, create a variable name `--penguin-skin` and give it a va
 `penguin` class should declare the `--penguin-skin` variable and assign it to `gray`.
 
 ```js
-assert.match(code,/\.penguin\s*\{[^{}]*?--penguin-skin\s*:\s*gr[ae]y\s*;[^{}]*?\}/gi);
+assert.match(__helpers.removeHTMLComments(code), /\.penguin\s*\{[^{}]*?--penguin-skin\s*:\s*gr[ae]y\s*;[^{}]*?\}/gi);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/create-a-custom-css-variable.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/create-a-custom-css-variable.md
@@ -26,7 +26,7 @@ In the `penguin` class, create a variable name `--penguin-skin` and give it a va
 `penguin` class should declare the `--penguin-skin` variable and assign it to `gray`.
 
 ```js
-assert.match(__helpers.removeHTMLComments(code), /\.penguin\s*\{[^{}]*?--penguin-skin\s*:\s*gr[ae]y\s*;[^{}]*?\}/gi);
+assert.match(__helpers.removeHtmlComments(code), /\.penguin\s*\{[^{}]*?--penguin-skin\s*:\s*gr[ae]y\s*;[^{}]*?\}/gi);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/give-a-background-color-to-a-div-element.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/give-a-background-color-to-a-div-element.md
@@ -28,19 +28,21 @@ Create a class called `silver-background` with the `background-color` of `silver
 Your`div` element should have the class `silver-background`.
 
 ```js
-assert($('div').hasClass('silver-background'));
+assert.isTrue(document.querySelector('div').classList.contains('silver-background'));
 ```
 
 Your `div` element should have a silver background.
 
 ```js
-assert($('div').css('background-color') === 'rgb(192, 192, 192)');
+const div = document.querySelector('div');
+const backgroundColor = window.getComputedStyle(div)['background-color']; 
+assert.strictEqual(backgroundColor,'rgb(192, 192, 192)');
 ```
 
 A class named `silver-background` should be defined within the `style` element and the value of `silver` should be assigned to the `background-color` property.
 
 ```js
-assert(code.match(/\.silver-background\s*{\s*background-color\s*:\s*silver\s*;?\s*}/));
+assert.match(code,/\.silver-background\s*{\s*background-color\s*:\s*silver\s*;?\s*}/);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/give-a-background-color-to-a-div-element.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/give-a-background-color-to-a-div-element.md
@@ -36,13 +36,13 @@ Your `div` element should have a silver background.
 ```js
 const div = document.querySelector('div');
 const backgroundColor = window.getComputedStyle(div)['background-color']; 
-assert.strictEqual(backgroundColor,'rgb(192, 192, 192)');
+assert.strictEqual(backgroundColor, 'rgb(192, 192, 192)');
 ```
 
 A class named `silver-background` should be defined within the `style` element and the value of `silver` should be assigned to the `background-color` property.
 
 ```js
-assert.match(code,/\.silver-background\s*{\s*background-color\s*:\s*silver\s*;?\s*}/);
+assert.match(__helpers.removeHTMLComments(code), /\.silver-background\s*{\s*background-color\s*:\s*silver\s*;?\s*}/);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/give-a-background-color-to-a-div-element.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/give-a-background-color-to-a-div-element.md
@@ -42,7 +42,7 @@ assert.strictEqual(backgroundColor, 'rgb(192, 192, 192)');
 A class named `silver-background` should be defined within the `style` element and the value of `silver` should be assigned to the `background-color` property.
 
 ```js
-assert.match(__helpers.removeHTMLComments(code), /\.silver-background\s*{\s*background-color\s*:\s*silver\s*;?\s*}/);
+assert.match(__helpers.removeHtmlComments(code), /\.silver-background\s*{\s*background-color\s*:\s*silver\s*;?\s*}/);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/import-a-google-font.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/import-a-google-font.md
@@ -40,37 +40,29 @@ Import the `Lobster` font to your web page. Then, use an element selector to set
 You should import the `Lobster` font.
 
 ```js
-assert($('link[href*="googleapis" i]').length);
+assert.exists(document.querySelector('link[href*="googleapis" i]'));
 ```
 
 Your `h2` element should use the font `Lobster`.
 
 ```js
-assert(
-  $('h2')
-    .css('font-family')
-    .match(/lobster/i)
-);
+const h2 = document.querySelector('h2'); 
+const fontFamily = window.getComputedStyle(h2)['font-family']; 
+assert.match(fontFamily,/lobster/i);
 ```
 
 You should only use an `h2` element selector to change the font.
 
 ```js
-assert(
-  /\s*[^\.]h2\s*\{\s*font-family\s*:\s*('|"|)Lobster\1\s*(,\s*('|"|)[a-z -]+\3\s*)?(;\s*\}|\})/gi.test(
-    code
-  )
-);
+assert.match(code,/\s*[^\.]h2\s*\{\s*font-family\s*:\s*('|"|)Lobster\1\s*(,\s*('|"|)[a-z -]+\3\s*)?(;\s*\}|\})/gi);
 ```
 
 Your `p` element should still use the font `monospace`.
 
 ```js
-assert(
-  $('p')
-    .css('font-family')
-    .match(/monospace/i)
-);
+const paragraphElement = document.querySelector('p');
+const fontFamily = window.getComputedStyle(paragraphElement)['font-family']; 
+assert.match(fontFamily,/monospace/i);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/import-a-google-font.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/import-a-google-font.md
@@ -54,7 +54,7 @@ assert.match(fontFamily, /lobster/i);
 You should only use an `h2` element selector to change the font.
 
 ```js
-assert.match(__helpers.removeHTMLComments(code), /\s*[^\.]h2\s*\{\s*font-family\s*:\s*('|"|)Lobster\1\s*(,\s*('|"|)[a-z -]+\3\s*)?(;\s*\}|\})/gi);
+assert.match(__helpers.removeHtmlComments(code), /\s*[^\.]h2\s*\{\s*font-family\s*:\s*('|"|)Lobster\1\s*(,\s*('|"|)[a-z -]+\3\s*)?(;\s*\}|\})/gi);
 ```
 
 Your `p` element should still use the font `monospace`.

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/import-a-google-font.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/import-a-google-font.md
@@ -48,13 +48,13 @@ Your `h2` element should use the font `Lobster`.
 ```js
 const h2 = document.querySelector('h2'); 
 const fontFamily = window.getComputedStyle(h2)['font-family']; 
-assert.match(fontFamily,/lobster/i);
+assert.match(fontFamily, /lobster/i);
 ```
 
 You should only use an `h2` element selector to change the font.
 
 ```js
-assert.match(code,/\s*[^\.]h2\s*\{\s*font-family\s*:\s*('|"|)Lobster\1\s*(,\s*('|"|)[a-z -]+\3\s*)?(;\s*\}|\})/gi);
+assert.match(__helpers.removeHTMLComments(code), /\s*[^\.]h2\s*\{\s*font-family\s*:\s*('|"|)Lobster\1\s*(,\s*('|"|)[a-z -]+\3\s*)?(;\s*\}|\})/gi);
 ```
 
 Your `p` element should still use the font `monospace`.
@@ -62,7 +62,7 @@ Your `p` element should still use the font `monospace`.
 ```js
 const paragraphElement = document.querySelector('p');
 const fontFamily = window.getComputedStyle(paragraphElement)['font-family']; 
-assert.match(fontFamily,/monospace/i);
+assert.match(fontFamily, /monospace/i);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/improve-compatibility-with-browser-fallbacks.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/improve-compatibility-with-browser-fallbacks.md
@@ -23,13 +23,9 @@ It looks like a variable is being used to set the background color of the `.red-
 Your `.red-box` rule should include a fallback with the `background` set to `red` immediately before the existing `background` declaration.
 
 ```js
-assert(
-  code
-    .replace(/\s/g, '')
-    .match(
-      /\.red-box{background:(red|#ff0000|#f00|rgb\(255,0,0\)|rgb\(100%,0%,0%\)|hsl\(0,100%,50%\));background:var\(--red-color\);height:200px;width:200px;}/gi
-    )
-);
+const spacelessCode = __helpers.removeWhiteSpace(code);
+assert.match(
+spacelessCode,/\.red-box{background:(red|#ff0000|#f00|rgb\(255,0,0\)|rgb\(100%,0%,0%\)|hsl\(0,100%,50%\));background:var\(--red-color\);height:200px;width:200px;}/gi)
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/improve-compatibility-with-browser-fallbacks.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/improve-compatibility-with-browser-fallbacks.md
@@ -23,9 +23,11 @@ It looks like a variable is being used to set the background color of the `.red-
 Your `.red-box` rule should include a fallback with the `background` set to `red` immediately before the existing `background` declaration.
 
 ```js
-const spacelessCode = __helpers.removeWhiteSpace(code);
+const spacelessCode = __helpers.removeWhiteSpace(__helpers.removeCssComments(code));
 assert.match(
-spacelessCode,/\.red-box{background:(red|#ff0000|#f00|rgb\(255,0,0\)|rgb\(100%,0%,0%\)|hsl\(0,100%,50%\));background:var\(--red-color\);height:200px;width:200px;}/gi)
+  spacelessCode,
+  /\.red-box{background:(red|#ff0000|#f00|rgb\(255,0,0\)|rgb\(100%,0%,0%\)|hsl\(0,100%,50%\));background:var\(--red-color\);height:200px;width:200px;}/gi
+);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/inherit-css-variables.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/inherit-css-variables.md
@@ -24,9 +24,7 @@ Define a variable named `--penguin-belly` in the `:root` selector and give it th
 The `--penguin-belly` variable should be declared in the `:root` and assigned the value `pink`.
 
 ```js
-assert(
-  code.match(/:root\s*?{[\s\S]*--penguin-belly\s*?:\s*?pink\s*?;[\s\S]*}/gi)
-);
+assert.match(code,/:root\s*?{[\s\S]*--penguin-belly\s*?:\s*?pink\s*?;[\s\S]*}/gi);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/inherit-css-variables.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/inherit-css-variables.md
@@ -24,7 +24,10 @@ Define a variable named `--penguin-belly` in the `:root` selector and give it th
 The `--penguin-belly` variable should be declared in the `:root` and assigned the value `pink`.
 
 ```js
-assert.match(code,/:root\s*?{[\s\S]*--penguin-belly\s*?:\s*?pink\s*?;[\s\S]*}/gi);
+assert.match(
+  __helpers.removeCssComments(code),
+  /:root\s*?{[\s\S]*--penguin-belly\s*?:\s*?pink\s*?;[\s\S]*}/gi
+);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/inherit-styles-from-the-body-element.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/inherit-styles-from-the-body-element.md
@@ -26,61 +26,53 @@ Finally, give your `body` element the font-family of `monospace` by adding `font
 You should create an `h1` element.
 
 ```js
-assert($('h1').length > 0);
+assert.isAtLeast(document.querySelectorAll('h1').length,1);
 ```
 
 Your `h1` element should have the text `Hello World`.
 
 ```js
-assert(
-  $('h1').length > 0 &&
-    $('h1')
-      .text()
-      .match(/hello world/i)
-);
+assert.match(document.querySelector('h1').textContent,/hello world/i);
 ```
 
 Your `h1` element should have a closing tag.
 
 ```js
-assert(
-  code.match(/<\/h1>/g) &&
-    code.match(/<h1/g) &&
-    code.match(/<\/h1>/g).length === code.match(/<h1/g).length
-);
+assert.match(code,/<\/h1>/g);
+assert.match(code,/<h1/g);
+assert.strictEqual(code.match(/<\/h1>/g).length,code.match(/<h1/g).length);
 ```
 
 Your `body` element should have the `color` property of `green`.
 
 ```js
-assert($('body').css('color') === 'rgb(0, 128, 0)');
+const bodyElement = document.querySelector('body');
+const color = window.getComputedStyle(bodyElement)['color']; 
+assert.strictEqual(color,'rgb(0, 128, 0)');
 ```
 
 Your `body` element should have the `font-family` property of `monospace`.
 
 ```js
-assert(
-  $('body')
-    .css('font-family')
-    .match(/monospace/i)
-);
+const bodyElement = document.querySelector('body');
+const fontFamily = window.getComputedStyle(bodyElement)['font-family'];
+assert.match(fontFamily,/monospace/i);
 ```
 
 Your `h1` element should inherit the font `monospace` from your `body` element.
 
 ```js
-assert(
-  $('h1').length > 0 &&
-    $('h1')
-      .css('font-family')
-      .match(/monospace/i)
-);
+const h1Element = document.querySelector('h1');
+const fontFamily = window.getComputedStyle(h1Element)['font-family'];
+assert.match(fontFamily,/monospace/i);
 ```
 
 Your `h1` element should inherit the color `green` from your `body` element.
 
 ```js
-assert($('h1').length > 0 && $('h1').css('color') === 'rgb(0, 128, 0)');
+const h1Element = document.querySelector('h1');
+const color = window.getComputedStyle(h1Element)['color'];
+assert.strictEqual(color,'rgb(0, 128, 0)');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/inherit-styles-from-the-body-element.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/inherit-styles-from-the-body-element.md
@@ -41,9 +41,9 @@ assert.match(
 Your `h1` element should have a closing tag.
 
 ```js
-const commentlessCode = __helpers.removeHTMLComments(code);
+const commentlessCode = __helpers.removeHtmlComments(code);
 assert.match(commentlessCode, /<\/h1>/g);
-assert.match(_commentlessCode, /<h1/g);
+assert.match(commentlessCode, /<h1/g);
 assert.lengthOf(commentlessCode.match(/<\/h1>/g), commentlessCode.match(/<h1/g).length);
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/inherit-styles-from-the-body-element.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/inherit-styles-from-the-body-element.md
@@ -26,21 +26,25 @@ Finally, give your `body` element the font-family of `monospace` by adding `font
 You should create an `h1` element.
 
 ```js
-assert.isAtLeast(document.querySelectorAll('h1').length,1);
+assert.isNotEmpty(document.querySelectorAll('h1'));
 ```
 
 Your `h1` element should have the text `Hello World`.
 
 ```js
-assert.match(document.querySelector('h1').textContent,/hello world/i);
+assert.match(
+  document.querySelector('h1').textContent,
+  /hello world/i
+);
 ```
 
 Your `h1` element should have a closing tag.
 
 ```js
-assert.match(code,/<\/h1>/g);
-assert.match(code,/<h1/g);
-assert.strictEqual(code.match(/<\/h1>/g).length,code.match(/<h1/g).length);
+const commentlessCode = __helpers.removeHTMLComments(code);
+assert.match(commentlessCode, /<\/h1>/g);
+assert.match(_commentlessCode, /<h1/g);
+assert.lengthOf(commentlessCode.match(/<\/h1>/g), commentlessCode.match(/<h1/g).length);
 ```
 
 Your `body` element should have the `color` property of `green`.
@@ -48,7 +52,7 @@ Your `body` element should have the `color` property of `green`.
 ```js
 const bodyElement = document.querySelector('body');
 const color = window.getComputedStyle(bodyElement)['color']; 
-assert.strictEqual(color,'rgb(0, 128, 0)');
+assert.strictEqual(color, 'rgb(0, 128, 0)');
 ```
 
 Your `body` element should have the `font-family` property of `monospace`.
@@ -56,7 +60,7 @@ Your `body` element should have the `font-family` property of `monospace`.
 ```js
 const bodyElement = document.querySelector('body');
 const fontFamily = window.getComputedStyle(bodyElement)['font-family'];
-assert.match(fontFamily,/monospace/i);
+assert.include(fontFamily.toLowerCase(), "monospace");
 ```
 
 Your `h1` element should inherit the font `monospace` from your `body` element.
@@ -64,7 +68,7 @@ Your `h1` element should inherit the font `monospace` from your `body` element.
 ```js
 const h1Element = document.querySelector('h1');
 const fontFamily = window.getComputedStyle(h1Element)['font-family'];
-assert.match(fontFamily,/monospace/i);
+assert.include(fontFamily.toLowerCase(), "monospace");
 ```
 
 Your `h1` element should inherit the color `green` from your `body` element.
@@ -72,7 +76,7 @@ Your `h1` element should inherit the color `green` from your `body` element.
 ```js
 const h1Element = document.querySelector('h1');
 const color = window.getComputedStyle(h1Element)['color'];
-assert.strictEqual(color,'rgb(0, 128, 0)');
+assert.strictEqual(color, 'rgb(0, 128, 0)');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/make-circular-images-with-a-border-radius.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/make-circular-images-with-a-border-radius.md
@@ -20,13 +20,16 @@ Give your cat photo a `border-radius` of `50%`.
 Your image should have a border radius of `50%`, making it perfectly circular.
 
 ```js
-assert(parseInt($('img').css('border-top-left-radius')) > 48);
+const image = document.querySelector('img');
+const borderTopLeftRadius = window.getComputedStyle(image)['border-top-left-radius'];
+
+assert.strictEqual(parseInt(borderTopLeftRadius),50);
 ```
 
 The `border-radius` value should use a percentage value of `50%`.
 
 ```js
-assert(code.match(/50%/g));
+assert.match(code,/50%/g);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/make-circular-images-with-a-border-radius.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/make-circular-images-with-a-border-radius.md
@@ -23,13 +23,13 @@ Your image should have a border radius of `50%`, making it perfectly circular.
 const image = document.querySelector('img');
 const borderTopLeftRadius = window.getComputedStyle(image)['border-top-left-radius'];
 
-assert.strictEqual(parseInt(borderTopLeftRadius),50);
+assert.strictEqual(parseInt(borderTopLeftRadius), 50);
 ```
 
 The `border-radius` value should use a percentage value of `50%`.
 
 ```js
-assert.match(code,/50%/g);
+assert.match(__helpers.removeCssComments(), /50%/g);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/make-circular-images-with-a-border-radius.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/make-circular-images-with-a-border-radius.md
@@ -22,14 +22,13 @@ Your image should have a border radius of `50%`, making it perfectly circular.
 ```js
 const image = document.querySelector('img');
 const borderTopLeftRadius = window.getComputedStyle(image)['border-top-left-radius'];
-
 assert.strictEqual(parseInt(borderTopLeftRadius), 50);
 ```
 
 The `border-radius` value should use a percentage value of `50%`.
 
 ```js
-assert.match(__helpers.removeCssComments(), /50%/g);
+assert.match(__helpers.removeCssComments(code), /50%/g);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/override-all-other-styles-by-using-important.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/override-all-other-styles-by-using-important.md
@@ -32,39 +32,40 @@ color: red !important;
 Your `h1` element should have the class `pink-text`.
 
 ```js
-assert($('h1').hasClass('pink-text'));
+assert.isTrue(document.querySelector('h1').classList.contains('pink-text'));
 ```
 
 Your `h1` element should have the class `blue-text`.
 
 ```js
-assert($('h1').hasClass('blue-text'));
+assert.isTrue(document.querySelector('h1').classList.contains('blue-text'));
 ```
 
 Your `h1` element should have the `id` of `orange-text`.
 
 ```js
-assert($('h1').attr('id') === 'orange-text');
+assert.strictEqual(document.querySelector('h1').getAttribute('id'),'orange-text');
 ```
 
 Your `h1` element should have the inline style of `color: white`.
 
 ```js
-assert(code.match(/<h1.*style/gi) && code.match(/<h1.*style.*color\s*?:/gi));
+assert.match(code,/<h1.*style/gi);
+assert.match(code,/<h1.*style.*color\s*?:/gi);
 ```
 
 Your `pink-text` class declaration should have the `!important` keyword to override all other declarations.
 
 ```js
-assert(
-  code.match(/\.pink-text\s*?\{[\s\S]*?color:.*pink.*!important\s*;?[^\.]*\}/g)
-);
+assert.match(code,/\.pink-text\s*?\{[\s\S]*?color:.*pink.*!important\s*;?[^\.]*\}/g);
 ```
 
 Your `h1` element should be pink.
 
 ```js
-assert($('h1').css('color') === 'rgb(255, 192, 203)');
+const h1Element = document.querySelector('h1');
+const color = window.getComputedStyle(h1Element)['color'];
+assert.strictEqual(color,'rgb(255, 192, 203)');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/override-all-other-styles-by-using-important.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/override-all-other-styles-by-using-important.md
@@ -44,20 +44,21 @@ assert.isTrue(document.querySelector('h1').classList.contains('blue-text'));
 Your `h1` element should have the `id` of `orange-text`.
 
 ```js
-assert.strictEqual(document.querySelector('h1').getAttribute('id'),'orange-text');
+assert.strictEqual(document.querySelector('h1').getAttribute('id'), 'orange-text');
 ```
 
 Your `h1` element should have the inline style of `color: white`.
 
 ```js
-assert.match(code,/<h1.*style/gi);
-assert.match(code,/<h1.*style.*color\s*?:/gi);
+const commentessCode = __helpers.removeHTMLComments(code);
+assert.match(commentessCode, /<h1.*style/gi);
+assert.match(commentessCode, /<h1.*style.*color\s*?:/gi);
 ```
 
 Your `pink-text` class declaration should have the `!important` keyword to override all other declarations.
 
 ```js
-assert.match(code,/\.pink-text\s*?\{[\s\S]*?color:.*pink.*!important\s*;?[^\.]*\}/g);
+assert.match(__helpers.removeCssComments(code), /\.pink-text\s*?\{[\s\S]*?color:.*pink.*!important\s*;?[^\.]*\}/g);
 ```
 
 Your `h1` element should be pink.
@@ -65,7 +66,7 @@ Your `h1` element should be pink.
 ```js
 const h1Element = document.querySelector('h1');
 const color = window.getComputedStyle(h1Element)['color'];
-assert.strictEqual(color,'rgb(255, 192, 203)');
+assert.strictEqual(color, 'rgb(255, 192, 203)');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/override-all-other-styles-by-using-important.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/override-all-other-styles-by-using-important.md
@@ -50,7 +50,7 @@ assert.strictEqual(document.querySelector('h1').getAttribute('id'), 'orange-text
 Your `h1` element should have the inline style of `color: white`.
 
 ```js
-const commentessCode = __helpers.removeHTMLComments(code);
+const commentessCode = __helpers.removeHtmlComments(code);
 assert.match(commentessCode, /<h1.*style/gi);
 assert.match(commentessCode, /<h1.*style.*color\s*?:/gi);
 ```

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/override-class-declarations-by-styling-id-attributes.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/override-class-declarations-by-styling-id-attributes.md
@@ -40,43 +40,45 @@ Create a CSS declaration for your `orange-text` id in your `style` element. Here
 Your `h1` element should have the class `pink-text`.
 
 ```js
-assert($('h1').hasClass('pink-text'));
+assert.isTrue(document.querySelector('h1').classList.contains('pink-text'));
 ```
 
 Your `h1` element should have the class `blue-text`.
 
 ```js
-assert($('h1').hasClass('blue-text'));
+assert.isTrue(document.querySelector('h1').classList.contains('blue-text'));
 ```
 
 Your `h1` element should have the id of `orange-text`.
 
 ```js
-assert($('h1').attr('id') === 'orange-text');
+assert.strictEqual(document.querySelector('h1').getAttribute('id'),'orange-text');
 ```
 
 There should be only one `h1` element.
 
 ```js
-assert($('h1').length === 1);
+assert.lengthOf(document.querySelectorAll('h1'), 1);
 ```
 
 Your `orange-text` id should have a CSS declaration.
 
 ```js
-assert(code.match(/#orange-text\s*{/gi));
+assert.match(code,/#orange-text\s*{/gi);
 ```
 
 Your `h1` should not have any `style` attributes.
 
 ```js
-assert(!code.match(/<h1.*style.*>/gi));
+assert.notMatch(code,/<h1.*style.*>/gi);
 ```
 
 Your `h1` element should be orange.
 
 ```js
-assert($('h1').css('color') === 'rgb(255, 165, 0)');
+const h1Element = document.querySelector('h1');
+const color = window.getComputedStyle(h1Element)['color']; 
+assert.strictEqual(color,'rgb(255, 165, 0)');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/override-class-declarations-by-styling-id-attributes.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/override-class-declarations-by-styling-id-attributes.md
@@ -70,7 +70,7 @@ assert.match(__helpers.removeCssComments(code), /#orange-text\s*{/gi);
 Your `h1` should not have any `style` attributes.
 
 ```js
-assert.notMatch(__helpers.removeHTMLComments(code), /<h1.*style.*>/gi);
+assert.notMatch(__helpers.removeHtmlComments(code), /<h1.*style.*>/gi);
 ```
 
 Your `h1` element should be orange.

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/override-class-declarations-by-styling-id-attributes.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/override-class-declarations-by-styling-id-attributes.md
@@ -64,13 +64,13 @@ assert.lengthOf(document.querySelectorAll('h1'), 1);
 Your `orange-text` id should have a CSS declaration.
 
 ```js
-assert.match(code,/#orange-text\s*{/gi);
+assert.match(__helpers.removeCssComments(code), /#orange-text\s*{/gi);
 ```
 
 Your `h1` should not have any `style` attributes.
 
 ```js
-assert.notMatch(code,/<h1.*style.*>/gi);
+assert.notMatch(__helpers.removeHTMLComments(code), /<h1.*style.*>/gi);
 ```
 
 Your `h1` element should be orange.
@@ -78,7 +78,7 @@ Your `h1` element should be orange.
 ```js
 const h1Element = document.querySelector('h1');
 const color = window.getComputedStyle(h1Element)['color']; 
-assert.strictEqual(color,'rgb(255, 165, 0)');
+assert.strictEqual(color, 'rgb(255, 165, 0)');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/override-class-declarations-with-inline-styles.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/override-class-declarations-with-inline-styles.md
@@ -28,31 +28,33 @@ Leave the `blue-text` and `pink-text` classes on your `h1` element.
 Your `h1` element should have the class `pink-text`.
 
 ```js
-assert($('h1').hasClass('pink-text'));
+assert.isTrue(document.querySelector('h1').classList.contains('pink-text'));
 ```
 
 Your `h1` element should have the class `blue-text`.
 
 ```js
-assert($('h1').hasClass('blue-text'));
+assert.isTrue(document.querySelector('h1').classList.contains('blue-text'));
 ```
 
 Your `h1` element should have the id of `orange-text`.
 
 ```js
-assert($('h1').attr('id') === 'orange-text');
+assert.strictEqual(document.querySelector('h1').getAttribute('id'),'orange-text');
 ```
 
 Your `h1` element should have an inline style.
 
 ```js
-assert(document.querySelector('h1[style]'));
+assert.exists(document.querySelector('h1[style]'));
 ```
 
 Your `h1` element should be white.
 
 ```js
-assert($('h1').css('color') === 'rgb(255, 255, 255)');
+const h1Element = document.querySelector('h1');
+const color = window.getComputedStyle(h1Element)['color']; 
+assert.strictEqual(color,'rgb(255, 255, 255)');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/override-class-declarations-with-inline-styles.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/override-class-declarations-with-inline-styles.md
@@ -40,7 +40,7 @@ assert.isTrue(document.querySelector('h1').classList.contains('blue-text'));
 Your `h1` element should have the id of `orange-text`.
 
 ```js
-assert.strictEqual(document.querySelector('h1').getAttribute('id'),'orange-text');
+assert.strictEqual(document.querySelector('h1').getAttribute('id'), 'orange-text');
 ```
 
 Your `h1` element should have an inline style.
@@ -54,7 +54,7 @@ Your `h1` element should be white.
 ```js
 const h1Element = document.querySelector('h1');
 const color = window.getComputedStyle(h1Element)['color']; 
-assert.strictEqual(color,'rgb(255, 255, 255)');
+assert.strictEqual(color, 'rgb(255, 255, 255)');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/override-styles-in-subsequent-css.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/override-styles-in-subsequent-css.md
@@ -34,25 +34,27 @@ However, the order of the `class` declarations in the `<style>` section is what 
 Your `h1` element should have the class `pink-text`.
 
 ```js
-assert($('h1').hasClass('pink-text'));
+assert.isTrue(document.querySelector('h1').classList.contains('pink-text'));
 ```
 
 Your `h1` element should have the class `blue-text`.
 
 ```js
-assert($('h1').hasClass('blue-text'));
+assert.isTrue(document.querySelector('h1').classList.contains('blue-text'));
 ```
 
 Both `blue-text` and `pink-text` should belong to the same `h1` element.
 
 ```js
-assert($('.pink-text').hasClass('blue-text'));
+assert.isTrue(document.querySelector('.pink-text').classList.contains('blue-text'));
 ```
 
 Your `h1` element should be blue.
 
 ```js
-assert($('h1').css('color') === 'rgb(0, 0, 255)');
+const h1Element = document.querySelector('h1');
+const color = window.getComputedStyle(h1Element)['color']; 
+assert.strictEqual(color, 'rgb(0, 0, 255)');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/prioritize-one-style-over-another.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/prioritize-one-style-over-another.md
@@ -26,19 +26,21 @@ Give your `h1` element the class of `pink-text`.
 Your `h1` element should have the class `pink-text`.
 
 ```js
-assert($('h1').hasClass('pink-text'));
+assert.isTrue(document.querySelector('h1').classList.contains('pink-text'));
 ```
 
 Your `<style>` should have a `pink-text` CSS class that changes the `color`.
 
 ```js
-assert(code.match(/\.pink-text\s*\{\s*color\s*:\s*.+\s*;?\s*\}/g));
+assert.match(code,/\.pink-text\s*\{\s*color\s*:\s*.+\s*;?\s*\}/g);
 ```
 
 Your `h1` element should be pink.
 
 ```js
-assert($('h1').css('color') === 'rgb(255, 192, 203)');
+const h1Element = document.querySelector('h1');
+const color = window.getComputedStyle(h1Element)['color']; 
+assert.strictEqual(color,'rgb(255, 192, 203)');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/prioritize-one-style-over-another.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/prioritize-one-style-over-another.md
@@ -32,7 +32,7 @@ assert.isTrue(document.querySelector('h1').classList.contains('pink-text'));
 Your `<style>` should have a `pink-text` CSS class that changes the `color`.
 
 ```js
-assert.match(code,/\.pink-text\s*\{\s*color\s*:\s*.+\s*;?\s*\}/g);
+assert.match(__helpers.removeCssComments(code), /\.pink-text\s*\{\s*color\s*:\s*.+\s*;?\s*\}/g);
 ```
 
 Your `h1` element should be pink.
@@ -40,7 +40,7 @@ Your `h1` element should be pink.
 ```js
 const h1Element = document.querySelector('h1');
 const color = window.getComputedStyle(h1Element)['color']; 
-assert.strictEqual(color,'rgb(255, 192, 203)');
+assert.strictEqual(color, 'rgb(255, 192, 203)');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/set-the-font-family-of-an-element.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/set-the-font-family-of-an-element.md
@@ -28,12 +28,9 @@ Make all of your `p` elements use the `monospace` font.
 Your `p` elements should use the font `monospace`.
 
 ```js
-assert(
-  $('p')
-    .not('.red-text')
-    .css('font-family')
-    .match(/monospace/i)
-);
+const notRed = document.querySelector('p:not(.red-text)');
+const fontFamily = window.getComputedStyle(notRed)['font-family']; 
+assert.match(fontFamily,/monospace/i);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/set-the-font-family-of-an-element.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/set-the-font-family-of-an-element.md
@@ -30,7 +30,7 @@ Your `p` elements should use the font `monospace`.
 ```js
 const notRed = document.querySelector('p:not(.red-text)');
 const fontFamily = window.getComputedStyle(notRed)['font-family']; 
-assert.match(fontFamily,/monospace/i);
+assert.match(fontFamily, /monospace/i);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/set-the-id-of-an-element.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/set-the-id-of-an-element.md
@@ -30,7 +30,7 @@ Give your `form` element the id `cat-photo-form`.
 Your `form` element should have the id of `cat-photo-form`.
 
 ```js
-assert($('form').attr('id') === 'cat-photo-form');
+assert.strictEqual(document.querySelector('form').getAttribute('id') ,'cat-photo-form');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/set-the-id-of-an-element.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/set-the-id-of-an-element.md
@@ -30,7 +30,7 @@ Give your `form` element the id `cat-photo-form`.
 Your `form` element should have the id of `cat-photo-form`.
 
 ```js
-assert.strictEqual(document.querySelector('form').getAttribute('id') ,'cat-photo-form');
+assert.strictEqual(document.querySelector('form').getAttribute('id'), 'cat-photo-form');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/size-your-images.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/size-your-images.md
@@ -29,19 +29,18 @@ Create a class called `smaller-image` and use it to resize the image so that it'
 Your `img` element should have the class `smaller-image`.
 
 ```js
-assert(
-  $("img[src='https://cdn.freecodecamp.org/curriculum/cat-photo-app/relaxing-cat.jpg']").attr('class')
-    .trim().split(/\s+/g).includes('smaller-image')
-);
+const relaxingCatImage = document.querySelector("img[src='https://cdn.freecodecamp.org/curriculum/cat-photo-app/relaxing-cat.jpg']");
+const catImageClass = relaxingCatImage.getAttribute('class').trim().split(/\s+/g);
+assert.include(catImageClass,'smaller-image');
 ```
 
 Your image should be 100 pixels wide.
 
 ```js
-assert(
-  $('img').width() < 200 &&
-    code.match(/\.smaller-image\s*{\s*width\s*:\s*100px\s*(;\s*}|})/i)
-);
+const image = document.querySelector('img');
+const width = image.getBoundingClientRect().width;
+assert.isBelow(width,200); 
+assert.match(code,/\.smaller-image\s*{\s*width\s*:\s*100px\s*(;\s*}|})/i);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/size-your-images.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/size-your-images.md
@@ -31,7 +31,7 @@ Your `img` element should have the class `smaller-image`.
 ```js
 const relaxingCatImage = document.querySelector("img[src='https://cdn.freecodecamp.org/curriculum/cat-photo-app/relaxing-cat.jpg']");
 const catImageClass = relaxingCatImage.getAttribute('class').trim().split(/\s+/g);
-assert.include(catImageClass,'smaller-image');
+assert.include(catImageClass, 'smaller-image');
 ```
 
 Your image should be 100 pixels wide.
@@ -39,8 +39,8 @@ Your image should be 100 pixels wide.
 ```js
 const image = document.querySelector('img');
 const width = image.getBoundingClientRect().width;
-assert.isBelow(width,200); 
-assert.match(code,/\.smaller-image\s*{\s*width\s*:\s*100px\s*(;\s*}|})/i);
+assert.isBelow(width, 200); 
+assert.match(__helpers.removeCssComments(code), /\.smaller-image\s*{\s*width\s*:\s*100px\s*(;\s*}|})/i);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/specify-how-fonts-should-degrade.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/specify-how-fonts-should-degrade.md
@@ -36,33 +36,27 @@ In the last challenge, you imported the `Lobster` font using the `link` tag. Now
 Your h2 element should use the font `Lobster`.
 
 ```js
-assert(
-  $('h2')
-    .css('font-family')
-    .match(/^"?lobster/i)
-);
+const h2Element = document.querySelector('h2');
+const fontFamily = window.getComputedStyle(h2Element)['font-family']; 
+assert.match(fontFamily,/^"?lobster/i);
 ```
 
 Your h2 element should degrade to the font `monospace` when `Lobster` is not available.
 
 ```js
-assert(
-  /\s*h2\s*\{\s*font-family\s*\:\s*(\'|"|)Lobster\1\s*,\s*monospace\s*;?\s*\}/gi.test(
-    code
-  )
-);
+assert.match(code,/\s*h2\s*\{\s*font-family\s*\:\s*(\'|"|)Lobster\1\s*,\s*monospace\s*;?\s*\}/gi);
 ```
 
 You should comment out your call to Google for the `Lobster` font by putting `<!--` in front of it.
 
 ```js
-assert(new RegExp('<!--[^fc]', 'gi').test(code));
+assert.match(code,/<!--[^fc]/gi);
 ```
 
 You should close your comment by adding `-->`.
 
 ```js
-assert(new RegExp('[^fc]-->', 'gi').test(code));
+assert.match(code,/[^fc]-->/gi);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/specify-how-fonts-should-degrade.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/specify-how-fonts-should-degrade.md
@@ -38,25 +38,25 @@ Your h2 element should use the font `Lobster`.
 ```js
 const h2Element = document.querySelector('h2');
 const fontFamily = window.getComputedStyle(h2Element)['font-family']; 
-assert.match(fontFamily,/^"?lobster/i);
+assert.match(fontFamily, /^"?lobster/i);
 ```
 
 Your h2 element should degrade to the font `monospace` when `Lobster` is not available.
 
 ```js
-assert.match(code,/\s*h2\s*\{\s*font-family\s*\:\s*(\'|"|)Lobster\1\s*,\s*monospace\s*;?\s*\}/gi);
+assert.match(__helpers.removeCssComments(code), /\s*h2\s*\{\s*font-family\s*\:\s*(\'|"|)Lobster\1\s*,\s*monospace\s*;?\s*\}/gi);
 ```
 
 You should comment out your call to Google for the `Lobster` font by putting `<!--` in front of it.
 
 ```js
-assert.match(code,/<!--[^fc]/gi);
+assert.match(code, /<!--[^fc]/gi);
 ```
 
 You should close your comment by adding `-->`.
 
 ```js
-assert.match(code,/[^fc]-->/gi);
+assert.match(code, /[^fc]-->/gi);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/style-multiple-elements-with-a-css-class.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/style-multiple-elements-with-a-css-class.md
@@ -16,34 +16,42 @@ Classes allow you to use the same CSS styles on multiple HTML elements. You can 
 Your `h2` element should be red.
 
 ```js
-assert($('h2').css('color') === 'rgb(255, 0, 0)');
+const h2Element = document.querySelector('h2');
+const color = window.getComputedStyle(h2Element)['color']; 
+assert.strictEqual(color,'rgb(255, 0, 0)');
 ```
 
 Your `h2` element should have the class `red-text`.
 
 ```js
-assert($('h2').hasClass('red-text'));
+assert.isTrue(document.querySelector('h2').classList.contains('red-text'));
 ```
 
 Your first `p` element should be red.
 
 ```js
-assert($('p:eq(0)').css('color') === 'rgb(255, 0, 0)');
+const paragraph = document.querySelectorAll('p')[0];
+const color = window.getComputedStyle(paragraph )['color'];
+assert.strictEqual(color,'rgb(255, 0, 0)');
 ```
 
 Your second and third `p` elements should not be red.
 
 ```js
-assert(
-  !($('p:eq(1)').css('color') === 'rgb(255, 0, 0)') &&
-    !($('p:eq(2)').css('color') === 'rgb(255, 0, 0)')
-);
+const paragraph2 = document.querySelectorAll('p')[1];
+const paragraph3 = document.querySelectorAll('p')[2];
+
+const color2 = window.getComputedStyle(paragraph2)['color'];
+const color3 = window.getComputedStyle(paragraph3)['color'];
+
+assert.notStrictEqual(color2,'rgb(255, 0, 0)');
+assert.notStrictEqual(color3,'rgb(255, 0, 0)');
 ```
 
 Your first `p` element should have the class `red-text`.
 
 ```js
-assert($('p:eq(0)').hasClass('red-text'));
+assert.isTrue(document.querySelectorAll('p')[0].classList.contains('red-text'));
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/style-multiple-elements-with-a-css-class.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/style-multiple-elements-with-a-css-class.md
@@ -18,7 +18,7 @@ Your `h2` element should be red.
 ```js
 const h2Element = document.querySelector('h2');
 const color = window.getComputedStyle(h2Element)['color']; 
-assert.strictEqual(color,'rgb(255, 0, 0)');
+assert.strictEqual(color, 'rgb(255, 0, 0)');
 ```
 
 Your `h2` element should have the class `red-text`.
@@ -32,7 +32,7 @@ Your first `p` element should be red.
 ```js
 const paragraph = document.querySelectorAll('p')[0];
 const color = window.getComputedStyle(paragraph )['color'];
-assert.strictEqual(color,'rgb(255, 0, 0)');
+assert.strictEqual(color, 'rgb(255, 0, 0)');
 ```
 
 Your second and third `p` elements should not be red.
@@ -44,8 +44,8 @@ const paragraph3 = document.querySelectorAll('p')[2];
 const color2 = window.getComputedStyle(paragraph2)['color'];
 const color3 = window.getComputedStyle(paragraph3)['color'];
 
-assert.notStrictEqual(color2,'rgb(255, 0, 0)');
-assert.notStrictEqual(color3,'rgb(255, 0, 0)');
+assert.notStrictEqual(color2, 'rgb(255, 0, 0)');
+assert.notStrictEqual(color3, 'rgb(255, 0, 0)');
 ```
 
 Your first `p` element should have the class `red-text`.

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/style-the-html-body-element.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/style-the-html-body-element.md
@@ -30,23 +30,22 @@ body {
 Your `body` element should have the `background-color` of black.
 
 ```js
-assert($('body').css('background-color') === 'rgb(0, 0, 0)');
+const body = document.querySelector('body');
+const backgroundColor = window.getComputedStyle(body)['background-color'];
+
+assert.strictEqual(backgroundColor,'rgb(0, 0, 0)');
 ```
 
 Your CSS rule should be properly formatted with both opening and closing curly brackets.
 
 ```js
-assert(
-  code.match(/<style>\s*body\s*\{\s*background.*\s*:\s*.*;\s*\}\s*<\/style>/i)
-);
+assert.match(code,/<style>\s*body\s*\{\s*background.*\s*:\s*.*;\s*\}\s*<\/style>/i);
 ```
 
 Your CSS rule should end with a semicolon.
 
 ```js
-assert(
-  code.match(/<style>\s*body\s*\{\s*background.*\s*:\s*.*;\s*\}\s*<\/style>/i)
-);
+assert.match(code,/<style>\s*body\s*\{\s*background.*\s*:\s*.*;\s*\}\s*<\/style>/i);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/style-the-html-body-element.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/style-the-html-body-element.md
@@ -33,19 +33,19 @@ Your `body` element should have the `background-color` of black.
 const body = document.querySelector('body');
 const backgroundColor = window.getComputedStyle(body)['background-color'];
 
-assert.strictEqual(backgroundColor,'rgb(0, 0, 0)');
+assert.strictEqual(backgroundColor, 'rgb(0, 0, 0)');
 ```
 
 Your CSS rule should be properly formatted with both opening and closing curly brackets.
 
 ```js
-assert.match(code,/<style>\s*body\s*\{\s*background.*\s*:\s*.*;\s*\}\s*<\/style>/i);
+assert.match(code, /<style>\s*body\s*\{\s*background.*\s*:\s*.*;\s*\}\s*<\/style>/i);
 ```
 
 Your CSS rule should end with a semicolon.
 
 ```js
-assert.match(code,/<style>\s*body\s*\{\s*background.*\s*:\s*.*;\s*\}\s*<\/style>/i);
+assert.match(code, /<style>\s*body\s*\{\s*background.*\s*:\s*.*;\s*\}\s*<\/style>/i);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/understand-absolute-versus-relative-units.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/understand-absolute-versus-relative-units.md
@@ -26,18 +26,19 @@ Add a `padding` property to the element with class `red-box` and set it to `1.5e
 Your `red-box` class should have a `padding` property.
 
 ```js
-assert(
-  $('.red-box').css('padding-top') != '0px' &&
-    $('.red-box').css('padding-right') != '0px' &&
-    $('.red-box').css('padding-bottom') != '0px' &&
-    $('.red-box').css('padding-left') != '0px'
-);
+const redBox =document.querySelector('.red-box'); 
+const style = window.getComputedStyle(redBox); 
+
+assert.notEqual(style['padding-top'],'0px');
+assert.notEqual(style['padding-right'],'0px');
+assert.notEqual(style['padding-bottom'],'0px');
+assert.notEqual(style['padding-left'],'0px');
 ```
 
 Your `red-box` class should give elements 1.5em of `padding`.
 
 ```js
-assert(code.match(/\.red-box\s*?{[\s\S]*padding\s*:\s*?1\.5em/gi));
+assert.match(code,/\.red-box\s*?{[\s\S]*padding\s*:\s*?1\.5em/gi);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/understand-absolute-versus-relative-units.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/understand-absolute-versus-relative-units.md
@@ -29,16 +29,16 @@ Your `red-box` class should have a `padding` property.
 const redBox =document.querySelector('.red-box'); 
 const style = window.getComputedStyle(redBox); 
 
-assert.notEqual(style['padding-top'],'0px');
-assert.notEqual(style['padding-right'],'0px');
-assert.notEqual(style['padding-bottom'],'0px');
-assert.notEqual(style['padding-left'],'0px');
+assert.notEqual(style['padding-top'], '0px');
+assert.notEqual(style['padding-right'], '0px');
+assert.notEqual(style['padding-bottom'], '0px');
+assert.notEqual(style['padding-left'], '0px');
 ```
 
 Your `red-box` class should give elements 1.5em of `padding`.
 
 ```js
-assert.match(code,/\.red-box\s*?{[\s\S]*padding\s*:\s*?1\.5em/gi);
+assert.match(__helpers.removeCssComments(code), /\.red-box\s*?{[\s\S]*padding\s*:\s*?1\.5em/gi);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/use-a-css-class-to-style-an-element.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/use-a-css-class-to-style-an-element.md
@@ -34,25 +34,27 @@ Give your `h2` element the `class` attribute with a value of `red-text`.
 Your `h2` element should be red.
 
 ```js
-assert($('h2').css('color') === 'rgb(255, 0, 0)');
+const h2Element = document.querySelector('h2'); 
+const color = window.getComputedStyle(h2Element)['color']; 
+assert.strictEqual(color, 'rgb(255, 0, 0)');
 ```
 
 Your `h2` element should have the class `red-text`.
 
 ```js
-assert($('h2').hasClass('red-text'));
+assert.isTrue(document.querySelector('h2').classList.contains('red-text'));
 ```
 
 Your stylesheet should declare a `red-text` class and have its color set to `red`.
 
 ```js
-assert(code.match(/\.red-text\s*\{\s*color\s*:\s*red;?\s*\}/g));
+assert.match(code,/\.red-text\s*\{\s*color\s*:\s*red;?\s*\}/g);
 ```
 
 You should not use inline style declarations like `style="color: red"` in your `h2` element.
 
 ```js
-assert($('h2').attr('style') === undefined);
+assert.notExists(document.querySelector('h2').getAttribute('style'));
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/use-a-css-class-to-style-an-element.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/use-a-css-class-to-style-an-element.md
@@ -48,7 +48,7 @@ assert.isTrue(document.querySelector('h2').classList.contains('red-text'));
 Your stylesheet should declare a `red-text` class and have its color set to `red`.
 
 ```js
-assert.match(code,/\.red-text\s*\{\s*color\s*:\s*red;?\s*\}/g);
+assert.match(__helpers.removeCssComments(code), /\.red-text\s*\{\s*color\s*:\s*red;?\s*\}/g);
 ```
 
 You should not use inline style declarations like `style="color: red"` in your `h2` element.

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/use-a-custom-css-variable.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/use-a-custom-css-variable.md
@@ -26,41 +26,25 @@ Apply the `--penguin-skin` variable to the `background` property of the `penguin
 The `--penguin-skin` variable should be applied to the `background` property of the `penguin-top` class.
 
 ```js
-assert(
-  code.match(
-    /.penguin-top\s*?{[\s\S]*background\s*?:\s*?var\s*?\(\s*?--penguin-skin\s*?\)\s*?;[\s\S]*}[\s\S]*.penguin-bottom\s{/gi
-  )
-);
+assert.match(code,/.penguin-top\s*?{[\s\S]*background\s*?:\s*?var\s*?\(\s*?--penguin-skin\s*?\)\s*?;[\s\S]*}[\s\S]*.penguin-bottom\s{/gi);
 ```
 
 The `--penguin-skin` variable should be applied to the `background` property of the `penguin-bottom` class.
 
 ```js
-assert(
-  code.match(
-    /.penguin-bottom\s*?{[\s\S]*background\s*?:\s*?var\s*?\(\s*?--penguin-skin\s*?\)\s*?;[\s\S]*}[\s\S]*.right-hand\s{/gi
-  )
-);
+assert.match(code,/.penguin-bottom\s*?{[\s\S]*background\s*?:\s*?var\s*?\(\s*?--penguin-skin\s*?\)\s*?;[\s\S]*}[\s\S]*.right-hand\s{/gi);
 ```
 
 The `--penguin-skin` variable should be applied to the `background` property of the `right-hand` class.
 
 ```js
-assert(
-  code.match(
-    /.right-hand\s*?{[\s\S]*background\s*?:\s*?var\s*?\(\s*?--penguin-skin\s*?\)\s*?;[\s\S]*}[\s\S]*.left-hand\s{/gi
-  )
-);
+assert.match(code,/.right-hand\s*?{[\s\S]*background\s*?:\s*?var\s*?\(\s*?--penguin-skin\s*?\)\s*?;[\s\S]*}[\s\S]*.left-hand\s{/gi);
 ```
 
 The `--penguin-skin` variable should be applied to the `background` property of the `left-hand` class.
 
 ```js
-assert(
-  code.match(
-    /.left-hand\s*?{[\s\S]*background\s*?:\s*?var\s*?\(\s*?--penguin-skin\s*?\)\s*?;[\s\S]*}/gi
-  )
-);
+assert.match(code,/.left-hand\s*?{[\s\S]*background\s*?:\s*?var\s*?\(\s*?--penguin-skin\s*?\)\s*?;[\s\S]*}/gi);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/use-a-custom-css-variable.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/use-a-custom-css-variable.md
@@ -26,25 +26,25 @@ Apply the `--penguin-skin` variable to the `background` property of the `penguin
 The `--penguin-skin` variable should be applied to the `background` property of the `penguin-top` class.
 
 ```js
-assert.match(code,/.penguin-top\s*?{[\s\S]*background\s*?:\s*?var\s*?\(\s*?--penguin-skin\s*?\)\s*?;[\s\S]*}[\s\S]*.penguin-bottom\s{/gi);
+assert.match(__helpers.removeCssComments(code), /.penguin-top\s*?{[\s\S]*background\s*?:\s*?var\s*?\(\s*?--penguin-skin\s*?\)\s*?;[\s\S]*}[\s\S]*.penguin-bottom\s{/gi);
 ```
 
 The `--penguin-skin` variable should be applied to the `background` property of the `penguin-bottom` class.
 
 ```js
-assert.match(code,/.penguin-bottom\s*?{[\s\S]*background\s*?:\s*?var\s*?\(\s*?--penguin-skin\s*?\)\s*?;[\s\S]*}[\s\S]*.right-hand\s{/gi);
+assert.match(__helpers.removeCssComments(code), /.penguin-bottom\s*?{[\s\S]*background\s*?:\s*?var\s*?\(\s*?--penguin-skin\s*?\)\s*?;[\s\S]*}[\s\S]*.right-hand\s{/gi);
 ```
 
 The `--penguin-skin` variable should be applied to the `background` property of the `right-hand` class.
 
 ```js
-assert.match(code,/.right-hand\s*?{[\s\S]*background\s*?:\s*?var\s*?\(\s*?--penguin-skin\s*?\)\s*?;[\s\S]*}[\s\S]*.left-hand\s{/gi);
+assert.match(__helpers.removeCssComments(code), /.right-hand\s*?{[\s\S]*background\s*?:\s*?var\s*?\(\s*?--penguin-skin\s*?\)\s*?;[\s\S]*}[\s\S]*.left-hand\s{/gi);
 ```
 
 The `--penguin-skin` variable should be applied to the `background` property of the `left-hand` class.
 
 ```js
-assert.match(code,/.left-hand\s*?{[\s\S]*background\s*?:\s*?var\s*?\(\s*?--penguin-skin\s*?\)\s*?;[\s\S]*}/gi);
+assert.match(__helpers.removeCssComments(code), /.left-hand\s*?{[\s\S]*background\s*?:\s*?var\s*?\(\s*?--penguin-skin\s*?\)\s*?;[\s\S]*}/gi);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/use-a-media-query-to-change-a-variable.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/use-a-media-query-to-change-a-variable.md
@@ -22,21 +22,13 @@ In the `:root` selector of the media query, change it so `--penguin-size` is red
 `:root` should reassign the `--penguin-size` variable to `200px`.
 
 ```js
-assert(
-  code.match(
-    /media\s*?\(\s*?max-width\s*?:\s*?350px\s*?\)\s*?{[\s\S]*:root\s*?{[\s\S]*--penguin-size\s*?:\s*?200px\s*?;[\s\S]*}[\s\S]*}/gi
-  )
-);
+assert.match(code,/media\s*?\(\s*?max-width\s*?:\s*?350px\s*?\)\s*?{[\s\S]*:root\s*?{[\s\S]*--penguin-size\s*?:\s*?200px\s*?;[\s\S]*}[\s\S]*}/gi);
 ```
 
 `:root` should reassign the `--penguin-skin` variable to `black`.
 
 ```js
-assert(
-  code.match(
-    /media\s*?\(\s*?max-width\s*?:\s*?350px\s*?\)\s*?{[\s\S]*:root\s*?{[\s\S]*--penguin-skin\s*?:\s*?black\s*?;[\s\S]*}[\s\S]*}/gi
-  )
-);
+assert.match(code,/media\s*?\(\s*?max-width\s*?:\s*?350px\s*?\)\s*?{[\s\S]*:root\s*?{[\s\S]*--penguin-skin\s*?:\s*?black\s*?;[\s\S]*}[\s\S]*}/gi);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/use-a-media-query-to-change-a-variable.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/use-a-media-query-to-change-a-variable.md
@@ -22,13 +22,13 @@ In the `:root` selector of the media query, change it so `--penguin-size` is red
 `:root` should reassign the `--penguin-size` variable to `200px`.
 
 ```js
-assert.match(code,/media\s*?\(\s*?max-width\s*?:\s*?350px\s*?\)\s*?{[\s\S]*:root\s*?{[\s\S]*--penguin-size\s*?:\s*?200px\s*?;[\s\S]*}[\s\S]*}/gi);
+assert.match(__helpers.removeCssComments(code), /media\s*?\(\s*?max-width\s*?:\s*?350px\s*?\)\s*?{[\s\S]*:root\s*?{[\s\S]*--penguin-size\s*?:\s*?200px\s*?;[\s\S]*}[\s\S]*}/gi);
 ```
 
 `:root` should reassign the `--penguin-skin` variable to `black`.
 
 ```js
-assert.match(code,/media\s*?\(\s*?max-width\s*?:\s*?350px\s*?\)\s*?{[\s\S]*:root\s*?{[\s\S]*--penguin-skin\s*?:\s*?black\s*?;[\s\S]*}[\s\S]*}/gi);
+assert.match(__helpers.removeCssComments(code), /media\s*?\(\s*?max-width\s*?:\s*?350px\s*?\)\s*?{[\s\S]*:root\s*?{[\s\S]*--penguin-skin\s*?:\s*?black\s*?;[\s\S]*}[\s\S]*}/gi);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/use-abbreviated-hex-code.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/use-abbreviated-hex-code.md
@@ -26,49 +26,57 @@ Go ahead, try using the abbreviated hex codes to color the correct elements.
 Your `h1` element with the text `I am red!` should be given the `color` red.
 
 ```js
-assert($('.red-text').css('color') === 'rgb(255, 0, 0)');
+const redText = document.querySelector('.red-text');
+const color = window.getComputedStyle(redText)['color']; 
+assert.strictEqual(color,'rgb(255, 0, 0)');
 ```
 
 The abbreviated hex code for the color red should be used instead of the hex code `#FF0000`.
 
 ```js
-assert(code.match(/\.red-text\s*?{\s*?color\s*:\s*?#F00\s*?;?\s*?}/gi));
+assert.match(code,/\.red-text\s*?{\s*?color\s*:\s*?#F00\s*?;?\s*?}/gi);
 ```
 
 Your `h1` element with the text `I am green!` should be given the `color` green.
 
 ```js
-assert($('.green-text').css('color') === 'rgb(0, 255, 0)');
+const greenText = document.querySelector('.green-text');
+const color = window.getComputedStyle(greenText)['color']; 
+assert.strictEqual(color,'rgb(0, 255, 0)');
 ```
 
 The abbreviated hex code for the color green should be used instead of the hex code `#00FF00`.
 
 ```js
-assert(code.match(/\.green-text\s*?{\s*?color\s*:\s*?#0F0\s*?;?\s*?}/gi));
+assert.match(code,/\.green-text\s*?{\s*?color\s*:\s*?#0F0\s*?;?\s*?}/gi);
 ```
 
 Your `h1` element with the text `I am cyan!` should be given the `color` cyan.
 
 ```js
-assert($('.cyan-text').css('color') === 'rgb(0, 255, 255)');
+const cyanText = document.querySelector('.cyan-text');
+const color = window.getComputedStyle(cyanText)['color']; 
+assert.strictEqual(color,'rgb(0, 255, 255)');
 ```
 
 The abbreviated hex code for the color cyan should be used instead of the hex code `#00FFFF`.
 
 ```js
-assert(code.match(/\.cyan-text\s*?{\s*?color\s*:\s*?#0FF\s*?;?\s*?}/gi));
+assert.match(code,/\.cyan-text\s*?{\s*?color\s*:\s*?#0FF\s*?;?\s*?}/gi);
 ```
 
 Your `h1` element with the text `I am fuchsia!` should be given the `color` fuchsia.
 
 ```js
-assert($('.fuchsia-text').css('color') === 'rgb(255, 0, 255)');
+const fuchsiaText = document.querySelector('.fuchsia-text');
+const color = window.getComputedStyle(fuchsiaText)['color']; 
+assert.strictEqual(color,'rgb(255, 0, 255)');
 ```
 
 The abbreviated hex code for the color fuchsia should be used instead of the hex code `#FF00FF`.
 
 ```js
-assert(code.match(/\.fuchsia-text\s*?{\s*?color\s*:\s*?#F0F\s*?;?\s*?}/gi));
+assert.match(code,/\.fuchsia-text\s*?{\s*?color\s*:\s*?#F0F\s*?;?\s*?}/gi);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/use-abbreviated-hex-code.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/use-abbreviated-hex-code.md
@@ -28,7 +28,7 @@ Your `h1` element with the text `I am red!` should be given the `color` red.
 ```js
 const redText = document.querySelector('.red-text');
 const color = window.getComputedStyle(redText)['color']; 
-assert.strictEqual(color,'rgb(255, 0, 0)');
+assert.strictEqual(color, 'rgb(255, 0, 0)');
 ```
 
 The abbreviated hex code for the color red should be used instead of the hex code `#FF0000`.
@@ -42,13 +42,13 @@ Your `h1` element with the text `I am green!` should be given the `color` green.
 ```js
 const greenText = document.querySelector('.green-text');
 const color = window.getComputedStyle(greenText)['color']; 
-assert.strictEqual(color,'rgb(0, 255, 0)');
+assert.strictEqual(color, 'rgb(0, 255, 0)');
 ```
 
 The abbreviated hex code for the color green should be used instead of the hex code `#00FF00`.
 
 ```js
-assert.match(code,/\.green-text\s*?{\s*?color\s*:\s*?#0F0\s*?;?\s*?}/gi);
+assert.match(__helpers.removeCssComments(code), /\.green-text\s*?{\s*?color\s*:\s*?#0F0\s*?;?\s*?}/gi);
 ```
 
 Your `h1` element with the text `I am cyan!` should be given the `color` cyan.
@@ -56,13 +56,13 @@ Your `h1` element with the text `I am cyan!` should be given the `color` cyan.
 ```js
 const cyanText = document.querySelector('.cyan-text');
 const color = window.getComputedStyle(cyanText)['color']; 
-assert.strictEqual(color,'rgb(0, 255, 255)');
+assert.strictEqual(color, 'rgb(0, 255, 255)');
 ```
 
 The abbreviated hex code for the color cyan should be used instead of the hex code `#00FFFF`.
 
 ```js
-assert.match(code,/\.cyan-text\s*?{\s*?color\s*:\s*?#0FF\s*?;?\s*?}/gi);
+assert.match(__helpers.removeCssComments(code), /\.cyan-text\s*?{\s*?color\s*:\s*?#0FF\s*?;?\s*?}/gi);
 ```
 
 Your `h1` element with the text `I am fuchsia!` should be given the `color` fuchsia.
@@ -76,7 +76,7 @@ assert.strictEqual(color,'rgb(255, 0, 255)');
 The abbreviated hex code for the color fuchsia should be used instead of the hex code `#FF00FF`.
 
 ```js
-assert.match(code,/\.fuchsia-text\s*?{\s*?color\s*:\s*?#F0F\s*?;?\s*?}/gi);
+assert.match(__helpers.removeCssComments(code), /\.fuchsia-text\s*?{\s*?color\s*:\s*?#F0F\s*?;?\s*?}/gi);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/use-an-id-attribute-to-style-an-element.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/use-an-id-attribute-to-style-an-element.md
@@ -32,28 +32,29 @@ Try giving your form, which now has the `id` attribute of `cat-photo-form`, a gr
 Your `form` element should have the id of `cat-photo-form`.
 
 ```js
-assert($('form').attr('id') === 'cat-photo-form');
+assert.strictEqual(document.querySelector('form').getAttribute('id'), 'cat-photo-form');
 ```
 
 Your `form` element should have the `background-color` of green.
 
 ```js
-assert($('#cat-photo-form').css('background-color') === 'rgb(0, 128, 0)');
+const catPhotoForm = document.querySelector('#cat-photo-form');
+const backgroundColor = window.getComputedStyle(catPhotoForm)['background-color'];
+assert.strictEqual(backgroundColor,'rgb(0, 128, 0)');
 ```
 
 Your `form` element should have an `id` attribute.
 
 ```js
-assert(
-  code.match(/<form.*cat-photo-form.*>/gi) &&
-    code.match(/<form.*cat-photo-form.*>/gi).length > 0
-);
+assert.match(code,/<form.*cat-photo-form.*>/gi);
+assert.strictEqual(code.match(/<form.*cat-photo-form.*>/gi).length,1)
 ```
 
 You should not give your `form` any `class` or `style` attributes.
 
 ```js
-assert(!code.match(/<form.*style.*>/gi) && !code.match(/<form.*class.*>/gi));
+assert.notMatch(code,/<form.*style.*>/gi);
+assert.notMatch(code,/<form.*class.*>/gi);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/use-an-id-attribute-to-style-an-element.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/use-an-id-attribute-to-style-an-element.md
@@ -46,15 +46,15 @@ assert.strictEqual(backgroundColor, 'rgb(0, 128, 0)');
 Your `form` element should have an `id` attribute.
 
 ```js
-assert.match(__helpers.removeHTMLComments(code), /<form.*cat-photo-form.*>/gi);
-assert.lengthOf(__helpers.removeHTMLComments(code).match(/<form.*cat-photo-form.*>/gi), 1)
+assert.match(__helpers.removeHtmlComments(code), /<form.*cat-photo-form.*>/gi);
+assert.lengthOf(__helpers.removeHtmlComments(code).match(/<form.*cat-photo-form.*>/gi), 1)
 ```
 
 You should not give your `form` any `class` or `style` attributes.
 
 ```js
-assert.notMatch(__helpers.removeHTMLComments(code), /<form.*style.*>/gi);
-assert.notMatch(__helpers.removeHTMLComments(code), /<form.*class.*>/gi);
+assert.notMatch(__helpers.removeHtmlComments(code), /<form.*style.*>/gi);
+assert.notMatch(__helpers.removeHtmlComments(code), /<form.*class.*>/gi);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/use-an-id-attribute-to-style-an-element.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/use-an-id-attribute-to-style-an-element.md
@@ -40,21 +40,21 @@ Your `form` element should have the `background-color` of green.
 ```js
 const catPhotoForm = document.querySelector('#cat-photo-form');
 const backgroundColor = window.getComputedStyle(catPhotoForm)['background-color'];
-assert.strictEqual(backgroundColor,'rgb(0, 128, 0)');
+assert.strictEqual(backgroundColor, 'rgb(0, 128, 0)');
 ```
 
 Your `form` element should have an `id` attribute.
 
 ```js
-assert.match(code,/<form.*cat-photo-form.*>/gi);
-assert.strictEqual(code.match(/<form.*cat-photo-form.*>/gi).length,1)
+assert.match(__helpers.removeHTMLComments(code), /<form.*cat-photo-form.*>/gi);
+assert.lengthOf(__helpers.removeHTMLComments(code).match(/<form.*cat-photo-form.*>/gi), 1)
 ```
 
 You should not give your `form` any `class` or `style` attributes.
 
 ```js
-assert.notMatch(code,/<form.*style.*>/gi);
-assert.notMatch(code,/<form.*class.*>/gi);
+assert.notMatch(__helpers.removeHTMLComments(code), /<form.*style.*>/gi);
+assert.notMatch(__helpers.removeHTMLComments(code), /<form.*class.*>/gi);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/use-attribute-selectors-to-style-elements.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/use-attribute-selectors-to-style-elements.md
@@ -30,43 +30,29 @@ Using the `type` attribute selector, try to give the checkboxes in CatPhotoApp a
 The `type` attribute selector should be used to select the checkboxes.
 
 ```js
-assert(
-  code.match(
-    /<style>[\s\S]*?\[\s*?type\s*?=\s*?("|')checkbox\1\s*?\]\s*?{[\s\S]*?}[\s\S]*?<\/style>/gi
-  )
-);
+assert.match(code,/<style>[\s\S]*?\[\s*?type\s*?=\s*?("|')checkbox\1\s*?\]\s*?{[\s\S]*?}[\s\S]*?<\/style>/gi);
 ```
 
 The top margins of the checkboxes should be 10px.
 
 ```js
-assert(
-  (function () {
-    var count = 0;
-    $("[type='checkbox']").each(function () {
-      if ($(this).css('marginTop') === '10px') {
-        count++;
-      }
-    });
-    return count === 3;
-  })()
-);
+const checkboxes = document.querySelectorAll("[type='checkbox']");
+checkboxes.forEach(function(checkbox)
+{
+  const marginTop = window.getComputedStyle(checkbox)['margin-top']; 
+  assert.strictEqual(marginTop,'10px');
+});
 ```
 
 The bottom margins of the checkboxes should be 15px.
 
 ```js
-assert(
-  (function () {
-    var count = 0;
-    $("[type='checkbox']").each(function () {
-      if ($(this).css('marginBottom') === '15px') {
-        count++;
-      }
-    });
-    return count === 3;
-  })()
-);
+const checkboxes = document.querySelectorAll("[type='checkbox']");
+checkboxes.forEach(function(checkbox)
+{
+  const marginTop = window.getComputedStyle(checkbox)['margin-bottom']; 
+  assert.strictEqual(marginTop,'15px');
+});
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/use-attribute-selectors-to-style-elements.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/use-attribute-selectors-to-style-elements.md
@@ -30,7 +30,7 @@ Using the `type` attribute selector, try to give the checkboxes in CatPhotoApp a
 The `type` attribute selector should be used to select the checkboxes.
 
 ```js
-assert.match(__helpers.removeHTMLComments(code), /<style>[\s\S]*?\[\s*?type\s*?=\s*?("|')checkbox\1\s*?\]\s*?{[\s\S]*?}[\s\S]*?<\/style>/gi);
+assert.match(__helpers.removeHtmlComments(code), /<style>[\s\S]*?\[\s*?type\s*?=\s*?("|')checkbox\1\s*?\]\s*?{[\s\S]*?}[\s\S]*?<\/style>/gi);
 ```
 
 The top margins of the checkboxes should be 10px.

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/use-attribute-selectors-to-style-elements.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/use-attribute-selectors-to-style-elements.md
@@ -30,17 +30,17 @@ Using the `type` attribute selector, try to give the checkboxes in CatPhotoApp a
 The `type` attribute selector should be used to select the checkboxes.
 
 ```js
-assert.match(code,/<style>[\s\S]*?\[\s*?type\s*?=\s*?("|')checkbox\1\s*?\]\s*?{[\s\S]*?}[\s\S]*?<\/style>/gi);
+assert.match(__helpers.removeHTMLComments(code), /<style>[\s\S]*?\[\s*?type\s*?=\s*?("|')checkbox\1\s*?\]\s*?{[\s\S]*?}[\s\S]*?<\/style>/gi);
 ```
 
 The top margins of the checkboxes should be 10px.
 
 ```js
 const checkboxes = document.querySelectorAll("[type='checkbox']");
-checkboxes.forEach(function(checkbox)
-{
+assert.isNotEmpty(checkboxes);
+checkboxes.forEach(function(checkbox) {
   const marginTop = window.getComputedStyle(checkbox)['margin-top']; 
-  assert.strictEqual(marginTop,'10px');
+  assert.strictEqual(marginTop, '10px');
 });
 ```
 
@@ -48,10 +48,10 @@ The bottom margins of the checkboxes should be 15px.
 
 ```js
 const checkboxes = document.querySelectorAll("[type='checkbox']");
-checkboxes.forEach(function(checkbox)
-{
-  const marginTop = window.getComputedStyle(checkbox)['margin-bottom']; 
-  assert.strictEqual(marginTop,'15px');
+assert.isNotEmpty(checkboxes);
+checkboxes.forEach(function(checkbox) {
+  const marginBottom = window.getComputedStyle(checkbox)['margin-bottom']; 
+  assert.strictEqual(marginBottom, '15px');
 });
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/use-clockwise-notation-to-specify-the-margin-of-an-element.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/use-clockwise-notation-to-specify-the-margin-of-an-element.md
@@ -28,35 +28,40 @@ Use Clockwise Notation to give the element with the `blue-box` class a margin of
 Your `blue-box` class should give the top of elements `40px` of `margin`.
 
 ```js
-assert($('.blue-box').css('margin-top') === '40px');
+const blueBox = document.querySelector('.blue-box');
+const marginTop = window.getComputedStyle(blueBox)['margin-top'];
+assert.strictEqual(marginTop,'40px');
 ```
 
 Your `blue-box` class should give the right of elements `20px` of `margin`.
 
 ```js
-assert($('.blue-box').css('margin-right') === '20px');
+const blueBox = document.querySelector('.blue-box');
+const marginRight = window.getComputedStyle(blueBox)['margin-right'];
+assert.strictEqual(marginRight,'20px');
 ```
 
 Your `blue-box` class should give the bottom of elements `20px` of `margin`.
 
 ```js
-assert($('.blue-box').css('margin-bottom') === '20px');
+const blueBox = document.querySelector('.blue-box');
+const marginBottom = window.getComputedStyle(blueBox)['margin-bottom'];
+assert.strictEqual(marginBottom,'20px');
 ```
 
 Your `blue-box` class should give the left of elements `40px` of `margin`.
 
 ```js
-assert($('.blue-box').css('margin-left') === '40px');
+const blueBox = document.querySelector('.blue-box');
+const marginLeft = window.getComputedStyle(blueBox)['margin-left'];
+assert.strictEqual(marginLeft,'40px');
 ```
 
 You should use the clockwise notation to set the margin of `blue-box` class.
 
 ```js
-assert(
-  /\.blue-box\s*{[\s\S]*margin[\s]*:\s*\d+px\s+\d+px\s+\d+px\s+\d+px(;\s*[^}]+\s*}|;?\s*})/.test(
-    __helpers.removeCssComments($('style').text())
-  )
-);
+const cssCode = __helpers.removeCssComments(document.querySelector('style:not(.fcc-hide-header)').textContent);
+assert.match(cssCode,/\.blue-box\s*{[\s\S]*margin[\s]*:\s*\d+px\s+\d+px\s+\d+px\s+\d+px(;\s*[^}]+\s*}|;?\s*})/);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/use-clockwise-notation-to-specify-the-margin-of-an-element.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/use-clockwise-notation-to-specify-the-margin-of-an-element.md
@@ -30,7 +30,7 @@ Your `blue-box` class should give the top of elements `40px` of `margin`.
 ```js
 const blueBox = document.querySelector('.blue-box');
 const marginTop = window.getComputedStyle(blueBox)['margin-top'];
-assert.strictEqual(marginTop,'40px');
+assert.strictEqual(marginTop, '40px');
 ```
 
 Your `blue-box` class should give the right of elements `20px` of `margin`.
@@ -38,7 +38,7 @@ Your `blue-box` class should give the right of elements `20px` of `margin`.
 ```js
 const blueBox = document.querySelector('.blue-box');
 const marginRight = window.getComputedStyle(blueBox)['margin-right'];
-assert.strictEqual(marginRight,'20px');
+assert.strictEqual(marginRight, '20px');
 ```
 
 Your `blue-box` class should give the bottom of elements `20px` of `margin`.
@@ -46,7 +46,7 @@ Your `blue-box` class should give the bottom of elements `20px` of `margin`.
 ```js
 const blueBox = document.querySelector('.blue-box');
 const marginBottom = window.getComputedStyle(blueBox)['margin-bottom'];
-assert.strictEqual(marginBottom,'20px');
+assert.strictEqual(marginBottom, '20px');
 ```
 
 Your `blue-box` class should give the left of elements `40px` of `margin`.
@@ -54,14 +54,14 @@ Your `blue-box` class should give the left of elements `40px` of `margin`.
 ```js
 const blueBox = document.querySelector('.blue-box');
 const marginLeft = window.getComputedStyle(blueBox)['margin-left'];
-assert.strictEqual(marginLeft,'40px');
+assert.strictEqual(marginLeft, '40px');
 ```
 
 You should use the clockwise notation to set the margin of `blue-box` class.
 
 ```js
 const cssCode = __helpers.removeCssComments(document.querySelector('style:not(.fcc-hide-header)').textContent);
-assert.match(cssCode,/\.blue-box\s*{[\s\S]*margin[\s]*:\s*\d+px\s+\d+px\s+\d+px\s+\d+px(;\s*[^}]+\s*}|;?\s*})/);
+assert.match(cssCode, /\.blue-box\s*{[\s\S]*margin[\s]*:\s*\d+px\s+\d+px\s+\d+px\s+\d+px(;\s*[^}]+\s*}|;?\s*})/);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/use-clockwise-notation-to-specify-the-padding-of-an-element.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/use-clockwise-notation-to-specify-the-padding-of-an-element.md
@@ -26,35 +26,40 @@ Use Clockwise Notation to give the `.blue-box` class a `padding` of `40px` on it
 Your `blue-box` class should give the top of elements `40px` of `padding`.
 
 ```js
-assert($('.blue-box').css('padding-top') === '40px');
+const blueBox = document.querySelector('.blue-box');
+const paddingTop = window.getComputedStyle(blueBox)['padding-top'];
+assert.strictEqual(paddingTop,'40px');
 ```
 
 Your `blue-box` class should give the right of elements `20px` of `padding`.
 
 ```js
-assert($('.blue-box').css('padding-right') === '20px');
+const blueBox = document.querySelector('.blue-box');
+const paddingRight = window.getComputedStyle(blueBox)['padding-right'];
+assert.strictEqual(paddingRight,'20px');
 ```
 
 Your `blue-box` class should give the bottom of elements `20px` of `padding`.
 
 ```js
-assert($('.blue-box').css('padding-bottom') === '20px');
+const blueBox = document.querySelector('.blue-box');
+const paddingBottom = window.getComputedStyle(blueBox)['padding-bottom'];
+assert.strictEqual(paddingBottom,'20px');
 ```
 
 Your `blue-box` class should give the left of elements `40px` of `padding`.
 
 ```js
-assert($('.blue-box').css('padding-left') === '40px');
+const blueBox = document.querySelector('.blue-box');
+const paddingLeft = window.getComputedStyle(blueBox)['padding-left'];
+assert.strictEqual(paddingLeft,'40px');
 ```
 
 You should use the clockwise notation to set the padding of `blue-box` class.
 
 ```js
-assert(
-  /\.blue-box\s*{[\s\S]*padding[\s]*:\s*\d+px\s+\d+px\s+\d+px\s+\d+px(;\s*[^}]+\s*}|;?\s*})/.test(
-    __helpers.removeCssComments($('style').text())
-  )
-);
+const css =  __helpers.removeCssComments(document.querySelector('style:not(.fcc-hide-header)').textContent);
+assert.match(css, /\.blue-box\s*{[\s\S]*padding\s*:\s*\d+px\s+\d+px\s+\d+px\s+\d+px(;\s*[^}]+\s*}|;?\s*})/);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/use-clockwise-notation-to-specify-the-padding-of-an-element.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/use-clockwise-notation-to-specify-the-padding-of-an-element.md
@@ -28,7 +28,7 @@ Your `blue-box` class should give the top of elements `40px` of `padding`.
 ```js
 const blueBox = document.querySelector('.blue-box');
 const paddingTop = window.getComputedStyle(blueBox)['padding-top'];
-assert.strictEqual(paddingTop,'40px');
+assert.strictEqual(paddingTop, '40px');
 ```
 
 Your `blue-box` class should give the right of elements `20px` of `padding`.
@@ -36,7 +36,7 @@ Your `blue-box` class should give the right of elements `20px` of `padding`.
 ```js
 const blueBox = document.querySelector('.blue-box');
 const paddingRight = window.getComputedStyle(blueBox)['padding-right'];
-assert.strictEqual(paddingRight,'20px');
+assert.strictEqual(paddingRight, '20px');
 ```
 
 Your `blue-box` class should give the bottom of elements `20px` of `padding`.
@@ -44,7 +44,7 @@ Your `blue-box` class should give the bottom of elements `20px` of `padding`.
 ```js
 const blueBox = document.querySelector('.blue-box');
 const paddingBottom = window.getComputedStyle(blueBox)['padding-bottom'];
-assert.strictEqual(paddingBottom,'20px');
+assert.strictEqual(paddingBottom, '20px');
 ```
 
 Your `blue-box` class should give the left of elements `40px` of `padding`.
@@ -52,7 +52,7 @@ Your `blue-box` class should give the left of elements `40px` of `padding`.
 ```js
 const blueBox = document.querySelector('.blue-box');
 const paddingLeft = window.getComputedStyle(blueBox)['padding-left'];
-assert.strictEqual(paddingLeft,'40px');
+assert.strictEqual(paddingLeft, '40px');
 ```
 
 You should use the clockwise notation to set the padding of `blue-box` class.

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/use-css-selectors-to-style-elements.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/use-css-selectors-to-style-elements.md
@@ -43,39 +43,38 @@ Delete your `h2` element's style attribute, and instead create a CSS `style` blo
 The `style` attribute should be removed from your `h2` element.
 
 ```js
-assert(!$('h2').attr('style'));
+assert.notExists(document.querySelector('h2').getAttribute('style'));
 ```
 
 You should create a `style` element.
 
 ```js
-assert($('style') && $('style').length >= 1);
+assert.exists(document.querySelector('style:not(.fcc-hide-header)'));
+assert.isAtLeast(document.querySelectorAll('style:not(.fcc-hide-header)').length,1);
 ```
 
 Your `h2` element should be blue.
 
 ```js
-assert($('h2').css('color') === 'rgb(0, 0, 255)');
+const h2Element = document.querySelector('h2');
+const color = window.getComputedStyle(h2Element)['color']; 
+assert.strictEqual(color,'rgb(0, 0, 255)');
 ```
 
 Your stylesheet `h2` declaration should be valid with a semicolon and closing brace.
 
 ```js
-assert(code.match(/h2\s*\{\s*color\s*:.*;\s*\}/g));
+assert.match(code,/h2\s*\{\s*color\s*:.*;\s*\}/g);
 ```
 
 All your `style` elements should be valid and have closing tags.
 
 ```js
-assert(
-  code.match(/<\/style>/g) &&
-    code.match(/<\/style>/g).length ===
-      (
-        code.match(
-          /<style((\s)*((type|media|scoped|title|disabled)="[^"]*")?(\s)*)*>/g
-        ) || []
-      ).length
-);
+assert.match(code,/<\/style>/g);
+
+const closingElementLength = code.match(/<\/style>/g).length;
+const openingElementsLength = (code.match(/<style((\s)*((type|media|scoped|title|disabled)="[^"]*")?(\s)*)*>/g) || []).length;
+assert.strictEqual(closingElementLength,openingElementsLength);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/use-css-selectors-to-style-elements.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/use-css-selectors-to-style-elements.md
@@ -70,10 +70,10 @@ assert.match(__helpers.removeCssComments(code), /h2\s*\{\s*color\s*:.*;\s*\}/g);
 All your `style` elements should be valid and have closing tags.
 
 ```js
-assert.match(__helpers.removeHTMLComments(code), /<\/style>/g);
+assert.match(__helpers.removeHtmlComments(code), /<\/style>/g);
 
-const closingElementLength = __helpers.removeHTMLComments(code).match(/<\/style>/g).length;
-const openingElementsLength = __helpers.removeHTMLComments(code).match(/<style((\s)*((type|media|scoped|title|disabled)="[^"]*")?(\s)*)*>/g).length;
+const closingElementLength = __helpers.removeHtmlComments(code).match(/<\/style>/g).length;
+const openingElementsLength = __helpers.removeHtmlComments(code).match(/<style((\s)*((type|media|scoped|title|disabled)="[^"]*")?(\s)*)*>/g).length;
 assert.strictEqual(closingElementLength, openingElementsLength);
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/use-css-selectors-to-style-elements.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/use-css-selectors-to-style-elements.md
@@ -50,7 +50,7 @@ You should create a `style` element.
 
 ```js
 assert.exists(document.querySelector('style:not(.fcc-hide-header)'));
-assert.isAtLeast(document.querySelectorAll('style:not(.fcc-hide-header)').length,1);
+assert.isAtLeast(document.querySelectorAll('style:not(.fcc-hide-header)').length, 1);
 ```
 
 Your `h2` element should be blue.
@@ -58,23 +58,23 @@ Your `h2` element should be blue.
 ```js
 const h2Element = document.querySelector('h2');
 const color = window.getComputedStyle(h2Element)['color']; 
-assert.strictEqual(color,'rgb(0, 0, 255)');
+assert.strictEqual(color, 'rgb(0, 0, 255)');
 ```
 
 Your stylesheet `h2` declaration should be valid with a semicolon and closing brace.
 
 ```js
-assert.match(code,/h2\s*\{\s*color\s*:.*;\s*\}/g);
+assert.match(__helpers.removeCssComments(code), /h2\s*\{\s*color\s*:.*;\s*\}/g);
 ```
 
 All your `style` elements should be valid and have closing tags.
 
 ```js
-assert.match(code,/<\/style>/g);
+assert.match(__helpers.removeHTMLComments(code), /<\/style>/g);
 
-const closingElementLength = code.match(/<\/style>/g).length;
-const openingElementsLength = (code.match(/<style((\s)*((type|media|scoped|title|disabled)="[^"]*")?(\s)*)*>/g) || []).length;
-assert.strictEqual(closingElementLength,openingElementsLength);
+const closingElementLength = __helpers.removeHTMLComments(code).match(/<\/style>/g).length;
+const openingElementsLength = __helpers.removeHTMLComments(code).match(/<style((\s)*((type|media|scoped|title|disabled)="[^"]*")?(\s)*)*>/g).length;
+assert.strictEqual(closingElementLength, openingElementsLength);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/use-css-variables-to-change-several-elements-at-once.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/use-css-variables-to-change-several-elements-at-once.md
@@ -22,25 +22,19 @@ In the `penguin` class, change the `black` value to `gray`, the `gray` value to 
 `penguin` class should declare the `--penguin-skin` variable and assign it to `gray`.
 
 ```js
-assert(
-  code.match(/.penguin\s*?{[\s\S]*--penguin-skin\s*?:\s*?gray\s*?;[\s\S]*}/gi)
-);
+assert.match(code,/.penguin\s*?{[\s\S]*--penguin-skin\s*?:\s*?gray\s*?;[\s\S]*}/gi);
 ```
 
 `penguin` class should declare the `--penguin-belly` variable and assign it to `white`.
 
 ```js
-assert(
-  code.match(/.penguin\s*?{[\s\S]*--penguin-belly\s*?:\s*?white\s*?;[\s\S]*}/gi)
-);
+assert.match(code,/.penguin\s*?{[\s\S]*--penguin-belly\s*?:\s*?white\s*?;[\s\S]*}/gi);
 ```
 
 `penguin` class should declare the `--penguin-beak` variable and assign it to `orange`.
 
 ```js
-assert(
-  code.match(/.penguin\s*?{[\s\S]*--penguin-beak\s*?:\s*?orange\s*?;[\s\S]*}/gi)
-);
+assert.match(code,/.penguin\s*?{[\s\S]*--penguin-beak\s*?:\s*?orange\s*?;[\s\S]*}/gi);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/use-css-variables-to-change-several-elements-at-once.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/use-css-variables-to-change-several-elements-at-once.md
@@ -22,19 +22,19 @@ In the `penguin` class, change the `black` value to `gray`, the `gray` value to 
 `penguin` class should declare the `--penguin-skin` variable and assign it to `gray`.
 
 ```js
-assert.match(code,/.penguin\s*?{[\s\S]*--penguin-skin\s*?:\s*?gray\s*?;[\s\S]*}/gi);
+assert.match(__helpers.removeHTMLComments(code), /.penguin\s*?{[\s\S]*--penguin-skin\s*?:\s*?gray\s*?;[\s\S]*}/gi);
 ```
 
 `penguin` class should declare the `--penguin-belly` variable and assign it to `white`.
 
 ```js
-assert.match(code,/.penguin\s*?{[\s\S]*--penguin-belly\s*?:\s*?white\s*?;[\s\S]*}/gi);
+assert.match(code, /.penguin\s*?{[\s\S]*--penguin-belly\s*?:\s*?white\s*?;[\s\S]*}/gi);
 ```
 
 `penguin` class should declare the `--penguin-beak` variable and assign it to `orange`.
 
 ```js
-assert.match(code,/.penguin\s*?{[\s\S]*--penguin-beak\s*?:\s*?orange\s*?;[\s\S]*}/gi);
+assert.match(code, /.penguin\s*?{[\s\S]*--penguin-beak\s*?:\s*?orange\s*?;[\s\S]*}/gi);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/use-css-variables-to-change-several-elements-at-once.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/use-css-variables-to-change-several-elements-at-once.md
@@ -22,7 +22,7 @@ In the `penguin` class, change the `black` value to `gray`, the `gray` value to 
 `penguin` class should declare the `--penguin-skin` variable and assign it to `gray`.
 
 ```js
-assert.match(__helpers.removeHTMLComments(code), /.penguin\s*?{[\s\S]*--penguin-skin\s*?:\s*?gray\s*?;[\s\S]*}/gi);
+assert.match(__helpers.removeHtmlComments(code), /.penguin\s*?{[\s\S]*--penguin-skin\s*?:\s*?gray\s*?;[\s\S]*}/gi);
 ```
 
 `penguin` class should declare the `--penguin-belly` variable and assign it to `white`.

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/use-hex-code-for-specific-colors.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/use-hex-code-for-specific-colors.md
@@ -30,17 +30,15 @@ Replace the word `black` in our `body` element's background-color with its hex c
 Your `body` element should have the `background-color` of black.
 
 ```js
-assert($('body').css('background-color') === 'rgb(0, 0, 0)');
+const body = document.querySelector('body');
+const backgroundColor = window.getComputedStyle(body)['background-color']; 
+assert.strictEqual(backgroundColor, 'rgb(0, 0, 0)');
 ```
 
 The hex code for the color black should be used instead of the word `black`.
 
 ```js
-assert(
-  code.match(
-    /body\s*{(([\s\S]*;\s*?)|\s*?)background.*\s*:\s*?#000(000)?((\s*})|(;[\s\S]*?}))/gi
-  )
-);
+assert.match(code,/body\s*{(([\s\S]*;\s*?)|\s*?)background.*\s*:\s*?#000(000)?((\s*})|(;[\s\S]*?}))/gi);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/use-hex-code-for-specific-colors.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/use-hex-code-for-specific-colors.md
@@ -38,7 +38,7 @@ assert.strictEqual(backgroundColor, 'rgb(0, 0, 0)');
 The hex code for the color black should be used instead of the word `black`.
 
 ```js
-assert.match(code,/body\s*{(([\s\S]*;\s*?)|\s*?)background.*\s*:\s*?#000(000)?((\s*})|(;[\s\S]*?}))/gi);
+assert.match(code, /body\s*{(([\s\S]*;\s*?)|\s*?)background.*\s*:\s*?#000(000)?((\s*})|(;[\s\S]*?}))/gi);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/use-hex-code-to-mix-colors.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/use-hex-code-to-mix-colors.md
@@ -30,49 +30,58 @@ Replace the color words in our `style` element with their correct hex codes.
 Your `h1` element with the text `I am red!` should be given the `color` red.
 
 ```js
-assert($('.red-text').css('color') === 'rgb(255, 0, 0)');
+const redText = document.querySelector('.red-text');
+const color = window.getComputedStyle(redText)['color']; 
+assert.strictEqual(color,'rgb(255, 0, 0)');
 ```
 
 The `hex code` for the color red should be used instead of the word `red`.
 
 ```js
-assert(code.match(/\.red-text\s*?{\s*?color\s*:\s*?(#FF0000|#F00)\s*?;?\s*?}/gi));
+assert.match(code,/\.red-text\s*?{\s*?color\s*:\s*?(#FF0000|#F00)\s*?;?\s*?}/gi);
 ```
 
 Your `h1` element with the text `I am green!` should be given the `color` green.
 
 ```js
-assert($('.green-text').css('color') === 'rgb(0, 255, 0)');
+const greenText = document.querySelector('.green-text');
+const color = window.getComputedStyle(greenText)['color']; 
+assert.strictEqual(color,'rgb(0, 255, 0)');
 ```
 
 The `hex code` for the color green should be used instead of the word `green`.
 
 ```js
-assert(code.match(/\.green-text\s*?{\s*?color\s*:\s*?(#00FF00|#0F0)\s*?;?\s*?}/gi));
+assert.match(code,/\.green-text\s*?{\s*?color\s*:\s*?(#00FF00|#0F0)\s*?;?\s*?}/gi);
 ```
 
 Your `h1` element with the text `I am dodger blue!` should be given the `color` dodger blue.
 
 ```js
-assert($('.dodger-blue-text').css('color') === 'rgb(30, 144, 255)');
+const blueText = document.querySelector('.dodger-blue-text');
+const color = window.getComputedStyle(blueText)['color']; 
+assert.strictEqual(color, 'rgb(30, 144, 255)');
 ```
 
 The `hex code` for the color dodger blue should be used instead of the word `dodgerblue`.
 
 ```js
-assert(code.match(/\.dodger-blue-text\s*?{\s*?color\s*:\s*?#1E90FF\s*?;?\s*?}/gi));
+assert.match(code,/\.dodger-blue-text\s*?{\s*?color\s*:\s*?#1E90FF\s*?;?\s*?}/gi);
 ```
 
 Your `h1` element with the text `I am orange!` should be given the `color` orange.
 
 ```js
-assert($('.orange-text').css('color') === 'rgb(255, 165, 0)');
+const orangeText = document.querySelector('.orange-text');
+const color = window.getComputedStyle(orangeText)['color']; 
+
+assert.strictEqual(color,'rgb(255, 165, 0)');
 ```
 
 The `hex code` for the color orange should be used instead of the word `orange`.
 
 ```js
-assert(code.match(/\.orange-text\s*?{\s*?color\s*:\s*?#FFA500\s*?;?\s*?}/gi));
+assert.match(code,/\.orange-text\s*?{\s*?color\s*:\s*?#FFA500\s*?;?\s*?}/gi);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/use-hex-code-to-mix-colors.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/use-hex-code-to-mix-colors.md
@@ -32,13 +32,13 @@ Your `h1` element with the text `I am red!` should be given the `color` red.
 ```js
 const redText = document.querySelector('.red-text');
 const color = window.getComputedStyle(redText)['color']; 
-assert.strictEqual(color,'rgb(255, 0, 0)');
+assert.strictEqual(color, 'rgb(255, 0, 0)');
 ```
 
 The `hex code` for the color red should be used instead of the word `red`.
 
 ```js
-assert.match(code,/\.red-text\s*?{\s*?color\s*:\s*?(#FF0000|#F00)\s*?;?\s*?}/gi);
+assert.match(code, /\.red-text\s*?{\s*?color\s*:\s*?(#FF0000|#F00)\s*?;?\s*?}/gi);
 ```
 
 Your `h1` element with the text `I am green!` should be given the `color` green.
@@ -46,13 +46,13 @@ Your `h1` element with the text `I am green!` should be given the `color` green.
 ```js
 const greenText = document.querySelector('.green-text');
 const color = window.getComputedStyle(greenText)['color']; 
-assert.strictEqual(color,'rgb(0, 255, 0)');
+assert.strictEqual(color, 'rgb(0, 255, 0)');
 ```
 
 The `hex code` for the color green should be used instead of the word `green`.
 
 ```js
-assert.match(code,/\.green-text\s*?{\s*?color\s*:\s*?(#00FF00|#0F0)\s*?;?\s*?}/gi);
+assert.match(code, /\.green-text\s*?{\s*?color\s*:\s*?(#00FF00|#0F0)\s*?;?\s*?}/gi);
 ```
 
 Your `h1` element with the text `I am dodger blue!` should be given the `color` dodger blue.
@@ -66,7 +66,7 @@ assert.strictEqual(color, 'rgb(30, 144, 255)');
 The `hex code` for the color dodger blue should be used instead of the word `dodgerblue`.
 
 ```js
-assert.match(code,/\.dodger-blue-text\s*?{\s*?color\s*:\s*?#1E90FF\s*?;?\s*?}/gi);
+assert.match(code, /\.dodger-blue-text\s*?{\s*?color\s*:\s*?#1E90FF\s*?;?\s*?}/gi);
 ```
 
 Your `h1` element with the text `I am orange!` should be given the `color` orange.
@@ -75,13 +75,13 @@ Your `h1` element with the text `I am orange!` should be given the `color` orang
 const orangeText = document.querySelector('.orange-text');
 const color = window.getComputedStyle(orangeText)['color']; 
 
-assert.strictEqual(color,'rgb(255, 165, 0)');
+assert.strictEqual(color, 'rgb(255, 165, 0)');
 ```
 
 The `hex code` for the color orange should be used instead of the word `orange`.
 
 ```js
-assert.match(code,/\.orange-text\s*?{\s*?color\s*:\s*?#FFA500\s*?;?\s*?}/gi);
+assert.match(code, /\.orange-text\s*?{\s*?color\s*:\s*?#FFA500\s*?;?\s*?}/gi);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/use-rgb-to-mix-colors.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/use-rgb-to-mix-colors.md
@@ -22,65 +22,57 @@ Replace the hex codes in our `style` element with their correct RGB values.
 Your `h1` element with the text `I am red!` should have the `color` red.
 
 ```js
-assert($('.red-text').css('color') === 'rgb(255, 0, 0)');
+const redText = document.querySelector('.red-text');
+const color = window.getComputedStyle(redText)['color']; 
+assert.strictEqual(color,'rgb(255, 0, 0)');
 ```
 
 You should use `rgb` for the color red.
 
 ```js
-assert(
-  code.match(
-    /\.red-text\s*{\s*color\s*:\s*rgb\(\s*255\s*,\s*0\s*,\s*0\s*\)\s*;?\s*}/gi
-  )
-);
+assert.match(code,/\.red-text\s*{\s*color\s*:\s*rgb\(\s*255\s*,\s*0\s*,\s*0\s*\)\s*;?\s*}/gi);
 ```
 
 Your `h1` element with the text `I am orchid!` should have the `color` orchid.
 
 ```js
-assert($('.orchid-text').css('color') === 'rgb(218, 112, 214)');
+const orchidText = document.querySelector('.orchid-text');
+const color = window.getComputedStyle(orchidText)['color']; 
+assert.strictEqual(color,'rgb(218, 112, 214)');
 ```
 
 You should use `rgb` for the color orchid.
 
 ```js
-assert(
-  code.match(
-    /\.orchid-text\s*{\s*color\s*:\s*rgb\(\s*218\s*,\s*112\s*,\s*214\s*\)\s*;?\s*}/gi
-  )
-);
+assert.match(code,/\.orchid-text\s*{\s*color\s*:\s*rgb\(\s*218\s*,\s*112\s*,\s*214\s*\)\s*;?\s*}/gi);
 ```
 
 Your `h1` element with the text `I am blue!` should have the `color` blue.
 
 ```js
-assert($('.blue-text').css('color') === 'rgb(0, 0, 255)');
+const blueText = document.querySelector('.blue-text');
+const color = window.getComputedStyle(blueText)['color']; 
+assert.strictEqual(color,'rgb(0, 0, 255)');
 ```
 
 You should use `rgb` for the color blue.
 
 ```js
-assert(
-  code.match(
-    /\.blue-text\s*{\s*color\s*:\s*rgb\(\s*0\s*,\s*0\s*,\s*255\s*\)\s*;?\s*}/gi
-  )
-);
+assert.match(code,/\.blue-text\s*{\s*color\s*:\s*rgb\(\s*0\s*,\s*0\s*,\s*255\s*\)\s*;?\s*}/gi);
 ```
 
 Your `h1` element with the text `I am sienna!` should have the `color` sienna.
 
 ```js
-assert($('.sienna-text').css('color') === 'rgb(160, 82, 45)');
+const siennaText = document.querySelector('.sienna-text');
+const color = window.getComputedStyle(siennaText)['color']; 
+assert.strictEqual(color, 'rgb(160, 82, 45)');
 ```
 
 You should use `rgb` for the color sienna.
 
 ```js
-assert(
-  code.match(
-    /\.sienna-text\s*{\s*color\s*:\s*rgb\(\s*160\s*,\s*82\s*,\s*45\s*\)\s*;?\s*}/gi
-  )
-);
+assert.match(code,/\.sienna-text\s*{\s*color\s*:\s*rgb\(\s*160\s*,\s*82\s*,\s*45\s*\)\s*;?\s*}/gi);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/use-rgb-to-mix-colors.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/use-rgb-to-mix-colors.md
@@ -24,13 +24,13 @@ Your `h1` element with the text `I am red!` should have the `color` red.
 ```js
 const redText = document.querySelector('.red-text');
 const color = window.getComputedStyle(redText)['color']; 
-assert.strictEqual(color,'rgb(255, 0, 0)');
+assert.strictEqual(color, 'rgb(255, 0, 0)');
 ```
 
 You should use `rgb` for the color red.
 
 ```js
-assert.match(code,/\.red-text\s*{\s*color\s*:\s*rgb\(\s*255\s*,\s*0\s*,\s*0\s*\)\s*;?\s*}/gi);
+assert.match(code, /\.red-text\s*{\s*color\s*:\s*rgb\(\s*255\s*,\s*0\s*,\s*0\s*\)\s*;?\s*}/gi);
 ```
 
 Your `h1` element with the text `I am orchid!` should have the `color` orchid.
@@ -38,13 +38,13 @@ Your `h1` element with the text `I am orchid!` should have the `color` orchid.
 ```js
 const orchidText = document.querySelector('.orchid-text');
 const color = window.getComputedStyle(orchidText)['color']; 
-assert.strictEqual(color,'rgb(218, 112, 214)');
+assert.strictEqual(color, 'rgb(218, 112, 214)');
 ```
 
 You should use `rgb` for the color orchid.
 
 ```js
-assert.match(code,/\.orchid-text\s*{\s*color\s*:\s*rgb\(\s*218\s*,\s*112\s*,\s*214\s*\)\s*;?\s*}/gi);
+assert.match(__helpers.removeCssComments(code), /\.orchid-text\s*{\s*color\s*:\s*rgb\(\s*218\s*,\s*112\s*,\s*214\s*\)\s*;?\s*}/gi);
 ```
 
 Your `h1` element with the text `I am blue!` should have the `color` blue.
@@ -52,13 +52,13 @@ Your `h1` element with the text `I am blue!` should have the `color` blue.
 ```js
 const blueText = document.querySelector('.blue-text');
 const color = window.getComputedStyle(blueText)['color']; 
-assert.strictEqual(color,'rgb(0, 0, 255)');
+assert.strictEqual(color, 'rgb(0, 0, 255)');
 ```
 
 You should use `rgb` for the color blue.
 
 ```js
-assert.match(code,/\.blue-text\s*{\s*color\s*:\s*rgb\(\s*0\s*,\s*0\s*,\s*255\s*\)\s*;?\s*}/gi);
+assert.match(__helpers.removeCssComments(code), /\.blue-text\s*{\s*color\s*:\s*rgb\(\s*0\s*,\s*0\s*,\s*255\s*\)\s*;?\s*}/gi);
 ```
 
 Your `h1` element with the text `I am sienna!` should have the `color` sienna.
@@ -72,7 +72,7 @@ assert.strictEqual(color, 'rgb(160, 82, 45)');
 You should use `rgb` for the color sienna.
 
 ```js
-assert.match(code,/\.sienna-text\s*{\s*color\s*:\s*rgb\(\s*160\s*,\s*82\s*,\s*45\s*\)\s*;?\s*}/gi);
+assert.match(__helpers.removeCssComments(code), /\.sienna-text\s*{\s*color\s*:\s*rgb\(\s*160\s*,\s*82\s*,\s*45\s*\)\s*;?\s*}/gi);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/use-rgb-values-to-color-elements.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/use-rgb-values-to-color-elements.md
@@ -44,13 +44,15 @@ Let's replace the hex code in our `body` element's background color with the RGB
 Your `body` element should have a black background.
 
 ```js
-assert($('body').css('background-color') === 'rgb(0, 0, 0)');
+const body = document.querySelector('body');
+const backgroundColor = window.getComputedStyle(body)['background-color']; 
+assert.strictEqual(backgroundColor,'rgb(0, 0, 0)');
 ```
 
 You should use `rgb` to give your `body` element a background of black.
 
 ```js
-assert(code.match(/rgb\s*\(\s*0\s*,\s*0\s*,\s*0\s*\)/gi));
+assert.match(code,/rgb\s*\(\s*0\s*,\s*0\s*,\s*0\s*\)/gi);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/use-rgb-values-to-color-elements.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/use-rgb-values-to-color-elements.md
@@ -46,13 +46,13 @@ Your `body` element should have a black background.
 ```js
 const body = document.querySelector('body');
 const backgroundColor = window.getComputedStyle(body)['background-color']; 
-assert.strictEqual(backgroundColor,'rgb(0, 0, 0)');
+assert.strictEqual(backgroundColor, 'rgb(0, 0, 0)');
 ```
 
 You should use `rgb` to give your `body` element a background of black.
 
 ```js
-assert.match(code,/rgb\s*\(\s*0\s*,\s*0\s*,\s*0\s*\)/gi);
+assert.match(__helpers.removeCssComments(code), /rgb\s*\(\s*0\s*,\s*0\s*,\s*0\s*\)/gi);
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
This removes jQuery from the Basic CSS Challenges and using modern ChaiJS assertions. In addition a test involving `style` was updated that was broken.

There is a default style element on the preview pages now  that has a class of `fcc-hide-header`. Tests to see if the camper has created a proper style element have been broken because it will always grab the `style.fcc-hide-header` one first. 

Edit: Looks like there was already a solution I didn't see? 