### PR TITLE
fix: check for total challenge completion before donation pop up

### DIFF
--- a/client/src/redux/selectors.js
+++ b/client/src/redux/selectors.js
@@ -42,6 +42,10 @@ export const shouldRequestDonationSelector = state => {
   // don't request donation if already donating
   if (isDonating) return false;
 
+  // donations only appear after the user has completed ten challenges (i.e.
+  // not before the 11th challenge has mounted)
+  if (completedChallengeCount < 10) return false;
+
   // a block has been completed
   if (recentlyClaimedBlock) return true;
 
@@ -55,10 +59,6 @@ export const shouldRequestDonationSelector = state => {
     // request
     return sessionChallengeData.countSinceSave >= 20;
   }
-
-  // donations only appear after the user has completed ten challenges (i.e.
-  // not before the 11th challenge has mounted)
-  if (completedChallengeCount < 10) return false;
 
   /*
    Show modal if user has completed 10 challanged in total

--- a/tools/scripts/seed/seed-demo-user.js
+++ b/tools/scripts/seed/seed-demo-user.js
@@ -10,7 +10,8 @@ const {
   blankUser,
   publicUser,
   fullyCertifiedUser,
-  userIds
+  userIds,
+  almostFullyCertifiedUser
 } = require('./user-data');
 
 const options = {
@@ -18,7 +19,8 @@ const options = {
   'top-contributor': { type: 'boolean' },
   'set-false': { type: 'string', multiple: true },
   'seed-trophy-challenges': { type: 'boolean' },
-  'certified-user': { type: 'boolean' }
+  'certified-user': { type: 'boolean' },
+  'almost-certified-user': { type: 'boolean' }
 };
 
 const { values: argValues } = parseArgs({ options });
@@ -124,13 +126,15 @@ const run = async () => {
   await dropUsers();
   if (argValues['certified-user']) {
     await user.insertOne(fullyCertifiedUser);
-    await user.insertOne(blankUser);
-    await user.insertOne(publicUser);
+  } else if (argValues['almost-certified-user']) {
+    await user.insertOne(almostFullyCertifiedUser);
   } else {
     await user.insertOne(demoUser);
-    await user.insertOne(blankUser);
-    await user.insertOne(publicUser);
   }
+
+  await user.insertOne(blankUser);
+  await user.insertOne(publicUser);
+
   log('local auth user seed complete');
 };
 

--- a/tools/scripts/seed/user-data.js
+++ b/tools/scripts/seed/user-data.js
@@ -5,8 +5,15 @@ const blankUserId = new ObjectId('5bd30e0f1caf6ac3ddddddb9');
 const publicUserId = new ObjectId('663b839b24a8b29f57728b13');
 const demoUserId = new ObjectId('5bd30e0f1caf6ac3ddddddb5');
 const fullyCertifiedUserId = new ObjectId('5fa2db00a25c1c1fa49ce067');
+const almostFullyCertifiedUserId = new ObjectId('5bd30e0f1caf6ac3ddddddb9');
 
-const userIds = [blankUserId, publicUserId, demoUserId, fullyCertifiedUserId];
+const userIds = [
+  blankUserId,
+  publicUserId,
+  demoUserId,
+  fullyCertifiedUserId,
+  almostFullyCertifiedUserId
+];
 
 module.exports.blankUser = {
   _id: blankUserId,
@@ -12285,6 +12292,15 @@ module.exports.fullyCertifiedUser = {
   emailVerifyTTL: null,
   externalId: '',
   unsubscribeId: 'tBX8stC5jiustPBteF2mV'
+};
+
+module.exports.almostFullyCertifiedUser = {
+  ...module.exports.fullyCertifiedUser,
+  id: almostFullyCertifiedUserId,
+  completedChallenges:
+    module.exports.fullyCertifiedUser.completedChallenges.filter(
+      challenge => challenge.id !== 'bd7158d8c442eddfaeb5bd13'
+    )
 };
 
 module.exports.userIds = userIds;


### PR DESCRIPTION
This pr should fix the premature donation modal for blocks that are smaller than 10 challenges. 



Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
