### PR TITLE
fix(curriculum): use correct lecture challenge video ids

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lecture-animations-and-accessibility/672aa8d65995be62ef1c7515.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-animations-and-accessibility/672aa8d65995be62ef1c7515.md
@@ -2,7 +2,7 @@
 id: 672aa8d65995be62ef1c7515
 title: What Are CSS Animations, and How Do They Work?
 challengeType: 11
-videoId: kISWzkA7gKg
+videoId: dryjwjTQllk
 dashedName: what-are-css-animations
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-animations-and-accessibility/672aa8d65995be62ef1c7515.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-animations-and-accessibility/672aa8d65995be62ef1c7515.md
@@ -2,7 +2,7 @@
 id: 672aa8d65995be62ef1c7515
 title: What Are CSS Animations, and How Do They Work?
 challengeType: 11
-videoId: nVAaxZ34khk
+videoId: kISWzkA7gKg
 dashedName: what-are-css-animations
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-animations-and-accessibility/672cf764cf55a70433590def.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-animations-and-accessibility/672cf764cf55a70433590def.md
@@ -2,7 +2,7 @@
 id: 672cf764cf55a70433590def
 title: What Are Accessibility Concerns Around Using Animations, and How Can prefers-reduced-motion Help?
 challengeType: 11
-videoId: nVAaxZ34khk
+videoId: bKM3ZhO5Sns
 dashedName: what-are-accessibility-concerns-around-using-animations
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-best-practices-for-accessibility-and-css/672aa82768e00d600305afc0.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-best-practices-for-accessibility-and-css/672aa82768e00d600305afc0.md
@@ -2,7 +2,7 @@
 id: 672aa82768e00d600305afc0
 title: What Are Some Tools to Check for Good Color Contrast on Sites?
 challengeType: 11
-videoId: nVAaxZ34khk
+videoId: 2qj6LcJ4wSk
 dashedName: what-are-some-tools-to-check-for-good-color-contrast-on-sites
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-best-practices-for-accessibility-and-css/672c35a79fa53e00de9f2a49.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-best-practices-for-accessibility-and-css/672c35a79fa53e00de9f2a49.md
@@ -2,7 +2,7 @@
 id: 672c35a79fa53e00de9f2a49
 title: "What Are Best Practices for Hiding Content So It Doesn't Become Inaccessible?"
 challengeType: 11
-videoId: nVAaxZ34khk
+videoId: ycYVairxSdQ
 dashedName: what-are-best-practices-for-hiding-content-so-it-doesnt-become-inaccessible
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-best-practices-for-responsive-web-design/672aa8873d4e25618870764f.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-best-practices-for-responsive-web-design/672aa8873d4e25618870764f.md
@@ -2,7 +2,7 @@
 id: 672aa8873d4e25618870764f
 title: What Is Responsive Web Design, and What Is Its Relationship to Tools Like CSS Grid and Flexbox?
 challengeType: 11
-videoId: nVAaxZ34khk
+videoId: ISOf41vPNJY
 dashedName: what-is-responsive-web-design
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-best-practices-for-responsive-web-design/672cf05c3ad533eabe1e8197.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-best-practices-for-responsive-web-design/672cf05c3ad533eabe1e8197.md
@@ -2,7 +2,7 @@
 id: 672cf05c3ad533eabe1e8197
 title: How Do Media Queries Work, and What Are Some Common Media Types and Features?
 challengeType: 11
-videoId: nVAaxZ34khk
+videoId: 1h0QErJG8DE
 dashedName: how-do-media-queries-work
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-best-practices-for-responsive-web-design/672cf06c8f46f9eb04db9832.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-best-practices-for-responsive-web-design/672cf06c8f46f9eb04db9832.md
@@ -2,7 +2,7 @@
 id: 672cf06c8f46f9eb04db9832
 title: What Is the Mobile First Approach in Responsive Web Design?
 challengeType: 11
