### PR TITLE
refactor: simplify is-audited logic

### DIFF
--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -27,7 +27,7 @@ import BlockHeader from './block-header';
 
 import '../intro.css';
 
-const { curriculumLocale, showUpcomingChanges, showNewCurriculum } = envData;
+const { curriculumLocale } = envData;
 
 type Challenge = ChallengeNode['challenge'];
 
@@ -111,10 +111,7 @@ class Block extends Component<BlockProps> {
       return isGridBased(superBlock, challenge.challengeType);
     });
 
-    const isAudited = isAuditedSuperBlock(curriculumLocale, superBlock, {
-      showNewCurriculum,
-      showUpcomingChanges
-    });
+    const isAudited = isAuditedSuperBlock(curriculumLocale, superBlock);
 
     const blockTitle = t(`intro:${superBlock}.blocks.${block}.title`);
     // the real type of TFunction is the type below, because intro can be an array of strings

--- a/client/src/templates/Introduction/components/help-translate.tsx
+++ b/client/src/templates/Introduction/components/help-translate.tsx
@@ -7,7 +7,7 @@ import { Link } from '../../../components/helpers';
 
 import envData from '../../../../config/env.json';
 
-const { clientLocale, showUpcomingChanges, showNewCurriculum } = envData;
+const { clientLocale } = envData;
 
 interface HelpTranslateProps {
   superBlock: SuperBlocks;
@@ -16,12 +16,7 @@ interface HelpTranslateProps {
 function HelpTranslate({ superBlock }: HelpTranslateProps): JSX.Element | null {
   const { t } = useTranslation();
 
-  if (
-    isAuditedSuperBlock(clientLocale, superBlock, {
-      showNewCurriculum,
-      showUpcomingChanges
-    })
-  ) {
+  if (isAuditedSuperBlock(clientLocale, superBlock)) {
     return null;
   }
 

--- a/curriculum/get-challenges.js
+++ b/curriculum/get-challenges.js
@@ -384,10 +384,7 @@ function generateChallengeCreator(lang, englishPath, i18nPath) {
           path.resolve(META_DIR, `${getBlockNameFromPath(filePath)}/meta.json`)
         );
 
-    const isAudited = isAuditedSuperBlock(lang, meta.superBlock, {
-      showNewCurriculum: process.env.SHOW_NEW_CURRICULUM,
-      showUpcomingChanges: process.env.SHOW_UPCOMING_CHANGES
-    });
+    const isAudited = isAuditedSuperBlock(lang, meta.superBlock);
 
     // If we can use the language, do so. Otherwise, default to english.
     const langUsed = isAudited && fs.existsSync(i18nPath) ? lang : 'english';

--- a/curriculum/utils.js
+++ b/curriculum/utils.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const {
-  createFlatSuperBlockMap,
+  generateSuperBlockList,
   SuperBlocks
 } = require('../shared/config/curriculum');
 
@@ -42,7 +42,7 @@ function createSuperOrder(superBlocks) {
   return superOrder;
 }
 
-const flatSuperBlockMap = createFlatSuperBlockMap({
+const flatSuperBlockMap = generateSuperBlockList({
   showNewCurriculum: process.env.SHOW_NEW_CURRICULUM === 'true',
   showUpcomingChanges: process.env.SHOW_UPCOMING_CHANGES === 'true'
 });

--- a/shared/config/curriculum.test.ts
+++ b/shared/config/curriculum.test.ts
@@ -4,7 +4,7 @@ import {
   SuperBlockStage,
   superBlockStages,
   notAuditedSuperBlocks,
-  createFlatSuperBlockMap,
+  generateSuperBlockList,
   getAuditedSuperBlocks
 } from './curriculum';
 
@@ -21,7 +21,7 @@ describe('superBlockOrder', () => {
 
 describe('createFlatSuperBlockMap', () => {
   it('should return an array of SuperBlocks object with New and Upcoming when { showNewCurriculum: true, showUpcomingChanges: true }', () => {
-    const result = createFlatSuperBlockMap({
+    const result = generateSuperBlockList({
       showNewCurriculum: true,
       showUpcomingChanges: true
     });
@@ -29,7 +29,7 @@ describe('createFlatSuperBlockMap', () => {
   });
 
   it('should return an array of SuperBlocks without New and Upcoming when { showNewCurriculum: false, showUpcomingChanges: false }', () => {
-    const result = createFlatSuperBlockMap({
+    const result = generateSuperBlockList({
       showNewCurriculum: false,
       showUpcomingChanges: false
     });
@@ -64,8 +64,6 @@ describe('getAuditedSuperBlocks', () => {
   Object.keys(notAuditedSuperBlocks).forEach(language => {
     it(`should return only audited SuperBlocks for ${language}`, () => {
       const auditedSuperBlocks = getAuditedSuperBlocks({
-        showNewCurriculum: true,
-        showUpcomingChanges: true,
         language
       });
 

--- a/shared/config/curriculum.test.ts
+++ b/shared/config/curriculum.test.ts
@@ -19,7 +19,7 @@ describe('superBlockOrder', () => {
   });
 });
 
-describe('createFlatSuperBlockMap', () => {
+describe('generateSuperBlockList', () => {
   it('should return an array of SuperBlocks object with New and Upcoming when { showNewCurriculum: true, showUpcomingChanges: true }', () => {
     const result = generateSuperBlockList({
       showNewCurriculum: true,

--- a/shared/config/curriculum.ts
+++ b/shared/config/curriculum.ts
@@ -248,28 +248,25 @@ type Config = {
   showUpcomingChanges: boolean;
 };
 
-type LanguagesConfig = Config & {
-  language: string;
-};
-
-export function createFlatSuperBlockMap(config: Config): SuperBlocks[] {
+export function generateSuperBlockList(config: Config): SuperBlocks[] {
   return getStageOrder(config)
     .map(stage => superBlockStages[stage])
     .flat();
 }
 
 export function getAuditedSuperBlocks({
-  language = 'english',
-  showNewCurriculum,
-  showUpcomingChanges
-}: LanguagesConfig): SuperBlocks[] {
+  language = 'english'
+}: {
+  language: string;
+}): SuperBlocks[] {
   if (!Object.prototype.hasOwnProperty.call(notAuditedSuperBlocks, language)) {
     throw Error(`'${language}' key not found in 'notAuditedSuperBlocks'`);
   }
 
-  const flatSuperBlockMap = createFlatSuperBlockMap({
-    showNewCurriculum,
-    showUpcomingChanges
+  // To find the audited superblocks, we need to start with all superblocks.
+  const flatSuperBlockMap = generateSuperBlockList({
+    showNewCurriculum: true,
+    showUpcomingChanges: true
   });
   const auditedSuperBlocks = flatSuperBlockMap.filter(
     superBlock =>

--- a/shared/utils/is-audited.ts
+++ b/shared/utils/is-audited.ts
@@ -3,22 +3,13 @@ import {
   getAuditedSuperBlocks
 } from '../../shared/config/curriculum';
 
-export function isAuditedSuperBlock(
-  language: string,
-  superblock: SuperBlocks,
-  {
-    showNewCurriculum,
-    showUpcomingChanges
-  }: { showNewCurriculum: boolean; showUpcomingChanges: boolean }
-) {
+export function isAuditedSuperBlock(language: string, superblock: SuperBlocks) {
   // TODO: when all the consumers of this function use TypeScript we can remove
   // this check
   if (!language || !superblock)
     throw Error('Both arguments must be provided for auditing');
 
   const auditedSuperBlocks = getAuditedSuperBlocks({
-    showNewCurriculum,
-    showUpcomingChanges,
     language
   });
   return auditedSuperBlocks.includes(superblock);

--- a/tools/challenge-auditor/index.ts
+++ b/tools/challenge-auditor/index.ts
@@ -112,20 +112,16 @@ void (async () => {
   const langsToCheck = availableLangs.curriculum.filter(
     lang => String(lang) !== 'english'
   );
-  for (const lang of langsToCheck) {
-    console.log(`\n=== ${lang} ===`);
-    const certs = getAuditedSuperBlocks({
-      language: lang,
-      showNewCurriculum: process.env.SHOW_NEW_CURRICULUM === 'true',
-      showUpcomingChanges: process.env.SHOW_UPCOMING_CHANGES === 'true'
-    });
+  for (const language of langsToCheck) {
+    console.log(`\n=== ${language} ===`);
+    const certs = getAuditedSuperBlocks({ language });
     const langCurriculumDirectory = join(
       process.cwd(),
       'curriculum',
       'i18n-curriculum',
       'curriculum',
       'challenges',
-      lang
+      language
     );
     const auditedFiles = englishFilePaths.filter(file =>
       certs.some(
@@ -139,7 +135,7 @@ void (async () => {
     const noMissingFiles = await auditChallengeFiles(auditedFiles, {
       langCurriculumDirectory
     });
-    const noDuplicateSlugs = await auditSlugs(lang, certs);
+    const noDuplicateSlugs = await auditSlugs(language, certs);
     if (noMissingFiles && noDuplicateSlugs) {
       console.log(`All challenges pass.`);
     } else {


### PR DESCRIPTION
Whether or not a superblock is audited is independent of whether or not it appears in the client. We don't need to care that the superblock is not going to be rendered when determining if it is audited. In that case the audited status will not be checked by the client.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->
