### PR TITLE
chore: use challengeType 24 for all lectures

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lecture-animations-and-accessibility/672aa8d65995be62ef1c7515.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-animations-and-accessibility/672aa8d65995be62ef1c7515.md
@@ -1,7 +1,7 @@
 ---
 id: 672aa8d65995be62ef1c7515
 title: What Are CSS Animations, and How Do They Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-css-animations
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-animations-and-accessibility/672cf764cf55a70433590def.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-animations-and-accessibility/672cf764cf55a70433590def.md
@@ -1,7 +1,7 @@
 ---
 id: 672cf764cf55a70433590def
 title: What Are Accessibility Concerns Around Using Animations, and How Can prefers-reduced-motion Help?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-accessibility-concerns-around-using-animations
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-best-practices-for-accessibility-and-css/672aa82768e00d600305afc0.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-best-practices-for-accessibility-and-css/672aa82768e00d600305afc0.md
@@ -1,7 +1,7 @@
 ---
 id: 672aa82768e00d600305afc0
 title: What Are Some Tools to Check for Good Color Contrast on Sites?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-some-tools-to-check-for-good-color-contrast-on-sites
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-best-practices-for-accessibility-and-css/672c35a79fa53e00de9f2a49.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-best-practices-for-accessibility-and-css/672c35a79fa53e00de9f2a49.md
@@ -1,7 +1,7 @@
 ---
 id: 672c35a79fa53e00de9f2a49
 title: "What Are Best Practices for Hiding Content So It Doesn't Become Inaccessible?"
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-best-practices-for-hiding-content-so-it-doesnt-become-inaccessible
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-best-practices-for-responsive-web-design/672aa8873d4e25618870764f.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-best-practices-for-responsive-web-design/672aa8873d4e25618870764f.md
@@ -1,7 +1,7 @@
 ---
 id: 672aa8873d4e25618870764f
 title: What Is Responsive Web Design, and What Is Its Relationship to Tools Like CSS Grid and Flexbox?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-responsive-web-design
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-best-practices-for-responsive-web-design/672cf05c3ad533eabe1e8197.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-best-practices-for-responsive-web-design/672cf05c3ad533eabe1e8197.md
@@ -1,7 +1,7 @@
 ---
 id: 672cf05c3ad533eabe1e8197
 title: How Do Media Queries Work, and What Are Some Common Media Types and Features?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-do-media-queries-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-best-practices-for-responsive-web-design/672cf06c8f46f9eb04db9832.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-best-practices-for-responsive-web-design/672cf06c8f46f9eb04db9832.md
@@ -1,7 +1,7 @@
 ---
 id: 672cf06c8f46f9eb04db9832
 title: What Is the Mobile First Approach in Responsive Web Design?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-the-mobile-first-approach-in-responsive-web-design
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-best-practices-for-responsive-web-design/672cf07a2b9796eb49719e03.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-best-practices-for-responsive-web-design/672cf07a2b9796eb49719e03.md
@@ -1,7 +1,7 @@
 ---
 id: 672cf07a2b9796eb49719e03
 title: What Are Media Breakpoints, and What Are Common Breakpoints in Modern Design?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-media-breakpoints
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-best-practices-for-styling-forms/672aa791227e755da64cf240.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-best-practices-for-styling-forms/672aa791227e755da64cf240.md
@@ -1,7 +1,7 @@
 ---
 id: 672aa791227e755da64cf240
 title: What Are Some Best Practices for Styling Text Inputs?
-challengeType: 11
+challengeType: 24
 videoId: VQGDm80L37A
 dashedName: what-are-some-best-practices-for-styling-text-inputs
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-best-practices-for-styling-forms/672bc9d9eecb65cdf63491de.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-best-practices-for-styling-forms/672bc9d9eecb65cdf63491de.md
@@ -1,7 +1,7 @@
 ---
 id: 672bc9d9eecb65cdf63491de
 title: "When Should You Use appearance: none to Deal with Issues Styling Search Inputs and Checkboxes?"
-challengeType: 11
+challengeType: 24
 videoId: 5HJv4lyfHxY
 dashedName: when-should-you-use-appearance-none-to-deal-with-issues-styling-search-inputs-and-checkboxes
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-best-practices-for-styling-forms/672bca660aa9f9ce9b2b2787.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-best-practices-for-styling-forms/672bca660aa9f9ce9b2b2787.md
@@ -1,7 +1,7 @@
 ---
 id: 672bca660aa9f9ce9b2b2787
 title: What Are Common Issues When Styling Special Input Elements?
-challengeType: 11
+challengeType: 24
 videoId: xGEG5ibAz4E
 dashedName: what-are-common-issues-when-styling-special-input-elements
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-browsing-the-web-effectively/672aa5bd69657d56ab49ec8a.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-browsing-the-web-effectively/672aa5bd69657d56ab49ec8a.md
@@ -1,7 +1,7 @@
 ---
 id: 672aa5bd69657d56ab49ec8a
 title: What Are Some of the Common Web Browsers Available Today and How Do You Install One?
-challengeType: 11
+challengeType: 24
 videoId: nG8IPlMJGLM
 dashedName: what-are-some-of-the-common-web-browsers-available-today
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-browsing-the-web-effectively/672ac96491845f43ea9a26d7.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-browsing-the-web-effectively/672ac96491845f43ea9a26d7.md
@@ -1,7 +1,7 @@
 ---
 id: 672ac96491845f43ea9a26d7
 title: What Is the Difference Between a Web Browser, a Website, and a Search Engine?
-challengeType: 11
+challengeType: 24
 videoId: PHAS3d5lyFk
 dashedName: what-is-the-difference-between-a-web-browser-a-website-and-a-search-engine
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-browsing-the-web-effectively/672ac9705b07a64439b73b59.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-browsing-the-web-effectively/672ac9705b07a64439b73b59.md
@@ -1,7 +1,7 @@
 ---
 id: 672ac9705b07a64439b73b59
 title: How to Use a Search Engine Effectively to Achieve Optimal Results
-challengeType: 11
+challengeType: 24
 videoId: N1zplPEM-OA
 dashedName: how-to-use-a-search-engine-effectively-to-achieve-optimal-results
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-common-design-tools/672aa7005c24e45bbd53b20d.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-common-design-tools/672aa7005c24e45bbd53b20d.md
@@ -1,7 +1,7 @@
 ---
 id: 672aa7005c24e45bbd53b20d
 title: What Are Design Briefs and How Do Developers Work with Them?
-challengeType: 11
+challengeType: 24
 videoId: 9IbDnoNf52w
 dashedName: what-are-design-briefs
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-common-design-tools/672bb619f0d4538d0528760d.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-common-design-tools/672bb619f0d4538d0528760d.md
@@ -1,7 +1,7 @@
 ---
 id: 672bb619f0d4538d0528760d
 title: What Are Some Common Tools Developers Should Know About That Are Used by Designers in the Industry?
-challengeType: 11
+challengeType: 24
 videoId: i5_Reeq4ueo
 dashedName: what-are-some-common-tools-developers-should-know-about
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-css-specificity-the-cascade-algorithm-and-inheritance/672aa62178d5ff57fe4f98e0.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-css-specificity-the-cascade-algorithm-and-inheritance/672aa62178d5ff57fe4f98e0.md
@@ -1,7 +1,7 @@
 ---
 id: 672aa62178d5ff57fe4f98e0
 title: What Is CSS Specificity, and the Specificity for Inline, Internal, and External CSS?
-challengeType: 11
+challengeType: 24
 videoId: prBqPmNfLWA
 dashedName: what-is-css-specificity-and-the-specificity-for-inline-internal-and-external-css
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-css-specificity-the-cascade-algorithm-and-inheritance/672b8e7eca8a4322306d15f8.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-css-specificity-the-cascade-algorithm-and-inheritance/672b8e7eca8a4322306d15f8.md
@@ -1,7 +1,7 @@
 ---
 id: 672b8e7eca8a4322306d15f8
 title: What Is the Universal Selector, and What Is Its Specificity?
-challengeType: 11
+challengeType: 24
 videoId: yaVWc4MGasE
 dashedName: what-is-the-universal-selector
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-css-specificity-the-cascade-algorithm-and-inheritance/672b8e8adcc27e235a154231.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-css-specificity-the-cascade-algorithm-and-inheritance/672b8e8adcc27e235a154231.md
@@ -1,7 +1,7 @@
 ---
 id: 672b8e8adcc27e235a154231
 title: What Is the Specificity for Type Selectors?
-challengeType: 11
+challengeType: 24
 videoId: E1hSIBfnZ0s
 dashedName: what-is-the-specificity-for-type-selectors
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-css-specificity-the-cascade-algorithm-and-inheritance/672b8e9892eafe238d6513a5.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-css-specificity-the-cascade-algorithm-and-inheritance/672b8e9892eafe238d6513a5.md
@@ -1,7 +1,7 @@
 ---
 id: 672b8e9892eafe238d6513a5
 title: What Is the Specificity for Class Selectors?
-challengeType: 11
+challengeType: 24
 videoId: VdC1xe7n8es
 dashedName: what-is-the-specificity-for-class-selectors
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-css-specificity-the-cascade-algorithm-and-inheritance/672b8ea434ceac23cc90f337.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-css-specificity-the-cascade-algorithm-and-inheritance/672b8ea434ceac23cc90f337.md
@@ -1,7 +1,7 @@
 ---
 id: 672b8ea434ceac23cc90f337
 title: What Is the Specificity for ID Selectors?
-challengeType: 11
+challengeType: 24
 videoId: ZUhV2wrlOXY
 dashedName: what-is-the-specificity-for-id-selectors
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-css-specificity-the-cascade-algorithm-and-inheritance/672b8f1399cabc2406c3227f.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-css-specificity-the-cascade-algorithm-and-inheritance/672b8f1399cabc2406c3227f.md
@@ -1,7 +1,7 @@
 ---
 id: 672b8f1399cabc2406c3227f
 title: What Is the important Keyword, and What Are the Best Practices for Using It?
-challengeType: 11
+challengeType: 24
 videoId: 3anMUQeGi6s
 dashedName: what-is-the-important-keyword
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-css-specificity-the-cascade-algorithm-and-inheritance/672b8f23511adf25646b4236.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-css-specificity-the-cascade-algorithm-and-inheritance/672b8f23511adf25646b4236.md
@@ -1,7 +1,7 @@
 ---
 id: 672b8f23511adf25646b4236
 title: How Does the Cascade Algorithm Work at a High Level?
-challengeType: 11
+challengeType: 24
 videoId: rSqLjJyT3GU
 dashedName: how-does-the-cascade-algorithm-work-at-a-high-level
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-css-specificity-the-cascade-algorithm-and-inheritance/672b8f382370e025aadd3f4e.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-css-specificity-the-cascade-algorithm-and-inheritance/672b8f382370e025aadd3f4e.md
@@ -1,7 +1,7 @@
 ---
 id: 672b8f382370e025aadd3f4e
 title: How Does Inheritance Work with CSS at a High Level?
-challengeType: 11
+challengeType: 24
 videoId: ZxsISsy8MnM
 dashedName: how-does-inheritance-work-with-css-at-a-high-level
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-debugging-css/672aa8c1ad423562a38b484d.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-debugging-css/672aa8c1ad423562a38b484d.md
@@ -1,7 +1,7 @@
 ---
 id: 672aa8c1ad423562a38b484d
 title: How Can You Use the DevTools Inspection Tool and CSS Validators to Debug Your CSS?
-challengeType: 11
+challengeType: 24
 videoId: KP-naaNBxEA
 dashedName: how-can-you-use-the-devtools-inspection-tool
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-debugging-techniques/6733aa9b006d29f4d11307a5.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-debugging-techniques/6733aa9b006d29f4d11307a5.md
@@ -1,7 +1,7 @@
 ---
 id: 6733aa9b006d29f4d11307a5
 title: What Are Some Examples of Common JavaScript Errors?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-some-examples-of-common-javascript-errors
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-debugging-techniques/6733bec70d86e13522e98a4f.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-debugging-techniques/6733bec70d86e13522e98a4f.md
@@ -1,7 +1,7 @@
 ---
 id: 6733bec70d86e13522e98a4f
 title: How Does the Throw Statement Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-does-the-throw-statement-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-debugging-techniques/6733becf4b0c353553b9bfa4.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-debugging-techniques/6733becf4b0c353553b9bfa4.md
@@ -1,7 +1,7 @@
 ---
 id: 6733becf4b0c353553b9bfa4
 title: How Does the Debugger Statement Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-does-the-debugger-statement-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-debugging-techniques/6733bee844600f35c05b8264.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-debugging-techniques/6733bee844600f35c05b8264.md
@@ -1,7 +1,7 @@
 ---
 id: 6733bee844600f35c05b8264
 title: How Does try...catch...finally Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-does-try-catch-finally-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-debugging-techniques/6733befb703ca6361da3755b.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-debugging-techniques/6733befb703ca6361da3755b.md
@@ -1,7 +1,7 @@
 ---
 id: 6733befb703ca6361da3755b
 title: What Are Some Examples of Using Advanced JavaScript Debugging Techniques?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-some-examples-of-using-advanced-javascript-debugging-techniques
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-html-fundamentals/670803abcb3e980233da4768.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-html-fundamentals/670803abcb3e980233da4768.md
@@ -1,7 +1,7 @@
 ---
 id: 670803abcb3e980233da4768
 title: What are Div Elements and When Should You Use Them?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-div-elements
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-html-fundamentals/6708143cab2b583ecd3324f5.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-html-fundamentals/6708143cab2b583ecd3324f5.md
@@ -1,7 +1,7 @@
 ---
 id: 6708143cab2b583ecd3324f5
 title: What Are Attributes, and How Do They Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-attributes
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-html-fundamentals/6708382cf088b216580a9ff1.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-html-fundamentals/6708382cf088b216580a9ff1.md
@@ -1,7 +1,7 @@
 ---
 id: 6708382cf088b216580a9ff1
 title: What Are IDs and Classes, and When Should You Use Them?
-challengeType: 11
+challengeType: 24
 videoId: yTuzVH6THdg
 dashedName: what-are-ids-and-classes
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-html-fundamentals/67083868d5fdcb17bf8c14bd.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-html-fundamentals/67083868d5fdcb17bf8c14bd.md
@@ -1,7 +1,7 @@
 ---
 id: 67083868d5fdcb17bf8c14bd
 title: What Are HTML Entities, and What Are Some Common Examples?
-challengeType: 11
+challengeType: 24
 videoId: VJmx-XzTqg8
 dashedName: what-are-html-entities
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-html-fundamentals/670838977810401844af6fe0.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-html-fundamentals/670838977810401844af6fe0.md
@@ -1,7 +1,7 @@
 ---
 id: 670838977810401844af6fe0
 title: What Is the Role of the Link Element in HTML, and How Can It Be Used to Link to External Stylesheets?
-challengeType: 11
+challengeType: 24
 videoId: qeGlYqpFRZA
 dashedName: what-is-the-role-of-the-link-element-in-html
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-html-fundamentals/670838b10ee87a18e5faff62.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-html-fundamentals/670838b10ee87a18e5faff62.md
@@ -1,7 +1,7 @@
 ---
 id: 670838b10ee87a18e5faff62
 title: What Is the Role of the Script Element in HTML, and How Can It Be Used to Link to External JavaScript Files?
-challengeType: 11
+challengeType: 24
 videoId: ZxpITCgbc5Y
 dashedName: what-is-the-role-of-the-script-element-in-html
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-html-fundamentals/670838e914096b194b0c51aa.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-html-fundamentals/670838e914096b194b0c51aa.md
@@ -1,7 +1,7 @@
 ---
 id: 670838e914096b194b0c51aa
 title: What Is an HTML Boilerplate, and Why Is It Important?
-challengeType: 11
+challengeType: 24
 videoId: UKxDoI54eLE
 dashedName: what-is-an-html-boilerplate
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-html-fundamentals/670839051794aa19fcef6dc8.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-html-fundamentals/670839051794aa19fcef6dc8.md
@@ -1,7 +1,7 @@
 ---
 id: 670839051794aa19fcef6dc8
 title: What Is UTF-8 Character Encoding, and Why Is It Needed?
-challengeType: 11
+challengeType: 24
 videoId: SuTPQkOpa10
 dashedName: what-is-utf-8-character-encoding
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-html-fundamentals/67083952f800051a8a21fcfd.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-html-fundamentals/67083952f800051a8a21fcfd.md
@@ -1,7 +1,7 @@
 ---
 id: 67083952f800051a8a21fcfd
 title: What Is the Role of the Meta Description, and How Does It Affect SEO?
-challengeType: 11
+challengeType: 24
 videoId: aLy7C2fGDQw
 dashedName: what-is-the-role-of-the-meta-description
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-html-fundamentals/6708396caa00e11b597b3365.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-html-fundamentals/6708396caa00e11b597b3365.md
@@ -1,7 +1,7 @@
 ---
 id: 6708396caa00e11b597b3365
 title: What Is the Role of Open Graph Tags, and How Do They Affect SEO?
