### PR TITLE
feat: remove next curriculum from challenge order

### DIFF
--- a/client/gatsby-node.js
+++ b/client/gatsby-node.js
@@ -4,8 +4,12 @@ const { createFilePath } = require('gatsby-source-filesystem');
 const uniq = require('lodash/uniq');
 const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin');
 const webpack = require('webpack');
-const env = require('./config/env.json');
 
+const {
+  superBlockStages,
+  SuperBlockStage
+} = require('../shared/config/curriculum');
+const env = require('./config/env.json');
 const {
   createChallengePages,
   createBlockIntroPages,
@@ -135,8 +139,48 @@ exports.createPages = async function createPages({
     }
   `);
 
+  const allChallengeNodes = result.data.allChallengeNode.edges.map(
+    ({ node }) => node
+  );
+
+  const inNextCurriculum = superBlock =>
+    superBlockStages[SuperBlockStage.Next].includes(superBlock);
+
+  const currentChallengeNodes = allChallengeNodes.filter(
+    node => !inNextCurriculum(node.challenge.superBlock)
+  );
+
+  const createIdToNextPathMap = nodes =>
+    nodes.reduce((map, node, index) => {
+      const nextNode = nodes[index + 1];
+      const nextPath = nextNode ? nextNode.challenge.fields.slug : null;
+      map[node.id] = nextPath;
+      return map;
+    }, {});
+
+  const createIdToPrevPathMap = nodes =>
+    nodes.reduce((map, node, index) => {
+      const prevNode = nodes[index - 1];
+      const prevPath = prevNode ? prevNode.challenge.fields.slug : null;
+      map[node.id] = prevPath;
+      return map;
+    }, {});
+
+  const idToNextPathCurrentCurriculum = createIdToNextPathMap(
+    currentChallengeNodes
+  );
+
+  const idToPrevPathCurrentCurriculum = createIdToPrevPathMap(
+    currentChallengeNodes
+  );
+
   // Create challenge pages.
-  result.data.allChallengeNode.edges.forEach(createChallengePages(createPage));
+  result.data.allChallengeNode.edges.forEach(
+    createChallengePages(createPage, {
+      idToNextPathCurrentCurriculum,
+      idToPrevPathCurrentCurriculum
+    })
+  );
 
   const blocks = uniq(
     result.data.allChallengeNode.edges.map(

--- a/client/gatsby-node.js
+++ b/client/gatsby-node.js
@@ -154,7 +154,7 @@ exports.createPages = async function createPages({
     nodes.reduce((map, node, index) => {
       const nextNode = nodes[index + 1];
       const nextPath = nextNode ? nextNode.challenge.fields.slug : null;
-      map[node.id] = nextPath;
+      if (nextPath) map[node.id] = nextPath;
       return map;
     }, {});
 
@@ -162,7 +162,7 @@ exports.createPages = async function createPages({
     nodes.reduce((map, node, index) => {
       const prevNode = nodes[index - 1];
       const prevPath = prevNode ? prevNode.challenge.fields.slug : null;
-      map[node.id] = prevPath;
+      if (prevPath) map[node.id] = prevPath;
       return map;
     }, {});
 

--- a/client/src/redux/prop-types.ts
+++ b/client/src/redux/prop-types.ts
@@ -404,8 +404,8 @@ export type ChallengeMeta = {
   id: string;
   introPath: string;
   isFirstStep: boolean;
-  nextChallengePath: string | null;
-  prevChallengePath: string | null;
+  nextChallengePath?: string;
+  prevChallengePath?: string;
   superBlock: SuperBlocks;
   title?: string;
   challengeType?: number;

--- a/client/utils/gatsby/challenge-page-creator.js
+++ b/client/utils/gatsby/challenge-page-creator.js
@@ -72,21 +72,14 @@ function getIsFirstStepInBlock(id, edges) {
   return previous.node.challenge.block !== current.node.challenge.block;
 }
 
-function getNextChallengePath(id, edges) {
-  const next = edges[id + 1];
-  return next ? next.node.challenge.fields.slug : null;
-}
-
-function getPrevChallengePath(id, edges) {
-  const prev = edges[id - 1];
-  return prev ? prev.node.challenge.fields.slug : null;
-}
-
 function getTemplateComponent(challengeType) {
   return views[viewTypes[challengeType]];
 }
 
-exports.createChallengePages = function (createPage) {
+exports.createChallengePages = function (
+  createPage,
+  { idToNextPathCurrentCurriculum, idToPrevPathCurrentCurriculum }
+) {
   return function ({ node }, index, allChallengeEdges) {
     const {
       dashedName,
@@ -121,8 +114,8 @@ exports.createChallengePages = function (createPage) {
           template,
           required,
           isLastChallengeInBlock: isLastChallengeInBlock,
-          nextChallengePath: getNextChallengePath(index, allChallengeEdges),
-          prevChallengePath: getPrevChallengePath(index, allChallengeEdges),
+          nextChallengePath: idToNextPathCurrentCurriculum[node.id],
+          prevChallengePath: idToPrevPathCurrentCurriculum[node.id],
           id
         },
         projectPreview: getProjectPreviewConfig(

--- a/client/utils/gatsby/page-loading.ts
+++ b/client/utils/gatsby/page-loading.ts
@@ -3,7 +3,7 @@
  * but the link of the page isn't rendered on the screen.
  * For more details, see https://github.com/freeCodeCamp/freeCodeCamp/pull/55472.
  */
-export const preloadPage = (path: string | null) => {
+export const preloadPage = (path?: string) => {
   if (!window.___loader || !path) return;
 
   window.___loader.hovering(path);


### PR DESCRIPTION
Part three of a (hopefully) four part series. Previous two:

https://github.com/freeCodeCamp/freeCodeCamp/pull/57346
https://github.com/freeCodeCamp/freeCodeCamp/pull/57349

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This just strips out the "next" curriculum from the challenge order. The challenge pages are still created and you can visit them by entering the url directly, but they're not linked to by any other challenge. So, learners will not encounter them accidentally.

In the, hopefully final, PR I'll update the challenge page logic so each page can determine its next and previous paths based on the Growthbook feature value. That should be it.

<!-- Feel free to add any additional description of changes below this line -->
