### PR TITLE
feat(client): stop transforming jsx extensions

### DIFF
--- a/client/src/templates/Challenges/rechallenge/transformers.js
+++ b/client/src/templates/Challenges/rechallenge/transformers.js
@@ -13,7 +13,6 @@ import sassData from '../../../../config/browser-scripts/sass-compile.json';
 import {
   transformContents,
   transformHeadTailAndContents,
-  setExt,
   compileHeadTail,
   createSource
 } from '../../../../../shared/utils/polyvinyl';
@@ -127,10 +126,10 @@ const getJSXTranspiler = loopProtectOptions => async challengeFile => {
   await loadBabel();
   await loadPresetReact();
   const babelOptions = getBabelOptions(presetsJSX, loopProtectOptions);
-  return flow(
-    partial(transformHeadTailAndContents, babelTransformCode(babelOptions)),
-    partial(setExt, 'js')
-  )(challengeFile);
+  return transformHeadTailAndContents(
+    babelTransformCode(babelOptions),
+    challengeFile
+  );
 };
 
 const getTSTranspiler = loopProtectOptions => async challengeFile => {
@@ -265,9 +264,7 @@ export const embedFilesInHtml = async function (challengeFiles) {
 
 function challengeFilesToObject(challengeFiles) {
   const indexHtml = challengeFiles.find(file => file.fileKey === 'indexhtml');
-  const indexJsx = challengeFiles.find(
-    file => file.fileKey === 'indexjs' && file.history[0] === 'index.jsx'
-  );
+  const indexJsx = challengeFiles.find(file => file.fileKey === 'indexjsx');
   const stylesCss = challengeFiles.find(file => file.fileKey === 'stylescss');
   const scriptJs = challengeFiles.find(file => file.fileKey === 'scriptjs');
   const indexTs = challengeFiles.find(file => file.fileKey === 'indexts');

--- a/shared/utils/polyvinyl.ts
+++ b/shared/utils/polyvinyl.ts
@@ -100,19 +100,6 @@ export function setContent(
   };
 }
 
-export async function setExt(ext: string, polyP: Promise<ChallengeFile>) {
-  const poly = await polyP;
-  checkPoly(poly);
-  const newPoly = {
-    ...poly,
-    ext,
-    path: poly.name + '.' + ext,
-    fileKey: poly.name + ext
-  };
-  newPoly.history = [...poly.history, newPoly.path];
-  return newPoly;
-}
-
 // This is currently only used to add back properties that are not stored in the
 // database.
 export function regeneratePathAndHistory(poly: ChallengeFile) {


### PR DESCRIPTION
We don't need to and it meant we had to handle jsx files differently from the rest.

I'm trying to make this code a bit more flexible so we can easily support additional scripts (like jsx) and, longer term, any number of files.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->
