### PR TITLE
fix(client//UI): block spacing on legacy superblock pages

### DIFF
--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -465,9 +465,8 @@ class Block extends Component<BlockProps> {
     return (
       <>
         {layoutToComponent[challenges[0].blockLayout]}
-        {(!isGridBlock || isProjectBlock) && !BlockLayouts.Link && (
-          <Spacer size='m' />
-        )}
+        {(!isGridBlock || isProjectBlock) &&
+          superBlock !== SuperBlocks.FullStackDeveloper && <Spacer size='m' />}
       </>
     );
   }


### PR DESCRIPTION
Some recent UI changes made the spacing on some of the superblock pages a little tight:

<details><summary>image</summary>

<img width="785" alt="Screenshot 2024-11-27 at 12 17 15 PM" src="https://github.com/user-attachments/assets/19e943e7-cba0-4f0e-bab9-a4e7baaeed12">

</details>

This should fix it without side effects.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
