### PR TITLE
fix(curriculum): shorten regex to relevant code

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/671141d8e32fe934c26fa1be.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/671141d8e32fe934c26fa1be.md
@@ -17,16 +17,16 @@ You should use the existing anchor element, do not create a new one.
 assert.lengthOf(document.querySelectorAll('a'), 1);
 ```
 
-You should have the words `See more ` before the anchor element.
+You should have the words `See more ` before the anchor element. Make sure you include the space after the last word.
 
 ```js
-assert.match(code, /See more <a href="https:\/\/freecatphotoapp\.com">cat photos<\/a>/)
+assert.match(code, /See more <a href=/)
 ```
 
-You should have the words `in our gallery` after the anchor element.
+You should have the words ` in our gallery` after the anchor element. Make sure you include the space before the first word.
 
 ```js
-assert.match(code, /<a href="https:\/\/freecatphotoapp\.com">cat photos<\/a> in our gallery/)
+assert.match(code, /<\/a> in our gallery/)
 ```
 
 You should have `See more <a href="https://freecatphotoapp.com">cat photos</a> in our gallery` in your code.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

If you make changes to the link element or its text, you get unhelpful hints about the `See more ` and ` in our gallery` text.

I think we should leave it to the last test to do the strict check of the full code so we avoid misleading hints for the other text tests.

Forum: https://forum.freecodecamp.org/t/html-step-12/722336

---

BTW, I'm looking to make a PR to fix leading spaces in the code block for the hints. Right now, you can't see the leading space for the ` in our gallery` text.
