### PR TITLE
Fix(Curriculum): Replaced curved backticks with straight backticks Eng blocks 1 to 4

### DIFF
--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-a-typical-workday-and-tasks/657e4a245cc71782126b3316.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-a-typical-workday-and-tasks/657e4a245cc71782126b3316.md
@@ -5,7 +5,7 @@ challengeType: 19
 dashedName: task-68
 ---
 
-<!-- (audio) Jake: “Well, yeah, security is a top priority and I have to make sure everything goes as expected.” -->
+<!-- (audio) Jake: "Well, yeah, security is a top priority and I have to make sure everything goes as expected." -->
 
 # --description--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-a-typical-workday-and-tasks/657e50576597e0a65cd97e24.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-a-typical-workday-and-tasks/657e50576597e0a65cd97e24.md
@@ -5,7 +5,7 @@ challengeType: 22
 dashedName: task-75
 ---
 
-<!-- (audio) Linda: Hey, James. So what is the meaning of “compliance”. Can you tell me? -->
+<!-- (audio) Linda: Hey, James. So what is the meaning of "compliance". Can you tell me? -->
 
 # --description--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66a91783d34e873290e9f5ec.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66a91783d34e873290e9f5ec.md
@@ -57,7 +57,7 @@ If she is going to a Hackathon this weekend.
 
 To find out what Bob wants to know, listen to the second question he asks. Pay attention what comes after `I hear you're going to...` which show what Bob is trying to find out. 
 
-He uses a question to confirm what he heard, specifically mentioning the event he thinks she’s attending. 
+He uses a question to confirm what he heard, specifically mentioning the event he thinks she's attending. 
 
 # --scene--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66a95606a32d5747dae3bfba.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66a95606a32d5747dae3bfba.md
@@ -8,7 +8,7 @@ dashedName: task-14
 <!--
 AUDIO REFERENCE:
 Lisa: We plan to develop a new app for real-time project collaboration. How does that sound to you?
-Bob: Interesting! Who’s on your team?
+Bob: Interesting! Who's on your team?
 -->
 
 # --instructions--

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66a958bb3ac85c4a75e5fe88.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66a958bb3ac85c4a75e5fe88.md
@@ -7,7 +7,7 @@ dashedName: task-18
 
 <!--
 AUDIO REFERENCE:
-Bob: Interesting! Who’s on your team?
+Bob: Interesting! Who's on your team?
 Lisa: A couple of developers from our branch in Seattle, and a UX designer I've collaborated with before.
 -->
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66a9599790c94a4ba0e5dbd9.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66a9599790c94a4ba0e5dbd9.md
@@ -53,7 +53,7 @@ Lisa is asking about similar projects happening soon, not about moving to a diff
 
 # --explanation--
 
-Lisa asks about what’s coming up, specifically looking for information on projects that are similar to the one she is currently working on. 
+Lisa asks about what's coming up, specifically looking for information on projects that are similar to the one she is currently working on. 
 
 Pay attention to the phrase `similar projects coming up here` to understand what Lisa is asking about.
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66a95ab699d0064d16bdf469.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66a95ab699d0064d16bdf469.md
@@ -55,7 +55,7 @@ Bob is not asking about development status.
 
 Bob uses the word `yet`, which signals that he is asking if something expected has already happened. 
 
-Pay attention to the words `potential name` and `yet` in Bob’s question, as these indicate that he is asking about the status of the app's name.
+Pay attention to the words `potential name` and `yet` in Bob's question, as these indicate that he is asking about the status of the app's name.
 
 # --scene--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66a961222115ad5437ddf4fb.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66a961222115ad5437ddf4fb.md
@@ -54,9 +54,9 @@ Bob has not decided yet. He says `Maybe`.
 
 # --explanation--
 
-People sometimes express uncertainty before making a decision. Bob hasn’t fully decided if he'll join the event. You can notice that because he says `Maybe`, which shows he is still thinking about it. 
+People sometimes express uncertainty before making a decision. Bob hasn't fully decided if he'll join the event. You can notice that because he says `Maybe`, which shows he is still thinking about it. 
 
-Pay attention to Bob’s follow-up question where he asks, `Where can I find...?` This reveals that he needs more details before deciding whether to join the event.
+Pay attention to Bob's follow-up question where he asks, `Where can I find...?` This reveals that he needs more details before deciding whether to join the event.
 
 # --scene--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66b13f2f0c5a415ccd41335e.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66b13f2f0c5a415ccd41335e.md
@@ -45,4 +45,4 @@ False
 
 # --explanation--
 
-To answer this question, focus on the part of the text that describes Lisa’s team. Look for the sentence that mentions `Her team includes...`. This will help you determine if there are developers from Seattle on her team.
+To answer this question, focus on the part of the text that describes Lisa's team. Look for the sentence that mentions `Her team includes...`. This will help you determine if there are developers from Seattle on her team.

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66b4f8f6c1af973bdfdc0228.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66b4f8f6c1af973bdfdc0228.md
@@ -40,7 +40,7 @@ When someone asks if you have a moment, they want to talk to you about something
 
 When someone asks if you have a moment, they want to discuss something important. 
 
-The correct response will show that you’re ready to listen or talk about the topic they want to discuss. Pay attention to options that focus on being open to a conversation.
+The correct response will show that you're ready to listen or talk about the topic they want to discuss. Pay attention to options that focus on being open to a conversation.
 
 # --scene--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66b56c0432933515821a4eeb.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66b56c0432933515821a4eeb.md
@@ -19,7 +19,7 @@ Listen to the audio and answer the question below.
 
 ## --text--
 
-Does Anna support Brian’s idea of using real-life scenarios?
+Does Anna support Brian's idea of using real-life scenarios?
 
 ## --answers--
 
@@ -43,7 +43,7 @@ She mentions that using real-life scenarios improves the training. This indicate
 
 ---
 
-She ignores Brian’s suggestion completely. This indicates she doesn't understands his idea.
+She ignores Brian's suggestion completely. This indicates she doesn't understands his idea.
 
 ### --feedback--
 
@@ -55,7 +55,7 @@ She didn't ignore Brian. Pay attention to the words she uses after `Using real-l
 
 # --explanation--
 
-People sometimes show support indirectly without explicitly saying they agree. To understand if Anna supports Brian’s idea, focus on her comment about the training.
+People sometimes show support indirectly without explicitly saying they agree. To understand if Anna supports Brian's idea, focus on her comment about the training.
 
 Instead of directly saying she likes the idea, she mentions that using real-life scenarios `makes the training more relevant`. This shows she agrees with Brian because she highlights a positive result of using his suggestion. 
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66b572bd3d3e122e9a8ff9df.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66b572bd3d3e122e9a8ff9df.md
@@ -36,9 +36,9 @@ Consider what phrase you would use to suggest connecting with someone to discuss
 
 `Touch base` means to make contact or to check in with someone, usually to discuss progress or updates. For example:
 
-- `Let’s touch base next week to see how the project is going.` - We'll talk again next week to discuss the project's progress.
+- `Let's touch base next week to see how the project is going.` - We'll talk again next week to discuss the project's progress.
 
-- `I’ll touch base with you later about the meeting.` - you'll contact this person later to talk about the meeting.
+- `I'll touch base with you later about the meeting.` - you'll contact this person later to talk about the meeting.
 
 # --scene--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66b57e127321d8524c7ddda7.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66b57e127321d8524c7ddda7.md
@@ -35,11 +35,11 @@ A couple of days after the conversation with Anna, Brian sent this email to the 
 
 `Why Attend?`
 
-`As you know, our company has recently faced some security threats. We’re adding a section on phishing, using real-life scenarios to ensure everyone uses strong passwords and protects our data.`
+`As you know, our company has recently faced some security threats. We're adding a section on phishing, using real-life scenarios to ensure everyone uses strong passwords and protects our data.`
 
 `Attendance:`
 
-`Attendance is mandatory. If you can’t attend, please inform your manager.`
+`Attendance is mandatory. If you can't attend, please inform your manager.`
 
 `Looking forward to seeing you all.`
 
@@ -83,4 +83,4 @@ Brian doesn't mention a party.
 
 # --explanation--
 
-Look at the email subject `Cybersecurity Training Session` and the first line `I want to update you on our next cybersecurity training session`. These show that Brian is informing the team about the upcoming session. There’s no mention of rescheduling, so the correct answer focuses on providing information about the training.
+Look at the email subject `Cybersecurity Training Session` and the first line `I want to update you on our next cybersecurity training session`. These show that Brian is informing the team about the upcoming session. There's no mention of rescheduling, so the correct answer focuses on providing information about the training.

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66b580cb9307d46113a8a637.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66b580cb9307d46113a8a637.md
@@ -35,11 +35,11 @@ A couple of days after the conversation with Anna, Brian sent this email to the 
 
 `Why Attend?`
 
-`As you know, our company has recently faced some security threats. We’re adding a section on phishing, using real-life scenarios to ensure everyone uses strong passwords and protects our data.`
+`As you know, our company has recently faced some security threats. We're adding a section on phishing, using real-life scenarios to ensure everyone uses strong passwords and protects our data.`
 
 `Attendance:`
 
-`Attendance is mandatory. If you can’t attend, please inform your manager.`
+`Attendance is mandatory. If you can't attend, please inform your manager.`
 
 `Looking forward to seeing you all.`
 
@@ -55,7 +55,7 @@ To know why the training session is important.
 
 ### --feedback--
 
-Although understanding the importance is useful, it doesn’t help you attend the meeting.
+Although understanding the importance is useful, it doesn't help you attend the meeting.
 
 ---
 
@@ -63,7 +63,7 @@ To bring a laptop to take notes during the session.
 
 ### --feedback--
 
-Bringing a laptop might be helpful, but it’s not essential information for attending the meeting.
+Bringing a laptop might be helpful, but it's not essential information for attending the meeting.
 
 ---
 
@@ -83,4 +83,4 @@ This is an important information, but it won't help you to attend the meeting. Q
 
 # --explanation--
 
-To answer correctly, focus on the details needed to attend the meeting: the `date`, `time`, `topic`, and `location`. These are listed under `Details` in the email. While informing a manager is important if you can’t attend, it doesn't help you participate in the session itself.
+To answer correctly, focus on the details needed to attend the meeting: the `date`, `time`, `topic`, and `location`. These are listed under `Details` in the email. While informing a manager is important if you can't attend, it doesn't help you participate in the session itself.

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66b58252cb001966f564c19e.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66b58252cb001966f564c19e.md
@@ -34,11 +34,11 @@ A couple of days after the conversation with Anna, Brian sent this email to the 
 
 `Why Attend?`
 
-`As you know, our company has recently faced some security threats. We’re adding a section on phishing, using real-life scenarios to ensure everyone uses strong passwords and protects our data.`
+`As you know, our company has recently faced some security threats. We're adding a section on phishing, using real-life scenarios to ensure everyone uses strong passwords and protects our data.`
 
 `Attendance:`
 
-`Attendance is mandatory. If you can’t attend, please inform your manager.`
+`Attendance is mandatory. If you can't attend, please inform your manager.`
 
 `Looking forward to seeing you all.`
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66b582d6978cff693c7b9455.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66b582d6978cff693c7b9455.md
@@ -35,11 +35,11 @@ A couple of days after the conversation with Anna, Brian sent this email to the 
 
 `Why Attend?`
 
-`As you know, our company has recently faced some security threats. We’re adding a section on phishing, using real-life scenarios to ensure everyone uses strong passwords and protects our data.`
+`As you know, our company has recently faced some security threats. We're adding a section on phishing, using real-life scenarios to ensure everyone uses strong passwords and protects our data.`
 
 `Attendance:`
 
-`Attendance is mandatory. If you can’t attend, please inform your manager.`
+`Attendance is mandatory. If you can't attend, please inform your manager.`
 
 `Looking forward to seeing you all.`
 
@@ -83,4 +83,4 @@ Think about whether the email mentions anything about meetings or focuses on cyb
 
 # --explanation--
 
-The email states, `We’re adding a section on phishing, using real-life scenarios.` This shows that the new section is focused on identifying phishing attempts, not scheduling meetings.
+The email states, `We're adding a section on phishing, using real-life scenarios.` This shows that the new section is focused on identifying phishing attempts, not scheduling meetings.

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66b583275950846a87e88de8.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66b583275950846a87e88de8.md
@@ -34,11 +34,11 @@ A couple of days after the conversation with Anna, Brian sent this email to the 
 
 `Why Attend?`
 
-`As you know, our company has recently faced some security threats. We’re adding a section on phishing, using real-life scenarios to ensure everyone uses strong passwords and protects our data.`
+`As you know, our company has recently faced some security threats. We're adding a section on phishing, using real-life scenarios to ensure everyone uses strong passwords and protects our data.`
 
 `Attendance:`
 
-`Attendance is mandatory. If you can’t attend, please inform your manager.`
+`Attendance is mandatory. If you can't attend, please inform your manager.`
 
 `Looking forward to seeing you all.`
 
@@ -46,7 +46,7 @@ A couple of days after the conversation with Anna, Brian sent this email to the 
 
 `Brian`
 
-What should you do if you can’t attend the meeting?
+What should you do if you can't attend the meeting?
 
 ## --answers--
 
@@ -83,4 +83,4 @@ Reflect on whether the email mentions this as an option or gives different instr
 
 # --explanation--
 
-The email says, `If you can’t attend, please inform your manager.` This clearly shows that the correct action is to inform your manager, not reschedule the meeting yourself.
+The email says, `If you can't attend, please inform your manager.` This clearly shows that the correct action is to inform your manager, not reschedule the meeting yourself.

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66bbba46fff0ef451b701bcd.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66bbba46fff0ef451b701bcd.md
@@ -45,7 +45,7 @@ Yes, but only for a moment because she has her own problems.
 
 ### --feedback--
 
-Sarah doesn’t limit the time; she simply states that she is not busy.
+Sarah doesn't limit the time; she simply states that she is not busy.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66bbc147bc59c25e60e18aec.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66bbc147bc59c25e60e18aec.md
@@ -44,7 +44,7 @@ The live preview is working correctly.
 
 ### --feedback--
 
-If it were working correctly, Tom wouldn’t say that it isn’t showing.
+If it were working correctly, Tom wouldn't say that it isn't showing.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66bbf183427671a86f5ac25e.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66bbf183427671a86f5ac25e.md
@@ -44,7 +44,7 @@ Not have this feature.
 
 ### --feedback--
 
-Pay attention to how Tom’s initial statement about the problem connects with his question, showing his surprise that the feature isn’t working as expected.
+Pay attention to how Tom's initial statement about the problem connects with his question, showing his surprise that the feature isn't working as expected.
   
 ## --video-solution--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c4e019a6cbfa3210603aef.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c4e019a6cbfa3210603aef.md
@@ -29,7 +29,7 @@ Place the following phrases in the correct spot:
 
 `Lisa: We plan to develop a new app for real-time project collaboration. BLANK sound to you?`
 
-`Bob: Interesting! Who’s on your team?`
+`Bob: Interesting! Who's on your team?`
 
 `Lisa: A couple of developers from our branch in Seattle, and a UX designer I've collaborated with before. BLANK we have any similar projects coming up here?`
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c4ec1a03bb27643063f262.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c4ec1a03bb27643063f262.md
@@ -32,7 +32,7 @@ This is a contraction for `it is`, indicating who or what is involved in the act
 
 ### --feedback--
 
-This word is used to make the sentence negative, showing that the action isn’t happening.
+This word is used to make the sentence negative, showing that the action isn't happening.
 
 # --explanation--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c4efaa80afd0729ae471d1.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c4efaa80afd0729ae471d1.md
@@ -44,11 +44,11 @@ Remember the verb `to be`.
 
 # --explanation--
 
-`Might` is used to express possibility. When Sarah says, `might not be running`, she’s suggesting that it’s possible the live server extension isn’t currently active or working. For example:
+`Might` is used to express possibility. When Sarah says, `might not be running`, she's suggesting that it's possible the live server extension isn't currently active or working. For example:
 
-- `The server might be down.` - It’s possible the server isn’t working.
+- `The server might be down.` - It's possible the server isn't working.
 
-- `She might not be available today.` - It’s possible she’s not free today.
+- `She might not be available today.` - It's possible she's not free today.
 
 # --scene--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c4f19f86b5f07a71ac7642.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c4f19f86b5f07a71ac7642.md
@@ -16,11 +16,11 @@ Listen to the audio and answer the question below.
 
 ## --text--
 
-What is the probable reason the live preview isn’t working?
+What is the probable reason the live preview isn't working?
 
 ## --answers--
 
-The live preview isn’t supported in Visual Studio Code.
+The live preview isn't supported in Visual Studio Code.
 
 ### --feedback--
 
@@ -40,7 +40,7 @@ Consider why Sarah would mention an issue if everything was working properly.
 
 ---
 
-Sarah doesn’t know what the problem is.
+Sarah doesn't know what the problem is.
 
 ### --feedback--
 
@@ -54,7 +54,7 @@ Think about whether Sarah suggested a possible cause for the issue.
 
 Sarah mentions three things that will help you to help identify the issue. 
 
-First, she says, `It should,` showing that the live preview is expected to work. Next, she states that it’s `not displaying,` which indicates a problem. Finally, she suggests a reason: `the live server extension might not be running.` 
+First, she says, `It should,` showing that the live preview is expected to work. Next, she states that it's `not displaying,` which indicates a problem. Finally, she suggests a reason: `the live server extension might not be running.` 
 
 By connecting these clues, you can determine the probable reason Sarah provides for the issue.
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c4f338d6b658809576ae77.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c4f338d6b658809576ae77.md
@@ -26,7 +26,7 @@ Which option is the best answer to Sarah's question?
 
 ### --feedback--
 
-This response doesn’t address whether Tom is using the extension Sarah mentioned.
+This response doesn't address whether Tom is using the extension Sarah mentioned.
 
 ---
 
@@ -38,7 +38,7 @@ This response doesn’t address whether Tom is using the extension Sarah mention
 
 # --explanation--
 
-Sarah is asking Tom if he’s using the live server extension, which is necessary for real-time previews in Visual Studio Code. Tom’s answer will help identify if this might be the cause of the problem. Select the option that answers Sarah's question.
+Sarah is asking Tom if he's using the live server extension, which is necessary for real-time previews in Visual Studio Code. Tom's answer will help identify if this might be the cause of the problem. Select the option that answers Sarah's question.
 
 # --scene--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c4f45289436884e6afc059.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c4f45289436884e6afc059.md
@@ -28,9 +28,9 @@ These two words together mean to configure something so it works correctly.
 
 # --explanation--
 
-`Set up right` means to configure something correctly so that it works as expected. If something isn’t `set up right`, it might not function properly. For example:
+`Set up right` means to configure something correctly so that it works as expected. If something isn't `set up right`, it might not function properly. For example:
 
-- `The printer isn’t working because it’s not set up right.` - The printer isn’t configured correctly.
+- `The printer isn't working because it's not set up right.` - The printer isn't configured correctly.
 
 - `Make sure the software is set up right before you start using it.` - You need to configure the software correctly to ensure it works.
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c4f90997120794595abd5c.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c4f90997120794595abd5c.md
@@ -21,7 +21,7 @@ Which sentence correctly uses `pop up`?
 
 ### --feedback--
 
-Think about whether `pop up` describes something that happens automatically, or if it’s something you actively do.
+Think about whether `pop up` describes something that happens automatically, or if it's something you actively do.
 
 ---
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c4fd010695b5a316201d03.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c4fd010695b5a316201d03.md
@@ -46,7 +46,7 @@ These two words together mean something suddenly appearing on the screen. The fi
 
 `IntelliJ IDEA` is a popular Integrated Development Environment (IDE) used by developers to write, test, and debug code. It is known for its powerful features, including `auto-completion`, which helps you code faster by suggesting possible completions as you type. 
 
-When Tom says that `auto-completion isn’t popping up`, he means that the feature, which normally suggests code as you type, isn’t appearing on the screen like it should.
+When Tom says that `auto-completion isn't popping up`, he means that the feature, which normally suggests code as you type, isn't appearing on the screen like it should.
 
 # --scene--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c4ffe51866ecadb48304b9.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c4ffe51866ecadb48304b9.md
@@ -6,7 +6,7 @@ dashedName: task-122
 ---
 
 <!-- Audio Reference:
-Tom: Also, in IntelliJ IDEA, the code auto-completion isn't popping up. Isn’t it automatic? -->
+Tom: Also, in IntelliJ IDEA, the code auto-completion isn't popping up. Isn't it automatic? -->
 
 # --instructions--
 
@@ -20,7 +20,7 @@ Listen to the audio and complete the sentence below.
 
 ## --blanks--
 
-`Isn’t it`
+`Isn't it`
 
 ### --feedback--
 
