### PR TITLE
refactor(client): stop passing around unused data

### DIFF
--- a/client/gatsby-node.js
+++ b/client/gatsby-node.js
@@ -86,6 +86,7 @@ exports.createPages = async function createPages({
                 blockHashSlug
               }
               id
+              isLastChallengeInBlock
               order
               required {
                 link

--- a/client/src/templates/Challenges/redux/completion-epic.js
+++ b/client/src/templates/Challenges/redux/completion-epic.js
@@ -219,7 +219,7 @@ export default function completionEpic(action$, state$) {
       const state = state$.value;
 
       const {
-        nextBlock,
+        isLastChallengeInBlock,
         nextChallengePath,
         challengeType,
         superBlock,
@@ -243,8 +243,7 @@ export default function completionEpic(action$, state$) {
         submitter = submitters[submitTypes[challengeType]];
       }
 
-      const lastChallengeInBlock = block !== nextBlock;
-      let pathToNavigateTo = lastChallengeInBlock
+      let pathToNavigateTo = isLastChallengeInBlock
         ? blockHashSlug
         : nextChallengePath;
 
@@ -254,7 +253,7 @@ export default function completionEpic(action$, state$) {
 
       return submitter(type, state).pipe(
         concat(
-          of(setIsAdvancing(!lastChallengeInBlock), setIsProcessing(false))
+          of(setIsAdvancing(!isLastChallengeInBlock), setIsProcessing(false))
         ),
         mergeMap(x =>
           canAllowDonationRequest(state, x)

--- a/client/src/templates/Challenges/redux/index.js
+++ b/client/src/templates/Challenges/redux/index.js
@@ -23,7 +23,7 @@ const initialState = {
     block: '',
     blockHashSlug: '/',
     id: '',
-    nextBlock: '',
+    isLastChallengeInBlock: false,
     nextChallengePath: '/',
     prevChallengePath: '/',
     challengeType: -1

--- a/client/utils/gatsby/challenge-page-creator.js
+++ b/client/utils/gatsby/challenge-page-creator.js
@@ -86,11 +86,6 @@ function getTemplateComponent(challengeType) {
   return views[viewTypes[challengeType]];
 }
 
-function getNextBlock(id, edges) {
-  const next = edges[id + 1];
-  return next ? next.node.challenge.block : null;
-}
-
 exports.createChallengePages = function (createPage) {
   return function ({ node }, index, allChallengeEdges) {
     const {
@@ -104,7 +99,8 @@ exports.createChallengePages = function (createPage) {
       required = [],
       template,
       challengeType,
-      id
+      id,
+      isLastChallengeInBlock
     } = node.challenge;
     // TODO: challengeType === 7 and isPrivate are the same, right? If so, we
     // should remove one of them.
@@ -124,7 +120,7 @@ exports.createChallengePages = function (createPage) {
           isFirstStep: getIsFirstStepInBlock(index, allChallengeEdges),
           template,
           required,
-          nextBlock: getNextBlock(index, allChallengeEdges),
+          isLastChallengeInBlock: isLastChallengeInBlock,
           nextChallengePath: getNextChallengePath(index, allChallengeEdges),
           prevChallengePath: getPrevChallengePath(index, allChallengeEdges),
           id

--- a/curriculum/get-challenges.js
+++ b/curriculum/get-challenges.js
@@ -304,6 +304,9 @@ function generateChallengeCreator(lang, englishPath, i18nPath) {
       ({ id }) => id === challenge.id
     );
 
+    const isLastChallengeInBlock =
+      meta.challengeOrder.length - 1 === challengeOrder;
+
     const isObjectIdFilename = /\/[a-z0-9]{24}\.md$/.test(englishPath);
     if (isObjectIdFilename) {
       const filename = englishPath.split('/').pop();
@@ -348,6 +351,7 @@ function generateChallengeCreator(lang, englishPath, i18nPath) {
     challenge.certification = hasDupe ? hasDupe.certification : meta.superBlock;
     challenge.superBlock = meta.superBlock;
     challenge.challengeOrder = challengeOrder;
+    challenge.isLastChallengeInBlock = isLastChallengeInBlock;
     challenge.isPrivate = challenge.isPrivate || meta.isPrivate;
     challenge.required = (meta.required || []).concat(challenge.required || []);
     challenge.template = meta.template;

--- a/curriculum/schema/challenge-schema.js
+++ b/curriculum/schema/challenge-schema.js
@@ -180,6 +180,7 @@ const schema = Joi.object()
       'Euler',
       'Rosetta'
     ),
+    isLastChallengeInBlock: Joi.boolean().required(),
     videoUrl: Joi.string().allow(''),
     fillInTheBlank: Joi.object().keys({
       sentence: Joi.string().required(),


### PR DESCRIPTION
Nowhere in the client do we need to know what the next block is, only if the challenge is the last one in a given block.

Also, we don't need to infer this from the block property, we can get it directly from the challenge order (i.e. the thing that determines what's in a block)

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->
