### PR TITLE
fix: trim whitespace from a string multiple choice question

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-common-string-methods/67326c3c3ab931c644cea05b.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-common-string-methods/67326c3c3ab931c644cea05b.md
@@ -95,7 +95,9 @@ console.log(str.trimEnd());
 
 ## --answers--
 
-`"Code"`
+```js
+"Code"
+```
 
 ### --feedback--
 
@@ -103,11 +105,15 @@ Consider which part of the string is affected by `trimEnd()`.
 
 ---
 
-`"   Code"`
+```js
+"   Code"
+```
 
 ---
 
-`"Code   "`
+```js
+"Code   "
+```
 
 ### --feedback--
 
@@ -115,7 +121,9 @@ Consider which part of the string is affected by `trimEnd()`.
 
 ---
 
-`" Code "`
+```js
+" Code "
+```
 
 ### --feedback--
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-common-string-methods/67326c3c3ab931c644cea05b.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-common-string-methods/67326c3c3ab931c644cea05b.md
@@ -103,11 +103,11 @@ Consider which part of the string is affected by `trimEnd()`.
 
 ---
 
-`" Code"`
+`"   Code"`
 
 ---
 
-`"Code "`
+`"Code   "`
 
 ### --feedback--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ ] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitPod.

<!-- Feel free to add any additional description of changes below this line -->
This PR adjusts the spacing for one of the distractors and the correct answer for q3.