-challengeType: 11
+challengeType: 24
 videoId: wQhsL9NjiuA
 dashedName: what-is-the-role-of-open-graph-tags
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-importance-of-accessibility-and-good-html-structure/672a51e9e4fd8b8552eeb758.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-importance-of-accessibility-and-good-html-structure/672a51e9e4fd8b8552eeb758.md
@@ -1,7 +1,7 @@
 ---
 id: 672a51e9e4fd8b8552eeb758
 title: What Is Accessibility?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-accessibility
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-importance-of-accessibility-and-good-html-structure/672a5310d7e46b8a34d48dfd.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-importance-of-accessibility-and-good-html-structure/672a5310d7e46b8a34d48dfd.md
@@ -1,7 +1,7 @@
 ---
 id: 672a5310d7e46b8a34d48dfd
 title: What Are Screen Readers, and Who Uses Them?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-screen-readers
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-importance-of-accessibility-and-good-html-structure/672a5326a7606a8a766cbedb.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-importance-of-accessibility-and-good-html-structure/672a5326a7606a8a766cbedb.md
@@ -1,7 +1,7 @@
 ---
 id: 672a5326a7606a8a766cbedb
 title: What Are Large Text or Braille Keyboards, and Who Uses Them?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-large-text-or-braille-keyboards
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-importance-of-accessibility-and-good-html-structure/672a533e6041c28ad680eb8f.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-importance-of-accessibility-and-good-html-structure/672a533e6041c28ad680eb8f.md
@@ -1,7 +1,7 @@
 ---
 id: 672a533e6041c28ad680eb8f
 title: What Are Alternative Pointing Devices Such as Trackballs, Joysticks, and Touchpads Used For?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-alternative-pointing-devices
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-importance-of-accessibility-and-good-html-structure/672a5361ef88158b25fbfba7.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-importance-of-accessibility-and-good-html-structure/672a5361ef88158b25fbfba7.md
@@ -1,7 +1,7 @@
 ---
 id: 672a5361ef88158b25fbfba7
 title: What Are Screen Magnifiers Used For?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-screen-magnifiers
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-importance-of-accessibility-and-good-html-structure/672a536f8386288b9ed0a154.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-importance-of-accessibility-and-good-html-structure/672a536f8386288b9ed0a154.md
@@ -1,7 +1,7 @@
 ---
 id: 672a536f8386288b9ed0a154
 title: What Is Voice Recognition Software Used For?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-voice-recognition-software
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-importance-of-accessibility-and-good-html-structure/672a537f05f3798bd4f57d2d.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-importance-of-accessibility-and-good-html-structure/672a537f05f3798bd4f57d2d.md
@@ -1,7 +1,7 @@
 ---
 id: 672a537f05f3798bd4f57d2d
 title: What Are Some Common Accessibility Auditing Tools to Use?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-some-common-accessibility-auditing-tools
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-importance-of-accessibility-and-good-html-structure/672a538c029f9e8c1687460e.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-importance-of-accessibility-and-good-html-structure/672a538c029f9e8c1687460e.md
@@ -1,7 +1,7 @@
 ---
 id: 672a538c029f9e8c1687460e
 title: How Does Proper Heading Level Structure Affect Accessibility?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-does-proper-heading-level-structure-affect-accessibility
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-importance-of-accessibility-and-good-html-structure/672a539b887ec68c593cdc4b.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-importance-of-accessibility-and-good-html-structure/672a539b887ec68c593cdc4b.md
@@ -1,7 +1,7 @@
 ---
 id: 672a539b887ec68c593cdc4b
 title: What Are Best Practices for Tables and Accessibility?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-best-practices-for-tables-and-accessibility
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-importance-of-accessibility-and-good-html-structure/672a53ae8f1ad28c8a1ed0f0.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-importance-of-accessibility-and-good-html-structure/672a53ae8f1ad28c8a1ed0f0.md
@@ -1,7 +1,7 @@
 ---
 id: 672a53ae8f1ad28c8a1ed0f0
 title: Why Is It Important for Inputs to Have an Associated Label?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: why-is-it-important-for-inputs-to-have-an-associated-label
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-importance-of-accessibility-and-good-html-structure/672a53cf67140d8cd85d4b0f.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-importance-of-accessibility-and-good-html-structure/672a53cf67140d8cd85d4b0f.md
@@ -1,7 +1,7 @@
 ---
 id: 672a53cf67140d8cd85d4b0f
 title: What Is the Purpose of WAI-ARIA, and How Does It Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-the-purpose-of-wai-aria
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-importance-of-accessibility-and-good-html-structure/672a549231b8728f7171ed9d.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-importance-of-accessibility-and-good-html-structure/672a549231b8728f7171ed9d.md
@@ -1,7 +1,7 @@
 ---
 id: 672a549231b8728f7171ed9d
 title: What Are ARIA Roles?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-aria-roles
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-importance-of-accessibility-and-good-html-structure/672a54a6675c168faa84252d.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-importance-of-accessibility-and-good-html-structure/672a54a6675c168faa84252d.md
@@ -1,7 +1,7 @@
 ---
 id: 672a54a6675c168faa84252d
 title: What Are the Roles of the aria-label and aria-labelledby Attributes?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-the-roles-of-the-aria-label-and-aria-labelledby-attributes
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-importance-of-accessibility-and-good-html-structure/672a54bc58319c8fe6f78ad4.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-importance-of-accessibility-and-good-html-structure/672a54bc58319c8fe6f78ad4.md
@@ -1,7 +1,7 @@
 ---
 id: 672a54bc58319c8fe6f78ad4
 title: What Is the aria-hidden Attribute, and How Does It Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-the-aria-hidden-attribute
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-importance-of-accessibility-and-good-html-structure/672a54ce90c19e9038f481d7.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-importance-of-accessibility-and-good-html-structure/672a54ce90c19e9038f481d7.md
@@ -1,7 +1,7 @@
 ---
 id: 672a54ce90c19e9038f481d7
 title: What Is the aria-expanded Attribute, and How Does It Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-the-aria-expanded-attribute
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-importance-of-accessibility-and-good-html-structure/672a54dff9dc439089f1a219.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-importance-of-accessibility-and-good-html-structure/672a54dff9dc439089f1a219.md
@@ -1,7 +1,7 @@
 ---
 id: 672a54dff9dc439089f1a219
 title: What Is the aria-live Attribute, and How Does It Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-the-aria-live-attribute
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-importance-of-accessibility-and-good-html-structure/672a54f29d783890d1f94740.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-importance-of-accessibility-and-good-html-structure/672a54f29d783890d1f94740.md
@@ -1,7 +1,7 @@
 ---
 id: 672a54f29d783890d1f94740
 title: What Are Some Common ARIA States Used on Custom Control Elements?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-some-common-aria-states-used-on-custom-control-elements
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-importance-of-accessibility-and-good-html-structure/672a5507d857a891139abc7f.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-importance-of-accessibility-and-good-html-structure/672a5507d857a891139abc7f.md
@@ -1,7 +1,7 @@
 ---
 id: 672a5507d857a891139abc7f
 title: What Is the aria-controls Attribute, and How Does It Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-the-aria-controls-attribute
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-importance-of-accessibility-and-good-html-structure/672a551975938a916c74802c.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-importance-of-accessibility-and-good-html-structure/672a551975938a916c74802c.md
@@ -1,7 +1,7 @@
 ---
 id: 672a551975938a916c74802c
 title: What Is the aria-describedby Attribute, and How Does It Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-the-aria-describedby-attribute
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-importance-of-accessibility-and-good-html-structure/672a55b5c0c14493328fe36e.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-importance-of-accessibility-and-good-html-structure/672a55b5c0c14493328fe36e.md
@@ -1,7 +1,7 @@
 ---
 id: 672a55b5c0c14493328fe36e
 title: When Is the alt Attribute Needed, and What Are Some Examples of Good Alt Text?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: when-is-the-alt-attribute-needed
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-importance-of-accessibility-and-good-html-structure/672a55dd1d86bc939606e204.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-importance-of-accessibility-and-good-html-structure/672a55dd1d86bc939606e204.md
@@ -1,7 +1,7 @@
 ---
 id: 672a55dd1d86bc939606e204
 title: What Are the Accessibility Benefits for Good Link Text, and What Are Examples of Good Link Text?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-the-accessibility-benefits-for-good-link-text
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-importance-of-accessibility-and-good-html-structure/672a55eb7791559421ff0cd3.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-importance-of-accessibility-and-good-html-structure/672a55eb7791559421ff0cd3.md
@@ -1,7 +1,7 @@
 ---
 id: 672a55eb7791559421ff0cd3
 title: What Are Good Ways to Make Audio and Video Content Accessible?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-good-ways-to-make-audio-and-video-content-accessible
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-importance-of-accessibility-and-good-html-structure/672a55fbc2d95a9453151caf.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-importance-of-accessibility-and-good-html-structure/672a55fbc2d95a9453151caf.md
@@ -1,7 +1,7 @@
 ---
 id: 672a55fbc2d95a9453151caf
 title: What Are Some Ways to Make Web Applications Keyboard Accessible?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-some-ways-to-make-web-applications-keyboard-accessible
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-importance-of-semantic-html/67298243760ae980de5266db.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-importance-of-semantic-html/67298243760ae980de5266db.md
@@ -1,7 +1,7 @@
 ---
 id: 67298243760ae980de5266db
 title: Why Should You Care About Semantic HTML?
-challengeType: 11
+challengeType: 24
 videoId: eS-0iTiT69U
 dashedName: why-should-you-care-about-semantic-html
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-importance-of-semantic-html/672985445d7da807c6b4f406.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-importance-of-semantic-html/672985445d7da807c6b4f406.md
@@ -1,7 +1,7 @@
 ---
 id: 672985445d7da807c6b4f406
 title: Why is it Important to Have Good Structural Hierarchy?
-challengeType: 11
+challengeType: 24
 videoId: FqHeH7vpmoU
 dashedName: why-is-it-important-to-have-good-structural-hierarchy
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-importance-of-semantic-html/672990ecf71a852804ababe7.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-importance-of-semantic-html/672990ecf71a852804ababe7.md
@@ -1,7 +1,7 @@
 ---
 id: 672990ecf71a852804ababe7
 title: What Is the Difference Between Presentational and Semantic HTML?
-challengeType: 11
+challengeType: 24
 videoId: b4h5D2tjNgY
 dashedName: what-is-the-difference-between-presentational-and-semantic-html
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-importance-of-semantic-html/6729959bf9c8e835f46b3f78.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-importance-of-semantic-html/6729959bf9c8e835f46b3f78.md
@@ -1,7 +1,7 @@
 ---
 id: 6729959bf9c8e835f46b3f78
 title: When Should You Use the Emphasis Element Over the Idiomatic Text Element?
-challengeType: 11
+challengeType: 24
 videoId: KMU335OtbWE
 dashedName: when-should-you-use-the-emphasis-element-over-the-idiomatic-text-element
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-importance-of-semantic-html/672995ac85fd943657c2ede5.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-importance-of-semantic-html/672995ac85fd943657c2ede5.md
@@ -1,7 +1,7 @@
 ---
 id: 672995ac85fd943657c2ede5
 title: When Should You Use the Strong Element Over the Bring Attention To Element?
-challengeType: 11
+challengeType: 24
 videoId: A2gclQIMRbc
 dashedName: when-should-you-use-the-strong-element-over-the-bring-attention-to-element
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-importance-of-semantic-html/672995bda6c67e369aaf8588.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-importance-of-semantic-html/672995bda6c67e369aaf8588.md
@@ -1,7 +1,7 @@
 ---
 id: 672995bda6c67e369aaf8588
 title: What Are Description Lists, and When Should You Use Them?
-challengeType: 11
+challengeType: 24
 videoId: s9Ypky95Jek
 dashedName: what-are-description-lists
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-importance-of-semantic-html/672995c9e6f69436dbcccc79.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-importance-of-semantic-html/672995c9e6f69436dbcccc79.md
@@ -1,7 +1,7 @@
 ---
 id: 672995c9e6f69436dbcccc79
 title: How Do Block and Inline Quotes Work in HTML?
-challengeType: 11
+challengeType: 24
 videoId: u3BtCj9caak
 dashedName: how-do-block-and-inline-quotes-work-in-html
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-importance-of-semantic-html/672995d673bd3237200b9e7c.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-importance-of-semantic-html/672995d673bd3237200b9e7c.md
@@ -1,7 +1,7 @@
 ---
 id: 672995d673bd3237200b9e7c
 title: How Do You Display Abbreviations and Acronyms in HTML?
-challengeType: 11
+challengeType: 24
 videoId: VdZ6_PM_cQs
 dashedName: how-do-you-display-abbreviations-and-acronyms-in-html
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-importance-of-semantic-html/672995e43674fb3775b9ec5d.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-importance-of-semantic-html/672995e43674fb3775b9ec5d.md
@@ -1,7 +1,7 @@
 ---
 id: 672995e43674fb3775b9ec5d
 title: How Do You Display Addresses in HTML?
-challengeType: 11
+challengeType: 24
 videoId: P1OCt7x5zSA
 dashedName: how-do-you-display-addresses-in-html
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-importance-of-semantic-html/672995f16ed97837b365a9f6.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-importance-of-semantic-html/672995f16ed97837b365a9f6.md
@@ -1,7 +1,7 @@
 ---
 id: 672995f16ed97837b365a9f6
 title: How Do You Display Times and Dates in HTML?
-challengeType: 11
+challengeType: 24
 videoId: gpY_PZC5Zl0
 dashedName: how-do-you-display-times-and-dates-in-html
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-importance-of-semantic-html/672995ffdfd2f337f5f215f8.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-importance-of-semantic-html/672995ffdfd2f337f5f215f8.md
@@ -1,7 +1,7 @@
 ---
 id: 672995ffdfd2f337f5f215f8
 title: How Do You Display Mathematical Equations and Chemical Formulas in HTML?
-challengeType: 11
+challengeType: 24
 videoId: QFxNWsesW6Q
 dashedName: how-do-you-display-mathematical-equations-and-chemical-formulas-in-html
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-importance-of-semantic-html/6729960ed6e2ca3825940e97.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-importance-of-semantic-html/6729960ed6e2ca3825940e97.md
@@ -1,7 +1,7 @@
 ---
 id: 6729960ed6e2ca3825940e97
 title: How Do You Represent Computer Code in HTML?
-challengeType: 11
+challengeType: 24
 videoId: sQt-STl2zoM
 dashedName: how-do-you-represent-computer-code-in-html
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-importance-of-semantic-html/6729963b1ab11638753cf082.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-importance-of-semantic-html/6729963b1ab11638753cf082.md
@@ -1,7 +1,7 @@
 ---
 id: 6729963b1ab11638753cf082
 title: What Are the U, S, and Ruby Elements Used For, and How Do They Work?
-challengeType: 11
+challengeType: 24
 videoId: YbmsYRjJpak
 dashedName: what-are-the-u-s-and-ruby-elements-used-for
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e3a9cc78faaf4248d335.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e3a9cc78faaf4248d335.md
@@ -1,7 +1,7 @@
 ---
 id: 6734e3a9cc78faaf4248d335
 title: What Is the Role of JS Libraries and Frameworks, and Why Are They Used in the Industry?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-the-role-of-js-libraries-and-frameworks-and-why-are-they-used-in-the-industry
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e867bbf41cc5b11648c4.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e867bbf41cc5b11648c4.md
@@ -1,7 +1,7 @@
 ---
 id: 6734e867bbf41cc5b11648c4
 title: What Are Single Page Applications, and What Are Some Issues Surrounding Them?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-single-page-applications-and-what-are-some-issues-surrounding-them
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e86f590727c5e7e9ec5e.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e86f590727c5e7e9ec5e.md
@@ -1,7 +1,7 @@
 ---
 id: 6734e86f590727c5e7e9ec5e
 title: What Is React, and What Is It Commonly Used For?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-react-and-what-is-it-commonly-used-for
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e879c78ee6c61db25b90.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e879c78ee6c61db25b90.md
@@ -1,7 +1,7 @@
 ---
 id: 6734e879c78ee6c61db25b90
 title: What Are Components in React, and How Do They Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-components-in-react-and-how-do-they-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e88cc46e6dc679420040.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e88cc46e6dc679420040.md
@@ -1,7 +1,7 @@
 ---
 id: 6734e88cc46e6dc679420040
 title: What is Vite and How Can It Be Used to Setup a New React Project?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-vite-and-how-can-it-be-used-to-setup-a-new-react-project
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/674ba6876f7ada867135bb95.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/674ba6876f7ada867135bb95.md
@@ -1,7 +1,7 @@
 ---
 id: 674ba6876f7ada867135bb95
 title: How Can You Import and Export Components in React?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-can-you-import-and-export-components-in-react
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript/672d26385dbe73203c4dac81.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript/672d26385dbe73203c4dac81.md
@@ -1,7 +1,7 @@
 ---
 id: 672d26385dbe73203c4dac81
 title: What Is JavaScript, and How Does It Work with HTML and CSS?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-javascript
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript/672d496eca926b5df8176a67.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript/672d496eca926b5df8176a67.md
@@ -1,7 +1,7 @@
 ---
 id: 672d496eca926b5df8176a67
 title: What Is a Data Type, and What Are the Different Data Types in JavaScript?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-a-data-type
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript/672d497cb1a1675e47bf7ea1.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript/672d497cb1a1675e47bf7ea1.md
@@ -1,7 +1,7 @@
 ---
 id: 672d497cb1a1675e47bf7ea1
 title: What Are Variables, and What Are Guidelines for Naming JavaScript Variables?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-variables
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript/672d49959621885e9d3e672c.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript/672d49959621885e9d3e672c.md
@@ -1,7 +1,7 @@
 ---
 id: 672d49959621885e9d3e672c
 title: How Do let and const Work Differently When It Comes to Variable Declaration, Assignment, and Reassignment?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-do-let-and-const-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript/672d49a5cf43945ee09e5fba.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript/672d49a5cf43945ee09e5fba.md
@@ -1,7 +1,7 @@
 ---
 id: 672d49a5cf43945ee09e5fba
 title: What Is a String in JavaScript, and What Is String Immutability?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-a-string
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript/672d49b2fb76df5f1d6117af.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript/672d49b2fb76df5f1d6117af.md
@@ -1,7 +1,7 @@
 ---
 id: 672d49b2fb76df5f1d6117af
 title: What Is String Concatenation, and How Can You Concatenate Strings with Variables?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-string-concatenation
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript/672d49c4e899345f5b33c24c.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript/672d49c4e899345f5b33c24c.md
@@ -1,7 +1,7 @@
 ---
 id: 672d49c4e899345f5b33c24c
 title: What Is console.log Used For, and How Does It Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-console-log
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript/672d49d93b54b85faa4dbad7.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript/672d49d93b54b85faa4dbad7.md
@@ -1,7 +1,7 @@
 ---
 id: 672d49d93b54b85faa4dbad7
 title: What Is the Role of Semicolons in JavaScript, and Programming in General?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-the-role-of-semicolons
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript/672d49e65a1c855fe7bb3fdb.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript/672d49e65a1c855fe7bb3fdb.md
@@ -1,7 +1,7 @@
 ---
 id: 672d49e65a1c855fe7bb3fdb
 title: What Are Comments in JavaScript, and When Should You Use Them?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-comments-in-javascript
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-styling-lists-and-links/672aa6441bcd3758e9f52ae0.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-styling-lists-and-links/672aa6441bcd3758e9f52ae0.md
@@ -1,7 +1,7 @@
 ---
 id: 672aa6441bcd3758e9f52ae0
 title: How Do You Space List Items Using margin or line-height?