-videoId: nVAaxZ34khk
+videoId: BuCdyShUzKQ
 dashedName: what-is-the-mobile-first-approach-in-responsive-web-design
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-best-practices-for-responsive-web-design/672cf07a2b9796eb49719e03.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-best-practices-for-responsive-web-design/672cf07a2b9796eb49719e03.md
@@ -2,7 +2,7 @@
 id: 672cf07a2b9796eb49719e03
 title: What Are Media Breakpoints, and What Are Common Breakpoints in Modern Design?
 challengeType: 11
-videoId: nVAaxZ34khk
+videoId: R0hiJEAXGIk
 dashedName: what-are-media-breakpoints
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-html-fundamentals/6708382cf088b216580a9ff1.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-html-fundamentals/6708382cf088b216580a9ff1.md
@@ -2,7 +2,7 @@
 id: 6708382cf088b216580a9ff1
 title: What Are IDs and Classes, and When Should You Use Them?
 challengeType: 11
-videoId: yTuzVH6THdg
+videoId: gM7Tngm3QXo
 dashedName: what-are-ids-and-classes
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-html-fundamentals/67083868d5fdcb17bf8c14bd.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-html-fundamentals/67083868d5fdcb17bf8c14bd.md
@@ -2,7 +2,7 @@
 id: 67083868d5fdcb17bf8c14bd
 title: What Are HTML Entities, and What Are Some Common Examples?
 challengeType: 11
-videoId: VJmx-XzTqg8
+videoId: Z9C18t3fXt0
 dashedName: what-are-html-entities
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-html-fundamentals/67083868d5fdcb17bf8c14bd.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-html-fundamentals/67083868d5fdcb17bf8c14bd.md
@@ -2,7 +2,7 @@
 id: 67083868d5fdcb17bf8c14bd
 title: What Are HTML Entities, and What Are Some Common Examples?
 challengeType: 11
-videoId: Z9C18t3fXt0
+videoId: mVdIq0H_B4E
 dashedName: what-are-html-entities
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-html-fundamentals/670838977810401844af6fe0.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-html-fundamentals/670838977810401844af6fe0.md
@@ -2,7 +2,7 @@
 id: 670838977810401844af6fe0
 title: What Is the Role of the Link Element in HTML, and How Can It Be Used to Link to External Stylesheets?
 challengeType: 11
-videoId: qeGlYqpFRZA
+videoId: Xdyig5C-oSU
 dashedName: what-is-the-role-of-the-link-element-in-html
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-html-fundamentals/670838b10ee87a18e5faff62.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-html-fundamentals/670838b10ee87a18e5faff62.md
@@ -2,7 +2,7 @@
 id: 670838b10ee87a18e5faff62
 title: What Is the Role of the Script Element in HTML, and How Can It Be Used to Link to External JavaScript Files?
 challengeType: 11
-videoId: ZxpITCgbc5Y
+videoId: rJ4C5KyFzcw
 dashedName: what-is-the-role-of-the-script-element-in-html
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-html-fundamentals/670838b10ee87a18e5faff62.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-html-fundamentals/670838b10ee87a18e5faff62.md
@@ -2,7 +2,7 @@
 id: 670838b10ee87a18e5faff62
 title: What Is the Role of the Script Element in HTML, and How Can It Be Used to Link to External JavaScript Files?
 challengeType: 11
-videoId: rJ4C5KyFzcw
+videoId: nNCwy4QUh8Q
 dashedName: what-is-the-role-of-the-script-element-in-html
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-html-fundamentals/670838e914096b194b0c51aa.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-html-fundamentals/670838e914096b194b0c51aa.md
@@ -2,7 +2,7 @@
 id: 670838e914096b194b0c51aa
 title: What Is an HTML Boilerplate, and Why Is It Important?
 challengeType: 11
-videoId: UKxDoI54eLE
+videoId: Z9C18t3fXt0
 dashedName: what-is-an-html-boilerplate
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-html-fundamentals/670838e914096b194b0c51aa.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-html-fundamentals/670838e914096b194b0c51aa.md
@@ -2,7 +2,7 @@
 id: 670838e914096b194b0c51aa
 title: What Is an HTML Boilerplate, and Why Is It Important?
 challengeType: 11
