### PR TITLE
fix(curriculum): remove mentions of span in HTML chapter

### DIFF
--- a/curriculum/challenges/_meta/lecture-html-fundamentals/meta.json
+++ b/curriculum/challenges/_meta/lecture-html-fundamentals/meta.json
@@ -9,7 +9,7 @@
   "challengeOrder": [
     {
       "id": "670803abcb3e980233da4768",
-      "title": "What Are Divs and Spans, and When Should You Use Them?"
+      "title": "What are Div Elements and When Should You Use Them?"
     },
     {
       "id": "6708143cab2b583ecd3324f5",

--- a/curriculum/challenges/english/25-front-end-development/lecture-html-fundamentals/670803abcb3e980233da4768.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-html-fundamentals/670803abcb3e980233da4768.md
@@ -1,9 +1,9 @@
 ---
 id: 670803abcb3e980233da4768
-title: What Are Divs and Spans, and When Should You Use Them?
+title: What are Div Elements and When Should You Use Them?
 challengeType: 11
 videoId: nVAaxZ34khk
-dashedName: what-are-divs-and-spans
+dashedName: what-are-div-elements
 ---
 
 # --description--
@@ -50,35 +50,43 @@ A block-level element.
 
 ## --text--
 
-What kind of an element is a `span` element?
+Which of the following is the correct syntax for a `div` element?
 
 ## --answers--
 
-An inline-level element.
+```html
+<divEl>content goes here</divEl>
+```
 
 ### --feedback--
 
-Focus on how a `span` element behaves within text or other elements.
+Review the beginning of the video for the correct syntax.
 
 ---
 
-An inline element.
+```html
+<div>content goes here</div>
+```
 
 ---
 
-A block element.
+```html
+<divElement>content goes here</divElement>
+```
 
 ### --feedback--
 
-Focus on how a `span` element behaves within text or other elements.
+Review the beginning of the video for the correct syntax.
 
 ---
 
-A block-level element.
+```html
+<divGroup>content goes here</divGroup>
+```
 
 ### --feedback--
 
-Focus on how a `span` element behaves within text or other elements.
+Review the beginning of the video for the correct syntax.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/25-front-end-development/quiz-basic-html/66df3b712c41c499e9d31e5b.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-basic-html/66df3b712c41c499e9d31e5b.md
@@ -723,23 +723,23 @@ Which attribute is used to start the audio again once it is finished?
 
 #### --text--
 
-Which of the following is the correct syntax for a `span` element?
+Which of the following is the correct syntax for a `div` element?
 
 #### --distractors--
 
-`<<span>>inline container<</span>>`
+`<<div>>block container<</div>>`
 
 ---
 
-`>>span>>inline container>>span>>`
+`>>div>>block container>>div>>`
 
 ---
 
-`[span]inline container[/span]`
+`[div]block container[/div]`
 
 #### --answer--
 
-`<span>inline container</span>`
+`<div>block container</div>`
 
 ### --question--
 

--- a/curriculum/challenges/english/25-front-end-development/review-basic-html/67072fc183c7ca6c588feb4d.md
+++ b/curriculum/challenges/english/25-front-end-development/review-basic-html/67072fc183c7ca6c588feb4d.md
@@ -12,7 +12,7 @@ Review the concepts below to prepare for the upcoming quiz.
 ## HTML Basics
 
 - **Role of HTML**: Foundation of web structure.
-- **Block-level vs. inline elements**: Understanding `div` and `span`.
+- **Block-level elements**: The `div` element is a generic HTML element that does not hold any semantic meaning. It is used as a generic container to hold over HTML elements.
 - **Attributes**: Adding metadata and behavior to elements.
 
 ## Identifiers and Grouping

--- a/curriculum/challenges/english/25-front-end-development/review-html/671a883163d5ab5d47145880.md
+++ b/curriculum/challenges/english/25-front-end-development/review-html/671a883163d5ab5d47145880.md
@@ -12,7 +12,7 @@ Review the concepts below to prepare for the upcoming prep exam.
 ## HTML Basics
 
 - **Role of HTML**: HTML represents the content and structure of a webpage.
-- **Block-level vs. inline elements**: The `div` element is a block-level element used for grouping content, while the `span` element is an inline element used for styling text.
+- **`div` Element**: The `div` element is a block-level element used for grouping content.
 - **Attributes**: Adding metadata and behavior to elements.
 
 ## Identifiers and Grouping


### PR DESCRIPTION
One of the lecture videos was updated to remove the portion talking about spans. So the lecture title and questions needed to be updated to reflect that.

Also, any references to it in the HTML chapter was removed because spans are taught in the CSS section.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.