-challengeType: 11
+challengeType: 24
 videoId: YQUWjqJQeAI
 dashedName: how-do-you-space-list-items-using-margin-or-line-height
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-styling-lists-and-links/672b951b1bf78038b1a2a0e7.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-styling-lists-and-links/672b951b1bf78038b1a2a0e7.md
@@ -1,7 +1,7 @@
 ---
 id: 672b951b1bf78038b1a2a0e7
 title: How Do the Different list-style Properties Work?
-challengeType: 11
+challengeType: 24
 videoId: 6ZC__eE23AM
 dashedName: how-do-the-different-list-style-properties-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-styling-lists-and-links/672b952d3a5c603908841971.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-styling-lists-and-links/672b952d3a5c603908841971.md
@@ -1,7 +1,7 @@
 ---
 id: 672b952d3a5c603908841971
 title: Why Are Default Link Styles Important for Usability on the Web?
-challengeType: 11
+challengeType: 24
 videoId: Jp3Qd4LU93E
 dashedName: why-are-default-link-styles-important-for-usability-on-the-web
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-styling-lists-and-links/672b9538c25634394ceb7b8f.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-styling-lists-and-links/672b9538c25634394ceb7b8f.md
@@ -1,7 +1,7 @@
 ---
 id: 672b9538c25634394ceb7b8f
 title: How Do You Style the Different Link States?
-challengeType: 11
+challengeType: 24
 videoId: TvKcF2R6JmA
 dashedName: how-do-you-style-the-different-link-states
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-the-var-keyword-and-hoisting/67329fbcfaf5ff5cdaa38a42.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-the-var-keyword-and-hoisting/67329fbcfaf5ff5cdaa38a42.md
@@ -1,7 +1,7 @@
 ---
 id: 67329fbcfaf5ff5cdaa38a42
 title: What Is the var Keyword, and Why Is It No Longer Suggested to Use It?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-the-var-keyword-and-why-is-it-no-longer-suggested-to-use-it
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-the-var-keyword-and-hoisting/67335f45489c5a11b71d0ed5.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-the-var-keyword-and-hoisting/67335f45489c5a11b71d0ed5.md
@@ -1,7 +1,7 @@
 ---
 id: 67335f45489c5a11b71d0ed5
 title: What Is Hoisting?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-hoisting
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-understanding-asynchronous-programming/6733b072bd8f5b06ccdbd9e2.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-understanding-asynchronous-programming/6733b072bd8f5b06ccdbd9e2.md
@@ -1,7 +1,7 @@
 ---
 id: 6733b072bd8f5b06ccdbd9e2
 title: What Is Asynchronous JavaScript, and How Does It Differ from Synchronous JavaScript?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-asynchronous-javascript-and-how-does-it-differ-from-synchronous-javascript
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-understanding-asynchronous-programming/67340798c2c1776709d8a5fe.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-understanding-asynchronous-programming/67340798c2c1776709d8a5fe.md
@@ -1,7 +1,7 @@
 ---
 id: 67340798c2c1776709d8a5fe
 title: How Does the Async Attribute Work Inside Script Elements, and How Does It Differ from the Defer Attribute?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-does-the-async-attribute-work-inside-script-elements-and-how-does-it-differ-from-the-defer-attribute
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-understanding-asynchronous-programming/673407a223891b6734563c89.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-understanding-asynchronous-programming/673407a223891b6734563c89.md
@@ -1,7 +1,7 @@
 ---
 id: 673407a223891b6734563c89
 title: What Is the Fetch API, and What Are Common Types of Resources That Are Fetched from the Network?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-the-fetch-api-and-what-are-common-types-of-resources-that-are-fetched-from-the-network
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-understanding-asynchronous-programming/673407be6af21d6766ed4b96.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-understanding-asynchronous-programming/673407be6af21d6766ed4b96.md
@@ -1,7 +1,7 @@
 ---
 id: 673407be6af21d6766ed4b96
 title: How Does the Fetch API Work with Common HTTP Methods and res.json()?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-does-the-fetch-api-work-with-common-http-methods-and-res-json
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-understanding-asynchronous-programming/673407ca21117a67cf9521ca.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-understanding-asynchronous-programming/673407ca21117a67cf9521ca.md
@@ -1,7 +1,7 @@
 ---
 id: 673407ca21117a67cf9521ca
 title: What Are Promises, and How Does Promise Chaining Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-promises-and-how-does-promise-chaining-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-understanding-asynchronous-programming/673407d56c3dce67fa97969b.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-understanding-asynchronous-programming/673407d56c3dce67fa97969b.md
@@ -1,7 +1,7 @@
 ---
 id: 673407d56c3dce67fa97969b
 title: What Is Async/Await, and How Does It Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-async-await-and-how-does-it-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-understanding-asynchronous-programming/673407e02bcf0d682b9a49a9.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-understanding-asynchronous-programming/673407e02bcf0d682b9a49a9.md
@@ -1,7 +1,7 @@
 ---
 id: 673407e02bcf0d682b9a49a9
 title: How Does the JavaScript Engine Work, and What Is a JavaScript Runtime?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-does-the-javascript-engine-work-and-what-is-a-javascript-runtime
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-understanding-asynchronous-programming/673407eb10ca9d68634e81d9.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-understanding-asynchronous-programming/673407eb10ca9d68634e81d9.md
@@ -1,7 +1,7 @@
 ---
 id: 673407eb10ca9d68634e81d9
 title: What Is the Geolocation API, and How Does the getCurrentPosition Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-the-geolocation-api-and-how-does-the-getcurrentposition-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-understanding-comparisons-and-conditionals/672d26917a8ab3220c038a42.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-understanding-comparisons-and-conditionals/672d26917a8ab3220c038a42.md
@@ -1,7 +1,7 @@
 ---
 id: 672d26917a8ab3220c038a42
 title: How Do Comparisons Work with Null and Undefined Data Types?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-do-comparisons-work-with-null-and-undefined-data-types
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-understanding-comparisons-and-conditionals/673282bea35dbf129efb63d6.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-understanding-comparisons-and-conditionals/673282bea35dbf129efb63d6.md
@@ -1,7 +1,7 @@
 ---
 id: 673282bea35dbf129efb63d6
 title: What Are Switch Statements and How Do They Differ from If/Else Chains?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-switch-statements-and-how-do-they-differ-from-if-else-chains
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-understanding-computer-internet-and-tooling-basics/672aa578a2129554d4675049.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-understanding-computer-internet-and-tooling-basics/672aa578a2129554d4675049.md
@@ -1,7 +1,7 @@
 ---
 id: 672aa578a2129554d4675049
 title: What Are the Basic Parts of a Computer?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-the-basic-parts-of-a-computer
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-understanding-computer-internet-and-tooling-basics/672ab82c1a9bbd0e3aabc39d.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-understanding-computer-internet-and-tooling-basics/672ab82c1a9bbd0e3aabc39d.md
@@ -1,7 +1,7 @@
 ---
 id: 672ab82c1a9bbd0e3aabc39d
 title: How Can You Effectively Work With Your Keyboard, Mouse, and Other Pointing Devices
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-to-effectively-work-with-your-keyboard-mouse-and-other-pointing-devices
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-understanding-computer-internet-and-tooling-basics/672ab83c4297910eade53c2e.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-understanding-computer-internet-and-tooling-basics/672ab83c4297910eade53c2e.md
@@ -1,7 +1,7 @@
 ---
 id: 672ab83c4297910eade53c2e
 title: What Are the Different Types of Internet Service Providers?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-the-different-types-of-internet-service-providers
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-understanding-computer-internet-and-tooling-basics/672ab849aa1ef70eefd29364.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-understanding-computer-internet-and-tooling-basics/672ab849aa1ef70eefd29364.md
@@ -1,7 +1,7 @@
 ---
 id: 672ab849aa1ef70eefd29364
 title: What Are Safe Ways to Sign Into Your Computer?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-safe-ways-to-sign-into-your-computer
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-understanding-computer-internet-and-tooling-basics/672ab8573f32480f192aaae1.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-understanding-computer-internet-and-tooling-basics/672ab8573f32480f192aaae1.md
@@ -1,7 +1,7 @@
 ---
 id: 672ab8573f32480f192aaae1
 title: What Are the Different Types of Tools Professional Developers Use?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-the-different-types-of-tools-professional-developers-use
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-understanding-core-javascript-fundamentals/67329f9e9eb84e5c6a5e4366.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-understanding-core-javascript-fundamentals/67329f9e9eb84e5c6a5e4366.md
@@ -1,7 +1,7 @@
 ---
 id: 67329f9e9eb84e5c6a5e4366
 title: What Is a String Object, and How Does It Differ from String Primitive?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-a-string-object-and-how-does-it-differ-from-string-primitive
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-understanding-core-javascript-fundamentals/6732c68f4520d160584a6fd2.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-understanding-core-javascript-fundamentals/6732c68f4520d160584a6fd2.md
@@ -1,7 +1,7 @@
 ---
 id: 6732c68f4520d160584a6fd2
 title: What Is the toString() Method, and How Does It Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-the-tostring-method-and-how-does-it-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-understanding-core-javascript-fundamentals/6732c69d82814160951b1aa7.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-understanding-core-javascript-fundamentals/6732c69d82814160951b1aa7.md
@@ -1,7 +1,7 @@
 ---
 id: 6732c69d82814160951b1aa7
 title: What Is the Number Constructor, and How Does It Work for Type Coercion?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-the-number-constructor-and-how-does-it-work-for-type-coercion
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-understanding-core-javascript-fundamentals/6732c6ab21031b60d2b0c999.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-understanding-core-javascript-fundamentals/6732c6ab21031b60d2b0c999.md
@@ -1,7 +1,7 @@
 ---
 id: 6732c6ab21031b60d2b0c999
 title: What Are Some Common Practices for Naming Variables and Functions?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-some-common-practices-for-naming-variables-and-functions
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-understanding-core-javascript-fundamentals/6732c6ba2ea42b610b9f9ce1.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-understanding-core-javascript-fundamentals/6732c6ba2ea42b610b9f9ce1.md
@@ -1,7 +1,7 @@
 ---
 id: 6732c6ba2ea42b610b9f9ce1
 title: How Do You Get the Length for an Array, and How Can You Create an Empty Array of Fixed Length?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-do-you-get-the-length-for-an-array-and-how-can-you-create-an-empty-array-of-fixed-length
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-understanding-core-javascript-fundamentals/6732c6c72d3738614e1230a2.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-understanding-core-javascript-fundamentals/6732c6c72d3738614e1230a2.md
@@ -1,7 +1,7 @@
 ---
 id: 6732c6c72d3738614e1230a2
 title: What Are Linters and Formatters, and How Can They Help You with Code Consistency?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-linters-and-formatters-and-how-can-they-help-you-with-code-consistency
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-understanding-core-javascript-fundamentals/6732c6d4dec34c61850a1276.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-understanding-core-javascript-fundamentals/6732c6d4dec34c61850a1276.md
@@ -1,7 +1,7 @@
 ---
 id: 6732c6d4dec34c61850a1276
 title: What Is Memory Management, and How Does It Work in JavaScript?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-memory-management-and-how-does-it-work-in-javascript
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-understanding-core-javascript-fundamentals/6732c6e281c14a61c4858361.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-understanding-core-javascript-fundamentals/6732c6e281c14a61c4858361.md
@@ -1,7 +1,7 @@
 ---
 id: 6732c6e281c14a61c4858361
 title: What Are Closures, and How Do They Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-closures-and-how-do-they-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-understanding-form-validation/6733aae9d25004f60d1e86f2.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-understanding-form-validation/6733aae9d25004f60d1e86f2.md
@@ -1,7 +1,7 @@
 ---
 id: 6733aae9d25004f60d1e86f2
 title: What Are Some Ways to Validate Forms Using JavaScript?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-some-ways-to-validate-forms-using-javascript
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-understanding-form-validation/6733d3a33abdd27cd562bdf2.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-understanding-form-validation/6733d3a33abdd27cd562bdf2.md
@@ -1,7 +1,7 @@
 ---
 id: 6733d3a33abdd27cd562bdf2
 title: What Is the Purpose of e.preventDefault?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-the-purpose-of-e-preventdefault
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-understanding-form-validation/6733d3ab69e94b7df7ee91b0.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-understanding-form-validation/6733d3ab69e94b7df7ee91b0.md
@@ -1,7 +1,7 @@
 ---
 id: 6733d3ab69e94b7df7ee91b0
 title: How Does the Submit Event Work with Forms?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-does-the-submit-event-work-with-forms
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-understanding-functional-programming/6733b0451d6be0065430b418.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-understanding-functional-programming/6733b0451d6be0065430b418.md
@@ -1,7 +1,7 @@
 ---
 id: 6733b0451d6be0065430b418
 title: What Is Functional Programming?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-functional-programming
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-understanding-functional-programming/6734061fe116df617a564a37.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-understanding-functional-programming/6734061fe116df617a564a37.md
@@ -1,7 +1,7 @@
 ---
 id: 6734061fe116df617a564a37
 title: What Is Currying, and How Does It Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-currying-and-how-does-it-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-understanding-how-to-work-with-classes-in-javascript/6733affc29df1304e2c97e88.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-understanding-how-to-work-with-classes-in-javascript/6733affc29df1304e2c97e88.md
@@ -1,7 +1,7 @@
 ---
 id: 6733affc29df1304e2c97e88
 title: What Are Classes, and How Do They Work in JavaScript?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-classes-and-how-do-they-work-in-javascript
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-understanding-how-to-work-with-classes-in-javascript/673403ca2bb16658309e3632.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-understanding-how-to-work-with-classes-in-javascript/673403ca2bb16658309e3632.md
@@ -1,7 +1,7 @@
 ---
 id: 673403ca2bb16658309e3632
 title: How Does the This Keyword Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-does-the-this-keyword-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-understanding-how-to-work-with-classes-in-javascript/673403d2aa52d8586a14a269.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-understanding-how-to-work-with-classes-in-javascript/673403d2aa52d8586a14a269.md
@@ -1,7 +1,7 @@
 ---
 id: 673403d2aa52d8586a14a269
 title: What Is Class Inheritance, and How Does It Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-class-inheritance-and-how-does-it-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-understanding-how-to-work-with-classes-in-javascript/673403dbf5c9835898632c84.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-understanding-how-to-work-with-classes-in-javascript/673403dbf5c9835898632c84.md
@@ -1,7 +1,7 @@
 ---
 id: 673403dbf5c9835898632c84
 title: What Are Static Properties and Methods in Classes?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-static-properties-and-methods-in-classes
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-understanding-how-to-work-with-floats-and-positioning-in-css/672aa86da9937560d3dfe3d6.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-understanding-how-to-work-with-floats-and-positioning-in-css/672aa86da9937560d3dfe3d6.md
@@ -1,7 +1,7 @@
 ---
 id: 672aa86da9937560d3dfe3d6
 title: What Are Common Use Cases for Using Floats, and How Do They Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-common-use-cases-for-using-floats
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-understanding-how-to-work-with-floats-and-positioning-in-css/672c3a84fb8d4613776cc99e.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-understanding-how-to-work-with-floats-and-positioning-in-css/672c3a84fb8d4613776cc99e.md
@@ -1,7 +1,7 @@
 ---
 id: 672c3a84fb8d4613776cc99e
 title: What Is Relative Positioning, and How Does This Differ from the Default Static Positioning?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-relative-positioning
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-understanding-how-to-work-with-floats-and-positioning-in-css/672c3a8fac7c5613b4bb75de.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-understanding-how-to-work-with-floats-and-positioning-in-css/672c3a8fac7c5613b4bb75de.md
@@ -1,7 +1,7 @@
 ---
 id: 672c3a8fac7c5613b4bb75de
 title: What Is Absolute Positioning, and How Does It Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-absolute-positioning
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-understanding-how-to-work-with-floats-and-positioning-in-css/672c3a9d32c56113fcaedf24.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-understanding-how-to-work-with-floats-and-positioning-in-css/672c3a9d32c56113fcaedf24.md
@@ -1,7 +1,7 @@
 ---
 id: 672c3a9d32c56113fcaedf24
 title: What Is Fixed and Sticky Positioning, and How Does It Differ from Absolute Positioning?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-fixed-and-sticky-positioning
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-understanding-how-to-work-with-floats-and-positioning-in-css/672c3aa9bc3a481425cb52b3.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-understanding-how-to-work-with-floats-and-positioning-in-css/672c3aa9bc3a481425cb52b3.md
@@ -1,7 +1,7 @@
 ---
 id: 672c3aa9bc3a481425cb52b3
 title: What Is the Z-Index Property, and How Does It Work to Control the Stacking of Positioned Elements?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-the-z-index-property
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-understanding-modules-imports-and-exports/67329fd6ad99c75d4a4b74e4.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-understanding-modules-imports-and-exports/67329fd6ad99c75d4a4b74e4.md
@@ -1,7 +1,7 @@
 ---
 id: 67329fd6ad99c75d4a4b74e4
 title: What Is a Module in JavaScript, and How Can You Import and Export Modules in Your Program?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-a-module-in-javascript-and-how-can-you-import-and-export-modules-in-your-program
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-understanding-recursion-and-the-call-stack/6733b02d1e556005a544c5e3.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-understanding-recursion-and-the-call-stack/6733b02d1e556005a544c5e3.md
@@ -1,7 +1,7 @@
 ---
 id: 6733b02d1e556005a544c5e3
 title: What Is Recursion, and How Does It Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-recursion-and-how-does-it-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-understanding-the-event-object-and-event-delegation/6732a06aed1b095f57b0bb82.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-understanding-the-event-object-and-event-delegation/6732a06aed1b095f57b0bb82.md
