### PR TITLE
fix(curriculum): Update handleEnter to accept a message argument

### DIFF
--- a/curriculum/challenges/english/03-front-end-development-libraries/react/add-event-listeners.md
+++ b/curriculum/challenges/english/03-front-end-development-libraries/react/add-event-listeners.md
@@ -117,14 +117,14 @@ class MyComponent extends React.Component {
 
   }
   // Change code above this line
-  handleEnter() {
+  handleEnter(message) {
     this.setState((state) => ({
-      message: state.message + 'You pressed the enter key! '
+      message: state.message + message,
     }));
   }
   handleKeyPress(event) {
     if (event.keyCode === 13) {
-      this.handleEnter();
+      this.handleEnter('You pressed the enter key! ');
     }
   }
   render() {
@@ -158,14 +158,14 @@ class MyComponent extends React.Component {
     document.removeEventListener('keydown', this.handleKeyPress);
     // Change code above this line
   }
-  handleEnter() {
+  handleEnter(message) {
     this.setState((state) => ({
-      message: state.message + 'You pressed the enter key! '
+      message: state.message + message,
     }));
   }
   handleKeyPress(event) {
     if (event.keyCode === 13) {
-      this.handleEnter();
+      this.handleEnter('You pressed the enter key! ');
     }
   }
   render() {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x ] My pull request targets the `main` branch of freeCodeCamp.
- [x ] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #57423

<!-- Feel free to add any additional description of changes below this line -->

The current implementation of the handleEnter function appends a hardcoded message ('You pressed the enter key! ') to the message state repeatedly. While this works for the current requirement, it limits the flexibility of the function.

If we anticipate future features that involve appending different types of messages based on user interactions, we can improve the code's maintainability and reusability by generalizing handleEnter to accept a dynamic message as an argument.