-videoId: Z9C18t3fXt0
+videoId: IlJEEVOc9o0
 dashedName: what-is-an-html-boilerplate
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-html-fundamentals/670839051794aa19fcef6dc8.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-html-fundamentals/670839051794aa19fcef6dc8.md
@@ -2,7 +2,7 @@
 id: 670839051794aa19fcef6dc8
 title: What Is UTF-8 Character Encoding, and Why Is It Needed?
 challengeType: 11
-videoId: SuTPQkOpa10
+videoId: T0VimOMROr8
 dashedName: what-is-utf-8-character-encoding
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-html-fundamentals/67083952f800051a8a21fcfd.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-html-fundamentals/67083952f800051a8a21fcfd.md
@@ -2,7 +2,7 @@
 id: 67083952f800051a8a21fcfd
 title: What Is the Role of the Meta Description, and How Does It Affect SEO?
 challengeType: 11
-videoId: aLy7C2fGDQw
+videoId: G-g2KBE05to
 dashedName: what-is-the-role-of-the-meta-description
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-html-fundamentals/6708396caa00e11b597b3365.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-html-fundamentals/6708396caa00e11b597b3365.md
@@ -2,7 +2,7 @@
 id: 6708396caa00e11b597b3365
 title: What Is the Role of Open Graph Tags, and How Do They Affect SEO?
 challengeType: 11
-videoId: wQhsL9NjiuA
+videoId: 94IAhyEfO8I
 dashedName: what-is-the-role-of-open-graph-tags
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript/672d26385dbe73203c4dac81.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript/672d26385dbe73203c4dac81.md
@@ -2,7 +2,7 @@
 id: 672d26385dbe73203c4dac81
 title: What Is JavaScript, and How Does It Work with HTML and CSS?
 challengeType: 11
-videoId: nVAaxZ34khk
+videoId: G7lc_Yt2fqY
 dashedName: what-is-javascript
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript/672d496eca926b5df8176a67.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript/672d496eca926b5df8176a67.md
@@ -2,7 +2,7 @@
 id: 672d496eca926b5df8176a67
 title: What Is a Data Type, and What Are the Different Data Types in JavaScript?
 challengeType: 11
-videoId: nVAaxZ34khk
+videoId: DQgf3RxOiQg
 dashedName: what-is-a-data-type
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript/672d497cb1a1675e47bf7ea1.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript/672d497cb1a1675e47bf7ea1.md
@@ -2,7 +2,7 @@
 id: 672d497cb1a1675e47bf7ea1
 title: What Are Variables, and What Are Guidelines for Naming JavaScript Variables?
 challengeType: 11
-videoId: nVAaxZ34khk
+videoId: h6ytd29mrrg
 dashedName: what-are-variables
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript/672d49959621885e9d3e672c.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript/672d49959621885e9d3e672c.md
@@ -2,7 +2,7 @@
 id: 672d49959621885e9d3e672c
 title: How Do let and const Work Differently When It Comes to Variable Declaration, Assignment, and Reassignment?
 challengeType: 11
-videoId: nVAaxZ34khk
+videoId: ax8XbAiG4Ek
 dashedName: how-do-let-and-const-work
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript/672d49a5cf43945ee09e5fba.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript/672d49a5cf43945ee09e5fba.md
@@ -2,7 +2,7 @@
 id: 672d49a5cf43945ee09e5fba
 title: What Is a String in JavaScript, and What Is String Immutability?
 challengeType: 11
-videoId: nVAaxZ34khk
+videoId: AXinCYvj7h8
 dashedName: what-is-a-string
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript/672d49b2fb76df5f1d6117af.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript/672d49b2fb76df5f1d6117af.md
@@ -2,7 +2,7 @@
 id: 672d49b2fb76df5f1d6117af
 title: What Is String Concatenation, and How Can You Concatenate Strings with Variables?
 challengeType: 11
-videoId: nVAaxZ34khk
+videoId: 4bCDHakINH8
 dashedName: what-is-string-concatenation
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript/672d49c4e899345f5b33c24c.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript/672d49c4e899345f5b33c24c.md
@@ -2,7 +2,7 @@
 id: 672d49c4e899345f5b33c24c
 title: What Is console.log Used For, and How Does It Work?
 challengeType: 11
