### PR TITLE
feat(tools): create a bash testing script

### DIFF
--- a/tools/scripts/test_challenges.sh
+++ b/tools/scripts/test_challenges.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+
+echo "Enter the ids of the challenges you wish to test (separated by commas) and hit enter."
+read input
+
+
+IFS=',' challengeIDS=($input)
+
+for challengeID in "${challengeIDS[@]}";
+do
+  challengeID="$(tr -d ' ' <<< "$challengeID")"
+  FCC_CHALLENGE_ID=$challengeID pnpm run test:curriculum
+done

--- a/tools/scripts/test_challenges.sh
+++ b/tools/scripts/test_challenges.sh
@@ -2,7 +2,7 @@
 
 
 echo "Enter the ids of the challenges you wish to test (separated by commas) and hit enter."
-read input
+read -r input
 
 
 IFS=',' challengeIDS=($input)


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
Due to the slight hassle of testing multiple challenge files in a row, I made a bash script intended to make things a little easier. With this, the script gets ran and challenge testers can enter the ids of the challenges that need to be tested separated by commas. 

I'm fairly sure that while the script use is niche (intended for challenges like the full stack cert ones) , it fills a gap. 