### PR TITLE
fix(client): add white-space pre-wrap to editor-lower-jaw code

### DIFF
--- a/client/src/templates/Challenges/classic/editor.css
+++ b/client/src/templates/Challenges/classic/editor.css
@@ -55,7 +55,8 @@ textarea.inputarea {
   max-width: unset !important;
 }
 
-.editor-upper-jaw code {
+.editor-upper-jaw code,
+.editor-lower-jaw code {
   white-space: pre-wrap;
 }
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Leading spaces in code blocks in the lower jaw do not show up without it.

Example, if you try to add a leading space to the ` in our gallery` text hint for step 12 of the cat photo app.

https://www.freecodecamp.org/learn/2022/responsive-web-design/learn-html-by-building-a-cat-photo-app/step-12
