### PR TITLE
fix(tools): sync up unit tests with client tests

### DIFF
--- a/client/src/templates/Challenges/utils/build.ts
+++ b/client/src/templates/Challenges/utils/build.ts
@@ -93,7 +93,7 @@ function buildSourceMap(challengeFiles: ChallengeFile[]): Source | undefined {
   return source;
 }
 
-const buildFunctions = {
+export const buildFunctions = {
   [challengeTypes.js]: buildJSChallenge,
   [challengeTypes.jsProject]: buildJSChallenge,
   [challengeTypes.html]: buildDOMChallenge,


### PR DESCRIPTION
By using the same build functions as the client, these tests should fail if the build is not allowed (i.e. uses an invalid challengeType).

Also, this makes the build module the single source of truth for how challenges are built.

https://github.com/freeCodeCamp/freeCodeCamp/pull/57441 introduced a bug, fixed by https://github.com/freeCodeCamp/freeCodeCamp/pull/57507, that should have been caught by our tests (and by me :disappointed:). Now those kinds of bugs will be obvious.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->
