### PR TITLE
fix(ui): Issue with Exercise Accessibility on Mobile

### DIFF
--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -814,7 +814,7 @@ const Editor = (props: EditorProps): JSX.Element => {
   ): HTMLDivElement {
     const scrollGutterNode = document.createElement('div');
     const lineGutterWidth = editor.getLayoutInfo().contentLeft;
-    scrollGutterNode.style.width = `${lineGutterWidth}px`;
+    scrollGutterNode.style.width = `${lineGutterWidth * 1.35}px`;
     scrollGutterNode.style.left = `-${lineGutterWidth}px`;
     scrollGutterNode.style.top = '0';
     scrollGutterNode.style.height = '10000px';


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #57029

<!-- Feel free to add any additional description of changes below this line -->

I extended the scroll gutter node to allow for mobile users to use it easier. This did not cause any visual changes, just allowing the event to register in a larger area. I tested this locally with mouse controls and devtools without any issues, but it has not been tested with touchscreen.