### PR TITLE
feat: prep semantic html for release

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -1718,6 +1718,7 @@
       "semantic-html": "Semantic HTML",
       "html-forms-and-tables": "Forms and Tables",
       "html-and-accessibility": "Accessibility",
+      "review-html": "HTML Review",
       "computer-basics": "Computer Basics",
       "basic-css": "Basic CSS",
       "design-for-developers": "Design",

--- a/client/src/templates/Introduction/components/super-block-accordion.tsx
+++ b/client/src/templates/Introduction/components/super-block-accordion.tsx
@@ -41,9 +41,12 @@ type Module = {
   blocks: {
     dashedName: string;
   }[];
+  moduleType?: string;
 };
 
-const modules = superBlockStructure.chapters.flatMap(({ modules }) => modules);
+const modules = superBlockStructure.chapters.flatMap<Module>(
+  ({ modules }) => modules
+);
 const chapters = superBlockStructure.chapters;
 
 const isLinkModule = (name: string) => {

--- a/curriculum/challenges/_meta/lab-event-hub/meta.json
+++ b/curriculum/challenges/_meta/lab-event-hub/meta.json
@@ -2,7 +2,7 @@
   "name": "Build an Event Hub",
   "blockType": "lab",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "dashedName": "lab-event-hub",
   "superBlock": "full-stack-developer",

--- a/curriculum/challenges/_meta/lecture-importance-of-semantic-html/meta.json
+++ b/curriculum/challenges/_meta/lecture-importance-of-semantic-html/meta.json
@@ -2,7 +2,7 @@
   "name": "Importance of Semantic HTML",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-importance-of-semantic-html",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/quiz-semantic-html/meta.json
+++ b/curriculum/challenges/_meta/quiz-semantic-html/meta.json
@@ -2,7 +2,7 @@
   "name": "Semantic HTML Quiz",
   "blockType": "quiz",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "quiz-semantic-html",
   "superBlock": "full-stack-developer",
   "challengeOrder": [{ "id": "66ed903cf45ce3ece4053ebe", "title": "Semantic HTML Quiz" }],

--- a/curriculum/challenges/_meta/review-semantic-html/meta.json
+++ b/curriculum/challenges/_meta/review-semantic-html/meta.json
@@ -2,7 +2,7 @@
   "name": "Semantic HTML Review",
   "blockType": "review",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "review-semantic-html",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/workshop-blog-page/meta.json
+++ b/curriculum/challenges/_meta/workshop-blog-page/meta.json
@@ -2,7 +2,7 @@
   "name": "Build a Cat Blog Page",
   "blockType": "workshop",
   "blockLayout": "challenge-grid",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "dashedName": "workshop-blog-page",

--- a/curriculum/superblock-structure/full-stack.json
+++ b/curriculum/superblock-structure/full-stack.json
@@ -12,10 +12,10 @@
     },
     {
       "dashedName": "html",
-      "comingSoon": true,
       "modules": [
         {
           "dashedName": "basic-html",
+          "comingSoon": true,
           "blocks": [
             { "dashedName": "lecture-what-is-html" },
             { "dashedName": "workshop-cat-photo-app" },
@@ -41,6 +41,7 @@
         },
         {
           "dashedName": "html-forms-and-tables",
+          "comingSoon": true,
           "blocks": [
             { "dashedName": "lecture-working-with-forms" },
             { "dashedName": "workshop-hotel-feedback-form" },
@@ -55,6 +56,7 @@
         },
         {
           "dashedName": "html-and-accessibility",
+          "comingSoon": true,
           "blocks": [
             {
               "dashedName": "lecture-importance-of-accessibility-and-good-html-structure"
@@ -66,6 +68,7 @@
         },
         {
           "moduleType": "review",
+          "comingSoon": true,
           "dashedName": "review-html",
           "blocks": [{ "dashedName": "review-html" }]
         }

--- a/curriculum/test/test-challenges.js
+++ b/curriculum/test/test-challenges.js
@@ -51,6 +51,7 @@ const {
   createHeader,
   testId
 } = require('../../client/src/templates/Challenges/utils/frame');
+const { SuperBlocks } = require('../../shared/config/curriculum');
 const ChallengeTitles = require('./utils/challenge-titles');
 const MongoIds = require('./utils/mongo-ids');
 const createPseudoWorker = require('./utils/pseudo-worker');
@@ -314,8 +315,12 @@ function populateTestsForLang({ lang, challenges, meta, superBlocks }) {
           );
         });
         filteredMeta.forEach((meta, index) => {
-          // ignore block order for upcoming blocks
-          if (!meta.isUpcomingChange) {
+          // Upcoming changes are in developmen so are not required to be in
+          // order. FullStackDeveloper does not use the meta for order.
+          if (
+            !meta.isUpcomingChange &&
+            meta.superBlock !== SuperBlocks.FullStackDeveloper
+          ) {
             it(`${meta.superBlock} ${meta.name} must be in order`, function () {
               assert.equal(meta.order, index);
             });


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This makes it possible to release just the Semantic HTML module. Everything else in the FSD superblock remains "coming soon".

When we deploy this should appear on staging, but not in production.

<!-- Feel free to add any additional description of changes below this line -->
