### PR TITLE
fix(curriculum): clarify wording for radio and checkbox options

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5ef9b03c81a63668521804dc.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5ef9b03c81a63668521804dc.md
@@ -9,7 +9,7 @@ dashedName: step-46
 
 You can use radio buttons for questions where you want only one answer out of multiple options.
 
-Here is an example of a radio button with the option of `cat`:
+Here is an example of a radio button with the text set as `cat`:
 
 ```html
 <input type="radio"> cat
@@ -17,7 +17,7 @@ Here is an example of a radio button with the option of `cat`:
 
 Remember that an `input` element is a void element.
 
-Before the text input, add a radio button with the option set as:
+Before the text input, add a radio button with the text set as:
 
 `Indoor`
 

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5ef9b03c81a63668521804e2.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5ef9b03c81a63668521804e2.md
@@ -9,7 +9,7 @@ dashedName: step-56
 
 Forms commonly use checkboxes for questions that may have more than one answer. The `input` element with a `type` attribute set to `checkbox` creates a checkbox.
 
-Under the `legend` element you just added, add an `input` with its `type` attribute set to `checkbox` and give it the option of:
+Under the `legend` element you just added, add an `input` with its `type` attribute set to `checkbox` and its text set to:
 
 `Loving`
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #57305

<!-- Feel free to add any additional description of changes below this line -->

- Replaced the word "option" with "text" in Step 46 and Step 56 to clarify the instructions for setting the text of radio buttons and checkboxes.
