### PR TITLE
fix(client): suppress babel transform warning

### DIFF
--- a/client/src/templates/Challenges/rechallenge/transformers.js
+++ b/client/src/templates/Challenges/rechallenge/transformers.js
@@ -214,6 +214,7 @@ async function transformScript(documentElement, { useModules }) {
   const scriptTags = documentElement.querySelectorAll('script');
   scriptTags.forEach(script => {
     const isBabel = script.type === 'text/babel';
+    const hasSource = !!script.src;
     // TODO: make the use of JSX conditional on more than just the script type.
     // It should only be used for React challenges since it would be confusing
     // for learners to see the results of a transformation they didn't ask for.
@@ -228,8 +229,18 @@ async function transformScript(documentElement, { useModules }) {
     // However, if we're importing modules, the type will be removed when the
     // scripts are embedded in the HTML.
     if (isBabel && !useModules) script.removeAttribute('type');
+    // We could use babel standalone to transform inline code in the preview,
+    // but that generates a warning that's shown to learner. By removing the
+    // type attribute and transforming the code we can avoid that warning.
+    if (isBabel && !hasSource) {
+      script.removeAttribute('type');
+      script.setAttribute('data-type', 'text/babel');
+    }
 
-    script.innerHTML = babelTransformCode(options)(script.innerHTML);
+    // Skip unnecessary transformations
+    script.innerHTML = script.innerHTML
+      ? babelTransformCode(options)(script.innerHTML)
+      : '';
   });
 }
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Prior to this PR, the inline script (see below) was transformed twice. Once by the transformation pipeline and again by the babel script we embed in the preview. The second transform, as well as being unnecessary, generates a warning:

```
You are using the in-browser Babel transformer. Be sure to precompile your scripts for production - https://babeljs.io/docs/setup/
```

and this PR skips it and stops the warning from appearing.

As an example we use inline React like this:

```html
    <script
        data-plugins="transform-modules-umd"
        type="text/babel"
        data-presets="react"
        data-type="module"
    >
        import { MoodBoard } from './index.jsx';
        ReactDOM.createRoot(document.getElementById('root')).render(
            <MoodBoard />
        );
    </script>
```

in https://github.com/freeCodeCamp/freeCodeCamp/blob/main/curriculum/challenges/english/25-front-end-development/lab-mood-board/673b3d6b7ef7318eef926d5a.md 
<!-- Feel free to add any additional description of changes below this line -->
