### PR TITLE
fix(client): Clear feedback message when all answers are correct

### DIFF
--- a/client/src/templates/Challenges/fill-in-the-blank/show.tsx
+++ b/client/src/templates/Challenges/fill-in-the-blank/show.tsx
@@ -150,6 +150,8 @@ const ShowFillInTheBlank = ({
     setAnswersCorrect(newAnswersCorrect);
     const hasWrongAnswer = newAnswersCorrect.some(a => a === false);
     if (!hasWrongAnswer) {
+      setShowFeedback(false);
+      setFeedback(null);
       openCompletionModal();
     } else {
       const firstWrongIndex = newAnswersCorrect.findIndex(a => a === false);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #57260

<!-- Feel free to add any additional description of changes below this line -->

- Updated show.tsx to reset feedback message (`setFeedback(null)`) and visibility (`setShowFeedback(false)`) when all answers are correct.
