### PR TITLE
fix(curriculum): cat painting check for proper selector

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-intermediate-css-by-building-a-cat-painting/646ceb843412c74edee27a79.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-intermediate-css-by-building-a-cat-painting/646ceb843412c74edee27a79.md
@@ -18,49 +18,49 @@ Using a class selector, give the `.cat-right-ear` element `height` and `width` p
 You should have a `.cat-right-ear` selector.
 
 ```js
-assert(new __helpers.CSSHelp(document)?.getStyle('.cat-head'))
+assert.exists(new __helpers.CSSHelp(document)?.getStyle('.cat-right-ear'))
 ```
 
 Your `.cat-right-ear` selector should have a `height` property set to `100px`. Don't forget to add a semi-colon.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.height === '100px')
+assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.height,'100px')
 ```
 
 Your `.cat-right-ear` selector should have a `width` property set to `100px`. Don't forget to add a semi-colon.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.width === '100px')
+assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.width,'100px')
 ```
 
 Your `.cat-right-ear` selector should have a `background-color` property set to `white`. Don't forget to add a semi-colon.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.backgroundColor === 'white')
+assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.backgroundColor,'white')
 ```
 
 Your `.cat-right-ear` selector should have a `border-left` property set to `35px solid blue`. Don't forget to add a semi-colon.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderLeft === '35px solid blue')
+assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderLeft,'35px solid blue')
 ```
 
 Your `.cat-right-ear` selector should have a `border-right` property set to `35px solid blue`. Don't forget to add a semi-colon.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderRight === '35px solid blue')
+assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderRight,'35px solid blue')
 ```
 
 Your `.cat-right-ear` selector should have a `border-top` property set to `35px solid red`. Don't forget to add a semi-colon.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderTop === '35px solid red')
+assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderTop,'35px solid red')
 ```
 
 Your `.cat-right-ear` selector should have a `border-bottom` property set to `35px solid red`. Don't forget to add a semi-colon.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderBottom === '35px solid red')
+assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderBottom,'35px solid red')
 ```
 
 # --seed--

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-intermediate-css-by-building-a-cat-painting/646ceb843412c74edee27a79.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-intermediate-css-by-building-a-cat-painting/646ceb843412c74edee27a79.md
@@ -24,43 +24,43 @@ assert.exists(new __helpers.CSSHelp(document)?.getStyle('.cat-right-ear'))
 Your `.cat-right-ear` selector should have a `height` property set to `100px`. Don't forget to add a semi-colon.
 
 ```js
-assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.height,'100px')
+assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.height, '100px')
 ```
 
 Your `.cat-right-ear` selector should have a `width` property set to `100px`. Don't forget to add a semi-colon.
 
 ```js
-assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.width,'100px')
+assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.width, '100px')
 ```
 
 Your `.cat-right-ear` selector should have a `background-color` property set to `white`. Don't forget to add a semi-colon.
 
 ```js
-assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.backgroundColor,'white')
+assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.backgroundColor, 'white')
 ```
 
 Your `.cat-right-ear` selector should have a `border-left` property set to `35px solid blue`. Don't forget to add a semi-colon.
 
 ```js
-assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderLeft,'35px solid blue')
+assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderLeft, '35px solid blue')
 ```
 
 Your `.cat-right-ear` selector should have a `border-right` property set to `35px solid blue`. Don't forget to add a semi-colon.
 
 ```js
-assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderRight,'35px solid blue')
+assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderRight, '35px solid blue')
 ```
 
 Your `.cat-right-ear` selector should have a `border-top` property set to `35px solid red`. Don't forget to add a semi-colon.
 
 ```js
-assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderTop,'35px solid red')
+assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderTop, '35px solid red')
 ```
 
 Your `.cat-right-ear` selector should have a `border-bottom` property set to `35px solid red`. Don't forget to add a semi-colon.
 
 ```js
-assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderBottom,'35px solid red')
+assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderBottom, '35px solid red')
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646ceb843412c74edee27a79.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646ceb843412c74edee27a79.md
@@ -14,49 +14,49 @@ Using a class selector, give the `.cat-right-ear` element `height` and `width` p
 You should have a `.cat-right-ear` selector.
 
 ```js
-assert(new __helpers.CSSHelp(document)?.getStyle('.cat-head'))
+assert.exists(new __helpers.CSSHelp(document)?.getStyle('.cat-right-ear'))
 ```
 
 Your `.cat-right-ear` selector should have a `height` property set to `100px`. Don't forget to add a semi-colon.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.height === '100px')
+assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.height,'100px')
 ```
 
 Your `.cat-right-ear` selector should have a `width` property set to `100px`. Don't forget to add a semi-colon.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.width === '100px')
+assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.width,'100px')
 ```
 
 Your `.cat-right-ear` selector should have a `background-color` property set to `white`. Don't forget to add a semi-colon.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.backgroundColor === 'white')
+assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.backgroundColor,'white')
 ```
 
 Your `.cat-right-ear` selector should have a `border-left` property set to `35px solid blue`. Don't forget to add a semi-colon.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderLeft === '35px solid blue')
+assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderLeft,'35px solid blue')
 ```
 
 Your `.cat-right-ear` selector should have a `border-right` property set to `35px solid blue`. Don't forget to add a semi-colon.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderRight === '35px solid blue')
+assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderRight,'35px solid blue')
 ```
 
 Your `.cat-right-ear` selector should have a `border-top` property set to `35px solid red`. Don't forget to add a semi-colon.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderTop === '35px solid red')
+assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderTop,'35px solid red')
 ```
 
 Your `.cat-right-ear` selector should have a `border-bottom` property set to `35px solid red`. Don't forget to add a semi-colon.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderBottom === '35px solid red')
+assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderBottom,'35px solid red')
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646ceb843412c74edee27a79.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646ceb843412c74edee27a79.md
@@ -20,43 +20,43 @@ assert.exists(new __helpers.CSSHelp(document)?.getStyle('.cat-right-ear'))
 Your `.cat-right-ear` selector should have a `height` property set to `100px`. Don't forget to add a semi-colon.
 
 ```js
-assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.height,'100px')
+assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.height, '100px')
 ```
 
 Your `.cat-right-ear` selector should have a `width` property set to `100px`. Don't forget to add a semi-colon.
 
 ```js
-assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.width,'100px')
+assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.width, '100px')
 ```
 
 Your `.cat-right-ear` selector should have a `background-color` property set to `white`. Don't forget to add a semi-colon.
 
 ```js
-assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.backgroundColor,'white')
+assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.backgroundColor, 'white')
 ```
 
 Your `.cat-right-ear` selector should have a `border-left` property set to `35px solid blue`. Don't forget to add a semi-colon.
 
 ```js
-assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderLeft,'35px solid blue')
+assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderLeft, '35px solid blue')
 ```
 
 Your `.cat-right-ear` selector should have a `border-right` property set to `35px solid blue`. Don't forget to add a semi-colon.
 
 ```js
-assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderRight,'35px solid blue')
+assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderRight, '35px solid blue')
 ```
 
 Your `.cat-right-ear` selector should have a `border-top` property set to `35px solid red`. Don't forget to add a semi-colon.
 
 ```js
-assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderTop,'35px solid red')
+assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderTop, '35px solid red')
 ```
 
 Your `.cat-right-ear` selector should have a `border-bottom` property set to `35px solid red`. Don't forget to add a semi-colon.
 
 ```js
-assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderBottom,'35px solid red')
+assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderBottom, '35px solid red')
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646cf2249f02ca5233d9af7c.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646cf2249f02ca5233d9af7c.md
@@ -16,25 +16,25 @@ Using a class selector, give the `.cat-right-ear` element a left and right borde
 You should have a `.cat-right-ear` selector.
 
 ```js 
-assert(new __helpers.CSSHelp(document).getStyle('.cat-right-ear'))
+assert.exists(new __helpers.CSSHelp(document).getStyle('.cat-right-ear'))
 ```
 
 Your `.cat-right-ear` selector should have a `border-left` property set to `35px solid transparent`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderLeft === '35px solid transparent')
+assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderLeft,'35px solid transparent')
 ```
 
 Your `.cat-right-ear` selector should have a `border-right` property set to `35px solid transparent`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderRight === '35px solid transparent')
+assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderRight,'35px solid transparent')
 ```
 
 Your `.cat-right-ear` selector should have a `border-bottom` property set to `70px solid #5e5e5e`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderBottom === '70px solid rgb(94, 94, 94)')
+assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderBottom,'70px solid rgb(94, 94, 94)')
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646cf2249f02ca5233d9af7c.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646cf2249f02ca5233d9af7c.md
@@ -22,19 +22,19 @@ assert.exists(new __helpers.CSSHelp(document).getStyle('.cat-right-ear'))
 Your `.cat-right-ear` selector should have a `border-left` property set to `35px solid transparent`.
 
 ```js
-assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderLeft,'35px solid transparent')
+assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderLeft, '35px solid transparent')
 ```
 
 Your `.cat-right-ear` selector should have a `border-right` property set to `35px solid transparent`.
 
 ```js
-assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderRight,'35px solid transparent')
+assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderRight, '35px solid transparent')
 ```
 
 Your `.cat-right-ear` selector should have a `border-bottom` property set to `70px solid #5e5e5e`.
 
 ```js
-assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderBottom,'70px solid rgb(94, 94, 94)')
+assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderBottom, '70px solid rgb(94, 94, 94)')
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/6676a8b01e56ec1a1e07c202.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/6676a8b01e56ec1a1e07c202.md
@@ -25,38 +25,38 @@ assert.exists(new __helpers.CSSHelp(document)?.getStyle('.cat-right-ear'))
 Your `.cat-right-ear` selector should have a `height` property set to `0`. Don't forget to add a semi-colon.
 
 ```js
-assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.height,'0px')
+assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.height, '0px')
 ```
 
 Your `.cat-right-ear` selector should have a `width` property set to `0`. Don't forget to add a semi-colon.
 
 ```js
-assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.width,'0px')
+assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.width, '0px')
 ```
 
 Your `.cat-right-ear` selector should have a `border-left` property set to `35px solid transparent`. Don't forget to add a semi-colon.
 
 ```js
-assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderLeft,'35px solid transparent')
+assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderLeft, '35px solid transparent')
 ```
 
 Your `.cat-right-ear` selector should have a `border-right` property set to `35px solid transparent`. Don't forget to add a semi-colon.
 
 ```js
-assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderRight,'35px solid transparent')
+assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderRight, '35px solid transparent')
 ```
 
 Your `.cat-right-ear` selector should have a `border-top` property set to `35px solid transparent`. Don't forget to add a semi-colon.
 
 ```js
-assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderTop,'35px solid transparent')
+assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderTop, '35px solid transparent')
 ```
 
 
 Your `.cat-right-ear` selector should have a `border-bottom` property set to `35px solid red`. Don't forget to add a semi-colon.
 
 ```js
-assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderBottom,'35px solid red')
+assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderBottom, '35px solid red')
 ```
 
 Your `.cat-right-ear` selector should not have a `background-color` property.

--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/6676a8b01e56ec1a1e07c202.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/6676a8b01e56ec1a1e07c202.md
@@ -19,50 +19,50 @@ Remove the `background-color` property, and you should see a triangle.
 You should have a `.cat-right-ear` selector.
 
 ```js
-assert(new __helpers.CSSHelp(document)?.getStyle('.cat-right-ear'))
+assert.exists(new __helpers.CSSHelp(document)?.getStyle('.cat-right-ear'))
 ```
 
 Your `.cat-right-ear` selector should have a `height` property set to `0`. Don't forget to add a semi-colon.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.height == '0px')
+assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.height,'0px')
 ```
 
 Your `.cat-right-ear` selector should have a `width` property set to `0`. Don't forget to add a semi-colon.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.width === '0px')
+assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.width,'0px')
 ```
 
 Your `.cat-right-ear` selector should have a `border-left` property set to `35px solid transparent`. Don't forget to add a semi-colon.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderLeft === '35px solid transparent')
+assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderLeft,'35px solid transparent')
 ```
 
 Your `.cat-right-ear` selector should have a `border-right` property set to `35px solid transparent`. Don't forget to add a semi-colon.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderRight === '35px solid transparent')
+assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderRight,'35px solid transparent')
 ```
 
 Your `.cat-right-ear` selector should have a `border-top` property set to `35px solid transparent`. Don't forget to add a semi-colon.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderTop === '35px solid transparent')
+assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderTop,'35px solid transparent')
 ```
 
 
 Your `.cat-right-ear` selector should have a `border-bottom` property set to `35px solid red`. Don't forget to add a semi-colon.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderBottom === '35px solid red')
+assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderBottom,'35px solid red')
 ```
 
 Your `.cat-right-ear` selector should not have a `background-color` property.
 
 ```js
-assert(!new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.backgroundColor)
+assert.isEmpty(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.backgroundColor)
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
I updated the assertions for the challenges that had the hint of `You should have a `.cat-right-ear` selector` because I needed to check every single instance if `.cat-head` was present. Unfortunately for me, this project shares the same ids across the new front end curriculum and the old one. 