### PR TITLE
fix(curriculum): add space in CSS variables intro

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -2378,7 +2378,7 @@
         "title": "CSS Variables Review",
         "intro": [
           "Before you are quizzed on the fundamentals of CSS variables, you first need to review.",
-          "Open up this page to review how to work with CSS custom properties(CSS variables) and the <code>@property</code> rule."
+          "Open up this page to review how to work with CSS custom properties (CSS variables) and the <code>@property</code> rule."
         ]
       },
       "quiz-css-variables": {


### PR DESCRIPTION
Checklist:


- [ x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ x] My pull request targets the `main` branch of freeCodeCamp.
- [ x] I have tested these changes either locally on my machine, or GitPod.


Closes #57220 

Added a space in a specific line of the CSS Variables Review intro as requested

