### PR TITLE
fix: show completion modal for labs

### DIFF
--- a/client/src/utils/curriculum-layout.ts
+++ b/client/src/utils/curriculum-layout.ts
@@ -33,7 +33,8 @@ const projectBasedChallengeTypes = [
   challengeTypes.multifileCertProject,
   challengeTypes.exam,
   challengeTypes.codeAllyPractice,
-  challengeTypes.multifilePythonCertProject
+  challengeTypes.multifilePythonCertProject,
+  challengeTypes.lab
 ];
 
 export const isProjectBased = (


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This is a quick fix so that the completion modal shows when a learner completes a lab via the hotkeys.

It has a side-effect that it changes the `revert to saved code` button into `reset this code`, but it doesn't change the functionality. I'll put together a followup PR to sort that out.

<!-- Feel free to add any additional description of changes below this line -->
