### PR TITLE
fix(api): extra 'at' in the certificate email template

### DIFF
--- a/api/src/routes/protected/certificate.ts
+++ b/api/src/routes/protected/certificate.ts
@@ -67,7 +67,7 @@ function renderCertifiedEmail({
 
 Congratulations on completing all of the freeCodeCamp certifications!
 
-All of your certifications are now live at at: https://www.freecodecamp.org/${username}
+All of your certifications are now live at: https://www.freecodecamp.org/${username}
 
 Please tell me a bit more about you and your near-term goals.
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

This PR - 
- removes an extra 'at' in the certificate generation template string