-videoId: nVAaxZ34khk
+videoId: J9CeRj7EBmM
 dashedName: what-is-console-log
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript/672d49d93b54b85faa4dbad7.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript/672d49d93b54b85faa4dbad7.md
@@ -2,7 +2,7 @@
 id: 672d49d93b54b85faa4dbad7
 title: What Is the Role of Semicolons in JavaScript, and Programming in General?
 challengeType: 11
-videoId: nVAaxZ34khk
+videoId: BgZYZV0_-UM
 dashedName: what-is-the-role-of-semicolons
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript/672d49e65a1c855fe7bb3fdb.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript/672d49e65a1c855fe7bb3fdb.md
@@ -2,7 +2,7 @@
 id: 672d49e65a1c855fe7bb3fdb
 title: What Are Comments in JavaScript, and When Should You Use Them?
 challengeType: 11
-videoId: nVAaxZ34khk
+videoId: HyYHnvP_EaM
 dashedName: what-are-comments-in-javascript
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-understanding-how-to-work-with-floats-and-positioning-in-css/672aa86da9937560d3dfe3d6.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-understanding-how-to-work-with-floats-and-positioning-in-css/672aa86da9937560d3dfe3d6.md
@@ -2,7 +2,7 @@
 id: 672aa86da9937560d3dfe3d6
 title: What Are Common Use Cases for Using Floats, and How Do They Work?
 challengeType: 11
-videoId: nVAaxZ34khk
+videoId: xUr2Oh1KE8I
 dashedName: what-are-common-use-cases-for-using-floats
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-understanding-how-to-work-with-floats-and-positioning-in-css/672c3a84fb8d4613776cc99e.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-understanding-how-to-work-with-floats-and-positioning-in-css/672c3a84fb8d4613776cc99e.md
@@ -2,7 +2,7 @@
 id: 672c3a84fb8d4613776cc99e
 title: What Is Relative Positioning, and How Does This Differ from the Default Static Positioning?
 challengeType: 11
-videoId: 14lSbuus3Ts
+videoId: 3BO43MUDd8Q
 dashedName: what-is-relative-positioning
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-understanding-how-to-work-with-floats-and-positioning-in-css/672c3a84fb8d4613776cc99e.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-understanding-how-to-work-with-floats-and-positioning-in-css/672c3a84fb8d4613776cc99e.md
@@ -2,7 +2,7 @@
 id: 672c3a84fb8d4613776cc99e
 title: What Is Relative Positioning, and How Does This Differ from the Default Static Positioning?
 challengeType: 11
-videoId: nVAaxZ34khk
+videoId: 14lSbuus3Ts
 dashedName: what-is-relative-positioning
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-understanding-how-to-work-with-floats-and-positioning-in-css/672c3a8fac7c5613b4bb75de.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-understanding-how-to-work-with-floats-and-positioning-in-css/672c3a8fac7c5613b4bb75de.md
@@ -2,7 +2,7 @@
 id: 672c3a8fac7c5613b4bb75de
 title: What Is Absolute Positioning, and How Does It Work?
 challengeType: 11
-videoId: nVAaxZ34khk
+videoId: KaTb9CL9lMQ
 dashedName: what-is-absolute-positioning
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-understanding-how-to-work-with-floats-and-positioning-in-css/672c3a9d32c56113fcaedf24.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-understanding-how-to-work-with-floats-and-positioning-in-css/672c3a9d32c56113fcaedf24.md
@@ -2,7 +2,7 @@
 id: 672c3a9d32c56113fcaedf24
 title: What Is Fixed and Sticky Positioning, and How Does It Differ from Absolute Positioning?
 challengeType: 11
