### PR TITLE
fix: search indicies

### DIFF
--- a/client/src/utils/algolia-locale-setup.ts
+++ b/client/src/utils/algolia-locale-setup.ts
@@ -37,18 +37,19 @@ const algoliaIndices = {
     name: 'news-ja',
     searchPage: 'https://www.freecodecamp.org/japanese/news/search/'
   },
-  // TODO: Replace with German news when we have more useful resources on that instance
+  korean: {
+    name: 'news-ko',
+    searchPage: 'https://www.freecodecamp.org/korean/news/search/'
+  },
+  // Note: We don't build News for the locales below, so show English
+  // hits and use the English search page
   german: {
     name: 'news',
     searchPage: 'https://www.freecodecamp.org/news/search/'
   },
   swahili: {
-    name: 'news-sw',
+    name: 'news',
     searchPage: 'https://www.freecodecamp.org/swahili/news/search/'
-  },
-  korean: {
-    name: 'news-ko',
-    searchPage: 'https://www.freecodecamp.org/korean/news/search/'
   }
 };
 

--- a/client/src/utils/algolia-locale-setup.ts
+++ b/client/src/utils/algolia-locale-setup.ts
@@ -29,10 +29,9 @@ const algoliaIndices = {
     name: 'news-pt-br',
     searchPage: 'https://www.freecodecamp.org/portuguese/news/search/'
   },
-  // TODO: Replace with Ukrainian news when we have more useful resources on that instance
   ukrainian: {
-    name: 'news',
-    searchPage: 'https://www.freecodecamp.org/news/search/'
+    name: 'news-uk',
+    searchPage: 'https://www.freecodecamp.org/ukrainian/news/search/'
   },
   japanese: {
     name: 'news-ja',

--- a/client/src/utils/algolia-locale-setup.ts
+++ b/client/src/utils/algolia-locale-setup.ts
@@ -26,7 +26,7 @@ const algoliaIndices = {
     searchPage: 'https://www.freecodecamp.org/italian/news/search/'
   },
   portuguese: {
-    name: 'news-pt',
+    name: 'news-pt-br',
     searchPage: 'https://www.freecodecamp.org/portuguese/news/search/'
   },
   // TODO: Replace with Ukrainian news when we have more useful resources on that instance

--- a/client/src/utils/algolia-locale-setup.ts
+++ b/client/src/utils/algolia-locale-setup.ts
@@ -49,7 +49,7 @@ const algoliaIndices = {
   },
   swahili: {
     name: 'news',
-    searchPage: 'https://www.freecodecamp.org/swahili/news/search/'
+    searchPage: 'https://www.freecodecamp.org/news/search/'
   }
 };
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!-- Feel free to add any additional description of changes below this line -->
This PR fixes search for Portuguese builds, enables Ukrainian search hits and redirects to the Ukrainian search page, and adds a note about a couple of locales we no longer build News for.