### PR TITLE
fix: wrapped svg elements in ul with li

### DIFF
--- a/client/src/components/landing/components/landing-top-b.tsx
+++ b/client/src/components/landing/components/landing-top-b.tsx
@@ -31,18 +31,32 @@ const LogoRow = (): JSX.Element => {
         className='logo-row'
         data-playwright-test-label='brand-logo-container'
       >
-        <AppleLogo />
-        <GoogleLogo />
-        <MicrosoftLogo />
+        <li>
+          <AppleLogo />
+        </li>
+        <li>
+          <GoogleLogo />
+        </li>
+        <li>
+          <MicrosoftLogo />
+        </li>
         {showChineseLogos ? (
           <>
-            <TencentLogo />
-            <AlibabaLogo />
+            <li>
+              <TencentLogo />
+            </li>
+            <li>
+              <AlibabaLogo />
+            </li>
           </>
         ) : (
           <>
-            <SpotifyLogo />
-            <AmazonLogo />
+            <li>
+              <SpotifyLogo />
+            </li>
+            <li>
+              <AmazonLogo />
+            </li>
           </>
         )}
       </ul>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #57352

<!-- Feel free to add any additional description of changes below this line -->

This PR fixes an accessibility issue in the LandingTopB component on the home page, where SVG elements representing tech company logos were direct children of an unordered list (ul), violating HTML semantics that require only li elements as direct children of ul. The SVG elements are now properly wrapped in li elements, ensuring compliance with accessibility standards and improving the user experience for assistive technologies.
