### PR TITLE
feat(client): coming soon chapters, modules and blocks

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -1696,7 +1696,8 @@
       "javascript": "JavaScript",
       "frontend-libraries": "Front End Libraries",
       "relational-databases": "Relational Databases",
-      "security-and-privacy": "Security and Privacy"
+      "backend-javascript": "Backend JavaScript",
+      "python": "Python"
     },
     "modules": {
       "getting-started-with-freecodecamp": "Getting Started with freeCodeCamp",

--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -749,6 +749,7 @@
     "result-list": "Search results"
   },
   "misc": {
+    "coming-soon": "Coming Soon",
     "offline": "You appear to be offline, your progress may not be saved",
     "server-offline": "The server could not be reached and your progress may not be saved. Please contact <0>support</0> if this message persists",
     "unsubscribed": "You have successfully been unsubscribed",

--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -129,6 +129,11 @@ class Block extends Component<BlockProps> {
       (completedCount / extendedChallenges.length) * 100
     );
 
+    // since the Blocks are not components, we need link to exist even if it's
+    // not being used to render anything
+    const link = challenges[0]?.fields.slug || '';
+    const blockLayout = challenges[0]?.blockLayout ?? BlockLayouts.ComingSoon;
+
     const courseCompletionStatus = () => {
       if (completedCount === 0) {
         return t('learn.not-started');
@@ -306,7 +311,7 @@ class Block extends Component<BlockProps> {
                 onClick={() => {
                   this.handleBlockClick();
                 }}
-                to={extendedChallenges[0].fields.slug}
+                to={link}
               >
                 <CheckMark isCompleted={isBlockCompleted} />
                 {blockTitle}{' '}
@@ -391,7 +396,7 @@ class Block extends Component<BlockProps> {
                 onClick={() => {
                   this.handleBlockClick();
                 }}
-                to={extendedChallenges[0].fields.slug}
+                to={link}
               >
                 <CheckMark isCompleted={isBlockCompleted} />
                 {blockType && <BlockLabel blockType={blockType} />}
@@ -456,12 +461,13 @@ class Block extends Component<BlockProps> {
       [BlockLayouts.ProjectList]: ProjectListBlock,
       [BlockLayouts.LegacyLink]: LegacyLinkBlock,
       [BlockLayouts.LegacyChallengeList]: LegacyChallengeListBlock,
-      [BlockLayouts.LegacyChallengeGrid]: LegacyChallengeGridBlock
+      [BlockLayouts.LegacyChallengeGrid]: LegacyChallengeGridBlock,
+      [BlockLayouts.ComingSoon]: <div>Coming Soon</div>
     };
 
     return (
       <>
-        {layoutToComponent[challenges[0].blockLayout]}
+        {layoutToComponent[blockLayout]}
         {(!isGridBlock || isProjectBlock) &&
           superBlock !== SuperBlocks.FullStackDeveloper && <Spacer size='m' />}
       </>

--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -461,8 +461,7 @@ class Block extends Component<BlockProps> {
       [BlockLayouts.ProjectList]: ProjectListBlock,
       [BlockLayouts.LegacyLink]: LegacyLinkBlock,
       [BlockLayouts.LegacyChallengeList]: LegacyChallengeListBlock,
-      [BlockLayouts.LegacyChallengeGrid]: LegacyChallengeGridBlock,
-      [BlockLayouts.ComingSoon]: <div>Coming Soon</div>
+      [BlockLayouts.LegacyChallengeGrid]: LegacyChallengeGridBlock
     };
 
     return (

--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -131,8 +131,9 @@ class Block extends Component<BlockProps> {
 
     // since the Blocks are not components, we need link to exist even if it's
     // not being used to render anything
-    const link = challenges[0]?.fields.slug || '';
-    const blockLayout = challenges[0]?.blockLayout ?? BlockLayouts.ComingSoon;
+    // all blocks should have at least one challenge
+    const link = challenges[0].fields.slug || '';
+    const blockLayout = challenges[0].blockLayout;
 
     const courseCompletionStatus = () => {
       if (completedCount === 0) {

--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, ReactNode } from 'react';
 import type { DefaultTFuncReturn, TFunction } from 'i18next';
 import { withTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
@@ -72,7 +72,7 @@ class Block extends Component<BlockProps> {
     toggleBlock(block);
   };
 
-  render(): JSX.Element {
+  render(): ReactNode {
     const {
       block,
       blockType,
@@ -131,9 +131,10 @@ class Block extends Component<BlockProps> {
 
     // since the Blocks are not components, we need link to exist even if it's
     // not being used to render anything
-    // all blocks should have at least one challenge
-    const link = challenges[0].fields.slug || '';
-    const blockLayout = challenges[0].blockLayout;
+    const link = challenges[0]?.fields.slug || '';
+    const blockLayout = challenges[0]?.blockLayout;
+
+    const isEmptyBlock = !challenges.length;
 
     const courseCompletionStatus = () => {
       if (completedCount === 0) {
@@ -466,11 +467,15 @@ class Block extends Component<BlockProps> {
     };
 
     return (
-      <>
-        {layoutToComponent[blockLayout]}
-        {(!isGridBlock || isProjectBlock) &&
-          superBlock !== SuperBlocks.FullStackDeveloper && <Spacer size='m' />}
-      </>
+      !isEmptyBlock && (
+        <>
+          {layoutToComponent[blockLayout]}
+          {(!isGridBlock || isProjectBlock) &&
+            superBlock !== SuperBlocks.FullStackDeveloper && (
+              <Spacer size='m' />
+            )}
+        </>
+      )
     );
   }
 }

--- a/client/src/templates/Introduction/components/super-block-accordion.css
+++ b/client/src/templates/Introduction/components/super-block-accordion.css
@@ -78,3 +78,11 @@
 .super-block-accordion .chapter-panel > li:last-child .block-grid {
   border-bottom: 0;
 }
+
+.super-block-accordion .badge {
+  background-color: var(--purple-background);
+  color: var(--purple-color);
+  padding: 4px 8px;
+  border-width: 1px;
+  border-color: var(--purple-color);
+}

--- a/client/src/templates/Introduction/components/super-block-accordion.css
+++ b/client/src/templates/Introduction/components/super-block-accordion.css
@@ -80,9 +80,21 @@
 }
 
 .super-block-accordion .badge {
-  background-color: var(--purple-background);
   color: var(--purple-color);
-  padding: 4px 8px;
-  border-width: 1px;
   border-color: var(--purple-color);
+  align-self: center;
+  height: fit-content;
+  padding: 1px 6px 2px;
+  font-size: 0.85rem;
+  border: 1px solid;
+  position: relative;
+  top: 1px;
+}
+
+.super-block-accordion .coming-soon {
+  border-bottom: 4px solid var(--secondary-background);
+}
+
+.super-block-accordion .coming-soon:last-child {
+  border-bottom: 0px;
 }

--- a/client/src/templates/Introduction/components/super-block-accordion.css
+++ b/client/src/templates/Introduction/components/super-block-accordion.css
@@ -80,12 +80,11 @@
 
 .super-block-accordion .badge {
   color: var(--purple-color);
-  border-color: var(--purple-color);
+  border: 1px solid var(--purple-color);
   align-self: center;
   height: fit-content;
   padding: 1px 6px 2px;
   font-size: 0.85rem;
-  border: 1px solid;
   position: relative;
   top: 1px;
 }

--- a/client/src/templates/Introduction/components/super-block-accordion.css
+++ b/client/src/templates/Introduction/components/super-block-accordion.css
@@ -18,7 +18,8 @@
 }
 
 .super-block-accordion .chapter,
-.super-block-accordion .link-block {
+.super-block-accordion .link-chapter,
+.super-block-accordion .link-module {
   background-color: var(--primary-background);
 }
 
@@ -74,13 +75,22 @@
   padding: 0 24px;
 }
 
-.super-block-accordion .chapter-panel > li:last-child .block-grid {
+.super-block-accordion .chapter-panel > li {
+  border-bottom: 4px solid var(--secondary-background);
+}
+
+.super-block-accordion .chapter-panel > li:last-child {
+  border-bottom: none;
+}
+
+.super-block-accordion .chapter-panel > li:last-child .block-grid,
+.super-block-accordion .module-panel > li:last-child .block-grid {
   border-bottom: 0;
 }
 
 .super-block-accordion .badge {
-  color: var(--purple-color);
-  border: 1px solid var(--purple-color);
+  color: var(--quaternary-color);
+  border: 1px solid var(--quaternary-color);
   align-self: center;
   height: fit-content;
   padding: 1px 6px 2px;
@@ -90,9 +100,15 @@
 }
 
 .super-block-accordion .coming-soon {
-  border-bottom: 4px solid var(--secondary-background);
+  background-color: var(--primary-background);
+  width: 100%;
+  padding: 20px;
+  display: flex;
+  align-items: center;
+  column-gap: 20px;
+  font-size: 1.5em;
 }
 
-.super-block-accordion .coming-soon:last-child {
-  border-bottom: 0px;
+.super-block-accordion .coming-soon-module {
+  font-size: 1.25rem;
 }

--- a/client/src/templates/Introduction/components/super-block-accordion.css
+++ b/client/src/templates/Introduction/components/super-block-accordion.css
@@ -18,8 +18,7 @@
 }
 
 .super-block-accordion .chapter,
-.super-block-accordion .link-chapter,
-.super-block-accordion .link-module {
+.super-block-accordion .link-block {
   background-color: var(--primary-background);
 }
 

--- a/client/src/templates/Introduction/components/super-block-accordion.tsx
+++ b/client/src/templates/Introduction/components/super-block-accordion.tsx
@@ -224,15 +224,6 @@ export const SuperBlockAccordion = ({
                 );
               }
 
-              // if blocks is missing or empty, or if challenges is missing or empty,
-              // don't render the module
-              if (
-                !module.blocks?.length ||
-                !module.blocks[0]?.challenges?.length
-              ) {
-                return null;
-              }
-
               if (isLinkModule(module.name)) {
                 const linkedChallenge = module.blocks[0].challenges[0];
                 return (
@@ -253,20 +244,17 @@ export const SuperBlockAccordion = ({
                   dashedName={module.name}
                   isExpanded={expandedModule === module.name}
                 >
-                  {module.blocks.map(block =>
-                    // if no challenges, don't render the block
+                  {module.blocks.map(block => (
                     // maybe TODO: allow blocks to be "coming soon"
-                    block.challenges.length ? (
-                      <li key={block.name}>
-                        <Block
-                          block={block.name}
-                          blockType={block.blockType}
-                          challenges={block.challenges}
-                          superBlock={superBlock}
-                        />
-                      </li>
-                    ) : null
-                  )}
+                    <li key={block.name}>
+                      <Block
+                        block={block.name}
+                        blockType={block.blockType}
+                        challenges={block.challenges}
+                        superBlock={superBlock}
+                      />
+                    </li>
+                  ))}
                 </Module>
               );
             })}

--- a/client/src/templates/Introduction/components/super-block-accordion.tsx
+++ b/client/src/templates/Introduction/components/super-block-accordion.tsx
@@ -162,6 +162,8 @@ export const SuperBlockAccordion = ({
               />
             </li>
           );
+        } else if (chapter.modules.length === 0) {
+          return <li key={chapter.name}>Chapter coming soon</li>;
         }
 
         return (
@@ -184,6 +186,8 @@ export const SuperBlockAccordion = ({
                     />
                   </li>
                 );
+              } else if (module.blocks.length === 0) {
+                return <li key={chapter.name}>Module coming soon</li>;
               }
 
               return (

--- a/client/src/templates/Introduction/components/super-block-accordion.tsx
+++ b/client/src/templates/Introduction/components/super-block-accordion.tsx
@@ -112,9 +112,35 @@ const Module = ({ dashedName, children, isExpanded }: ModuleProps) => {
   );
 };
 
-const Badge = ({ children }: { children: ReactNode }) => (
-  <span className='badge'>{children}</span>
-);
+const LinkBlock = ({
+  superBlock,
+  challenges
+}: {
+  superBlock: SuperBlocks;
+  challenges?: ChallengeNode['challenge'][];
+  key: string;
+}) => {
+  const firstChallenge = challenges ? challenges[0] : null;
+  return (
+    <li className='link-block'>
+      <Block
+        block={firstChallenge?.block ?? ''}
+        blockType={firstChallenge?.blockType ?? null}
+        challenges={challenges ?? []}
+        superBlock={superBlock}
+      />
+    </li>
+  );
+};
+
+const ComingSoon = ({ children }: { children: ReactNode }) => {
+  const { t } = useTranslation();
+  return (
+    <li className='coming-soon'>
+      <span className='badge'>{t('misc.coming-soon')}</span> {children}
+    </li>
+  );
+};
 
 export const SuperBlockAccordion = ({
   challenges,
@@ -155,24 +181,18 @@ export const SuperBlockAccordion = ({
     <ul className='super-block-accordion'>
       {allChapters.map(chapter => {
         if (isLinkChapter(chapter.name)) {
-          const challenges = chapter.modules[0]?.blocks[0]?.challenges;
-          const firstChallenge = challenges ? challenges[0] : null;
           return (
-            <li key={chapter.name} className='link-chapter'>
-              <Block
-                block={firstChallenge?.block ?? ''}
-                blockType={firstChallenge?.blockType ?? null}
-                challenges={challenges}
-                superBlock={superBlock}
-              />
-            </li>
+            <LinkBlock
+              key={chapter.name}
+              superBlock={superBlock}
+              challenges={chapter.modules[0]?.blocks[0]?.challenges}
+            />
           );
         } else if (chapter.modules.length === 0) {
           return (
-            <li className='coming-soon' key={chapter.name}>
-              <Badge>{t('misc.coming-soon')}</Badge>{' '}
+            <ComingSoon key={chapter.name}>
               {t(`intro:full-stack-developer.chapters.${chapter.name}`)}
-            </li>
+            </ComingSoon>
           );
         }
 
@@ -184,24 +204,18 @@ export const SuperBlockAccordion = ({
           >
             {chapter.modules.map(module => {
               if (isLinkModule(module.name)) {
-                const challenges = module.blocks[0]?.challenges;
-                const firstChallenge = challenges ? challenges[0] : null;
                 return (
-                  <li key={module.name} className='link-module'>
-                    <Block
-                      block={firstChallenge?.block ?? ''}
-                      blockType={firstChallenge?.blockType ?? null}
-                      challenges={challenges}
-                      superBlock={superBlock}
-                    />
-                  </li>
+                  <LinkBlock
+                    key={module.name}
+                    superBlock={superBlock}
+                    challenges={module.blocks[0]?.challenges}
+                  />
                 );
               } else if (module.blocks.length === 0) {
                 return (
-                  <li className='coming-soon' key={module.name}>
-                    <Badge>{t('misc.coming-soon')}</Badge>{' '}
+                  <ComingSoon key={module.name}>
                     {t(`intro:full-stack-developer.modules.${module.name}`)}
-                  </li>
+                  </ComingSoon>
                 );
               }
 
@@ -214,10 +228,9 @@ export const SuperBlockAccordion = ({
                   {module.blocks.map(block => {
                     if (block.challenges.length === 0) {
                       return (
-                        <li className='coming-soon' key={block.name}>
-                          <Badge>{t('misc.coming-soon')}</Badge>{' '}
+                        <ComingSoon key={block.name}>
                           {t(`intro:${superBlock}.blocks.${block.name}.title`)}
-                        </li>
+                        </ComingSoon>
                       );
                     }
                     return (

--- a/client/src/templates/Introduction/components/super-block-accordion.tsx
+++ b/client/src/templates/Introduction/components/super-block-accordion.tsx
@@ -198,7 +198,7 @@ export const SuperBlockAccordion = ({
                 );
               } else if (module.blocks.length === 0) {
                 return (
-                  <li key={chapter.name}>
+                  <li key={module.name}>
                     <Badge>{t('misc.coming-soon')}</Badge>{' '}
                     {t(`intro:full-stack-developer.modules.${module.name}`)}
                   </li>

--- a/client/src/templates/Introduction/components/super-block-accordion.tsx
+++ b/client/src/templates/Introduction/components/super-block-accordion.tsx
@@ -35,6 +35,14 @@ interface SuperBlockTreeViewProps {
   chosenBlock: string;
 }
 
+type Module = {
+  dashedName: string;
+  comingSoon?: boolean;
+  blocks: {
+    dashedName: string;
+  }[];
+};
+
 const modules = superBlockStructure.chapters.flatMap(({ modules }) => modules);
 const chapters = superBlockStructure.chapters;
 
@@ -146,10 +154,10 @@ export const SuperBlockAccordion = ({
 
     const allChapters = chapters.map(chapter => ({
       name: chapter.dashedName,
-      comingSoon: 'comingSoon' in chapter ? chapter.comingSoon : false,
-      modules: chapter.modules.map(module => ({
+      comingSoon: chapter.comingSoon,
+      modules: chapter.modules.map((module: Module) => ({
         name: module.dashedName,
-        comingSoon: 'comingSoon' in module ? module.comingSoon : false,
+        comingSoon: module.comingSoon,
         blocks: populateBlocks(module.blocks)
       }))
     }));

--- a/client/src/templates/Introduction/components/super-block-accordion.tsx
+++ b/client/src/templates/Introduction/components/super-block-accordion.tsx
@@ -211,16 +211,26 @@ export const SuperBlockAccordion = ({
                   dashedName={module.name}
                   isExpanded={expandedModule === module.name}
                 >
-                  {module.blocks.map(block => (
-                    <li key={block.name}>
-                      <Block
-                        block={block.name}
-                        blockType={block.blockType}
-                        challenges={block.challenges}
-                        superBlock={superBlock}
-                      />
-                    </li>
-                  ))}
+                  {module.blocks.map(block => {
+                    if (block.challenges.length === 0) {
+                      return (
+                        <li key={block.name}>
+                          <Badge>{t('misc.coming-soon')}</Badge>{' '}
+                          {t(`intro:${superBlock}.blocks.${block.name}.title`)}
+                        </li>
+                      );
+                    }
+                    return (
+                      <li key={block.name}>
+                        <Block
+                          block={block.name}
+                          blockType={block.blockType}
+                          challenges={block.challenges}
+                          superBlock={superBlock}
+                        />
+                      </li>
+                    );
+                  })}
                 </Module>
               );
             })}

--- a/client/src/templates/Introduction/components/super-block-accordion.tsx
+++ b/client/src/templates/Introduction/components/super-block-accordion.tsx
@@ -121,6 +121,7 @@ export const SuperBlockAccordion = ({
   superBlock,
   chosenBlock
 }: SuperBlockTreeViewProps) => {
+  const { t } = useTranslation();
   const { allChapters } = useMemo(() => {
     const populateBlocks = (blocks: { dashedName: string }[]) =>
       blocks.map(block => {
@@ -169,7 +170,8 @@ export const SuperBlockAccordion = ({
         } else if (chapter.modules.length === 0) {
           return (
             <li key={chapter.name}>
-              <Badge>Coming soon</Badge> Chapter name
+              <Badge>{t('misc.coming-soon')}</Badge>{' '}
+              {t(`intro:full-stack-developer.chapters.${chapter.name}`)}
             </li>
           );
         }
@@ -197,7 +199,8 @@ export const SuperBlockAccordion = ({
               } else if (module.blocks.length === 0) {
                 return (
                   <li key={chapter.name}>
-                    <Badge>Coming soon</Badge> Module name
+                    <Badge>{t('misc.coming-soon')}</Badge>{' '}
+                    {t(`intro:full-stack-developer.modules.${module.name}`)}
                   </li>
                 );
               }

--- a/client/src/templates/Introduction/components/super-block-accordion.tsx
+++ b/client/src/templates/Introduction/components/super-block-accordion.tsx
@@ -132,6 +132,24 @@ const ComingSoon = ({ children }: { children: ReactNode }) => {
   );
 };
 
+const LinkBlock = ({
+  superBlock,
+  challenges
+}: {
+  superBlock: SuperBlocks;
+  challenges?: ChallengeNode['challenge'][];
+}) =>
+  challenges?.length ? (
+    <li className='link-block'>
+      <Block
+        block={challenges[0].block}
+        blockType={challenges[0].blockType}
+        challenges={challenges}
+        superBlock={superBlock}
+      />
+    </li>
+  ) : null;
+
 export const SuperBlockAccordion = ({
   challenges,
   superBlock,
@@ -181,28 +199,13 @@ export const SuperBlockAccordion = ({
           );
         }
 
-        // if modules is missing or empty, or if module[0].blocks is
-        // missing or empty, or if module[0].blocks[0].challenges is
-        // missing or empty, don't render the chapter
-        if (
-          !chapter.modules?.length ||
-          !chapter.modules[0]?.blocks?.length ||
-          !chapter.modules[0]?.blocks[0]?.challenges?.length
-        ) {
-          return null;
-        }
-
         if (isLinkChapter(chapter.name)) {
-          const linkedChallenge = chapter.modules[0].blocks[0].challenges[0];
           return (
-            <li key={chapter.name} className='link-chapter'>
-              <Block
-                block={linkedChallenge.block}
-                blockType={linkedChallenge.blockType}
-                challenges={[linkedChallenge]}
-                superBlock={superBlock}
-              />
-            </li>
+            <LinkBlock
+              key={chapter.name}
+              superBlock={superBlock}
+              challenges={chapter.modules[0]?.blocks[0]?.challenges}
+            />
           );
         }
 
@@ -225,16 +228,12 @@ export const SuperBlockAccordion = ({
               }
 
               if (isLinkModule(module.name)) {
-                const linkedChallenge = module.blocks[0].challenges[0];
                 return (
-                  <li key={module.name} className='link-module'>
-                    <Block
-                      block={linkedChallenge.block}
-                      blockType={linkedChallenge.blockType}
-                      challenges={[linkedChallenge]}
-                      superBlock={superBlock}
-                    />
-                  </li>
+                  <LinkBlock
+                    key={module.name}
+                    superBlock={superBlock}
+                    challenges={module.blocks[0]?.challenges}
+                  />
                 );
               }
 

--- a/client/src/templates/Introduction/components/super-block-accordion.tsx
+++ b/client/src/templates/Introduction/components/super-block-accordion.tsx
@@ -48,6 +48,33 @@ const isLinkChapter = (name: string) => {
   return chapter?.chapterType === 'exam';
 };
 
+const getBlockToChapterMap = () => {
+  const blockToChapterMap = new Map<string, string>();
+  chapters.forEach(chapter => {
+    chapter.modules.forEach(module => {
+      module.blocks.forEach(block => {
+        blockToChapterMap.set(block.dashedName, chapter.dashedName);
+      });
+    });
+  });
+
+  return blockToChapterMap;
+};
+
+const getBlockToModuleMap = () => {
+  const blockToModuleMap = new Map<string, string>();
+  modules.forEach(module => {
+    module.blocks.forEach(block => {
+      blockToModuleMap.set(block.dashedName, module.dashedName);
+    });
+  });
+
+  return blockToModuleMap;
+};
+
+const blockToChapterMap = getBlockToChapterMap();
+const blockToModuleMap = getBlockToModuleMap();
+
 const Chapter = ({ dashedName, children, isExpanded }: ChapterProps) => {
   const { t } = useTranslation();
 
@@ -91,7 +118,7 @@ export const SuperBlockAccordion = ({
   superBlock,
   chosenBlock
 }: SuperBlockTreeViewProps) => {
-  const { currentChapters, currentBlocks } = useMemo(() => {
+  const { currentChapters } = useMemo(() => {
     const currentBlocks = uniqBy(challenges, 'block').map(
       ({ block, blockType, chapter, module }) => ({
         name: block,
@@ -117,20 +144,12 @@ export const SuperBlockAccordion = ({
       })
     );
 
-    return {
-      currentChapters,
-      currentModules,
-      currentBlocks
-    };
+    return { currentChapters };
   }, [challenges]);
 
   // Expand the outer layers in order to reveal the chosen block.
-  const expandedChapter = currentBlocks.find(
-    ({ name }) => chosenBlock === name
-  )?.chapter;
-  const expandedModule = currentBlocks.find(
-    ({ name }) => chosenBlock === name
-  )?.module;
+  const expandedChapter = blockToChapterMap.get(chosenBlock);
+  const expandedModule = blockToModuleMap.get(chosenBlock);
 
   return (
     <ul className='super-block-accordion'>

--- a/client/src/templates/Introduction/components/super-block-accordion.tsx
+++ b/client/src/templates/Introduction/components/super-block-accordion.tsx
@@ -33,9 +33,8 @@ interface SuperBlockTreeViewProps {
   chosenBlock: string;
 }
 
-const modules = superBlockStructure.chapters.flatMap(
-  chapter => chapter.modules
-);
+const modules = superBlockStructure.chapters.flatMap(({ modules }) => modules);
+const chapters = superBlockStructure.chapters;
 
 const isLinkModule = (name: string) => {
   const module = modules.find(module => module.dashedName === name);
@@ -44,9 +43,7 @@ const isLinkModule = (name: string) => {
 };
 
 const isLinkChapter = (name: string) => {
-  const chapter = superBlockStructure.chapters.find(
-    chapter => chapter.dashedName === name
-  );
+  const chapter = chapters.find(chapter => chapter.dashedName === name);
 
   return chapter?.chapterType === 'exam';
 };
@@ -94,8 +91,8 @@ export const SuperBlockAccordion = ({
   superBlock,
   chosenBlock
 }: SuperBlockTreeViewProps) => {
-  const { allChapters, allBlocks } = useMemo(() => {
-    const allBlocks = uniqBy(challenges, 'block').map(
+  const { currentChapters, currentBlocks } = useMemo(() => {
+    const currentBlocks = uniqBy(challenges, 'block').map(
       ({ block, blockType, chapter, module }) => ({
         name: block,
         blockType,
@@ -105,37 +102,39 @@ export const SuperBlockAccordion = ({
       })
     );
 
-    const allModules = uniqBy(allBlocks, 'module').map(
+    const currentModules = uniqBy(currentBlocks, 'module').map(
       ({ module, chapter }) => ({
         name: module,
         chapter,
-        blocks: allBlocks.filter(({ module: m }) => m === module)
+        blocks: currentBlocks.filter(({ module: m }) => m === module)
       })
     );
 
-    const allChapters = uniqBy(allModules, 'chapter').map(({ chapter }) => ({
-      name: chapter,
-      modules: allModules.filter(({ chapter: c }) => c === chapter)
-    }));
+    const currentChapters = uniqBy(currentModules, 'chapter').map(
+      ({ chapter }) => ({
+        name: chapter,
+        modules: currentModules.filter(({ chapter: c }) => c === chapter)
+      })
+    );
 
     return {
-      allChapters,
-      allModules,
-      allBlocks
+      currentChapters,
+      currentModules,
+      currentBlocks
     };
   }, [challenges]);
 
   // Expand the outer layers in order to reveal the chosen block.
-  const expandedChapter = allBlocks.find(
+  const expandedChapter = currentBlocks.find(
     ({ name }) => chosenBlock === name
   )?.chapter;
-  const expandedModule = allBlocks.find(
+  const expandedModule = currentBlocks.find(
     ({ name }) => chosenBlock === name
   )?.module;
 
   return (
     <ul className='super-block-accordion'>
-      {allChapters.map(chapter => {
+      {currentChapters.map(chapter => {
         if (isLinkChapter(chapter.name)) {
           const linkedChallenge = chapter.modules[0].blocks[0].challenges[0];
           return (

--- a/client/src/templates/Introduction/components/super-block-accordion.tsx
+++ b/client/src/templates/Introduction/components/super-block-accordion.tsx
@@ -150,13 +150,14 @@ export const SuperBlockAccordion = ({
     <ul className='super-block-accordion'>
       {allChapters.map(chapter => {
         if (isLinkChapter(chapter.name)) {
-          const linkedChallenge = chapter.modules[0].blocks[0].challenges[0];
+          const challenges = chapter.modules[0]?.blocks[0]?.challenges;
+          const firstChallenge = challenges ? challenges[0] : null;
           return (
             <li key={chapter.name} className='link-chapter'>
               <Block
-                block={linkedChallenge.block}
-                blockType={linkedChallenge.blockType}
-                challenges={[linkedChallenge]}
+                block={firstChallenge?.block ?? ''}
+                blockType={firstChallenge?.blockType ?? null}
+                challenges={challenges}
                 superBlock={superBlock}
               />
             </li>
@@ -171,13 +172,14 @@ export const SuperBlockAccordion = ({
           >
             {chapter.modules.map(module => {
               if (isLinkModule(module.name)) {
-                const linkedChallenge = module.blocks[0].challenges[0];
+                const challenges = module.blocks[0]?.challenges;
+                const firstChallenge = challenges ? challenges[0] : null;
                 return (
                   <li key={module.name} className='link-module'>
                     <Block
-                      block={linkedChallenge.block}
-                      blockType={linkedChallenge.blockType}
-                      challenges={[linkedChallenge]}
+                      block={firstChallenge?.block ?? ''}
+                      blockType={firstChallenge?.blockType ?? null}
+                      challenges={challenges}
                       superBlock={superBlock}
                     />
                   </li>

--- a/client/src/templates/Introduction/components/super-block-accordion.tsx
+++ b/client/src/templates/Introduction/components/super-block-accordion.tsx
@@ -169,7 +169,7 @@ export const SuperBlockAccordion = ({
           );
         } else if (chapter.modules.length === 0) {
           return (
-            <li key={chapter.name}>
+            <li className='coming-soon' key={chapter.name}>
               <Badge>{t('misc.coming-soon')}</Badge>{' '}
               {t(`intro:full-stack-developer.chapters.${chapter.name}`)}
             </li>
@@ -198,7 +198,7 @@ export const SuperBlockAccordion = ({
                 );
               } else if (module.blocks.length === 0) {
                 return (
-                  <li key={module.name}>
+                  <li className='coming-soon' key={module.name}>
                     <Badge>{t('misc.coming-soon')}</Badge>{' '}
                     {t(`intro:full-stack-developer.modules.${module.name}`)}
                   </li>
@@ -214,7 +214,7 @@ export const SuperBlockAccordion = ({
                   {module.blocks.map(block => {
                     if (block.challenges.length === 0) {
                       return (
-                        <li key={block.name}>
+                        <li className='coming-soon' key={block.name}>
                           <Badge>{t('misc.coming-soon')}</Badge>{' '}
                           {t(`intro:${superBlock}.blocks.${block.name}.title`)}
                         </li>

--- a/client/src/templates/Introduction/components/super-block-accordion.tsx
+++ b/client/src/templates/Introduction/components/super-block-accordion.tsx
@@ -112,6 +112,10 @@ const Module = ({ dashedName, children, isExpanded }: ModuleProps) => {
   );
 };
 
+const Badge = ({ children }: { children: ReactNode }) => (
+  <span className='badge'>{children}</span>
+);
+
 export const SuperBlockAccordion = ({
   challenges,
   superBlock,
@@ -163,7 +167,11 @@ export const SuperBlockAccordion = ({
             </li>
           );
         } else if (chapter.modules.length === 0) {
-          return <li key={chapter.name}>Chapter coming soon</li>;
+          return (
+            <li key={chapter.name}>
+              <Badge>Coming soon</Badge> Chapter name
+            </li>
+          );
         }
 
         return (
@@ -187,7 +195,11 @@ export const SuperBlockAccordion = ({
                   </li>
                 );
               } else if (module.blocks.length === 0) {
-                return <li key={chapter.name}>Module coming soon</li>;
+                return (
+                  <li key={chapter.name}>
+                    <Badge>Coming soon</Badge> Module name
+                  </li>
+                );
               }
 
               return (

--- a/curriculum/schema/superblock-structure-schema.js
+++ b/curriculum/schema/superblock-structure-schema.js
@@ -7,18 +7,22 @@ const schema = Joi.object()
     chapters: Joi.array().items(
       Joi.object().keys({
         dashedName: Joi.string().regex(slugRE).required(),
+        comingSoon: Joi.boolean().optional(),
         chapterType: Joi.valid('exam').optional(),
-        modules: Joi.array().items(
-          Joi.object().keys({
-            moduleType: Joi.valid('review', 'exam').optional(),
-            dashedName: Joi.string().regex(slugRE).required(),
-            blocks: Joi.array().items(
-              Joi.object().keys({
-                dashedName: Joi.string().regex(slugRE).required()
-              })
-            )
-          })
-        )
+        modules: Joi.array()
+          .items(
+            Joi.object().keys({
+              moduleType: Joi.valid('review', 'exam').optional(),
+              comingSoon: Joi.boolean().optional(),
+              dashedName: Joi.string().regex(slugRE).required(),
+              blocks: Joi.array().items(
+                Joi.object().keys({
+                  dashedName: Joi.string().regex(slugRE).required()
+                })
+              )
+            })
+          )
+          .required()
       })
     )
   })

--- a/curriculum/superblock-structure/full-stack.json
+++ b/curriculum/superblock-structure/full-stack.json
@@ -2,6 +2,7 @@
   "chapters": [
     {
       "dashedName": "freecodecamp",
+      "comingSoon": true,
       "modules": [
         {
           "dashedName": "getting-started-with-freecodecamp",
@@ -11,6 +12,7 @@
     },
     {
       "dashedName": "html",
+      "comingSoon": true,
       "modules": [
         {
           "dashedName": "basic-html",
@@ -71,6 +73,7 @@
     },
     {
       "dashedName": "css",
+      "comingSoon": true,
       "modules": [
         {
           "dashedName": "computer-basics",
@@ -275,6 +278,7 @@
     },
     {
       "dashedName": "javascript",
+      "comingSoon": true,
       "modules": [
         {
           "dashedName": "code-editors",
@@ -541,6 +545,7 @@
 
     {
       "dashedName": "frontend-libraries",
+      "comingSoon": true,
       "modules": [
         {
           "dashedName": "react-fundamentals",

--- a/curriculum/superblock-structure/full-stack.json
+++ b/curriculum/superblock-structure/full-stack.json
@@ -558,6 +558,7 @@
         },
         {
           "dashedName": "react-state-hooks-and-routing",
+          "comingSoon": true,
           "blocks": [
             { "dashedName": "quiz-react-state-and-hooks" },
             { "dashedName": "quiz-advanced-react" }
@@ -565,6 +566,7 @@
         },
         {
           "dashedName": "performance",
+          "comingSoon": true,
           "blocks": [
             { "dashedName": "review-web-performance" },
             { "dashedName": "quiz-web-performance" }
@@ -572,6 +574,7 @@
         },
         {
           "dashedName": "css-libraries-and-frameworks",
+          "comingSoon": true,
           "blocks": [
             { "dashedName": "review-css-libraries-and-frameworks" },
             { "dashedName": "quiz-css-libraries-and-frameworks" }
@@ -579,6 +582,7 @@
         },
         {
           "dashedName": "testing",
+          "comingSoon": true,
           "blocks": [
             { "dashedName": "review-testing" },
             { "dashedName": "quiz-testing" }
@@ -586,6 +590,7 @@
         },
         {
           "dashedName": "typescript-fundamentals",
+          "comingSoon": true,
           "blocks": [
             { "dashedName": "review-typescript" },
             { "dashedName": "quiz-typescript" }
@@ -600,6 +605,7 @@
     },
     {
       "dashedName": "relational-databases",
+      "comingSoon": true,
       "modules": [
         {
           "dashedName": "bash-fundamentals",
@@ -663,6 +669,16 @@
           "blocks": [{ "dashedName": "review-relational-databases" }]
         }
       ]
+    },
+    {
+      "dashedName": "backend-javascript",
+      "comingSoon": true,
+      "modules": []
+    },
+    {
+      "dashedName": "python",
+      "comingSoon": true,
+      "modules": []
     },
     {
       "chapterType": "exam",

--- a/shared/config/blocks.ts
+++ b/shared/config/blocks.ts
@@ -42,12 +42,5 @@ export enum BlockLayouts {
    * This layout is used in legacy certifications.
    * Example: https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/#javascript-algorithms-and-data-structures-projects
    */
-  ProjectList = 'project-list',
-
-  /**
-   * ComingSoon just displays a message that the block is coming soon.
-   * This layout is used for blocks that are not yet implemented.
-   */
-
-  ComingSoon = 'coming-soon'
+  ProjectList = 'project-list'
 }

--- a/shared/config/blocks.ts
+++ b/shared/config/blocks.ts
@@ -42,5 +42,12 @@ export enum BlockLayouts {
    * This layout is used in legacy certifications.
    * Example: https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/#javascript-algorithms-and-data-structures-projects
    */
-  ProjectList = 'project-list'
+  ProjectList = 'project-list',
+
+  /**
+   * ComingSoon just displays a message that the block is coming soon.
+   * This layout is used for blocks that are not yet implemented.
+   */
+
+  ComingSoon = 'coming-soon'
 }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

If a block doesn't exist yet, we can now create that block in the superblock [structure](https://github.com/freeCodeCamp/freeCodeCamp/blob/main/curriculum/superblock-structure/full-stack.json) and it will render as a "coming soon" block on the superblock page.

For example, https://github.com/freeCodeCamp/freeCodeCamp/blob/ea15720fe34f134a54ee01c203ebd12426d4c41c/curriculum/superblock-structure/full-stack.json#L140-L146

would become

```json
          "dashedName": "css-colors",
          "blocks": [
            { "dashedName": "lecture-working-with-colors-in-css" },
            { "dashedName": "workshop-colored-markers" },
            { "dashedName": "review-css-colors" },
            { "dashedName": "this-block-is-not-ready-yet" },
            { "dashedName": "quiz-css-colors" }
          ]
```

and that module would look like this:

![new module ui](https://github.com/user-attachments/assets/1e236264-8074-4b01-86d8-3a5d2caaf995)

It's also possible to create entire empty chapters or modules in the same way. E.g.

```json
    {
      "dashedName": "coming-soon-chapter-1",
      "modules": [
        {
          "dashedName": "coming-soon-module-1",
          "blocks": [{ "dashedName": "coming-soon-block" }]
        }
      ]
    }
```

and that will look like this

![image](https://github.com/user-attachments/assets/6ecff7cd-fe8b-44b0-bf08-66afadd581cf)

Ref: https://github.com/freeCodeCamp/fcc10/issues/41 (arguably, it closes it, but the UI is horrid)

<!-- Feel free to add any additional description of changes below this line -->
