### PR TITLE
refactor(client): put scene logic into custom hook

### DIFF
--- a/client/src/redux/prop-types.ts
+++ b/client/src/redux/prop-types.ts
@@ -86,7 +86,7 @@ export interface CharacterPosition {
   z?: number;
 }
 
-export interface SceneCommand {
+interface SceneCommand {
   background?: string;
   character: string;
   position?: CharacterPosition;
@@ -121,7 +121,7 @@ export type Characters =
   | 'Sophie'
   | 'Tom';
 
-export interface SetupCharacter {
+interface SetupCharacter {
   character: Characters;
   position: CharacterPosition;
   opacity: number;

--- a/client/src/redux/prop-types.ts
+++ b/client/src/redux/prop-types.ts
@@ -74,8 +74,9 @@ export interface VideoLocaleIds {
 }
 
 // English types for animations
-interface Dialogue {
+export interface Dialogue {
   text: string;
+  label: string;
   align: 'left' | 'right' | 'center';
 }
 
@@ -85,7 +86,7 @@ export interface CharacterPosition {
   z?: number;
 }
 
-interface SceneCommand {
+export interface SceneCommand {
   background?: string;
   character: string;
   position?: CharacterPosition;
@@ -120,7 +121,7 @@ export type Characters =
   | 'Sophie'
   | 'Tom';
 
-interface SetupCharacter {
+export interface SetupCharacter {
   character: Characters;
   position: CharacterPosition;
   opacity: number;

--- a/client/src/redux/prop-types.ts
+++ b/client/src/redux/prop-types.ts
@@ -211,7 +211,7 @@ export type ChallengeNode = {
     quizzes: Quiz[];
     assignments: string[];
     required: Required[];
-    scene: FullScene;
+    scene: FullScene | null;
     solutions: {
       [T in FileKey]: FileKeyChallenge;
     };

--- a/client/src/templates/Challenges/components/scene/scene.tsx
+++ b/client/src/templates/Challenges/components/scene/scene.tsx
@@ -1,21 +1,14 @@
-import React, { useEffect, useState, useRef } from 'react'; //, ReactElement } from 'react';
+import React from 'react'; //, ReactElement } from 'react';
 import { Col, Spacer } from '@freecodecamp/ui';
 import { useTranslation } from 'react-i18next';
 import { FullScene } from '../../../../redux/prop-types';
 import { Loader } from '../../../../components/helpers';
 import ClosedCaptionsIcon from '../../../../assets/icons/closedcaptions';
-import { sounds, images, backgrounds, characterAssets } from './scene-assets';
+import { images, backgrounds } from './scene-assets';
 import Character from './character';
+import { useScene } from './use-scene';
 
 import './scene.css';
-
-const sToMs = (n: number) => {
-  return n * 1000;
-};
-
-const loadImage = (src: string | null) => {
-  if (src) new Image().src = src;
-};
 
 export function Scene({
   scene,
@@ -27,199 +20,21 @@ export function Scene({
   setIsPlaying: (shouldPlay: boolean) => void;
 }): JSX.Element {
   const { t } = useTranslation();
-  const { setup, commands } = scene;
-  const { audio, alwaysShowDialogue } = setup;
-  const { startTimestamp = null, finishTimestamp = null } = audio;
 
-  const hasTimestamps = startTimestamp !== null && finishTimestamp !== null;
-  const audioTimestamp = hasTimestamps ? `#t=${startTimestamp}` : '';
-
-  const audioRef = useRef<HTMLAudioElement>(new Audio());
-
-  // if there are timestamps, we use the difference between them as the duration
-  // if not, we assume we're playing the whole audio file.
-  const duration = hasTimestamps
-    ? sToMs(finishTimestamp - startTimestamp)
-    : Infinity;
-
-  // on mount
-  useEffect(() => {
-    const { current } = audioRef;
-
-    if (current) {
-      current.addEventListener('canplaythrough', audioLoaded);
-      current.src = `${sounds}/${audio.filename}${audioTimestamp}`;
-      current.load();
-    }
-
-    // preload images
-    loadImage(`${backgrounds}/${setup.background}`);
-
-    setup.characters
-      .map(({ character }) => Object.values(characterAssets[character]))
-      .flat()
-      .forEach(loadImage);
-
-    commands
-      .map(({ background }) =>
-        background ? `${backgrounds}/${background}` : null
-      )
-      .forEach(loadImage);
-
-    // on unmount
-    return () => {
-      if (current) {
-        current.pause();
-        current.currentTime = 0;
-        current.removeEventListener('canplaythrough', audioLoaded);
-      }
-    };
-  }, [
-    audioRef,
-    audio.filename,
-    audioTimestamp,
-    setup.background,
-    setup.characters,
-    commands
-  ]);
-
-  const initBackground = setup.background;
-  const initDialogue = { label: '', text: '', align: 'left' };
-  const initCharacters = setup.characters.map(character => {
-    return {
-      ...character,
-      opacity: character.opacity ?? 1,
-      isTalking: false
-    };
+  const {
+    accessibilityOn,
+    background,
+    characters,
+    dialogue,
+    sceneIsReady,
+    alwaysShowDialogue,
+    setAccessibilityOn,
+    showDialogue
+  } = useScene({
+    scene,
+    isPlaying,
+    setIsPlaying
   });
-
-  const [sceneIsReady, setSceneIsReady] = useState(false);
-  const [showDialogue, setShowDialogue] = useState(false);
-  const [accessibilityOn, setAccessibilityOn] = useState(false);
-  const [characters, setCharacters] = useState(initCharacters);
-  const [dialogue, setDialogue] = useState(initDialogue);
-  const [background, setBackground] = useState(initBackground);
-
-  useEffect(() => {
-    if (isPlaying) {
-      playScene();
-    } else {
-      resetScene();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isPlaying]);
-
-  const audioLoaded = () => {
-    setSceneIsReady(true);
-  };
-
-  let start = 0;
-  let stopAudio = false;
-
-  // this function exists because we couldn't reliably stop the audio when
-  // playing only part of the audio file. So it would get cut off
-  function maybeStopAudio() {
-    const runningTime = Date.now() - start;
-
-    if (runningTime >= duration) {
-      stopAudio = true;
-      audioRef.current.pause();
-    }
-
-    if (!stopAudio) {
-      window.requestAnimationFrame(maybeStopAudio);
-    }
-  }
-
-  const playScene = () => {
-    setShowDialogue(true);
-
-    setTimeout(() => {
-      if (audioRef.current.paused) {
-        start = Date.now();
-        void audioRef.current.play();
-      }
-      // if there are no timestamps, we can let the audio play to the end
-      if (hasTimestamps) maybeStopAudio();
-    }, sToMs(audio.startTime));
-
-    commands.forEach((command, commandIndex) => {
-      // Start command timeout
-      setTimeout(() => {
-        if (command.background) setBackground(command.background);
-
-        setDialogue(
-          command.dialogue
-            ? { ...command.dialogue, label: command.character }
-            : initDialogue
-        );
-
-        setCharacters(prevCharacters => {
-          const newCharacters = prevCharacters.map(character => {
-            if (character.character === command.character) {
-              return {
-                ...character,
-                position: command.position ?? character.position,
-                opacity: command.opacity ?? character.opacity,
-                isTalking: command.dialogue ? true : false
-              };
-            }
-            return character;
-          });
-          return newCharacters;
-        });
-      }, sToMs(command.startTime));
-
-      // Finish command timeout, only used when there's a dialogue
-      if (command.dialogue) {
-        setTimeout(
-          () => {
-            setCharacters(prevCharacters => {
-              const newCharacters = prevCharacters.map(character => {
-                if (character.character === command.character) {
-                  return {
-                    ...character,
-                    isTalking: false
-                  };
-                }
-                return character;
-              });
-              return newCharacters;
-            });
-          },
-          sToMs(command.finishTime as number)
-        );
-      }
-
-      // Last command timeout
-      if (commandIndex === commands.length - 1) {
-        setTimeout(
-          () => {
-            setIsPlaying(false);
-          },
-          // an extra 500ms at the end to let the characters fade out (CSS transition)
-          command.finishTime
-            ? sToMs(command.finishTime) + 500
-            : sToMs(command.startTime) + 500
-        );
-      }
-    });
-  };
-
-  const resetScene = () => {
-    const { current } = audioRef;
-    if (current) {
-      current.pause();
-      current.src = `${sounds}/${audio.filename}${audioTimestamp}`;
-      current.load();
-      current.currentTime = audio.startTimestamp || 0;
-    }
-
-    setShowDialogue(false);
-    setDialogue(initDialogue);
-    setCharacters(initCharacters);
-    setBackground(initBackground);
-  };
 
   return (
     <Col lg={10} lgOffset={1} md={10} mdOffset={1}>

--- a/client/src/templates/Challenges/components/scene/scene.tsx
+++ b/client/src/templates/Challenges/components/scene/scene.tsx
@@ -1,4 +1,4 @@
-import React from 'react'; //, ReactElement } from 'react';
+import React from 'react';
 import { Col, Spacer } from '@freecodecamp/ui';
 import { useTranslation } from 'react-i18next';
 import { Loader } from '../../../../components/helpers';

--- a/client/src/templates/Challenges/components/scene/scene.tsx
+++ b/client/src/templates/Challenges/components/scene/scene.tsx
@@ -1,7 +1,6 @@
 import React from 'react'; //, ReactElement } from 'react';
 import { Col, Spacer } from '@freecodecamp/ui';
 import { useTranslation } from 'react-i18next';
-import { FullScene } from '../../../../redux/prop-types';
 import { Loader } from '../../../../components/helpers';
 import ClosedCaptionsIcon from '../../../../assets/icons/closedcaptions';
 import { images, backgrounds } from './scene-assets';
@@ -10,31 +9,24 @@ import { useScene } from './use-scene';
 
 import './scene.css';
 
+type Props = ReturnType<typeof useScene> & {
+  setIsPlaying: (shouldPlay: boolean) => void;
+  isPlaying: boolean;
+};
+
 export function Scene({
-  scene,
+  background,
+  characters,
+  sceneIsReady,
+  dialogue,
+  showDialogue,
+  alwaysShowDialogue,
+  accessibilityOn,
+  setAccessibilityOn,
   isPlaying,
   setIsPlaying
-}: {
-  scene: FullScene;
-  isPlaying: boolean;
-  setIsPlaying: (shouldPlay: boolean) => void;
-}): JSX.Element {
+}: Props): JSX.Element {
   const { t } = useTranslation();
-
-  const {
-    accessibilityOn,
-    background,
-    characters,
-    dialogue,
-    sceneIsReady,
-    alwaysShowDialogue,
-    setAccessibilityOn,
-    showDialogue
-  } = useScene({
-    scene,
-    isPlaying,
-    setIsPlaying
-  });
 
   return (
     <Col lg={10} lgOffset={1} md={10} mdOffset={1}>

--- a/client/src/templates/Challenges/components/scene/use-scene.tsx
+++ b/client/src/templates/Challenges/components/scene/use-scene.tsx
@@ -1,0 +1,225 @@
+import { useEffect, useRef, useState } from 'react';
+
+import type { Dialogue, FullScene } from '../../../../redux/prop-types';
+import { sounds, backgrounds, characterAssets } from './scene-assets';
+
+type Args = {
+  scene: FullScene;
+  isPlaying: boolean;
+  setIsPlaying: (shouldPlay: boolean) => void;
+};
+
+const loadImage = (src: string | null) => {
+  if (src) new Image().src = src;
+};
+
+const sToMs = (n: number) => {
+  return n * 1000;
+};
+
+export function useScene({ scene, isPlaying, setIsPlaying }: Args) {
+  const { setup, commands } = scene;
+  const { audio, alwaysShowDialogue } = setup;
+  const { startTimestamp = null, finishTimestamp = null } = audio;
+
+  const initBackground = setup.background;
+  const initDialogue = { label: '', text: '', align: 'left' as const };
+  const initCharacters = setup.characters.map(character => {
+    return {
+      ...character,
+      opacity: character.opacity ?? 1,
+      isTalking: false
+    };
+  });
+
+  const [sceneIsReady, setSceneIsReady] = useState(false);
+  const [showDialogue, setShowDialogue] = useState(false);
+  const [accessibilityOn, setAccessibilityOn] = useState(false);
+  const [characters, setCharacters] = useState(initCharacters);
+  const [dialogue, setDialogue] = useState<Dialogue>(initDialogue);
+  const [background, setBackground] = useState(initBackground);
+
+  let start = 0;
+  let stopAudio = false;
+
+  const hasTimestamps = startTimestamp !== null && finishTimestamp !== null;
+  const audioTimestamp = hasTimestamps ? `#t=${startTimestamp}` : '';
+
+  const audioRef = useRef<HTMLAudioElement>(new Audio());
+
+  // if there are timestamps, we use the difference between them as the duration
+  // if not, we assume we're playing the whole audio file.
+  const duration = hasTimestamps
+    ? sToMs(finishTimestamp - startTimestamp)
+    : Infinity;
+
+  // on mount
+  useEffect(() => {
+    const audioLoaded = () => {
+      setSceneIsReady(true);
+    };
+    const { current } = audioRef;
+
+    if (current) {
+      current.addEventListener('canplaythrough', audioLoaded);
+      current.src = `${sounds}/${audio.filename}${audioTimestamp}`;
+      current.load();
+    }
+
+    // preload images
+    loadImage(`${backgrounds}/${setup.background}`);
+
+    setup.characters
+      .map(({ character }) => Object.values(characterAssets[character]))
+      .flat()
+      .forEach(loadImage);
+
+    commands
+      .map(({ background }) =>
+        background ? `${backgrounds}/${background}` : null
+      )
+      .forEach(loadImage);
+
+    // on unmount
+    return () => {
+      if (current) {
+        current.pause();
+        current.currentTime = 0;
+        current.removeEventListener('canplaythrough', audioLoaded);
+      }
+    };
+  }, [
+    setSceneIsReady,
+    audioRef,
+    audio.filename,
+    audioTimestamp,
+    setup.background,
+    setup.characters,
+    commands
+  ]);
+
+  useEffect(() => {
+    if (isPlaying) {
+      playScene();
+    } else {
+      resetScene();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isPlaying]);
+
+  const playScene = () => {
+    setShowDialogue(true);
+
+    setTimeout(() => {
+      if (audioRef.current.paused) {
+        start = Date.now();
+        void audioRef.current.play();
+      }
+      // if there are no timestamps, we can let the audio play to the end
+      if (hasTimestamps) maybeStopAudio();
+    }, sToMs(audio.startTime));
+
+    commands.forEach((command, commandIndex) => {
+      // Start command timeout
+      setTimeout(() => {
+        if (command.background) setBackground(command.background);
+
+        setDialogue(
+          command.dialogue
+            ? { ...command.dialogue, label: command.character }
+            : initDialogue
+        );
+
+        setCharacters(prevCharacters => {
+          const newCharacters = prevCharacters.map(character => {
+            if (character.character === command.character) {
+              return {
+                ...character,
+                position: command.position ?? character.position,
+                opacity: command.opacity ?? character.opacity,
+                isTalking: command.dialogue ? true : false
+              };
+            }
+            return character;
+          });
+          return newCharacters;
+        });
+      }, sToMs(command.startTime));
+
+      // Finish command timeout, only used when there's a dialogue
+      if (command.dialogue) {
+        setTimeout(
+          () => {
+            setCharacters(prevCharacters => {
+              const newCharacters = prevCharacters.map(character => {
+                if (character.character === command.character) {
+                  return {
+                    ...character,
+                    isTalking: false
+                  };
+                }
+                return character;
+              });
+              return newCharacters;
+            });
+          },
+          sToMs(command.finishTime as number)
+        );
+      }
+
+      // Last command timeout
+      if (commandIndex === commands.length - 1) {
+        setTimeout(
+          () => {
+            setIsPlaying(false);
+          },
+          // an extra 500ms at the end to let the characters fade out (CSS transition)
+          command.finishTime
+            ? sToMs(command.finishTime) + 500
+            : sToMs(command.startTime) + 500
+        );
+      }
+    });
+  };
+
+  const resetScene = () => {
+    const { current } = audioRef;
+    if (current) {
+      current.pause();
+      current.src = `${sounds}/${audio.filename}${audioTimestamp}`;
+      current.load();
+      current.currentTime = audio.startTimestamp || 0;
+    }
+
+    setShowDialogue(false);
+    setDialogue(initDialogue);
+    setCharacters(initCharacters);
+    setBackground(initBackground);
+  };
+
+  // this function exists because we couldn't reliably stop the audio when
+  // playing only part of the audio file. So it would get cut off
+  function maybeStopAudio() {
+    const runningTime = Date.now() - start;
+
+    if (runningTime >= duration) {
+      stopAudio = true;
+      audioRef.current.pause();
+    }
+
+    if (!stopAudio) {
+      window.requestAnimationFrame(maybeStopAudio);
+    }
+  }
+
+  return {
+    accessibilityOn,
+    background,
+    characters,
+    dialogue,
+    sceneIsReady,
+    alwaysShowDialogue,
+    setAccessibilityOn,
+    showDialogue
+  };
+}

--- a/client/src/templates/Challenges/components/scene/use-scene.tsx
+++ b/client/src/templates/Challenges/components/scene/use-scene.tsx
@@ -5,8 +5,6 @@ import { sounds, backgrounds, characterAssets } from './scene-assets';
 
 type Args = {
   scene: FullScene;
-  isPlaying: boolean;
-  setIsPlaying: (shouldPlay: boolean) => void;
 };
 
 const loadImage = (src: string | null) => {
@@ -17,7 +15,7 @@ const sToMs = (n: number) => {
   return n * 1000;
 };
 
-export function useScene({ scene, isPlaying, setIsPlaying }: Args) {
+export function useScene({ scene }: Args) {
   const { setup, commands } = scene;
   const { audio, alwaysShowDialogue } = setup;
   const { startTimestamp = null, finishTimestamp = null } = audio;
@@ -32,6 +30,7 @@ export function useScene({ scene, isPlaying, setIsPlaying }: Args) {
     };
   });
 
+  const [isPlaying, setIsPlaying] = useState(false);
   const [sceneIsReady, setSceneIsReady] = useState(false);
   const [showDialogue, setShowDialogue] = useState(false);
   const [accessibilityOn, setAccessibilityOn] = useState(false);
@@ -214,12 +213,14 @@ export function useScene({ scene, isPlaying, setIsPlaying }: Args) {
 
   return {
     accessibilityOn,
+    alwaysShowDialogue,
     background,
     characters,
     dialogue,
+    isPlaying,
     sceneIsReady,
-    alwaysShowDialogue,
     setAccessibilityOn,
+    setIsPlaying,
     showDialogue
   };
 }

--- a/client/src/templates/Challenges/components/scene/use-scene.tsx
+++ b/client/src/templates/Challenges/components/scene/use-scene.tsx
@@ -4,7 +4,7 @@ import type { Dialogue, FullScene } from '../../../../redux/prop-types';
 import { sounds, backgrounds, characterAssets } from './scene-assets';
 
 type Args = {
-  scene: FullScene;
+  initSceneData: FullScene;
 };
 
 const loadImage = (src: string | null) => {
@@ -15,8 +15,8 @@ const sToMs = (n: number) => {
   return n * 1000;
 };
 
-export function useScene({ scene }: Args) {
-  const { setup, commands } = scene;
+export function useScene({ initSceneData }: Args) {
+  const { setup, commands } = initSceneData;
   const { audio, alwaysShowDialogue } = setup;
   const { startTimestamp = null, finishTimestamp = null } = audio;
 

--- a/client/src/templates/Challenges/fill-in-the-blank/show.tsx
+++ b/client/src/templates/Challenges/fill-in-the-blank/show.tsx
@@ -86,7 +86,7 @@ const ShowFillInTheBlank = ({
         challengeType,
         fillInTheBlank,
         helpCategory,
-        scene
+        scene: initSceneData
       }
     }
   },
@@ -108,8 +108,8 @@ const ShowFillInTheBlank = ({
   const [feedback, setFeedback] = useState<string | null>(null);
   const [showFeedback, setShowFeedback] = useState(false);
 
-  const sceneProps = useScene({
-    scene
+  const scene = useScene({
+    initSceneData
   });
 
   const container = useRef<HTMLElement | null>(null);
@@ -188,7 +188,7 @@ const ShowFillInTheBlank = ({
   };
 
   const handlePlayScene = (shouldPlay: boolean) => {
-    sceneProps.setIsPlaying(shouldPlay);
+    scene.setIsPlaying(shouldPlay);
   };
 
   const blockNameTitle = `${t(
@@ -222,7 +222,7 @@ const ShowFillInTheBlank = ({
               <Spacer size='m' />
             </Col>
 
-            {scene && <Scene {...sceneProps} />}
+            {initSceneData && <Scene {...scene} />}
 
             <Col md={8} mdOffset={2} sm={10} smOffset={1} xs={12}>
               {instructions && (

--- a/client/src/templates/Challenges/fill-in-the-blank/show.tsx
+++ b/client/src/templates/Challenges/fill-in-the-blank/show.tsx
@@ -107,12 +107,9 @@ const ShowFillInTheBlank = ({
   const [allBlanksFilled, setAllBlanksFilled] = useState(false);
   const [feedback, setFeedback] = useState<string | null>(null);
   const [showFeedback, setShowFeedback] = useState(false);
-  const [isScenePlaying, setIsScenePlaying] = useState(false);
 
   const sceneProps = useScene({
-    scene,
-    isPlaying: isScenePlaying,
-    setIsPlaying: setIsScenePlaying
+    scene
   });
 
   const container = useRef<HTMLElement | null>(null);
@@ -191,7 +188,7 @@ const ShowFillInTheBlank = ({
   };
 
   const handlePlayScene = (shouldPlay: boolean) => {
-    setIsScenePlaying(shouldPlay);
+    sceneProps.setIsPlaying(shouldPlay);
   };
 
   const blockNameTitle = `${t(
@@ -225,13 +222,7 @@ const ShowFillInTheBlank = ({
               <Spacer size='m' />
             </Col>
 
-            {scene && (
-              <Scene
-                {...sceneProps}
-                isPlaying={isScenePlaying}
-                setIsPlaying={setIsScenePlaying}
-              />
-            )}
+            {scene && <Scene {...sceneProps} />}
 
             <Col md={8} mdOffset={2} sm={10} smOffset={1} xs={12}>
               {instructions && (

--- a/client/src/templates/Challenges/fill-in-the-blank/show.tsx
+++ b/client/src/templates/Challenges/fill-in-the-blank/show.tsx
@@ -31,6 +31,7 @@ import {
 } from '../redux/actions';
 import Scene from '../components/scene/scene';
 import { isChallengeCompletedSelector } from '../redux/selectors';
+import { useScene } from '../components/scene/use-scene';
 
 import './show.css';
 
@@ -107,6 +108,12 @@ const ShowFillInTheBlank = ({
   const [feedback, setFeedback] = useState<string | null>(null);
   const [showFeedback, setShowFeedback] = useState(false);
   const [isScenePlaying, setIsScenePlaying] = useState(false);
+
+  const sceneProps = useScene({
+    scene,
+    isPlaying: isScenePlaying,
+    setIsPlaying: setIsScenePlaying
+  });
 
   const container = useRef<HTMLElement | null>(null);
 
@@ -220,7 +227,7 @@ const ShowFillInTheBlank = ({
 
             {scene && (
               <Scene
-                scene={scene}
+                {...sceneProps}
                 isPlaying={isScenePlaying}
                 setIsPlaying={setIsScenePlaying}
               />

--- a/client/src/templates/Challenges/generic/show.tsx
+++ b/client/src/templates/Challenges/generic/show.tsx
@@ -28,6 +28,7 @@ import Scene from '../components/scene/scene';
 import MultipleChoiceQuestions from '../components/multiple-choice-questions';
 import ChallengeExplanation from '../components/challenge-explanation';
 import HelpModal from '../components/help-modal';
+import { useScene } from '../components/scene/use-scene';
 
 // Styles
 import './show.css';
@@ -144,6 +145,12 @@ const ShowGeneric = ({
   // scene
   const [isScenePlaying, setIsScenePlaying] = useState(false);
 
+  const sceneProps = useScene({
+    scene,
+    isPlaying: isScenePlaying,
+    setIsPlaying: setIsScenePlaying
+  });
+
   // assignments
   const [assignmentsCompleted, setAssignmentsCompleted] = useState(0);
   const allAssignmentsCompleted = assignmentsCompleted === assignments.length;
@@ -233,7 +240,7 @@ const ShowGeneric = ({
 
             {scene && (
               <Scene
-                scene={scene}
+                {...sceneProps}
                 isPlaying={isScenePlaying}
                 setIsPlaying={setIsScenePlaying}
               />

--- a/client/src/templates/Challenges/generic/show.tsx
+++ b/client/src/templates/Challenges/generic/show.tsx
@@ -82,7 +82,7 @@ const ShowGeneric = ({
         questions,
         title,
         translationPending,
-        scene,
+        scene: initSceneData,
         superBlock,
         videoId,
         videoLocaleIds
@@ -142,8 +142,8 @@ const ShowGeneric = ({
     setVideoIsLoaded(true);
   };
 
-  const sceneProps = useScene({
-    scene
+  const scene = useScene({
+    initSceneData
   });
 
   // assignments
@@ -197,7 +197,7 @@ const ShowGeneric = ({
       containerRef={container}
       nextChallengePath={nextChallengePath}
       prevChallengePath={prevChallengePath}
-      playScene={scene ? () => sceneProps.setIsPlaying(true) : undefined}
+      playScene={initSceneData ? () => scene.setIsPlaying(true) : undefined}
     >
       <LearnLayout>
         <Helmet
@@ -233,7 +233,7 @@ const ShowGeneric = ({
               )}
             </Col>
 
-            {scene && <Scene {...sceneProps} />}
+            {initSceneData && <Scene {...scene} />}
 
             <Col md={8} mdOffset={2} sm={10} smOffset={1} xs={12}>
               {instructions && (

--- a/client/src/templates/Challenges/generic/show.tsx
+++ b/client/src/templates/Challenges/generic/show.tsx
@@ -142,13 +142,8 @@ const ShowGeneric = ({
     setVideoIsLoaded(true);
   };
 
-  // scene
-  const [isScenePlaying, setIsScenePlaying] = useState(false);
-
   const sceneProps = useScene({
-    scene,
-    isPlaying: isScenePlaying,
-    setIsPlaying: setIsScenePlaying
+    scene
   });
 
   // assignments
@@ -202,7 +197,7 @@ const ShowGeneric = ({
       containerRef={container}
       nextChallengePath={nextChallengePath}
       prevChallengePath={prevChallengePath}
-      playScene={scene ? () => setIsScenePlaying(true) : undefined}
+      playScene={scene ? () => sceneProps.setIsPlaying(true) : undefined}
     >
       <LearnLayout>
         <Helmet
@@ -238,13 +233,7 @@ const ShowGeneric = ({
               )}
             </Col>
 
-            {scene && (
-              <Scene
-                {...sceneProps}
-                isPlaying={isScenePlaying}
-                setIsPlaying={setIsScenePlaying}
-              />
-            )}
+            {scene && <Scene {...sceneProps} />}
 
             <Col md={8} mdOffset={2} sm={10} smOffset={1} xs={12}>
               {instructions && (


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Aside from (obviously) increasing encapsulation, this solves one awkward problem. How can the hotkeys start a scene? 

Before, we had to manage some state (i.e. `isScenePlaying` and `setIsScenePlaying`) in the show components. That was passed to the hotkeys and down into the scene.

Now, `useScene` controls that, providing a `setIsPlaying` function that both the hotkeys and the `Scene` component can call as needed.

What's next? Starting and stopping the scene directly, rather than through `useEffect`. I think the current PR is enough, though!


<!-- Feel free to add any additional description of changes below this line -->
