### PR TITLE
feat: prep b1 english for release

### DIFF
--- a/client/gatsby-node.js
+++ b/client/gatsby-node.js
@@ -143,11 +143,12 @@ exports.createPages = async function createPages({
     ({ node }) => node
   );
 
-  const inNextCurriculum = superBlock =>
-    superBlockStages[SuperBlockStage.Next].includes(superBlock);
+  const inCurrentCurriculum = superBlock =>
+    !superBlockStages[SuperBlockStage.Next].includes(superBlock) &&
+    !superBlockStages[SuperBlockStage.NextEnglish].includes(superBlock);
 
-  const currentChallengeNodes = allChallengeNodes.filter(
-    node => !inNextCurriculum(node.challenge.superBlock)
+  const currentChallengeNodes = allChallengeNodes.filter(node =>
+    inCurrentCurriculum(node.challenge.superBlock)
   );
 
   const createIdToNextPathMap = nodes =>

--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -167,6 +167,7 @@
     "interview-prep-heading": "Prepare for the developer interview job search:",
     "legacy-curriculum-heading": "Explore our Legacy Curriculum:",
     "next-heading": "Try our beta curriculum:",
+    "next-english-heading": "Try our latest English curriculum:",
     "upcoming-heading": "Upcoming curriculum:",
     "faq": "Frequently asked questions:",
     "faqs": [

--- a/client/src/components/Map/index.tsx
+++ b/client/src/components/Map/index.tsx
@@ -63,6 +63,7 @@ const superBlockHeadings: { [key in SuperBlockStage]: string } = {
   [SuperBlockStage.Legacy]: 'landing.legacy-curriculum-heading',
   [SuperBlockStage.New]: '', // TODO: add translation
   [SuperBlockStage.Next]: 'landing.next-heading',
+  [SuperBlockStage.NextEnglish]: 'landing.next-english-heading',
   [SuperBlockStage.Upcoming]: 'landing.upcoming-heading'
 };
 

--- a/e2e/landing.spec.ts
+++ b/e2e/landing.spec.ts
@@ -30,6 +30,7 @@ const superBlocks = [
   intro[SuperBlocks.CollegeAlgebraPy].title,
   intro[SuperBlocks.FullStackDeveloper].title,
   intro[SuperBlocks.A2English].title,
+  intro[SuperBlocks.B1English].title,
   intro[SuperBlocks.FoundationalCSharp].title,
   intro[SuperBlocks.TheOdinProject].title,
   intro[SuperBlocks.CodingInterviewPrep].title,

--- a/e2e/map.spec.ts
+++ b/e2e/map.spec.ts
@@ -12,6 +12,7 @@ const superBlocksWithLinks = [
   ...superBlockStages[SuperBlockStage.Core],
   ...superBlockStages[SuperBlockStage.Next],
   ...superBlockStages[SuperBlockStage.English],
+  ...superBlockStages[SuperBlockStage.NextEnglish],
   ...superBlockStages[SuperBlockStage.Professional],
   ...superBlockStages[SuperBlockStage.Extra],
   ...superBlockStages[SuperBlockStage.Legacy]

--- a/shared/config/curriculum.test.ts
+++ b/shared/config/curriculum.test.ts
@@ -51,6 +51,7 @@ describe('generateSuperBlockList', () => {
     tempSuperBlockMap[SuperBlockStage.New] = [];
     tempSuperBlockMap[SuperBlockStage.Upcoming] = [];
     tempSuperBlockMap[SuperBlockStage.Next] = [];
+    tempSuperBlockMap[SuperBlockStage.NextEnglish] = [];
     expect(result).toHaveLength(Object.values(tempSuperBlockMap).flat().length);
   });
 });
@@ -59,19 +60,19 @@ describe('Immutability of superBlockOrder, notAuditedSuperBlocks, and flatSuperB
   it('should not allow modification of superBlockOrder', () => {
     expect(() => {
       superBlockStages[SuperBlockStage.Core] = [];
-    }).toThrowError(TypeError);
+    }).toThrow(TypeError);
   });
 
   it('should not allow modification of notAuditedSuperBlocks', () => {
     expect(() => {
       notAuditedSuperBlocks[Languages.English] = [];
-    }).toThrowError(TypeError);
+    }).toThrow(TypeError);
   });
 
   it('should not allow modification of flatSuperBlockMap', () => {
     expect(() => {
       notAuditedSuperBlocks[Languages.English] = [];
-    }).toThrowError(TypeError);
+    }).toThrow(TypeError);
   });
 });
 

--- a/shared/config/curriculum.ts
+++ b/shared/config/curriculum.ts
@@ -48,13 +48,15 @@ export enum SuperBlockStage {
   Legacy,
   New,
   Upcoming,
-  Next
+  Next,
+  NextEnglish
 }
 
 const defaultStageOrder = [
   SuperBlockStage.Core,
   SuperBlockStage.Next,
   SuperBlockStage.English,
+  SuperBlockStage.NextEnglish,
   SuperBlockStage.Professional,
   SuperBlockStage.Extra,
   SuperBlockStage.Legacy
@@ -65,9 +67,12 @@ export function getStageOrder({
   showUpcomingChanges,
   showNextCurriculum
 }: Config): SuperBlockStage[] {
+  const isCurrentStage = (stage: SuperBlockStage) =>
+    !(stage === SuperBlockStage.Next) &&
+    !(stage === SuperBlockStage.NextEnglish);
   const stageOrder = showNextCurriculum
     ? [...defaultStageOrder]
-    : [...defaultStageOrder.filter(stage => stage !== SuperBlockStage.Next)];
+    : [...defaultStageOrder.filter(isCurrentStage)];
 
   if (showNewCurriculum) stageOrder.push(SuperBlockStage.New);
   if (showUpcomingChanges) stageOrder.push(SuperBlockStage.Upcoming);
@@ -96,6 +101,7 @@ export const superBlockStages: StageMap = {
   ],
   [SuperBlockStage.Next]: [SuperBlocks.FullStackDeveloper],
   [SuperBlockStage.English]: [SuperBlocks.A2English],
+  [SuperBlockStage.NextEnglish]: [SuperBlocks.B1English],
   [SuperBlockStage.Professional]: [SuperBlocks.FoundationalCSharp],
   [SuperBlockStage.Extra]: [
     SuperBlocks.TheOdinProject,
@@ -109,7 +115,7 @@ export const superBlockStages: StageMap = {
     SuperBlocks.PythonForEverybody
   ],
   [SuperBlockStage.New]: [],
-  [SuperBlockStage.Upcoming]: [SuperBlocks.B1English]
+  [SuperBlockStage.Upcoming]: []
 };
 
 Object.freeze(superBlockStages);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This ties the release of B1 English to the release of FSD. Just the superblock as a whole, not individual blocks.

With the fcc-10 feature on:

![/learn curriculum map with feature enabled](https://github.com/user-attachments/assets/1f082f8f-32e8-4835-bfe7-b0b3fe43278d)

In principle we could include them in the same stage, but that would require changes to the growthbook release. Currently it's only possible to release entire stages and I'd like to keep it simple. 



<!-- Feel free to add any additional description of changes below this line -->