@@ -30,11 +30,11 @@ A tag question using the contraction of `is not` followed by a pronoun. The firs
 
 A `tag question` is a short question added to the end of a sentence to confirm or check something. It's often used when the speaker expects the listener to agree with them. For example: 
 
-- `It’s a nice day, isn’t it?` - The speaker expects that the listener will agree that it’s a nice day.
+- `It's a nice day, isn't it?` - The speaker expects that the listener will agree that it's a nice day.
 
-- `They are coming to the meeting, aren’t they?` - The speaker expects that the listener will agree that they are coming to the meeting.
+- `They are coming to the meeting, aren't they?` - The speaker expects that the listener will agree that they are coming to the meeting.
 
-When Tom says, `Isn’t it automatic?`, he is asking for confirmation that the auto-completion should happen automatically.
+When Tom says, `Isn't it automatic?`, he is asking for confirmation that the auto-completion should happen automatically.
 
 # --scene--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c5012e6643c2b32b3af0be.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c5012e6643c2b32b3af0be.md
@@ -6,7 +6,7 @@ dashedName: task-123
 ---
 
 <!-- Audio Reference:
-Tom: Also, in IntelliJ IDEA, the code auto-completion isn't popping up. Isn’t it automatic? -->
+Tom: Also, in IntelliJ IDEA, the code auto-completion isn't popping up. Isn't it automatic? -->
 
 # --instructions--
 
@@ -16,7 +16,7 @@ Listen to the audio and answer the question below.
 
 ## --text--
 
-Why does Tom ask `Isn’t it automatic?`
+Why does Tom ask `Isn't it automatic?`
 
 ## --answers--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c507bef7c69ac73fbc82cc.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c507bef7c69ac73fbc82cc.md
@@ -6,7 +6,7 @@ dashedName: task-124
 ---
 
 <!-- Audio Reference:
-Tom: The code auto-completion isn't popping up. Isn’t it automatic? -->
+Tom: The code auto-completion isn't popping up. Isn't it automatic? -->
 
 <!-- SPEAKING -->
 
@@ -30,9 +30,9 @@ Which option is the best answer to Tom's question?
 
 ### --feedback--
 
-This options is wrong because it contradicts itself. It starts saying `It is`, confirming Tom’s question, but then it adds that auto-completion needs to be enabled manually every time. 
+This options is wrong because it contradicts itself. It starts saying `It is`, confirming Tom's question, but then it adds that auto-completion needs to be enabled manually every time. 
 
-This doesn’t make sense — if something is automatic, you wouldn’t need to enable it manually.
+This doesn't make sense — if something is automatic, you wouldn't need to enable it manually.
   
 ## --video-solution--
 
@@ -40,7 +40,7 @@ This doesn’t make sense — if something is automatic, you wouldn’t need to 
 
 # --explanation--
 
-Tom says, `The code auto-completion isn't popping up. Isn’t it automatic?` This means he expects auto-completion to work automatically. 
+Tom says, `The code auto-completion isn't popping up. Isn't it automatic?` This means he expects auto-completion to work automatically. 
 
 A good response would either confirm that auto-completion should be automatic or explain why it might not be working. 
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c611f2d1e400c2f41ad5d9.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c611f2d1e400c2f41ad5d9.md
@@ -42,7 +42,7 @@ In the `Present Simple` tense, the negative form is created using `doesn't` or `
 
 - Use `isn't` with forms of `to be` to show that something is not true, like `isn't set up.`
 
-In this sentence, you’ll need both `doesn't` and `isn't` to correctly describe why the feature isn’t working as expected.
+In this sentence, you'll need both `doesn't` and `isn't` to correctly describe why the feature isn't working as expected.
 
 # --scene--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c613a4d11b69cdd746b5ed.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c613a4d11b69cdd746b5ed.md
@@ -54,13 +54,13 @@ Pay attention to what Sarah says after `it doesn't work if...`.
 
 # --explanation--
 
-When Listening to Sarah’s, pay attention to the word `if`. This word often introduces the cause of a problem, explaining what needs to happen for something else to occur. 
+When Listening to Sarah's, pay attention to the word `if`. This word often introduces the cause of a problem, explaining what needs to happen for something else to occur. 
 
-After finding `if`, identify the part of the sentence that describes what happens when that condition isn’t met (the effect). In Sarah’s sentence:
+After finding `if`, identify the part of the sentence that describes what happens when that condition isn't met (the effect). In Sarah's sentence:
 
-- **Effect:** `The auto-completion doesn’t work`.
+- **Effect:** `The auto-completion doesn't work`.
 
-- **Cause** introduced by `if`: `If the project isn’t set up correctly`.
+- **Cause** introduced by `if`: `If the project isn't set up correctly`.
 
 Understanding this relationship helps you explain problems and solutions clearly.
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c616d281199cda967c144d.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c616d281199cda967c144d.md
@@ -22,11 +22,11 @@ Tom is not sure he checked the settings and wants to check it again. How can he 
 
 ## --answers--
 
-`I don’t think the settings matter.`
+`I don't think the settings matter.`
 
 ### --feedback--
 
-The correct answer would say that he isn’t sure if he has checked the settings, so he needs to check them again.
+The correct answer would say that he isn't sure if he has checked the settings, so he needs to check them again.
 
 ---
 
@@ -38,11 +38,11 @@ The correct answer would say that he isn’t sure if he has checked the settings
 
 # --explanation--
 
-Sometimes, when you’re not sure if you’ve done something, it’s important to say that you’re unsure. For example:
+Sometimes, when you're not sure if you've done something, it's important to say that you're unsure. For example:
 
 - `I'm not sure this is the correct settings.` - You are unsure whether the settings are according to what is expected or not.
 
-The correct answer will reflect Tom’s uncertainty and his plan to check the settings again.
+The correct answer will reflect Tom's uncertainty and his plan to check the settings again.
 
 # --scene--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c6184eda8a8be150b1a0b4.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c6184eda8a8be150b1a0b4.md
@@ -32,7 +32,7 @@ These two words together mean that something is necessary or required.
 
 ### --feedback--
 
-This verb means to look at something carefully to find out if it’s correct or working properly.
+This verb means to look at something carefully to find out if it's correct or working properly.
 
 ---
 
@@ -46,7 +46,7 @@ This word means to do something one more time.
 
 `Have to` is used to express that something is necessary or required. It indicates that there is no choice but to do something. For example:
 
-- `You have to save your changes before closing the program.` - This means it’s necessary to save changes before closing the program.
+- `You have to save your changes before closing the program.` - This means it's necessary to save changes before closing the program.
 
 When Tom says, `I'll have to check again`, he is stating that it's necessary for him to check the settings one more time, suggesting he's not sure about it.
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c6193e7546c4e51cbf64c9.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c6193e7546c4e51cbf64c9.md
@@ -6,7 +6,7 @@ dashedName: task-130
 ---
 
 <!-- Audio Reference:
-Tom: And in Eclipse, it’s not showing the Git tools. -->
+Tom: And in Eclipse, it's not showing the Git tools. -->
 
 # --instructions--
 
@@ -36,9 +36,9 @@ This word means that something is supposed to be visible. It ends with `-ing`.
 
 # --explanation--
 
-`It’s not showing` is used to explain that something expected to appear on the screen isn’t visible. For example:
+`It's not showing` is used to explain that something expected to appear on the screen isn't visible. For example:
 
-- `The image isn’t showing on the screen.` - The image is supposed to be there, but it’s not visible.
+- `The image isn't showing on the screen.` - The image is supposed to be there, but it's not visible.
 
 # --scene--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c61a0197d7e7e87191e033.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c61a0197d7e7e87191e033.md
@@ -6,7 +6,7 @@ dashedName: task-131
 ---
 
 <!-- Audio Reference:
-Tom: And in Eclipse, it’s not showing the Git tools. -->
+Tom: And in Eclipse, it's not showing the Git tools. -->
 
 # --instructions--
 
@@ -20,7 +20,7 @@ What problem is Tom facing now?
 
 ## --answers--
 
-He doesn’t know how to use Git tools.
+He doesn't know how to use Git tools.
 
 ### --feedback--
 
@@ -28,11 +28,11 @@ Pay attention to the part where Tom talks about something that should be visible
 
 ---
 
-He can’t see the Git tools in Eclipse.
+He can't see the Git tools in Eclipse.
 
 ---
 
-He can’t open the Eclipse software.
+He can't open the Eclipse software.
 
 ### --feedback--
 
@@ -40,7 +40,7 @@ Pay attention to the part where Tom talks about something that should be visible
 
 ---
 
-He doesn’t have Git installed.
+He doesn't have Git installed.
 
 ### --feedback--
 
@@ -52,7 +52,7 @@ Pay attention to the part where Tom talks about something that should be visible
 
 # --explanation--
 
-Tom says, `it’s not showing the Git tools,` which gives important clues to identify his problem. 
+Tom says, `it's not showing the Git tools,` which gives important clues to identify his problem. 
 
 The key phrase is `not showing`, which points to a visibility issue rather than a problem with knowledge or installation. 
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c61a57f6eca6e9fb0f61d7.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c61a57f6eca6e9fb0f61d7.md
@@ -6,7 +6,7 @@ dashedName: task-132
 ---
 
 <!-- Audio Reference:
-Tom: And in Eclipse, it’s not showing the Git tools. Are they built-in? -->
+Tom: And in Eclipse, it's not showing the Git tools. Are they built-in? -->
 
 # --instructions--
 
@@ -16,7 +16,7 @@ Listen to the audio and complete the sentence below.
 
 ## --sentence--
 
-`And in Eclipse, it’s not showing the Git tools. Are they BLANK?`
+`And in Eclipse, it's not showing the Git tools. Are they BLANK?`
 
 ## --blanks--
 
@@ -30,7 +30,7 @@ Something has been included as part of a larger system or structure from the sta
 
 `Built-in` refers to features or tools that are included as part of a software program or device from the start, without needing to be added or installed separately. 
 
-When something is `built-in`, it’s already there and ready to use. For example:
+When something is `built-in`, it's already there and ready to use. For example:
 
 - `This laptop has a built-in camera.` - The camera is included as part of the laptop.
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c61dee09da09f603fa3dbc.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c61dee09da09f603fa3dbc.md
@@ -6,7 +6,7 @@ dashedName: task-133
 ---
 
 <!-- Audio Reference:
-Tom: It’s not showing the Git tools. Are they built-in? -->
+Tom: It's not showing the Git tools. Are they built-in? -->
 
 <!-- SPEAKING -->
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c62046cf3df2fe7cf92230.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c62046cf3df2fe7cf92230.md
@@ -20,7 +20,7 @@ According to Sarah, in which case won't the Git tools be visible?
 
 ## --answers--
 
-If the project isn’t saved correctly.
+If the project isn't saved correctly.
 
 ### --feedback--
 
@@ -28,7 +28,7 @@ Pay attention to what Sarah says after `but they're not visible if...`.
 
 ---
 
-If Eclipse isn’t updated to the latest version.
+If Eclipse isn't updated to the latest version.
 
 ### --feedback--
 
@@ -36,11 +36,11 @@ Pay attention to what Sarah says after `but they're not visible if...`.
 
 ---
 
-If the project isn’t linked to Git.
+If the project isn't linked to Git.
 
 ---
 
-If the Git tools aren’t installed manually.
+If the Git tools aren't installed manually.
 
 ### --feedback--
 
@@ -58,7 +58,7 @@ After `but`, Sarah mentions `they're not visible`, followed by the condition `if
 
 This tells you that the tools are hidden unless the project is connected to Git. 
 
-The phrase `if the project isn't` is a key marker that introduces the condition under which the Git tools won’t appear.
+The phrase `if the project isn't` is a key marker that introduces the condition under which the Git tools won't appear.
 
 In Sarah's sentence, she uses `they're not` to explain that the Git tools are not visible, and `isn't` to say that the project is not linked to Git.
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c6213241b74d023adcf637.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c6213241b74d023adcf637.md
@@ -34,7 +34,7 @@ When forming questions with the verb `to be`, the usual word order of the subjec
 
 - `Is your project connected to Git?` (Question)
 
-In Sarah’s sentence, she uses this inversion to ask Tom if his project is connected to Git in Eclipse.
+In Sarah's sentence, she uses this inversion to ask Tom if his project is connected to Git in Eclipse.
 
 # --scene--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c62515cf6ae70e34eb361d.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c62515cf6ae70e34eb361d.md
@@ -16,11 +16,11 @@ Listen to the audio and answer the question below.
 
 ## --text--
 
-Tom believes his project should be connected to Git, but he isn’t completely sure. What should he answer Sarah?
+Tom believes his project should be connected to Git, but he isn't completely sure. What should he answer Sarah?
 
 ## --answers--
 
-`It’s supposed to be.`
+`It's supposed to be.`
 
 ---
 
@@ -36,11 +36,11 @@ Think about whether Tom is completely sure about the connection.
 
 # --explanation--
 
-Sometimes, when you're not completely sure about something, but you believe it should be true, you can use the phrase `It’s supposed to` + verb. 
+Sometimes, when you're not completely sure about something, but you believe it should be true, you can use the phrase `It's supposed to` + verb. 
 
-This will express that something is expected to be a certain way, even if you haven’t confirmed it yet. For example:
+This will express that something is expected to be a certain way, even if you haven't confirmed it yet. For example:
 
-- `The update is supposed to fix the bug.` - This means you expect the update to fix the bug, but you haven’t confirmed it yet.
+- `The update is supposed to fix the bug.` - This means you expect the update to fix the bug, but you haven't confirmed it yet.
 
 # --scene--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c625e03abcb711ca38ba5f.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c625e03abcb711ca38ba5f.md
@@ -32,13 +32,13 @@ These two words start the sentence and are used to describe something that is ha
 
 ### --feedback--
 
-An adjective that describes the feeling of being upset or annoyed because something isn’t working as expected. It ends with `-ing`.
+An adjective that describes the feeling of being upset or annoyed because something isn't working as expected. It ends with `-ing`.
 
 # --explanation--
 
 `This is` is a simple way to start a sentence when describing something.
 
-`Frustrating` is an adjective that describes a feeling of being upset or annoyed because something isn’t working as expected. For example:
+`Frustrating` is an adjective that describes a feeling of being upset or annoyed because something isn't working as expected. For example:
 
 - `This is confusing.` - The situation is hard to understand.
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c62747744dc4178785207d.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c62747744dc4178785207d.md
@@ -20,7 +20,7 @@ Why is Tom frustrated?
 
 ## --answers--
 
-Because he doesn’t know how to code.
+Because he doesn't know how to code.
 
 ### --feedback--
 
@@ -28,7 +28,7 @@ Tom's frustration is not related to his coding skills.
 
 ---
 
-Because he didn’t save his project.
+Because he didn't save his project.
 
 ### --feedback--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c628215739f51ac74cb5cc.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c628215739f51ac74cb5cc.md
@@ -30,11 +30,11 @@ This word introduces the condition or situation that causes something to happen.
 
 `when` is used here to describe a specific condition or situation that causes something to happen. 
 
-In Sarah’s sentence, `when` introduces the condition where the IDEs become tricky: `if they’re not set up properly`. For example:
+In Sarah's sentence, `when` introduces the condition where the IDEs become tricky: `if they're not set up properly`. For example:
 
 - `The program crashes when it runs out of memory.` - The condition of running out of memory causes the program to crash.
 
-- `The printer only works when it’s plugged in.` - The condition of being plugged in allows the printer to work.
+- `The printer only works when it's plugged in.` - The condition of being plugged in allows the printer to work.
 
 In both cases, `when` is used to explain the situation in which something occurs.
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c6293f674a0a1e960027c3.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c6293f674a0a1e960027c3.md
@@ -41,7 +41,7 @@ The IDEs are tricky because they lack built-in tools.
 
 ### --feedback--
 
-Reflect on whether Sarah’s explanation was about built-in tools or the setup of the IDEs.
+Reflect on whether Sarah's explanation was about built-in tools or the setup of the IDEs.
   
 ## --video-solution--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c62b0c65018625985a897d.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c62b0c65018625985a897d.md
@@ -26,7 +26,7 @@ Tom wants to accept Sarah's offer. How could he reply to her?
 
 ---
 
-`I’m not sure if that will help.`
+`I'm not sure if that will help.`
 
 ### --feedback--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c637ce17705151c64f9059.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c637ce17705151c64f9059.md
@@ -29,11 +29,11 @@ Place the following phrases in the correct spot:
 
 `Sarah: It should, but BLANK because the live server extension might not be running. Are you using that extension for real-time previews?`
 
-`Tom: I think we are, but maybe BLANK right. Also, in IntelliJ IDEA, the code auto-completion isn't popping up. Isn’t it automatic?`
+`Tom: I think we are, but maybe BLANK right. Also, in IntelliJ IDEA, the code auto-completion isn't popping up. Isn't it automatic?`
 
 `Sarah: It usually is, but it doesn't work if the project isn't set up right. Have you checked the settings?`
 
-`Tom: I'll have to check again. And in Eclipse, it’s not showing the Git tools. BLANK built in?`
+`Tom: I'll have to check again. And in Eclipse, it's not showing the Git tools. BLANK built in?`
 
 `Sarah: Yes, they are, but BLANK if the project isn't linked to Git. Is your project connected to Git in Eclipse?`
 
@@ -57,7 +57,7 @@ This phrase is used when checking if something should be working automatically. 
 
 ### --feedback--
 
-This phrase indicates that something expected to be visible on the screen isn’t appearing.
+This phrase indicates that something expected to be visible on the screen isn't appearing.
 
 ---
 
@@ -65,7 +65,7 @@ This phrase indicates that something expected to be visible on the screen isn’
 
 ### --feedback--
 
-This phrase explains that something isn’t arranged or configured correctly.
+This phrase explains that something isn't arranged or configured correctly.
 
 ---
 
@@ -81,7 +81,7 @@ This phrase is used to ask if something, like the Git tools, is included or buil
 
 ### --feedback--
 
-This phrase indicates that something, like the Git tools, can’t be seen on the screen.
+This phrase indicates that something, like the Git tools, can't be seen on the screen.
 
 ---
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c63db09b73ad6539eeee61.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c63db09b73ad6539eeee61.md
@@ -26,17 +26,17 @@ Sarah decided to e-mail and document their conversation:
 
 `2. IntelliJ IDEA - Auto-Completion:`
 
-`Double-check your project settings. If auto-completion isn’t working, the project might not be set up right. Go to your project settings and verify that all necessary plugins are enabled.`
+`Double-check your project settings. If auto-completion isn't working, the project might not be set up right. Go to your project settings and verify that all necessary plugins are enabled.`
 
 `3. Eclipse - Git Tools:`
 
-`The Git tools are built-in, but they won’t be visible unless your project is linked to Git. Make sure your project is connected to the Git repository.`
+`The Git tools are built-in, but they won't be visible unless your project is linked to Git. Make sure your project is connected to the Git repository.`
 
 `Let me know if you need any more help, or if you'd like to go through a detailed walkthrough together.`
 
 `Best, Sarah`
 
-What should Tom do if the Live Preview isn’t displaying in Visual Studio Code?
+What should Tom do if the Live Preview isn't displaying in Visual Studio Code?
 
 ## --answers--
 
@@ -44,7 +44,7 @@ Restart Visual Studio Code and check the project settings.
 
 ### --feedback--
 
-Consider whether restarting the program is Sarah’s suggested solution or if she focuses more on project settings.
+Consider whether restarting the program is Sarah's suggested solution or if she focuses more on project settings.
 
 ---
 
@@ -64,7 +64,7 @@ Switch to a different IDE to see if the issue persists. She prefers Eclipse.
 
 ### --feedback--
 
-Reflect on whether Sarah’s advice is about changing IDEs or troubleshooting within Visual Studio Code.
+Reflect on whether Sarah's advice is about changing IDEs or troubleshooting within Visual Studio Code.
 
 ## --video-solution--
 
@@ -72,8 +72,8 @@ Reflect on whether Sarah’s advice is about changing IDEs or troubleshooting wi
 
 # --explanation--
 
-To find the answer, focus on the section of Sarah’s email labeled `1. Visual Studio Code - Live preview.` 
+To find the answer, focus on the section of Sarah's email labeled `1. Visual Studio Code - Live preview.` 
 
-In this part, she explains that if the Live Preview isn’t displaying, Tom should first make sure the live server extension is installed and running. 
+In this part, she explains that if the Live Preview isn't displaying, Tom should first make sure the live server extension is installed and running. 
 
-Then, if it’s still not working, she advises checking the project settings to ensure everything is correctly set up for real-time previews.
+Then, if it's still not working, she advises checking the project settings to ensure everything is correctly set up for real-time previews.

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c63fda0e11806e78090f36.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c63fda0e11806e78090f36.md
@@ -26,11 +26,11 @@ Sarah decided to e-mail and document their conversation:
 
 `2. IntelliJ IDEA - Auto-Completion:`
 