@@ -1,7 +1,7 @@
 ---
 id: 6732a06aed1b095f57b0bb82
 title: What Is the Change Event, and How Does It Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-the-change-event-and-how-does-it-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-understanding-the-event-object-and-event-delegation/67338e93b75977a344cf6d40.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-understanding-the-event-object-and-event-delegation/67338e93b75977a344cf6d40.md
@@ -1,7 +1,7 @@
 ---
 id: 67338e93b75977a344cf6d40
 title: How Do Event Bubbling, and Event Delegation Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-do-event-bubbling-and-event-delegation-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-user-centered-design/672aa6ee9011775b27e23399.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-user-centered-design/672aa6ee9011775b27e23399.md
@@ -1,7 +1,7 @@
 ---
 id: 672aa6ee9011775b27e23399
 title: What Is User-Centered Design?
-challengeType: 11
+challengeType: 24
 videoId: 1OBUf7Jdcmk
 dashedName: what-is-user-centered-design
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-user-centered-design/672bafd715f6ba77d57f3ec0.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-user-centered-design/672bafd715f6ba77d57f3ec0.md
@@ -1,7 +1,7 @@
 ---
 id: 672bafd715f6ba77d57f3ec0
 title: What Are User Requirements, User Research, and Testing?
-challengeType: 11
+challengeType: 24
 videoId: U3AE224w-d0
 dashedName: what-is-user-research-and-testing-and-user-requirements
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-user-centered-design/672bafe4ef812b78696b0e27.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-user-centered-design/672bafe4ef812b78696b0e27.md
@@ -1,7 +1,7 @@
 ---
 id: 672bafe4ef812b78696b0e27
 title: What Are Best Practices for Designing a Dark Mode Feature?
-challengeType: 11
+challengeType: 24
 videoId: fhW5T_fJnLI
 dashedName: what-are-best-practices-for-designing-a-dark-mode-feature
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-user-centered-design/672baff13bc5b3789691c75c.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-user-centered-design/672baff13bc5b3789691c75c.md
@@ -1,7 +1,7 @@
 ---
 id: 672baff13bc5b3789691c75c
 title: What Are Best Practices for Designing Breadcrumbs?
-challengeType: 11
+challengeType: 24
 videoId: u5PbtBwcdFE
 dashedName: what-are-best-practices-for-designing-breadcrumbs
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-user-centered-design/672baffc684be178dd02fa06.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-user-centered-design/672baffc684be178dd02fa06.md
@@ -1,7 +1,7 @@
 ---
 id: 672baffc684be178dd02fa06
 title: What Are Best Practices for Designing Cards?
-challengeType: 11
+challengeType: 24
 videoId: IfHiiYdvQ3I
 dashedName: what-are-best-practices-for-designing-cards
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-user-centered-design/672bb009952c7a7904a750cb.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-user-centered-design/672bb009952c7a7904a750cb.md
@@ -1,7 +1,7 @@
 ---
 id: 672bb009952c7a7904a750cb
 title: What Are Best Practices for Designing Infinite Scrolls?
-challengeType: 11
+challengeType: 24
 videoId: yOpOd3gudQw
 dashedName: what-are-best-practices-for-designing-infinite-scrolls
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-user-centered-design/672bb015cfc889794359c4e0.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-user-centered-design/672bb015cfc889794359c4e0.md
@@ -1,7 +1,7 @@
 ---
 id: 672bb015cfc889794359c4e0
 title: What Are Best Practices for Designing Modal Dialogs?
-challengeType: 11
+challengeType: 24
 videoId: PbGkibOy27M
 dashedName: what-are-best-practices-for-designing-modal-dialogs
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-user-centered-design/672bb02009ffc0797ca567ab.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-user-centered-design/672bb02009ffc0797ca567ab.md
@@ -1,7 +1,7 @@
 ---
 id: 672bb02009ffc0797ca567ab
 title: What Are Best Practices for Progress Indication on Forms, Registration, and Setup?
-challengeType: 11
+challengeType: 24
 videoId: 1GLv71oPffs
 dashedName: what-are-best-practices-for-progress-indication-on-forms-registration-and-setup
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-user-centered-design/672bb02ecb230779bbbaccd9.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-user-centered-design/672bb02ecb230779bbbaccd9.md
@@ -1,7 +1,7 @@
 ---
 id: 672bb02ecb230779bbbaccd9
 title: What Are Best Practices for Designing Shopping Carts?
-challengeType: 11
+challengeType: 24
 videoId: _j1vT9yHN9w
 dashedName: what-are-best-practices-for-designing-shopping-carts
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-user-centered-design/672bb03999f39379f67d8972.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-user-centered-design/672bb03999f39379f67d8972.md
@@ -1,7 +1,7 @@
 ---
 id: 672bb03999f39379f67d8972
 title: What Is Progressive Disclosure?
-challengeType: 11
+challengeType: 24
 videoId: Qy29tDRCJl4
 dashedName: what-is-progressive-disclosure
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-user-centered-design/672bb04476b1997a1da8b79b.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-user-centered-design/672bb04476b1997a1da8b79b.md
@@ -1,7 +1,7 @@
 ---
 id: 672bb04476b1997a1da8b79b
 title: What Is Deferred and Lazy Registration?
-challengeType: 11
+challengeType: 24
 videoId: itW2wgtgC3A
 dashedName: what-is-deferred-and-lazy-registration
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-user-interface-design-fundamentals/672aa6c9e379285acca5a2aa.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-user-interface-design-fundamentals/672aa6c9e379285acca5a2aa.md
@@ -1,7 +1,7 @@
 ---
 id: 672aa6c9e379285acca5a2aa
 title: What Are Common Design Terms to Help You Communicate with Designers?
-challengeType: 11
+challengeType: 24
 videoId: lLchbUmf8Lw
 dashedName: what-are-common-design-terms-to-help-you-communicate-with-designers
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-user-interface-design-fundamentals/672baa97f2990e6631d522e7.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-user-interface-design-fundamentals/672baa97f2990e6631d522e7.md
@@ -1,7 +1,7 @@
 ---
 id: 672baa97f2990e6631d522e7
 title: How Do You Create Good Background and Foreground Contrast in Your Designs?
-challengeType: 11
+challengeType: 24
 videoId: VjKxo-QAz5k
 dashedName: how-do-you-create-good-background-and-foreground-contrast-in-your-designs
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-user-interface-design-fundamentals/672baaa62d4b46667a8ac869.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-user-interface-design-fundamentals/672baaa62d4b46667a8ac869.md
@@ -1,7 +1,7 @@
 ---
 id: 672baaa62d4b46667a8ac869
 title: What Is the Importance of Good Visual Hierarchy in Design?
-challengeType: 11
+challengeType: 24
 videoId: mO7-xcBtftg
 dashedName: what-is-the-importance-of-good-visual-hierarchy-in-design
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-user-interface-design-fundamentals/672baab2a0c3df66ad987b94.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-user-interface-design-fundamentals/672baab2a0c3df66ad987b94.md
@@ -1,7 +1,7 @@
 ---
 id: 672baab2a0c3df66ad987b94
 title: How Does Scale Work in Design?
-challengeType: 11
+challengeType: 24
 videoId: v-6Yh-GnDtg
 dashedName: how-does-scale-work-in-design
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-user-interface-design-fundamentals/672baabf16290b66e6b79a39.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-user-interface-design-fundamentals/672baabf16290b66e6b79a39.md
@@ -1,7 +1,7 @@
 ---
 id: 672baabf16290b66e6b79a39
 title: How Does Alignment Work in Design?
-challengeType: 11
+challengeType: 24
 videoId: pdU32PTAb28
 dashedName: how-does-alignment-work-in-design
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-user-interface-design-fundamentals/672baacb7f2f446728e77efe.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-user-interface-design-fundamentals/672baacb7f2f446728e77efe.md
@@ -1,7 +1,7 @@
 ---
 id: 672baacb7f2f446728e77efe
 title: What Is the Importance of Whitespace in Design?
-challengeType: 11
+challengeType: 24
 videoId: _gG8xxq1TcA
 dashedName: what-is-the-importance-of-whitespace-in-design
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-user-interface-design-fundamentals/672baad7bbc4f86762ca173e.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-user-interface-design-fundamentals/672baad7bbc4f86762ca173e.md
@@ -1,7 +1,7 @@
 ---
 id: 672baad7bbc4f86762ca173e
 title: What Are Best Practices for Working with Images in Your Designs?
-challengeType: 11
+challengeType: 24
 videoId: CYHzEAPnPzU
 dashedName: what-are-best-practices-for-working-with-images-in-your-designs
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-user-interface-design-fundamentals/672baae11d06c867a16f64e1.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-user-interface-design-fundamentals/672baae11d06c867a16f64e1.md
@@ -1,7 +1,7 @@
 ---
 id: 672baae11d06c867a16f64e1
 title: What Is Progressive Enhancement?
-challengeType: 11
+challengeType: 24
 videoId: G-LBLlpdNGg
 dashedName: what-is-progressive-enhancement
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-welcome-to-freecodecamp/6734e2c5780912abd874e79c.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-welcome-to-freecodecamp/6734e2c5780912abd874e79c.md
@@ -1,7 +1,7 @@
 ---
 id: 6734e2c5780912abd874e79c
 title: How Does the Certification Process Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-does-the-certification-process-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-welcome-to-freecodecamp/6734e2dcb965e5ac0ea38e0f.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-welcome-to-freecodecamp/6734e2dcb965e5ac0ea38e0f.md
@@ -1,7 +1,7 @@
 ---
 id: 6734e2dcb965e5ac0ea38e0f
 title: How to Develop Effective Learning Habits
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-to-develop-effective-learning-habits
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-what-is-css/672aa5e1f8b935577acfb2b9.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-what-is-css/672aa5e1f8b935577acfb2b9.md
@@ -1,7 +1,7 @@
 ---
 id: 672aa5e1f8b935577acfb2b9
 title: What Is CSS, and What Is Its Role on the Web?
-challengeType: 11
+challengeType: 24
 videoId: yqcOCDoE29w
 dashedName: what-is-css
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-what-is-css/672acbbe2891564c4e316164.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-what-is-css/672acbbe2891564c4e316164.md
@@ -1,7 +1,7 @@
 ---
 id: 672acbbe2891564c4e316164
 title: What Is the Basic Anatomy of a CSS Rule?
-challengeType: 11
+challengeType: 24
 videoId: s4rjwX3zWCs
 dashedName: what-is-the-basic-anatomy-of-a-css-rule
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-what-is-css/672acbce8163374c903253c9.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-what-is-css/672acbce8163374c903253c9.md
@@ -1,7 +1,7 @@
 ---
 id: 672acbce8163374c903253c9
 title: What Is the Meta Viewport Element Used For?
-challengeType: 11
+challengeType: 24
 videoId: 8X647U15ZFo
 dashedName: what-is-the-meta-viewport-element-used-for
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-what-is-css/672acbdd06b44c4cd3bf8713.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-what-is-css/672acbdd06b44c4cd3bf8713.md
@@ -1,7 +1,7 @@
 ---
 id: 672acbdd06b44c4cd3bf8713
 title: What Are Some Default Browser Styles Applied to HTML?
-challengeType: 11
+challengeType: 24
 videoId: 6njPY1xaE8k
 dashedName: what-are-some-default-browser-styles-applied-to-html
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-what-is-css/672acbf7490c054d213a8c1f.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-what-is-css/672acbf7490c054d213a8c1f.md
@@ -1,7 +1,7 @@
 ---
 id: 672acbf7490c054d213a8c1f
 title: What Are Inline, Internal, and External CSS, and When Should You Use Each One?
-challengeType: 11
+challengeType: 24
 videoId: BmzjTr_bnSs
 dashedName: what-are-inline-internal-and-external-css
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-what-is-css/672acc03c257524d6a5151e8.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-what-is-css/672acc03c257524d6a5151e8.md
@@ -1,7 +1,7 @@
 ---
 id: 672acc03c257524d6a5151e8
 title: How Do Width and Height Work?
-challengeType: 11
+challengeType: 24
 videoId: IFVdOw40EK0
 dashedName: how-do-width-and-height-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-what-is-css/672acc100d59d24da7b4e09c.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-what-is-css/672acc100d59d24da7b4e09c.md
@@ -1,7 +1,7 @@
 ---
 id: 672acc100d59d24da7b4e09c
 title: What Are the Different Types of CSS Combinators?
-challengeType: 11
+challengeType: 24
 videoId: fk16FfT6jpU
 dashedName: what-are-the-different-types-of-css-combinators
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-what-is-css/672acc1e24c1e54df5ad89bd.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-what-is-css/672acc1e24c1e54df5ad89bd.md
@@ -1,7 +1,7 @@
 ---
 id: 672acc1e24c1e54df5ad89bd
 title: What Is the Difference Between Inline and Block-Level Elements in CSS?
-challengeType: 11
+challengeType: 24
 videoId: u4OnJrEwfY0
 dashedName: what-is-the-difference-between-inline-and-block-level-elements-in-css
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-what-is-css/672acc3f6f3e3c4e31ec3e12.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-what-is-css/672acc3f6f3e3c4e31ec3e12.md
@@ -1,7 +1,7 @@
 ---
 id: 672acc3f6f3e3c4e31ec3e12
 title: How Does Inline-Block Work, and How Does It Differ from Inline and Block Elements?
-challengeType: 11
+challengeType: 24
 videoId: PFQnVbZvZJY
 dashedName: how-does-inline-block-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-what-is-css/672acc538e6ef24e9dd3c94f.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-what-is-css/672acc538e6ef24e9dd3c94f.md
@@ -1,7 +1,7 @@
 ---
 id: 672acc538e6ef24e9dd3c94f
 title: What Are Margins and Padding, and How Do They Work?
-challengeType: 11
+challengeType: 24
 videoId: Y3kOn6bRWRQ
 dashedName: what-are-margins-and-padding
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-what-is-html/66f6db08d55022680a3cfbc9.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-what-is-html/66f6db08d55022680a3cfbc9.md
@@ -1,7 +1,7 @@
 ---
 id: 66f6db08d55022680a3cfbc9
 title: What Is HTML, and What Role Does It Play on the Web?
-challengeType: 11
+challengeType: 24
 videoId: Me-GFJKL-9E
 dashedName: what-is-html
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-arrays/67329f508a6ec45b046700b3.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-arrays/67329f508a6ec45b046700b3.md
@@ -1,7 +1,7 @@
 ---
 id: 67329f508a6ec45b046700b3
 title: What Are the Key Characteristics of JavaScript Arrays?
-challengeType: 11
+challengeType: 24
 videoId: 9NrHUUdAbvo
 dashedName: what-are-the-key-characteristics-of-javascript-arrays
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-arrays/6732aebaa8abb9086a9bb17a.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-arrays/6732aebaa8abb9086a9bb17a.md
@@ -1,7 +1,7 @@
 ---
 id: 6732aebaa8abb9086a9bb17a
 title: How Do You Access and Update Elements in an Array?
-challengeType: 11
+challengeType: 24
 videoId: 7J_uai_mqic
 dashedName: how-do-you-access-and-update-elements-in-an-array
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-arrays/6732aec982904608b637716b.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-arrays/6732aec982904608b637716b.md
@@ -1,7 +1,7 @@
 ---
 id: 6732aec982904608b637716b
 title: How Do You Add and Remove Elements from the Beginning and End of an Array?
-challengeType: 11
+challengeType: 24
 videoId: P0kM47wpYk0
 dashedName: how-do-you-add-and-remove-elements-from-the-beginning-and-end-of-an-array
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-arrays/6732aed2ac3d3c08f6149dd6.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-arrays/6732aed2ac3d3c08f6149dd6.md
@@ -1,7 +1,7 @@
 ---
 id: 6732aed2ac3d3c08f6149dd6
 title: What Is the Difference Between One-Dimensional and Two-Dimensional Arrays?
-challengeType: 11
+challengeType: 24
 videoId: gxZjhCCEYII
 dashedName: what-is-the-difference-between-one-dimensional-and-two-dimensional-arrays
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-arrays/6732aedd2d92e30923b9bc24.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-arrays/6732aedd2d92e30923b9bc24.md
@@ -1,7 +1,7 @@
 ---
 id: 6732aedd2d92e30923b9bc24
 title: What Is Array Destructuring, and How Does It Work?
-challengeType: 11
+challengeType: 24
 videoId: _h0kbN13AVY
 dashedName: what-is-array-destructuring-and-how-does-it-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-attribute-selectors/672aa840de72b3607bba4bed.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-attribute-selectors/672aa840de72b3607bba4bed.md
@@ -1,7 +1,7 @@
 ---
 id: 672aa840de72b3607bba4bed
 title: What Is the Attribute Selector, and How Can It Be Used to Target Links with the href and title Attributes?
-challengeType: 11
+challengeType: 24
 videoId: Qknh5QKRCEk
 dashedName: what-is-the-attribute-selector
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-attribute-selectors/672c37498952920879c43de9.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-attribute-selectors/672c37498952920879c43de9.md
@@ -1,7 +1,7 @@
 ---
 id: 672c37498952920879c43de9
 title: How to Use the Attribute Selector to Target Elements with the lang and data-lang Attributes?
-challengeType: 11
+challengeType: 24
 videoId: RxGaefX-ROY
 dashedName: how-to-use-the-attribute-selector-to-target-elements-with-the-lang-and-data-lang-attributes
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-attribute-selectors/672c375857128708d04d0e22.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-attribute-selectors/672c375857128708d04d0e22.md
@@ -1,7 +1,7 @@
 ---
 id: 672c375857128708d04d0e22
 title: How to Use the Attribute Selector to Target Ordered List Elements with the type Attribute?
