### PR TITLE
fix(curriculum): remove videoId from dialogue-4-chatting-about-gadgets

### DIFF
--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a3dafe5c945761cef35199.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a3dafe5c945761cef35199.md
@@ -1,6 +1,5 @@
 ---
 id: 65a3dafe5c945761cef35199
-videoId: nLDychdBwUg
 title: "Dialogue 4: Chatting About Gadgets"
 challengeType: 21
 dashedName: dialogue-4-chatting-about-gadgets


### PR DESCRIPTION
Checklist:
- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

Closes #57235

<!-- Feel free to add any additional description of changes below this line -->
The PR removes the videoId property from the file located at curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a3dafe5c945761cef35199.md. Attached is a screenshot of the page after the videoId has been removed from the specified file.

![image](https://github.com/user-attachments/assets/24cb2d92-151c-4021-846f-a566aed40e52)