-`Double-check your project settings. If auto-completion isn’t working, the project might not be set up right. Go to your project settings and verify that all necessary plugins are enabled.`
+`Double-check your project settings. If auto-completion isn't working, the project might not be set up right. Go to your project settings and verify that all necessary plugins are enabled.`
 
 `3. Eclipse - Git Tools:`
 
-`The Git tools are built-in, but they won’t be visible unless your project is linked to Git. Make sure your project is connected to the Git repository.`
+`The Git tools are built-in, but they won't be visible unless your project is linked to Git. Make sure your project is connected to the Git repository.`
 
 `Let me know if you need any more help, or if you'd like to go through a detailed walkthrough together.`
 
@@ -40,7 +40,7 @@ Why might auto-completion not work in IntelliJ IDEA, according to Sarah's email?
 
 ## --answers--
 
-The live server extension isn’t installed.
+The live server extension isn't installed.
 
 ### --feedback--
 
@@ -52,7 +52,7 @@ The Git tools are not visible.
 
 ### --feedback--
 
-Consider whether the visibility of Git tools affects auto-completion, or if it’s more about the project setup.
+Consider whether the visibility of Git tools affects auto-completion, or if it's more about the project setup.
 
 ---
 
@@ -74,4 +74,4 @@ Reflect on whether Sarah mentioned file corruption as a reason for auto-completi
 
 Pay close attention to the section labeled `2. IntelliJ IDEA - Auto-Completion.` 
 
-In this part, Sarah mentions that if auto-completion isn’t working, the problem is likely due to the project not being set up correctly. She suggests checking the project settings and verifying that all necessary plugins are enabled.
+In this part, Sarah mentions that if auto-completion isn't working, the problem is likely due to the project not being set up correctly. She suggests checking the project settings and verifying that all necessary plugins are enabled.

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c6409f492e5e71621d06b8.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c6409f492e5e71621d06b8.md
@@ -26,11 +26,11 @@ Sarah decided to e-mail and document their conversation:
 
 `2. IntelliJ IDEA - Auto-Completion:`
 
-`Double-check your project settings. If auto-completion isn’t working, the project might not be set up right. Go to your project settings and verify that all necessary plugins are enabled.`
+`Double-check your project settings. If auto-completion isn't working, the project might not be set up right. Go to your project settings and verify that all necessary plugins are enabled.`
 
 `3. Eclipse - Git Tools:`
 
-`The Git tools are built-in, but they won’t be visible unless your project is linked to Git. Make sure your project is connected to the Git repository.`
+`The Git tools are built-in, but they won't be visible unless your project is linked to Git. Make sure your project is connected to the Git repository.`
 
 `Let me know if you need any more help, or if you'd like to go through a detailed walkthrough together.`
 
@@ -40,7 +40,7 @@ What does Sarah say about the Git tools in Eclipse?
 
 ## --answers--
 
-They are built-in but won’t be visible unless your project is linked to Git.
+They are built-in but won't be visible unless your project is linked to Git.
 
 ---
 
@@ -60,7 +60,7 @@ Consider if Sarah said the tools are automatically visible or if she mentioned a
 
 ---
 
-They only work if you’re using IntelliJ IDEA.
+They only work if you're using IntelliJ IDEA.
 
 ### --feedback--
 
@@ -74,4 +74,4 @@ Reflect on whether Sarah was talking about Eclipse or if this applies to a diffe
 
 Sarah provides instructions specifically about the Git tools in Eclipse under the section `3. Eclipse - Git Tools.` 
 
-She mentions that the tools are built-in, but they won’t be visible unless the project is linked to Git. 
+She mentions that the tools are built-in, but they won't be visible unless the project is linked to Git. 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c640e2f81416727a42fd4c.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c640e2f81416727a42fd4c.md
@@ -26,11 +26,11 @@ Sarah decided to e-mail and document their conversation:
 
 `2. IntelliJ IDEA - Auto-Completion:`
 
-`Double-check your project settings. If auto-completion isn’t working, the project might not be set up right. Go to your project settings and verify that all necessary plugins are enabled.`
+`Double-check your project settings. If auto-completion isn't working, the project might not be set up right. Go to your project settings and verify that all necessary plugins are enabled.`
 
 `3. Eclipse - Git Tools:`
 
-`The Git tools are built-in, but they won’t be visible unless your project is linked to Git. Make sure your project is connected to the Git repository.`
+`The Git tools are built-in, but they won't be visible unless your project is linked to Git. Make sure your project is connected to the Git repository.`
 
 `Let me know if you need any more help, or if you'd like to go through a detailed walkthrough together.`
 
@@ -52,7 +52,7 @@ She suggests that Tom should hire someone else to fix the issues.
 
 ### --feedback--
 
-Consider if Sarah’s tone is more supportive or if she is suggesting an alternative solution.
+Consider if Sarah's tone is more supportive or if she is suggesting an alternative solution.
 
 ---
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-activities/67325a5443667173c717856f.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-activities/67325a5443667173c717856f.md
@@ -5,7 +5,7 @@ challengeType: 22
 dashedName: task-111
 ---
 
-<!-- (audio) Linda: That’s true! You've been integrating UX into your work more than ever before. -->
+<!-- (audio) Linda: That's true! You've been integrating UX into your work more than ever before. -->
 
 # --instructions--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-activities/67325bae5d23157c74091944.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-activities/67325bae5d23157c74091944.md
@@ -5,7 +5,7 @@ challengeType: 22
 dashedName: task-112
 ---
 
-<!-- (audio) Linda: That’s true! You've been integrating UX into your work more than ever before. -->
+<!-- (audio) Linda: That's true! You've been integrating UX into your work more than ever before. -->
 
 # --instructions--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-activities/67326cb0e9a72b69d6efd417.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-activities/67326cb0e9a72b69d6efd417.md
@@ -5,7 +5,7 @@ challengeType: 22
 dashedName: task-123
 ---
 
-<!-- (audio) James: I’m happy to hear that. After all, we're proactively enhancing the platform based on what we've learned. -->
+<!-- (audio) James: I'm happy to hear that. After all, we're proactively enhancing the platform based on what we've learned. -->
 
 # --instructions--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-activities/67326fb4b198b97e4bcf4a69.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-activities/67326fb4b198b97e4bcf4a69.md
@@ -5,7 +5,7 @@ challengeType: 19
 dashedName: task-125
 ---
 
-<!-- (audio) James: I’m happy to hear that. After all, we're proactively enhancing the platform based on what we've learned. -->
+<!-- (audio) James: I'm happy to hear that. After all, we're proactively enhancing the platform based on what we've learned. -->
 
 # --instructions--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-activities/6732800300eff4f49912e30f.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-activities/6732800300eff4f49912e30f.md
@@ -17,7 +17,7 @@ Read the text and answer the question below.
 
 Linda posted an update about her team's development process:
 
-`Over the past year, we've been focusing on user feedback more than ever, and it's really changed our approach to development. Instead of just tackling technical issues, we're now looking at everything from the user’s perspective.`
+`Over the past year, we've been focusing on user feedback more than ever, and it's really changed our approach to development. Instead of just tackling technical issues, we're now looking at everything from the user's perspective.`
 
 `Last month, we rolled out a major update inspired by user feedback, and the response has been amazing. Now, rather than just reacting to issues, we're proactively making improvements based on what our users tell us.`
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/6704f438e6e9120d5a1274c6.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/6704f438e6e9120d5a1274c6.md
@@ -43,7 +43,7 @@ A new feature in the software
 
 ### --feedback--
 
-A `bug` is not a feature; it’s an unintended issue that needs to be fixed.
+A `bug` is not a feature; it's an unintended issue that needs to be fixed.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/67050fd29a37de112051064b.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/67050fd29a37de112051064b.md
@@ -33,7 +33,7 @@ Question: `Did you finish the project?`
 Short answer: `Yes, I did.`
 
 Question: `Did they call you back?`
-Short answer: `No, they didn’t.`
+Short answer: `No, they didn't.`
 
 In the dialogue, James uses `Yes, I did` to confirm that he found the bug Lisa asked about.
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/67051b185149b6130426a9ad.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/67051b185149b6130426a9ad.md
@@ -23,7 +23,7 @@ Why James found the bug.
 
 ### --feedback--
 
-Lisa’s question focuses on what James discovered, not on the reason for that.
+Lisa's question focuses on what James discovered, not on the reason for that.
 
 ---
 
@@ -31,7 +31,7 @@ When James found the bug.
 
 ### --feedback--
 
-Lisa’s question is not related to time. It’s about what James found.
+Lisa's question is not related to time. It's about what James found.
 
 ---
 
@@ -39,7 +39,7 @@ How James fixed the bug.
 
 ### --feedback--
 
-Lisa isn’t asking about the method or solution. She’s asking for the result of James’s search.
+Lisa isn't asking about the method or solution. She's asking for the result of James's search.
 
 ---
 
