### PR TITLE
Add network error message to error-messages.ts

### DIFF
--- a/client/src/components/Flash/redux/flash-messages.ts
+++ b/client/src/components/Flash/redux/flash-messages.ts
@@ -36,6 +36,7 @@ export enum FlashMessages {
   MsTrophyErr6 = 'flash.ms.trophy.err-6',
   MsTrophyVerified = 'flash.ms.trophy.verified',
   NameNeeded = 'flash.name-needed',
+  NetworkIssue = 'Network issue occurred' ,
   None = '',
   NotEligible = 'flash.not-eligible',
   NotHonest = 'flash.not-honest',

--- a/client/src/utils/error-messages.ts
+++ b/client/src/utils/error-messages.ts
@@ -24,3 +24,8 @@ export const msTrophyVerified = {
   type: 'success',
   message: FlashMessages.MsTrophyVerified
 };
+
+export const networkErrorMessage = {
+  type: 'danger',
+  message: FlashMessages.NetworkIssue
+};


### PR DESCRIPTION
This PR adds a new network error message to the error-messages.ts file for better handling of network issues.
