### PR TITLE
fix(curriculum): remove usesMultifileEditor from quiz meta

### DIFF
--- a/curriculum/challenges/_meta/quiz-advanced-react/meta.json
+++ b/curriculum/challenges/_meta/quiz-advanced-react/meta.json
@@ -3,7 +3,6 @@
   "blockType": "quiz",
   "blockLayout": "link",
   "isUpcomingChange": true,
-  "usesMultifileEditor": true,
   "dashedName": "quiz-advanced-react",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/quiz-asynchronous-javascript/meta.json
+++ b/curriculum/challenges/_meta/quiz-asynchronous-javascript/meta.json
@@ -3,7 +3,6 @@
   "blockType": "quiz",
   "blockLayout": "link",
   "isUpcomingChange": true,
-  "usesMultifileEditor": true,
   "dashedName": "quiz-asynchronous-javascript",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/quiz-bash-and-sql/meta.json
+++ b/curriculum/challenges/_meta/quiz-bash-and-sql/meta.json
@@ -3,7 +3,6 @@
   "blockType": "quiz",
   "blockLayout": "link",
   "isUpcomingChange": true,
-  "usesMultifileEditor": true,
   "dashedName": "quiz-bash-and-sql",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/quiz-bash-commands/meta.json
+++ b/curriculum/challenges/_meta/quiz-bash-commands/meta.json
@@ -3,7 +3,6 @@
   "blockType": "quiz",
   "blockLayout": "link",
   "isUpcomingChange": true,
-  "usesMultifileEditor": true,
   "dashedName": "quiz-bash-commands",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/quiz-bash-scripting/meta.json
+++ b/curriculum/challenges/_meta/quiz-bash-scripting/meta.json
@@ -3,7 +3,6 @@
   "blockType": "quiz",
   "blockLayout": "link",
   "isUpcomingChange": true,
-  "usesMultifileEditor": true,
   "dashedName": "quiz-bash-scripting",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/quiz-css-libraries-and-frameworks/meta.json
+++ b/curriculum/challenges/_meta/quiz-css-libraries-and-frameworks/meta.json
@@ -3,7 +3,6 @@
   "blockType": "quiz",
   "blockLayout": "link",
   "isUpcomingChange": true,
-  "usesMultifileEditor": true,
   "dashedName": "quiz-css-libraries-and-frameworks",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/quiz-debugging-javascript/meta.json
+++ b/curriculum/challenges/_meta/quiz-debugging-javascript/meta.json
@@ -3,7 +3,6 @@
   "blockType": "quiz",
   "blockLayout": "link",
   "isUpcomingChange": true,
-  "usesMultifileEditor": true,
   "dashedName": "quiz-debugging-javascript",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/quiz-dom-manipulation-and-click-event-with-javascript/meta.json
+++ b/curriculum/challenges/_meta/quiz-dom-manipulation-and-click-event-with-javascript/meta.json
@@ -3,7 +3,6 @@
   "blockType": "quiz",
   "blockLayout": "link",
   "isUpcomingChange": true,
-  "usesMultifileEditor": true,
   "dashedName": "quiz-dom-manipulation-and-click-event-with-javascript",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/quiz-form-validation-with-javascript/meta.json
+++ b/curriculum/challenges/_meta/quiz-form-validation-with-javascript/meta.json
@@ -3,7 +3,6 @@
   "blockType": "quiz",
   "blockLayout": "link",
   "isUpcomingChange": true,
-  "usesMultifileEditor": true,
   "dashedName": "quiz-form-validation-with-javascript",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/quiz-git/meta.json
+++ b/curriculum/challenges/_meta/quiz-git/meta.json
@@ -3,7 +3,6 @@
   "blockType": "quiz",
   "blockLayout": "link",
   "isUpcomingChange": true,
-  "usesMultifileEditor": true,
   "dashedName": "quiz-git",
   "superBlock": "full-stack-developer",
   "challengeOrder": [{ "id": "66f1b06a5a5d10cc100af620", "title": "Git Quiz" }],

--- a/curriculum/challenges/_meta/quiz-javascript-arrays/meta.json
+++ b/curriculum/challenges/_meta/quiz-javascript-arrays/meta.json
@@ -3,7 +3,6 @@
   "blockType": "quiz",
   "blockLayout": "link",
   "isUpcomingChange": true,
