### PR TITLE
fix(client): set flex to 1 when preview and console is not shown

### DIFF
--- a/client/src/templates/Challenges/classic/desktop-layout.tsx
+++ b/client/src/templates/Challenges/classic/desktop-layout.tsx
@@ -193,6 +193,9 @@ const DesktopLayout = (props: DesktopLayoutProps): JSX.Element => {
     testsPane
   } = layoutState;
 
+  const editorPaneFlex =
+    !displayPreviewConsole && !displayPreviewPane ? 1 : editorPane.flex;
+
   return (
     <div className='desktop-layout' data-playwright-test-label='desktop-layout'>
       {(projectBasedChallenge || isMultifileCertProject) && (
@@ -228,7 +231,7 @@ const DesktopLayout = (props: DesktopLayoutProps): JSX.Element => {
         )}
 
         <ReflexElement
-          flex={editorPane.flex}
+          flex={editorPaneFlex}
           name='editorPane'
           {...resizeProps}
           data-playwright-test-label='editor-pane'


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #57229

<!-- Feel free to add any additional description of changes below this line -->

I'm sure it could be done earlier, so the value is never less than 1 if the preview or console isn't shown. This just seemed like a simple way of doing it, and if nothing else serves as an example.