-videoId: nVAaxZ34khk
+videoId: H7sJoYv_zmA
 dashedName: what-is-fixed-and-sticky-positioning
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-understanding-how-to-work-with-floats-and-positioning-in-css/672c3aa9bc3a481425cb52b3.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-understanding-how-to-work-with-floats-and-positioning-in-css/672c3aa9bc3a481425cb52b3.md
@@ -2,7 +2,7 @@
 id: 672c3aa9bc3a481425cb52b3
 title: What Is the Z-Index Property, and How Does It Work to Control the Stacking of Positioned Elements?
 challengeType: 11
-videoId: nVAaxZ34khk
+videoId: IkEM5npJM5E
 dashedName: what-is-the-z-index-property
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-common-string-methods/672d266034b5242126271995.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-common-string-methods/672d266034b5242126271995.md
@@ -2,7 +2,7 @@
 id: 672d266034b5242126271995
 title: What Is ASCII, and How Does It Work with charCodeAt() and fromCharCode()?
 challengeType: 11
-videoId: nVAaxZ34khk
+videoId: xpB7Wr4kiis
 dashedName: what-is-ascii-and-how-does-it-work-with-charcodeat-and-fromcharcode
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-common-string-methods/67326c0d7bef01c539120766.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-common-string-methods/67326c0d7bef01c539120766.md
@@ -2,7 +2,7 @@
 id: 67326c0d7bef01c539120766
 title: How Can You Test if a String Contains a Substring?
 challengeType: 11
-videoId: nVAaxZ34khk
+videoId: XBva3_87hWg
 dashedName: how-can-you-test-if-a-string-contains-a-substring
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-common-string-methods/67326c15b3b2f0c5827927cc.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-common-string-methods/67326c15b3b2f0c5827927cc.md
@@ -2,7 +2,7 @@
 id: 67326c15b3b2f0c5827927cc
 title: How Can You Extract a Substring from a String?
 challengeType: 11
-videoId: nVAaxZ34khk
+videoId: xLKJvMJKYAU
 dashedName: how-can-you-extract-a-substring-from-a-string
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-common-string-methods/67326c1fdaf9c0c5ad1a2589.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-common-string-methods/67326c1fdaf9c0c5ad1a2589.md
@@ -2,7 +2,7 @@
 id: 67326c1fdaf9c0c5ad1a2589
 title: How Can You Change the Casing for a String?
 challengeType: 11
-videoId: nVAaxZ34khk
+videoId: KOaGZ2IXzV0
 dashedName: how-can-you-change-the-casing-for-a-string
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-common-string-methods/67326c29dcd98fc5ecc49779.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-common-string-methods/67326c29dcd98fc5ecc49779.md
@@ -2,7 +2,7 @@
 id: 67326c29dcd98fc5ecc49779
 title: How Can You Replace Parts of a String with Another?
 challengeType: 11
-videoId: nVAaxZ34khk
+videoId: -Ft7Whs9xRY
 dashedName: how-can-you-replace-parts-of-a-string-with-another
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-common-string-methods/67326c3392068ec6184a0c95.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-common-string-methods/67326c3392068ec6184a0c95.md
@@ -2,7 +2,7 @@
 id: 67326c3392068ec6184a0c95
 title: How Can You Repeat a String x Number of Times?
 challengeType: 11
-videoId: nVAaxZ34khk
+videoId: G78i7JW70hE
 dashedName: how-can-you-repeat-a-string-x-number-of-times
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-common-string-methods/67326c3c3ab931c644cea05b.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-common-string-methods/67326c3c3ab931c644cea05b.md
@@ -2,7 +2,7 @@
 id: 67326c3c3ab931c644cea05b
 title: How Can You Trim Whitespace from a String?
 challengeType: 11
-videoId: nVAaxZ34khk
+videoId: qVjDfh-K2SY
 dashedName: how-can-you-trim-whitespace-from-a-string
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-transforms-overflow-and-filters/672aa7e03c2e365e906e5733.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-transforms-overflow-and-filters/672aa7e03c2e365e906e5733.md
@@ -2,7 +2,7 @@
 id: 672aa7e03c2e365e906e5733
 title: What Is Overflow in CSS, and How Does It Work?
 challengeType: 11