-  "usesMultifileEditor": true,
   "dashedName": "quiz-javascript-arrays",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/quiz-javascript-audio-and-video/meta.json
+++ b/curriculum/challenges/_meta/quiz-javascript-audio-and-video/meta.json
@@ -3,7 +3,6 @@
   "blockType": "quiz",
   "blockLayout": "link",
   "isUpcomingChange": true,
-  "usesMultifileEditor": true,
   "dashedName": "quiz-javascript-audio-and-video",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/quiz-javascript-comparisons-and-conditionals/meta.json
+++ b/curriculum/challenges/_meta/quiz-javascript-comparisons-and-conditionals/meta.json
@@ -3,7 +3,6 @@
   "blockType": "quiz",
   "blockLayout": "link",
   "isUpcomingChange": true,
-  "usesMultifileEditor": true,
   "dashedName": "quiz-javascript-comparisons-and-conditionals",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/quiz-javascript-dates/meta.json
+++ b/curriculum/challenges/_meta/quiz-javascript-dates/meta.json
@@ -3,7 +3,6 @@
   "blockType": "quiz",
   "blockLayout": "link",
   "isUpcomingChange": true,
-  "usesMultifileEditor": true,
   "dashedName": "quiz-javascript-dates",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/quiz-javascript-events/meta.json
+++ b/curriculum/challenges/_meta/quiz-javascript-events/meta.json
@@ -3,7 +3,6 @@
   "blockType": "quiz",
   "blockLayout": "link",
   "isUpcomingChange": true,
-  "usesMultifileEditor": true,
   "dashedName": "quiz-javascript-events",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/quiz-javascript-functional-programming/meta.json
+++ b/curriculum/challenges/_meta/quiz-javascript-functional-programming/meta.json
@@ -3,7 +3,6 @@
   "blockType": "quiz",
   "blockLayout": "link",
   "isUpcomingChange": true,
-  "usesMultifileEditor": true,
   "dashedName": "quiz-javascript-functional-programming",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/quiz-javascript-functions/meta.json
+++ b/curriculum/challenges/_meta/quiz-javascript-functions/meta.json
@@ -3,7 +3,6 @@
   "blockType": "quiz",
   "blockLayout": "link",
   "isUpcomingChange": true,
-  "usesMultifileEditor": true,
   "dashedName": "quiz-javascript-functions",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/quiz-javascript-fundamentals/meta.json
+++ b/curriculum/challenges/_meta/quiz-javascript-fundamentals/meta.json
@@ -3,7 +3,6 @@
   "blockType": "quiz",
   "blockLayout": "link",
   "isUpcomingChange": true,
-  "usesMultifileEditor": true,
   "dashedName": "quiz-javascript-fundamentals",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/quiz-javascript-higher-order-functions/meta.json
+++ b/curriculum/challenges/_meta/quiz-javascript-higher-order-functions/meta.json
@@ -3,7 +3,6 @@
   "blockType": "quiz",
   "blockLayout": "link",
   "isUpcomingChange": true,
-  "usesMultifileEditor": true,
   "dashedName": "quiz-javascript-higher-order-functions",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/quiz-javascript-loops/meta.json
+++ b/curriculum/challenges/_meta/quiz-javascript-loops/meta.json
@@ -3,7 +3,6 @@
   "blockType": "quiz",
   "blockLayout": "link",
   "isUpcomingChange": true,
-  "usesMultifileEditor": true,
   "dashedName": "quiz-javascript-loops",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/quiz-javascript-math/meta.json
+++ b/curriculum/challenges/_meta/quiz-javascript-math/meta.json
@@ -3,7 +3,6 @@
   "blockType": "quiz",
   "blockLayout": "link",
   "isUpcomingChange": true,
-  "usesMultifileEditor": true,
   "dashedName": "quiz-javascript-math",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/quiz-javascript-objects/meta.json
+++ b/curriculum/challenges/_meta/quiz-javascript-objects/meta.json
@@ -3,7 +3,6 @@
   "blockType": "quiz",
   "blockLayout": "link",
   "isUpcomingChange": true,
-  "usesMultifileEditor": true,
   "dashedName": "quiz-javascript-objects",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/quiz-javascript-regular-expressions/meta.json
