### PR TITLE
feat(curriculum): change isupcoming flags on fsd blocks

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -1767,6 +1767,8 @@
       "css-libraries-and-frameworks": "CSS Libraries and Frameworks",
       "testing": "Testing",
       "typescript-fundamentals": "TypeScript Fundamentals",
+      "review-front-end-libraries": "Front End Libraries Review",
+      "exam-front-end-libraries": "Front End Libraries Exam",
       "sql-and-bash": "SQL and Bash",
       "git": "Git",
       "security-and-privacy": "Security and Privacy"

--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -1710,7 +1710,8 @@
       "frontend-libraries": "Front End Libraries",
       "relational-databases": "Relational Databases",
       "backend-javascript": "Backend JavaScript",
-      "python": "Python"
+      "python": "Python",
+      "exam-certified-full-stack-developer": "Certified Full Stack Developer Exam"
     },
     "modules": {
       "getting-started-with-freecodecamp": "Getting Started with freeCodeCamp",
@@ -1719,6 +1720,7 @@
       "html-forms-and-tables": "Forms and Tables",
       "html-and-accessibility": "Accessibility",
       "review-html": "HTML Review",
+      "exam-html": "HTML Exam",
       "computer-basics": "Computer Basics",
       "basic-css": "Basic CSS",
       "design-for-developers": "Design",
@@ -1736,6 +1738,7 @@
       "css-variables": "Variables",
       "css-grid": "Grid",
       "css-animations": "Animations",
+      "exam-css": "CSS Exam",
       "code-editors": "Code Editors",
       "javascript-variables-and-strings": "Variables and Strings",
       "javascript-booleans-and-numbers": "Booleans and Numbers",
@@ -1757,6 +1760,7 @@
       "recursion": "Recursion",
       "functional-programming": "Functional Programming",
       "asynchronous-javascript": "Asynchronous JavaScript",
+      "exam-javascript": "JavaScript Exam",
       "react-fundamentals": "React Fundamentals",
       "react-state-hooks-and-routing": "React State, Hooks, and Routing",
       "performance": "Performance",

--- a/curriculum/challenges/_meta/lab-availability-table/meta.json
+++ b/curriculum/challenges/_meta/lab-availability-table/meta.json
@@ -2,7 +2,7 @@
   "name": "Build an Availability Table",
   "blockType": "lab",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "dashedName": "lab-availability-table",
   "superBlock": "full-stack-developer",

--- a/curriculum/challenges/_meta/lab-bank-account-manager/meta.json
+++ b/curriculum/challenges/_meta/lab-bank-account-manager/meta.json
@@ -1,6 +1,6 @@
 {
   "name": "Build a Bank Account Management Program",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "dashedName": "lab-bank-account-manager",
   "superBlock": "full-stack-developer",

--- a/curriculum/challenges/_meta/lab-blog-post-card/meta.json
+++ b/curriculum/challenges/_meta/lab-blog-post-card/meta.json
@@ -1,6 +1,6 @@
 {
   "name": "Design a Blog Post Card",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "dashedName": "lab-blog-post-card",
   "superBlock": "full-stack-developer",

--- a/curriculum/challenges/_meta/lab-book-catalog-table/meta.json
+++ b/curriculum/challenges/_meta/lab-book-catalog-table/meta.json
@@ -2,7 +2,7 @@
   "name": "Build a Book Catalog Table",
   "blockType": "lab",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "dashedName": "lab-book-catalog-table",
   "superBlock": "full-stack-developer",

--- a/curriculum/challenges/_meta/lab-book-inventory-app/meta.json
+++ b/curriculum/challenges/_meta/lab-book-inventory-app/meta.json
@@ -2,7 +2,7 @@
   "name": "Build a Book Inventory App",
   "blockType": "lab",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "dashedName": "lab-book-inventory-app",
   "superBlock": "full-stack-developer",

--- a/curriculum/challenges/_meta/lab-book-organizer/meta.json
+++ b/curriculum/challenges/_meta/lab-book-organizer/meta.json
@@ -1,6 +1,6 @@
 {
   "name": "Build a Book Organizer",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "dashedName": "lab-book-organizer",
   "superBlock": "full-stack-developer",

--- a/curriculum/challenges/_meta/lab-bookmark-manager-app/meta.json
+++ b/curriculum/challenges/_meta/lab-bookmark-manager-app/meta.json
@@ -2,7 +2,7 @@
   "name": "Build a Bookmark Manager App",
   "blockType": "lab",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "dashedName": "lab-bookmark-manager-app",
   "superBlock": "full-stack-developer",

--- a/curriculum/challenges/_meta/lab-business-card/meta.json
+++ b/curriculum/challenges/_meta/lab-business-card/meta.json
@@ -2,7 +2,7 @@
   "name": "Design a Business Card",
   "blockType": "lab",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "dashedName": "lab-business-card",
   "superBlock": "full-stack-developer",

--- a/curriculum/challenges/_meta/lab-checkout-page/meta.json
+++ b/curriculum/challenges/_meta/lab-checkout-page/meta.json
@@ -2,7 +2,7 @@
   "name": "Build a Checkout Page",
   "blockType": "lab",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "dashedName": "lab-checkout-page",
   "superBlock": "full-stack-developer",

--- a/curriculum/challenges/_meta/lab-colored-boxes/meta.json
+++ b/curriculum/challenges/_meta/lab-colored-boxes/meta.json
@@ -1,6 +1,6 @@
 {
   "name": "Design a Set of Colored Boxes",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "dashedName": "lab-colored-boxes",
   "superBlock": "full-stack-developer",

--- a/curriculum/challenges/_meta/lab-confidential-email-page/meta.json
+++ b/curriculum/challenges/_meta/lab-confidential-email-page/meta.json
@@ -2,7 +2,7 @@
   "name": "Build a Confidential Email Page",
   "blockType": "lab",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "dashedName": "lab-confidential-email-page",
   "superBlock": "full-stack-developer",

--- a/curriculum/challenges/_meta/lab-contact-form/meta.json
+++ b/curriculum/challenges/_meta/lab-contact-form/meta.json
@@ -2,7 +2,7 @@
   "name": "Design a Contact Form",
   "blockType": "lab",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "dashedName": "lab-contact-form",
   "superBlock": "full-stack-developer",

--- a/curriculum/challenges/_meta/lab-customer-complaint-form/meta.json
+++ b/curriculum/challenges/_meta/lab-customer-complaint-form/meta.json
@@ -1,6 +1,6 @@
 {
   "name": "Build a Customer Complaint Form",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "blockType": "lab",
   "blockLayout": "link",

--- a/curriculum/challenges/_meta/lab-date-conversion/meta.json
+++ b/curriculum/challenges/_meta/lab-date-conversion/meta.json
@@ -2,7 +2,7 @@
   "name": "Build a Date Conversion Program",
   "blockType": "lab",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "dashedName": "lab-date-conversion",
   "superBlock": "full-stack-developer",

--- a/curriculum/challenges/_meta/lab-email-masker/meta.json
+++ b/curriculum/challenges/_meta/lab-email-masker/meta.json
@@ -2,7 +2,7 @@
   "name": "Build an Email Masker",
   "blockType": "lab",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "dashedName": "lab-email-masker",
   "superBlock": "full-stack-developer",

--- a/curriculum/challenges/_meta/lab-event-flyer-page/meta.json
+++ b/curriculum/challenges/_meta/lab-event-flyer-page/meta.json
@@ -2,7 +2,7 @@
   "name": "Build an Event Flyer Page",
   "blockType": "lab",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "dashedName": "lab-event-flyer-page",
   "superBlock": "full-stack-developer",

--- a/curriculum/challenges/_meta/lab-factorial-calculator/meta.json
+++ b/curriculum/challenges/_meta/lab-factorial-calculator/meta.json
@@ -2,7 +2,7 @@
   "name": "Build a Factorial Calculator ",
   "blockType": "lab",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "dashedName": "lab-factorial-calculator",
   "superBlock": "full-stack-developer",

--- a/curriculum/challenges/_meta/lab-favorite-icon-toggler/meta.json
+++ b/curriculum/challenges/_meta/lab-favorite-icon-toggler/meta.json
@@ -2,7 +2,7 @@
   "name": "Build a Favorite Icon Toggler",
   "blockType": "lab",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "dashedName": "lab-favorite-icon-toggler",
   "superBlock": "full-stack-developer",

--- a/curriculum/challenges/_meta/lab-fcc-forum-leaderboard/meta.json
+++ b/curriculum/challenges/_meta/lab-fcc-forum-leaderboard/meta.json
@@ -1,6 +1,6 @@
 {
   "name": "Build an fCC Forum Leaderboard",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "blockType": "lab",
   "blockLayout": "link",

--- a/curriculum/challenges/_meta/lab-football-team-cards/meta.json
+++ b/curriculum/challenges/_meta/lab-football-team-cards/meta.json
@@ -2,7 +2,7 @@
   "name": "Build a Set of Football Team Cards",
   "blockType": "lab",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "dashedName": "lab-football-team-cards",
   "superBlock": "full-stack-developer",

--- a/curriculum/challenges/_meta/lab-fortune-teller/meta.json
+++ b/curriculum/challenges/_meta/lab-fortune-teller/meta.json
@@ -2,7 +2,7 @@
   "name": "Build a Fortune Teller App",
   "blockType": "lab",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "dashedName": "lab-fortune-teller",
   "superBlock": "full-stack-developer",

--- a/curriculum/challenges/_meta/lab-gradebook-app/meta.json
+++ b/curriculum/challenges/_meta/lab-gradebook-app/meta.json
@@ -2,7 +2,7 @@
   "name": "Build a Gradebook App",
   "blockType": "lab",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "dashedName": "lab-gradebook-app",
   "superBlock": "full-stack-developer",

--- a/curriculum/challenges/_meta/lab-house-painting/meta.json
+++ b/curriculum/challenges/_meta/lab-house-painting/meta.json
@@ -2,7 +2,7 @@
   "name": "Build a House Painting",
   "blockType": "lab",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "dashedName": "lab-house-painting",
   "superBlock": "full-stack-developer",

--- a/curriculum/challenges/_meta/lab-inventory-management-program/meta.json
+++ b/curriculum/challenges/_meta/lab-inventory-management-program/meta.json
@@ -2,7 +2,7 @@
   "name": "Build an Inventory Management Program",
   "blockType": "lab",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "dashedName": "lab-inventory-management-program",
   "superBlock": "full-stack-developer",

--- a/curriculum/challenges/_meta/lab-javascript-trivia-bot/meta.json
+++ b/curriculum/challenges/_meta/lab-javascript-trivia-bot/meta.json
@@ -2,7 +2,7 @@
   "name": "Build a JavaScript Trivia Bot",
   "blockType": "lab",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "dashedName": "lab-javascript-trivia-bot",
   "superBlock": "full-stack-developer",

--- a/curriculum/challenges/_meta/lab-job-application-form/meta.json
+++ b/curriculum/challenges/_meta/lab-job-application-form/meta.json
@@ -2,7 +2,7 @@
   "name": "Build a Job Application Form",
   "blockType": "lab",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "dashedName": "lab-job-application-form",
   "superBlock": "full-stack-developer",

--- a/curriculum/challenges/_meta/lab-leap-year-calculator/meta.json
+++ b/curriculum/challenges/_meta/lab-leap-year-calculator/meta.json
@@ -2,7 +2,7 @@
   "name": "Build a Leap Year Calculator ",
   "blockType": "lab",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "dashedName": "lab-leap-year-calculator",
   "superBlock": "full-stack-developer",

--- a/curriculum/challenges/_meta/lab-lightbox-viewer/meta.json
+++ b/curriculum/challenges/_meta/lab-lightbox-viewer/meta.json
@@ -2,7 +2,7 @@
   "name": "Build a Lightbox Viewer",
   "blockType": "lab",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "dashedName": "lab-lightbox-viewer",
   "superBlock": "full-stack-developer",

--- a/curriculum/challenges/_meta/lab-lunch-picker-program/meta.json
+++ b/curriculum/challenges/_meta/lab-lunch-picker-program/meta.json
@@ -2,7 +2,7 @@
   "name": "Build a Lunch Picker Program",
   "blockType": "lab",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "dashedName": "lab-lunch-picker-program",
   "superBlock": "full-stack-developer",

--- a/curriculum/challenges/_meta/lab-markdown-to-html-converter/meta.json
+++ b/curriculum/challenges/_meta/lab-markdown-to-html-converter/meta.json
@@ -1,6 +1,6 @@
 {
   "name": "Build a Markdown to HTML Converter",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "blockType": "lab",
   "blockLayout": "link",

--- a/curriculum/challenges/_meta/lab-mood-board/meta.json
+++ b/curriculum/challenges/_meta/lab-mood-board/meta.json
@@ -1,6 +1,6 @@
 {
   "name": "Build a Mood Board",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "dashedName": "lab-mood-board",
   "superBlock": "full-stack-developer",

--- a/curriculum/challenges/_meta/lab-moon-orbit/meta.json
+++ b/curriculum/challenges/_meta/lab-moon-orbit/meta.json
@@ -2,7 +2,7 @@
   "name": "Build a Moon Orbit",
   "blockType": "lab",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": false,
   "dashedName": "lab-moon-orbit",

--- a/curriculum/challenges/_meta/lab-newspaper-article/meta.json
+++ b/curriculum/challenges/_meta/lab-newspaper-article/meta.json
@@ -2,7 +2,7 @@
   "name": "Build a Newspaper Article",
   "blockType": "lab",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "dashedName": "lab-newspaper-article",
   "superBlock": "full-stack-developer",

--- a/curriculum/challenges/_meta/lab-page-of-playing-cards/meta.json
+++ b/curriculum/challenges/_meta/lab-page-of-playing-cards/meta.json
@@ -2,7 +2,7 @@
   "name": "Build a Page of Playing Cards",
   "blockType": "lab",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "dashedName": "lab-page-of-playing-cards",
   "superBlock": "full-stack-developer",

--- a/curriculum/challenges/_meta/lab-palindrome-checker/meta.json
+++ b/curriculum/challenges/_meta/lab-palindrome-checker/meta.json
@@ -2,7 +2,7 @@
   "name": "Build a Palindrome Checker",
   "blockType": "lab",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "dashedName": "lab-palindrome-checker",
   "superBlock": "full-stack-developer",

--- a/curriculum/challenges/_meta/lab-password-generator/meta.json
+++ b/curriculum/challenges/_meta/lab-password-generator/meta.json
@@ -1,6 +1,6 @@
 {
   "name": "Build a Password Generator App",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "blockType": "lab",
   "dashedName": "lab-password-generator",

--- a/curriculum/challenges/_meta/lab-permutation-generator/meta.json
+++ b/curriculum/challenges/_meta/lab-permutation-generator/meta.json
@@ -1,6 +1,6 @@
 {
   "name": "Build a Permutation Generator",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "dashedName": "lab-permutation-generator",
   "superBlock": "full-stack-developer",

--- a/curriculum/challenges/_meta/lab-personal-portfolio/meta.json
+++ b/curriculum/challenges/_meta/lab-personal-portfolio/meta.json
@@ -2,7 +2,7 @@
   "name": "Build a Personal Portfolio",
   "blockType": "lab",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "dashedName": "lab-personal-portfolio",
   "superBlock": "full-stack-developer",

--- a/curriculum/challenges/_meta/lab-product-landing-page/meta.json
+++ b/curriculum/challenges/_meta/lab-product-landing-page/meta.json
@@ -2,7 +2,7 @@
   "name": "Build a Product Landing Page",
   "blockType": "lab",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "dashedName": "lab-product-landing-page",
   "superBlock": "full-stack-developer",

--- a/curriculum/challenges/_meta/lab-project-idea-board/meta.json
+++ b/curriculum/challenges/_meta/lab-project-idea-board/meta.json
@@ -1,6 +1,6 @@
 {
   "name": "Build a Project Idea Board",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "dashedName": "lab-project-idea-board",
   "superBlock": "full-stack-developer",

--- a/curriculum/challenges/_meta/lab-pyramid-generator/meta.json
+++ b/curriculum/challenges/_meta/lab-pyramid-generator/meta.json
@@ -2,7 +2,7 @@
   "name": "Build a Pyramid Generator",
   "blockType": "lab",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "dashedName": "lab-pyramid-generator",
   "superBlock": "full-stack-developer",

--- a/curriculum/challenges/_meta/lab-quiz-game/meta.json
+++ b/curriculum/challenges/_meta/lab-quiz-game/meta.json
@@ -2,7 +2,7 @@
   "name": "Build a Quiz Game",
   "blockType": "lab",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "dashedName": "lab-quiz-game",
   "superBlock": "full-stack-developer",

--- a/curriculum/challenges/_meta/lab-random-background-color-changer/meta.json
+++ b/curriculum/challenges/_meta/lab-random-background-color-changer/meta.json
@@ -2,7 +2,7 @@
   "name": "Debug a Random Background Color Changer",
   "blockLayout": "link",
   "blockType": "lab",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "dashedName": "lab-random-background-color-changer",
   "superBlock": "full-stack-developer",

--- a/curriculum/challenges/_meta/lab-real-time-counter/meta.json
+++ b/curriculum/challenges/_meta/lab-real-time-counter/meta.json
@@ -2,7 +2,7 @@
   "name": "Build a Real Time Counter",
   "blockType": "lab",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "dashedName": "lab-real-time-counter",
   "superBlock": "full-stack-developer",

--- a/curriculum/challenges/_meta/lab-recipe-page/meta.json
+++ b/curriculum/challenges/_meta/lab-recipe-page/meta.json
@@ -2,7 +2,7 @@
   "name": "Build a Recipe Page",
   "blockType": "lab",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "dashedName": "lab-recipe-page",
   "superBlock": "full-stack-developer",

--- a/curriculum/challenges/_meta/lab-regex-sandbox/meta.json
+++ b/curriculum/challenges/_meta/lab-regex-sandbox/meta.json
@@ -2,7 +2,7 @@
   "name": "Build a RegEx Sandbox",
   "blockType": "lab",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "dashedName": "lab-regex-sandbox",
   "superBlock": "full-stack-developer",

--- a/curriculum/challenges/_meta/lab-reusable-footer/meta.json
+++ b/curriculum/challenges/_meta/lab-reusable-footer/meta.json
@@ -1,6 +1,6 @@
 {
   "name": "Build a Reusable Footer",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "dashedName": "lab-reusable-footer",
   "superBlock": "full-stack-developer",

--- a/curriculum/challenges/_meta/lab-sentence-maker/meta.json
+++ b/curriculum/challenges/_meta/lab-sentence-maker/meta.json
@@ -2,7 +2,7 @@
   "name": "Build a Sentence Maker",
   "blockType": "lab",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "dashedName": "lab-sentence-maker",
   "superBlock": "full-stack-developer",

--- a/curriculum/challenges/_meta/lab-sorting-visualizer/meta.json
+++ b/curriculum/challenges/_meta/lab-sorting-visualizer/meta.json
@@ -1,6 +1,6 @@
 {
   "name": "Build a Sorting Visualizer",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "blockType": "lab",
   "blockLayout": "link",

--- a/curriculum/challenges/_meta/lab-stylized-to-do-list/meta.json
+++ b/curriculum/challenges/_meta/lab-stylized-to-do-list/meta.json
@@ -2,7 +2,7 @@
   "name": "Build a Stylized To-Do List",
   "blockType": "lab",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "dashedName": "lab-stylized-to-do-list",
   "superBlock": "full-stack-developer",

--- a/curriculum/challenges/_meta/lab-survey-form/meta.json
+++ b/curriculum/challenges/_meta/lab-survey-form/meta.json
@@ -2,7 +2,7 @@
   "name": "Build a Survey Form",
   "blockType": "lab",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "dashedName": "lab-survey-form",
   "superBlock": "full-stack-developer",

--- a/curriculum/challenges/_meta/lab-technical-documentation-page/meta.json
+++ b/curriculum/challenges/_meta/lab-technical-documentation-page/meta.json
@@ -2,7 +2,7 @@
   "name": "Build a Technical Documentation Page",
   "blockType": "lab",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "dashedName": "lab-technical-documentation-page",
   "superBlock": "full-stack-developer",

--- a/curriculum/challenges/_meta/lab-travel-agency-page/meta.json
+++ b/curriculum/challenges/_meta/lab-travel-agency-page/meta.json
@@ -2,7 +2,7 @@
   "name": "Build a Travel Agency Page",
   "blockType": "lab",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "dashedName": "lab-travel-agency-page",
   "superBlock": "full-stack-developer",

--- a/curriculum/challenges/_meta/lab-tribute-page/meta.json
+++ b/curriculum/challenges/_meta/lab-tribute-page/meta.json
@@ -2,7 +2,7 @@
   "name": "Build a Tribute Page",
   "blockType": "lab",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "dashedName": "lab-tribute-page",
   "superBlock": "full-stack-developer",

--- a/curriculum/challenges/_meta/lab-video-compilation-page/meta.json
+++ b/curriculum/challenges/_meta/lab-video-compilation-page/meta.json
@@ -2,7 +2,7 @@
   "name": "Build a Video Compilation Page",
   "blockType": "lab",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "dashedName": "lab-video-compilation-page",
   "superBlock": "full-stack-developer",

--- a/curriculum/challenges/_meta/lab-voting-system/meta.json
+++ b/curriculum/challenges/_meta/lab-voting-system/meta.json
@@ -1,6 +1,6 @@
 {
   "name": "Build a Voting System",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "dashedName": "lab-voting-system",
   "superBlock": "full-stack-developer",

--- a/curriculum/challenges/_meta/lab-weather-app/meta.json
+++ b/curriculum/challenges/_meta/lab-weather-app/meta.json
@@ -1,6 +1,6 @@
 {
   "name": "Build a Weather App",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "dashedName": "lab-weather-app",
   "superBlock": "full-stack-developer",

--- a/curriculum/challenges/_meta/lecture-animations-and-accessibility/meta.json
+++ b/curriculum/challenges/_meta/lecture-animations-and-accessibility/meta.json
@@ -2,7 +2,7 @@
   "name": "Animations and Accessibility",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-animations-and-accessibility",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/lecture-best-practices-for-accessibility-and-css/meta.json
+++ b/curriculum/challenges/_meta/lecture-best-practices-for-accessibility-and-css/meta.json
@@ -2,7 +2,7 @@
   "name": "Best Practices for Accessibility and CSS",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-best-practices-for-accessibility-and-css",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/lecture-best-practices-for-responsive-web-design/meta.json
+++ b/curriculum/challenges/_meta/lecture-best-practices-for-responsive-web-design/meta.json
@@ -2,7 +2,7 @@
   "name": "Best Practices for Responsive Web Design",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-best-practices-for-responsive-web-design",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/lecture-best-practices-for-styling-forms/meta.json
+++ b/curriculum/challenges/_meta/lecture-best-practices-for-styling-forms/meta.json
@@ -2,7 +2,7 @@
   "name": "Best Practices for Styling Forms",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-best-practices-for-styling-forms",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/lecture-browsing-the-web-effectively/meta.json
+++ b/curriculum/challenges/_meta/lecture-browsing-the-web-effectively/meta.json
@@ -2,7 +2,7 @@
   "name": "Browsing the Web Effectively",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-browsing-the-web-effectively",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/lecture-common-design-tools/meta.json
+++ b/curriculum/challenges/_meta/lecture-common-design-tools/meta.json
@@ -2,7 +2,7 @@
   "name": "Common Design Tools",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-common-design-tools",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/lecture-css-specificity-the-cascade-algorithm-and-inheritance/meta.json
+++ b/curriculum/challenges/_meta/lecture-css-specificity-the-cascade-algorithm-and-inheritance/meta.json
@@ -2,7 +2,7 @@
   "name": "CSS Specificity, the Cascade Algorithm, and Inheritance",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-css-specificity-the-cascade-algorithm-and-inheritance",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/lecture-debugging-css/meta.json
+++ b/curriculum/challenges/_meta/lecture-debugging-css/meta.json
@@ -2,7 +2,7 @@
   "name": "Debugging CSS",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-debugging-css",
   "superBlock": "full-stack-developer",
   "challengeOrder": [{ "id": "672aa8c1ad423562a38b484d", "title": "How Can You Use the DevTools Inspection Tool and CSS Validators to Debug Your CSS?" }],

--- a/curriculum/challenges/_meta/lecture-debugging-techniques/meta.json
+++ b/curriculum/challenges/_meta/lecture-debugging-techniques/meta.json
@@ -2,7 +2,7 @@
   "name": "Debugging Techniques",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-debugging-techniques",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/lecture-html-fundamentals/meta.json
+++ b/curriculum/challenges/_meta/lecture-html-fundamentals/meta.json
@@ -2,7 +2,7 @@
   "name": "HTML Fundamentals",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-html-fundamentals",
   "superBlock": "full-stack-developer",
   "helpCategory": "HTML-CSS",

--- a/curriculum/challenges/_meta/lecture-importance-of-accessibility-and-good-html-structure/meta.json
+++ b/curriculum/challenges/_meta/lecture-importance-of-accessibility-and-good-html-structure/meta.json
@@ -2,7 +2,7 @@
   "name": "Importance of Accessibility and Good HTML Structure",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-importance-of-accessibility-and-good-html-structure",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/lecture-introduction-to-javascript-libraries-and-frameworks/meta.json
+++ b/curriculum/challenges/_meta/lecture-introduction-to-javascript-libraries-and-frameworks/meta.json
@@ -2,7 +2,7 @@
   "name": "Introduction to JavaScript Libraries and Frameworks",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-introduction-to-javascript-libraries-and-frameworks",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/lecture-introduction-to-javascript/meta.json
+++ b/curriculum/challenges/_meta/lecture-introduction-to-javascript/meta.json
@@ -2,7 +2,7 @@
   "name": "Introduction to JavaScript",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-introduction-to-javascript",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/lecture-styling-lists-and-links/meta.json
+++ b/curriculum/challenges/_meta/lecture-styling-lists-and-links/meta.json
@@ -2,7 +2,7 @@
   "name": "Styling Lists and Links",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-styling-lists-and-links",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/lecture-the-var-keyword-and-hoisting/meta.json
+++ b/curriculum/challenges/_meta/lecture-the-var-keyword-and-hoisting/meta.json
@@ -2,7 +2,7 @@
   "name": "The var Keyword and Hoisting",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-the-var-keyword-and-hoisting",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/lecture-understanding-asynchronous-programming/meta.json
+++ b/curriculum/challenges/_meta/lecture-understanding-asynchronous-programming/meta.json
@@ -2,7 +2,7 @@
   "name": "Understanding Asynchronous Programming",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-understanding-asynchronous-programming",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/lecture-understanding-comparisons-and-conditionals/meta.json
+++ b/curriculum/challenges/_meta/lecture-understanding-comparisons-and-conditionals/meta.json
@@ -2,7 +2,7 @@
   "name": "Understanding Comparisons and Conditionals",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-understanding-comparisons-and-conditionals",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/lecture-understanding-computer-internet-and-tooling-basics/meta.json
+++ b/curriculum/challenges/_meta/lecture-understanding-computer-internet-and-tooling-basics/meta.json
@@ -2,7 +2,7 @@
   "name": "Understanding Computer, Internet, and Tooling Basics",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-understanding-computer-internet-and-tooling-basics",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/lecture-understanding-core-javascript-fundamentals/meta.json
+++ b/curriculum/challenges/_meta/lecture-understanding-core-javascript-fundamentals/meta.json
@@ -2,7 +2,7 @@
   "name": "Understanding Core JavaScript Fundamentals",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-understanding-core-javascript-fundamentals",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/lecture-understanding-form-validation/meta.json
+++ b/curriculum/challenges/_meta/lecture-understanding-form-validation/meta.json
@@ -2,7 +2,7 @@
   "name": "Understanding Form Validation",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-understanding-form-validation",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/lecture-understanding-functional-programming/meta.json
+++ b/curriculum/challenges/_meta/lecture-understanding-functional-programming/meta.json
@@ -2,7 +2,7 @@
   "name": "Understanding Functional Programming",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-understanding-functional-programming",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/lecture-understanding-how-to-work-with-classes-in-javascript/meta.json
+++ b/curriculum/challenges/_meta/lecture-understanding-how-to-work-with-classes-in-javascript/meta.json
@@ -2,7 +2,7 @@
   "name": "Understanding How to Work with Classes in JavaScript",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-understanding-how-to-work-with-classes-in-javascript",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/lecture-understanding-how-to-work-with-floats-and-positioning-in-css/meta.json
+++ b/curriculum/challenges/_meta/lecture-understanding-how-to-work-with-floats-and-positioning-in-css/meta.json
@@ -2,7 +2,7 @@
   "name": "Understanding How to Work with Floats and Positioning in CSS",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-understanding-how-to-work-with-floats-and-positioning-in-css",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/lecture-understanding-modules-imports-and-exports/meta.json
+++ b/curriculum/challenges/_meta/lecture-understanding-modules-imports-and-exports/meta.json
@@ -2,7 +2,7 @@
   "name": "Understanding Modules, Imports, and Exports",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-understanding-modules-imports-and-exports",
   "superBlock": "full-stack-developer",
   "challengeOrder": [{ "id": "67329fd6ad99c75d4a4b74e4", "title": "What Is a Module in JavaScript, and How Can You Import and Export Modules in Your Program?" }],

--- a/curriculum/challenges/_meta/lecture-understanding-recursion-and-the-call-stack/meta.json
+++ b/curriculum/challenges/_meta/lecture-understanding-recursion-and-the-call-stack/meta.json
@@ -2,7 +2,7 @@
   "name": "Understanding Recursion and the Call Stack",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-understanding-recursion-and-the-call-stack",
   "superBlock": "full-stack-developer",
   "challengeOrder": [{ "id": "6733b02d1e556005a544c5e3", "title": "What Is Recursion, and How Does It Work?" }],

--- a/curriculum/challenges/_meta/lecture-understanding-the-event-object-and-event-delegation/meta.json
+++ b/curriculum/challenges/_meta/lecture-understanding-the-event-object-and-event-delegation/meta.json
@@ -2,7 +2,7 @@
   "name": "Understanding the Event Object and Event Delegation",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-understanding-the-event-object-and-event-delegation",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/lecture-user-centered-design/meta.json
+++ b/curriculum/challenges/_meta/lecture-user-centered-design/meta.json
@@ -2,7 +2,7 @@
   "name": "User-Centered Design",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-user-centered-design",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/lecture-user-interface-design-fundamentals/meta.json
+++ b/curriculum/challenges/_meta/lecture-user-interface-design-fundamentals/meta.json
@@ -2,7 +2,7 @@
   "name": "User Interface Design Fundamentals",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-user-interface-design-fundamentals",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/lecture-welcome-to-freecodecamp/meta.json
+++ b/curriculum/challenges/_meta/lecture-welcome-to-freecodecamp/meta.json
@@ -2,7 +2,7 @@
   "name": "Welcome to freeCodeCamp",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-welcome-to-freecodecamp",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/lecture-what-is-css/meta.json
+++ b/curriculum/challenges/_meta/lecture-what-is-css/meta.json
@@ -2,7 +2,7 @@
   "name": "What Is CSS?",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-what-is-css",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/lecture-what-is-html/meta.json
+++ b/curriculum/challenges/_meta/lecture-what-is-html/meta.json
@@ -1,6 +1,6 @@
 {
   "name": "What is HTML?",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-what-is-html",
   "superBlock": "full-stack-developer",
   "challengeOrder": [{ "id": "66f6db08d55022680a3cfbc9", "title": "What Is HTML, and What Role Does It Play on the Web?" }],

--- a/curriculum/challenges/_meta/lecture-working-with-arrays/meta.json
+++ b/curriculum/challenges/_meta/lecture-working-with-arrays/meta.json
@@ -2,7 +2,7 @@
   "name": "Working with Arrays",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-working-with-arrays",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/lecture-working-with-attribute-selectors/meta.json
+++ b/curriculum/challenges/_meta/lecture-working-with-attribute-selectors/meta.json
@@ -2,7 +2,7 @@
   "name": "Working with Attribute Selectors",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-working-with-attribute-selectors",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/lecture-working-with-audio-and-video/meta.json
+++ b/curriculum/challenges/_meta/lecture-working-with-audio-and-video/meta.json
@@ -2,7 +2,7 @@
   "name": "Working with Audio and Video",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-working-with-audio-and-video",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/lecture-working-with-backgrounds-and-borders/meta.json
+++ b/curriculum/challenges/_meta/lecture-working-with-backgrounds-and-borders/meta.json
@@ -2,7 +2,7 @@
   "name": "Working with Backgrounds and Borders",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-working-with-backgrounds-and-borders",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/lecture-working-with-client-side-storage-and-crud-operations/meta.json
+++ b/curriculum/challenges/_meta/lecture-working-with-client-side-storage-and-crud-operations/meta.json
@@ -2,7 +2,7 @@
   "name": "Working with Client-Side Storage and CRUD Operations",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-working-with-client-side-storage-and-crud-operations",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/lecture-working-with-code-editors-and-ides/meta.json
+++ b/curriculum/challenges/_meta/lecture-working-with-code-editors-and-ides/meta.json
@@ -2,7 +2,7 @@
   "name": "Working with Code Editors and IDE's",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-working-with-code-editors-and-ides",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/lecture-working-with-colors-in-css/meta.json
+++ b/curriculum/challenges/_meta/lecture-working-with-colors-in-css/meta.json
@@ -2,7 +2,7 @@
   "name": "Working with Colors in CSS",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-working-with-colors-in-css",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/lecture-working-with-common-array-methods/meta.json
+++ b/curriculum/challenges/_meta/lecture-working-with-common-array-methods/meta.json
@@ -2,7 +2,7 @@
   "name": "Working with Common Array Methods",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-working-with-common-array-methods",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/lecture-working-with-common-string-methods/meta.json
+++ b/curriculum/challenges/_meta/lecture-working-with-common-string-methods/meta.json
@@ -2,7 +2,7 @@
   "name": "Working with Common String Methods",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-working-with-common-string-methods",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/lecture-working-with-css-flexbox/meta.json
+++ b/curriculum/challenges/_meta/lecture-working-with-css-flexbox/meta.json
@@ -2,7 +2,7 @@
   "name": "Working with CSS Flexbox",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-working-with-css-flexbox",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/lecture-working-with-css-fonts/meta.json
+++ b/curriculum/challenges/_meta/lecture-working-with-css-fonts/meta.json
@@ -2,7 +2,7 @@
   "name": "Working with CSS Fonts",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-working-with-css-fonts",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/lecture-working-with-css-grid/meta.json
+++ b/curriculum/challenges/_meta/lecture-working-with-css-grid/meta.json
@@ -2,7 +2,7 @@
   "name": "Working with CSS Grid",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-working-with-css-grid",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/lecture-working-with-css-transforms-overflow-and-filters/meta.json
+++ b/curriculum/challenges/_meta/lecture-working-with-css-transforms-overflow-and-filters/meta.json
@@ -2,7 +2,7 @@
   "name": "Working with CSS Transforms, Overflow, and Filters",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-working-with-css-transforms-overflow-and-filters",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/lecture-working-with-css-variables/meta.json
+++ b/curriculum/challenges/_meta/lecture-working-with-css-variables/meta.json
@@ -2,7 +2,7 @@
   "name": "Working with CSS Variables",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-working-with-css-variables",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/lecture-working-with-data-in-react/meta.json
+++ b/curriculum/challenges/_meta/lecture-working-with-data-in-react/meta.json
@@ -2,7 +2,7 @@
   "name": "Working with Data in React",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-working-with-data-in-react",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/lecture-working-with-data-types/meta.json
+++ b/curriculum/challenges/_meta/lecture-working-with-data-types/meta.json
@@ -2,7 +2,7 @@
   "name": "Working with Data Types",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-working-with-data-types",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/lecture-working-with-dates/meta.json
+++ b/curriculum/challenges/_meta/lecture-working-with-dates/meta.json
@@ -2,7 +2,7 @@
   "name": "Working with Dates",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-working-with-dates",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/lecture-working-with-file-systems/meta.json
+++ b/curriculum/challenges/_meta/lecture-working-with-file-systems/meta.json
@@ -2,7 +2,7 @@
   "name": "Working with File Systems",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-working-with-file-systems",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/lecture-working-with-forms/meta.json
+++ b/curriculum/challenges/_meta/lecture-working-with-forms/meta.json
@@ -2,7 +2,7 @@
   "name": "Working with Forms",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-working-with-forms",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/lecture-working-with-functions/meta.json
+++ b/curriculum/challenges/_meta/lecture-working-with-functions/meta.json
@@ -2,7 +2,7 @@
   "name": "Working with Functions",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-working-with-functions",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/lecture-working-with-higher-order-functions-and-callbacks/meta.json
+++ b/curriculum/challenges/_meta/lecture-working-with-higher-order-functions-and-callbacks/meta.json
@@ -2,7 +2,7 @@
   "name": "Working with Higher Order Functions and Callbacks",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-working-with-higher-order-functions-and-callbacks",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/lecture-working-with-html-tools/meta.json
+++ b/curriculum/challenges/_meta/lecture-working-with-html-tools/meta.json
@@ -2,7 +2,7 @@
   "name": "Working with HTML Tools",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-working-with-html-tools",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/lecture-working-with-links/meta.json
+++ b/curriculum/challenges/_meta/lecture-working-with-links/meta.json
@@ -2,7 +2,7 @@
   "name": "Working with Links",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-working-with-links",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/lecture-working-with-loops/meta.json
+++ b/curriculum/challenges/_meta/lecture-working-with-loops/meta.json
@@ -2,7 +2,7 @@
   "name": "Working with Loops",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-working-with-loops",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/lecture-working-with-maps-and-sets/meta.json
+++ b/curriculum/challenges/_meta/lecture-working-with-maps-and-sets/meta.json
@@ -2,7 +2,7 @@
   "name": "Working with Maps and Sets",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-working-with-maps-and-sets",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/lecture-working-with-media/meta.json
+++ b/curriculum/challenges/_meta/lecture-working-with-media/meta.json
@@ -2,7 +2,7 @@
   "name": "Working with Media",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-working-with-media",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/lecture-working-with-numbers-and-common-number-methods/meta.json
+++ b/curriculum/challenges/_meta/lecture-working-with-numbers-and-common-number-methods/meta.json
@@ -2,7 +2,7 @@
   "name": "Working with Numbers and Common Number Methods",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-working-with-numbers-and-common-number-methods",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/lecture-working-with-numbers-booleans-and-the-math-object/meta.json
+++ b/curriculum/challenges/_meta/lecture-working-with-numbers-booleans-and-the-math-object/meta.json
@@ -2,7 +2,7 @@
   "name": "Working with Numbers, Booleans, and the Math Object",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-working-with-numbers-booleans-and-the-math-object",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/lecture-working-with-objects/meta.json
+++ b/curriculum/challenges/_meta/lecture-working-with-objects/meta.json
@@ -2,7 +2,7 @@
   "name": "Working with Objects",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-working-with-objects",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/lecture-working-with-pseudo-classes-and-pseudo-elements-in-css/meta.json
+++ b/curriculum/challenges/_meta/lecture-working-with-pseudo-classes-and-pseudo-elements-in-css/meta.json
@@ -2,7 +2,7 @@
   "name": "Working with Pseudo-Classes and Pseudo-Elements in CSS",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-working-with-pseudo-classes-and-pseudo-elements-in-css",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/lecture-working-with-regular-expressions/meta.json
+++ b/curriculum/challenges/_meta/lecture-working-with-regular-expressions/meta.json
@@ -2,7 +2,7 @@
   "name": "Working with Regular Expressions",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-working-with-regular-expressions",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/lecture-working-with-relative-and-absolute-units/meta.json
+++ b/curriculum/challenges/_meta/lecture-working-with-relative-and-absolute-units/meta.json
@@ -2,7 +2,7 @@
   "name": "Working with Relative and Absolute Units",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-working-with-relative-and-absolute-units",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/lecture-working-with-strings-in-javascript/meta.json
+++ b/curriculum/challenges/_meta/lecture-working-with-strings-in-javascript/meta.json
@@ -2,7 +2,7 @@
   "name": "Working with Strings in JavaScript",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-working-with-strings-in-javascript",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/lecture-working-with-tables/meta.json
+++ b/curriculum/challenges/_meta/lecture-working-with-tables/meta.json
@@ -2,7 +2,7 @@
   "name": "Working with Tables",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-working-with-tables",
   "superBlock": "full-stack-developer",
   "challengeOrder": [{ "id": "672a4e04a24858778f57ebfe", "title": "What Are HTML Tables Used For, and What Should They Not Be Used For?" }],

--- a/curriculum/challenges/_meta/lecture-working-with-the-dom-click-events-and-web-apis/meta.json
+++ b/curriculum/challenges/_meta/lecture-working-with-the-dom-click-events-and-web-apis/meta.json
@@ -2,7 +2,7 @@
   "name": "Working with the DOM, Click Events, and Web APIs",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "lecture-working-with-the-dom-click-events-and-web-apis",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/quiz-asynchronous-javascript/meta.json
+++ b/curriculum/challenges/_meta/quiz-asynchronous-javascript/meta.json
@@ -2,7 +2,7 @@
   "name": "Asynchronous JavaScript Quiz",
   "blockType": "quiz",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "quiz-asynchronous-javascript",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/quiz-basic-css/meta.json
+++ b/curriculum/challenges/_meta/quiz-basic-css/meta.json
@@ -2,7 +2,7 @@
   "name": "Basic CSS Quiz",
   "blockType": "quiz",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "quiz-basic-css",
   "superBlock": "full-stack-developer",
   "challengeOrder": [{ "id": "66ed8fa2f45ce3ece4053eab", "title": "Basic CSS Quiz" }],

--- a/curriculum/challenges/_meta/quiz-basic-html/meta.json
+++ b/curriculum/challenges/_meta/quiz-basic-html/meta.json
@@ -2,7 +2,7 @@
   "name": "Basic HTML Quiz",
   "blockType": "quiz",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "quiz-basic-html",
   "superBlock": "full-stack-developer",
   "challengeOrder": [{ "id": "66df3b712c41c499e9d31e5b", "title": "Basic HTML Quiz" }],

--- a/curriculum/challenges/_meta/quiz-computer-basics/meta.json
+++ b/curriculum/challenges/_meta/quiz-computer-basics/meta.json
@@ -2,7 +2,7 @@
   "name": "Computer Basics Quiz",
   "blockType": "quiz",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "quiz-computer-basics",
   "superBlock": "full-stack-developer",
   "challengeOrder": [{ "id": "66ed8fb9f45ce3ece4053eac", "title": "Computer Basics Quiz" }],

--- a/curriculum/challenges/_meta/quiz-css-accessibility/meta.json
+++ b/curriculum/challenges/_meta/quiz-css-accessibility/meta.json
@@ -2,7 +2,7 @@
   "name": "CSS Accessibility Quiz",
   "blockType": "quiz",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "quiz-css-accessibility",
   "superBlock": "full-stack-developer",
   "challengeOrder": [{ "id": "66ed8fc1f45ce3ece4053ead", "title": "CSS Accessibility Quiz" }],

--- a/curriculum/challenges/_meta/quiz-css-animations/meta.json
+++ b/curriculum/challenges/_meta/quiz-css-animations/meta.json
@@ -2,7 +2,7 @@
   "name": "CSS Animations Quiz",
   "blockType": "quiz",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "quiz-css-animations",
   "superBlock": "full-stack-developer",
   "challengeOrder": [{ "id": "66ed8fc9f45ce3ece4053eae", "title": "CSS Animations Quiz" }],

--- a/curriculum/challenges/_meta/quiz-css-attribute-selectors/meta.json
+++ b/curriculum/challenges/_meta/quiz-css-attribute-selectors/meta.json
@@ -2,7 +2,7 @@
   "name": "CSS Attribute Selectors Quiz",
   "blockType": "quiz",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "quiz-css-attribute-selectors",
   "superBlock": "full-stack-developer",
   "challengeOrder": [{ "id": "66ed8fd0f45ce3ece4053eaf", "title": "CSS Attribute Selectors Quiz" }],

--- a/curriculum/challenges/_meta/quiz-css-backgrounds-and-borders/meta.json
+++ b/curriculum/challenges/_meta/quiz-css-backgrounds-and-borders/meta.json
@@ -2,7 +2,7 @@
   "name": "CSS Backgrounds and Borders Quiz",
   "blockType": "quiz",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "quiz-css-backgrounds-and-borders",
   "superBlock": "full-stack-developer",
   "challengeOrder": [{ "id": "66ed8fd7f45ce3ece4053eb0", "title": "CSS Backgrounds and Borders Quiz" }],

--- a/curriculum/challenges/_meta/quiz-css-colors/meta.json
+++ b/curriculum/challenges/_meta/quiz-css-colors/meta.json
@@ -2,7 +2,7 @@
   "name": "CSS Colors Quiz",
   "blockType": "quiz",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "quiz-css-colors",
   "superBlock": "full-stack-developer",
   "challengeOrder": [{ "id": "66ed8fe1f45ce3ece4053eb1", "title": "CSS Colors Quiz" }],

--- a/curriculum/challenges/_meta/quiz-css-flexbox/meta.json
+++ b/curriculum/challenges/_meta/quiz-css-flexbox/meta.json
@@ -2,7 +2,7 @@
   "name": "CSS Flexbox Quiz",
   "blockType": "quiz",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "quiz-css-flexbox",
   "superBlock": "full-stack-developer",
   "challengeOrder": [{ "id": "66ed8fe7f45ce3ece4053eb2", "title": "CSS Flexbox Quiz" }],

--- a/curriculum/challenges/_meta/quiz-css-grid/meta.json
+++ b/curriculum/challenges/_meta/quiz-css-grid/meta.json
@@ -2,7 +2,7 @@
   "name": "CSS Grid Quiz",
   "blockType": "quiz",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "quiz-css-grid",
   "superBlock": "full-stack-developer",
   "challengeOrder": [{ "id": "66ed8fedf45ce3ece4053eb3", "title": "CSS Grid Quiz" }],

--- a/curriculum/challenges/_meta/quiz-css-layout-and-effects/meta.json
+++ b/curriculum/challenges/_meta/quiz-css-layout-and-effects/meta.json
@@ -2,7 +2,7 @@
   "name": "CSS Layout and Effects Quiz",
   "blockType": "quiz",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "quiz-css-layout-and-effects",
   "superBlock": "full-stack-developer",
   "challengeOrder": [{ "id": "66ed8ff4f45ce3ece4053eb4", "title": "CSS Layout and Effects Quiz" }],

--- a/curriculum/challenges/_meta/quiz-css-positioning/meta.json
+++ b/curriculum/challenges/_meta/quiz-css-positioning/meta.json
@@ -2,7 +2,7 @@
   "name": "CSS Positioning Quiz",
   "blockType": "quiz",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "quiz-css-positioning",
   "superBlock": "full-stack-developer",
   "challengeOrder": [{ "id": "66ed8ffcf45ce3ece4053eb5", "title": "CSS Positioning Quiz" }],

--- a/curriculum/challenges/_meta/quiz-css-pseudo-classes/meta.json
+++ b/curriculum/challenges/_meta/quiz-css-pseudo-classes/meta.json
@@ -2,7 +2,7 @@
   "name": "CSS Pseudo-classes Quiz",
   "blockType": "quiz",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "quiz-css-pseudo-classes",
   "superBlock": "full-stack-developer",
   "challengeOrder": [{ "id": "66ed9002f45ce3ece4053eb6", "title": "CSS Pseudo-classes Quiz" }],

--- a/curriculum/challenges/_meta/quiz-css-relative-and-absolute-units/meta.json
+++ b/curriculum/challenges/_meta/quiz-css-relative-and-absolute-units/meta.json
@@ -2,7 +2,7 @@
   "name": "CSS Relative and Absolute Units Quiz",
   "blockType": "quiz",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "quiz-css-relative-and-absolute-units",
   "superBlock": "full-stack-developer",
   "challengeOrder": [{ "id": "66ed9009f45ce3ece4053eb7", "title": "CSS Relative and Absolute Units Quiz" }],

--- a/curriculum/challenges/_meta/quiz-css-typography/meta.json
+++ b/curriculum/challenges/_meta/quiz-css-typography/meta.json
@@ -2,7 +2,7 @@
   "name": "CSS Typography Quiz",
   "blockType": "quiz",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "quiz-css-typography",
   "superBlock": "full-stack-developer",
   "challengeOrder": [{ "id": "66ed9010f45ce3ece4053eb8", "title": "CSS Typography Quiz" }],

--- a/curriculum/challenges/_meta/quiz-css-variables/meta.json
+++ b/curriculum/challenges/_meta/quiz-css-variables/meta.json
@@ -2,7 +2,7 @@
   "name": "CSS Variables Quiz",
   "blockType": "quiz",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "quiz-css-variables",
   "superBlock": "full-stack-developer",
   "challengeOrder": [{ "id": "66ed9018f45ce3ece4053eb9", "title": "CSS Variables Quiz" }],

--- a/curriculum/challenges/_meta/quiz-debugging-javascript/meta.json
+++ b/curriculum/challenges/_meta/quiz-debugging-javascript/meta.json
@@ -2,7 +2,7 @@
   "name": "Debugging JavaScript Quiz",
   "blockType": "quiz",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "quiz-debugging-javascript",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/quiz-design-fundamentals/meta.json
+++ b/curriculum/challenges/_meta/quiz-design-fundamentals/meta.json
@@ -2,7 +2,7 @@
   "name": "Design Fundamentals Quiz",
   "blockType": "quiz",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "quiz-design-fundamentals",
   "superBlock": "full-stack-developer",
   "challengeOrder": [{ "id": "66ed901ff45ce3ece4053eba", "title": "Design Fundamentals Quiz" }],

--- a/curriculum/challenges/_meta/quiz-dom-manipulation-and-click-event-with-javascript/meta.json
+++ b/curriculum/challenges/_meta/quiz-dom-manipulation-and-click-event-with-javascript/meta.json
@@ -2,7 +2,7 @@
   "name": "DOM Manipulation and Click Events with JavaScript Quiz",
   "blockType": "quiz",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "quiz-dom-manipulation-and-click-event-with-javascript",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/quiz-form-validation-with-javascript/meta.json
+++ b/curriculum/challenges/_meta/quiz-form-validation-with-javascript/meta.json
@@ -2,7 +2,7 @@
   "name": "Form Validation with JavaScript Quiz",
   "blockType": "quiz",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "quiz-form-validation-with-javascript",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/quiz-html-accessibility/meta.json
+++ b/curriculum/challenges/_meta/quiz-html-accessibility/meta.json
@@ -2,7 +2,7 @@
   "name": "HTML Accessibility Quiz",
   "blockType": "quiz",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "quiz-html-accessibility",
   "superBlock": "full-stack-developer",
   "challengeOrder": [{ "id": "66ed9026f45ce3ece4053ebb", "title": "HTML Accessibility Quiz" }],

--- a/curriculum/challenges/_meta/quiz-html-tables-and-forms/meta.json
+++ b/curriculum/challenges/_meta/quiz-html-tables-and-forms/meta.json
@@ -2,7 +2,7 @@
   "name": "HTML Tables and Forms Quiz",
   "blockType": "quiz",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "quiz-html-tables-and-forms",
   "superBlock": "full-stack-developer",
   "challengeOrder": [{ "id": "66ed902df45ce3ece4053ebc", "title": "HTML Tables and Forms Quiz" }],

--- a/curriculum/challenges/_meta/quiz-javascript-arrays/meta.json
+++ b/curriculum/challenges/_meta/quiz-javascript-arrays/meta.json
@@ -2,7 +2,7 @@
   "name": "JavaScript Arrays Quiz",
   "blockType": "quiz",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "quiz-javascript-arrays",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/quiz-javascript-audio-and-video/meta.json
+++ b/curriculum/challenges/_meta/quiz-javascript-audio-and-video/meta.json
@@ -2,7 +2,7 @@
   "name": "JavaScript Audio and Video Quiz",
   "blockType": "quiz",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "quiz-javascript-audio-and-video",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/quiz-javascript-classes/meta.json
+++ b/curriculum/challenges/_meta/quiz-javascript-classes/meta.json
@@ -2,7 +2,7 @@
   "name": "JavaScript Classes Quiz",
   "blockType": "quiz",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "quiz-javascript-classes",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/quiz-javascript-comparisons-and-conditionals/meta.json
+++ b/curriculum/challenges/_meta/quiz-javascript-comparisons-and-conditionals/meta.json
@@ -2,7 +2,7 @@
   "name": "JavaScript Comparisons and Conditionals Quiz",
   "blockType": "quiz",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "quiz-javascript-comparisons-and-conditionals",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/quiz-javascript-dates/meta.json
+++ b/curriculum/challenges/_meta/quiz-javascript-dates/meta.json
@@ -2,7 +2,7 @@
   "name": "JavaScript Dates Quiz",
   "blockType": "quiz",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "quiz-javascript-dates",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/quiz-javascript-events/meta.json
+++ b/curriculum/challenges/_meta/quiz-javascript-events/meta.json
@@ -2,7 +2,7 @@
   "name": "JavaScript Events Quiz",
   "blockType": "quiz",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "quiz-javascript-events",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/quiz-javascript-functional-programming/meta.json
+++ b/curriculum/challenges/_meta/quiz-javascript-functional-programming/meta.json
@@ -2,7 +2,7 @@
   "name": "JavaScript Functional Programming Quiz",
   "blockType": "quiz",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "quiz-javascript-functional-programming",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/quiz-javascript-functions/meta.json
+++ b/curriculum/challenges/_meta/quiz-javascript-functions/meta.json
@@ -2,7 +2,7 @@
   "name": "JavaScript Functions Quiz",
   "blockType": "quiz",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "quiz-javascript-functions",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/quiz-javascript-fundamentals/meta.json
+++ b/curriculum/challenges/_meta/quiz-javascript-fundamentals/meta.json
@@ -2,7 +2,7 @@
   "name": "JavaScript Fundamentals Quiz",
   "blockType": "quiz",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "quiz-javascript-fundamentals",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/quiz-javascript-higher-order-functions/meta.json
+++ b/curriculum/challenges/_meta/quiz-javascript-higher-order-functions/meta.json
@@ -2,7 +2,7 @@
   "name": "JavaScript Higher Order Functions Quiz",
   "blockType": "quiz",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "quiz-javascript-higher-order-functions",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/quiz-javascript-loops/meta.json
+++ b/curriculum/challenges/_meta/quiz-javascript-loops/meta.json
@@ -2,7 +2,7 @@
   "name": "JavaScript Loops Quiz",
   "blockType": "quiz",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "quiz-javascript-loops",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/quiz-javascript-maps-and-sets/meta.json
+++ b/curriculum/challenges/_meta/quiz-javascript-maps-and-sets/meta.json
@@ -2,7 +2,7 @@
   "name": "JavaScript Maps and Sets Quiz",
   "blockType": "quiz",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "quiz-javascript-maps-and-sets",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/quiz-javascript-math/meta.json
+++ b/curriculum/challenges/_meta/quiz-javascript-math/meta.json
@@ -2,7 +2,7 @@
   "name": "JavaScript Math Quiz",
   "blockType": "quiz",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "quiz-javascript-math",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/quiz-javascript-objects/meta.json
+++ b/curriculum/challenges/_meta/quiz-javascript-objects/meta.json
@@ -2,7 +2,7 @@
   "name": "JavaScript Objects Quiz",
   "blockType": "quiz",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "quiz-javascript-objects",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/quiz-javascript-regular-expressions/meta.json
+++ b/curriculum/challenges/_meta/quiz-javascript-regular-expressions/meta.json
@@ -2,7 +2,7 @@
   "name": "JavaScript Regular Expressions Quiz",
   "blockType": "quiz",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "quiz-javascript-regular-expressions",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/quiz-javascript-strings/meta.json
+++ b/curriculum/challenges/_meta/quiz-javascript-strings/meta.json
@@ -2,7 +2,7 @@
   "name": "JavaScript Strings Quiz",
   "blockType": "quiz",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "quiz-javascript-strings",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/quiz-javascript-variables-and-data-types/meta.json
+++ b/curriculum/challenges/_meta/quiz-javascript-variables-and-data-types/meta.json
@@ -2,7 +2,7 @@
   "name": "JavaScript Variables and Data Types Quiz",
   "blockType": "quiz",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "quiz-javascript-variables-and-data-types",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/quiz-local-storage-and-crud/meta.json
+++ b/curriculum/challenges/_meta/quiz-local-storage-and-crud/meta.json
@@ -2,7 +2,7 @@
   "name": "Local Storage and CRUD Quiz",
   "blockType": "quiz",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "quiz-local-storage-and-crud",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/quiz-react-basics/meta.json
+++ b/curriculum/challenges/_meta/quiz-react-basics/meta.json
@@ -2,7 +2,7 @@
   "name": "React Basics Quiz",
   "blockType": "quiz",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "quiz-react-basics",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/quiz-recursion/meta.json
+++ b/curriculum/challenges/_meta/quiz-recursion/meta.json
@@ -2,7 +2,7 @@
   "name": "Recursion Quiz",
   "blockType": "quiz",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "quiz-recursion",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/quiz-responsive-web-design/meta.json
+++ b/curriculum/challenges/_meta/quiz-responsive-web-design/meta.json
@@ -2,7 +2,7 @@
   "name": "Responsive Web Design Quiz",
   "blockType": "quiz",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "quiz-responsive-web-design",
   "superBlock": "full-stack-developer",
   "challengeOrder": [{ "id": "66ed9034f45ce3ece4053ebd", "title": "Responsive Web Design Quiz" }],

--- a/curriculum/challenges/_meta/quiz-styling-forms/meta.json
+++ b/curriculum/challenges/_meta/quiz-styling-forms/meta.json
@@ -2,7 +2,7 @@
   "name": "Styling Forms Quiz",
   "blockType": "quiz",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "quiz-styling-forms",
   "superBlock": "full-stack-developer",
   "challengeOrder": [{ "id": "66ed9043f45ce3ece4053ebf", "title": "Styling Forms Quiz" }],

--- a/curriculum/challenges/_meta/review-asynchronous-javascript/meta.json
+++ b/curriculum/challenges/_meta/review-asynchronous-javascript/meta.json
@@ -2,7 +2,7 @@
   "name": "Asynchronous JavaScript Review",
   "blockType": "review",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "review-asynchronous-javascript",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/review-basic-css/meta.json
+++ b/curriculum/challenges/_meta/review-basic-css/meta.json
@@ -2,7 +2,7 @@
   "name": "Basic CSS Review",
   "blockType": "review",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "review-basic-css",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/review-basic-html/meta.json
+++ b/curriculum/challenges/_meta/review-basic-html/meta.json
@@ -1,7 +1,7 @@
 {
   "name": "Basic HTML Review",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "review-basic-html",
   "superBlock": "full-stack-developer",
   "challengeOrder": [{ "id": "67072fc183c7ca6c588feb4d", "title": "Basic HTML Review" }],

--- a/curriculum/challenges/_meta/review-computer-basics/meta.json
+++ b/curriculum/challenges/_meta/review-computer-basics/meta.json
@@ -2,7 +2,7 @@
   "name": "Computer Basics Review",
   "blockType": "review",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "review-computer-basics",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/review-css-accessibility/meta.json
+++ b/curriculum/challenges/_meta/review-css-accessibility/meta.json
@@ -2,7 +2,7 @@
   "name": "CSS Accessibility Review",
   "blockType": "review",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "review-css-accessibility",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/review-css-animations/meta.json
+++ b/curriculum/challenges/_meta/review-css-animations/meta.json
@@ -2,7 +2,7 @@
   "name": "CSS Animations Review",
   "blockType": "review",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "review-css-animations",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/review-css-attribute-selectors/meta.json
+++ b/curriculum/challenges/_meta/review-css-attribute-selectors/meta.json
@@ -2,7 +2,7 @@
   "name": "CSS Attribute Selectors Review",
   "blockType": "review",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "review-css-attribute-selectors",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/review-css-backgrounds-and-borders/meta.json
+++ b/curriculum/challenges/_meta/review-css-backgrounds-and-borders/meta.json
@@ -2,7 +2,7 @@
   "name": "CSS Backgrounds and Borders Review",
   "blockType": "review",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "review-css-backgrounds-and-borders",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/review-css-colors/meta.json
+++ b/curriculum/challenges/_meta/review-css-colors/meta.json
@@ -2,7 +2,7 @@
   "name": "CSS Colors Review",
   "blockType": "review",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "review-css-colors",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/review-css-flexbox/meta.json
+++ b/curriculum/challenges/_meta/review-css-flexbox/meta.json
@@ -2,7 +2,7 @@
   "name": "CSS Flexbox Review",
   "blockType": "review",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "review-css-flexbox",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/review-css-grid/meta.json
+++ b/curriculum/challenges/_meta/review-css-grid/meta.json
@@ -2,7 +2,7 @@
   "name": "CSS Grid Review",
   "blockType": "review",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "review-css-grid",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/review-css-layout-and-effects/meta.json
+++ b/curriculum/challenges/_meta/review-css-layout-and-effects/meta.json
@@ -2,7 +2,7 @@
   "name": "CSS Layouts and Effects Review",
   "blockType": "review",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "review-css-layout-and-effects",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/review-css-positioning/meta.json
+++ b/curriculum/challenges/_meta/review-css-positioning/meta.json
@@ -2,7 +2,7 @@
   "name": "CSS Positioning Review",
   "blockType": "review",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "review-css-positioning",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/review-css-pseudo-classes/meta.json
+++ b/curriculum/challenges/_meta/review-css-pseudo-classes/meta.json
@@ -2,7 +2,7 @@
   "name": "CSS Pseudo-classes Review",
   "blockType": "review",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "review-css-pseudo-classes",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/review-css-relative-and-absolute-units/meta.json
+++ b/curriculum/challenges/_meta/review-css-relative-and-absolute-units/meta.json
@@ -2,7 +2,7 @@
   "name": "CSS Relative and Absolute Units Review",
   "blockType": "review",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "review-css-relative-and-absolute-units",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/review-css-typography/meta.json
+++ b/curriculum/challenges/_meta/review-css-typography/meta.json
@@ -2,7 +2,7 @@
   "name": "CSS Typography Review",
   "blockType": "review",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "review-css-typography",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/review-css-variables/meta.json
+++ b/curriculum/challenges/_meta/review-css-variables/meta.json
@@ -2,7 +2,7 @@
   "name": "CSS Variables Review",
   "blockType": "review",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "review-css-variables",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/review-css/meta.json
+++ b/curriculum/challenges/_meta/review-css/meta.json
@@ -2,7 +2,7 @@
   "name": "CSS Review",
   "blockType": "review",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "review-css",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/review-debugging-javascript/meta.json
+++ b/curriculum/challenges/_meta/review-debugging-javascript/meta.json
@@ -2,7 +2,7 @@
   "name": "Debugging JavaScript Review",
   "blockType": "review",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "review-debugging-javascript",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/review-design-fundamentals/meta.json
+++ b/curriculum/challenges/_meta/review-design-fundamentals/meta.json
@@ -2,7 +2,7 @@
   "name": "Design Fundamentals Review",
   "blockType": "review",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "review-design-fundamentals",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/review-dom-manipulation-and-click-events-with-javascript/meta.json
+++ b/curriculum/challenges/_meta/review-dom-manipulation-and-click-events-with-javascript/meta.json
@@ -2,7 +2,7 @@
   "name": "DOM Manipulation and Click Events with JavaScript Review",
   "blockType": "review",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "review-dom-manipulation-and-click-events-with-javascript",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/review-form-validation-with-javascript/meta.json
+++ b/curriculum/challenges/_meta/review-form-validation-with-javascript/meta.json
@@ -2,7 +2,7 @@
   "name": "Form Validation with JavaScript Review",
   "blockType": "review",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "review-form-validation-with-javascript",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/review-html-accessibility/meta.json
+++ b/curriculum/challenges/_meta/review-html-accessibility/meta.json
@@ -2,7 +2,7 @@
   "name": "HTML Accessibility Review",
   "blockType": "review",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "review-html-accessibility",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/review-html-tables-and-forms/meta.json
+++ b/curriculum/challenges/_meta/review-html-tables-and-forms/meta.json
@@ -2,7 +2,7 @@
   "name": "HTML Tables and Forms Review",
   "blockType": "review",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "review-html-tables-and-forms",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/review-html/meta.json
+++ b/curriculum/challenges/_meta/review-html/meta.json
@@ -2,7 +2,7 @@
   "name": "HTML Review",
   "blockType": "review",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "review-html",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/review-javascript-arrays/meta.json
+++ b/curriculum/challenges/_meta/review-javascript-arrays/meta.json
@@ -2,7 +2,7 @@
   "name": "JavaScript Arrays Review",
   "blockType": "review",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "review-javascript-arrays",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/review-javascript-audio-and-video/meta.json
+++ b/curriculum/challenges/_meta/review-javascript-audio-and-video/meta.json
@@ -2,7 +2,7 @@
   "name": "JavaScript Audio and Video Review",
   "blockType": "review",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "review-javascript-audio-and-video",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/review-javascript-classes/meta.json
+++ b/curriculum/challenges/_meta/review-javascript-classes/meta.json
@@ -2,7 +2,7 @@
   "name": "JavaScript Classes Review",
   "blockType": "review",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "review-javascript-classes",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/review-javascript-comparisons-and-conditionals/meta.json
+++ b/curriculum/challenges/_meta/review-javascript-comparisons-and-conditionals/meta.json
@@ -2,7 +2,7 @@
   "name": "JavaScript Comparisons and Conditionals Review",
   "blockType": "review",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "review-javascript-comparisons-and-conditionals",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/review-javascript-dates/meta.json
+++ b/curriculum/challenges/_meta/review-javascript-dates/meta.json
@@ -2,7 +2,7 @@
   "name": "JavaScript Dates Review",
   "blockType": "review",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "review-javascript-dates",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/review-javascript-events/meta.json
+++ b/curriculum/challenges/_meta/review-javascript-events/meta.json
@@ -2,7 +2,7 @@
   "name": "JavaScript Events Review",
   "blockType": "review",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "review-javascript-events",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/review-javascript-functional-programming/meta.json
+++ b/curriculum/challenges/_meta/review-javascript-functional-programming/meta.json
@@ -2,7 +2,7 @@
   "name": "JavaScript Functional Programming Review",
   "blockType": "review",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "review-javascript-functional-programming",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/review-javascript-functions/meta.json
+++ b/curriculum/challenges/_meta/review-javascript-functions/meta.json
@@ -2,7 +2,7 @@
   "name": "JavaScript Functions Review",
   "blockType": "review",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "review-javascript-functions",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/review-javascript-fundamentals/meta.json
+++ b/curriculum/challenges/_meta/review-javascript-fundamentals/meta.json
@@ -2,7 +2,7 @@
   "name": "JavaScript Fundamentals Review",
   "blockType": "review",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "review-javascript-fundamentals",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/review-javascript-higher-order-functions/meta.json
+++ b/curriculum/challenges/_meta/review-javascript-higher-order-functions/meta.json
@@ -2,7 +2,7 @@
   "name": "JavaScript Higher Order Functions Review",
   "blockType": "review",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "review-javascript-higher-order-functions",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/review-javascript-loops/meta.json
+++ b/curriculum/challenges/_meta/review-javascript-loops/meta.json
@@ -2,7 +2,7 @@
   "name": "JavaScript Loops Review",
   "blockType": "review",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "review-javascript-loops",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/review-javascript-maps-and-sets/meta.json
+++ b/curriculum/challenges/_meta/review-javascript-maps-and-sets/meta.json
@@ -2,7 +2,7 @@
   "name": "JavaScript Maps and Sets Review",
   "blockType": "review",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "review-javascript-maps-and-sets",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/review-javascript-math/meta.json
+++ b/curriculum/challenges/_meta/review-javascript-math/meta.json
@@ -2,7 +2,7 @@
   "name": "JavaScript Math Review",
   "blockType": "review",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "review-javascript-math",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/review-javascript-objects/meta.json
+++ b/curriculum/challenges/_meta/review-javascript-objects/meta.json
@@ -2,7 +2,7 @@
   "name": "JavaScript Objects Review",
   "blockType": "review",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "review-javascript-objects",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/review-javascript-regular-expressions/meta.json
+++ b/curriculum/challenges/_meta/review-javascript-regular-expressions/meta.json
@@ -2,7 +2,7 @@
   "name": "JavaScript Regular Expressions Review",
   "blockType": "review",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "review-javascript-regular-expressions",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/review-javascript-strings/meta.json
+++ b/curriculum/challenges/_meta/review-javascript-strings/meta.json
@@ -2,7 +2,7 @@
   "name": "JavaScript Strings Review",
   "blockType": "review",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "review-javascript-strings",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/review-javascript-variables-and-data-types/meta.json
+++ b/curriculum/challenges/_meta/review-javascript-variables-and-data-types/meta.json
@@ -2,7 +2,7 @@
   "name": "JavaScript Variables and Data Types Review",
   "blockType": "review",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "review-javascript-variables-and-data-types",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/review-javascript/meta.json
+++ b/curriculum/challenges/_meta/review-javascript/meta.json
@@ -2,7 +2,7 @@
   "name": "JavaScript Review",
   "blockType": "review",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "review-javascript",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/review-local-storage-and-crud/meta.json
+++ b/curriculum/challenges/_meta/review-local-storage-and-crud/meta.json
@@ -2,7 +2,7 @@
   "name": "Local Storage and CRUD Review",
   "blockType": "review",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "review-local-storage-and-crud",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/review-react-basics/meta.json
+++ b/curriculum/challenges/_meta/review-react-basics/meta.json
@@ -2,7 +2,7 @@
   "name": "React Basics",
   "blockType": "review",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "review-react-basics",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/review-recursion/meta.json
+++ b/curriculum/challenges/_meta/review-recursion/meta.json
@@ -2,7 +2,7 @@
   "name": "Recursion Review",
   "blockType": "review",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "review-recursion",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/review-responsive-web-design/meta.json
+++ b/curriculum/challenges/_meta/review-responsive-web-design/meta.json
@@ -2,7 +2,7 @@
   "name": "Responsive Web Design Review",
   "blockType": "review",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "review-responsive-web-design",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/review-styling-forms/meta.json
+++ b/curriculum/challenges/_meta/review-styling-forms/meta.json
@@ -2,7 +2,7 @@
   "name": "Styling Forms Review",
   "blockType": "review",
   "blockLayout": "link",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "review-styling-forms",
   "superBlock": "full-stack-developer",
   "challengeOrder": [

--- a/curriculum/challenges/_meta/workshop-accessibility-quiz/meta.json
+++ b/curriculum/challenges/_meta/workshop-accessibility-quiz/meta.json
@@ -2,7 +2,7 @@
   "name": "Build a Quiz Webpage",
   "blockType": "workshop",
   "blockLayout": "challenge-grid",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "dashedName": "workshop-accessibility-quiz",

--- a/curriculum/challenges/_meta/workshop-balance-sheet/meta.json
+++ b/curriculum/challenges/_meta/workshop-balance-sheet/meta.json
@@ -2,7 +2,7 @@
   "name": "Build a Balance Sheet",
   "blockType": "workshop",
   "blockLayout": "challenge-grid",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "dashedName": "workshop-balance-sheet",

--- a/curriculum/challenges/_meta/workshop-cafe-menu/meta.json
+++ b/curriculum/challenges/_meta/workshop-cafe-menu/meta.json
@@ -2,7 +2,7 @@
   "name": "Design a Cafe Menu",
   "blockType": "workshop",
   "blockLayout": "challenge-grid",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "dashedName": "workshop-cafe-menu",

--- a/curriculum/challenges/_meta/workshop-calculator/meta.json
+++ b/curriculum/challenges/_meta/workshop-calculator/meta.json
@@ -2,7 +2,7 @@
   "name": "Build a Calculator",
   "blockType": "workshop",
   "blockLayout": "challenge-grid",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "dashedName": "workshop-calculator",

--- a/curriculum/challenges/_meta/workshop-calorie-counter/meta.json
+++ b/curriculum/challenges/_meta/workshop-calorie-counter/meta.json
@@ -1,6 +1,6 @@
 {
   "name": "Build a Calorie Counter",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "blockType": "workshop",

--- a/curriculum/challenges/_meta/workshop-cat-painting/meta.json
+++ b/curriculum/challenges/_meta/workshop-cat-painting/meta.json
@@ -2,7 +2,7 @@
   "name": "Build a Cat Painting",
   "blockType": "workshop",
   "blockLayout": "challenge-grid",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "dashedName": "workshop-cat-painting",

--- a/curriculum/challenges/_meta/workshop-cat-photo-app/meta.json
+++ b/curriculum/challenges/_meta/workshop-cat-photo-app/meta.json
@@ -2,7 +2,7 @@
   "name": "Build a Cat Photo App",
   "blockType": "workshop",
   "blockLayout": "challenge-grid",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "dashedName": "workshop-cat-photo-app",

--- a/curriculum/challenges/_meta/workshop-city-skyline/meta.json
+++ b/curriculum/challenges/_meta/workshop-city-skyline/meta.json
@@ -2,7 +2,7 @@
   "name": "Build a City Skyline",
   "blockType": "workshop",
   "blockLayout": "challenge-grid",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "dashedName": "workshop-city-skyline",

--- a/curriculum/challenges/_meta/workshop-colored-markers/meta.json
+++ b/curriculum/challenges/_meta/workshop-colored-markers/meta.json
@@ -1,7 +1,7 @@
 {
   "name": "Build a Set of Colored Markers",
   "blockType": "workshop",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "dashedName": "workshop-colored-markers",

--- a/curriculum/challenges/_meta/workshop-decimal-to-binary-converter/meta.json
+++ b/curriculum/challenges/_meta/workshop-decimal-to-binary-converter/meta.json
@@ -2,7 +2,7 @@
   "name": "Build a Decimal to Binary Converter",
   "blockType": "workshop",
   "blockLayout": "challenge-grid",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "dashedName": "workshop-decimal-to-binary-converter",

--- a/curriculum/challenges/_meta/workshop-fcc-authors-page/meta.json
+++ b/curriculum/challenges/_meta/workshop-fcc-authors-page/meta.json
@@ -2,7 +2,7 @@
   "name": "Build an fCC Authors Page",
   "blockType": "workshop",
   "blockLayout": "challenge-grid",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "dashedName": "workshop-fcc-authors-page",

--- a/curriculum/challenges/_meta/workshop-ferris-wheel/meta.json
+++ b/curriculum/challenges/_meta/workshop-ferris-wheel/meta.json
@@ -1,6 +1,6 @@
 {
   "name": "Build an Animated Ferris Wheel",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "dashedName": "workshop-ferris-wheel",

--- a/curriculum/challenges/_meta/workshop-final-exams-table/meta.json
+++ b/curriculum/challenges/_meta/workshop-final-exams-table/meta.json
@@ -2,7 +2,7 @@
   "name": "Build a Final Exams Table",
   "blockType": "workshop",
   "blockLayout": "challenge-grid",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "dashedName": "workshop-final-exams-table",

--- a/curriculum/challenges/_meta/workshop-flappy-penguin/meta.json
+++ b/curriculum/challenges/_meta/workshop-flappy-penguin/meta.json
@@ -2,7 +2,7 @@
   "name": "Build a Flappy Penguin",
   "blockType": "workshop",
   "blockLayout": "challenge-grid",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "dashedName": "workshop-flappy-penguin",

--- a/curriculum/challenges/_meta/workshop-flexbox-photo-gallery/meta.json
+++ b/curriculum/challenges/_meta/workshop-flexbox-photo-gallery/meta.json
@@ -2,7 +2,7 @@
   "name": "Build a Flexbox Photo Gallery",
   "blockType": "workshop",
   "blockLayout": "challenge-grid",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "dashedName": "workshop-flexbox-photo-gallery",

--- a/curriculum/challenges/_meta/workshop-greeting-bot/meta.json
+++ b/curriculum/challenges/_meta/workshop-greeting-bot/meta.json
@@ -2,7 +2,7 @@
   "name": "Build a Greeting Bot",
   "blockType": "workshop",
   "blockLayout": "challenge-grid",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "dashedName": "workshop-greeting-bot",

--- a/curriculum/challenges/_meta/workshop-greeting-card/meta.json
+++ b/curriculum/challenges/_meta/workshop-greeting-card/meta.json
@@ -1,6 +1,6 @@
 {
   "name": "Design a Greeting Card",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "dashedName": "workshop-greeting-card",

--- a/curriculum/challenges/_meta/workshop-hotel-feedback-form/meta.json
+++ b/curriculum/challenges/_meta/workshop-hotel-feedback-form/meta.json
@@ -2,7 +2,7 @@
   "name": "Build a Hotel Feedback Form",
   "blockType": "workshop",
   "blockLayout": "challenge-grid",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "dashedName": "workshop-hotel-feedback-form",

--- a/curriculum/challenges/_meta/workshop-library-manager/meta.json
+++ b/curriculum/challenges/_meta/workshop-library-manager/meta.json
@@ -1,7 +1,7 @@
 {
   "name": "Build a Library Manager",
   "blockLayout": "challenge-grid",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "dashedName": "workshop-library-manager",

--- a/curriculum/challenges/_meta/workshop-loan-qualification-checker/meta.json
+++ b/curriculum/challenges/_meta/workshop-loan-qualification-checker/meta.json
@@ -2,7 +2,7 @@
   "name": "Build a Loan Qualification Checker",
   "blockType": "workshop",
   "blockLayout": "challenge-grid",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "dashedName": "workshop-loan-qualification-checker",

--- a/curriculum/challenges/_meta/workshop-magazine/meta.json
+++ b/curriculum/challenges/_meta/workshop-magazine/meta.json
@@ -2,7 +2,7 @@
   "name": "Build a Magazine",
   "blockType": "workshop",
   "blockLayout": "challenge-grid",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "dashedName": "workshop-magazine",

--- a/curriculum/challenges/_meta/workshop-mathbot/meta.json
+++ b/curriculum/challenges/_meta/workshop-mathbot/meta.json
@@ -2,7 +2,7 @@
   "name": "Build a Mathbot",
   "blockType": "workshop",
   "blockLayout": "challenge-grid",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "dashedName": "workshop-mathbot",

--- a/curriculum/challenges/_meta/workshop-music-instrument-filter/meta.json
+++ b/curriculum/challenges/_meta/workshop-music-instrument-filter/meta.json
@@ -2,7 +2,7 @@
   "name": "Build a Music Instrument Filter",
   "blockType": "workshop",
   "blockLayout": "challenge-grid",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "dashedName": "workshop-music-instrument-filter",

--- a/curriculum/challenges/_meta/workshop-music-player/meta.json
+++ b/curriculum/challenges/_meta/workshop-music-player/meta.json
@@ -2,7 +2,7 @@
   "name": "Build a Music Player",
   "blockType": "workshop",
   "blockLayout": "challenge-grid",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "dashedName": "workshop-music-player",

--- a/curriculum/challenges/_meta/workshop-nutritional-label/meta.json
+++ b/curriculum/challenges/_meta/workshop-nutritional-label/meta.json
@@ -2,7 +2,7 @@
   "name": "Build a Nutritional Label",
   "blockType": "workshop",
   "blockLayout": "challenge-grid",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "dashedName": "workshop-nutritional-label",

--- a/curriculum/challenges/_meta/workshop-piano/meta.json
+++ b/curriculum/challenges/_meta/workshop-piano/meta.json
@@ -2,7 +2,7 @@
   "name": "Design a Piano",
   "blockType": "workshop",
   "blockLayout": "challenge-grid",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "dashedName": "workshop-piano",

--- a/curriculum/challenges/_meta/workshop-plant-nursery-catalog/meta.json
+++ b/curriculum/challenges/_meta/workshop-plant-nursery-catalog/meta.json
@@ -1,6 +1,6 @@
 {
   "name": "Build a Plant Nursery Catalog",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "dashedName": "workshop-plant-nursery-catalog",

--- a/curriculum/challenges/_meta/workshop-recipe-ingredient-converter/meta.json
+++ b/curriculum/challenges/_meta/workshop-recipe-ingredient-converter/meta.json
@@ -1,7 +1,7 @@
 {
   "name": "Build a Recipe Ingredient Converter",
   "blockLayout": "challenge-grid",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "dashedName": "workshop-recipe-ingredient-converter",

--- a/curriculum/challenges/_meta/workshop-recipe-tracker/meta.json
+++ b/curriculum/challenges/_meta/workshop-recipe-tracker/meta.json
@@ -1,7 +1,7 @@
 {
   "name": "Build a Recipe Tracker",
   "blockLayout": "challenge-grid",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "dashedName": "workshop-recipe-tracker",

--- a/curriculum/challenges/_meta/workshop-registration-form/meta.json
+++ b/curriculum/challenges/_meta/workshop-registration-form/meta.json
@@ -2,7 +2,7 @@
   "name": "Design a Registration Form",
   "blockType": "workshop",
   "blockLayout": "challenge-grid",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "dashedName": "workshop-registration-form",

--- a/curriculum/challenges/_meta/workshop-reusable-mega-navbar/meta.json
+++ b/curriculum/challenges/_meta/workshop-reusable-mega-navbar/meta.json
@@ -1,6 +1,6 @@
 {
   "name": "Build a Reusable Mega Navbar",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "blockType": "workshop",
   "blockLayout": "challenge-grid",
   "usesMultifileEditor": true,

--- a/curriculum/challenges/_meta/workshop-reusable-profile-card-component/meta.json
+++ b/curriculum/challenges/_meta/workshop-reusable-profile-card-component/meta.json
@@ -1,6 +1,6 @@
 {
   "name": "Build a Reusable Profile Card Component",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "blockType": "workshop",
   "blockLayout": "challenge-grid",
   "usesMultifileEditor": true,

--- a/curriculum/challenges/_meta/workshop-rothko-painting/meta.json
+++ b/curriculum/challenges/_meta/workshop-rothko-painting/meta.json
@@ -2,7 +2,7 @@
   "name": "Design a Rothko Painting",
   "blockType": "workshop",
   "blockLayout": "challenge-grid",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "dashedName": "workshop-rothko-painting",

--- a/curriculum/challenges/_meta/workshop-rps-game/meta.json
+++ b/curriculum/challenges/_meta/workshop-rps-game/meta.json
@@ -2,7 +2,7 @@
   "name": "Build a Rock, Paper, Scissors Game",
   "blockType": "workshop",
   "blockLayout": "challenge-grid",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "dashedName": "workshop-rps-game",

--- a/curriculum/challenges/_meta/workshop-sentence-analyzer/meta.json
+++ b/curriculum/challenges/_meta/workshop-sentence-analyzer/meta.json
@@ -2,7 +2,7 @@
   "name": "Build a Sentence Analyzer",
   "blockType": "workshop",
   "blockLayout": "challenge-grid",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "dashedName": "workshop-sentence-analyzer",

--- a/curriculum/challenges/_meta/workshop-shopping-cart/meta.json
+++ b/curriculum/challenges/_meta/workshop-shopping-cart/meta.json
@@ -2,7 +2,7 @@
   "name": "Build a Shopping Cart",
   "blockType": "workshop",
   "blockLayout": "challenge-grid",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "dashedName": "workshop-shopping-cart",

--- a/curriculum/challenges/_meta/workshop-shopping-list/meta.json
+++ b/curriculum/challenges/_meta/workshop-shopping-list/meta.json
@@ -2,7 +2,7 @@
   "name": "Build a Shopping List",
   "blockType": "workshop",
   "blockLayout": "challenge-grid",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "dashedName": "workshop-shopping-list",

--- a/curriculum/challenges/_meta/workshop-spam-filter/meta.json
+++ b/curriculum/challenges/_meta/workshop-spam-filter/meta.json
@@ -2,7 +2,7 @@
   "name": "Build a Spam Filter",
   "blockType": "workshop",
   "blockLayout": "challenge-grid",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "dashedName": "workshop-spam-filter",

--- a/curriculum/challenges/_meta/workshop-storytelling-app/meta.json
+++ b/curriculum/challenges/_meta/workshop-storytelling-app/meta.json
@@ -1,6 +1,6 @@
 {
   "name": "Build a Storytelling App",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "blockType": "workshop",

--- a/curriculum/challenges/_meta/workshop-teacher-chatbot/meta.json
+++ b/curriculum/challenges/_meta/workshop-teacher-chatbot/meta.json
@@ -2,7 +2,7 @@
   "name": "Build a Teacher Chatbot",
   "blockType": "workshop",
   "blockLayout": "challenge-grid",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "dashedName": "workshop-teacher-chatbot",

--- a/curriculum/challenges/_meta/workshop-todo-app/meta.json
+++ b/curriculum/challenges/_meta/workshop-todo-app/meta.json
@@ -1,6 +1,6 @@
 {
   "name": "Build a Todo App using Local Storage",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "dashedName": "workshop-todo-app",

--- a/curriculum/superblock-structure/full-stack.json
+++ b/curriculum/superblock-structure/full-stack.json
@@ -1,6 +1,16 @@
 {
   "chapters": [
     {
+      "dashedName": "freecodecamp",
+      "comingSoon": true,
+      "modules": [
+        {
+          "dashedName": "getting-started-with-freecodecamp",
+          "blocks": [{ "dashedName": "lecture-welcome-to-freecodecamp" }]
+        }
+      ]
+    },
+    {
       "dashedName": "html",
       "modules": [
         {

--- a/curriculum/superblock-structure/full-stack.json
+++ b/curriculum/superblock-structure/full-stack.json
@@ -5,7 +5,6 @@
       "modules": [
         {
           "dashedName": "basic-html",
-          "comingSoon": true,
           "blocks": [
             { "dashedName": "lecture-what-is-html" },
             { "dashedName": "workshop-cat-photo-app" },
@@ -31,7 +30,6 @@
         },
         {
           "dashedName": "html-forms-and-tables",
-          "comingSoon": true,
           "blocks": [
             { "dashedName": "lecture-working-with-forms" },
             { "dashedName": "workshop-hotel-feedback-form" },
@@ -46,7 +44,6 @@
         },
         {
           "dashedName": "html-and-accessibility",
-          "comingSoon": true,
           "blocks": [
             {
               "dashedName": "lecture-importance-of-accessibility-and-good-html-structure"
@@ -58,7 +55,6 @@
         },
         {
           "moduleType": "review",
-          "comingSoon": true,
           "dashedName": "review-html",
           "blocks": [{ "dashedName": "review-html" }]
         },
@@ -617,8 +613,15 @@
         },
         {
           "moduleType": "review",
+          "comingSoon": true,
           "dashedName": "review-front-end-libraries",
           "blocks": [{ "dashedName": "review-front-end-libraries" }]
+        },
+        {
+          "moduleType": "exam",
+          "comingSoon": true,
+          "dashedName": "exam-front-end-libraries",
+          "blocks": []
         }
       ]
     },

--- a/curriculum/superblock-structure/full-stack.json
+++ b/curriculum/superblock-structure/full-stack.json
@@ -1,16 +1,6 @@
 {
   "chapters": [
     {
-      "dashedName": "freecodecamp",
-      "comingSoon": true,
-      "modules": [
-        {
-          "dashedName": "getting-started-with-freecodecamp",
-          "blocks": [{ "dashedName": "lecture-welcome-to-freecodecamp" }]
-        }
-      ]
-    },
-    {
       "dashedName": "html",
       "modules": [
         {
@@ -71,12 +61,17 @@
           "comingSoon": true,
           "dashedName": "review-html",
           "blocks": [{ "dashedName": "review-html" }]
+        },
+        {
+          "moduleType": "exam",
+          "comingSoon": true,
+          "dashedName": "exam-html",
+          "blocks": []
         }
       ]
     },
     {
       "dashedName": "css",
-      "comingSoon": true,
       "modules": [
         {
           "dashedName": "computer-basics",
@@ -277,12 +272,17 @@
           "moduleType": "review",
           "dashedName": "review-css",
           "blocks": [{ "dashedName": "review-css" }]
+        },
+        {
+          "moduleType": "exam",
+          "comingSoon": true,
+          "dashedName": "exam-css",
+          "blocks": []
         }
       ]
     },
     {
       "dashedName": "javascript",
-      "comingSoon": true,
       "modules": [
         {
           "dashedName": "code-editors",
@@ -547,13 +547,18 @@
           "moduleType": "review",
           "dashedName": "review-javascript",
           "blocks": [{ "dashedName": "review-javascript" }]
+        },
+        {
+          "moduleType": "exam",
+          "comingSoon": true,
+          "dashedName": "exam-javascript",
+          "blocks": []
         }
       ]
     },
 
     {
       "dashedName": "frontend-libraries",
-      "comingSoon": true,
       "modules": [
         {
           "dashedName": "react-fundamentals",
@@ -696,6 +701,7 @@
     },
     {
       "chapterType": "exam",
+      "comingSoon": true,
       "dashedName": "exam-certified-full-stack-developer",
       "modules": [
         {


### PR DESCRIPTION
This changes the `isUpcomingChange` flag to `false` for most of the curriculum.

It makes everything through the end of React Fundamentals visible and available. With the exception of the welcome block, and the three prep exams - which are labelled as "Coming soon". After that, everything else is coming soon. I also added the Front end libraries review and exam as coming soon, as well as the final exam as coming soon.

I think this is about what it will look like for release. We can make PR's to add the rest of the content up to the end of the react fundamentals section. e.g. update all the video id's - or add transcripts where we don't have the videos ready. Add the last two labs. And hopefully add the first three exams.

Be sure to set `SHOW_UPCOMING_CHANGES=false` in your `.env` to test this - and it will look the same as it will on staging and, when we release, production.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