-videoId: nVAaxZ34khk
+videoId: iqnkHaVCLww
 dashedName: what-is-overflow-in-css
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-transforms-overflow-and-filters/672bcc8ccc976fd791610f43.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-transforms-overflow-and-filters/672bcc8ccc976fd791610f43.md
@@ -2,7 +2,7 @@
 id: 672bcc8ccc976fd791610f43
 title: What Is the CSS Transform Property, and How Does It Work?
 challengeType: 11
-videoId: nVAaxZ34khk
+videoId: X47hZ_MwfJA
 dashedName: what-is-the-css-transform-property
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-transforms-overflow-and-filters/672bcc8ccc976fd791610f43.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-transforms-overflow-and-filters/672bcc8ccc976fd791610f43.md
@@ -2,7 +2,7 @@
 id: 672bcc8ccc976fd791610f43
 title: What Is the CSS Transform Property, and How Does It Work?
 challengeType: 11
-videoId: X47hZ_MwfJA
+videoId: pC59ipGpaDk
 dashedName: what-is-the-css-transform-property
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-transforms-overflow-and-filters/672bcc9c4a6dd6d7dd3e6357.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-transforms-overflow-and-filters/672bcc9c4a6dd6d7dd3e6357.md
@@ -2,7 +2,7 @@
 id: 672bcc9c4a6dd6d7dd3e6357
 title: What Is the CSS Box Model, and How Does It Work?
 challengeType: 11
-videoId: nVAaxZ34khk
+videoId: oBIIFdfLGos
 dashedName: what-is-the-css-box-model
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-transforms-overflow-and-filters/672bccae6e556cd81cef6af2.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-transforms-overflow-and-filters/672bccae6e556cd81cef6af2.md
@@ -2,7 +2,7 @@
 id: 672bccae6e556cd81cef6af2
 title: What Is Margin Collapsing, and How Does It Work?
 challengeType: 11
-videoId: nVAaxZ34khk
+videoId: MMWBC8duT_0
 dashedName: what-is-margin-collapsing
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-transforms-overflow-and-filters/672bccc8ea33bad87abb3c56.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-transforms-overflow-and-filters/672bccc8ea33bad87abb3c56.md
@@ -2,7 +2,7 @@
 id: 672bccc8ea33bad87abb3c56
 title: What Is the Difference Between content-box and border-box?
 challengeType: 11
-videoId: nVAaxZ34khk
+videoId: eKqNs2XXG14
 dashedName: what-is-the-difference-between-content-box-and-border-box
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-transforms-overflow-and-filters/672bccdb8f1823d8c60f914c.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-transforms-overflow-and-filters/672bccdb8f1823d8c60f914c.md
@@ -2,7 +2,7 @@
 id: 672bccdb8f1823d8c60f914c
 title: What Is a CSS Reset, and What Are Some Common Examples?
 challengeType: 11
-videoId: nVAaxZ34khk
+videoId: 2VPFQpukQV8
 dashedName: what-is-a-css-reset
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-transforms-overflow-and-filters/672bccebe1fc82d911c3f078.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-transforms-overflow-and-filters/672bccebe1fc82d911c3f078.md
@@ -2,7 +2,7 @@
 id: 672bccebe1fc82d911c3f078
 title: What Is the CSS Filter Property, and What Are Common Examples?
 challengeType: 11
-videoId: nVAaxZ34khk
+videoId: 9ta8m4T9KYc
 dashedName: what-is-the-css-filter-property
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-variables/672aa8985acb7361e656f94c.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-variables/672aa8985acb7361e656f94c.md
@@ -2,7 +2,7 @@
 id: 672aa8985acb7361e656f94c
 title: What Are CSS Custom Properties, and How Do They Work?
 challengeType: 11
-videoId: nVAaxZ34khk
+videoId: rG9-26gM3eU
 dashedName: what-are-css-custom-properties
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-variables/672cf3ca326da9f63683e236.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-variables/672cf3ca326da9f63683e236.md
@@ -2,7 +2,7 @@
 id: 672cf3ca326da9f63683e236
 title: What Is the @property Rule, and How Does It Work with Fallbacks?
 challengeType: 11
