### PR TITLE
breaking(api): remove submission time from exam env

### DIFF
--- a/api/__mocks__/env-exam.ts
+++ b/api/__mocks__/env-exam.ts
@@ -45,7 +45,8 @@ export const config: EnvConfig = {
       numberOfCorrectAnswers: 1,
       numberOfIncorrectAnswers: 1
     }
-  ]
+  ],
+  retakeTimeInMS: 24 * 60 * 60 * 1000
 };
 
 export const questionSets: EnvQuestionSet[] = [
@@ -292,8 +293,7 @@ export const examAttempt: EnvExamAttempt = {
     }
   ],
   startTimeInMS: Date.now(),
-  userId: defaultUserId,
-  submissionTimeInMS: null
+  userId: defaultUserId
 };
 
 export const examAttemptSansSubmissionTimeInMS: Static<

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -223,15 +223,17 @@ type EnvAnswer {
 /// Configuration for an exam in the Exam Environment App
 type EnvConfig {
   /// Human-readable exam name
-  name          String
+  name           String
   /// Notes given about exam
-  note          String
+  note           String
   /// Category configuration for question selection
-  tags          EnvTagConfig[]
+  tags           EnvTagConfig[]
   /// Total time allocated for exam in milliseconds
-  totalTimeInMS Int
+  totalTimeInMS  Int
   /// Configuration for sets of questions
-  questionSets  EnvQuestionSetConfig[]
+  questionSets   EnvQuestionSetConfig[]
+  /// Duration after exam completion before a retake is allowed in milliseconds
+  retakeTimeInMS Int
 }
 
 /// Configuration for a set of questions in the Exam Environment App
@@ -267,14 +269,10 @@ model EnvExamAttempt {
   /// Foreign key to generated exam id
   generatedExamId String @db.ObjectId
 
-  questionSets       EnvQuestionSetAttempt[]
+  questionSets  EnvQuestionSetAttempt[]
   /// Time exam was started as milliseconds since epoch
-  startTimeInMS      Int
-  /// Time exam was submitted as milliseconds since epoch
-  ///
-  /// As attempt might not be submitted (disconnection or quit), field is optional
-  submissionTimeInMS Int?
-  needsRetake        Boolean
+  startTimeInMS Int
+  needsRetake   Boolean
 
   // Relations
   user          user             @relation(fields: [userId], references: [id], onDelete: Cascade)
@@ -301,7 +299,6 @@ type EnvMultipleChoiceQuestionAttempt {
 /// A generated exam for the Exam Environment App
 ///
 /// This is the user-facing information for an exam.
-/// TODO: Add userId?
 model EnvGeneratedExam {
   id           String                    @id @default(auto()) @map("_id") @db.ObjectId
   /// Foreign key to exam

--- a/api/src/exam-environment/routes/exam-environment.test.ts
+++ b/api/src/exam-environment/routes/exam-environment.test.ts
@@ -576,7 +576,8 @@ describe('/exam-environment/', () => {
               config: {
                 name: mock.exam.config.name,
                 note: mock.exam.config.note,
-                totalTimeInMS: mock.exam.config.totalTimeInMS
+                totalTimeInMS: mock.exam.config.totalTimeInMS,
+                retakeTimeInMS: mock.exam.config.retakeTimeInMS
               },
               id: mock.examId
             }

--- a/api/src/exam-environment/routes/exam-environment.test.ts
+++ b/api/src/exam-environment/routes/exam-environment.test.ts
@@ -435,8 +435,6 @@ describe('/exam-environment/', () => {
           24 * 60 * 60 * 1000 -
           mock.exam.config.totalTimeInMS -
           1 * 60 * 60 * 1000;
-        submittedAttempt.submissionTimeInMS =
-          Date.now() - mock.exam.config.totalTimeInMS - 24 * 60 * 60 * 1000;
         await fastifyTestInstance.prisma.envExamAttempt.create({
           data: submittedAttempt
         });

--- a/api/src/exam-environment/routes/exam-environment.test.ts
+++ b/api/src/exam-environment/routes/exam-environment.test.ts
@@ -490,7 +490,6 @@ describe('/exam-environment/', () => {
           generatedExamId: generatedExam!.id,
           questionSets: [],
           needsRetake: false,
-          submissionTimeInMS: null,
           // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
           startTimeInMS: expect.any(Number)
         });

--- a/api/src/exam-environment/routes/exam-environment.ts
+++ b/api/src/exam-environment/routes/exam-environment.ts
@@ -425,20 +425,6 @@ async function postExamAttemptHandler(
     latest.startTimeInMS > current.startTimeInMS ? latest : current
   );
 
-  // TODO: Currently, submission time is set when all questions have been answered.
-  //       This might not necessarily be fully submitted. So, provided there is time
-  //       left on the clock, the attempt should still be updated, even if the submission
-  //       time is set.
-  //       The submission time just needs to be updated.
-  // if (latestAttempt.submissionTimeInMS !== null) {
-  //   void reply.code(403);
-  //   return reply.send(
-  //     ERRORS.FCC_EINVAL_EXAM_ENVIRONMENT_EXAM_ATTEMPT(
-  //       'Attempt has already been submitted.'
-  //     )
-  //   );
-  // }
-
   const maybeExam = await mapErr(
     this.prisma.envExam.findUnique({
       where: {

--- a/api/src/exam-environment/routes/exam-environment.ts
+++ b/api/src/exam-environment/routes/exam-environment.ts
@@ -566,7 +566,8 @@ async function getExams(
       config: {
         name: exam.config.name,
         note: exam.config.note,
-        totalTimeInMS: exam.config.totalTimeInMS
+        totalTimeInMS: exam.config.totalTimeInMS,
+        retakeTimeInMS: exam.config.retakeTimeInMS
       },
       canTake: isExamPrerequisitesMet
     };

--- a/api/src/exam-environment/schemas/exams.ts
+++ b/api/src/exam-environment/schemas/exams.ts
@@ -12,7 +12,8 @@ export const examEnvironmentExams = {
           config: Type.Object({
             name: Type.String(),
             note: Type.String(),
-            totalTimeInMS: Type.Number()
+            totalTimeInMS: Type.Number(),
+            retakeTimeInMS: Type.Number()
           }),
           canTake: Type.Boolean()
         })

--- a/api/src/exam-environment/utils/exam.ts
+++ b/api/src/exam-environment/utils/exam.ts
@@ -101,7 +101,8 @@ export function constructUserExam(
   const config = {
     totalTimeInMS: exam.config.totalTimeInMS,
     name: exam.config.name,
-    note: exam.config.note
+    note: exam.config.note,
+    retakeTimeInMS: exam.config.retakeTimeInMS
   };
 
   const userExam: UserExam = {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes https://github.com/freeCodeCamp/exam-env/issues/2

Adds a `retakeTimeInMS` in place of the hard-coded, 24-hour cool-down. This is most obviously useful for things like the example exam, which we do not necessarily want to limit to complete-able once every 24 hours.