### PR TITLE
fix: search conditional rendering

### DIFF
--- a/client/src/components/Header/components/universal-nav.tsx
+++ b/client/src/components/Header/components/universal-nav.tsx
@@ -23,6 +23,7 @@ type UniversalNavProps = Omit<
 > & {
   fetchState: { pending: boolean };
   searchBarRef?: React.RefObject<HTMLDivElement>;
+  pathname: string;
 };
 const UniversalNav = ({
   displayMenu,
@@ -31,7 +32,8 @@ const UniversalNav = ({
   menuButtonRef,
   searchBarRef,
   user,
-  fetchState
+  fetchState,
+  pathname
 }: UniversalNavProps): JSX.Element => {
   const { pending } = fetchState;
   const { t } = useTranslation();
@@ -40,12 +42,11 @@ const UniversalNav = ({
   });
 
   const search =
-    typeof window !== `undefined` && isLanding(window.location.pathname) ? (
+    typeof window !== `undefined` && isLanding(pathname) ? (
       <SearchBarOptimized innerRef={searchBarRef} />
     ) : (
       <SearchBar innerRef={searchBarRef} />
     );
-
   return (
     <nav
       aria-label={t('aria.primary-nav')}

--- a/client/src/components/Header/components/universal-nav.tsx
+++ b/client/src/components/Header/components/universal-nav.tsx
@@ -41,12 +41,11 @@ const UniversalNav = ({
     query: `(min-width: ${SEARCH_EXPOSED_WIDTH}px)`
   });
 
-  const search =
-    typeof window !== `undefined` && isLanding(pathname) ? (
-      <SearchBarOptimized innerRef={searchBarRef} />
-    ) : (
-      <SearchBar innerRef={searchBarRef} />
-    );
+  const search = isLanding(pathname) ? (
+    <SearchBarOptimized innerRef={searchBarRef} />
+  ) : (
+    <SearchBar innerRef={searchBarRef} />
+  );
   return (
     <nav
       aria-label={t('aria.primary-nav')}

--- a/client/src/components/Header/index.tsx
+++ b/client/src/components/Header/index.tsx
@@ -28,6 +28,7 @@ type Props = PropsFromRedux & {
   fetchState: { pending: boolean };
   user: User;
   skipButtonText: string;
+  pathname: string;
 };
 
 class Header extends React.Component<Props, { displayMenu: boolean }> {
@@ -79,7 +80,8 @@ class Header extends React.Component<Props, { displayMenu: boolean }> {
 
   render(): JSX.Element {
     const { displayMenu } = this.state;
-    const { examInProgress, fetchState, user, skipButtonText } = this.props;
+    const { examInProgress, fetchState, user, skipButtonText, pathname } =
+      this.props;
     return (
       <header className='site-header'>
         <a
@@ -96,6 +98,7 @@ class Header extends React.Component<Props, { displayMenu: boolean }> {
             displayMenu={displayMenu}
             fetchState={fetchState}
             hideMenu={this.hideMenu}
+            pathname={pathname}
             menuButtonRef={this.menuButtonRef}
             searchBarRef={this.searchBarRef}
             showMenu={this.showMenu}

--- a/client/src/components/layouts/default.tsx
+++ b/client/src/components/layouts/default.tsx
@@ -136,6 +136,7 @@ function DefaultLayout({
   superBlock,
   theme,
   user,
+  pathname,
   fetchUser
 }: DefaultLayoutProps): JSX.Element {
   const { t } = useTranslation();
@@ -269,6 +270,7 @@ function DefaultLayout({
           <Header
             fetchState={fetchState}
             user={user}
+            pathname={pathname}
             skipButtonText={t('learn.skip-to-content')}
           />
           <OfflineWarning

--- a/client/src/components/search/searchBar/search-bar-optimized.tsx
+++ b/client/src/components/search/searchBar/search-bar-optimized.tsx
@@ -60,6 +60,7 @@ const SearchBarOptimized = ({
               type='search'
               value={value}
               ref={inputElementRef}
+              data-playwright-test-label='search-optimized'
             />
             <button className='ais-SearchBox-submit' type='submit'>
               <Magnifier />

--- a/client/src/components/search/searchBar/search-bar-optimized.tsx
+++ b/client/src/components/search/searchBar/search-bar-optimized.tsx
@@ -60,7 +60,6 @@ const SearchBarOptimized = ({
               type='search'
               value={value}
               ref={inputElementRef}
-              data-playwright-test-label='search-optimized'
             />
             <button className='ais-SearchBox-submit' type='submit'>
               <Magnifier />

--- a/e2e/search-bar-optimized.spec.ts
+++ b/e2e/search-bar-optimized.spec.ts
@@ -93,29 +93,19 @@ test.describe('Search bar optimized', () => {
     await expect(searchInput).toHaveValue('');
   });
 
-  test('should not exist when the user navigates to a different page from the root', async ({
-    page
-  }) => {
-    await page.getByTestId('curriculum-map-button').nth(0).click();
-
-    // Any of the searchbar elements wont be visible for a certain amount of time, thus the timeout.
-    await page.waitForTimeout(500);
-
-    await expect(page.getByTestId('search-optimized')).not.toBeVisible();
-  });
-
-  test('should exist when the user navigates back to the root page', async ({
+  test('The optimized searchbar component should not render when not on the landing page', async ({
     page,
     isMobile
   }) => {
+    // This means that the default search bar should be rendered ^.
     await page.getByTestId('curriculum-map-button').nth(0).click();
 
-    // If we do not wait here the history is not yet pushed in to
-    // the browser context and the back navigation will default to about: blank
-    await page.waitForTimeout(500);
+    if (isMobile) {
+      const menuButton = page.getByTestId('header-menu-button');
+      await expect(menuButton).toBeVisible();
+      await menuButton.click();
+    }
 
-    await page.goBack();
-    await getSearchInput({ page, isMobile });
-    await expect(page.getByTestId('search-optimized')).toBeVisible();
+    await expect(page.getByTestId('header-search')).toBeVisible();
   });
 });

--- a/e2e/search-bar-optimized.spec.ts
+++ b/e2e/search-bar-optimized.spec.ts
@@ -92,4 +92,29 @@ test.describe('Search bar optimized', () => {
 
     await expect(searchInput).toHaveValue('');
   });
+
+  test('should not exist when the user navigates to a different page from the root', async ({
+    page
+  }) => {
+    await page.getByTestId('curriculum-map-button').nth(0).click();
+
+    // Any of the searchbar elements wont be visible for a certain amount of time, thus the timeout.
+    await page.waitForTimeout(500);
+
+    await expect(page.getByTestId('search-optimized')).not.toBeVisible();
+  });
+
+  test('should exist when the user navigates back to the root page', async ({
+    page
+  }) => {
+    await page.getByTestId('curriculum-map-button').nth(0).click();
+
+    // If we do not wait here the history is not yet pushed in to
+    // the browser context and the back navigation will default to about: blank
+    await page.waitForTimeout(500);
+
+    await page.goBack();
+
+    await expect(page.getByTestId('search-optimized')).toBeVisible();
+  });
 });

--- a/e2e/search-bar-optimized.spec.ts
+++ b/e2e/search-bar-optimized.spec.ts
@@ -105,7 +105,8 @@ test.describe('Search bar optimized', () => {
   });
 
   test('should exist when the user navigates back to the root page', async ({
-    page
+    page,
+    isMobile
   }) => {
     await page.getByTestId('curriculum-map-button').nth(0).click();
 
@@ -114,7 +115,7 @@ test.describe('Search bar optimized', () => {
     await page.waitForTimeout(500);
 
     await page.goBack();
-
+    await getSearchInput({ page, isMobile });
     await expect(page.getByTestId('search-optimized')).toBeVisible();
   });
 });


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Currently the conditional rendering of the searchbar and searchbar-optimized is not behaving as desired. If you go to production. Type in the optimized search bar (the one that doesn't show a list of results) click on one of the curriculum buttons. Try to type. See that it is still using the optimized search bar instead of the default one (the one which shows a list of results).

This fixes that by using the provided pathname by Gatsby. Which updates accordingly. 

The path name we used was not updated every time we navigated somewhere else because there was no reason to re-render the component.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