-challengeType: 11
+challengeType: 24
 videoId: 5ldovhY8R5U
 dashedName: how-to-use-the-attribute-selector-to-target-ordered-list-elements-with-the-type-attribute
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-audio-and-video/6733ab12b60bd7f6b2b0b0c0.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-audio-and-video/6733ab12b60bd7f6b2b0b0c0.md
@@ -1,7 +1,7 @@
 ---
 id: 6733ab12b60bd7f6b2b0b0c0
 title: How Does the Audio Constructor Work, and What Are Some Common Methods?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-does-the-audio-constructor-work-and-what-are-some-common-methods
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-audio-and-video/6733d8203da84a08a0f5eab4.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-audio-and-video/6733d8203da84a08a0f5eab4.md
@@ -1,7 +1,7 @@
 ---
 id: 6733d8203da84a08a0f5eab4
 title: What Are the Different Types of Video and Audio Formats?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-the-different-types-of-video-and-audio-formats
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-audio-and-video/6733d829d983c008d2db41a1.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-audio-and-video/6733d829d983c008d2db41a1.md
@@ -1,7 +1,7 @@
 ---
 id: 6733d829d983c008d2db41a1
 title: What Is Codecs and How Does It Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-codecs-and-how-does-it-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-audio-and-video/6733d83630e76f08ff49e6dc.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-audio-and-video/6733d83630e76f08ff49e6dc.md
@@ -1,7 +1,7 @@
 ---
 id: 6733d83630e76f08ff49e6dc
 title: What Is the HTMLMediaElement API and How Does It Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-the-htmlmediaelement-api-and-how-does-it-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-audio-and-video/6733d852175df50937f06061.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-audio-and-video/6733d852175df50937f06061.md
@@ -1,7 +1,7 @@
 ---
 id: 6733d852175df50937f06061
 title: How Can You Work with the Media Streams to Capture Video and Audio from a Local Device?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-can-you-work-with-the-media-streams-getusermedia-to-capture-video-and-audio-from-a-local-device
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-audio-and-video/6733d8606fb893099e3d0df3.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-audio-and-video/6733d8606fb893099e3d0df3.md
@@ -1,7 +1,7 @@
 ---
 id: 6733d8606fb893099e3d0df3
 title: What Are Some Other Examples of Video and Audio APIs?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-some-other-examples-of-video-and-audio-apis
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-backgrounds-and-borders/672aa669960f6a596081fcad.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-backgrounds-and-borders/672aa669960f6a596081fcad.md
@@ -1,7 +1,7 @@
 ---
 id: 672aa669960f6a596081fcad
 title: How Do Background Image Size, Repeat, Position, and Attachment Work?
-challengeType: 11
+challengeType: 24
 videoId: cVcBaVhPUsA
 dashedName: how-to-work-with-background-image-size-repeat-position-and-attachment
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-backgrounds-and-borders/672b98be592cfb451f651451.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-backgrounds-and-borders/672b98be592cfb451f651451.md
@@ -1,7 +1,7 @@
 ---
 id: 672b98be592cfb451f651451
 title: What Is a Background Gradient, and How Does It Work?
-challengeType: 11
+challengeType: 24
 videoId: bKlXmSl7ywE
 dashedName: what-is-a-background-gradient
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-backgrounds-and-borders/672b98cd77b6b7456b6ef2de.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-backgrounds-and-borders/672b98cd77b6b7456b6ef2de.md
@@ -1,7 +1,7 @@
 ---
 id: 672b98cd77b6b7456b6ef2de
 title: What Are Some Accessibility Considerations for Backgrounds?
-challengeType: 11
+challengeType: 24
 videoId: XQGKmK_L14k
 dashedName: what-are-some-accessibility-considerations-for-backgrounds
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-backgrounds-and-borders/672b98db3bcdd545ab3b3c73.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-backgrounds-and-borders/672b98db3bcdd545ab3b3c73.md
@@ -1,7 +1,7 @@
 ---
 id: 672b98db3bcdd545ab3b3c73
 title: What Are the Different Ways You Can Add Borders Around Images?
-challengeType: 11
+challengeType: 24
 videoId: Ztny13IjMnE
 dashedName: what-are-the-different-ways-you-can-add-borders-around-images
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-client-side-storage-and-crud-operations/6733ab64775d35f78f5238fe.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-client-side-storage-and-crud-operations/6733ab64775d35f78f5238fe.md
@@ -1,7 +1,7 @@
 ---
 id: 6733ab64775d35f78f5238fe
 title: What Does CRUD Stand For, and How Do the Basic Operations Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-does-crud-stand-for-and-how-do-the-basic-operations-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-client-side-storage-and-crud-operations/6733ff4a9319c8486750886c.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-client-side-storage-and-crud-operations/6733ff4a9319c8486750886c.md
@@ -1,7 +1,7 @@
 ---
 id: 6733ff4a9319c8486750886c
 title: What Is localStorage, and What Are Some Common Methods?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-localstorage-and-what-are-some-common-methods
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-client-side-storage-and-crud-operations/6733ff5814129c48b4fca88e.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-client-side-storage-and-crud-operations/6733ff5814129c48b4fca88e.md
@@ -1,7 +1,7 @@
 ---
 id: 6733ff5814129c48b4fca88e
 title: What Is sessionStorage, and What Are Some Common Methods?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-sessionstorage-and-what-are-some-common-methods
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-client-side-storage-and-crud-operations/6733ff6f02dde548ebe4a6d5.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-client-side-storage-and-crud-operations/6733ff6f02dde548ebe4a6d5.md
@@ -1,7 +1,7 @@
 ---
 id: 6733ff6f02dde548ebe4a6d5
 title: What Are Cookies, and How Do They Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-cookies-and-how-do-they-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-client-side-storage-and-crud-operations/6733ff8d06376149474a0c0d.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-client-side-storage-and-crud-operations/6733ff8d06376149474a0c0d.md
@@ -1,7 +1,7 @@
 ---
 id: 6733ff8d06376149474a0c0d
 title: What Is the Cache API, and How Does It Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-the-cache-api-and-how-does-that-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-client-side-storage-and-crud-operations/6733ff9d2fb9c449af68ad99.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-client-side-storage-and-crud-operations/6733ff9d2fb9c449af68ad99.md
@@ -1,7 +1,7 @@
 ---
 id: 6733ff9d2fb9c449af68ad99
 title: What Are Some Negative Patterns Associated with Client-Side Storage?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-some-negative-patterns-associated-with-client-side-storage
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-client-side-storage-and-crud-operations/6733ffacd0ad1e49ec2af051.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-client-side-storage-and-crud-operations/6733ffacd0ad1e49ec2af051.md
@@ -1,7 +1,7 @@
 ---
 id: 6733ffacd0ad1e49ec2af051
 title: How Can You Use Cookies to Store Arbitrary Data, Normally Controlled by HTTP Headers?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-can-you-use-cookies-to-store-arbitrary-data-normally-controlled-by-http-headers
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-client-side-storage-and-crud-operations/6733ffb59c62ee4a23522efe.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-client-side-storage-and-crud-operations/6733ffb59c62ee4a23522efe.md
@@ -1,7 +1,7 @@
 ---
 id: 6733ffb59c62ee4a23522efe
 title: What Is IndexedDB, and How Does It Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-indexeddb-and-how-does-it-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-client-side-storage-and-crud-operations/6733ffc7353af34a61ed683a.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-client-side-storage-and-crud-operations/6733ffc7353af34a61ed683a.md
@@ -1,7 +1,7 @@
 ---
 id: 6733ffc7353af34a61ed683a
 title: What Are Cache and Service Workers, and How Do They Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-cache-service-workers-and-how-do-they-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-code-editors-and-ides/672d26269456511aa3db614d.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-code-editors-and-ides/672d26269456511aa3db614d.md
@@ -1,7 +1,7 @@
 ---
 id: 672d26269456511aa3db614d
 title: What Is a Code Editor and IDE?
-challengeType: 11
+challengeType: 24
 videoId: cD8alVrsiRE
 dashedName: what-is-a-code-editor-and-ide
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-code-editors-and-ides/672d45583fd75a504136fbbb.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-code-editors-and-ides/672d45583fd75a504136fbbb.md
@@ -1,7 +1,7 @@
 ---
 id: 672d45583fd75a504136fbbb
 title: How to Install Visual Studio Code onto Your Computer
-challengeType: 11
+challengeType: 24
 videoId: hWa_PgsNSw0
 dashedName: how-to-install-visual-studio-code-onto-your-computer
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-code-editors-and-ides/672d45651d83b450801efb3a.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-code-editors-and-ides/672d45651d83b450801efb3a.md
@@ -1,7 +1,7 @@
 ---
 id: 672d45651d83b450801efb3a
 title: How to Create a Project and Run Your Code Locally in VS Code
-challengeType: 11
+challengeType: 24
 videoId: 9F98HQgLaPU
 dashedName: how-to-create-a-project-and-run-your-code-locally-in-vs-code
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-code-editors-and-ides/672d456f4ac35950b300e93f.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-code-editors-and-ides/672d456f4ac35950b300e93f.md
@@ -1,7 +1,7 @@
 ---
 id: 672d456f4ac35950b300e93f
 title: What Are Several Useful Keyboard Shortcuts for Maximizing Productivity in VS Code?
-challengeType: 11
+challengeType: 24
 videoId: 54vVx07YxYM
 dashedName: what-are-several-useful-keyboard-shortcuts-for-maximizing-productivity-in-vs-code
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-code-editors-and-ides/672d457bcdd8b350ec2b6254.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-code-editors-and-ides/672d457bcdd8b350ec2b6254.md
@@ -1,7 +1,7 @@
 ---
 id: 672d457bcdd8b350ec2b6254
 title: What Are Some Good VS Code Extensions You Can Use in Your Editor?
-challengeType: 11
+challengeType: 24
 videoId: Pc_M9oyFu7I
 dashedName: what-are-some-good-vs-code-extensions-you-can-use-in-your-editor
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-colors-in-css/672aa7678e05e35d42e33522.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-colors-in-css/672aa7678e05e35d42e33522.md
@@ -1,7 +1,7 @@
 ---
 id: 672aa7678e05e35d42e33522
 title: What Is Color Theory in Design?
-challengeType: 11
+challengeType: 24
 videoId: AUNryEIMjNQ
 dashedName: what-is-color-theory-in-design
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-colors-in-css/672bc4ff5e7a4bbdee8ba013.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-colors-in-css/672bc4ff5e7a4bbdee8ba013.md
@@ -1,7 +1,7 @@
 ---
 id: 672bc4ff5e7a4bbdee8ba013
 title: What Are Named Colors in CSS, and When to Use Them?
-challengeType: 11
+challengeType: 24
 videoId: YD7ndioXOyM
 dashedName: what-are-named-colors-in-css
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-colors-in-css/672bc51370c789be459186b4.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-colors-in-css/672bc51370c789be459186b4.md
@@ -1,7 +1,7 @@
 ---
 id: 672bc51370c789be459186b4
 title: What Is the RGB Color Model, and How Does the RGB Function Work in CSS?
-challengeType: 11
+challengeType: 24
 videoId: RpmqPy_KY4c
 dashedName: what-is-the-rgb-color-model
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-colors-in-css/672bc523324694be91d90d96.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-colors-in-css/672bc523324694be91d90d96.md
@@ -1,7 +1,7 @@
 ---
 id: 672bc523324694be91d90d96
 title: What Is the HSL Color Model, and How Does the HSL Function Work in CSS?
-challengeType: 11
+challengeType: 24
 videoId: 7wgi0xRlZDo
 dashedName: what-is-the-hsl-color-model
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-colors-in-css/672bc5344330d7bee2f9c2ed.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-colors-in-css/672bc5344330d7bee2f9c2ed.md
@@ -1,7 +1,7 @@
 ---
 id: 672bc5344330d7bee2f9c2ed
 title: What Are Hex Codes, and How Do They Work in CSS?
-challengeType: 11
+challengeType: 24
 videoId: -mAJpbtCtao
 dashedName: what-are-hex-codes
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-colors-in-css/672bc544196a17bf28594e64.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-colors-in-css/672bc544196a17bf28594e64.md
@@ -1,7 +1,7 @@
 ---
 id: 672bc544196a17bf28594e64
 title: What Are Linear and Radial Gradients, and How Do They Work in CSS?
-challengeType: 11
+challengeType: 24
 videoId: pQqkca5Xor8
 dashedName: what-are-linear-and-radial-gradients
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-common-array-methods/67329f64e0ef5c5b7388158d.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-common-array-methods/67329f64e0ef5c5b7388158d.md
@@ -1,7 +1,7 @@
 ---
 id: 67329f64e0ef5c5b7388158d
 title: How Do You Get the Index for an Element in an Array Using the indexOf Method?
-challengeType: 11
+challengeType: 24
 videoId: Pg-wwP3YQF8
 dashedName: how-do-you-get-the-index-for-an-element-in-an-array-using-the-indexof-method
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-common-array-methods/6732b284901f8c1539e20bcb.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-common-array-methods/6732b284901f8c1539e20bcb.md
@@ -1,7 +1,7 @@
 ---
 id: 6732b284901f8c1539e20bcb
 title: How Do You Add and Remove Elements from the Middle of an Array?
-challengeType: 11
+challengeType: 24
 videoId: 6sfsfbQQjpI
 dashedName: how-do-you-add-remove-elements-from-the-middle-of-an-array
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-common-array-methods/6732b28eeadda1158cdbff7b.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-common-array-methods/6732b28eeadda1158cdbff7b.md
@@ -1,7 +1,7 @@
 ---
 id: 6732b28eeadda1158cdbff7b
 title: How Can You Check if an Array Contains a Certain Value?
-challengeType: 11
+challengeType: 24
 videoId: NjZI_TlIiXk
 dashedName: how-can-you-check-if-an-array-contains-a-certain-value
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-common-array-methods/6732b29b8b7d4f15b94d12ca.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-common-array-methods/6732b29b8b7d4f15b94d12ca.md
@@ -1,7 +1,7 @@
 ---
 id: 6732b29b8b7d4f15b94d12ca
 title: What Is a Shallow Copy of an Array, and What Are Some Ways to Create These Copies?
-challengeType: 11
+challengeType: 24
 videoId: acgI-aTElCo
 dashedName: what-is-a-shallow-copy-of-an-array-and-what-are-some-ways-to-create-these-copies
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-common-array-methods/6732b2a6de5a1c15edf05b75.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-common-array-methods/6732b2a6de5a1c15edf05b75.md
@@ -1,7 +1,7 @@
 ---
 id: 6732b2a6de5a1c15edf05b75
 title: How Can You Use String and Array Methods to Reverse a String?
-challengeType: 11
+challengeType: 24
 videoId: iwX0qWJkM5o
 dashedName: how-can-you-use-string-and-array-methods-to-reverse-a-string
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-common-string-methods/672d266034b5242126271995.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-common-string-methods/672d266034b5242126271995.md
@@ -1,7 +1,7 @@
 ---
 id: 672d266034b5242126271995
 title: What Is ASCII, and How Does It Work with charCodeAt() and fromCharCode()?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-ascii-and-how-does-it-work-with-charcodeat-and-fromcharcode
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-common-string-methods/67326c0d7bef01c539120766.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-common-string-methods/67326c0d7bef01c539120766.md
@@ -1,7 +1,7 @@
 ---
 id: 67326c0d7bef01c539120766
 title: How Can You Test if a String Contains a Substring?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-can-you-test-if-a-string-contains-a-substring
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-common-string-methods/67326c15b3b2f0c5827927cc.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-common-string-methods/67326c15b3b2f0c5827927cc.md
@@ -1,7 +1,7 @@
 ---
 id: 67326c15b3b2f0c5827927cc
 title: How Can You Extract a Substring from a String?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-can-you-extract-a-substring-from-a-string
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-common-string-methods/67326c1fdaf9c0c5ad1a2589.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-common-string-methods/67326c1fdaf9c0c5ad1a2589.md
@@ -1,7 +1,7 @@
 ---
 id: 67326c1fdaf9c0c5ad1a2589
 title: How Can You Change the Casing for a String?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-can-you-change-the-casing-for-a-string
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-common-string-methods/67326c29dcd98fc5ecc49779.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-common-string-methods/67326c29dcd98fc5ecc49779.md
@@ -1,7 +1,7 @@
 ---
 id: 67326c29dcd98fc5ecc49779
 title: How Can You Replace Parts of a String with Another?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-can-you-replace-parts-of-a-string-with-another
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-common-string-methods/67326c3392068ec6184a0c95.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-common-string-methods/67326c3392068ec6184a0c95.md
@@ -1,7 +1,7 @@
 ---
 id: 67326c3392068ec6184a0c95
 title: How Can You Repeat a String x Number of Times?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-can-you-repeat-a-string-x-number-of-times
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-common-string-methods/67326c3c3ab931c644cea05b.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-common-string-methods/67326c3c3ab931c644cea05b.md
@@ -1,7 +1,7 @@
 ---
 id: 67326c3c3ab931c644cea05b
 title: How Can You Trim Whitespace from a String?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-can-you-trim-whitespace-from-a-string
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-flexbox/672aa7f7284b235f46f7d4e9.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-flexbox/672aa7f7284b235f46f7d4e9.md
@@ -1,7 +1,7 @@
 ---
 id: 672aa7f7284b235f46f7d4e9
 title: What Is CSS Flexbox, and When Should You Use It?
-challengeType: 11
+challengeType: 24
 videoId: PLe24PzNFgA
 dashedName: what-is-css-flexbox
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-flexbox/672bd658c0e190f674a5e057.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-flexbox/672bd658c0e190f674a5e057.md
@@ -1,7 +1,7 @@
 ---
 id: 672bd658c0e190f674a5e057
 title: What Are Some Common Flex Properties, and How Do They Work?
