### PR TITLE
refactor: decouple progress/completion modal logic

### DIFF
--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -36,6 +36,7 @@ import { editorToneOptions } from '../../../utils/tone/editor-config';
 import { editorNotes } from '../../../utils/tone/editor-notes';
 import {
   canSaveToDB,
+  canShowCompletionModal,
   challengeTypes
 } from '../../../../../shared/config/challenge-types';
 import {
@@ -67,7 +68,6 @@ import {
 } from '../utils/index';
 import { initializeMathJax } from '../../../utils/math-jax';
 import { getScrollbarWidth } from '../../../utils/scrollbar-width';
-import { isProjectBased } from '../../../utils/curriculum-layout';
 import LowerJaw from './lower-jaw';
 import './editor.css';
 
@@ -518,7 +518,10 @@ const Editor = (props: EditorProps): JSX.Element => {
         monaco.KeyMod.WinCtrl | monaco.KeyCode.Enter
       ],
       run: () => {
-        if (props.usesMultifileEditor && !isProjectBased(props.challengeType)) {
+        if (
+          props.usesMultifileEditor &&
+          !canShowCompletionModal(props.challengeType)
+        ) {
           if (challengeIsComplete()) {
             tryToSubmitChallenge();
           } else {

--- a/client/src/templates/Challenges/components/hotkeys.tsx
+++ b/client/src/templates/Challenges/components/hotkeys.tsx
@@ -10,6 +10,7 @@ import type {
   User,
   ChallengeMeta
 } from '../../../redux/prop-types';
+import { canShowCompletionModal } from '../../../../../shared/config/challenge-types';
 import { userSelector } from '../../../redux/selectors';
 import {
   setEditorFocusability,
@@ -27,9 +28,9 @@ import {
   isResetModalOpenSelector,
   isShortcutsModalOpenSelector
 } from '../redux/selectors';
-import './hotkeys.css';
-import { isProjectBased } from '../../../utils/curriculum-layout';
 import type { EditorProps } from '../classic/editor';
+
+import './hotkeys.css';
 
 const mapStateToProps = createSelector(
   isHelpModalOpenSelector,
@@ -163,7 +164,7 @@ function Hotkeys({
       if (
         usesMultifileEditor &&
         typeof challengeType == 'number' &&
-        !isProjectBased(challengeType)
+        !canShowCompletionModal(challengeType)
       ) {
         if (testsArePassing) {
           submitChallenge();

--- a/client/src/utils/get-completion-percentage.ts
+++ b/client/src/utils/get-completion-percentage.ts
@@ -1,5 +1,5 @@
+import { isCertificationProject } from '../../../shared/config/challenge-types';
 import { AllChallengesInfo } from '../redux/prop-types';
-import { isProjectBased } from './curriculum-layout';
 
 export function getCompletedPercentage(
   completedChallengesIds: string[] = [],
@@ -48,7 +48,7 @@ export const getCurrentBlockIds = (
     .filter(node => node.challenge.block === block)
     .map(node => node.challenge.id);
 
-  return isProjectBased(challengeType)
+  return isCertificationProject(challengeType)
     ? currentCertificateIds
     : currentBlockIds;
 };

--- a/shared/config/challenge-types.ts
+++ b/shared/config/challenge-types.ts
@@ -147,3 +147,34 @@ export const submitTypes = {
 export const canSaveToDB = (challengeType: number): boolean =>
   challengeType === challengeTypes.multifileCertProject ||
   challengeType === challengeTypes.multifilePythonCertProject;
+
+// Challenge that can show a completion modal
+const challengesUsingModal = [
+  frontEndProject,
+  backEndProject,
+  jsProject,
+  pythonProject,
+  codeAllyCert,
+  multifileCertProject,
+  exam,
+  codeAllyPractice,
+  multifilePythonCertProject,
+  lab
+];
+
+export const canShowCompletionModal = (challengeType: number): boolean =>
+  challengesUsingModal.includes(challengeType);
+
+// Project challenges that are part of certifications
+const certificationProjectTypes = [
+  frontEndProject,
+  backEndProject,
+  jsProject,
+  pythonProject,
+  multifileCertProject,
+  multifilePythonCertProject,
+  codeAllyCert
+];
+
+export const isCertificationProject = (challengeType: number): boolean =>
+  certificationProjectTypes.includes(challengeType);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

There's some overlap between challenges that should use the completion modal and challenges that make up a certification, but they're not the same, so DRYing was a mistake.

<!-- Feel free to add any additional description of changes below this line -->
