### PR TITLE
fix(a11y): completion state of LinkBlock and LegacyLinkBlock

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -501,6 +501,7 @@
     "complete-both-steps": "Complete both steps below to finish the challenge.",
     "runs-in-vm": "The project runs in a virtual machine, complete the user stories described in there and get all the tests to pass to finish step 1.",
     "completed": "Completed",
+    "not-completed": "Not completed",
     "not-started": "Not started",
     "test": "Test",
     "sorry-try-again": "Sorry, your code does not pass. Try again.",

--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -314,7 +314,9 @@ class Block extends Component<BlockProps> {
                 <CheckMark isCompleted={isBlockCompleted} />
                 {blockTitle}{' '}
                 <span className='sr-only'>
-                  {t('misc.certification-project')}
+                  {isBlockCompleted
+                    ? `${t('misc.certification-project')}, ${t('learn.completed')}`
+                    : `${t('misc.certification-project')}, ${t('learn.not-completed')}`}
                 </span>
               </Link>
             </h3>
@@ -399,6 +401,11 @@ class Block extends Component<BlockProps> {
                 <CheckMark isCompleted={isBlockCompleted} />
                 {blockType && <BlockLabel blockType={blockType} />}
                 {blockTitle}
+                <span className='sr-only'>
+                  {isBlockCompleted
+                    ? `, ${t('learn.completed')}`
+                    : `, ${t('learn.not-completed')}`}
+                </span>
               </Link>
             </h3>
           </div>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

In LinkBlock and LegacyLinkBlock, we show a `CheckMark` next to the block title, but the CheckMark component hides its content from screen readers: 

https://github.com/freeCodeCamp/freeCodeCamp/blob/5f4fd05580f4baf1ca0f777154d5c305a816439a/client/src/templates/Introduction/components/check-mark.tsx#L6-L9

This prevents screen readers from reading the `aria-label` of the icon, and allows us to apply different completion states to the block title (for example, in grid-based blocks, the states can be "not started", "X% completed", or "completed").

However, LinkBlock and LegacyLinkBlock currently don't have any alternative text for the completion state, so this information is not available for non-sighted users.

This PR addresses this issue.

<!-- Feel free to add any additional description of changes below this line -->