-challengeType: 11
+challengeType: 24
 videoId: KjtpYr-7QNs
 dashedName: what-are-some-common-flex-properties
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-fonts/672aa80bc17f355fabd2e9e8.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-fonts/672aa80bc17f355fabd2e9e8.md
@@ -1,7 +1,7 @@
 ---
 id: 672aa80bc17f355fabd2e9e8
 title: What Are the Fundamentals of Typography?
-challengeType: 11
+challengeType: 24
 videoId: JwnppEOqpg4
 dashedName: what-are-the-fundamentals-of-typography
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-fonts/672bd807c49548fc9be66aca.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-fonts/672bd807c49548fc9be66aca.md
@@ -1,7 +1,7 @@
 ---
 id: 672bd807c49548fc9be66aca
 title: What Are Some Best Practices for Working with Typography in Your Designs?
-challengeType: 11
+challengeType: 24
 videoId: eG2De9tjinA
 dashedName: what-are-some-best-practices-for-working-with-typography-in-your-designs
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-fonts/672bd814105a0ffcf36f9233.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-fonts/672bd814105a0ffcf36f9233.md
@@ -1,7 +1,7 @@
 ---
 id: 672bd814105a0ffcf36f9233
 title: What Are Font Families and How Do They Work?
-challengeType: 11
+challengeType: 24
 videoId: fNmhMAJpfQs
 dashedName: what-are-font-families
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-fonts/672bd81ee07c43fd2070f0fe.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-fonts/672bd81ee07c43fd2070f0fe.md
@@ -1,7 +1,7 @@
 ---
 id: 672bd81ee07c43fd2070f0fe
 title: What Are Web Safe Fonts?
-challengeType: 11
+challengeType: 24
 videoId: EeVOIWwcqO4
 dashedName: what-are-web-safe-fonts
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-fonts/672bd834cedccefd5939a913.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-fonts/672bd834cedccefd5939a913.md
@@ -1,7 +1,7 @@
 ---
 id: 672bd834cedccefd5939a913
 title: What Is the @font-face At-Rule, and How Does It Work?
-challengeType: 11
+challengeType: 24
 videoId: hpD2-pwEQjc
 dashedName: what-is-the-font-face-at-rule
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-fonts/672bd8453d1371fdb1510fe5.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-fonts/672bd8453d1371fdb1510fe5.md
@@ -1,7 +1,7 @@
 ---
 id: 672bd8453d1371fdb1510fe5
 title: How Do You Work with External Fonts Like Font Squirrel and Google Fonts?
-challengeType: 11
+challengeType: 24
 videoId: C1BThgucM-I
 dashedName: how-do-you-work-with-external-fonts-like-font-squirrel-and-google-fonts
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-fonts/672bd853c985cdfdeb32f4f9.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-fonts/672bd853c985cdfdeb32f4f9.md
@@ -1,7 +1,7 @@
 ---
 id: 672bd853c985cdfdeb32f4f9
 title: What Is the text-shadow Property, and How Does It Work?
-challengeType: 11
+challengeType: 24
 videoId: 3iQDpb-ofDs
 dashedName: what-is-the-text-shadow-property
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-grid/672aa8ac4631d1623ec5cd86.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-grid/672aa8ac4631d1623ec5cd86.md
@@ -1,7 +1,7 @@
 ---
 id: 672aa8ac4631d1623ec5cd86
 title: What Is CSS Grid, and How Does It Differ from Flexbox?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-css-grid
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-grid/673226732b19aa1cacd0a75c.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-grid/673226732b19aa1cacd0a75c.md
@@ -1,7 +1,7 @@
 ---
 id: 673226732b19aa1cacd0a75c
 title: How Can You Create Flexible Grids with the fr Unit?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-can-you-create-flexible-grids-with-the-fr-unit
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-grid/6732267ecab2151ced471cd4.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-grid/6732267ecab2151ced471cd4.md
@@ -1,7 +1,7 @@
 ---
 id: 6732267ecab2151ced471cd4
 title: How Can You Create Gaps Between Tracks in a Grid?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-can-you-create-gaps-between-tracks-in-a-grid
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-grid/6732268d05c3661d32a0fee8.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-grid/6732268d05c3661d32a0fee8.md
@@ -1,7 +1,7 @@
 ---
 id: 6732268d05c3661d32a0fee8
 title: How Can You Repeat Track Listings in a Grid Layout?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-can-you-repeat-track-listings-in-a-grid-layout
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-grid/6732269a7aa2ca1d6b6574fe.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-grid/6732269a7aa2ca1d6b6574fe.md
@@ -1,7 +1,7 @@
 ---
 id: 6732269a7aa2ca1d6b6574fe
 title: What Is the Difference Between an Implicit and Explicit Grid?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-the-difference-between-an-implicit-and-explicit-grid
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-grid/673226a62eb2121da41a3d68.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-grid/673226a62eb2121da41a3d68.md
@@ -1,7 +1,7 @@
 ---
 id: 673226a62eb2121da41a3d68
 title: What Is the minmax() Function and How Does It Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-the-minmax-function-and-how-does-it-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-grid/673226afcd33991dd751937a.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-grid/673226afcd33991dd751937a.md
@@ -1,7 +1,7 @@
 ---
 id: 673226afcd33991dd751937a
 title: How Do the grid-column and grid-row Properties Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-do-the-grid-column-and-grid-row-properties-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-grid/673226b97d4a731e0577ae93.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-grid/673226b97d4a731e0577ae93.md
@@ -1,7 +1,7 @@
 ---
 id: 673226b97d4a731e0577ae93
 title: How Can You Position Items on the Grid Using the grid-template-areas Property?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-can-you-position-items-on-the-grid-using-the-grid-template-areas-property
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-transforms-overflow-and-filters/672aa7e03c2e365e906e5733.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-transforms-overflow-and-filters/672aa7e03c2e365e906e5733.md
@@ -1,7 +1,7 @@
 ---
 id: 672aa7e03c2e365e906e5733
 title: What Is Overflow in CSS, and How Does It Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-overflow-in-css
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-transforms-overflow-and-filters/672bcc8ccc976fd791610f43.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-transforms-overflow-and-filters/672bcc8ccc976fd791610f43.md
@@ -1,7 +1,7 @@
 ---
 id: 672bcc8ccc976fd791610f43
 title: What Is the CSS Transform Property, and How Does It Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-the-css-transform-property
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-transforms-overflow-and-filters/672bcc9c4a6dd6d7dd3e6357.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-transforms-overflow-and-filters/672bcc9c4a6dd6d7dd3e6357.md
@@ -1,7 +1,7 @@
 ---
 id: 672bcc9c4a6dd6d7dd3e6357
 title: What Is the CSS Box Model, and How Does It Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-the-css-box-model
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-transforms-overflow-and-filters/672bccae6e556cd81cef6af2.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-transforms-overflow-and-filters/672bccae6e556cd81cef6af2.md
@@ -1,7 +1,7 @@
 ---
 id: 672bccae6e556cd81cef6af2
 title: What Is Margin Collapsing, and How Does It Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-margin-collapsing
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-transforms-overflow-and-filters/672bccc8ea33bad87abb3c56.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-transforms-overflow-and-filters/672bccc8ea33bad87abb3c56.md
@@ -1,7 +1,7 @@
 ---
 id: 672bccc8ea33bad87abb3c56
 title: What Is the Difference Between content-box and border-box?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-the-difference-between-content-box-and-border-box
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-transforms-overflow-and-filters/672bccdb8f1823d8c60f914c.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-transforms-overflow-and-filters/672bccdb8f1823d8c60f914c.md
@@ -1,7 +1,7 @@
 ---
 id: 672bccdb8f1823d8c60f914c
 title: What Is a CSS Reset, and What Are Some Common Examples?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-a-css-reset
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-transforms-overflow-and-filters/672bccebe1fc82d911c3f078.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-transforms-overflow-and-filters/672bccebe1fc82d911c3f078.md
@@ -1,7 +1,7 @@
 ---
 id: 672bccebe1fc82d911c3f078
 title: What Is the CSS Filter Property, and What Are Common Examples?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-the-css-filter-property
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-variables/672aa8985acb7361e656f94c.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-variables/672aa8985acb7361e656f94c.md
@@ -1,7 +1,7 @@
 ---
 id: 672aa8985acb7361e656f94c
 title: What Are CSS Custom Properties, and How Do They Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-css-custom-properties
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-variables/672cf3ca326da9f63683e236.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-variables/672cf3ca326da9f63683e236.md
@@ -1,7 +1,7 @@
 ---
 id: 672cf3ca326da9f63683e236
 title: What Is the @property Rule, and How Does It Work with Fallbacks?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-the-at-property-rule
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-in-react/6734e3ceee2da4b0301719b7.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-in-react/6734e3ceee2da4b0301719b7.md
@@ -1,7 +1,7 @@
 ---
 id: 6734e3ceee2da4b0301719b7
 title: How Do You Pass Props from Parent to Child Component in React?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-do-you-pass-props-from-parent-to-child-component-in-react
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-in-react/673500abfe36cd015b67b1b7.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-in-react/673500abfe36cd015b67b1b7.md
@@ -1,7 +1,7 @@
 ---
 id: 673500abfe36cd015b67b1b7
 title: How Does Conditional Rendering Work in React Components?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-does-conditional-rendering-work-in-react-components
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-in-react/673500b41af8500191febedc.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-in-react/673500b41af8500191febedc.md
@@ -1,7 +1,7 @@
 ---
 id: 673500b41af8500191febedc
 title: How Do You Render Lists in React?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-do-you-render-lists-in-react
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-in-react/673500bfe1f41601c1ddb1a2.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-in-react/673500bfe1f41601c1ddb1a2.md
@@ -1,7 +1,7 @@
 ---
 id: 673500bfe1f41601c1ddb1a2
 title: How Do Inline Styles Work in React?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-do-inline-styles-work-in-react
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-types/672d264645e289208e562f10.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-types/672d264645e289208e562f10.md
@@ -1,7 +1,7 @@
 ---
 id: 672d264645e289208e562f10
 title: What Is Dynamic Typing in JavaScript, and How Does It Differ from Statically Typed Languages?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-dynamic-typing-in-javascript-and-how-does-it-differ-from-statically-typed-languages
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-types/6732518a8627876f4fcd18a4.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-types/6732518a8627876f4fcd18a4.md
@@ -1,7 +1,7 @@
 ---
 id: 6732518a8627876f4fcd18a4
 title: How Does the typeof Operator Work, and What Is the typeof null Bug in JavaScript?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-does-the-typeof-operator-work-and-what-is-the-typeof-null-bug-in-javascript
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-dates/6733aafb9c0802f66cc1e056.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-dates/6733aafb9c0802f66cc1e056.md
@@ -1,7 +1,7 @@
 ---
 id: 6733aafb9c0802f66cc1e056
 title: How Does the JavaScript Data Object Work, and What Are Some Common Methods?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-does-the-javascript-data-object-work-and-what-are-some-common-methods
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-dates/6733d608654c17868e01c0a2.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-dates/6733d608654c17868e01c0a2.md
@@ -1,7 +1,7 @@
 ---
 id: 6733d608654c17868e01c0a2
 title: What Are the Different Ways to Format Dates?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-the-different-ways-to-format-dates
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-file-systems/672aa58c389eb9565978495d.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-file-systems/672aa58c389eb9565978495d.md
@@ -1,7 +1,7 @@
 ---
 id: 672aa58c389eb9565978495d
 title: How Can You Use File Management Applications on Your Computer?
-challengeType: 11
+challengeType: 24
 videoId: oXl1NJu1a1k
 dashedName: how-can-you-use-file-management-applications-on-your-computer
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-file-systems/672ac37104dc2530a769e6a4.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-file-systems/672ac37104dc2530a769e6a4.md
@@ -1,7 +1,7 @@
 ---
 id: 672ac37104dc2530a769e6a4
 title: What Are Best Practices for Naming Files for Web Applications?
-challengeType: 11
+challengeType: 24
 videoId: EGsE7yVJCCk
 dashedName: what-are-best-practices-for-naming-files-for-web-applications
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-file-systems/672ac39a22b0cc30eb8fd65e.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-file-systems/672ac39a22b0cc30eb8fd65e.md
@@ -1,7 +1,7 @@
 ---
 id: 672ac39a22b0cc30eb8fd65e
 title: What Are Best Practices for File/Folder Organization in Web Applications?
-challengeType: 11
+challengeType: 24
 videoId: GFc60yQ02Xs
 dashedName: what-are-best-practices-for-file-folder-organization-in-web-applications
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-file-systems/672ac3c5d0e9fd31835ff772.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-file-systems/672ac3c5d0e9fd31835ff772.md
@@ -1,7 +1,7 @@
 ---
 id: 672ac3c5d0e9fd31835ff772
 title: How Can You Create, Move, and Delete Files and Folders Using Explorer/Finder?
-challengeType: 11
+challengeType: 24
 videoId: XnPxIz8HuZs
 dashedName: how-to-create-move-and-delete-files-and-folders-using-explorer-finder
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-file-systems/672ac3f129efbf327742eb33.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-file-systems/672ac3f129efbf327742eb33.md
@@ -1,7 +1,7 @@
 ---
 id: 672ac3f129efbf327742eb33
 title: How Can You Search for Files and Folders on Your Computer?
-challengeType: 11
+challengeType: 24
 videoId: oHu2S9KgACU
 dashedName: how-to-search-for-files-and-folders-on-your-computer
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-file-systems/672ac403a9ba7732b31c6480.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-file-systems/672ac403a9ba7732b31c6480.md
@@ -1,7 +1,7 @@
 ---
 id: 672ac403a9ba7732b31c6480
 title: What Are Some Common File Types You Will Work With in Web Applications?
-challengeType: 11
+challengeType: 24
 videoId: eIa7UxHdbGI
 dashedName: what-are-some-common-file-types-you-will-work-with-in-web-applications
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-forms/6729974ec29be33cb00eb54d.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-forms/6729974ec29be33cb00eb54d.md
@@ -1,7 +1,7 @@
 ---
 id: 6729974ec29be33cb00eb54d
 title: How Do Forms, Labels, and Inputs Work in HTML?
-challengeType: 11
+challengeType: 24
 videoId: O14Wb3N4wDQ
 dashedName: how-do-forms-labels-and-inputs-work-in-html
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-forms/672a4cd3d59756726657efb8.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-forms/672a4cd3d59756726657efb8.md
@@ -1,7 +1,7 @@
 ---
 id: 672a4cd3d59756726657efb8
 title: What Are the Different Types of Buttons, and When Should You Use Them?
-challengeType: 11
+challengeType: 24
 videoId: tlumOah6l4k
 dashedName: what-are-the-different-types-of-buttons
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-forms/672a4ce6dab9eb735828b48b.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-forms/672a4ce6dab9eb735828b48b.md
@@ -1,7 +1,7 @@
 ---
 id: 672a4ce6dab9eb735828b48b
 title: What Is Client-Side Form Validation in HTML Forms, and What Are Some Examples?
-challengeType: 11
+challengeType: 24
 videoId: isHriKH6a34
 dashedName: what-is-client-side-form-validation-in-html-forms
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-forms/672a4cf959443073a6774908.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-forms/672a4cf959443073a6774908.md
@@ -1,7 +1,7 @@
 ---
 id: 672a4cf959443073a6774908
 title: What Are the Different Form States, and Why Are They Important?
-challengeType: 11
+challengeType: 24
 videoId: 0kD-EwXqRG4
 dashedName: what-are-the-different-form-states
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-functions/672d269da46786225e3fe3fd.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-functions/672d269da46786225e3fe3fd.md
@@ -1,7 +1,7 @@
 ---
 id: 672d269da46786225e3fe3fd
 title: What Is the Purpose of Functions, and How Do They Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-the-purpose-of-functions-and-how-do-they-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-functions/673284d5e52ef81a2169b097.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-functions/673284d5e52ef81a2169b097.md
@@ -1,7 +1,7 @@
 ---
 id: 673284d5e52ef81a2169b097
 title: What Are Arrow Functions, and How Do They Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-arrow-functions-and-how-do-they-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-functions/673284e7244c0c1a649121b9.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-functions/673284e7244c0c1a649121b9.md
@@ -1,7 +1,7 @@
 ---
 id: 673284e7244c0c1a649121b9
 title: What Is Scope in Programming, and How Does Global, Local, and Block Scope Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-scope-in-programming-and-how-does-global-local-and-block-scope-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-higher-order-functions-and-callbacks/67329ffd75010f5ddeb4ea13.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-higher-order-functions-and-callbacks/67329ffd75010f5ddeb4ea13.md
@@ -1,7 +1,7 @@
 ---
 id: 67329ffd75010f5ddeb4ea13
 title: What Is a Callback Function, and How Does It Work with the forEach Method?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-a-callback-function-and-how-does-it-work-with-the-foreach-method
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-higher-order-functions-and-callbacks/67336296a3c1591da81856c2.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-higher-order-functions-and-callbacks/67336296a3c1591da81856c2.md
@@ -1,7 +1,7 @@
 ---
 id: 67336296a3c1591da81856c2
 title: What Are Higher-Order Functions?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-higher-order-functions
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-higher-order-functions-and-callbacks/673362a34edda41dedf87623.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-higher-order-functions-and-callbacks/673362a34edda41dedf87623.md
@@ -1,7 +1,7 @@
 ---
 id: 673362a34edda41dedf87623
 title: What Is the Map Method, and How Does It Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-the-map-method-and-how-does-it-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-higher-order-functions-and-callbacks/673362b3f763ae1e38e17df7.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-higher-order-functions-and-callbacks/673362b3f763ae1e38e17df7.md
@@ -1,7 +1,7 @@
 ---
 id: 673362b3f763ae1e38e17df7
 title: What Is the Filter Method, and How Does It Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-the-filter-method-and-how-does-it-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-higher-order-functions-and-callbacks/673362be2f70c21e65bc5459.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-higher-order-functions-and-callbacks/673362be2f70c21e65bc5459.md