-videoId: nVAaxZ34khk
+videoId: lFwXJzcJ9fg
 dashedName: what-is-the-at-property-rule
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-types/672d264645e289208e562f10.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-types/672d264645e289208e562f10.md
@@ -2,7 +2,7 @@
 id: 672d264645e289208e562f10
 title: What Is Dynamic Typing in JavaScript, and How Does It Differ from Statically Typed Languages?
 challengeType: 11
-videoId: nVAaxZ34khk
+videoId: IOKsF08zioQ
 dashedName: what-is-dynamic-typing-in-javascript-and-how-does-it-differ-from-statically-typed-languages
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-types/6732518a8627876f4fcd18a4.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-types/6732518a8627876f4fcd18a4.md
@@ -2,7 +2,7 @@
 id: 6732518a8627876f4fcd18a4
 title: How Does the typeof Operator Work, and What Is the typeof null Bug in JavaScript?
 challengeType: 11
-videoId: nVAaxZ34khk
+videoId: DDHu5VDlkPM
 dashedName: how-does-the-typeof-operator-work-and-what-is-the-typeof-null-bug-in-javascript
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-links/6716744f7245947a3dd60009.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-links/6716744f7245947a3dd60009.md
@@ -1,6 +1,6 @@
 ---
 id: 6716744f7245947a3dd60009
-videoId: D4PO-NUqmzg
+videoId: zf4bbN-hYOg
 title: What Are the Different Target Attribute Types, and How Do They Work?
 challengeType: 11
 dashedName: what-are-the-different-target-attribute-types

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-links/671682dd88e461a8e2620f38.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-links/671682dd88e461a8e2620f38.md
@@ -1,6 +1,6 @@
 ---
 id: 671682dd88e461a8e2620f38
-videoId: hpEmssjWh-0
+videoId: bxr4p5Ik4js
 title: What Is the Difference Between Absolute and Relative Paths?
 challengeType: 11
 dashedName: what-is-the-difference-between-absolute-and-relative-paths

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-links/6716830dbaf95da9564f2e3b.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-links/6716830dbaf95da9564f2e3b.md
@@ -1,6 +1,6 @@
 ---
 id: 6716830dbaf95da9564f2e3b
-videoId: nVAaxZ34khk
+videoId: GTgzy4wPXcM
 title: What Is the Difference Between Slashes, a Single Dot, and Double Dot in Path Syntax?
 challengeType: 11
 dashedName: what-is-the-difference-between-slashes-a-single-dot-and-double-dot-in-path-syntax

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-links/67168323932391a9ee0d3a9e.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-links/67168323932391a9ee0d3a9e.md
@@ -1,6 +1,6 @@
 ---
 id: 67168323932391a9ee0d3a9e
-videoId: O86-AxNc0nU
+videoId: ztu_9h2ZJrA
 title: What Are the Different Link States, and Why Are They Important?
 challengeType: 11
 dashedName: what-are-the-different-link-states

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-loops/67329f7f3d1bd75c17896c66.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-loops/67329f7f3d1bd75c17896c66.md
@@ -2,7 +2,7 @@
 id: 67329f7f3d1bd75c17896c66
 title: How Do Loops and Iteration Work in JavaScript?
 challengeType: 11
-videoId: nVAaxZ34khk
+videoId: 2h4RsvyUDH4
 dashedName: how-do-loops-and-iteration-work-in-javascript
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-loops/6732c04638420641dcca2e6e.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-loops/6732c04638420641dcca2e6e.md
@@ -2,7 +2,7 @@
 id: 6732c04638420641dcca2e6e
 title: How Does the For...of Loop Work, and When Should You Use It?
 challengeType: 11
-videoId: nVAaxZ34khk
+videoId: 3EvkUpl4IQs
 dashedName: how-does-the-for-of-loop-work-and-when-should-you-use-it
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-loops/6732c05595ca7d422b9e55ff.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-loops/6732c05595ca7d422b9e55ff.md
@@ -2,7 +2,7 @@
 id: 6732c05595ca7d422b9e55ff
 title: What Is the For...in Loop, and When Should You Use It?
 challengeType: 11