+++ b/curriculum/challenges/_meta/quiz-javascript-regular-expressions/meta.json
@@ -3,7 +3,6 @@
   "blockType": "quiz",
   "blockLayout": "link",
   "isUpcomingChange": true,
-  "usesMultifileEditor": true,
   "dashedName": "quiz-javascript-regular-expressions",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/quiz-javascript-strings/meta.json
+++ b/curriculum/challenges/_meta/quiz-javascript-strings/meta.json
@@ -3,7 +3,6 @@
   "blockType": "quiz",
   "blockLayout": "link",
   "isUpcomingChange": true,
-  "usesMultifileEditor": true,
   "dashedName": "quiz-javascript-strings",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/quiz-javascript-variables-and-data-types/meta.json
+++ b/curriculum/challenges/_meta/quiz-javascript-variables-and-data-types/meta.json
@@ -3,7 +3,6 @@
   "blockType": "quiz",
   "blockLayout": "link",
   "isUpcomingChange": true,
-  "usesMultifileEditor": true,
   "dashedName": "quiz-javascript-variables-and-data-types",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/quiz-local-storage-and-crud/meta.json
+++ b/curriculum/challenges/_meta/quiz-local-storage-and-crud/meta.json
@@ -3,7 +3,6 @@
   "blockType": "quiz",
   "blockLayout": "link",
   "isUpcomingChange": true,
-  "usesMultifileEditor": true,
   "dashedName": "quiz-local-storage-and-crud",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/quiz-nano/meta.json
+++ b/curriculum/challenges/_meta/quiz-nano/meta.json
@@ -3,7 +3,6 @@
   "blockType": "quiz",
   "blockLayout": "link",
   "isUpcomingChange": true,
-  "usesMultifileEditor": true,
   "dashedName": "quiz-nano",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/quiz-react-basics/meta.json
+++ b/curriculum/challenges/_meta/quiz-react-basics/meta.json
@@ -3,7 +3,6 @@
   "blockType": "quiz",
   "blockLayout": "link",
   "isUpcomingChange": true,
-  "usesMultifileEditor": true,
   "dashedName": "quiz-react-basics",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/quiz-react-state-and-hooks/meta.json
+++ b/curriculum/challenges/_meta/quiz-react-state-and-hooks/meta.json
@@ -3,7 +3,6 @@
   "blockType": "quiz",
   "blockLayout": "link",
   "isUpcomingChange": true,
-  "usesMultifileEditor": true,
   "dashedName": "quiz-react-state-and-hooks",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/quiz-recursion/meta.json
+++ b/curriculum/challenges/_meta/quiz-recursion/meta.json
@@ -3,7 +3,6 @@
   "blockType": "quiz",
   "blockLayout": "link",
   "isUpcomingChange": true,
-  "usesMultifileEditor": true,
   "dashedName": "quiz-recursion",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/quiz-relational-database/meta.json
+++ b/curriculum/challenges/_meta/quiz-relational-database/meta.json
@@ -3,7 +3,6 @@
   "blockType": "quiz",
   "blockLayout": "link",
   "isUpcomingChange": true,
-  "usesMultifileEditor": true,
   "dashedName": "quiz-relational-database",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/quiz-testing/meta.json
+++ b/curriculum/challenges/_meta/quiz-testing/meta.json
@@ -3,7 +3,6 @@
   "blockType": "quiz",
   "blockLayout": "link",
   "isUpcomingChange": true,
-  "usesMultifileEditor": true,
   "dashedName": "quiz-testing",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/quiz-typescript/meta.json
+++ b/curriculum/challenges/_meta/quiz-typescript/meta.json
@@ -3,7 +3,6 @@
   "blockType": "quiz",
   "blockLayout": "link",
   "isUpcomingChange": true,
-  "usesMultifileEditor": true,
   "dashedName": "quiz-typescript",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/quiz-web-performance/meta.json
+++ b/curriculum/challenges/_meta/quiz-web-performance/meta.json
@@ -3,7 +3,6 @@
   "blockType": "quiz",
   "blockLayout": "link",
   "isUpcomingChange": true,
-  "usesMultifileEditor": true,
   "dashedName": "quiz-web-performance",
   "superBlock": "full-stack-developer",
   "challengeOrder": [


### PR DESCRIPTION
Minor clean-up - remove the `"usesMultifileEditor": true` from the quiz meta.json files that had it.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