@@ -1,7 +1,7 @@
 ---
 id: 673362be2f70c21e65bc5459
 title: What Is the Reduce Method, and How Does It Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-the-reduce-method-and-how-does-it-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-higher-order-functions-and-callbacks/673362cbb475e21eab726506.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-higher-order-functions-and-callbacks/673362cbb475e21eab726506.md
@@ -1,7 +1,7 @@
 ---
 id: 673362cbb475e21eab726506
 title: What Is Method Chaining, and How Does It Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-method-chaining-and-how-does-it-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-higher-order-functions-and-callbacks/673362d7f94d551edb532d24.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-higher-order-functions-and-callbacks/673362d7f94d551edb532d24.md
@@ -1,7 +1,7 @@
 ---
 id: 673362d7f94d551edb532d24
 title: How Does the Sort Method Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-does-the-sort-method-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-higher-order-functions-and-callbacks/673362e43d57b51f1ad2d466.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-higher-order-functions-and-callbacks/673362e43d57b51f1ad2d466.md
@@ -1,7 +1,7 @@
 ---
 id: 673362e43d57b51f1ad2d466
 title: How Do the every() and some() Methods Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-do-the-every-and-some-methods-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-html-tools/672a4fa7d335bc7cfb63a392.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-html-tools/672a4fa7d335bc7cfb63a392.md
@@ -1,7 +1,7 @@
 ---
 id: 672a4fa7d335bc7cfb63a392
 title: What Is an HTML Validator, and How Can It Help You Debug Your Code?
-challengeType: 11
+challengeType: 24
 videoId: gniy8iis5ok
 dashedName: what-is-an-html-validator
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-html-tools/672a511bb408ec81c592eb68.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-html-tools/672a511bb408ec81c592eb68.md
@@ -1,7 +1,7 @@
 ---
 id: 672a511bb408ec81c592eb68
 title: How to Use the DOM Inspector and DevTools to Debug and Build Your Projects
-challengeType: 11
+challengeType: 24
 videoId: aigMtKHvkSM
 dashedName: how-to-use-the-dom-inspector-and-devtools
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-links/6716744f7245947a3dd60009.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-links/6716744f7245947a3dd60009.md
@@ -2,7 +2,7 @@
 id: 6716744f7245947a3dd60009
 videoId: D4PO-NUqmzg
 title: What Are the Different Target Attribute Types, and How Do They Work?
-challengeType: 11
+challengeType: 24
 dashedName: what-are-the-different-target-attribute-types
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-links/671682dd88e461a8e2620f38.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-links/671682dd88e461a8e2620f38.md
@@ -2,7 +2,7 @@
 id: 671682dd88e461a8e2620f38
 videoId: hpEmssjWh-0
 title: What Is the Difference Between Absolute and Relative Paths?
-challengeType: 11
+challengeType: 24
 dashedName: what-is-the-difference-between-absolute-and-relative-paths
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-links/6716830dbaf95da9564f2e3b.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-links/6716830dbaf95da9564f2e3b.md
@@ -2,7 +2,7 @@
 id: 6716830dbaf95da9564f2e3b
 videoId: nVAaxZ34khk
 title: What Is the Difference Between Slashes, a Single Dot, and Double Dot in Path Syntax?
-challengeType: 11
+challengeType: 24
 dashedName: what-is-the-difference-between-slashes-a-single-dot-and-double-dot-in-path-syntax
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-links/67168323932391a9ee0d3a9e.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-links/67168323932391a9ee0d3a9e.md
@@ -2,7 +2,7 @@
 id: 67168323932391a9ee0d3a9e
 videoId: O86-AxNc0nU
 title: What Are the Different Link States, and Why Are They Important?
-challengeType: 11
+challengeType: 24
 dashedName: what-are-the-different-link-states
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-loops/67329f7f3d1bd75c17896c66.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-loops/67329f7f3d1bd75c17896c66.md
@@ -1,7 +1,7 @@
 ---
 id: 67329f7f3d1bd75c17896c66
 title: How Do Loops and Iteration Work in JavaScript?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-do-loops-and-iteration-work-in-javascript
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-loops/6732c04638420641dcca2e6e.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-loops/6732c04638420641dcca2e6e.md
@@ -1,7 +1,7 @@
 ---
 id: 6732c04638420641dcca2e6e
 title: How Does the For...of Loop Work, and When Should You Use It?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-does-the-for-of-loop-work-and-when-should-you-use-it
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-loops/6732c05595ca7d422b9e55ff.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-loops/6732c05595ca7d422b9e55ff.md
@@ -1,7 +1,7 @@
 ---
 id: 6732c05595ca7d422b9e55ff
 title: What Is the For...in Loop, and When Should You Use It?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-the-for-in-loop-and-when-should-you-use-it
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-loops/6732c06654ea3442724284fe.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-loops/6732c06654ea3442724284fe.md
@@ -1,7 +1,7 @@
 ---
 id: 6732c06654ea3442724284fe
 title: What Is a While Loop, and How Does It Differ from the Do...while Loop?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-a-while-loop-and-how-does-it-differ-from-the-do-while-loop
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-loops/6732c07238355642a9781dfb.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-loops/6732c07238355642a9781dfb.md
@@ -1,7 +1,7 @@
 ---
 id: 6732c07238355642a9781dfb
 title: What Are the Break and Continue Statements Used for in Loops?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-the-break-and-continue-statements-used-for-in-loops
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-maps-and-sets/6733ab269b378bf724c9ac71.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-maps-and-sets/6733ab269b378bf724c9ac71.md
@@ -1,7 +1,7 @@
 ---
 id: 6733ab269b378bf724c9ac71
 title: What Are Sets in JavaScript, and How Does It Differ from WeakSets?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-sets-in-javascript-and-how-does-it-differ-from-weaksets
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-maps-and-sets/6733dd694f91d61a5272b4ac.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-maps-and-sets/6733dd694f91d61a5272b4ac.md
@@ -1,7 +1,7 @@
 ---
 id: 6733dd694f91d61a5272b4ac
 title: What Is the Map Object, and How Does It Differ from WeakMaps?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-the-map-object-and-how-does-it-differ-from-weakmaps
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-media/6716743531fc9a797351c21e.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-media/6716743531fc9a797351c21e.md
@@ -2,7 +2,7 @@
 id: 6716743531fc9a797351c21e
 videoId: E652pcln6EQ
 title: What Are Replaced Elements, and What Are Some Examples?
-challengeType: 11
+challengeType: 24
 dashedName: what-are-replaced-elements
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-media/67167835def3588873f339c6.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-media/67167835def3588873f339c6.md
@@ -2,7 +2,7 @@
 id: 67167835def3588873f339c6
 videoId: _KzjV5RScSE
 title: What Are Common Ways to Optimize Media Assets?
-challengeType: 11
+challengeType: 24
 dashedName: what-are-common-ways-to-optimize-media-assets
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-media/6716823876aa22a68ba3e2ec.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-media/6716823876aa22a68ba3e2ec.md
@@ -2,7 +2,7 @@
 id: 6716823876aa22a68ba3e2ec
 videoId: grui-CD6Uck
 title: What Are the Different Types of Image Licenses, and How Do They Work?
-challengeType: 11
+challengeType: 24
 dashedName: what-are-the-different-types-of-image-licenses
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-media/6716825aff3434a71fdc3e99.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-media/6716825aff3434a71fdc3e99.md
@@ -2,7 +2,7 @@
 id: 6716825aff3434a71fdc3e99
 videoId: mWa1_S3bHVA
 title: What Are SVGs, and When Should You Use Them?
-challengeType: 11
+challengeType: 24
 dashedName: what-are-svgs
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-media/67168278ac6df6a799555db5.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-media/67168278ac6df6a799555db5.md
@@ -2,7 +2,7 @@
 id: 67168278ac6df6a799555db5
 videoId: AYp1sMo4TyQ
 title: What Are the Roles of the HTML Audio and Video Elements, and How Do They Work?
-challengeType: 11
+challengeType: 24
 dashedName: what-are-the-roles-of-the-html-audio-and-video-elements
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-media/671682b3983489a819507553.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-media/671682b3983489a819507553.md
@@ -2,7 +2,7 @@
 id: 671682b3983489a819507553
 videoId: I0_951_MPE0
 title: How Do You Embed Videos onto Your Page Using the iframe Element?
-challengeType: 11
+challengeType: 24
 dashedName: how-do-you-embed-videos-onto-your-page-using-the-iframe-element
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-numbers-and-common-number-methods/672d26809d388621ad1ecd43.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-numbers-and-common-number-methods/672d26809d388621ad1ecd43.md
@@ -1,7 +1,7 @@
 ---
 id: 672d26809d388621ad1ecd43
 title: How Does isNaN Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-does-isnan-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-numbers-and-common-number-methods/6732808f3221720adc833e81.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-numbers-and-common-number-methods/6732808f3221720adc833e81.md
@@ -1,7 +1,7 @@
 ---
 id: 6732808f3221720adc833e81
 title: How Do the parseFloat() and parseInt() Methods Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-do-the-parsefloat-and-parseint-methods-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-numbers-and-common-number-methods/673280a1c29d0a0b17316e56.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-numbers-and-common-number-methods/673280a1c29d0a0b17316e56.md
@@ -1,7 +1,7 @@
 ---
 id: 673280a1c29d0a0b17316e56
 title: What Is the toFixed() Method, and How Does It Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-the-tofixed-method-and-how-does-it-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-numbers-booleans-and-the-math-object/672d266e014ef8216df987d2.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-numbers-booleans-and-the-math-object/672d266e014ef8216df987d2.md
@@ -1,7 +1,7 @@
 ---
 id: 672d266e014ef8216df987d2
 title: What Is the Number Type in JavaScript, and What Are the Different Types of Numbers Available?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-the-number-type-in-javascript-and-what-are-the-different-types-of-numbers-available
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-numbers-booleans-and-the-math-object/673271884bf678d8b9c64f56.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-numbers-booleans-and-the-math-object/673271884bf678d8b9c64f56.md
@@ -1,7 +1,7 @@
 ---
 id: 673271884bf678d8b9c64f56
 title: What Are the Different Arithmetic Operators in JavaScript?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-the-different-arithmetic-operators-in-javascript
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-numbers-booleans-and-the-math-object/67327195e77b1bd90bdd49d7.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-numbers-booleans-and-the-math-object/67327195e77b1bd90bdd49d7.md
@@ -1,7 +1,7 @@
 ---
 id: 67327195e77b1bd90bdd49d7
 title: What Happens When You Try to Do Calculations with Numbers and Strings?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-happens-when-you-try-to-do-calculations-with-numbers-and-strings
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-numbers-booleans-and-the-math-object/6732719e2e3ad4d947410b65.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-numbers-booleans-and-the-math-object/6732719e2e3ad4d947410b65.md
@@ -1,7 +1,7 @@
 ---
 id: 6732719e2e3ad4d947410b65
 title: How Does Operator Precedence Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-does-operator-precedence-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-numbers-booleans-and-the-math-object/673271a8998ddfd97578d095.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-numbers-booleans-and-the-math-object/673271a8998ddfd97578d095.md
@@ -1,7 +1,7 @@
 ---
 id: 673271a8998ddfd97578d095
 title: How Do the Increment and Decrement Operators Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-do-the-increment-and-decrement-operators-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-numbers-booleans-and-the-math-object/673271b4213033d9b661c70e.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-numbers-booleans-and-the-math-object/673271b4213033d9b661c70e.md
@@ -1,7 +1,7 @@
 ---
 id: 673271b4213033d9b661c70e
 title: What Are Compound Assignment Operators in JavaScript, and How Do They Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-compound-assignment-operators-in-javascript-and-how-do-they-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-numbers-booleans-and-the-math-object/673271c7581a27d9dd78f6d6.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-numbers-booleans-and-the-math-object/673271c7581a27d9dd78f6d6.md
@@ -1,7 +1,7 @@
 ---
 id: 673271c7581a27d9dd78f6d6
 title: What Are Booleans, and How Do They Work with Equality and Inequality Operators?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-booleans-and-how-do-they-work-with-equality-and-inequality-operators
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-numbers-booleans-and-the-math-object/673271dffbc34fda31da9515.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-numbers-booleans-and-the-math-object/673271dffbc34fda31da9515.md
@@ -1,7 +1,7 @@
 ---
 id: 673271dffbc34fda31da9515
 title: What Are Comparison Operators, and How Do They Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-comparison-operators-and-how-do-they-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-numbers-booleans-and-the-math-object/673271e8e3d43bda89f723b3.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-numbers-booleans-and-the-math-object/673271e8e3d43bda89f723b3.md
@@ -1,7 +1,7 @@
 ---
 id: 673271e8e3d43bda89f723b3
 title: What Are Unary Operators, and How Do They Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-unary-operators-and-how-do-they-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-numbers-booleans-and-the-math-object/673271f39f124ddac28866d5.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-numbers-booleans-and-the-math-object/673271f39f124ddac28866d5.md
@@ -1,7 +1,7 @@
 ---
 id: 673271f39f124ddac28866d5
 title: What Are Bitwise Operators, and How Do They Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-bitwise-operators-and-how-do-they-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-numbers-booleans-and-the-math-object/673271fd11d063daf0cf8d20.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-numbers-booleans-and-the-math-object/673271fd11d063daf0cf8d20.md
@@ -1,7 +1,7 @@
 ---
 id: 673271fd11d063daf0cf8d20
 title: What Are Conditional Statements, and How Do If/Else If/Else Statements Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-conditional-statements-and-how-do-if-else-if-else-statements-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-numbers-booleans-and-the-math-object/6732720e95f6a0db526a2e4d.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-numbers-booleans-and-the-math-object/6732720e95f6a0db526a2e4d.md
@@ -1,7 +1,7 @@
 ---
 id: 6732720e95f6a0db526a2e4d
 title: What Are Binary Logical Operators, and How Do They Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-binary-logical-operators-and-how-do-they-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-numbers-booleans-and-the-math-object/67327217e70ee0db7913b255.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-numbers-booleans-and-the-math-object/67327217e70ee0db7913b255.md
@@ -1,7 +1,7 @@
 ---
 id: 67327217e70ee0db7913b255
 title: What Is the Math Object in JavaScript, and What Are Some Common Methods?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-the-math-object-in-javascript-and-what-are-some-common-methods
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-objects/67329f737126b75bcb949e13.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-objects/67329f737126b75bcb949e13.md
@@ -1,7 +1,7 @@
 ---
 id: 67329f737126b75bcb949e13
 title: What Is an Object in JavaScript, and How Can You Access Properties from an Object?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-an-object-in-javascript-and-how-can-you-access-properties-from-an-object
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-objects/6732b721eb98f224868b44a6.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-objects/6732b721eb98f224868b44a6.md
@@ -1,7 +1,7 @@
 ---
 id: 6732b721eb98f224868b44a6
 title: How Can You Remove Properties from an Object?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-can-you-remove-properties-from-an-object
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-objects/6732b72961f94324bd6390de.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-objects/6732b72961f94324bd6390de.md
@@ -1,7 +1,7 @@
 ---
 id: 6732b72961f94324bd6390de
 title: How to Check If an Object Has a Property?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-to-check-if-an-object-has-a-property
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-objects/6732b73509f71f24ef05e86e.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-objects/6732b73509f71f24ef05e86e.md
@@ -1,7 +1,7 @@
 ---
 id: 6732b73509f71f24ef05e86e
 title: How Do You Work with Accessing Properties from Nested Objects and Arrays in Objects?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-do-you-work-with-accessing-properties-from-nested-objects-and-arrays-in-objects
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-objects/6732b73d25cc01251b778043.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-objects/6732b73d25cc01251b778043.md
@@ -1,7 +1,7 @@
 ---
 id: 6732b73d25cc01251b778043
 title: What Is the Difference Between Primitive and Non-Primitive Data Types?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-the-difference-between-primitive-and-non-primitive-data-types
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-objects/6732b749b8aad125523dcda5.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-objects/6732b749b8aad125523dcda5.md
@@ -1,7 +1,7 @@
 ---
 id: 6732b749b8aad125523dcda5
 title: What Is the Difference Between Functions and Object Methods?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-the-difference-between-functions-and-object-methods
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-objects/6732b758194c97257d23fc72.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-objects/6732b758194c97257d23fc72.md
@@ -1,7 +1,7 @@
 ---
 id: 6732b758194c97257d23fc72
 title: What Is the Object() Constructor, and When Should You Use It?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-the-object-constructor-and-when-should-you-use-it
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-objects/6732b76c03f7d825c7fc74ee.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-objects/6732b76c03f7d825c7fc74ee.md
@@ -1,7 +1,7 @@
 ---
 id: 6732b76c03f7d825c7fc74ee
 title: What Is the Optional Chaining Operator, and How Does It Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-the-optional-chaining-operator-and-how-does-it-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-objects/6732b77adf9de12617a2dbb3.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-objects/6732b77adf9de12617a2dbb3.md
@@ -1,7 +1,7 @@
 ---
 id: 6732b77adf9de12617a2dbb3
 title: What Is Object Destructuring, and How Does It Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-object-destructuring-and-how-does-it-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-objects/6732b788046862264eeb1c39.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-objects/6732b788046862264eeb1c39.md
@@ -1,7 +1,7 @@
 ---
 id: 6732b788046862264eeb1c39
 title: What Is JSON, and How Do You Access Values Using Bracket and Dot Notation?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-json-and-how-do-you-access-values-using-bracket-and-dot-notation
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-objects/6732b79c6aa77826855a3f11.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-objects/6732b79c6aa77826855a3f11.md
@@ -1,7 +1,7 @@
 ---
 id: 6732b79c6aa77826855a3f11
 title: How Do JSON.parse() and JSON.stringify() Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-do-json-parse-and-json-stringify-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-pseudo-classes-and-pseudo-elements-in-css/672aa74f761c065c9828a95e.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-pseudo-classes-and-pseudo-elements-in-css/672aa74f761c065c9828a95e.md
