### PR TITLE
Corrected a typo in a lesson 

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/650757918a9e97418dc3d71a.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/650757918a9e97418dc3d71a.md
@@ -17,7 +17,7 @@ Congratulations! You have completed the platformer game project!
 
 # --hints--
 
-You should add an `else if` clause to check is the player's `x` position is greater than or equal to the checkpoint's `x` position and less than or equal to the checkpoint's `x` position plus `40`.
+You should add an `else if` clause to check if the player's `x` position is greater than or equal to the checkpoint's `x` position and less than or equal to the checkpoint's `x` position plus `40`.
 
 ```js
 assert.match(code, /if\s*\(\s*index\s*===\s*checkpoints\.length\s*-\s*1\s*\)\s*\{\s*isCheckpointCollisionDetectionActive\s*=\s*false\s*;?\s*showCheckpointScreen\(\s*("|'|`)You reached the final checkpoint!\1\s*\)\s*;?\s*movePlayer\(\s*("|'|`)ArrowRight\2\s*,\s*0\s*,\s*false\s*\)\s*;?\s*\}\s*else\s+if\s*\(\s*player\.position\.x\s*>=\s*checkpoint\.position\.x\s*&&\s*player\.position\.x\s*<=\s*checkpoint\.position\.x\s\+\s*40\s*\)\s*\{\s*/)


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ ] I have read and followed the [how to open a pull request guide](https://cotribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #57288

<!-- Feel free to add any additional description of changes below this line -->

The typo located in the console error message where the word "is" is used instead of "if". This can cause confusion for developers trying to debug their code.
