### PR TITLE
fix(curriculum): fix Building a Dice Game - Step 14 - passing with incorrect code

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/review-algorithmic-thinking-by-building-a-dice-game/657e230500602983e01fff6e.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/review-algorithmic-thinking-by-building-a-dice-game/657e230500602983e01fff6e.md
@@ -21,6 +21,12 @@ Your `checkForStraights` variable should be a function.
 assert.isFunction(checkForStraights);
 ```
 
+You should call `checkForStraights` function when the `rollDiceBtn` is clicked.
+
+```js
+assert.match(code, /checkForStraights\s*\(\s*diceValuesArr\s*\)\s*/)
+```
+
 If a small straight is rolled, your `checkForStraights` function should enable the fourth radio button, set the value to `30`, and update the displayed text to `, score = 30`.
 
 ```js
@@ -56,13 +62,18 @@ assert.strictEqual(scoreSpans[3].innerText, ", score = 30");
 If no straight is rolled, your `checkForStraights` function should enable the final radio button, set the value to `0`, and update the displayed text to `, score = 0`.
 
 ```js
-resetRadioOptions();
-checkForStraights([1,1,1,1,1]);
-assert.isTrue(scoreInputs[3].disabled);
-assert.isTrue(scoreInputs[4].disabled);
-assert.isFalse(scoreInputs[5].disabled);
-assert.strictEqual(scoreInputs[5].value, "0");
-assert.strictEqual(scoreSpans[5].innerText, ", score = 0");
+assertNoStraight([1,1,1,1,1]);
+assertNoStraight([1,1,4,4,4]);
+
+const assertNoStraight = (diceValuesArr) => {
+  resetRadioOptions();
+  checkForStraights(diceValuesArr);
+  assert.isTrue(scoreInputs[3].disabled);
+  assert.isTrue(scoreInputs[4].disabled);
+  assert.isFalse(scoreInputs[5].disabled);
+  assert.strictEqual(scoreInputs[5].value, "0");
+  assert.strictEqual(scoreSpans[5].innerText, ", score = 0");
+}
 ```
 
 # --seed--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/review-algorithmic-thinking-by-building-a-dice-game/657e230500602983e01fff6e.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/review-algorithmic-thinking-by-building-a-dice-game/657e230500602983e01fff6e.md
@@ -62,9 +62,6 @@ assert.strictEqual(scoreSpans[3].innerText, ", score = 30");
 If no straight is rolled, your `checkForStraights` function should enable the final radio button, set the value to `0`, and update the displayed text to `, score = 0`.
 
 ```js
-assertNoStraight([1,1,1,1,1]);
-assertNoStraight([1,1,4,4,4]);
-
 const assertNoStraight = (diceValuesArr) => {
   resetRadioOptions();
   checkForStraights(diceValuesArr);
@@ -74,6 +71,9 @@ const assertNoStraight = (diceValuesArr) => {
   assert.strictEqual(scoreInputs[5].value, "0");
   assert.strictEqual(scoreSpans[5].innerText, ", score = 0");
 }
+
+assertNoStraight([1,1,1,1,1]);
+assertNoStraight([1,1,4,4,4]);
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #55703
Closes #56688

<!-- Feel free to add any additional description of changes below this line -->

### Testing in local
If there is no function call of `checkForStraights`, the code will not pass
![image](https://github.com/user-attachments/assets/7e748413-8d89-4bf9-863a-63251bfd88ba)

If there is function call with wrong argument, the code will not pass
![image](https://github.com/user-attachments/assets/c6a83ba4-61c8-4e76-8f27-a15667eb24cc)

Use the `checkForStraights` function from the issue #55703, the code will not pass
![image](https://github.com/user-attachments/assets/36ba66ce-1290-4899-a801-599e3e378cc7)

Use the `checkForStraights` function from the solution the code will pass
![image](https://github.com/user-attachments/assets/b39ee043-5082-4829-a6c2-17eed73964e5)