@@ -55,7 +55,7 @@ In the `Simple Past`, questions may start with a question word (e.g., `what`, `w
 
 **Question word + `did` + subject + base verb.**
 
-Lisa’s question, `What did you find there?`, uses `what` to ask for specific information about the result of James’s actions. Other examples include:
+Lisa's question, `What did you find there?`, uses `what` to ask for specific information about the result of James's actions. Other examples include:
 
 - `Where did you go yesterday?` - You are asking about a location.
 
@@ -63,7 +63,7 @@ Lisa’s question, `What did you find there?`, uses `what` to ask for specific i
 
 - `Who did you call last night?` - You are asking about a person.
 
-In the dialog, Lisa is asking about James’s discovery while searching for the bug.
+In the dialog, Lisa is asking about James's discovery while searching for the bug.
 
 # --scene--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/67053619dd65bd1459449bf0.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/67053619dd65bd1459449bf0.md
@@ -39,7 +39,7 @@ What James says contradicts the idea that he found everything.
 
 ---
 
-He didn’t look for anything.
+He didn't look for anything.
 
 ### --feedback--
 
@@ -61,15 +61,15 @@ In contrast, in negative sentences, you'll use `anything` instead of `nothing`. 
 
 - Affirmative: `He found nothing.` - There were no discoveries.
 
-- Negative: `He didn’t find anything.` - There were no discoveries.  
+- Negative: `He didn't find anything.` - There were no discoveries.  
 
 Notice that, in negative sentences and in questions with `did`, the main verb (in this case, `find`) is in its base form. The auxiliary verb `did` is what shows that this sentence is in the past tense. For example:
 
-- `They didn’t find anything wrong with the program.` - Not finding anything was in the past.
+- `They didn't find anything wrong with the program.` - Not finding anything was in the past.
 
-- `I didn’t see anything unusual during the presentation.` - Nothing unusual was seen in the presentation that happened in the past.
+- `I didn't see anything unusual during the presentation.` - Nothing unusual was seen in the presentation that happened in the past.
 
-This structure helps avoid double negatives. James’s answer, `Nothing at first`, reflects an affirmative sentence emphasizing that he couldn't find anything when he began his search.
+This structure helps avoid double negatives. James's answer, `Nothing at first`, reflects an affirmative sentence emphasizing that he couldn't find anything when he began his search.
 
 # --scene--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/67053faa1471c916446ad615.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/67053faa1471c916446ad615.md
@@ -19,7 +19,7 @@ What did James discover when reviewing the error logs?
 
 ## --answers--
 
-He didn’t discover anything.
+He didn't discover anything.
 
 ### --feedback--
 
@@ -39,7 +39,7 @@ James mentions finding `something odd`. `Odd` is different from `common`.
 
 ---
 
-He didn’t look for anything.
+He didn't look for anything.
 
 ### --feedback--
 
@@ -59,11 +59,11 @@ James was actively investigating and found something during his review.
 
 In contrast, `anything` is used in negative sentences or questions. For example:
 
-- Negative: `He didn’t find anything in the logs.` - The logs did not help him understand the problem.
+- Negative: `He didn't find anything in the logs.` - The logs did not help him understand the problem.
 
 - Question: `Did she notice anything during the meeting?` - You are asking if she was able to see something during the meeting.
 
-In negative sentences with `did not` or `didn’t`, the main verb remains in its base form (`find`, `notice` etc.), and `anything` is used instead of `something`.
+In negative sentences with `did not` or `didn't`, the main verb remains in its base form (`find`, `notice` etc.), and `anything` is used instead of `something`.
 
 Here, James says, `That's when I noticed something odd`, meaning he found something during his review process.
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/6705442e6a6ebf1725bc8e1f.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/6705442e6a6ebf1725bc8e1f.md
@@ -23,7 +23,7 @@ She wants to know where it was.
 
 ### --feedback--
 
-Lisa’s question is not about the location of the problem, but about what James noticed.
+Lisa's question is not about the location of the problem, but about what James noticed.
 
 ---
 
@@ -35,7 +35,7 @@ She wants to know when it happened.
 
 ### --feedback--
 
-Lisa’s question is not about time. It’s about identifying the odd thing.
+Lisa's question is not about time. It's about identifying the odd thing.
 
 ---
 
@@ -43,7 +43,7 @@ She wants to know why it was odd.
 
 ### --feedback--
 
-Lisa’s question focuses on what the odd thing was, not about why James thought it was odd.
+Lisa's question focuses on what the odd thing was, not about why James thought it was odd.
 
 ## --video-solution--
 
@@ -55,7 +55,7 @@ The verb `to be` in the `Simple Past` is used to describe or ask about states or
 
 - Affirmative: `The meeting was productive.` - You had a good opinion about the meeting
 
-- Negative: `The meeting wasn’t productive.` - Your opinion about the meeting was that it was a waste of time.
+- Negative: `The meeting wasn't productive.` - Your opinion about the meeting was that it was a waste of time.
 
 In questions, the verb `to be` and the subject are inverted. For example:
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/6705573e13b1211820a3ac67.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/6705573e13b1211820a3ac67.md
@@ -23,7 +23,7 @@ The system was connecting to many databases at the same time.
 
 ### --feedback--
 
-James states that the system wasn’t connecting properly to the database. There is no mention of more than one database in the sentence.
+James states that the system wasn't connecting properly to the database. There is no mention of more than one database in the sentence.
 
 ---
 
@@ -31,11 +31,11 @@ The system was turned off.
 
 ### --feedback--
 
-James didn’t mention that the system was off. The issue was with its connection to the database.
+James didn't mention that the system was off. The issue was with its connection to the database.
 
 ---
 
-The system wasn’t connecting to the database properly.
+The system wasn't connecting to the database properly.
 
 ---
 
@@ -43,7 +43,7 @@ There were no errors in the system.
 
 ### --feedback--
 
-James found an error: the system wasn’t connecting to the database.
+James found an error: the system wasn't connecting to the database.
 
 ## --video-solution--
 
@@ -51,13 +51,13 @@ James found an error: the system wasn’t connecting to the database.
 
 # --explanation--
 
-The negative form of the verb `to be` in the `Simple Past` tense is `was not` or `wasn’t` for singular subjects, and `were not` or `weren’t` for plural subjects. It is used to describe something that did not happen or was not true. For example:  
+The negative form of the verb `to be` in the `Simple Past` tense is `was not` or `wasn't` for singular subjects, and `were not` or `weren't` for plural subjects. It is used to describe something that did not happen or was not true. For example:  
 
-- Singular: `The code wasn’t running as expected.` - An issue was happening with the code.
+- Singular: `The code wasn't running as expected.` - An issue was happening with the code.
 
-- Plural: `The changes weren’t implemented correctly.` - Errors in the implementation caused the bugs.
+- Plural: `The changes weren't implemented correctly.` - Errors in the implementation caused the bugs.
 
-In James's sentence, he uses `wasn’t` to explain that the system was failing to connect to the database. Negative sentences with `wasn’t` or `weren’t` indicate what did not occur or work as you might expect.
+In James's sentence, he uses `wasn't` to explain that the system was failing to connect to the database. Negative sentences with `wasn't` or `weren't` indicate what did not occur or work as you might expect.
 
 # --scene--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/67055872382df21871200427.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/67055872382df21871200427.md
@@ -29,11 +29,11 @@ This word means in the correct or appropriate way.
 
 `Properly` is the adverb form of the adjective `proper`. Both words can express doing something in the correct or suitable manner, but their usage differs depending on the sentence structure. For example:  
 
-- `The application didn’t function properly after the update.` - This means the updates brought errors to the code. The adverb `properly` modifies the verb `function`.
+- `The application didn't function properly after the update.` - This means the updates brought errors to the code. The adverb `properly` modifies the verb `function`.
 
 - `This wasn't a proper configuration of the database.` - The adjective `proper` describes the noun `configuration`.
 
-Here, James uses `properly` to describe that the system wasn’t connecting to the database in the correct way.
+Here, James uses `properly` to describe that the system wasn't connecting to the database in the correct way.
 
 # --scene--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/6705605c7fb8f619e0068634.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/6705605c7fb8f619e0068634.md
@@ -35,7 +35,7 @@ She is asking if James fixed the database.
 
 ### --feedback--
 
-Lisa’s question specifically refers to the credentials, not to the database as a whole.
+Lisa's question specifically refers to the credentials, not to the database as a whole.
 
 ---
 
@@ -43,7 +43,7 @@ She is asking if there are more issues.
 
 ### --feedback--
 
-Lisa’s question focuses on whether James fixed the credentials.
+Lisa's question focuses on whether James fixed the credentials.
 
 ## --video-solution--
 
@@ -57,13 +57,13 @@ Lisa’s question focuses on whether James fixed the credentials.
 
 - `The main issue was a missing file.` - The problem was caused by a file not being where it should be.
 
-`Them` is a pronoun used to replace plural nouns already mentioned. In Lisa’s question, `them` refers to the `credentials`. For example:
+`Them` is a pronoun used to replace plural nouns already mentioned. In Lisa's question, `them` refers to the `credentials`. For example:
 
 - `The files were corrupted. Did you fix them?` - `them` refers to the files.
 
 - `The permissions were incorrect. I updated them this morning.` - `them` refers to the permissions.
 
-Lisa’s question asks if James fixed the credentials.
+Lisa's question asks if James fixed the credentials.
 
 # --scene--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/670561a8af3d901a431549fe.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/670561a8af3d901a431549fe.md
@@ -23,7 +23,7 @@ Restarting the app.
 
 ### --feedback--
 
-James doesn’t mention restarting the app as the solution. He says updating the credentials was necessary.
+James doesn't mention restarting the app as the solution. He says updating the credentials was necessary.
 
 ---
 
@@ -57,7 +57,7 @@ James says updating the credentials solved the issue, not reinstalling the app.
 
 - `Her solution to the problem was successful and saved a lot of time.` - meaning she found a good solution to the problem.
 
-In James’s case, updating the credentials to make a successful connection to the database was necessary for the app to start working again.
+In James's case, updating the credentials to make a successful connection to the database was necessary for the app to start working again.
 
 # --scene--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/670564e883b7911b4ec31e29.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/670564e883b7911b4ec31e29.md
@@ -15,7 +15,7 @@ Listen to the audio and answer the question below.
 
 ## --text--
 
-What can you conclude based on Lisa’s comment?
+What can you conclude based on Lisa's comment?
 
 ## --answers--
 
@@ -23,7 +23,7 @@ She is telling James the app is broken.
 
 ### --feedback--
 
-Lisa’s comment intends to praise James for fixing the app, not to criticize him.
+Lisa's comment intends to praise James for fixing the app, not to criticize him.
 
 ---
 
@@ -35,7 +35,7 @@ She is asking James to work faster.
 
 ### --feedback--
 
-Lisa’s comment is about appreciating James's work, not asking for speed.
+Lisa's comment is about appreciating James's work, not asking for speed.
 
 ---
 
@@ -43,7 +43,7 @@ She is unsure if the app is working.
 
 ### --feedback--
 
-Lisa’s comment shows that she is confident in James's success and appreciates his work.
+Lisa's comment shows that she is confident in James's success and appreciates his work.
 
 ## --video-solution--
 
@@ -55,7 +55,7 @@ The phrase `Great job` is used to praise or compliment someone for their effort 
 
 `You fixed the bug in record time. Great job!` - meaning you think it is great that the other person fixed the bug so fast.
 
-Lisa’s use of `Great job` in the dialogue reflects her recognition of James's effort in solving the problem and getting the app working again.
+Lisa's use of `Great job` in the dialogue reflects her recognition of James's effort in solving the problem and getting the app working again.
 
 # --scene--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/67056b4950144e1cf10c53a6.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/67056b4950144e1cf10c53a6.md
@@ -21,7 +21,7 @@ This is James' email to his team.
 
 `Hey team,`
 
-`I found the bug from yesterday. First, I checked the recent code changes but didn’t see anything. Then, I looked at the error logs and realized the system wasn’t connecting to the database properly. We hadn’t updated the credentials after the last security patch. I fixed the credentials, and the app is now running smoothly!`
+`I found the bug from yesterday. First, I checked the recent code changes but didn't see anything. Then, I looked at the error logs and realized the system wasn't connecting to the database properly. We hadn't updated the credentials after the last security patch. I fixed the credentials, and the app is now running smoothly!`
 
 `Best regards,`
 `James`
@@ -46,7 +46,7 @@ This subject is relevant but a bit too vague about the exact problem James fixed
 
 ### --feedback--
 
-This subject is misleading because the security patch wasn’t the problem, it was the credentials not being updated after the patch.
+This subject is misleading because the security patch wasn't the problem, it was the credentials not being updated after the patch.
 
 ---
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/670570ad97d26e1d6bad572d.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/670570ad97d26e1d6bad572d.md
@@ -23,7 +23,7 @@ This is James' email to his team.
 
 `Hey team,`
 
-`I found the bug from yesterday. First, I checked the recent code changes but didn’t see anything. Then, I looked at the error logs and realized the system wasn’t connecting to the database properly. We hadn’t updated the credentials after the last security patch. I fixed the credentials, and the app is now running smoothly!`
+`I found the bug from yesterday. First, I checked the recent code changes but didn't see anything. Then, I looked at the error logs and realized the system wasn't connecting to the database properly. We hadn't updated the credentials after the last security patch. I fixed the credentials, and the app is now running smoothly!`
 
 `Best regards,`
 `James`

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/6705725e2814c91dd738e8f4.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/6705725e2814c91dd738e8f4.md
@@ -23,7 +23,7 @@ This is James' email to his team.
 
 `Hey team,`
 
-`I found the bug from yesterday. First, I checked the recent code changes but didn’t see anything. Then, I looked at the error logs and realized the system wasn’t connecting to the database properly. We hadn’t updated the credentials after the last security patch. I fixed the credentials, and the app is now running smoothly!`
+`I found the bug from yesterday. First, I checked the recent code changes but didn't see anything. Then, I looked at the error logs and realized the system wasn't connecting to the database properly. We hadn't updated the credentials after the last security patch. I fixed the credentials, and the app is now running smoothly!`
 
 `Best regards,`
 `James`
@@ -40,7 +40,7 @@ This is incorrect because the issue wasn't related to the logs.
 
 ---
 
-The system wasn’t connecting to the database properly.
+The system wasn't connecting to the database properly.
 
 ---
 
@@ -48,7 +48,7 @@ The code changes introduced a new error.
 
 ### --feedback--
 
-The bug wasn’t directly caused by the code changes.
+The bug wasn't directly caused by the code changes.
 
 ---
 
@@ -64,4 +64,4 @@ James doesn't mention this.
 
 # --explanation--
 
-To find out the main cause of the bug, look for the part of the text that talks about the system’s connection. Focus on the sentence that starts with `Then, I...`.
+To find out the main cause of the bug, look for the part of the text that talks about the system's connection. Focus on the sentence that starts with `Then, I...`.

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/6705742b9616e01e275e5c08.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/6705742b9616e01e275e5c08.md
@@ -23,7 +23,7 @@ This is James' email to his team.
 
 `Hey team,`
 
-`I found the bug from yesterday. First, I checked the recent code changes but didn’t see anything. Then, I looked at the error logs and realized the system wasn't connecting to the database properly. We hadn't updated the credentials after the last security patch. I fixed the credentials, and the app is now running smoothly!`
+`I found the bug from yesterday. First, I checked the recent code changes but didn't see anything. Then, I looked at the error logs and realized the system wasn't connecting to the database properly. We hadn't updated the credentials after the last security patch. I fixed the credentials, and the app is now running smoothly!`
 
 `Best regards,`
 `James`

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/67057604ca099f1e7df78e77.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/67057604ca099f1e7df78e77.md
@@ -23,7 +23,7 @@ This is James' email to his team.
 
 `Hey team,`
 
-`I found the bug from yesterday. First, I checked the recent code changes but didn’t see anything. Then, I looked at the error logs and realized the system wasn’t connecting to the database properly. We hadn’t updated the credentials after the last security patch. I fixed the credentials, and the app is now running smoothly!`
+`I found the bug from yesterday. First, I checked the recent code changes but didn't see anything. Then, I looked at the error logs and realized the system wasn't connecting to the database properly. We hadn't updated the credentials after the last security patch. I fixed the credentials, and the app is now running smoothly!`
 
 `Best regards,`
 `James`
@@ -36,7 +36,7 @@ Before the bug was found.
 
 ### --feedback--
 
-The credentials weren’t updated before the bug was found, which was actually the cause of the issue.
+The credentials weren't updated before the bug was found, which was actually the cause of the issue.
 
 ---
 
@@ -48,7 +48,7 @@ When the error logs were cleared.
 
 ### --feedback--
 
-The error logs revealed the issue, but the credentials weren’t updated when the logs were cleared.
+The error logs revealed the issue, but the credentials weren't updated when the logs were cleared.
 
 ---
 
@@ -56,7 +56,7 @@ During the last system backup.
 
 ### --feedback--
 
-No mention of a system backup was made, so this doesn’t apply to the situation.
+No mention of a system backup was made, so this doesn't apply to the situation.
 
 ## --video-solution--
 
@@ -64,4 +64,4 @@ No mention of a system backup was made, so this doesn’t apply to the situation
 
 # --explanation--
 
-To find out when the credentials were updated, check the part where James explains why the app wasn’t working. Focus on the sentence starting with, `We hadn’t updated...`. 
+To find out when the credentials were updated, check the part where James explains why the app wasn't working. Focus on the sentence starting with, `We hadn't updated...`. 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/67057e02da44871f492f6f35.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/67057e02da44871f492f6f35.md
@@ -23,7 +23,7 @@ This is James' email to his team.
 
 `Hey team,`
 
-`I found the bug from yesterday. First, I checked the recent code changes but didn’t see anything. Then, I looked at the error logs and realized the system wasn’t connecting to the database properly. We hadn’t updated the credentials after the last security patch. I fixed the credentials, and the app is now running smoothly!`
+`I found the bug from yesterday. First, I checked the recent code changes but didn't see anything. Then, I looked at the error logs and realized the system wasn't connecting to the database properly. We hadn't updated the credentials after the last security patch. I fixed the credentials, and the app is now running smoothly!`
 
 `Best regards,`
 `James`
@@ -40,7 +40,7 @@ The bug was fixed after updating the credentials, so the app no longer has issue
 
 ---
 
-Yes, it’s running smoothly.
+Yes, it's running smoothly.
 
 ---
 
@@ -48,7 +48,7 @@ No, the database is still down.
 
 ### --feedback--
 
-The database connection issue was resolved, so it’s not down anymore.
+The database connection issue was resolved, so it's not down anymore.
 
 ---
 
@@ -64,4 +64,4 @@ The app is fully operational, not partially working.
 
 # --explanation--
 
-To figure out if the app is working now, look at the last part of James’ explanation where he says, `I fixed...`.
+To figure out if the app is working now, look at the last part of James' explanation where he says, `I fixed...`.

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/670f71de33e0be053934a9c3.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/670f71de33e0be053934a9c3.md
@@ -19,7 +19,7 @@ What does Linda mean by `postmortem`?
 
 ## --answers--
 
-She means a review of the design project after its completion to analyze what went well and what didn’t.
+She means a review of the design project after its completion to analyze what went well and what didn't.
 
 ---
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/670f74145be4b907a1b9c915.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/670f74145be4b907a1b9c915.md
@@ -39,7 +39,7 @@ The `Past Continuous` tense is used to describe actions or thoughts that were in
 
 This tense is often used to describe background actions or ongoing processes in the past. The structure is **`was`/`were` + verb ending in `-ing`**.  
 
-In this sentence, `I was thinking` shows that Linda’s thought about doing a postmortem was in progress at a specific time. Another example:  
+In this sentence, `I was thinking` shows that Linda's thought about doing a postmortem was in progress at a specific time. Another example:  
 
 `He was reviewing the report when the meeting started.` - Meaning that the action of reviewing the report was in progress and another situation interrupted it.
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/6710bf5df20df90498c991a2.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/6710bf5df20df90498c991a2.md
@@ -43,7 +43,7 @@ He was fixing a bug in the project.
 
 ### --feedback--
 
-Jake’s focus was on reviewing the security protocols, not fixing a bug.
+Jake's focus was on reviewing the security protocols, not fixing a bug.
 
 ## --video-solution--
 
@@ -53,7 +53,7 @@ Jake’s focus was on reviewing the security protocols, not fixing a bug.
 
 The `Past Continuous` tense often emphasizes the duration or background of an action in the past. It is used to describe an action that was ongoing at a specific time in the past. The structure is: **`was`/`were` + verb ending in `-ing`**. 
 
-In Jake’s sentence, `I was reviewing` shows that the action of reviewing was in progress yesterday. Another example: 
+In Jake's sentence, `I was reviewing` shows that the action of reviewing was in progress yesterday. Another example: 
 
 `She was testing the new feature when the system crashed.` - Here, the crashing of the system happened in the middle of her action of testing the new feature - the test was a longer ongoing action.
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/6710c7bd388290075f19552c.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/6710c7bd388290075f19552c.md
@@ -35,7 +35,7 @@ He is asking if Linda is busy.
 
 ### --feedback--
 
-Jake’s question is about her thoughts, not her availability.
+Jake's question is about her thoughts, not her availability.
 
 ---
 
@@ -53,7 +53,7 @@ While the question could refer to concerns, it is more general, asking about wha
 
 `What's on your mind?` is used to ask someone what they are thinking about or if they have any concerns or thoughts they want to share. 
 
-It’s often used in both personal and professional settings to encourage open communication. It is a conversational way to invite someone to express their thoughts. For example: 
+It's often used in both personal and professional settings to encourage open communication. It is a conversational way to invite someone to express their thoughts. For example: 
 
 `You seem quiet today. What's on your mind?` - You are asking the other person what they are thinking about.
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/67121d26052fb606bd59705c.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/67121d26052fb606bd59705c.md
@@ -23,7 +23,7 @@ He is asking if the team always considered security implications.
 
 ### --feedback--
 
-Jake’s question suggests there might have been a time when security was overlooked.
+Jake's question suggests there might have been a time when security was overlooked.
 
 ---
 
@@ -31,7 +31,7 @@ He is asking if security was never important.
 
 ### --feedback--
 
-Jake’s question focuses on whether there was a specific time when security wasn’t considered, not on its overall importance.
+Jake's question focuses on whether there was a specific time when security wasn't considered, not on its overall importance.
 
 ---
 
@@ -55,7 +55,7 @@ He is asking if there was a time when security concerns were not taken into acco
 
 `Before launching the new feature, the team discussed the implications for user privacy.` - Meaning they discussed the possible consequences to user privacy that this new feature could bring.
 
-In Jake’s question, he is referring to the potential negative outcomes of not considering security during past updates.
+In Jake's question, he is referring to the potential negative outcomes of not considering security during past updates.
 
 # --scene--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/6717756d3483e6060d2cd800.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/6717756d3483e6060d2cd800.md
@@ -23,7 +23,7 @@ She is asking if security updates are currently being checked.
 
 ### --feedback--
 
-Linda’s question is about a past habit, not about the current practice.
+Linda's question is about a past habit, not about the current practice.
 
 ---
 
@@ -35,7 +35,7 @@ She is asking if security vulnerabilities are easy to fix.
 
 ### --feedback--
 
-Linda’s question is about whether they used to check for vulnerabilities, not their ease of fixing.
+Linda's question is about whether they used to check for vulnerabilities, not their ease of fixing.
 
 ---
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/671775877ee558061e6eebf8.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/671775877ee558061e6eebf8.md
@@ -39,7 +39,7 @@ The phrase `in real time` refers to something happening immediately as events oc
 
 `The system updates the dashboard in real time, so you can see changes instantly.` - Meaning the dashboard changes immediately after the updates after the updates are applied.
 
-In Jake's sentence, he means that while he checked for security vulnerabilities, it wasn’t always done immediately as the updates happened.
+In Jake's sentence, he means that while he checked for security vulnerabilities, it wasn't always done immediately as the updates happened.
 
 # --scene--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/671775a360c128062f906b24.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/671775a360c128062f906b24.md
@@ -19,7 +19,7 @@ What did Jake think about checking the updates a day later?
 
 ## --answers--
 
-He thought it wasn’t ideal.
+He thought it wasn't ideal.
 
 ---
 
@@ -31,11 +31,11 @@ Jake explicitly says it wasn't ideal.
 
 ---
 
-He didn’t think it was a problem.
+He didn't think it was a problem.
 
 ### --feedback--
 
-Jake’s comment shows that he recognized it wasn’t an ideal approach.
+Jake's comment shows that he recognized it wasn't an ideal approach.
 
 ---
 
@@ -43,7 +43,7 @@ He thought it was impossible.
 
 ### --feedback--
 
-Jake mentions that he did check them a day later, but it wasn’t ideal.
+Jake mentions that he did check them a day later, but it wasn't ideal.
 
 ## --video-solution--
 
@@ -51,11 +51,11 @@ Jake mentions that he did check them a day later, but it wasn’t ideal.
 
 # --explanation--
 
-`Which` is a relative pronoun used to provide additional information about something mentioned earlier in the sentence. In this case, `which` refers to the entire idea of checking the updates a day later and clarifies that it wasn’t ideal. For example:
+`Which` is a relative pronoun used to provide additional information about something mentioned earlier in the sentence. In this case, `which` refers to the entire idea of checking the updates a day later and clarifies that it wasn't ideal. For example:
 
 `She missed the deadline, which caused a delay in the project.` - Here, `which` refers to `missing the deadline` and explains the resulting delay.
 
-Similarly, Jake uses `which` to express that checking updates a day later wasn’t the best practice.
+Similarly, Jake uses `which` to express that checking updates a day later wasn't the best practice.
 
 # --scene--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/671775db2ecd44064fdb1f04.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/671775db2ecd44064fdb1f04.md
@@ -43,7 +43,7 @@ A `security issue` refers to a problem or vulnerability that could compromise th
 
 `The team addressed a security issue that allowed unauthorized access.` - meaning the team had to deal with a problem in security that was giving access to people without the proper authorization.
 
-In this context, Linda is asking about Jake’s work on a specific problem related to security because she vividly remembers that was what was happening at the time.
+In this context, Linda is asking about Jake's work on a specific problem related to security because she vividly remembers that was what was happening at the time.
 
 # --scene--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/6717b543037e030fc7008aa7.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/6717b543037e030fc7008aa7.md
@@ -53,7 +53,7 @@ This is the main verb in the `Past Continuous`. It means to remain ready or expe
 
 The verb `address` in this context means to deal with or resolve an issue or problem. Jake was focusing on resolving the matter while the team waited for his approval. For example: 
 
-`The manager addressed the client’s concerns during the meeting.` - Here, `addressed` refers to taking action to deal with the client’s concerns.
+`The manager addressed the client's concerns during the meeting.` - Here, `addressed` refers to taking action to deal with the client's concerns.
 
 In the sentence, Jake uses the `Past Continuous` (`was addressing`) to describe the ongoing action of resolving the issue while another ongoing action (`the team was waiting`) happened simultaneously.
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/6717b55fb3b4160fd757b7af.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/6717b55fb3b4160fd757b7af.md
@@ -31,7 +31,7 @@ They were waiting for new instructions.
 
 ### --feedback--
 
-Jake’s sentence focuses on the team waiting for his approval, not new instructions.
+Jake's sentence focuses on the team waiting for his approval, not new instructions.
 
 ---
 
@@ -39,7 +39,7 @@ They were waiting for the system to restart.
 
 ### --feedback--
 
-Jake doesn’t mention the system restarting. The team was waiting for his permission.
+Jake doesn't mention the system restarting. The team was waiting for his permission.
 
 ---
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/6717b5754dcaae0fe7bb179b.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/6717b5754dcaae0fe7bb179b.md
@@ -29,9 +29,9 @@ This word is used to emphasize the degree or extent of something.
 
 `Quite` is used in this context to emphasize the significant degree or extent of the learning curve. It adds intensity, suggesting that the learning experience was challenging or noteworthy. For example: 
 
-`The project was quite a success, exceeding all expectations.` - Here, `quite` highlights the extent of the project’s success. 
+`The project was quite a success, exceeding all expectations.` - Here, `quite` highlights the extent of the project's success. 
 
-In Linda’s sentence, it emphasizes that the learning curve was substantial for the team.
+In Linda's sentence, it emphasizes that the learning curve was substantial for the team.
 
 # --scene--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/6717b59830cdb50ff9f67623.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/6717b59830cdb50ff9f67623.md
@@ -31,7 +31,7 @@ She thought it was unnecessary to work on security aspects.
 
 ### --feedback--
 
-Linda’s comment suggests that working on security aspects was a valuable learning experience, not unnecessary.
+Linda's comment suggests that working on security aspects was a valuable learning experience, not unnecessary.
 
 ---
 
@@ -43,7 +43,7 @@ She thought it was unrelated to the project.
 
 ### --feedback--
 
-Linda’s comment directly relates to the team’s work on security aspects, describing it as a significant learning experience.
+Linda's comment directly relates to the team's work on security aspects, describing it as a significant learning experience.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/6717b5b2b0c1d21009b2b0fd.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/6717b5b2b0c1d21009b2b0fd.md
@@ -41,9 +41,9 @@ This structure emphasizes that an action was not habitual or common in the past.
 
 **Important:** The auxiliary verb `didn't` makes the sentence negative. The verb `use` stays in its base form because the past tense is already conveyed by `didn't`. For example: 
 
-`We didn’t use to have weekly meetings, but now we do.` - This means weekly meetings were not common back then. 
+`We didn't use to have weekly meetings, but now we do.` - This means weekly meetings were not common back then. 
 
-In Linda’s sentence, she is saying that integrating security and design was not a regular practice in the past.
+In Linda's sentence, she is saying that integrating security and design was not a regular practice in the past.
 
 # --scene--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/6717b5c73e81e8101bed0ea2.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/6717b5c73e81e8101bed0ea2.md
@@ -37,7 +37,7 @@ When you use `nonsense` to reply to a comment, it is because you do not believe 
 
 # --explanation--
 
-`Agreed` is a concise way to express strong agreement with someone’s statement. It is the opposite of the expression `Nonsense.` 
+`Agreed` is a concise way to express strong agreement with someone's statement. It is the opposite of the expression `Nonsense.` 
 
 `Agreed` is often used in professional or conversational contexts to show alignment with what has been said. For Example: 
 
@@ -45,7 +45,7 @@ Person 1: `We should prioritize user feedback in our next update.`
 
 Person 2: `Agreed.` - This answer implies you strongly agree with prioritizing used feedback on the next update.
 
-In this context, Jake could use `Agreed` to acknowledge that he fully supports Linda’s statement about the lack of integration between security and design in the past.
+In this context, Jake could use `Agreed` to acknowledge that he fully supports Linda's statement about the lack of integration between security and design in the past.
 
 # --scene--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/6717b5f5be4456103b8ff767.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/6717b5f5be4456103b8ff767.md
@@ -31,11 +31,11 @@ They should happen after the design updates are complete.
 
 ### --feedback--
 
-Jake’s statement indicates the checks should happen during, not after, the updates.
+Jake's statement indicates the checks should happen during, not after, the updates.
 
 ---
 
-They don’t need to happen at all.
+They don't need to happen at all.
 
 ### --feedback--
 
@@ -55,7 +55,7 @@ The `Present Continuous` tense is used here to describe two ongoing actions happ
 
 `The team is testing the new feature while the developers are fixing bugs.` - This means the tests and the process of bug fixing are happening at the same time.
 
-This tense is often used to indicate that two events are occurring at the same time, creating a sense of coordination or overlap in actions. In Jake’s statement, he stresses the importance of ensuring that both actions occur simultaneously.
+This tense is often used to indicate that two events are occurring at the same time, creating a sense of coordination or overlap in actions. In Jake's statement, he stresses the importance of ensuring that both actions occur simultaneously.
 
 # --scene--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/6717b6a5308335105c51cfe6.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/6717b6a5308335105c51cfe6.md
@@ -15,7 +15,7 @@ Listen to the audio and answer the question below.
 
 ## --text--
 
-What, in Jake’s opinion, can't they afford to do anymore?
+What, in Jake's opinion, can't they afford to do anymore?
 
 ## --answers--
 
@@ -23,7 +23,7 @@ They can't afford to prioritize this aspect.
 
 ### --feedback--
 
-Jake’s concern is about not ignoring the aspect, not about prioritizing it.
+Jake's concern is about not ignoring the aspect, not about prioritizing it.
 
 ---
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/671f7579f5e0000560fcce55.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/671f7579f5e0000560fcce55.md
@@ -39,7 +39,7 @@ The structure `what` + an indefinite article is used to emphasize strong feeling
 
 `What a beautiful day it is!` - Here, the structure highlights the speaker's admiration for the day. 
 
-Similarly, in Maria’s sentence, `What a surprise` emphasizes her astonishment at seeing Brian at PyCon.  
+Similarly, in Maria's sentence, `What a surprise` emphasizes her astonishment at seeing Brian at PyCon.  
 
 `PyCon` is a well-known conference for Python programming enthusiasts, developers, and professionals. It provides a platform for learning, networking, and sharing Python-related knowledge.  For example: 
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/671f75e368cbd505a301ca7d.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/671f75e368cbd505a301ca7d.md
@@ -29,7 +29,7 @@ How could Maria succinctly tell Brian she attended some sessions at PyCon as wel
 
 ### --feedback--
 
-`Why not?` doesn’t indicate agreement or a shared experience.
+`Why not?` doesn't indicate agreement or a shared experience.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/671f761703824805c35c2eda.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/671f761703824805c35c2eda.md
@@ -43,7 +43,7 @@ She is asking if he remembers the latest tech updates.
 
 ### --feedback--
 
-Maria’s focus is on their shared feelings about new technology in the past, not current updates.
+Maria's focus is on their shared feelings about new technology in the past, not current updates.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/671f7708379ef00668b843d4.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/671f7708379ef00668b843d4.md
@@ -59,7 +59,7 @@ However, `would` focuses more on the action itself, while `used to` can describe
 
 `She used to live in New York before moving here.` - here `used to` is used because living in a place expresses a state of things not an action or something you would habitually do.
 
-In this sentence, Maria uses `would` to describe Brian’s repeated habit of staying late to fine-tune the code, which emphasizes his dedication.
+In this sentence, Maria uses `would` to describe Brian's repeated habit of staying late to fine-tune the code, which emphasizes his dedication.
 
 # --scene--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/671f7767854d6806ac4fb5f4.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/671f7767854d6806ac4fb5f4.md
@@ -19,11 +19,11 @@ Why could Maria not attend the cybersecurity workshop in the morning?
 
 ## --answers--
 
-Because she wasn’t interested in the topic.
+Because she wasn't interested in the topic.
 
 ### --feedback--
 
-Maria doesn’t mention a lack of interest; she was in another workshop.
+Maria doesn't mention a lack of interest; she was in another workshop.
 
 ---
 
@@ -59,7 +59,7 @@ A `design sprint` is a time-boxed, collaborative process where a team works on s
 
 `The team completed a design sprint to test the new user interface concept.` This means the team participated in this collaborative process to test the concept. 
 
-In this context, Maria couldn’t attend the cybersecurity workshop because she was actively participating in a design sprint workshop.
+In this context, Maria couldn't attend the cybersecurity workshop because she was actively participating in a design sprint workshop.
 
 # --scene--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/674609a92ccf079d86cd81db.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/674609a92ccf079d86cd81db.md
@@ -29,7 +29,7 @@ This phrase is used to indicate a small amount or degree.
 
 `A bit` is used to indicate a small amount or degree of something. For Example: 
 
-`I was a bit tired after the long day.` - Here, `a bit` emphasizes that the speaker was slightly tired, but it wasn’t extreme.
+`I was a bit tired after the long day.` - Here, `a bit` emphasizes that the speaker was slightly tired, but it wasn't extreme.
 
 This phrase is commonly used in informal contexts to soften statements or describe minor degrees of feelings or situations. In this dialog, James is admitting that the situation was slightly stressful but not overwhelming.
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/67460b84234b70a4772d2094.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/67460b84234b70a4772d2094.md
@@ -44,7 +44,7 @@ Person 1: `Do you think we should move forward with this plan?`
 
 Person 2: `Absolutely!` -  Here, `Absolutely` shows that the speaker is fully in favor of the plan and has no doubts.
 
-In this dialog, Lisa is strongly agreeing with James’s point about their job being interesting because of the challenges they solve.
+In this dialog, Lisa is strongly agreeing with James's point about their job being interesting because of the challenges they solve.
 
 # --scene--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/674616565854f7c788740cee.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/674616565854f7c788740cee.md
@@ -23,7 +23,7 @@ She wants to know why James was debugging.
 
 ### --feedback--
 
-Lisa’s question isn’t about the reason for debugging; it’s about whether other issues came up during that time.
+Lisa's question isn't about the reason for debugging; it's about whether other issues came up during that time.
 
 ---
 
@@ -31,7 +31,7 @@ She wants to know when James started debugging.
 
 ### --feedback--
 
-Lisa’s question focuses on what else happened during debugging, not the timing.
+Lisa's question focuses on what else happened during debugging, not the timing.
 
 ---
 
@@ -43,7 +43,7 @@ She wants to know if debugging is finished.
 
 ### --feedback--
 
-Lisa’s question is about what happened during debugging, not whether it is finished.
+Lisa's question is about what happened during debugging, not whether it is finished.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/674619b6699a06d064c9717f.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/674619b6699a06d064c9717f.md
@@ -43,7 +43,7 @@ This word refers to identifying and fixing errors or issues in code. Use the `-i
 
 `The team spent hours debugging the software before the release.` - Meaning they spent a long time identifying and solving these errors.
 
-Lisa’s question asks if any other unexpected issues could be seen during the process of fixing code errors.
+Lisa's question asks if any other unexpected issues could be seen during the process of fixing code errors.
 
 # --scene--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/67461c06865e13d715967f1d.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/67461c06865e13d715967f1d.md
@@ -37,7 +37,7 @@ In affirmative sentences, use `something` to indicate the existence of a thing. 
  
 In negative sentences, use `anything` to indicate that no thing occurred or existed. For example: 
 
-`I didn’t see anything unusual in the report.` - meaning there were no surprises in the report.
+`I didn't see anything unusual in the report.` - meaning there were no surprises in the report.
 
 
 # --scene--

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/6758486d05a8fcf01a20c8b4.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/6758486d05a8fcf01a20c8b4.md
@@ -19,7 +19,7 @@ What did Brian think about the cybersecurity workshop?
 
 ## --answers--
 
-He thought it didn’t provide useful information.
+He thought it didn't provide useful information.
 
 ### --feedback--
 
@@ -39,7 +39,7 @@ Brian explicitly connects the workshop to how they handled security in earlier p
 
 ---
 
-He thought it wasn’t worth attending.
+He thought it wasn't worth attending.
 
 ### --feedback--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/67165185a42acc499c6ada3d.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/67165185a42acc499c6ada3d.md
@@ -23,7 +23,7 @@ If the screen reader updates are completely finished.
 
 ### --feedback--
 
-Tom’s question is about an ongoing process, not whether the updates are fully completed.
+Tom's question is about an ongoing process, not whether the updates are fully completed.
 
 ---
 
@@ -31,7 +31,7 @@ If the screen reader updates have not started yet.
 
 ### --feedback--
 
-Tom’s question suggests that the updates have already started, not that they haven’t begun.
+Tom's question suggests that the updates have already started, not that they haven't begun.
 
 ---
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/6716531210ee374ae822fe83.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/6716531210ee374ae822fe83.md
@@ -5,7 +5,7 @@ challengeType: 19
 dashedName: task-6
 ---
 
-<!-- (audio) Sophie: Yes, I started a few months ago. We've been addressing the feedback from our last user survey. How’s the design side coming along? -->
+<!-- (audio) Sophie: Yes, I started a few months ago. We've been addressing the feedback from our last user survey. How's the design side coming along? -->
 
 # --instructions--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671655545e5bfc4c3dfe9871.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671655545e5bfc4c3dfe9871.md
@@ -5,7 +5,7 @@ challengeType: 22
 dashedName: task-7
 ---
 
-<!-- (audio) Sophie: Yes, I started a few months ago. We've been addressing the feedback from our last user survey. How’s the design side coming along? -->
+<!-- (audio) Sophie: Yes, I started a few months ago. We've been addressing the feedback from our last user survey. How's the design side coming along? -->
 
 # --instructions--
 
@@ -15,7 +15,7 @@ Listen to the audio and complete the sentence below.
 
 ## --sentence--
 
-`Yes, I started a few months ago. BLANK been BLANK the BLANK from our last user BLANK. How’s the design side coming along?`
+`Yes, I started a few months ago. BLANK been BLANK the BLANK from our last user BLANK. How's the design side coming along?`
 
 ## --blanks--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/67165855c3dd824eabc1b474.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/67165855c3dd824eabc1b474.md
@@ -5,7 +5,7 @@ challengeType: 19
 dashedName: task-8
 ---
 
-<!-- (audio) Sophie: Yes, I started a few months ago. We've been addressing the feedback from our last user survey. How’s the design side coming along? -->
+<!-- (audio) Sophie: Yes, I started a few months ago. We've been addressing the feedback from our last user survey. How's the design side coming along? -->
 
 # --instructions--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/6716593b4f24da4fac3154bf.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/6716593b4f24da4fac3154bf.md
@@ -5,7 +5,7 @@ challengeType: 22
 dashedName: task-9
 ---
 
-<!-- (audio) Sophie: Yes, I started a few months ago. We've been addressing the feedback from our last user survey. How’s the design side coming along? -->
+<!-- (audio) Sophie: Yes, I started a few months ago. We've been addressing the feedback from our last user survey. How's the design side coming along? -->
 
 # --instructions--
 
@@ -15,7 +15,7 @@ Listen to the audio and complete the sentence below.
 
 ## --sentence--
 
-`Yes, I started a few months ago. We've been addressing the feedback from our last user survey. How’s the BLANK side BLANK?`
+`Yes, I started a few months ago. We've been addressing the feedback from our last user survey. How's the BLANK side BLANK?`
 
 ## --blanks--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/6717b20b952c096b3dee0834.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/6717b20b952c096b3dee0834.md
@@ -5,7 +5,7 @@ challengeType: 19
 dashedName: task-10
 ---
 
-<!-- (audio) Sophie: Yes, I started a few months ago. We've been addressing the feedback from our last user survey. How’s the design side coming along? -->
+<!-- (audio) Sophie: Yes, I started a few months ago. We've been addressing the feedback from our last user survey. How's the design side coming along? -->
 
 <!-- SPEAKING --> 
 
@@ -17,7 +17,7 @@ Listen to the audio and answer the question below.
 
 ## --text--
 
-What’s the best answer to Sophie's question about the design side?
+What's the best answer to Sophie's question about the design side?
 
 ## --answers--
 
@@ -37,7 +37,7 @@ This response is unrelated to the design side and does not answer Sophie's quest
 
 # --explanation--
 
-Sophie's question `How’s the design side coming along?` asks about the progress of the design work. The best answer should provide a relevant update.
+Sophie's question `How's the design side coming along?` asks about the progress of the design work. The best answer should provide a relevant update.
 
 # --scene--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/6717b6aa217d3d6ed6f83e53.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/6717b6aa217d3d6ed6f83e53.md
@@ -45,7 +45,7 @@ These are the rules or instructions that provide direction for how something sho
 
 To `tweak` means to make a slight adjustment or modification. For example:
 
-`The developer tweaked the code to improve the app’s performance.` - This means that the developer made small changes to the code to enhance how the app functions.
+`The developer tweaked the code to improve the app's performance.` - This means that the developer made small changes to the code to enhance how the app functions.
 
 `Layouts` are the arrangement or structure of elements on a page or interface. For example:
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/6717ba3d37ec4e73a50878da.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/6717ba3d37ec4e73a50878da.md
@@ -5,7 +5,7 @@ challengeType: 22
 dashedName: task-13
 ---
 
-<!-- (audio) Sophie: That’s good to hear. Do you think the users have noticed the improvements? -->
+<!-- (audio) Sophie: That's good to hear. Do you think the users have noticed the improvements? -->
 
 # --instructions--
 
@@ -15,7 +15,7 @@ Listen to the audio and complete the sentence below.
 
 ## --sentence--
 
-`That’s good to hear. Do you think the users BLANK BLANK the BLANK?`
+`That's good to hear. Do you think the users BLANK BLANK the BLANK?`
 
 ## --blanks--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/6717c0dc8b764279dfc9326b.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/6717c0dc8b764279dfc9326b.md
@@ -5,7 +5,7 @@ challengeType: 19
 dashedName: task-15
 ---
 
-<!-- (audio) Sophie: That’s good to hear. Do you think the users have noticed the improvements? -->
+<!-- (audio) Sophie: That's good to hear. Do you think the users have noticed the improvements? -->
 
 # --instructions--
 
@@ -23,7 +23,7 @@ If the users are happy with the design updates.
 
 ### --feedback--
 
-Sophie’s focus is on whether users have observed the improvements, not if they are happy with the design.
+Sophie's focus is on whether users have observed the improvements, not if they are happy with the design.
 
 ---
 
@@ -51,7 +51,7 @@ Sophie is interested in whether users have observed the improvements, not about 
 
 # --explanation--
 
-Sophie’s question shows her curiosity about whether users are aware of the positive changes made to the product.
+Sophie's question shows her curiosity about whether users are aware of the positive changes made to the product.
 
 # --scene--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/6717c3557815a17d6369a778.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/6717c3557815a17d6369a778.md
@@ -5,7 +5,7 @@ challengeType: 22
 dashedName: task-16
 ---
 
-<!-- (audio) Tom: I think so. We haven’t been receiving as many negative comments. -->
+<!-- (audio) Tom: I think so. We haven't been receiving as many negative comments. -->
 
 # --instructions--
 
@@ -47,7 +47,7 @@ These are opinions or feedback shared by users, in the plural form.
 
 `Negative` refers to something unfavorable or critical. For example:
 
-`The user left a negative review about the app’s performance.` - Here, `negative` describes the unfavorable nature of the review.
+`The user left a negative review about the app's performance.` - Here, `negative` describes the unfavorable nature of the review.
 
 `Comment` is an opinion or piece of feedback provided by someone. Its plural form is `comments`. For example:
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671a383a56179f510b83cc1e.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671a383a56179f510b83cc1e.md
@@ -5,9 +5,9 @@ challengeType: 19
 dashedName: task-17
 ---
 
-<!-- (audio) Sophie: That’s good to hear. Do you think the users have noticed the improvements?
+<!-- (audio) Sophie: That's good to hear. Do you think the users have noticed the improvements?
 
-Tom: I think so. We haven’t been receiving as many negative comments. -->
+Tom: I think so. We haven't been receiving as many negative comments. -->
 
 # --instructions--
 
@@ -17,7 +17,7 @@ Listen to the audio and answer the question below.
 
 ## --text--
 
-How does Tom respond to Sophie’s question about user feedback?
+How does Tom respond to Sophie's question about user feedback?
 
 ## --answers--
 
@@ -25,11 +25,11 @@ He says the users have noticed more negative comments.
 
 ### --feedback--
 
-Tom actually mentions that they haven’t been receiving as many negative comments.
+Tom actually mentions that they haven't been receiving as many negative comments.
 
 ---
 
-He says they haven’t been receiving as many negative comments.
+He says they haven't been receiving as many negative comments.
 
 ---
 
@@ -41,7 +41,7 @@ Tom does not specifically mention positive comments, only that the negative ones
 
 ---
 
-He says he’s waiting for more feedback.
+He says he's waiting for more feedback.
 
 ### --feedback--
 
@@ -53,7 +53,7 @@ Tom is talking about the current trend of fewer negative comments, not waiting f
 
 # --explanation--
 
-Tom's response, `We haven’t been receiving as many negative comments`, uses the `Present Perfect Continuous` in the negative form. This tense is formed by `haven’t/hasn’t + been + verb(-ing)` and is used to describe actions that have not been happening over a period of time. In this case, it shows that fewer negative comments have been received over time, indicating a possible improvement.
+Tom's response, `We haven't been receiving as many negative comments`, uses the `Present Perfect Continuous` in the negative form. This tense is formed by `haven't/hasn't + been + verb(-ing)` and is used to describe actions that have not been happening over a period of time. In this case, it shows that fewer negative comments have been received over time, indicating a possible improvement.
 
 # --scene--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671a3c13a3d6b21a1b0008f7.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671a3c13a3d6b21a1b0008f7.md
@@ -5,7 +5,7 @@ challengeType: 22
 dashedName: task-18
 ---
 
-<!-- (audio) Sophie: That’s a relief. How long do you think we’ll need to keep making adjustments? -->
+<!-- (audio) Sophie: That's a relief. How long do you think we'll need to keep making adjustments? -->
 
 # --instructions--
 
@@ -41,7 +41,7 @@ This refers to changes made to improve or adapt something. It's plural form.
 
 `Adjustments` means small changes made to improve or adapt something. For example,
 
-`We made adjustments to the app’s layout for better user experience.` - `Adjustments` refers to the changes made to improve how users interact with the app.
+`We made adjustments to the app's layout for better user experience.` - `Adjustments` refers to the changes made to improve how users interact with the app.
 
 # --scene--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671a3dde9c50241c6c16e331.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671a3dde9c50241c6c16e331.md
@@ -5,7 +5,7 @@ challengeType: 19
 dashedName: task-19
 ---
 
-<!-- (audio) Sophie: That’s a relief. How long do you think we’ll need to keep making adjustments? -->
+<!-- (audio) Sophie: That's a relief. How long do you think we'll need to keep making adjustments? -->
 
 # --instructions--
 
@@ -51,7 +51,7 @@ Sophie does not express frustration. She mentions feeling relieved instead.
 
 # --explanation--
 
-Sophie’s use of `That’s a relief` indicates that she feels better or more comfortable about the progress being made, rather than feeling worried, confused, or frustrated.
+Sophie's use of `That's a relief` indicates that she feels better or more comfortable about the progress being made, rather than feeling worried, confused, or frustrated.
 
 # --scene--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671a3ed10fd6e81d06dd4690.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671a3ed10fd6e81d06dd4690.md
@@ -5,7 +5,7 @@ challengeType: 19
 dashedName: task-20
 ---
 
-<!-- (audio) Sophie: That’s a relief. How long do you think we’ll need to keep making adjustments? -->
+<!-- (audio) Sophie: That's a relief. How long do you think we'll need to keep making adjustments? -->
 
 # --instructions--
 
@@ -51,7 +51,7 @@ Sophie is not asking about the effectiveness of the adjustments.
 
 # --explanation--
 
-Sophie’s question shows that she is trying to understand the time required to continue making changes, focusing on the duration rather than the reasons or results.
+Sophie's question shows that she is trying to understand the time required to continue making changes, focusing on the duration rather than the reasons or results.
 
 # --scene--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671a40b415343c1f26e0c005.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671a40b415343c1f26e0c005.md
@@ -5,7 +5,7 @@ challengeType: 19
 dashedName: task-21
 ---
 
-<!-- (audio) Sophie: That’s a relief. How long do you think we’ll need to keep making adjustments? -->
+<!-- (audio) Sophie: That's a relief. How long do you think we'll need to keep making adjustments? -->
 
 <!-- SPEAKING -->
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671a41b8576531207749bdae.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671a41b8576531207749bdae.md
@@ -5,7 +5,7 @@ challengeType: 22
 dashedName: task-22
 ---
 
-<!-- (audio) Tom: Probably a few more weeks. We've been making steady progress, and I believe we’re close to finalizing the major changes. -->
+<!-- (audio) Tom: Probably a few more weeks. We've been making steady progress, and I believe we're close to finalizing the major changes. -->
 
 # --instructions--
 
@@ -15,7 +15,7 @@ Listen to the audio and complete the sentence below.
 
 ## --sentence--
 
-`Probably a few more weeks. We've been making steady BLANK, and I believe we’re close to BLANK the major changes.`
+`Probably a few more weeks. We've been making steady BLANK, and I believe we're close to BLANK the major changes.`
 
 ## --blanks--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671a438ac97103231787ab5a.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671a438ac97103231787ab5a.md
@@ -5,7 +5,7 @@ challengeType: 19
 dashedName: task-23
 ---
 
-<!-- (audio) Tom: Probably a few more weeks. We've been making steady progress, and I believe we’re close to finalizing the major changes. -->
+<!-- (audio) Tom: Probably a few more weeks. We've been making steady progress, and I believe we're close to finalizing the major changes. -->
 
 # --instructions--
 
@@ -51,7 +51,7 @@ Tom estimates that they will need only a few more weeks, not several months.
 
 # --explanation--
 
-Tom’s statement indicates that the team has been working consistently and expects to complete the changes in a few more weeks.
+Tom's statement indicates that the team has been working consistently and expects to complete the changes in a few more weeks.
 
 # --scene--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671a45f9b4ee3325393f0d0b.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671a45f9b4ee3325393f0d0b.md
@@ -5,7 +5,7 @@ challengeType: 22
 dashedName: task-24
 ---
 
-<!-- (audio) Sophie: That’s good news! It feels great to make our app more accessible. -->
+<!-- (audio) Sophie: That's good news! It feels great to make our app more accessible. -->
 
 # --instructions--
 
@@ -15,7 +15,7 @@ Listen to the audio and complete the sentence below.
 
 ## --sentence--
 
-`That’s good news! It feels great to make our app more BLANK.`
+`That's good news! It feels great to make our app more BLANK.`
 
 ## --blanks--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671a46fe18ae6a26c76f42f6.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671a46fe18ae6a26c76f42f6.md
@@ -5,7 +5,7 @@ challengeType: 19
 dashedName: task-25
 ---
 
-<!-- (audio) Sophie: That’s good news! It feels great to make our app more accessible. -->
+<!-- (audio) Sophie: That's good news! It feels great to make our app more accessible. -->
 
 # --instructions--
 
@@ -23,7 +23,7 @@ She is happy about making the app look more colorful.
 
 ### --feedback--
 
-No, `accessible` doesn’t refer to colors or design aesthetics. It means making the app easier for all users, including those with different needs, to use.
+No, `accessible` doesn't refer to colors or design aesthetics. It means making the app easier for all users, including those with different needs, to use.
 
 ---
 
@@ -31,7 +31,7 @@ She is pleased that the app is becoming easier for everyone to use, including us
 
 ---
 
-She thinks the app’s loading speed has improved significantly.
+She thinks the app's loading speed has improved significantly.
 
 ### --feedback--
 
@@ -51,7 +51,7 @@ Sophie is focused on making the app easier to use for all, which is what `access
 
 # --explanation--
 
-When Sophie says `It feels great to make our app more accessible`, she’s emphasizing the importance of making the app easier to use for all users, regardless of their abilities. Being `accessible` or `accessibility` aims to ensure that everyone, including people with disabilities, can interact with the app effectively.
+When Sophie says `It feels great to make our app more accessible`, she's emphasizing the importance of making the app easier to use for all users, regardless of their abilities. Being `accessible` or `accessibility` aims to ensure that everyone, including people with disabilities, can interact with the app effectively.
 
 
 # --scene--

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671a4aeac046082b1bf6335b.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671a4aeac046082b1bf6335b.md
@@ -33,7 +33,7 @@ An app introduces a new payment gateway to make transactions faster.
 
 ### --feedback--
 
-While this improves functionality, it doesn’t relate to making the app accessible to users with different needs.
+While this improves functionality, it doesn't relate to making the app accessible to users with different needs.
 
 ---
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671a4e181afe602d37786dd8.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671a4e181afe602d37786dd8.md
@@ -13,7 +13,7 @@ This is a review of the entire dialogue you just studied.
 
 # --instructions--
 
-Place the following phrases in the correct spot: `negative comments`, `been addressing`, `That’s a relief`, `more accessible`, and `keep making adjustments`.
+Place the following phrases in the correct spot: `negative comments`, `been addressing`, `That's a relief`, `more accessible`, and `keep making adjustments`.
 
 # --fillInTheBlank--
 
@@ -21,19 +21,19 @@ Place the following phrases in the correct spot: `negative comments`, `been addr
 
 `Tom: Hey Sophie, have you been working on the screen reader updates recently?`
 
-`Sophie: Yes, I started a few months ago. We've BLANK the feedback from our last user survey. How’s the design side coming along?`
+`Sophie: Yes, I started a few months ago. We've BLANK the feedback from our last user survey. How's the design side coming along?`
 
 `Tom: Pretty well, actually. I've been tweaking the layouts based on the guidelines you shared.`
 
-`Sophie: That’s good to hear. Do you think the users have noticed the improvements?`
+`Sophie: That's good to hear. Do you think the users have noticed the improvements?`
 
-`Tom: I think so. We haven’t been receiving as many BLANK.`
+`Tom: I think so. We haven't been receiving as many BLANK.`
 
-`Sophie: BLANK. How long do you think we’ll need to BLANK?`
+`Sophie: BLANK. How long do you think we'll need to BLANK?`
 
-`Tom: Probably a few more weeks. We've been making steady progress, and I believe we’re close to finalizing the major changes.`
+`Tom: Probably a few more weeks. We've been making steady progress, and I believe we're close to finalizing the major changes.`
 
-`Sophie: That’s good news! It feels great to make our app BLANK.`
+`Sophie: That's good news! It feels great to make our app BLANK.`
 
 ## --blanks--
 
@@ -53,7 +53,7 @@ This phrase refers to unfavorable feedback from users.
 
 ---
 
-`That’s a relief`
+`That's a relief`
 
 ### --feedback--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671b71da8e1b963c69b6d011.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671b71da8e1b963c69b6d011.md
@@ -19,7 +19,7 @@ Read the text and answer the question below.
 
 `Recently, they added special labels to buttons, menus, and forms, so screen readers can understand these parts better. They also improved the way headings, lists, and tables are organized, making the layouts easier for users to move through the app.`
 
-`Tom has been testing these improvements using popular screen readers, while Sophie has been focusing on tweaking the app’s text-to-speech function. They also increased the contrast, which helps users see different sections more clearly.`
+`Tom has been testing these improvements using popular screen readers, while Sophie has been focusing on tweaking the app's text-to-speech function. They also increased the contrast, which helps users see different sections more clearly.`
 
 `Sophie still wonders, “Have we done enough to make our app accessible?” They plan to conduct some surveys and add features like adjustable colors and keyboard shortcuts to make the app even more user-friendly.`
 
@@ -47,7 +47,7 @@ The focus is on making the app easier to use with screen readers, not on speed.
 
 ---
 
-They changed the app’s language settings.
+They changed the app's language settings.
 
 ### --feedback--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671b71da8e1b963c69b6d011.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671b71da8e1b963c69b6d011.md
@@ -21,7 +21,7 @@ Read the text and answer the question below.
 
 `Tom has been testing these improvements using popular screen readers, while Sophie has been focusing on tweaking the app's text-to-speech function. They also increased the contrast, which helps users see different sections more clearly.`
 
-`Sophie still wonders, “Have we done enough to make our app accessible?” They plan to conduct some surveys and add features like adjustable colors and keyboard shortcuts to make the app even more user-friendly.`
+`Sophie still wonders, "Have we done enough to make our app accessible?" They plan to conduct some surveys and add features like adjustable colors and keyboard shortcuts to make the app even more user-friendly.`
 
 What changes have Tom and Sophie made to help screen readers?
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671b769169e38f3fe57b141c.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671b769169e38f3fe57b141c.md
@@ -21,7 +21,7 @@ Read the text and answer the question below.
 
 `Tom has been testing these improvements using popular screen readers, while Sophie has been focusing on tweaking the app's text-to-speech function. They also increased the contrast, which helps users see different sections more clearly.`
 
-`Sophie still wonders, “Have we done enough to make our app accessible?” They plan to conduct some surveys and add features like adjustable colors and keyboard shortcuts to make the app even more user-friendly.`
+`Sophie still wonders, "Have we done enough to make our app accessible?" They plan to conduct some surveys and add features like adjustable colors and keyboard shortcuts to make the app even more user-friendly.`
 
 What was Tom's main role in improving screen reader compatibility?
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671b769169e38f3fe57b141c.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671b769169e38f3fe57b141c.md
@@ -19,11 +19,11 @@ Read the text and answer the question below.
 
 `Recently, they added special labels to buttons, menus, and forms, so screen readers can understand these parts better. They also improved the way headings, lists, and tables are organized, making the layouts easier for users to move through the app.`
 
-`Tom has been testing these improvements using popular screen readers, while Sophie has been focusing on tweaking the app’s text-to-speech function. They also increased the contrast, which helps users see different sections more clearly.`
+`Tom has been testing these improvements using popular screen readers, while Sophie has been focusing on tweaking the app's text-to-speech function. They also increased the contrast, which helps users see different sections more clearly.`
 
 `Sophie still wonders, “Have we done enough to make our app accessible?” They plan to conduct some surveys and add features like adjustable colors and keyboard shortcuts to make the app even more user-friendly.`
 
-What was Tom’s main role in improving screen reader compatibility?
+What was Tom's main role in improving screen reader compatibility?
 
 ## --answers--
 
@@ -31,11 +31,11 @@ He tested the new features to make sure they worked well.
 
 ---
 
-He designed the app’s new color scheme.
+He designed the app's new color scheme.
 
 ### --feedback--
 
-Tom’s focus was on testing the screen reader features, not designing the color scheme.
+Tom's focus was on testing the screen reader features, not designing the color scheme.
 
 ---
 
@@ -43,7 +43,7 @@ He translated the app into different languages.
 
 ### --feedback--
 
-Translating the app was not part of Tom’s role in this context.
+Translating the app was not part of Tom's role in this context.
 
 ---
 
@@ -51,7 +51,7 @@ He added more images to the app.
 
 ### --feedback--
 
-Tom’s main task was to test screen reader compatibility, not to add images.
+Tom's main task was to test screen reader compatibility, not to add images.
 
 ## --video-solution--
 
@@ -59,7 +59,7 @@ Tom’s main task was to test screen reader compatibility, not to add images.
 
 # --explanation--
 
-To find the correct answer, pay attention to the section that explains Tom’s main role in improving the app.
+To find the correct answer, pay attention to the section that explains Tom's main role in improving the app.
 
 The paragraph states that Tom `has been testing these improvements` to ensure they were effective for screen reader users, which shows his focus on checking the compatibility of these updates.
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671b77cf9ef25a416449b109.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671b77cf9ef25a416449b109.md
@@ -19,7 +19,7 @@ Read the text and answer the question below.
 
 `Recently, they added special labels to buttons, menus, and forms, so screen readers can understand these parts better. They also improved the way headings, lists, and tables are organized, making the layouts easier for users to move through the app.`
 
-`Tom has been testing these improvements using popular screen readers, while Sophie has been focusing on tweaking the app’s text-to-speech function. They also increased the contrast, which helps users see different sections more clearly.`
+`Tom has been testing these improvements using popular screen readers, while Sophie has been focusing on tweaking the app's text-to-speech function. They also increased the contrast, which helps users see different sections more clearly.`
 
 `Sophie still wonders, “Have we done enough to make our app accessible?” They plan to conduct some surveys and add features like adjustable colors and keyboard shortcuts to make the app even more user-friendly.`
 
@@ -35,11 +35,11 @@ Adding colorful icons is not related to spoken content or screen reader compatib
 
 ---
 
-She worked on making the app’s speech output clearer.
+She worked on making the app's speech output clearer.
 
 ---
 
-She changed the app’s loading speed.
+She changed the app's loading speed.
 
 ### --feedback--
 
@@ -47,7 +47,7 @@ Changing the loading speed is not related to improving spoken content.
 
 ---
 
-She redesigned the app’s interface layout.
+She redesigned the app's interface layout.
 
 ### --feedback--
 
@@ -59,8 +59,8 @@ Sophie's work specifically aimed to improve how users hear and understand the sp
 
 # --explanation--
 
-Focus on the part that describes Sophie’s efforts to enhance screen reader compatibility.
+Focus on the part that describes Sophie's efforts to enhance screen reader compatibility.
 
-The paragraph mentions that her focus is `tweaking the app’s text-to-speech function` to help users better understand spoken content from the app.
+The paragraph mentions that her focus is `tweaking the app's text-to-speech function` to help users better understand spoken content from the app.
 
-Look for an option that aligns with Sophie’s specific task of enhancing the app’s text-to-speech functionality.
+Look for an option that aligns with Sophie's specific task of enhancing the app's text-to-speech functionality.

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671b77cf9ef25a416449b109.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671b77cf9ef25a416449b109.md
@@ -21,7 +21,7 @@ Read the text and answer the question below.
 
 `Tom has been testing these improvements using popular screen readers, while Sophie has been focusing on tweaking the app's text-to-speech function. They also increased the contrast, which helps users see different sections more clearly.`
 
-`Sophie still wonders, “Have we done enough to make our app accessible?” They plan to conduct some surveys and add features like adjustable colors and keyboard shortcuts to make the app even more user-friendly.`
+`Sophie still wonders, "Have we done enough to make our app accessible?" They plan to conduct some surveys and add features like adjustable colors and keyboard shortcuts to make the app even more user-friendly.`
 
 What specific improvement did Sophie make to help users understand spoken content better?
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671b7c10cd0d274552e7b686.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671b7c10cd0d274552e7b686.md
@@ -19,11 +19,11 @@ Read the text and answer the question below.
 
 `Recently, they added special labels to buttons, menus, and forms, so screen readers can understand these parts better. They also improved the way headings, lists, and tables are organized, making the layouts easier for users to move through the app.`
 
-`Tom has been testing these improvements using popular screen readers, while Sophie has been focusing on tweaking the app’s text-to-speech function. They also increased the contrast, which helps users see different sections more clearly.`
+`Tom has been testing these improvements using popular screen readers, while Sophie has been focusing on tweaking the app's text-to-speech function. They also increased the contrast, which helps users see different sections more clearly.`
 
 `Sophie still wonders, “Have we done enough to make our app accessible?” They plan to conduct some surveys and add features like adjustable colors and keyboard shortcuts to make the app even more user-friendly.`
 
-What is Sophie concerned about regarding the app’s accessibility?
+What is Sophie concerned about regarding the app's accessibility?
 
 ## --answers--
 
@@ -31,15 +31,15 @@ Whether users like the new color scheme.
 
 ### --feedback--
 
-Sophie’s concern is about making the app accessible overall, not about color preferences.
+Sophie's concern is about making the app accessible overall, not about color preferences.
 
 ---
 
-Whether the app’s speed has improved enough.
+Whether the app's speed has improved enough.
 
 ### --feedback--
 
-Sophie’s focus is on making the app more accessible, not its speed.
+Sophie's focus is on making the app more accessible, not its speed.
 
 ---
 
@@ -47,7 +47,7 @@ Whether they have enough user surveys completed.
 
 ### --feedback--
 
-Sophie’s concern is not about the number of surveys but about the app's overall accessibility.
+Sophie's concern is not about the number of surveys but about the app's overall accessibility.
 
 ---
 
@@ -59,8 +59,8 @@ Whether they have done enough to make the app accessible.
 
 # --explanation--
 
-To find the correct answer, focus on Sophie’s concern mentioned in the paragraph.
+To find the correct answer, focus on Sophie's concern mentioned in the paragraph.
 
 The paragraph states that Sophie wonders, `Have we done enough to make our app accessible?` This indicates her focus on overall accessibility improvements.
 
-Look for an option that reflects Sophie’s concern about making the app accessible for users.
+Look for an option that reflects Sophie's concern about making the app accessible for users.

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671b7c10cd0d274552e7b686.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671b7c10cd0d274552e7b686.md
@@ -21,7 +21,7 @@ Read the text and answer the question below.
 
 `Tom has been testing these improvements using popular screen readers, while Sophie has been focusing on tweaking the app's text-to-speech function. They also increased the contrast, which helps users see different sections more clearly.`
 
-`Sophie still wonders, “Have we done enough to make our app accessible?” They plan to conduct some surveys and add features like adjustable colors and keyboard shortcuts to make the app even more user-friendly.`
+`Sophie still wonders, "Have we done enough to make our app accessible?" They plan to conduct some surveys and add features like adjustable colors and keyboard shortcuts to make the app even more user-friendly.`
 
 What is Sophie concerned about regarding the app's accessibility?
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671b7dd730712747aa2d9974.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671b7dd730712747aa2d9974.md
@@ -21,7 +21,7 @@ Read the text and answer the question below.
 
 `Tom has been testing these improvements using popular screen readers, while Sophie has been focusing on tweaking the app's text-to-speech function. They also increased the contrast, which helps users see different sections more clearly.`
 
-`Sophie still wonders, “Have we done enough to make our app accessible?” They plan to conduct some surveys and add features like adjustable colors and keyboard shortcuts to make the app even more user-friendly.`
+`Sophie still wonders, "Have we done enough to make our app accessible?" They plan to conduct some surveys and add features like adjustable colors and keyboard shortcuts to make the app even more user-friendly.`
 
 What might be Tom and Sophie's next step to improve accessibility?
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671b7dd730712747aa2d9974.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671b7dd730712747aa2d9974.md
@@ -19,11 +19,11 @@ Read the text and answer the question below.
 
 `Recently, they added special labels to buttons, menus, and forms, so screen readers can understand these parts better. They also improved the way headings, lists, and tables are organized, making the layouts easier for users to move through the app.`
 
-`Tom has been testing these improvements using popular screen readers, while Sophie has been focusing on tweaking the app’s text-to-speech function. They also increased the contrast, which helps users see different sections more clearly.`
+`Tom has been testing these improvements using popular screen readers, while Sophie has been focusing on tweaking the app's text-to-speech function. They also increased the contrast, which helps users see different sections more clearly.`
 
 `Sophie still wonders, “Have we done enough to make our app accessible?” They plan to conduct some surveys and add features like adjustable colors and keyboard shortcuts to make the app even more user-friendly.`
 
-What might be Tom and Sophie’s next step to improve accessibility?
+What might be Tom and Sophie's next step to improve accessibility?
 
 ## --answers--
 
@@ -39,7 +39,7 @@ Introducing features like adjustable colors and keyboard shortcuts.
 
 ---
 
-Increasing the app’s speed for faster navigation.
+Increasing the app's speed for faster navigation.
 
 ### --feedback--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671f46b8a64a336294268cf6.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671f46b8a64a336294268cf6.md
@@ -49,4 +49,4 @@ This sentence is in the `Present Simple` tense, not the `Present Perfect continu
 
 # --explanation--
 
-The negative form of the `Present Perfect continuous` tense tense is created with `hasn't/haven't + been + present participle`. It describes an ongoing action that started in the past and continues or remains relevant but hasn’t occurred as expected. 
+The negative form of the `Present Perfect continuous` tense tense is created with `hasn't/haven't + been + present participle`. It describes an ongoing action that started in the past and continues or remains relevant but hasn't occurred as expected. 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671f4766b90543639b60a79d.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671f4766b90543639b60a79d.md
@@ -49,7 +49,7 @@ This is the `Present Simple` tense.
 
 # --explanation--
 
-The `Present Perfect Continuous` tense negative form is formed with `hasn't/haven't + been + present participle`, indicating an ongoing action that hasn’t occurred as expected over time. For example:
+The `Present Perfect Continuous` tense negative form is formed with `hasn't/haven't + been + present participle`, indicating an ongoing action that hasn't occurred as expected over time. For example:
 
 `He hasn't been exercising regularly.` - This means his exercise routine has been irregular.
   

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671f47b9343cd364309aa802.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671f47b9343cd364309aa802.md
@@ -49,7 +49,7 @@ This is in the `Present Simple` tense, not related to ongoing or completed actio
 
 # --explanation--
 
-`Present Perfect Continuous` tense negative form emphasizes an ongoing action that has lacked consistency over time, while the `Present Perfect` tense negative form indicates that an action hasn’t occurred at all up to now.
+`Present Perfect Continuous` tense negative form emphasizes an ongoing action that has lacked consistency over time, while the `Present Perfect` tense negative form indicates that an action hasn't occurred at all up to now.
 
 `Past Continuous` tense negative form deals with an action that was not happening at a specific past moment, focusing solely on the past.
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671f4c29b6c10a677571c3e9.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671f4c29b6c10a677571c3e9.md
@@ -45,7 +45,7 @@ This word refers to the ease of use for all users, including those with disabili
 
 `Misaligned` means not lined up or positioned correctly. For example:
 
-`The images were misaligned in the presentation, making it look messy.` - This indicates that the images were not positioned properly, affecting the presentation’s clarity.
+`The images were misaligned in the presentation, making it look messy.` - This indicates that the images were not positioned properly, affecting the presentation's clarity.
 
 `Out of sync` describes when two or more elements are not coordinated in time or movement. For example:
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671f8ab3f5add66eb16be177.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671f8ab3f5add66eb16be177.md
@@ -5,7 +5,7 @@ challengeType: 22
 dashedName: task-43
 ---
 
-<!-- (Audio) Alice: Exactly. Do you know if it’s been affecting all the videos or just a few? -->
+<!-- (Audio) Alice: Exactly. Do you know if it's been affecting all the videos or just a few? -->
 
 # --instructions--
 
@@ -15,7 +15,7 @@ Listen to the audio and complete the sentence below.
 
 ## --sentence--
 
-`BLANK. Do you know if it’s been BLANK all the videos or just a few?`
+`BLANK. Do you know if it's been BLANK all the videos or just a few?`
 
 ## --blanks--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671f8cdb0d31cb710d7ad031.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671f8cdb0d31cb710d7ad031.md
@@ -5,7 +5,7 @@ challengeType: 19
 dashedName: task-44
 ---
 
-<!-- (Audio) Alice: Exactly. Do you know if it’s been affecting all the videos or just a few? -->
+<!-- (Audio) Alice: Exactly. Do you know if it's been affecting all the videos or just a few? -->
 
 <!-- SPEAKING -->
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671f8e2ca90546729b1911fa.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671f8e2ca90546729b1911fa.md
@@ -5,7 +5,7 @@ challengeType: 22
 dashedName: task-45
 ---
 
-<!-- (Audio) James: It seems to be affecting several videos. Our quality assurance team has been testing the platform, and noticed that the captions aren’t syncing properly. -->
+<!-- (Audio) James: It seems to be affecting several videos. Our quality assurance team has been testing the platform, and noticed that the captions aren't syncing properly. -->
 
 # --instructions--
 
@@ -15,7 +15,7 @@ Listen to the audio and complete the sentence below.
 
 ## --sentence--
 
-`It seems to be affecting several videos. Our BLANK team has been BLANK the platform, and noticed that the captions aren’t BLANK properly.`
+`It seems to be affecting several videos. Our BLANK team has been BLANK the platform, and noticed that the captions aren't BLANK properly.`
 
 ## --blanks--
 
@@ -45,7 +45,7 @@ This word in `-ing` form refers to the process of making things happen at the sa
 
 `Quality assurance` is the process of ensuring that a product meets set quality standards. For example:
 
-`The quality assurance team checks the software for bugs before release.` - Here, `quality assurance` emphasizes the team’s role in maintaining the product's standard.
+`The quality assurance team checks the software for bugs before release.` - Here, `quality assurance` emphasizes the team's role in maintaining the product's standard.
 
 `Testing` means evaluating or examining a product to verify its performance. For example:
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671f92684454b37660c3f82a.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671f92684454b37660c3f82a.md
@@ -5,7 +5,7 @@ challengeType: 19
 dashedName: task-46
 ---
 
-<!-- (Audio) James: It seems to be affecting several videos. Our quality assurance team has been testing the platform, and noticed that the captions aren’t syncing properly. -->
+<!-- (Audio) James: It seems to be affecting several videos. Our quality assurance team has been testing the platform, and noticed that the captions aren't syncing properly. -->
 
 # --instructions--
 
@@ -15,7 +15,7 @@ Listen to the audio and answer the question below.
 
 ## --text--
 
-Why is it a problem that `the captions aren’t syncing properly`?
+Why is it a problem that `the captions aren't syncing properly`?
 
 ## --answers--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671f9ca66765d781de7213f3.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671f9ca66765d781de7213f3.md
@@ -5,7 +5,7 @@ challengeType: 22
 dashedName: task-53
 ---
 
-<!-- (Audio) James: We're working on it. The development team hasn't found a definitive solution yet, but they’re narrowing down the possibilities. -->
+<!-- (Audio) James: We're working on it. The development team hasn't found a definitive solution yet, but they're narrowing down the possibilities. -->
 
 # --instructions--
 
@@ -15,7 +15,7 @@ Listen to the audio and complete the sentence below.
 
 ## --sentence--
 
-`We're working on it. The BLANK hasn't found a definitive BLANK yet, but they’re BLANK the possibilities.`
+`We're working on it. The BLANK hasn't found a definitive BLANK yet, but they're BLANK the possibilities.`
 
 ## --blanks--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671f9e83b440da8486fdf76e.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671f9e83b440da8486fdf76e.md
@@ -5,7 +5,7 @@ challengeType: 19
 dashedName: task-54
 ---
 
-<!-- (Audio) James: We're working on it. The development team hasn't found a definitive solution yet, but they’re narrowing down the possibilities. -->
+<!-- (Audio) James: We're working on it. The development team hasn't found a definitive solution yet, but they're narrowing down the possibilities. -->
 
 # --instructions--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/6720cf38beae8c4f1d7af1c0.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/6720cf38beae8c4f1d7af1c0.md
@@ -23,9 +23,9 @@ Place the following phrases in the correct spot: `rendering consistently`, `clos
 
 `James: Yes. For some reason, It hasn't been BLANK for some users. The captions are misaligned and BLANK, which isn't good for accessibility.`
 
-`Alice: Exactly. Do you know if it’s been affecting all the videos or just a few?`
+`Alice: Exactly. Do you know if it's been affecting all the videos or just a few?`
 
-`James: It seems to be affecting several videos. Our quality assurance team has been testing the platform, and noticed that the captions aren’t syncing properly.`
+`James: It seems to be affecting several videos. Our quality assurance team has been testing the platform, and noticed that the captions aren't syncing properly.`
 
 `Alice: BLANK. Have they found out why it's happening?`
 
@@ -33,7 +33,7 @@ Place the following phrases in the correct spot: `rendering consistently`, `clos
 
 `Alice: Is there a plan to fix it?`
 
-`James: We're working on it. The development team hasn't found a BLANK yet, but they’re narrowing down the possibilities.`
+`James: We're working on it. The development team hasn't found a BLANK yet, but they're narrowing down the possibilities.`
 
 ## --blanks--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/6720e69c2152da7b9dad577e.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/6720e69c2152da7b9dad577e.md
@@ -23,9 +23,9 @@ After their conversation, James wrote an email to Alice to update her about what
 
 `The development team has been working hard to find the cause of the issues. We think some of the problems, like captions being misaligned or out of sync, are because the synchronization code is old. We are now updating the code and testing it on different devices to make sure the captions work better everywhere.`
 
-`We haven’t found a final solution yet, but we are seeing some improvements. The captions are showing up better on most devices, but we still need to do more testing to make sure it works well on all of them. We also plan to add a system that will catch any new errors quickly.`
+`We haven't found a final solution yet, but we are seeing some improvements. The captions are showing up better on most devices, but we still need to do more testing to make sure it works well on all of them. We also plan to add a system that will catch any new errors quickly.`
 
-`I’ll keep you updated as we make more progress. If you have any questions or ideas, please let me know.`
+`I'll keep you updated as we make more progress. If you have any questions or ideas, please let me know.`
 
 `Best,`
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/6720f18957013d8de8ebbe91.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/6720f18957013d8de8ebbe91.md
@@ -23,9 +23,9 @@ After their conversation, James wrote an email to Alice to update her about what
 
 `The development team has been working hard to find the cause of the issues. We think some of the problems, like captions being misaligned or out of sync, are because the synchronization code is old. We are now updating the code and testing it on different devices to make sure the captions work better everywhere.`
 
-`We haven’t found a final solution yet, but we are seeing some improvements. The captions are showing up better on most devices, but we still need to do more testing to make sure it works well on all of them. We also plan to add a system that will catch any new errors quickly.`
+`We haven't found a final solution yet, but we are seeing some improvements. The captions are showing up better on most devices, but we still need to do more testing to make sure it works well on all of them. We also plan to add a system that will catch any new errors quickly.`
 
-`I’ll keep you updated as we make more progress. If you have any questions or ideas, please let me know.`
+`I'll keep you updated as we make more progress. If you have any questions or ideas, please let me know.`
 
 `Best,`
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/6720f2d525d22693e3fe2a99.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/6720f2d525d22693e3fe2a99.md
@@ -23,9 +23,9 @@ After their conversation, James wrote an email to Alice to update her about what
 
 `The development team has been working hard to find the cause of the issues. We think some of the problems, like captions being misaligned or out of sync, are because the synchronization code is old. We are now updating the code and testing it on different devices to make sure the captions work better everywhere.`
 
-`We haven’t found a final solution yet, but we are seeing some improvements. The captions are showing up better on most devices, but we still need to do more testing to make sure it works well on all of them. We also plan to add a system that will catch any new errors quickly.`
+`We haven't found a final solution yet, but we are seeing some improvements. The captions are showing up better on most devices, but we still need to do more testing to make sure it works well on all of them. We also plan to add a system that will catch any new errors quickly.`
 
-`I’ll keep you updated as we make more progress. If you have any questions or ideas, please let me know.`
+`I'll keep you updated as we make more progress. If you have any questions or ideas, please let me know.`
 
 `Best,`
  
@@ -39,7 +39,7 @@ The problem is fully solved now.
 
 ### --feedback--
 
-James clearly states that they haven’t found a final solution yet, so this is incorrect.
+James clearly states that they haven't found a final solution yet, so this is incorrect.
 
 ---
 
@@ -67,6 +67,6 @@ James does not provide a specific timeline for when the solution will be ready.
 
 # --explanation--
 
-To identify the correct answer, focus on where James says `We haven’t found a final solution yet`. This indicates that the issue is still unresolved.
+To identify the correct answer, focus on where James says `We haven't found a final solution yet`. This indicates that the issue is still unresolved.
 
 Look for the option that emphasizes this ongoing problem, which matches James's update.

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/6720f45529e496998cced6b6.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/6720f45529e496998cced6b6.md
@@ -23,9 +23,9 @@ After their conversation, James wrote an email to Alice to update her about what
 
 `The development team has been working hard to find the cause of the issues. We think some of the problems, like captions being misaligned or out of sync, are because the synchronization code is old. We are now updating the code and testing it on different devices to make sure the captions work better everywhere.`
 
-`We haven’t found a final solution yet, but we are seeing some improvements. The captions are showing up better on most devices, but we still need to do more testing to make sure it works well on all of them. We also plan to add a system that will catch any new errors quickly.`
+`We haven't found a final solution yet, but we are seeing some improvements. The captions are showing up better on most devices, but we still need to do more testing to make sure it works well on all of them. We also plan to add a system that will catch any new errors quickly.`
 
-`I’ll keep you updated as we make more progress. If you have any questions or ideas, please let me know.`
+`I'll keep you updated as we make more progress. If you have any questions or ideas, please let me know.`
 
 `Best,`
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/6720f45ff33dd69a10d14e9d.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/6720f45ff33dd69a10d14e9d.md
@@ -23,9 +23,9 @@ After their conversation, James wrote an email to Alice to update her about what
 
 `The development team has been working hard to find the cause of the issues. We think some of the problems, like captions being misaligned or out of sync, are because the synchronization code is old. We are now updating the code and testing it on different devices to make sure the captions work better everywhere.`
 
-`We haven’t found a final solution yet, but we are seeing some improvements. The captions are showing up better on most devices, but we still need to do more testing to make sure it works well on all of them. We also plan to add a system that will catch any new errors quickly.`
+`We haven't found a final solution yet, but we are seeing some improvements. The captions are showing up better on most devices, but we still need to do more testing to make sure it works well on all of them. We also plan to add a system that will catch any new errors quickly.`
 
-`I’ll keep you updated as we make more progress. If you have any questions or ideas, please let me know.`
+`I'll keep you updated as we make more progress. If you have any questions or ideas, please let me know.`
 
 `Best,`
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672830d9aa2e0c2ff2fad7f8.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672830d9aa2e0c2ff2fad7f8.md
@@ -5,7 +5,7 @@ challengeType: 22
 dashedName: task-63
 ---
 
-<!-- (audio) Linda: Yes, I’ve been testing them since the latest software update. -->
+<!-- (audio) Linda: Yes, I've been testing them since the latest software update. -->
 
 # --instructions--
 
@@ -15,7 +15,7 @@ Listen to the audio and complete the sentence below.
 
 ## --sentence--
 
-`Yes, I’ve been testing them BLANK the latest BLANK.`
+`Yes, I've been testing them BLANK the latest BLANK.`
 
 ## --blanks--
 
@@ -37,7 +37,7 @@ These two words together refer to a version of software that has been improved o
 
 In the `Present Perfect Continuous` tense, `since` is used to indicate when an action began and continues up to the present. For example:
 
-`I’ve been learning JavaScript since 2020.` - It shows that the action of learning JavaScript started in 2020 and is still ongoing.
+`I've been learning JavaScript since 2020.` - It shows that the action of learning JavaScript started in 2020 and is still ongoing.
 
 The term `software update` refers to changes or improvements made to a computer program. For example:
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672836d6ec0ae23f4724ccb1.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672836d6ec0ae23f4724ccb1.md
@@ -5,7 +5,7 @@ challengeType: 19
 dashedName: task-65
 ---
 
-<!-- (audio) Linda: Yes, I’ve been testing them since the latest software update. -->
+<!-- (audio) Linda: Yes, I've been testing them since the latest software update. -->
 
 # --instructions--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/6728378c94eaf541fce8f334.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/6728378c94eaf541fce8f334.md
@@ -5,7 +5,7 @@ challengeType: 22
 dashedName: task-66
 ---
 
-<!-- (audio) Linda: We’ve had some positive feedback, but there are still a few bugs to fix. -->
+<!-- (audio) Linda: We've had some positive feedback, but there are still a few bugs to fix. -->
 
 # --instructions--
 
@@ -15,7 +15,7 @@ Listen to the audio and complete the sentence below.
 
 ## --sentence--
 
-`We’ve had some positive BLANK, but there are still a few BLANK to fix.`
+`We've had some positive BLANK, but there are still a few BLANK to fix.`
 
 ## --blanks--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/67289c4908f407948ef08a55.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/67289c4908f407948ef08a55.md
@@ -5,7 +5,7 @@ challengeType: 19
 dashedName: task-67
 ---
 
-<!-- (audio) Linda: We’ve had some positive feedback, but there are still a few bugs to fix. -->
+<!-- (audio) Linda: We've had some positive feedback, but there are still a few bugs to fix. -->
 
 # --instructions--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/6728c369d38d3ea6634c1649.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/6728c369d38d3ea6634c1649.md
@@ -5,7 +5,7 @@ challengeType: 22
 dashedName: task-73
 ---
 
-<!-- (audio) Linda: I’ve been trying to cover all scenarios to ensure that the commands work consistently. -->
+<!-- (audio) Linda: I've been trying to cover all scenarios to ensure that the commands work consistently. -->
 
 # --instructions--
 
@@ -15,7 +15,7 @@ Listen to the audio and complete the sentence below.
 
 ## --sentence--
 
-`I’ve been trying to cover all BLANK to ensure that the commands work BLANK.`
+`I've been trying to cover all BLANK to ensure that the commands work BLANK.`
 
 ## --blanks--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/6728c6fad8d9caa92837c75f.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/6728c6fad8d9caa92837c75f.md
@@ -5,7 +5,7 @@ challengeType: 19
 dashedName: task-74
 ---
 
-<!-- (audio) Linda: For the past couple of weeks. I’ve been trying to cover all scenarios to ensure that the commands work consistently. -->
+<!-- (audio) Linda: For the past couple of weeks. I've been trying to cover all scenarios to ensure that the commands work consistently. -->
 
 # --instructions--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672a1c6ca33f8115728e7f79.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672a1c6ca33f8115728e7f79.md
@@ -35,7 +35,7 @@ If the device has been working properly.
 
 ### --feedback--
 
-Bob is asking about potential issues related to voice recognition, not the device’s general performance.
+Bob is asking about potential issues related to voice recognition, not the device's general performance.
 
 ---
 
@@ -43,7 +43,7 @@ If there is a new update for the voice recognition system.
 
 ### --feedback--
 
-Bob’s question is about problems with voice recognition, not about updates.
+Bob's question is about problems with voice recognition, not about updates.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672a1e2fbec6a61bf477ea49.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672a1e2fbec6a61bf477ea49.md
@@ -49,7 +49,7 @@ It refers to how correct or precise something is. In this case, it means how wel
 
 `Background noise` refers to unwanted sounds that can interfere with hearing something clearly. For example:
   
-- `The microphone couldn’t pick up my voice because of the background noise.` - In this sentence, `background noise` refers to sounds like music or traffic that made it difficult for the microphone to hear your voice clearly.
+- `The microphone couldn't pick up my voice because of the background noise.` - In this sentence, `background noise` refers to sounds like music or traffic that made it difficult for the microphone to hear your voice clearly.
 
 `Accuracy` refers to how precise or correct something is. In the case of `voice recognition`, it means how well the system can understand and process speech without errors. For example:
   

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672a21a4b40ed3279d513888.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672a21a4b40ed3279d513888.md
@@ -15,11 +15,11 @@ Listen to the audio and answer the question below.
 
 ## --text--
 
-What might Linda be suggesting about the system’s current performance?
+What might Linda be suggesting about the system's current performance?
 
 ## --answers--
 
-It’s working perfectly fine with all accents and environments.
+It's working perfectly fine with all accents and environments.
 
 ### --feedback--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672a296a309d9c46658c071a.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672a296a309d9c46658c071a.md
@@ -5,7 +5,7 @@ challengeType: 19
 dashedName: task-85
 ---
 
-<!-- (audio) Linda: Not entirely. It’s had issues connecting with our older devices, but we’re working on it. The development team has been brainstorming solutions. -->
+<!-- (audio) Linda: Not entirely. It's had issues connecting with our older devices, but we're working on it. The development team has been brainstorming solutions. -->
 
 # --instructions--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672afc3d3758e25087697611.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672afc3d3758e25087697611.md
@@ -5,7 +5,7 @@ challengeType: 19
 dashedName: task-86
 ---
 
-<!-- (audio) Linda: Not entirely. It’s had issues connecting with our older devices, but we’re working on it. The development team has been brainstorming solutions. -->
+<!-- (audio) Linda: Not entirely. It's had issues connecting with our older devices, but we're working on it. The development team has been brainstorming solutions. -->
 
 # --instructions--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672afe3809d2a55224868ea5.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672afe3809d2a55224868ea5.md
@@ -31,7 +31,7 @@ He thinks the project is fully complete and ready for launch.
 
 ### --feedback--
 
-Bob’s question about testing with real users suggests he sees the project as ongoing, not fully complete.
+Bob's question about testing with real users suggests he sees the project as ongoing, not fully complete.
 
 ---
 
@@ -39,7 +39,7 @@ He believes the team needs to stop working and start a new project.
 
 ### --feedback--
 
-Bob’s comment suggests he thinks the project is progressing well, not that it should be stopped.
+Bob's comment suggests he thinks the project is progressing well, not that it should be stopped.
 
 ---
 
@@ -51,7 +51,7 @@ He thinks the project has made good initial progress but needs further testing.
 
 # --explanation--
 
-Bob’s comment `That's a good start` shows that he is pleased with the progress so far. However, his follow-up question about testing with real users suggests he thinks more steps are needed before the project is complete. This indicates that he feels positive about the current status but sees the need for further validation and testing.
+Bob's comment `That's a good start` shows that he is pleased with the progress so far. However, his follow-up question about testing with real users suggests he thinks more steps are needed before the project is complete. This indicates that he feels positive about the current status but sees the need for further validation and testing.
 
 # --scene--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672b25e2a59e2956bca1a42f.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672b25e2a59e2956bca1a42f.md
@@ -19,7 +19,7 @@ What does Linda mean when she says `it would be helpful`?
 
 ## --answers--
 
-She thinks they don’t need any more feedback.
+She thinks they don't need any more feedback.
 
 ### --feedback--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672b33b15bd8bf5b2523772a.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672b33b15bd8bf5b2523772a.md
@@ -21,11 +21,11 @@ Place the following phrases in the correct spot: `software update`, `real-world 
 
 `Bob: Hi Linda, have you been working on the new BLANK features?`
 
-`Linda: Yes, I’ve been testing them since the latest BLANK. We’ve had some positive feedback, but there are still a few bugs to fix.`
+`Linda: Yes, I've been testing them since the latest BLANK. We've had some positive feedback, but there are still a few bugs to fix.`
 
 `Bob: How long have you been focusing on this evaluation?`
 
-`Linda: For the past couple of weeks. I’ve been trying to cover BLANK to ensure that the commands work consistently.`
+`Linda: For the past couple of weeks. I've been trying to cover BLANK to ensure that the commands work consistently.`
 
 `Bob: Have you had any problems with voice recognition?`
 
@@ -33,7 +33,7 @@ Place the following phrases in the correct spot: `software update`, `real-world 
 
 `Bob: What about the integration with other systems? Has it been seamless?`
 
-`Linda: Not entirely. It’s had issues connecting with our older devices, but we’re working on it. The development team has been BLANK.`
+`Linda: Not entirely. It's had issues connecting with our older devices, but we're working on it. The development team has been BLANK.`
 
 `Bob: That's a good start. By the way, have we tested it with real users yet?`
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672b42dafa37fe61e80a2b40.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672b42dafa37fe61e80a2b40.md
@@ -19,7 +19,7 @@ Read the text and answer the question below.
 
 `One challenge is making sure the system understands different accents. The team has been testing the system with users from different regions, but there are still some problems with background noise. `
 
-`For example, the system sometimes has trouble understanding voices in noisy rooms, like kitchens or living rooms with TVs or radios on. To fix this, they are improving the system’s ability to filter out noise and better recognize commands.`
+`For example, the system sometimes has trouble understanding voices in noisy rooms, like kitchens or living rooms with TVs or radios on. To fix this, they are improving the system's ability to filter out noise and better recognize commands.`
 
 `Before launching the system, the team plans to gather real-world feedback from users to see how well it works in different home settings. This feedback will help them make the system more accurate and ready for everyone to use.`
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672b4539b9ab5d645e7dcfb8.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672b4539b9ab5d645e7dcfb8.md
@@ -19,7 +19,7 @@ Read the text and answer the question below.
 
 `One challenge is making sure the system understands different accents. The team has been testing the system with users from different regions, but there are still some problems with background noise.`
 
-`For example, the system sometimes has trouble understanding voices in noisy rooms, like kitchens or living rooms with TVs or radios on. To fix this, they are improving the system’s ability to filter out noise and better recognize commands.`
+`For example, the system sometimes has trouble understanding voices in noisy rooms, like kitchens or living rooms with TVs or radios on. To fix this, they are improving the system's ability to filter out noise and better recognize commands.`
 
 `Before launching the system, the team plans to gather real-world feedback from users to see how well it works in different home settings. This feedback will help them make the system more accurate and ready for everyone to use.`
 
@@ -51,7 +51,7 @@ Reducing the size of the devices.
 
 ### --feedback--
 
-The paragraph doesn’t mention device size as a challenge.
+The paragraph doesn't mention device size as a challenge.
 
 ## --video-solution--
 
@@ -63,4 +63,4 @@ To find the correct answer, focus on the part where Linda explains the challenge
 
 The paragraph highlights that the team is facing difficulties with background noise and accents, which makes it challenging for the system to accurately recognize commands in noisy environments. 
 
-Look for an option that addresses the issue of the system’s ability to handle accents and background noise.
+Look for an option that addresses the issue of the system's ability to handle accents and background noise.

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672b46def9325065dbc7b29f.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672b46def9325065dbc7b29f.md
@@ -19,7 +19,7 @@ Read the text and answer the question below.
 
 `One challenge is making sure the system understands different accents. The team has been testing the system with users from different regions, but there are still some problems with background noise.`
 
-`For example, the system sometimes has trouble understanding voices in noisy rooms, like kitchens or living rooms with TVs or radios on. To fix this, they are improving the system’s ability to filter out noise and better recognize commands.`
+`For example, the system sometimes has trouble understanding voices in noisy rooms, like kitchens or living rooms with TVs or radios on. To fix this, they are improving the system's ability to filter out noise and better recognize commands.`
 
 `Before launching the system, the team plans to gather real-world feedback from users to see how well it works in different home settings. This feedback will help them make the system more accurate and ready for everyone to use.`
 
@@ -35,7 +35,7 @@ Real-world feedback is meant to test the system in real home settings, not just 
 
 ---
 
-To improve the system’s visual design.
+To improve the system's visual design.
 
 ### --feedback--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672b4812ec997567058875da.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672b4812ec997567058875da.md
@@ -19,7 +19,7 @@ Read the text and answer the question below.
 
 `One challenge is making sure the system understands different accents. The team has been testing the system with users from different regions, but there are still some problems with background noise.`
 
-`For example, the system sometimes has trouble understanding voices in noisy rooms, like kitchens or living rooms with TVs or radios on. To fix this, they are improving the system’s ability to filter out noise and better recognize commands.`
+`For example, the system sometimes has trouble understanding voices in noisy rooms, like kitchens or living rooms with TVs or radios on. To fix this, they are improving the system's ability to filter out noise and better recognize commands.`
 
 `Before launching the system, the team plans to gather real-world feedback from users to see how well it works in different home settings. This feedback will help them make the system more accurate and ready for everyone to use.`
 
@@ -63,4 +63,4 @@ To find the correct answer, look at the part where Linda talks about what the te
 
 The paragraph mentions that the development team `has been brainstorming solutions` to fix the issues with voice recognition, which shows they are actively working on improving the system.
 
-Look for an option that describes the team’s approach to solving the problems they’ve encountered.
+Look for an option that describes the team's approach to solving the problems they've encountered.

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672b491aa3c094689007baf1.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672b491aa3c094689007baf1.md
@@ -19,7 +19,7 @@ Read the text and answer the question below.
 
 `One challenge is making sure the system understands different accents. The team has been testing the system with users from different regions, but there are still some problems with background noise.`
 
-`For example, the system sometimes has trouble understanding voices in noisy rooms, like kitchens or living rooms with TVs or radios on. To fix this, they are improving the system’s ability to filter out noise and better recognize commands.`
+`For example, the system sometimes has trouble understanding voices in noisy rooms, like kitchens or living rooms with TVs or radios on. To fix this, they are improving the system's ability to filter out noise and better recognize commands.`
 
 `Before launching the system, the team plans to gather real-world feedback from users to see how well it works in different home settings. This feedback will help them make the system more accurate and ready for everyone to use.`
 
@@ -31,7 +31,7 @@ They will immediately launch the system to all users.
 
 ### --feedback--
 
-The team is still testing and improving the system before it’s ready for a wider launch.
+The team is still testing and improving the system before it's ready for a wider launch.
 
 ---
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672cca3d15975a9390545877.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672cca3d15975a9390545877.md
@@ -51,7 +51,7 @@ Anna's question does not ask if James needs help; it focuses on whether he has r
 
 # --explanation--
 
-Anna’s question is specifically about whether James has reviewed the feedback from a training program related to accessibility.
+Anna's question is specifically about whether James has reviewed the feedback from a training program related to accessibility.
 
 # --scene--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672ccc988693199500b4cdfd.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672ccc988693199500b4cdfd.md
@@ -5,7 +5,7 @@ challengeType: 19
 dashedName: task-100
 ---
 
-<!-- (Audio) James: Yes, I’ve been working on it since the last training session. -->
+<!-- (Audio) James: Yes, I've been working on it since the last training session. -->
 
 # --instructions--
 
@@ -35,7 +35,7 @@ By saying he finished working soon after the last session.
 
 ### --feedback--
 
-James’s statement indicates ongoing work, not that he finished shortly after starting.
+James's statement indicates ongoing work, not that he finished shortly after starting.
 
 ---
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672dc928d8765dc9f923ca71.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672dc928d8765dc9f923ca71.md
@@ -51,7 +51,7 @@ A `gradual process` refers to something that develops slowly, over time, rather 
 
 `The team has made steady progress in completing the project.` - This shows that the team is moving forward regularly and effectively, without major delays.
 
-`Understanding` refers to a person’s knowledge or awareness about a subject. For example:
+`Understanding` refers to a person's knowledge or awareness about a subject. For example:
 
 `Her understanding of coding improved with practice.` - It highlights how her knowledge of coding grew as she spent more time practicing.
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672de8ad97d683d3734ce5cd.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672de8ad97d683d3734ce5cd.md
@@ -23,7 +23,7 @@ He is frustrated that progress has been slow.
 
 ### --feedback--
 
-James doesn’t express frustration; he acknowledges the gradual nature of the process positively.
+James doesn't express frustration; he acknowledges the gradual nature of the process positively.
 
 ---
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672debc75e32a8d6e2593eac.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672debc75e32a8d6e2593eac.md
@@ -31,7 +31,7 @@ If there are too many tasks for the team to finish.
 
 ### --feedback--
 
-Anna’s question is about performance in some areas, not the number of tasks.
+Anna's question is about performance in some areas, not the number of tasks.
 
 ---
 
@@ -43,7 +43,7 @@ If people need more tools to do their work better.
 
 ### --feedback--
 
-Anna’s question is about finding areas of lower performance, not about needing more tools.
+Anna's question is about finding areas of lower performance, not about needing more tools.
 
 ## --video-solution--
 
@@ -51,7 +51,7 @@ Anna’s question is about finding areas of lower performance, not about needing
 
 # --explanation--
 
-Anna’s question is asking if there are any parts of the work where the team isn’t doing as well as they were expected to.
+Anna's question is asking if there are any parts of the work where the team isn't doing as well as they were expected to.
 
 # --scene--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672dec93f008b3d8169568e8.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672dec93f008b3d8169568e8.md
@@ -37,7 +37,7 @@ This answer points out areas needing improvement, which is not a positive respon
 
 # --explanation--
 
-A positive answer to Anna’s question would mean that everyone is performing as well as expected, and there is nothing that needs to be improved.
+A positive answer to Anna's question would mean that everyone is performing as well as expected, and there is nothing that needs to be improved.
 
 # --scene--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672e0ec28d829ee2b5e909f3.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672e0ec28d829ee2b5e909f3.md
@@ -35,7 +35,7 @@ He believes the activities were well-received by all participants.
 
 ### --feedback--
 
-James points out that the activities were not fully relevant, meaning they weren’t well-received by everyone.
+James points out that the activities were not fully relevant, meaning they weren't well-received by everyone.
 
 ---
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672e16bcc0d877e5d3eb7f4e.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672e16bcc0d877e5d3eb7f4e.md
@@ -23,7 +23,7 @@ Listen to the audio and complete the sentence below.
 
 ### --feedback--
 
-This word describes something that catches people’s interest and keeps them involved.
+This word describes something that catches people's interest and keeps them involved.
 
 # --explanation--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672e17e63be5dce6ff5b9189.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672e17e63be5dce6ff5b9189.md
@@ -43,7 +43,7 @@ If the activities already meet all the learning goals.
 
 ### --feedback--
 
-Anna’s question suggests she thinks the activities could be improved to be `more engaging`, so she isn’t assuming they already meet all goals.
+Anna's question suggests she thinks the activities could be improved to be `more engaging`, so she isn't assuming they already meet all goals.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672e1bb0774f2fea953e9388.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672e1bb0774f2fea953e9388.md
@@ -31,7 +31,7 @@ The team has been brainstorming ideas to make the sessions better.
 
 ---
 
-The team hasn’t yet considered any changes to the sessions.
+The team hasn't yet considered any changes to the sessions.
 
 ### --feedback--
 
@@ -43,7 +43,7 @@ The team feels the sessions are as interactive as they need to be.
 
 ### --feedback--
 
-James says they are working on making the sessions more interactive, so they don’t feel the sessions are finished.
+James says they are working on making the sessions more interactive, so they don't feel the sessions are finished.
 
 ## --video-solution--
 
@@ -51,7 +51,7 @@ James says they are working on making the sessions more interactive, so they don
 
 # --explanation--
 
-James uses the `Present Perfect Continuous` tense (`has been brainstorming`) to show that the team’s work on improving the sessions is ongoing. This tense expresses that they started brainstorming in the past and are still actively doing it now, indicating continuous effort in finding new ideas.
+James uses the `Present Perfect Continuous` tense (`has been brainstorming`) to show that the team's work on improving the sessions is ongoing. This tense expresses that they started brainstorming in the past and are still actively doing it now, indicating continuous effort in finding new ideas.
 
 # --scene--
 	

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672e1c3031816ceb9dccc66a.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672e1c3031816ceb9dccc66a.md
@@ -23,7 +23,7 @@ Add activities that focus on memorizing definitions.
 
 ### --feedback--
 
-Memorizing definitions doesn’t involve real-life application or hands-on practice, which James implies they are aiming for.
+Memorizing definitions doesn't involve real-life application or hands-on practice, which James implies they are aiming for.
 
 ---
 
@@ -31,7 +31,7 @@ Use theoretical case studies with no practical application.
 
 ### --feedback--
 
-Theoretical case studies alone don’t fully connect to real-life tasks, which James wants to include.
+Theoretical case studies alone don't fully connect to real-life tasks, which James wants to include.
 
 ---
 
@@ -39,7 +39,7 @@ Have participants discuss unrelated topics to build general communication skills
 
 ### --feedback--
 
-Unrelated discussions don’t meet the goal of incorporating relevant, real-life situations.
+Unrelated discussions don't meet the goal of incorporating relevant, real-life situations.
 
 ---
 
@@ -51,7 +51,7 @@ Create exercises that use realistic situations participants might encounter on t
 
 # --explanation--
 
-Since James mentions `incorporating more real-life scenarios`, they’re likely planning to add exercises that reflect situations participants could actually encounter in their roles. This makes the training more engaging and relevant, unlike focusing on definitions, unrelated discussions, or purely theoretical case studies.
+Since James mentions `incorporating more real-life scenarios`, they're likely planning to add exercises that reflect situations participants could actually encounter in their roles. This makes the training more engaging and relevant, unlike focusing on definitions, unrelated discussions, or purely theoretical case studies.
 
 # --scene--
 	

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672e1f1a51e86aed84df7c94.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672e1f1a51e86aed84df7c94.md
@@ -37,7 +37,7 @@ This word in the plural form refers to specific targets or objectives the team i
 
 `Keep in touch` means to stay in regular communication with someone. For example:
 
-`Let’s keep in touch about the project updates.` - This means staying connected and sharing information to make sure everyone is updated on the project's progress.
+`Let's keep in touch about the project updates.` - This means staying connected and sharing information to make sure everyone is updated on the project's progress.
 
 `Goals` are the specific targets or objectives a person or team wants to achieve. It the plural form of `goal`. For example:
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672e1fff03af3aeed5d7a84b.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672e1fff03af3aeed5d7a84b.md
@@ -31,7 +31,7 @@ She thinks James' ideas are confusing and suggests focusing only on accessibilit
 
 ### --feedback--
 
-Anna doesn’t find James’ ideas confusing; she agrees and wants to monitor progress on their shared goals.
+Anna doesn't find James' ideas confusing; she agrees and wants to monitor progress on their shared goals.
 
 ---
 
@@ -43,7 +43,7 @@ She thinks James' ideas are unnecessary and suggests stopping the project.
 
 ### --feedback--
 
-Anna doesn’t suggest stopping; she supports James’ ideas and wants to stay updated.
+Anna doesn't suggest stopping; she supports James' ideas and wants to stay updated.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672f4b05585d501f533789b4.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672f4b05585d501f533789b4.md
@@ -21,7 +21,7 @@ Place the following phrases in the correct spot: `gradual process` , `more engag
 
 `Anna: Hi James, have you been reviewing the BLANK for our accessibility program?`
 
-`James: Yes, I’ve been working on it since the last training session. We've received a lot of positive comments, but there are some areas we still need to improve.`
+`James: Yes, I've been working on it since the last training session. We've received a lot of positive comments, but there are some areas we still need to improve.`
 
 `Anna: That's great to hear. How long have we been running these sessions?`
 
@@ -43,7 +43,7 @@ Place the following phrases in the correct spot: `gradual process` , `more engag
 
 ### --feedback--
 
-This phrase refers to the feedback received from participants about the training sessions to see what worked well and what didn’t.
+This phrase refers to the feedback received from participants about the training sessions to see what worked well and what didn't.
 
 ---
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672f606201263928a06b2a04.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672f606201263928a06b2a04.md
@@ -19,7 +19,7 @@ Read the text and answer the question below.
 
 `The training will start by conducting an overview of essential accessibility concepts, such as color contrast, screen reader compatibility, and keyboard navigation. To make the sessions engaging, the plan includes interactive activities and real-life scenarios — like navigating without a mouse or relying on a screen reader. These exercises are designed to show the importance of removing accessibility barriers.`
 
-`Throughout the training, they will gather feedback to understand what’s effective and find areas to improve. This approach will help the team develop practical skills and make accessibility a natural part of their work.`
+`Throughout the training, they will gather feedback to understand what's effective and find areas to improve. This approach will help the team develop practical skills and make accessibility a natural part of their work.`
 
 What is the main goal of the accessibility training?
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672f630337512b2b62595731.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672f630337512b2b62595731.md
@@ -19,7 +19,7 @@ Read the text and answer the question below.
 
 `The training will start by conducting an overview of essential accessibility concepts, such as color contrast, screen reader compatibility, and keyboard navigation. To make the sessions engaging, the plan includes interactive activities and real-life scenarios — like navigating without a mouse or relying on a screen reader. These exercises are designed to show the importance of removing accessibility barriers.`
 
-`Throughout the training, they will gather feedback to understand what’s effective and find areas to improve. This approach will help the team develop practical skills and make accessibility a natural part of their work.`
+`Throughout the training, they will gather feedback to understand what's effective and find areas to improve. This approach will help the team develop practical skills and make accessibility a natural part of their work.`
 
 What does the training overview include?
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672f63cadac41a2c9b1897a1.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672f63cadac41a2c9b1897a1.md
@@ -19,7 +19,7 @@ Read the text and answer the question below.
 
 `The training will start by conducting an overview of essential accessibility concepts, such as color contrast, screen reader compatibility, and keyboard navigation. To make the sessions engaging, the plan includes interactive activities and real-life scenarios — like navigating without a mouse or relying on a screen reader. These exercises are designed to show the importance of removing accessibility barriers.`
 
-`Throughout the training, they will gather feedback to understand what’s effective and find areas to improve. This approach will help the team develop practical skills and make accessibility a natural part of their work.`
+`Throughout the training, they will gather feedback to understand what's effective and find areas to improve. This approach will help the team develop practical skills and make accessibility a natural part of their work.`
 
 How does the training plan make the sessions engaging?
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672f64ba4f91492e1192b829.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672f64ba4f91492e1192b829.md
@@ -19,7 +19,7 @@ Read the text and answer the question below.
 
 `The training will start by conducting an overview of essential accessibility concepts, such as color contrast, screen reader compatibility, and keyboard navigation. To make the sessions engaging, the plan includes interactive activities and real-life scenarios — like navigating without a mouse or relying on a screen reader. These exercises are designed to show the importance of removing accessibility barriers.`
 
-`Throughout the training, they will gather feedback to understand what’s effective and find areas to improve. This approach will help the team develop practical skills and make accessibility a natural part of their work.`
+`Throughout the training, they will gather feedback to understand what's effective and find areas to improve. This approach will help the team develop practical skills and make accessibility a natural part of their work.`
 
 Why are real-life scenarios included in the training?
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672f657580a34f2f78e278e2.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672f657580a34f2f78e278e2.md
@@ -19,7 +19,7 @@ Read the text and answer the question below.
 
 `The training will start by conducting an overview of essential accessibility concepts, such as color contrast, screen reader compatibility, and keyboard navigation. To make the sessions engaging, the plan includes interactive activities and real-life scenarios — like navigating without a mouse or relying on a screen reader. These exercises are designed to show the importance of removing accessibility barriers.`
 
-`Throughout the training, they will gather feedback to understand what’s effective and find areas to improve. This approach will help the team develop practical skills and make accessibility a natural part of their work.`
+`Throughout the training, they will gather feedback to understand what's effective and find areas to improve. This approach will help the team develop practical skills and make accessibility a natural part of their work.`
 
 What is the purpose of gathering training feedback?
 
@@ -29,11 +29,11 @@ To decide if the training should be canceled.
 
 ### --feedback--
 
-The feedback is collected to understand what’s effective and find areas to improve, not to cancel the training.
+The feedback is collected to understand what's effective and find areas to improve, not to cancel the training.
 
 ---
 
-To identify areas to improve and understand what’s effective.
+To identify areas to improve and understand what's effective.
 
 ---
 
@@ -49,7 +49,7 @@ To see how quickly participants finish the activities.
 
 ### --feedback--
 
-The purpose of feedback is to assess the training’s effectiveness, not activity speed.
+The purpose of feedback is to assess the training's effectiveness, not activity speed.
 
 ## --video-solution--
 
@@ -59,6 +59,6 @@ The purpose of feedback is to assess the training’s effectiveness, not activit
 
 To find the correct answer, focus on why training feedback is gathered.
 
-The paragraph states that feedback helps identify `what’s effective` and points out `areas to improve`.
+The paragraph states that feedback helps identify `what's effective` and points out `areas to improve`.
 
 Look for the option that describes feedback as a way to assess and enhance the training process.

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/673de712f2dc6db0cfe76b31.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/673de712f2dc6db0cfe76b31.md
@@ -29,7 +29,7 @@ This word means completely or fully.
 
 The word `entirely` means completely or fully. The phrase `not entirely` indicates that something is not complete or perfect. For example:
 
-`I don’t entirely agree with his opinion.` - It means you don’t fully agree with the opinion, suggesting some level of disagreement.
+`I don't entirely agree with his opinion.` - It means you don't fully agree with the opinion, suggesting some level of disagreement.
 
 # --scene--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/673df0c78bdd11c7195010cb.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/673df0c78bdd11c7195010cb.md
@@ -15,7 +15,7 @@ This task doesn't have audio. Read the question below and select the correct ans
 
 ## --text--
 
-A colleague asks if your team has implemented the new feature yet. What is the best way to respond if you haven’t started but plan to?
+A colleague asks if your team has implemented the new feature yet. What is the best way to respond if you haven't started but plan to?
 
 ## --answers--
 
@@ -23,11 +23,11 @@ A colleague asks if your team has implemented the new feature yet. What is the b
 
 ---
 
-`Yes, it’s been running perfectly for years.`
+`Yes, it's been running perfectly for years.`
 
 ### --feedback--
 
-It implies that the feature has been implemented and in use for years, which contradicts the fact that the feature is new and hasn’t been started yet.
+It implies that the feature has been implemented and in use for years, which contradicts the fact that the feature is new and hasn't been started yet.
 
 ## --video-solution--
 


### PR DESCRIPTION
I’ve replaced all curved backticks with straight ones to ensure the formatting aligns with fCC standards. This PR is for the B1 curriculum. There's another one for A2: https://github.com/freeCodeCamp/freeCodeCamp/pull/57568
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