-videoId: nVAaxZ34khk
+videoId: K0dZ8f9AZt4
 dashedName: what-is-the-for-in-loop-and-when-should-you-use-it
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-loops/6732c06654ea3442724284fe.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-loops/6732c06654ea3442724284fe.md
@@ -2,7 +2,7 @@
 id: 6732c06654ea3442724284fe
 title: What Is a While Loop, and How Does It Differ from the Do...while Loop?
 challengeType: 11
-videoId: nVAaxZ34khk
+videoId: 93KL4Ou1eXU
 dashedName: what-is-a-while-loop-and-how-does-it-differ-from-the-do-while-loop
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-loops/6732c07238355642a9781dfb.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-loops/6732c07238355642a9781dfb.md
@@ -2,7 +2,7 @@
 id: 6732c07238355642a9781dfb
 title: What Are the Break and Continue Statements Used for in Loops?
 challengeType: 11
-videoId: nVAaxZ34khk
+videoId: U3gATVuQTxQ
 dashedName: what-are-the-break-and-continue-statements-used-for-in-loops
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-strings-in-javascript/672d2654f78cbf20e0ba4501.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-strings-in-javascript/672d2654f78cbf20e0ba4501.md
@@ -2,7 +2,7 @@
 id: 672d2654f78cbf20e0ba4501
 title: What Is Bracket Notation, and How Do You Access Characters from a String?
 challengeType: 11
-videoId: nVAaxZ34khk
+videoId: VFYqtU7nzFo
 dashedName: what-is-bracket-notation-and-how-do-you-access-characters-from-a-string
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-strings-in-javascript/673263d58da27ea7809963bf.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-strings-in-javascript/673263d58da27ea7809963bf.md
@@ -2,7 +2,7 @@
 id: 673263d58da27ea7809963bf
 title: What Are Template Literals, and What Is String Interpolation?
 challengeType: 11
-videoId: nVAaxZ34khk
+videoId: kISWzkA7gKg
 dashedName: what-are-template-literals-and-what-is-string-interpolation
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-strings-in-javascript/673263df0eb568a7b450f2fc.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-strings-in-javascript/673263df0eb568a7b450f2fc.md
@@ -2,7 +2,7 @@
 id: 673263df0eb568a7b450f2fc
 title: How Do You Create a Newline in Strings and Escape Strings?
 challengeType: 11
-videoId: nVAaxZ34khk
+videoId: gOLjFbJnTIM
 dashedName: how-do-you-create-a-newline-in-strings-and-escape-strings
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-strings-in-javascript/673263e80dd43da7df3ae565.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-strings-in-javascript/673263e80dd43da7df3ae565.md
@@ -2,7 +2,7 @@
 id: 673263e80dd43da7df3ae565
 title: How Can You Find the Position of a Substring in a String?
 challengeType: 11
-videoId: nVAaxZ34khk
+videoId: k2QaBPHl_00
 dashedName: how-can-you-find-the-position-of-a-substring-in-a-string
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-strings-in-javascript/673263f4a5899da8124542fd.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-strings-in-javascript/673263f4a5899da8124542fd.md
@@ -2,7 +2,7 @@
 id: 673263f4a5899da8124542fd
 title: What Is the Prompt Method, and How Does It Work?
 challengeType: 11
-videoId: nVAaxZ34khk
+videoId: lgAEO6_vNPQ
 dashedName: what-is-the-prompt-method-and-how-does-it-work
 ---
 


### PR DESCRIPTION
Update video ID's for these blocks:

- `HTML Fundamentals`
^ needs new id for "What are divs and when should you use them?" : 670803abcb3e980233da4768
- `Best Practices for Accessibility and CSS`
- `Introduction to JavaScript`
- `Working with Data Types`
- `Working with Loops`
- `Working with CSS variables`
- `Working with Links`
- `Working with CSS Transforms, Overflow, and Filters`
- `Understanding How to Work with Floats and Positioning in CSS`
- `Best Practices for Responsive Web Design`
- `Animations and Accessibility`
- `Working with Strings in JavaScript`
- `Working with Common String Methods`

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
