### PR TITLE
chore(api): remove `version` field from docker-compose.yml

### DIFF
--- a/api/tools/docker-compose.yml
+++ b/api/tools/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   db:
     image: mongo


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

I'm getting a "`version` is obsolete" warning when running `docker compose up -d`. The `version` field is now no longer needed, so I'm removing it.

Ref: https://forums.docker.com/t/docker-compose-yml-version-is-obsolete/141313.

<!-- Feel free to add any additional description of changes below this line -->
