### PR TITLE
fix(api): return after reply (save-challenge)

### DIFF
--- a/api/src/routes/protected/challenge.ts
+++ b/api/src/routes/protected/challenge.ts
@@ -391,7 +391,9 @@ export const challengeRoutes: FastifyPluginCallbackTypebox = (
         !multifileCertProjectIds.includes(challengeId) &&
         !multifilePythonCertProjectIds.includes(challengeId)
       ) {
-        void reply.code(403).send('That challenge type is not saveable.');
+        return void reply
+          .code(400)
+          .send('That challenge type is not saveable.');
       }
 
       const userSavedChallenges = saveUserChallengeData(


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

If we don't return after `reply.send`ing, we see:

```
[14:55:42 UTC] WARN: Reply was already sent, did you forget to "return reply" in "/save-challenge" (POST)?
```

To which the answer is "yes, we did".

I made some other minor tweaks (status code, test descriptions). The big thing I didn't change was the response - it's still text (not json) so that the client will fail to parse it, throw an error and show the error response. It's a bit silly, but we'll be revisiting the all the responses post-MVP.

<!-- Feel free to add any additional description of changes below this line -->
