### PR TITLE
chore(curriculum): make step 14 cat photo app clearer

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/671141feba228a35cefba82d.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/671141feba228a35cefba82d.md
@@ -7,7 +7,7 @@ dashedName: step-14
 
 # --description--
 
-Turn the text `cute cats` into an anchor elements that links to `https://cdn.freecodecamp.org/curriculum/cat-photo-app/running-cats.jpg`.
+Turn the existing text `cute cats` into an anchor elements that links to `https://cdn.freecodecamp.org/curriculum/cat-photo-app/running-cats.jpg`.
 
 # --hints--
 
@@ -27,6 +27,12 @@ The `href` attribute of the new anchor element should be `https://cdn.freecodeca
 
 ```js
 assert.strictEqual(document.querySelector('a')?.href, "https://cdn.freecodecamp.org/curriculum/cat-photo-app/running-cats.jpg");
+```
+
+There should only be one instance of the phrase `cute cats` in your code.  
+
+```js
+assert.strictEqual(code.indexOf("cute cats"),code.lastIndexOf("cute cats")); 
 ```
 
 The text of the `p` element should still be `Everyone loves cute cats online!`.

--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-photo-app/671141feba228a35cefba82d.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-photo-app/671141feba228a35cefba82d.md
@@ -7,7 +7,7 @@ dashedName: step-14
 
 # --description--
 
-Turn the text `cute cats` into an anchor elements that links to `https://cdn.freecodecamp.org/curriculum/cat-photo-app/running-cats.jpg`.
+Turn the existing text `cute cats` into an anchor elements that links to `https://cdn.freecodecamp.org/curriculum/cat-photo-app/running-cats.jpg`.
 
 # --hints--
 
@@ -27,6 +27,12 @@ The `href` attribute of the new anchor element should be `https://cdn.freecodeca
 
 ```js
 assert.strictEqual(document.querySelector('a')?.href, "https://cdn.freecodecamp.org/curriculum/cat-photo-app/running-cats.jpg");
+```
+
+There should only be one instance of the phrase `cute cats` in your code.  
+
+```js
+assert.strictEqual(code.indexOf("cute cats"),code.lastIndexOf("cute cats")); 
 ```
 
 The text of the `p` element should still be `Everyone loves cute cats online!`.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

I wanted to make it clearer that campers shouldn't enter code like ```<p>Everyone loves cute cats online!<a href="https://cdn.freecodecamp.org/curriculum/cat-photo-app/running-cats.jpg">cute cats</a</p>``` for this particular challenge. Mentioning the phrase `existing` and the hint should help I believe. 
