### PR TITLE
fix(api): only query for potentially valid tokens

### DIFF
--- a/api/src/exam-environment/routes/exam-environment.test.ts
+++ b/api/src/exam-environment/routes/exam-environment.test.ts
@@ -1,4 +1,6 @@
 import { Static } from '@fastify/type-provider-typebox';
+import jwt from 'jsonwebtoken';
+
 import {
   createSuperRequest,
   defaultUserId,
@@ -11,6 +13,7 @@ import {
 } from '../schemas';
 import * as mock from '../../../__mocks__/env-exam';
 import { constructUserExam } from '../utils/exam';
+import { JWT_SECRET } from '../../utils/env';
 
 jest.mock('../../utils/env', () => {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return
@@ -641,7 +644,7 @@ describe('/exam-environment/', () => {
     });
 
     describe('GET /exam-environment/token-meta', () => {
-      it('should allow a valid request', async () => {
+      it('should reject invalid tokens', async () => {
         const res = await superGet('/exam-environment/token-meta').set(
           'exam-environment-authorization-token',
           'invalid-token'
@@ -649,6 +652,24 @@ describe('/exam-environment/', () => {
 
         expect(res).toMatchObject({
           status: 418,
+          body: {
+            code: 'FCC_EINVAL_EXAM_ENVIRONMENT_AUTHORIZATION_TOKEN'
+          }
+        });
+      });
+
+      it('should tell the requester if the token does not exist', async () => {
+        const validToken = jwt.sign(
+          { examEnvironmentAuthorizationToken: 'does-not-exist' },
+          JWT_SECRET
+        );
+        const res = await superGet('/exam-environment/token-meta').set(
+          'exam-environment-authorization-token',
+          validToken
+        );
+
+        expect(res).toMatchObject({
+          status: 404,
           body: {
             code: 'FCC_EINVAL_EXAM_ENVIRONMENT_AUTHORIZATION_TOKEN'
           }

--- a/api/src/exam-environment/routes/exam-environment.test.ts
+++ b/api/src/exam-environment/routes/exam-environment.test.ts
@@ -669,7 +669,7 @@ describe('/exam-environment/', () => {
         );
 
         expect(res).toMatchObject({
-          status: 404,
+          status: 418,
           body: {
             code: 'FCC_EINVAL_EXAM_ENVIRONMENT_AUTHORIZATION_TOKEN'
           }

--- a/api/src/exam-environment/routes/exam-environment.ts
+++ b/api/src/exam-environment/routes/exam-environment.ts
@@ -107,7 +107,9 @@ async function tokenMetaHandler(
   if (!isObjectID(payload.examEnvironmentAuthorizationToken)) {
     void reply.code(418);
     return reply.send(
-      ERRORS.FCC_EINVAL_EXAM_ENVIRONMENT_AUTHORIZATION_TOKEN('Token is not valid')
+      ERRORS.FCC_EINVAL_EXAM_ENVIRONMENT_AUTHORIZATION_TOKEN(
+        'Token is not valid'
+      )
     );
   }
 

--- a/api/src/exam-environment/routes/exam-environment.ts
+++ b/api/src/exam-environment/routes/exam-environment.ts
@@ -104,17 +104,18 @@ async function tokenMetaHandler(
     );
   }
 
-  const tokenId = isObjectID(payload.examEnvironmentAuthorizationToken)
-    ? payload.examEnvironmentAuthorizationToken
-    : null;
+  if (!isObjectID(payload.examEnvironmentAuthorizationToken)) {
+    void reply.code(418);
+    return reply.send(
+      ERRORS.FCC_EINVAL_EXAM_ENVIRONMENT_AUTHORIZATION_TOKEN('Token is not valid')
+    );
+  }
 
-  const token = tokenId
-    ? await this.prisma.examEnvironmentAuthorizationToken.findUnique({
-        where: {
-          id: tokenId
-        }
-      })
-    : null;
+  const token = await this.prisma.examEnvironmentAuthorizationToken.findUnique({
+    where: {
+      id: payload.examEnvironmentAuthorizationToken
+    }
+  });
 
   if (!token) {
     // Endpoint is valid, but resource does not exists


### PR DESCRIPTION
If the token id is not an objectID there cannot be a corresponding token.

Ref: https://freecodecamp.sentry.io/issues/6093481611/?project=4508182869508096&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&sort=date&statsPeriod=14d&stream_index=0

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->



<!-- Feel free to add any additional description of changes below this line -->
