### PR TITLE
refactor: remove unnecessary useEffect

### DIFF
--- a/client/src/templates/Challenges/codeally/show.tsx
+++ b/client/src/templates/Challenges/codeally/show.tsx
@@ -177,7 +177,9 @@ function ShowCodeAlly(props: ShowCodeAllyProps) {
     });
     challengeMounted(challengeMeta.id);
     container.current?.focus();
-  }, [props]); // TODO: split props, so that it doesn't rerender on every prop change
+    // This effect should be run once on mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const openGitpod = (userToken?: string) => {
     const {

--- a/client/src/templates/Challenges/fill-in-the-blank/show.tsx
+++ b/client/src/templates/Challenges/fill-in-the-blank/show.tsx
@@ -124,23 +124,6 @@ const ShowFillInTheBlank = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  useEffect(() => {
-    updateChallengeMeta({
-      ...challengeMeta,
-      title,
-      challengeType,
-      helpCategory
-    });
-    challengeMounted(challengeMeta.id);
-  }, [
-    title,
-    challengeMeta,
-    challengeType,
-    helpCategory,
-    challengeMounted,
-    updateChallengeMeta
-  ]);
-
   const handleSubmit = () => {
     const blankAnswers = fillInTheBlank.blanks.map(b => b.answer);
 

--- a/client/src/templates/Challenges/generic/show.tsx
+++ b/client/src/templates/Challenges/generic/show.tsx
@@ -117,23 +117,6 @@ const ShowGeneric = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  useEffect(() => {
-    updateChallengeMeta({
-      ...challengeMeta,
-      title,
-      challengeType,
-      helpCategory
-    });
-    challengeMounted(challengeMeta.id);
-  }, [
-    title,
-    challengeMeta,
-    challengeType,
-    helpCategory,
-    challengeMounted,
-    updateChallengeMeta
-  ]);
-
   // video
   const [videoIsLoaded, setVideoIsLoaded] = useState(false);
 

--- a/client/src/templates/Challenges/quiz/show.tsx
+++ b/client/src/templates/Challenges/quiz/show.tsx
@@ -202,23 +202,6 @@ const ShowQuiz = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  useEffect(() => {
-    updateChallengeMeta({
-      ...challengeMeta,
-      title,
-      challengeType,
-      helpCategory
-    });
-    challengeMounted(challengeMeta.id);
-  }, [
-    title,
-    challengeMeta,
-    challengeType,
-    helpCategory,
-    challengeMounted,
-    updateChallengeMeta
-  ]);
-
   const handleFinishQuiz = () => {
     setShowUnanswered(true);
 


### PR DESCRIPTION
A common pattern we use is to update the redux store with challenge data on page load. Since this data is static (for a given challenge) there's no need to re-run the effect when the data changes (it doesn't).

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