@@ -1,7 +1,7 @@
 ---
 id: 672aa74f761c065c9828a95e
 title: What Are Pseudo-classes, and How Do They Work?
-challengeType: 11
+challengeType: 24
 videoId: QPg8XhZU5Qw
 dashedName: what-are-pseudo-classes
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-pseudo-classes-and-pseudo-elements-in-css/672bbe9171a5cca90f2edeea.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-pseudo-classes-and-pseudo-elements-in-css/672bbe9171a5cca90f2edeea.md
@@ -1,7 +1,7 @@
 ---
 id: 672bbe9171a5cca90f2edeea
 title: What Are Examples of Element User Action Pseudo-classes?
-challengeType: 11
+challengeType: 24
 videoId: M80PYgBglmY
 dashedName: what-are-examples-of-element-user-action-pseudo-classes
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-pseudo-classes-and-pseudo-elements-in-css/672bbe9d6ec03ea954d92ff7.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-pseudo-classes-and-pseudo-elements-in-css/672bbe9d6ec03ea954d92ff7.md
@@ -1,7 +1,7 @@
 ---
 id: 672bbe9d6ec03ea954d92ff7
 title: What Are Examples of Input Pseudo-classes?
-challengeType: 11
+challengeType: 24
 videoId: qsiIDeAVRiM
 dashedName: what-are-examples-of-input-pseudo-classes
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-pseudo-classes-and-pseudo-elements-in-css/672bbeaa5afdc5a98d5ab8ff.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-pseudo-classes-and-pseudo-elements-in-css/672bbeaa5afdc5a98d5ab8ff.md
@@ -1,7 +1,7 @@
 ---
 id: 672bbeaa5afdc5a98d5ab8ff
 title: What Are Examples of Location Pseudo-classes?
-challengeType: 11
+challengeType: 24
 videoId: i-J4xVUGY5c
 dashedName: what-are-examples-of-location-pseudo-classes
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-pseudo-classes-and-pseudo-elements-in-css/672bbeb6eefd7ca9c003ea00.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-pseudo-classes-and-pseudo-elements-in-css/672bbeb6eefd7ca9c003ea00.md
@@ -1,7 +1,7 @@
 ---
 id: 672bbeb6eefd7ca9c003ea00
 title: What Are Examples of Tree-structural Pseudo-classes?
-challengeType: 11
+challengeType: 24
 videoId: 7lQACnY4opw
 dashedName: what-are-examples-of-tree-structural-pseudo-classes
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-pseudo-classes-and-pseudo-elements-in-css/672bbec3b86dbdaa07a5a5be.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-pseudo-classes-and-pseudo-elements-in-css/672bbec3b86dbdaa07a5a5be.md
@@ -1,7 +1,7 @@
 ---
 id: 672bbec3b86dbdaa07a5a5be
 title: What Are Examples of Functional Pseudo-classes?
-challengeType: 11
+challengeType: 24
 videoId: eQwf6Y3N_kY
 dashedName: what-are-examples-of-functional-pseudo-classes
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-pseudo-classes-and-pseudo-elements-in-css/672bbed37c6f51aa3a15e78c.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-pseudo-classes-and-pseudo-elements-in-css/672bbed37c6f51aa3a15e78c.md
@@ -1,7 +1,7 @@
 ---
 id: 672bbed37c6f51aa3a15e78c
 title: What Are Pseudo-elements, and How Do They Work?
-challengeType: 11
+challengeType: 24
 videoId: sVll3Ta3-D8
 dashedName: what-are-pseudo-elements
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-regular-expressions/6733aad43b3ebff588a26fb5.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-regular-expressions/6733aad43b3ebff588a26fb5.md
@@ -1,7 +1,7 @@
 ---
 id: 6733aad43b3ebff588a26fb5
 title: What Are Regular Expressions, and What Are Some Common Methods?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-regular-expressions-and-what-are-some-common-methods
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-regular-expressions/6733c5ba834ded4bb067e67c.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-regular-expressions/6733c5ba834ded4bb067e67c.md
@@ -1,7 +1,7 @@
 ---
 id: 6733c5ba834ded4bb067e67c
 title: What Are Some Common Regular Expression Modifiers Used for Searching?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-some-common-regular-expression-modifiers-used-for-searching
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-regular-expressions/6733c5c549775c4be710237c.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-regular-expressions/6733c5c549775c4be710237c.md
@@ -1,7 +1,7 @@
 ---
 id: 6733c5c549775c4be710237c
 title: How Can You Match and Replace All Occurrences in a String?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-can-you-match-and-replace-all-occurrences-in-a-string
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-regular-expressions/6733c5d0048bb74c18431296.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-regular-expressions/6733c5d0048bb74c18431296.md
@@ -1,7 +1,7 @@
 ---
 id: 6733c5d0048bb74c18431296
 title: What Are Character Classes, and What Are Some Common Examples?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-character-classes-and-what-are-some-common-examples
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-regular-expressions/6733c5dc74176e4c496d09e6.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-regular-expressions/6733c5dc74176e4c496d09e6.md
@@ -1,7 +1,7 @@
 ---
 id: 6733c5dc74176e4c496d09e6
 title: What Are Lookaheads and Lookbehind Assertions, and How Do They Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-lookaheads-and-lookbehind-assertions-and-how-do-they-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-regular-expressions/6733c5e54e3a154c8078ed48.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-regular-expressions/6733c5e54e3a154c8078ed48.md
@@ -1,7 +1,7 @@
 ---
 id: 6733c5e54e3a154c8078ed48
 title: What Are Regex Quantifiers, and How Do They Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-regex-quantifiers-and-how-do-they-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-regular-expressions/6733c5f20cc9584cada942a4.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-regular-expressions/6733c5f20cc9584cada942a4.md
@@ -1,7 +1,7 @@
 ---
 id: 6733c5f20cc9584cada942a4
 title: What Are Capturing Groups and Backreferences, and How Do They Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-capturing-groups-and-backreferences-and-how-do-they-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-relative-and-absolute-units/672aa7194614b55c16b879a1.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-relative-and-absolute-units/672aa7194614b55c16b879a1.md
@@ -1,7 +1,7 @@
 ---
 id: 672aa7194614b55c16b879a1
 title: What Are Absolute Units in CSS, and When Should You Use Them?
-challengeType: 11
+challengeType: 24
 videoId: 2exAs5vGSpU
 dashedName: what-are-absolute-units-in-css
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-relative-and-absolute-units/672bb7d659f0089377a91eab.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-relative-and-absolute-units/672bb7d659f0089377a91eab.md
@@ -1,7 +1,7 @@
 ---
 id: 672bb7d659f0089377a91eab
 title: What Are Percentages in CSS, and When Should You Use Them?
-challengeType: 11
+challengeType: 24
 videoId: cj58l9QPkts
 dashedName: what-are-percentages-in-css
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-relative-and-absolute-units/672bb7f08b58df93ed2a8768.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-relative-and-absolute-units/672bb7f08b58df93ed2a8768.md
@@ -1,7 +1,7 @@
 ---
 id: 672bb7f08b58df93ed2a8768
 title: What Are ems and rems in CSS, and When Should You Use Them?
-challengeType: 11
+challengeType: 24
 videoId: __rgTD09izM
 dashedName: what-are-ems-and-rems-in-css
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-relative-and-absolute-units/672bb83c3a9906945536cff2.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-relative-and-absolute-units/672bb83c3a9906945536cff2.md
@@ -1,7 +1,7 @@
 ---
 id: 672bb83c3a9906945536cff2
 title: What Are vh and vw Units, and When Should You Use Them?
-challengeType: 11
+challengeType: 24
 videoId: 43qyWzJArH8
 dashedName: what-are-vh-and-vw-units
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-relative-and-absolute-units/672bb851b068e3954a05b9b1.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-relative-and-absolute-units/672bb851b068e3954a05b9b1.md
@@ -1,7 +1,7 @@
 ---
 id: 672bb851b068e3954a05b9b1
 title: What Is the calc() Function, and How Does It Work?
-challengeType: 11
+challengeType: 24
 videoId: OtYl8n4cXDk
 dashedName: what-is-the-calc-function
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-strings-in-javascript/672d2654f78cbf20e0ba4501.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-strings-in-javascript/672d2654f78cbf20e0ba4501.md
@@ -1,7 +1,7 @@
 ---
 id: 672d2654f78cbf20e0ba4501
 title: What Is Bracket Notation, and How Do You Access Characters from a String?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-bracket-notation-and-how-do-you-access-characters-from-a-string
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-strings-in-javascript/673263d58da27ea7809963bf.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-strings-in-javascript/673263d58da27ea7809963bf.md
@@ -1,7 +1,7 @@
 ---
 id: 673263d58da27ea7809963bf
 title: What Are Template Literals, and What Is String Interpolation?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-template-literals-and-what-is-string-interpolation
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-strings-in-javascript/673263df0eb568a7b450f2fc.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-strings-in-javascript/673263df0eb568a7b450f2fc.md
@@ -1,7 +1,7 @@
 ---
 id: 673263df0eb568a7b450f2fc
 title: How Do You Create a Newline in Strings and Escape Strings?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-do-you-create-a-newline-in-strings-and-escape-strings
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-strings-in-javascript/673263e80dd43da7df3ae565.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-strings-in-javascript/673263e80dd43da7df3ae565.md
@@ -1,7 +1,7 @@
 ---
 id: 673263e80dd43da7df3ae565
 title: How Can You Find the Position of a Substring in a String?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-can-you-find-the-position-of-a-substring-in-a-string
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-strings-in-javascript/673263f4a5899da8124542fd.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-strings-in-javascript/673263f4a5899da8124542fd.md
@@ -1,7 +1,7 @@
 ---
 id: 673263f4a5899da8124542fd
 title: What Is the Prompt Method, and How Does It Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-the-prompt-method-and-how-does-it-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-tables/672a4e04a24858778f57ebfe.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-tables/672a4e04a24858778f57ebfe.md
@@ -1,7 +1,7 @@
 ---
 id: 672a4e04a24858778f57ebfe
 title: What Are HTML Tables Used For, and What Should They Not Be Used For?
-challengeType: 11
+challengeType: 24
 videoId: l_M9cKRPzN4
 dashedName: what-are-html-tables-used-for
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-the-dom-click-events-and-web-apis/6732a0472f52015e511f8e58.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-the-dom-click-events-and-web-apis/6732a0472f52015e511f8e58.md
@@ -1,7 +1,7 @@
 ---
 id: 6732a0472f52015e511f8e58
 title: What Is an API, and What Are Web APIs?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-an-api-and-what-are-web-apis
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-the-dom-click-events-and-web-apis/67336894ae148431a870694d.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-the-dom-click-events-and-web-apis/67336894ae148431a870694d.md
@@ -1,7 +1,7 @@
 ---
 id: 67336894ae148431a870694d
 title: What Is the DOM, and How Do You Access Elements?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-the-dom-and-how-do-you-access-elements
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-the-dom-click-events-and-web-apis/6733689f9f31dd31e7d9c789.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-the-dom-click-events-and-web-apis/6733689f9f31dd31e7d9c789.md
@@ -1,7 +1,7 @@
 ---
 id: 6733689f9f31dd31e7d9c789
 title: How Do DOM Nodes Exist Relative to Each Other in the DOM Tree?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-do-dom-nodes-exist-relative-to-each-other-in-the-dom-tree
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-the-dom-click-events-and-web-apis/673368b1cf26253212a3cfb2.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-the-dom-click-events-and-web-apis/673368b1cf26253212a3cfb2.md
@@ -1,7 +1,7 @@
 ---
 id: 673368b1cf26253212a3cfb2
 title: What Is the querySelectorAll() Method, and When Should You Use It?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-the-queryselectorall-method-and-when-should-you-use-it
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-the-dom-click-events-and-web-apis/673368c0161e6b326a7e03f0.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-the-dom-click-events-and-web-apis/673368c0161e6b326a7e03f0.md
@@ -1,7 +1,7 @@
 ---
 id: 673368c0161e6b326a7e03f0
 title: How Do You Create New Nodes Using innerHTML() and createElement()?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-do-you-create-new-nodes-using-innerhtml-and-createelement
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-the-dom-click-events-and-web-apis/673368ccf52205329b729378.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-the-dom-click-events-and-web-apis/673368ccf52205329b729378.md
@@ -1,7 +1,7 @@
 ---
 id: 673368ccf52205329b729378
 title: What Is the Difference Between innerText, textContent, and innerHTML?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-the-difference-between-innertext-textcontent-and-innerhtml
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-the-dom-click-events-and-web-apis/673368d97e8ce232cdcd6b68.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-the-dom-click-events-and-web-apis/673368d97e8ce232cdcd6b68.md
@@ -1,7 +1,7 @@
 ---
 id: 673368d97e8ce232cdcd6b68
 title: How Do You Add and Remove Nodes from the DOM with appendChild() and removeChild()?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-do-you-add-and-remove-nodes-from-the-dom-with-appendchild-and-removechild
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-the-dom-click-events-and-web-apis/673368e7bd043f331919514d.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-the-dom-click-events-and-web-apis/673368e7bd043f331919514d.md
@@ -1,7 +1,7 @@
 ---
 id: 673368e7bd043f331919514d
 title: How Do the Navigator, Window, and Document Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-do-the-navigator-window-and-document-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-the-dom-click-events-and-web-apis/673368f272706633516e4873.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-the-dom-click-events-and-web-apis/673368f272706633516e4873.md
@@ -1,7 +1,7 @@
 ---
 id: 673368f272706633516e4873
 title: How Do You Add Attributes with setAttribute()?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-do-you-add-attributes-with-setattribute
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-the-dom-click-events-and-web-apis/673368fbe12a2b337645053d.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-the-dom-click-events-and-web-apis/673368fbe12a2b337645053d.md
@@ -1,7 +1,7 @@
 ---
 id: 673368fbe12a2b337645053d
 title: What Is the Event Object?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-the-event-object
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-the-dom-click-events-and-web-apis/673369067f824d33a90a0534.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-the-dom-click-events-and-web-apis/673369067f824d33a90a0534.md
@@ -1,7 +1,7 @@
 ---
 id: 673369067f824d33a90a0534
 title: How Does the addEventListener Method Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-does-the-addeventlistener-method-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-the-dom-click-events-and-web-apis/673369101e5c4a33db0e8a02.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-the-dom-click-events-and-web-apis/673369101e5c4a33db0e8a02.md
@@ -1,7 +1,7 @@
 ---
 id: 673369101e5c4a33db0e8a02
 title: How Does the removeEventListener Method Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-does-the-removeeventlistener-method-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-the-dom-click-events-and-web-apis/6733691d88e3053414689276.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-the-dom-click-events-and-web-apis/6733691d88e3053414689276.md
@@ -1,7 +1,7 @@
 ---
 id: 6733691d88e3053414689276
 title: What Are Inline Event Handlers, and Why Is It Best Practice to Use addEventListener Instead?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-are-inline-event-handlers-and-why-is-it-best-practice-to-use-addeventlistener-instead
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-the-dom-click-events-and-web-apis/6733692ffe1da034469f7917.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-the-dom-click-events-and-web-apis/6733692ffe1da034469f7917.md
@@ -1,7 +1,7 @@
 ---
 id: 6733692ffe1da034469f7917
 title: How Do You Manipulate Styles Using Element.style and Element.classList?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-do-you-manipulate-styles-using-elementstyle-and-elementclasslist
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-the-dom-click-events-and-web-apis/6733693bfce9a43489a355db.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-the-dom-click-events-and-web-apis/6733693bfce9a43489a355db.md
@@ -1,7 +1,7 @@
 ---
 id: 6733693bfce9a43489a355db
 title: What Is the DOMContentLoaded Event, and How Does It Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-the-domcontentloaded-event-and-how-does-it-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-the-dom-click-events-and-web-apis/6733694805a85d34ced08a9b.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-the-dom-click-events-and-web-apis/6733694805a85d34ced08a9b.md
@@ -1,7 +1,7 @@
 ---
 id: 6733694805a85d34ced08a9b
 title: How Do the setTimeout and setInterval Methods Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-do-the-settimeout-and-setinterval-methods-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-the-dom-click-events-and-web-apis/67336956340e8a34fbd5d9f3.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-the-dom-click-events-and-web-apis/67336956340e8a34fbd5d9f3.md
@@ -1,7 +1,7 @@
 ---
 id: 67336956340e8a34fbd5d9f3
 title: What Is the requestAnimationFrame() API, and How Can It Be Used to Set Up an Animation Loop?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-the-requestanimationframe-api-and-how-can-it-be-used-to-set-up-an-animation-loop
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-the-dom-click-events-and-web-apis/6733696567d2273540aa6033.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-the-dom-click-events-and-web-apis/6733696567d2273540aa6033.md
@@ -1,7 +1,7 @@
 ---
 id: 6733696567d2273540aa6033
 title: What Is the Web Animations API, and How Does It Relate to CSS Animation Properties?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-the-web-animations-api-and-how-does-it-relate-to-css-animation-properties
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-the-dom-click-events-and-web-apis/6733697661182d357fc643d2.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-the-dom-click-events-and-web-apis/6733697661182d357fc643d2.md
@@ -1,7 +1,7 @@
 ---
 id: 6733697661182d357fc643d2
 title: What Is the Canvas API, and How Does It Work?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: what-is-the-canvas-api-and-how-does-it-work
 ---

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-the-dom-click-events-and-web-apis/673369829e232835c2732656.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-the-dom-click-events-and-web-apis/673369829e232835c2732656.md
@@ -1,7 +1,7 @@
 ---
 id: 673369829e232835c2732656
 title: How Do You Open and Close Dialog Elements Using JavaScript?
-challengeType: 11
+challengeType: 24
 videoId: nVAaxZ34khk
 dashedName: how-do-you-open-and-close-dialog-elements-using-javascript
 ---


### PR DESCRIPTION
Makes all lectures use challengeType 24. Not necessary at the moment, mainly for consistency - but maybe we can get rid of some of the related stuff (view components, challenge types, other) at some point if we move them all over.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
