### PR TITLE
fix(client): profile card background

### DIFF
--- a/client/src/components/profile/profile.css
+++ b/client/src/components/profile/profile.css
@@ -8,7 +8,7 @@
   margin: 0;
   padding: 1em;
   box-shadow: none;
-  background: var(--gray00);
+  background: var(--primary-background);
   border: 1px solid var(--gray15);
   margin-bottom: 1em;
 }

--- a/client/src/components/profile/profile.css
+++ b/client/src/components/profile/profile.css
@@ -9,7 +9,7 @@
   padding: 1em;
   box-shadow: none;
   background: var(--primary-background);
-  border: 1px solid var(--gray15);
+  border: 1px solid var(--quaternary-background);
   margin-bottom: 1em;
 }
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

We're using `gray00` as the background color of the profile cards, and this is causing the text to be unreadable in dark theme.

<details>
<summary>Screenshot</summary>

<img width="845" alt="Screenshot 2024-12-14 at 05 28 16" src="https://github.com/user-attachments/assets/7e76e6bd-39d1-4b58-9f94-ba6ab9cd2303" />
</details>

I'm changing the variable to `primary-background` instead, so that the color can change based on the selected theme.

| Light | Dark |
| --- | --- |
| <img width="1680" alt="Screenshot 2024-12-14 at 05 45 57" src="https://github.com/user-attachments/assets/af4236fa-4f2b-44ba-a370-4e1b1640e94a" /> | <img width="1680" alt="Screenshot 2024-12-14 at 05 45 46" src="https://github.com/user-attachments/assets/cc719b50-65bd-4d38-9aad-bb5806ea91be" /> |

<!-- Feel free to add any additional description of changes below this line -->
