### PR TITLE
fix(client/UI): add new icon for fsd

### DIFF
--- a/client/src/assets/icons/code.tsx
+++ b/client/src/assets/icons/code.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+function Code(
+  props: JSX.IntrinsicAttributes & React.SVGProps<SVGSVGElement>
+): JSX.Element {
+  return (
+    <>
+      <svg
+        xmlns='http://www.w3.org/2000/svg'
+        viewBox='0 0 640 512'
+        fill='none'
+        {...props}
+      >
+        <path d='M392.8 1.2c-17-4.9-34.7 5-39.6 22l-128 448c-4.9 17 5 34.7 22 39.6s34.7-5 39.6-22l128-448c4.9-17-5-34.7-22-39.6zm80.6 120.1c-12.5 12.5-12.5 32.8 0 45.3L562.7 256l-89.4 89.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0l112-112c12.5-12.5 12.5-32.8 0-45.3l-112-112c-12.5-12.5-32.8-12.5-45.3 0zm-306.7 0c-12.5-12.5-32.8-12.5-45.3 0l-112 112c-12.5 12.5-12.5 32.8 0 45.3l112 112c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L77.3 256l89.4-89.4c12.5-12.5 12.5-32.8 0-45.3z' />
+      </svg>
+    </>
+  );
+}
+
+Code.displayName = 'Code';
+
+export default Code;

--- a/client/src/assets/icons/superblock-icon.tsx
+++ b/client/src/assets/icons/superblock-icon.tsx
@@ -19,6 +19,7 @@ import CSharpLogo from './c-sharp-logo';
 import A2EnglishIcon from './a2-english';
 import B1EnglishIcon from './b1-english';
 import RosettaCodeIcon from './rosetta-code';
+import Code from './code';
 
 const iconMap = {
   [SuperBlocks.RespWebDesignNew]: ResponsiveDesign,
@@ -39,7 +40,7 @@ const iconMap = {
   [SuperBlocks.ProjectEuler]: Graduation,
   [SuperBlocks.CollegeAlgebraPy]: CollegeAlgebra,
   [SuperBlocks.FoundationalCSharp]: CSharpLogo,
-  [SuperBlocks.FullStackDeveloper]: ResponsiveDesign,
+  [SuperBlocks.FullStackDeveloper]: Code,
   [SuperBlocks.A2English]: A2EnglishIcon,
   [SuperBlocks.B1English]: B1EnglishIcon,
   [SuperBlocks.RosettaCode]: RosettaCodeIcon,


### PR DESCRIPTION
This adds a code icon and changes the fsd superblock to use it.

<details><summary>images</summary>

<img width="797" alt="Screenshot 2024-12-09 at 12 30 53 PM" src="https://github.com/user-attachments/assets/919346ce-6c5d-4f86-8afa-7614c9edc19a">

<img width="818" alt="Screenshot 2024-12-09 at 12 30 59 PM" src="https://github.com/user-attachments/assets/c0526645-2d5d-4536-b72e-fecd05240760">

</details>

Related to https://github.com/freeCodeCamp/freeCodeCamp/pull/57465

We could potentially use this icon for the HTML chapter, and find something else for this - or just find something else for this. Seems like we've used all our other icons for quite a while, I thought something new here would be nice.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes https://github.com/freeCodeCamp/fCC10/issues/46

<!-- Feel free to add any additional description of changes below this line -->
