### PR TITLE
Fix(Curriculum): Replaced curved quotes with straight ones for Eng Curriculum A2 blocks 

### DIFF
--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657b068e28a3bd135ced0042.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657b068e28a3bd135ced0042.md
@@ -21,7 +21,7 @@ What does `so far` mean in Sarah's question to Tom?
 
 ## --answers--
 
-It asks for Tom’s complete opinion about the workplace.
+It asks for Tom's complete opinion about the workplace.
 
 ### --feedback--
 
@@ -37,15 +37,15 @@ It does not ask about the future or what Tom expects.
 
 ---
 
-It asks about Tom’s feelings from his first day to the present time.
+It asks about Tom's feelings from his first day to the present time.
 
 ---
 
-It asks only about Tom’s first day at the workplace.
+It asks only about Tom's first day at the workplace.
 
 ### --feedback--
 
-It is about Tom’s experience until the time he is asked.
+It is about Tom's experience until the time he is asked.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657b190c4e736f5c4005b132.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657b190c4e736f5c4005b132.md
@@ -24,7 +24,7 @@ What is Sarah referring to when she says `these activities`?
 
 ## --answers--
 
-`Yes, it’s great!`
+`Yes, it's great!`
 
 ### --feedback--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657b1ae0c2fb4c64071ade7a.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657b1ae0c2fb4c64071ade7a.md
@@ -19,7 +19,7 @@ For example: `What is your name?` or `What are they doing?`
 
 Choose the correct question that Tom is asking Sarah:
 
-`Absolutely! They are really fun. What is the team’s favorite?`
+`Absolutely! They are really fun. What is the team's favorite?`
 
 ## --answers--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657b23ad0df43588a6eadfa4.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657b23ad0df43588a6eadfa4.md
@@ -5,7 +5,7 @@ challengeType: 19
 dashedName: task-12
 ---
 
-<!-- (Audio) Tom: Absolutely! They are really fun. What is the team’s favorite?
+<!-- (Audio) Tom: Absolutely! They are really fun. What is the team's favorite?
 
 Sarah: Many of us enjoy the monthly game night. Are you into board games?
 
@@ -31,7 +31,7 @@ The first sentence is correct, but the second one does not ask about interest. I
 
 ---
 
-`What is the team’s favorite?` and `Many of us enjoy the monthly game night. `
+`What is the team's favorite?` and `Many of us enjoy the monthly game night. `
 
 ### --feedback--
 
@@ -47,7 +47,7 @@ The phrase `Are you going to board games?` is not grammatically correct. The sec
 
 ---
 
-`What is the team’s favorite?` and `Are you into playing board games?`
+`What is the team's favorite?` and `Are you into playing board games?`
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657b24e5edd7708e93549565.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657b24e5edd7708e93549565.md
@@ -18,7 +18,7 @@ The present perfect is a tense used to indicate a link between the present and t
 
 `I have played this game before.` - This is in the present perfect tense. It states that the action of playing the game happened at an unspecified time in the past.
 
-`I’ve played this game before.` - This sentence is also in the present perfect tense, using the contraction `I've` for `I have`. Like the previous example, it states that the action of playing the game happened at an unspecified time in the past.
+`I've played this game before.` - This sentence is also in the present perfect tense, using the contraction `I've` for `I have`. Like the previous example, it states that the action of playing the game happened at an unspecified time in the past.
 
 
 # --questions--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657b69e10d6606a0185d4d4f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657b69e10d6606a0185d4d4f.md
@@ -13,7 +13,7 @@ So far you have learned how to create questions with the verb `to be`. In senten
 
 `You are a developer` -> `Are you a developer?`
 
-Changing the order of the noun and the verb doesn’t work in every situation. Most sentences need you to add an auxiliary verb to create questions. One of the most common auxiliary verbs is `Do`.
+Changing the order of the noun and the verb doesn't work in every situation. Most sentences need you to add an auxiliary verb to create questions. One of the most common auxiliary verbs is `Do`.
 
 You can use the verb `do` as an auxiliary to most verbs. In the present tense it assumes the form of `do` (I, you, we, they) and `does`(he, she, it). It is like a marker you will add to the beginning of your sentence and lets everyone know that sentence is a question. For example:
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657b6f641e5c3ab1afc6efc1.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657b6f641e5c3ab1afc6efc1.md
@@ -13,7 +13,7 @@ Before you learned to ask questions using `do`, you can also use it to create ne
 
 `It does not function` - (Subject + `does` + `not` + main verb)
 
-Often, to be more practical people abbreviate `do not` to `don't` and `does not` to `doesn’t`. 
+Often, to be more practical people abbreviate `do not` to `don't` and `does not` to `doesn't`. 
 
 Just like with questions, when you use `don't`, the main verb that comes after it will always be in its base form, no matter who you're talking about. 
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657b70cc934e0ab83cab4dbe.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657b70cc934e0ab83cab4dbe.md
@@ -31,7 +31,7 @@ Read the dialogue excerpt and fill in the blanks using `do` or `don't.`
 
 ### --feedback--
 
-In the first blank, Tom is asking a question about Sophie’s hobbies, which requires `do.`
+In the first blank, Tom is asking a question about Sophie's hobbies, which requires `do.`
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657b92b25858f24caf6894aa.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657b92b25858f24caf6894aa.md
@@ -11,7 +11,7 @@ Tom: It's a deal! -->
 
 # --description--
 
-The expression `only if` is used to set a condition for something to happen. It’s like saying `this will happen if that happens.` It's a way of making an agreement where one action depends on another.
+The expression `only if` is used to set a condition for something to happen. It's like saying `this will happen if that happens.` It's a way of making an agreement where one action depends on another.
 
 For example: if your friend says, `I'll go out only if it doesn't rain,` it means they will go out but the weather must be good - no rain.
 
@@ -20,7 +20,7 @@ For example: if your friend says, `I'll go out only if it doesn't rain,` it mean
 
 ## --text--
 
-What is Sophie’s condition?
+What is Sophie's condition?
 
 ## --answers--
 
@@ -44,7 +44,7 @@ There is no mention of Sophie wanting to show pictures.
 
 ---
 
-She doesn’t want to hear Tom play.
+She doesn't want to hear Tom play.
 
 ### --feedback--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657cb68bf15f349a744b5fba.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657cb68bf15f349a744b5fba.md
@@ -7,11 +7,11 @@ dashedName: task-43
 
 # --description--
 
-When you want to learn about a person’s character or personality without specifying their gender, you can use `they` as a singular pronoun and ask, `What are they like?`.
+When you want to learn about a person's character or personality without specifying their gender, you can use `they` as a singular pronoun and ask, `What are they like?`.
 
 This is a respectful and inclusive way to ask about someone. Using `they` in this way ensures that you don't make assumptions about people. Example:
 
-Imagine there is a new team member joining your programming project, but you haven’t met them yet. Instead of assuming their gender, you can ask your supervisor, `What are they like?` 
+Imagine there is a new team member joining your programming project, but you haven't met them yet. Instead of assuming their gender, you can ask your supervisor, `What are they like?` 
 
 This question helps you find out about the new member's personality, such as being organized, creative, or detail-oriented.
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657cdc5a8e30191d1abec8b7.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657cdc5a8e30191d1abec8b7.md
@@ -9,7 +9,7 @@ dashedName: task-58
 
 # --description--
 
-Let’s practice listening to verbs conjugated in the third person. 
+Let's practice listening to verbs conjugated in the third person. 
 
 # --fillInTheBlank--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657ce061cda4a42a99c65d89.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657ce061cda4a42a99c65d89.md
@@ -13,7 +13,7 @@ dashedName: task-60
 
 ## --text--
 
-Choose the correct question for asking about someone’s usual work location.
+Choose the correct question for asking about someone's usual work location.
 
 ## --answers--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657cfeeeabb34d946d437dc7.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657cfeeeabb34d946d437dc7.md
@@ -11,7 +11,7 @@ dashedName: task-75
 
 The expression `to be in good hands` means that someone is being taken care of by a competent or capable person. 
 
-It’s like saying you can relax because you trust the person helping or looking after you.
+It's like saying you can relax because you trust the person helping or looking after you.
 
 # --questions--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657cff86dd812f98672e2649.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657cff86dd812f98672e2649.md
@@ -35,7 +35,7 @@ Sophie's words are very positive, more than just average.
 
 ---
 
-She is unsure about Maria’s leadership skills.
+She is unsure about Maria's leadership skills.
 
 ### --feedback--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657dc1d18a0a6f25302badba.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657dc1d18a0a6f25302badba.md
@@ -13,7 +13,7 @@ The word `reasonable` means something is fair, makes sense, or is acceptable in 
 
 ## --text--
 
-What does `that’s reasonable` mean?
+What does `that's reasonable` mean?
 
 ## --answers--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657dc50830f9be380105f1ee.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657dc50830f9be380105f1ee.md
@@ -9,7 +9,7 @@ dashedName: task-94
 
 In English, the verb `know` is conjugated to `knows` when the subject is singular and in third person. 
 
-`Everyone` refers to a group but it is treated as a singular noun, that’s why in English the correct form is `everyone knows`.
+`Everyone` refers to a group but it is treated as a singular noun, that's why in English the correct form is `everyone knows`.
 
 
 # --questions--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657dc568fe84e53acc962fc3.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657dc568fe84e53acc962fc3.md
@@ -10,7 +10,7 @@ Tom: Good to know! Do they involve everyone on the team? -->
 
 # --description--
 
-Listen carefully to Tom’s question about the team meetings.
+Listen carefully to Tom's question about the team meetings.
 
 # --questions--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657dc9946a177a5938ad3854.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657dc9946a177a5938ad3854.md
@@ -14,7 +14,7 @@ dashedName: task-104
 How long it takes to make a website depends on how big or small the job is.
 Choosing the coding language depends on the computer or system we use.
 
-Notice that after `depends` there’s always the preposition `on`. 
+Notice that after `depends` there's always the preposition `on`. 
 
 # --instructions--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657dce8ff35869721311a5e3.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657dce8ff35869721311a5e3.md
@@ -21,7 +21,7 @@ Which sentence is correct for describing one place near you?
 
 ### --feedback--
 
-`There are` is used for plural nouns, and `bank` is singular. You’ll learn about `there are` in the next few lessons. 
+`There are` is used for plural nouns, and `bank` is singular. You'll learn about `there are` in the next few lessons. 
 
 ---
 
@@ -29,7 +29,7 @@ Which sentence is correct for describing one place near you?
 
 ### --feedback--
 
-This option is a question form, not a statement. You’ll learn about questions later. 
+This option is a question form, not a statement. You'll learn about questions later. 
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657ddaaf8d89b4a56e3fdf78.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657ddaaf8d89b4a56e3fdf78.md
@@ -11,9 +11,9 @@ dashedName: task-123
 
 Maria mentions that she doesn't know of any theater in the area. When you want to express that something does not exist or is not present somewhere, you use `there isn't` for singular nouns or `there aren't` for plural nouns.
 
-`There isn’t` is an abbreviation of `there is not`.
+`There isn't` is an abbreviation of `there is not`.
 
-`There aren’t` is an abbreviation of `there are not`.
+`There aren't` is an abbreviation of `there are not`.
 
 # --instructions--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657ddd7d4fc512b03741d9a3.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657ddd7d4fc512b03741d9a3.md
@@ -21,11 +21,11 @@ There are closed malls.
 
 ### --feedback--
 
-They don’t discuss the opening hours of malls.
+They don't discuss the opening hours of malls.
 
 ---
 
-There aren’t any malls.
+There aren't any malls.
 
 ### --feedback--
 
@@ -33,7 +33,7 @@ Malls are easy to locate.
 
 ---
 
-Malls aren’t very common in this area.
+Malls aren't very common in this area.
 
 ### --feedback--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd6a37495961c5f242c5d.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd6a37495961c5f242c5d.md
@@ -46,7 +46,7 @@ She doesn't ask about his family. Try again.
 
 ### --feedback--
 
-She doesn’t ask for reasons. Try again.
+She doesn't ask for reasons. Try again.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b30e1b9f035e7e656fd01.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b30e1b9f035e7e656fd01.md
@@ -5,7 +5,7 @@ challengeType: 19
 dashedName: task-91
 ---
 
-<!-- (Audio) Anna: I saw that tech companies appreciate innovation and care for the employees’ well-being. -->
+<!-- (Audio) Anna: I saw that tech companies appreciate innovation and care for the employees' well-being. -->
 
 # --description--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/65f3a5111de04c216a38d998.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/65f3a5111de04c216a38d998.md
@@ -5,7 +5,7 @@ challengeType: 22
 dashedName: task-61
 ---
 
-<!-- (Audio) Brian: They weren’t exactly big projects. Most of them were smaller scale. But it was a great learning experience. -->
+<!-- (Audio) Brian: They weren't exactly big projects. Most of them were smaller scale. But it was a great learning experience. -->
 
 # --description--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/65f3a5733a199c21ca589173.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/65f3a5733a199c21ca589173.md
@@ -6,7 +6,7 @@ dashedName: task-62
 ---
 
 <!-- (Audio) Sophie: That sounds cool. Did you ever work on any big projects during your studies? 
-Brian: They weren’t exactly big projects. Most of them were smaller scale. But it was a great learning experience. -->
+Brian: They weren't exactly big projects. Most of them were smaller scale. But it was a great learning experience. -->
 
 # --description--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-for-clarification-on-code-understanding/65f52f761f23715bce60f9ce.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-for-clarification-on-code-understanding/65f52f761f23715bce60f9ce.md
@@ -15,7 +15,7 @@ Listen to the audio and answer the question.
 
 ## --text--
 
-What part of Sarah’s answer suggests a course of action?
+What part of Sarah's answer suggests a course of action?
 
 ## --answers--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-clarify-information-in-different-interactions/66415d2fc70cf753ed0723a4.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-clarify-information-in-different-interactions/66415d2fc70cf753ed0723a4.md
@@ -11,7 +11,7 @@ dashedName: task-76
 
 `That's strange` means you think something is unusual or unexpected. For example, if you see it snowing in the summer, you might say, `That's strange.` It means you did not expect that to happen.
 
-`I'm sure` means you are confident that something is true. For example, if you know your friend’s birthday is tomorrow, you can say, `I'm sure it's tomorrow.` It means you believe it without doubt.
+`I'm sure` means you are confident that something is true. For example, if you know your friend's birthday is tomorrow, you can say, `I'm sure it's tomorrow.` It means you believe it without doubt.
 
 Listen and fill in the blanks.
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-clarify-information-in-different-interactions/664274a516894a70a9111cb6.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-clarify-information-in-different-interactions/664274a516894a70a9111cb6.md
@@ -11,7 +11,7 @@ dashedName: task-78
 
 `Now that I think about it` means you have remembered or realized something after thinking more. For example, if you forgot where you put your keys but then remember, you might say, `Now that I think about it, they are on the table.` It means you have thought again and found new information.
 
-`To confuse something with something else` means to mix up two things and think one is the other. For example, if you see someone’s twin and think it is your friend, you can say `Sorry. I confused your twin with you`. It means you mistake one thing for another.
+`To confuse something with something else` means to mix up two things and think one is the other. For example, if you see someone's twin and think it is your friend, you can say `Sorry. I confused your twin with you`. It means you mistake one thing for another.
 
 # --questions--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-clarify-information-in-different-interactions/6642914bd5def3734c59b763.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-clarify-information-in-different-interactions/6642914bd5def3734c59b763.md
@@ -11,7 +11,7 @@ dashedName: task-79
 
 A `tray` is a flat, shallow container used to carry or hold things. For example, you use a `tray` to bring food or drinks from the kitchen to the table.
 
-`Enough` means having as much as you need. For example, if you have `enough water`, it means you have all the water you need to drink and you don’t need more. It can be used to talk about quantity, like having `enough food`, or to talk about quality, like when something is `good enough`.
+`Enough` means having as much as you need. For example, if you have `enough water`, it means you have all the water you need to drink and you don't need more. It can be used to talk about quantity, like having `enough food`, or to talk about quality, like when something is `good enough`.
 
 Listen to the dialogue and fill in the blanks.
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/655b76340ecb8285060ab6d5.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/655b76340ecb8285060ab6d5.md
@@ -23,7 +23,7 @@ Sophie helps her team and James checked cybersecurity
 
 ### --feedback--
 
-This option incorrectly uses the simple present tense for Sophie and the simple past tense for James. They don’t reflect the continuous, ongoing nature of their current activities.
+This option incorrectly uses the simple present tense for Sophie and the simple past tense for James. They don't reflect the continuous, ongoing nature of their current activities.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/655c9a89818e18606c18ca4b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/655c9a89818e18606c18ca4b.md
@@ -5,7 +5,7 @@ challengeType: 22
 dashedName: task-22
 ---
 
-<!-- (Audio) Mark: Hi Maria! I'm testing a new software to find problems. It’s a nice experience so far, but we're doing more tests to make sure everything works. -->
+<!-- (Audio) Mark: Hi Maria! I'm testing a new software to find problems. It's a nice experience so far, but we're doing more tests to make sure everything works. -->
 
 # --description--
 
@@ -15,7 +15,7 @@ In this dialogue, Mark talks about his activities related to a project.
 
 ## --sentence--
 
-`Hi Maria! I'm BLANK a new software to BLANK problems. It’s a nice experience so far, but we're BLANK more tests to BLANK sure everything BLANK`
+`Hi Maria! I'm BLANK a new software to BLANK problems. It's a nice experience so far, but we're BLANK more tests to BLANK sure everything BLANK`
 
 ## --blanks--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/655c9bcb5bedb4620acb6f18.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/655c9bcb5bedb4620acb6f18.md
@@ -5,7 +5,7 @@ challengeType: 19
 dashedName: task-24
 ---
 
-<!-- (Audio) Mark: It’s a nice experience so far, but we're doing more tests to make sure everything works. -->
+<!-- (Audio) Mark: It's a nice experience so far, but we're doing more tests to make sure everything works. -->
 
 # --description--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a44b06bea9443b8ff45bd.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a44b06bea9443b8ff45bd.md
@@ -5,7 +5,7 @@ challengeType: 22
 dashedName: task-34
 ---
 
-<!-- (Audio) Amy: It's exciting. I'm interviewing some experts and I’m getting information for the articles. It's keeping me busy, but I enjoy it. -->
+<!-- (Audio) Amy: It's exciting. I'm interviewing some experts and I'm getting information for the articles. It's keeping me busy, but I enjoy it. -->
 
 # --description--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a456b46b4b04437f2d3e9.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a456b46b4b04437f2d3e9.md
@@ -5,7 +5,7 @@ challengeType: 19
 dashedName: task-35
 ---
 
-<!-- (Audio) Amy: It's exciting. I'm interviewing some experts and I’m getting information for the articles. It's keeping me busy, but I enjoy it. -->
+<!-- (Audio) Amy: It's exciting. I'm interviewing some experts and I'm getting information for the articles. It's keeping me busy, but I enjoy it. -->
 
 # --description--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a4ac4529e0f49ab900c3b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a4ac4529e0f49ab900c3b.md
@@ -23,7 +23,7 @@ She is learning about project management
 
 ### --feedback--
 
-Sarah doesn’t mention project management.
+Sarah doesn't mention project management.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a4d1943d8f24c030ded74.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a4d1943d8f24c030ded74.md
@@ -13,7 +13,7 @@ When someone uses `either` at the end of a negative sentence, it means the same 
 
 `I don't like carrots. My sister doesn't like them, either.` 
 
-Here, `either` means both the speaker and their sister don’t like carrots.
+Here, `either` means both the speaker and their sister don't like carrots.
 
 # --questions--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-popular-trends-in-technology/65fe10ef733aebd257f0677d.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-popular-trends-in-technology/65fe10ef733aebd257f0677d.md
@@ -9,7 +9,7 @@ dashedName: task-2
 
 # --description--
 
-`AI` stands for Artificial Intelligence. It’s an abbreviation of Artificial Intelligence.
+`AI` stands for Artificial Intelligence. It's an abbreviation of Artificial Intelligence.
 
 # --questions--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-popular-trends-in-technology/65ff086669d84512c7d132f1.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-popular-trends-in-technology/65ff086669d84512c7d132f1.md
@@ -9,7 +9,7 @@ dashedName: task-4
 
 # --description--
 
-`like` is a preposition used to describe the similarity between two things, people, or concepts. It indicates that there are shared qualities or characteristics between the compared elements. It’s commonly used in comparisons to highlight similarities. Example: `Her eyes are blue like the sky.`
+`like` is a preposition used to describe the similarity between two things, people, or concepts. It indicates that there are shared qualities or characteristics between the compared elements. It's commonly used in comparisons to highlight similarities. Example: `Her eyes are blue like the sky.`
 
 Fill in the blank with proper word.
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-popular-trends-in-technology/6617e75a204e044552675f58.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-popular-trends-in-technology/6617e75a204e044552675f58.md
@@ -9,7 +9,7 @@ dashedName: task-5
 
 # --description--
 
-In this challenge, you’ll practice what you learned in previous challenges. Listen to the dialogue and choose the correct answer.
+In this challenge, you'll practice what you learned in previous challenges. Listen to the dialogue and choose the correct answer.
 
 # --questions--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-popular-trends-in-technology/661ed01f09114567cc8fa939.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-popular-trends-in-technology/661ed01f09114567cc8fa939.md
@@ -9,7 +9,7 @@ dashedName: task-88
 
 # --description--
 
-You learned how to talk about an unspecified thing or information with a broad term that didn’t point to a specific item. Let’s review it in this challenge.
+You learned how to talk about an unspecified thing or information with a broad term that didn't point to a specific item. Let's review it in this challenge.
 
 Listen and fill in the blank.
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-popular-trends-in-technology/661edda6df434c6f2161bea5.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-popular-trends-in-technology/661edda6df434c6f2161bea5.md
@@ -39,7 +39,7 @@ This answer limits `AR` to one aspect, which is not what `it is a mix` suggests.
 
 ### --feedback--
 
-`It is a mix` doesn’t mean `AR` is separate from reality.
+`It is a mix` doesn't mean `AR` is separate from reality.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-popular-trends-in-technology/661ee1436ecb9271c66be82c.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-popular-trends-in-technology/661ee1436ecb9271c66be82c.md
@@ -9,7 +9,7 @@ dashedName: task-92
 
 # --description--
 
-Let’s review what Sophie and Tom talk about.
+Let's review what Sophie and Tom talk about.
 
 Listen and fill in the blanks to complete the dialogue.
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-popular-trends-in-technology/661eea69ca8a5177320d5e90.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-popular-trends-in-technology/661eea69ca8a5177320d5e90.md
@@ -9,7 +9,7 @@ dashedName: task-97
 
 # --description--
 
-Let’s review what Sophie and Tom talk about, to understand how AR works.
+Let's review what Sophie and Tom talk about, to understand how AR works.
 
 # --fillInTheBlank--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65b22d1aeb5ecf1d590d30bf.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65b22d1aeb5ecf1d590d30bf.md
@@ -5,7 +5,7 @@ challengeType: 22
 dashedName: task-6
 ---
 
-<!-- (Audio) Sophie: No, I haven’t seen her yet. What can you tell me about her? -->
+<!-- (Audio) Sophie: No, I haven't seen her yet. What can you tell me about her? -->
 
 # --description--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65b22e5388370c209a6b0b73.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65b22e5388370c209a6b0b73.md
@@ -5,7 +5,7 @@ challengeType: 19
 dashedName: task-7
 ---
 
-<!-- (Audio) Sophie: No, I haven’t seen her yet. What can you tell me about her? -->
+<!-- (Audio) Sophie: No, I haven't seen her yet. What can you tell me about her? -->
 
 # --description--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65b25b541262654062a21e74.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65b25b541262654062a21e74.md
@@ -5,7 +5,7 @@ challengeType: 22
 dashedName: task-13
 ---
 
-<!-- (Audio) Bob: You’ll recognize her right away. -->
+<!-- (Audio) Bob: You'll recognize her right away. -->
 
 # --description--
 
@@ -17,7 +17,7 @@ The phrase `right away` means quickly or very soon. For instance, `If you find a
 
 ## --sentence--
 
-`You’ll BLANK her BLANK BLANK.`
+`You'll BLANK her BLANK BLANK.`
 
 ## --blanks--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65b25bcc98b00d41d06d2a2b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65b25bcc98b00d41d06d2a2b.md
@@ -5,7 +5,7 @@ challengeType: 19
 dashedName: task-14
 ---
 
-<!-- (Audio) Bob: You’ll recognize her right away. -->
+<!-- (Audio) Bob: You'll recognize her right away. -->
 
 # --description--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d86e08994c4a0436d92766.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d86e08994c4a0436d92766.md
@@ -5,7 +5,7 @@ challengeType: 19
 dashedName: task-71
 ---
 
-<!-- (Audio) Tom: Ah, speaking of procedures, is there anything he’s told you that we need to do when it comes to office security? -->
+<!-- (Audio) Tom: Ah, speaking of procedures, is there anything he's told you that we need to do when it comes to office security? -->
 
 # --description--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d89562dff69551e7683df3.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d89562dff69551e7683df3.md
@@ -5,7 +5,7 @@ challengeType: 22
 dashedName: task-82
 ---
 
-<!-- (Audio) Bob: I also can’t disclose sensitive information to anyone outside of the company. -->
+<!-- (Audio) Bob: I also can't disclose sensitive information to anyone outside of the company. -->
 
 # --description--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65daa8143ae77767ad914ba4.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65daa8143ae77767ad914ba4.md
@@ -5,7 +5,7 @@ challengeType: 22
 dashedName: task-94
 ---
 
-<!-- (Audio) Sophie: I also don’t want to neglect my health, so two months ago I started jogging regularly. -->
+<!-- (Audio) Sophie: I also don't want to neglect my health, so two months ago I started jogging regularly. -->
 
 # --description--
 
@@ -17,7 +17,7 @@ For example, if you don't eat healthy food or exercise, you might be `neglecting
 
 ## --sentence--
 
-`I also don’t want to BLANK BLANK BLANK, so two months ago I started jogging regularly.`
+`I also don't want to BLANK BLANK BLANK, so two months ago I started jogging regularly.`
 
 ## --blanks--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65daa8cce1b9206995e4aec3.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65daa8cce1b9206995e4aec3.md
@@ -5,7 +5,7 @@ challengeType: 22
 dashedName: task-95
 ---
 
-<!-- (Audio) Sophie: I also don’t want to neglect my health, so two months ago I started jogging regularly. -->
+<!-- (Audio) Sophie: I also don't want to neglect my health, so two months ago I started jogging regularly. -->
 
 # --description--
 
@@ -17,7 +17,7 @@ For example, if you say `I moved here a year ago`, it means that one year has pa
 
 ## --sentence--
 
-`I also don’t want to neglect my health, so two months BLANK I started jogging regularly.`
+`I also don't want to neglect my health, so two months BLANK I started jogging regularly.`
 
 ## --blanks--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65daab9b713d3e6e6272c8bf.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65daab9b713d3e6e6272c8bf.md
@@ -5,7 +5,7 @@ challengeType: 22
 dashedName: task-97
 ---
 
-<!-- (Audio) Sophie: I also don’t want to neglect my health, so two months ago I started jogging regularly. -->
+<!-- (Audio) Sophie: I also don't want to neglect my health, so two months ago I started jogging regularly. -->
 
 # --description--
 
@@ -21,7 +21,7 @@ Examples:
 
 ## --sentence--
 
-`I also don’t want to neglect my health, so two months ago I started BLANK BLANK.`
+`I also don't want to neglect my health, so two months ago I started BLANK BLANK.`
 
 ## --blanks--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65dab1186529467ee5e463a7.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65dab1186529467ee5e463a7.md
@@ -6,7 +6,7 @@ dashedName: task-99
 ---
 
 <!-- (Audio) Brian: Tell me about your responsibilities beyond work.
-Sophie: Well, I have to make time for my family – that's really important to me. I also don’t want to neglect my health, so two months ago I started jogging regularly. It helps me relax and stay fit. -->
+Sophie: Well, I have to make time for my family – that's really important to me. I also don't want to neglect my health, so two months ago I started jogging regularly. It helps me relax and stay fit. -->
 
 # --description--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65dad153fd675cb51e8423b0.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65dad153fd675cb51e8423b0.md
@@ -5,7 +5,7 @@ challengeType: 19
 dashedName: task-106
 ---
 
-<!-- (Audio) Sophie: Sometimes, it’s the simple and free things that bring us the result we’re looking for. -->
+<!-- (Audio) Sophie: Sometimes, it's the simple and free things that bring us the result we're looking for. -->
 
 # --description--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/6636f834a7b32443a43fa4e0.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/6636f834a7b32443a43fa4e0.md
@@ -43,7 +43,7 @@ It disconnects applications from the internet, focusing on internal networks.
 
 ### --feedback--
 
-Serverless computing still uses the internet as part of cloud services; it doesn’t focus on internal networks.
+Serverless computing still uses the internet as part of cloud services; it doesn't focus on internal networks.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/663855865f5d53510f9cd9a5.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/663855865f5d53510f9cd9a5.md
@@ -5,7 +5,7 @@ challengeType: 22
 dashedName: task-38
 ---
 
-<!-- (Audio) Bob: Sarah, I’m hearing a lot about AI in programming these days, but I don't know how to use it. Any ideas? -->
+<!-- (Audio) Bob: Sarah, I'm hearing a lot about AI in programming these days, but I don't know how to use it. Any ideas? -->
 
 # --description--
 
@@ -17,7 +17,7 @@ For example, `He is hearing different opinions on the topic.` It shows he is cur
 
 ## --sentence--
 
-`Sarah, I’m BLANK a lot BLANK AI in programming these days, but I don't know how to use it. Any ideas?`
+`Sarah, I'm BLANK a lot BLANK AI in programming these days, but I don't know how to use it. Any ideas?`
 
 ## --blanks--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/6638994f7dbcb3548e458202.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/6638994f7dbcb3548e458202.md
@@ -5,7 +5,7 @@ challengeType: 19
 dashedName: task-41
 ---
 
-<!-- (Audio) Bob: Sarah, I’m hearing a lot about AI in programming these days, but I don't know how to use it. Any ideas? -->
+<!-- (Audio) Bob: Sarah, I'm hearing a lot about AI in programming these days, but I don't know how to use it. Any ideas? -->
 
 # --description--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/66389a37bc8a4b5539eab451.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/66389a37bc8a4b5539eab451.md
@@ -5,7 +5,7 @@ challengeType: 19
 dashedName: task-42
 ---
 
-<!-- (Audio) Bob: Sarah, I’m hearing a lot about AI in programming these days, but I don't know how to use it. Any ideas? -->
+<!-- (Audio) Bob: Sarah, I'm hearing a lot about AI in programming these days, but I don't know how to use it. Any ideas? -->
 
 # --description--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/66389e09cec2fa569567b15a.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/66389e09cec2fa569567b15a.md
@@ -23,7 +23,7 @@ Using a program that automatically improves code efficiency
 
 ### --feedback--
 
-This is an example of AI, as it involves using technology to improve code, aligning with Sarah’s description.
+This is an example of AI, as it involves using technology to improve code, aligning with Sarah's description.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/6557e5c6a854bfcad48808c4.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/6557e5c6a854bfcad48808c4.md
@@ -15,7 +15,7 @@ This challenge is designed to summarize and reinforce the understanding of James
 
 ## --sentence--
 
-`Sarah has a consistent morning routine. She BLANK up around 7 AM and starts her day by BLANK a bit. After making a cup of BLANK, she takes a BLANK shower and goes to the kitchen to BLANK a balanced breakfast. This helps her stay BLANK during the morning. She checks her BLANK and messages before BLANK to work. She likes to stay BLANK about the day’s tasks. James thinks her productivity BLANK coming to work is impressive and says he BLANK try some of her habits to become more BLANK in the morning as well.`
+`Sarah has a consistent morning routine. She BLANK up around 7 AM and starts her day by BLANK a bit. After making a cup of BLANK, she takes a BLANK shower and goes to the kitchen to BLANK a balanced breakfast. This helps her stay BLANK during the morning. She checks her BLANK and messages before BLANK to work. She likes to stay BLANK about the day's tasks. James thinks her productivity BLANK coming to work is impressive and says he BLANK try some of her habits to become more BLANK in the morning as well.`
 
 ## --blanks--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655a54506b259313b2d59577.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655a54506b259313b2d59577.md
@@ -17,7 +17,7 @@ Conditional sentences often use `if` to describe a situation (cause) that will l
 
 ## --text--
 
-What is the cause and consequence of the expert’s advice?
+What is the cause and consequence of the expert's advice?
 
 ## --answers--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655b266c2ea5495f43b97ea5.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655b266c2ea5495f43b97ea5.md
@@ -39,7 +39,7 @@ That is the wrong time.
 
 ### --feedback--
 
-That’s the wrong time of the day.
+That's the wrong time of the day.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655b3197bb31ca670081f6d7.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655b3197bb31ca670081f6d7.md
@@ -19,7 +19,7 @@ Long adjectives: Just add `the most` before the adjective.
 
 `This is the most interesting book I've read.` (`the most` + `interesting`)
 
-This is an introduction to these adjectives. You’ll learn more in the future.
+This is an introduction to these adjectives. You'll learn more in the future.
 
 # --fillInTheBlank--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-document-code-for-a-project/65e46524078f872c3a871f9f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-document-code-for-a-project/65e46524078f872c3a871f9f.md
@@ -41,7 +41,7 @@ Transparent
 
 ### --feedback--
 
-It’s another meaning of `clear`, referring to something allowing light to pass through so that objects behind can be distinctly seen. In documentation, `clear` is about understandability, not transparency.
+It's another meaning of `clear`, referring to something allowing light to pass through so that objects behind can be distinctly seen. In documentation, `clear` is about understandability, not transparency.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/661757150c7a75961a574a39.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/661757150c7a75961a574a39.md
@@ -5,7 +5,7 @@ challengeType: 19
 dashedName: task-7
 ---
 
-<!-- (Audio) Bob: Thanks for your feedback. I’ll share this feedback with Tom and give him some extra time to work on these colors and fonts. -->
+<!-- (Audio) Bob: Thanks for your feedback. I'll share this feedback with Tom and give him some extra time to work on these colors and fonts. -->
 
 # --description--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/66175792ec93b19771c55c62.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/66175792ec93b19771c55c62.md
@@ -29,7 +29,7 @@ This option is incorrect. Sophie's comments suggest she sees areas for improveme
 
 ---
 
-She doesn’t know and needs more time to form an opinion.
+She doesn't know and needs more time to form an opinion.
 
 ### --feedback--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/661772551b64ddd40c834b1e.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/661772551b64ddd40c834b1e.md
@@ -35,7 +35,7 @@ Yes, she completely agrees with Brian and suggests additional features for the m
 
 ### --feedback--
 
-Sarah's statement indicates disagreement with Brian’s focus on the mobile app, as she believes the web app requires more attention.
+Sarah's statement indicates disagreement with Brian's focus on the mobile app, as she believes the web app requires more attention.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/661796e4635cd3eb1c8c78a4.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/661796e4635cd3eb1c8c78a4.md
@@ -5,7 +5,7 @@ challengeType: 22
 dashedName: task-14
 ---
 
-<!-- (Audio) Brian: Well, here’s what I think we could do. Why don’t we allocate resources to both platforms equally? We could give equal priority to both the web app and the mobile app. -->
+<!-- (Audio) Brian: Well, here's what I think we could do. Why don't we allocate resources to both platforms equally? We could give equal priority to both the web app and the mobile app. -->
 
 # --description--
 
@@ -19,7 +19,7 @@ To `allocate` means to distribute or assign resources or responsibilities to dif
 
 ## --sentence--
 
-`Well, here’s what I think we could do. Why don’t we BLANK resources to both platforms BLANK? We could give equal priority to BLANK the web app and the mobile app.`
+`Well, here's what I think we could do. Why don't we BLANK resources to both platforms BLANK? We could give equal priority to BLANK the web app and the mobile app.`
 
 ## --blanks--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/661797b505f2d3ed4b170d74.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/661797b505f2d3ed4b170d74.md
@@ -5,7 +5,7 @@ challengeType: 19
 dashedName: task-15
 ---
 
-<!-- (Audio) Brian: Well, here’s what I think we could do. Why don’t we allocate resources to both platforms equally? We could give equal priority to both the web app and the mobile app. -->
+<!-- (Audio) Brian: Well, here's what I think we could do. Why don't we allocate resources to both platforms equally? We could give equal priority to both the web app and the mobile app. -->
 
 # --description--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/66179829f664e3ee9b42ce5f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/66179829f664e3ee9b42ce5f.md
@@ -5,7 +5,7 @@ challengeType: 19
 dashedName: task-16
 ---
 
-<!-- (Audio) Sarah: I'm not sure I agree with that, Brian. The web app needs attention. It has more users. Prioritizing the web app makes more sense given its larger user base. Brian: Well, here’s what I think we could do. Why don’t we allocate resources to both platforms equally? We could give equal priority to both the web app and the mobile app. -->
+<!-- (Audio) Sarah: I'm not sure I agree with that, Brian. The web app needs attention. It has more users. Prioritizing the web app makes more sense given its larger user base. Brian: Well, here's what I think we could do. Why don't we allocate resources to both platforms equally? We could give equal priority to both the web app and the mobile app. -->
 
 # --description--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617994636fa13f16060b12b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617994636fa13f16060b12b.md
@@ -5,7 +5,7 @@ challengeType: 22
 dashedName: task-17
 ---
 
-<!-- (Audio) Sarah: I still think we should dedicate more time to the web app, but I see where you’re coming from, Brian. I think we can try giving equal priority for a while. -->
+<!-- (Audio) Sarah: I still think we should dedicate more time to the web app, but I see where you're coming from, Brian. I think we can try giving equal priority for a while. -->
 
 # --description--
 
@@ -23,7 +23,7 @@ Understanding these terms is key for discussing work plans and responsibilities.
 
 ## --sentence--
 
-`I BLANK think we should BLANK more time to the web app, but I see where you’re coming from, Brian. I think we can try giving equal BLANK for a while.`
+`I BLANK think we should BLANK more time to the web app, but I see where you're coming from, Brian. I think we can try giving equal BLANK for a while.`
 
 ## --blanks--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617aea9ccdd68f7088368d1.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617aea9ccdd68f7088368d1.md
@@ -5,7 +5,7 @@ challengeType: 19
 dashedName: task-18
 ---
 
-<!-- (Audio) Sarah: I still think we should dedicate more time to the web app, but I see where you’re coming from, Brian. -->
+<!-- (Audio) Sarah: I still think we should dedicate more time to the web app, but I see where you're coming from, Brian. -->
 
 # --description--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617af3ab73475f87b53a59d.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617af3ab73475f87b53a59d.md
@@ -5,7 +5,7 @@ challengeType: 19
 dashedName: task-19
 ---
 
-<!-- (Audio) Sarah: I still think we should dedicate more time to the web app, but I see where you’re coming from, Brian. I think we can try giving equal priority for a while. -->
+<!-- (Audio) Sarah: I still think we should dedicate more time to the web app, but I see where you're coming from, Brian. I think we can try giving equal priority for a while. -->
 
 # --description--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617b500a7049808f3a2a593.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617b500a7049808f3a2a593.md
@@ -5,7 +5,7 @@ challengeType: 22
 dashedName: task-29
 ---
 
-<!-- (Audio) Sarah: I see what you mean. I strongly feel that Agile aligns with our team's strengths, though. I think we’ll have a greater chance of success with it. -->
+<!-- (Audio) Sarah: I see what you mean. I strongly feel that Agile aligns with our team's strengths, though. I think we'll have a greater chance of success with it. -->
 
 # --description--
 
@@ -15,7 +15,7 @@ Focus on the word `greater`. `Greater` is used to describe something that is mor
 
 ## --sentence--
 
-`I see what you mean. I strongly feel that Agile aligns with our team's strengths, though. I think we’ll have a BLANK chance of success with it.`
+`I see what you mean. I strongly feel that Agile aligns with our team's strengths, though. I think we'll have a BLANK chance of success with it.`
 
 ## --blanks--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617b53e5eda8e09c6c67d28.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617b53e5eda8e09c6c67d28.md
@@ -5,7 +5,7 @@ challengeType: 22
 dashedName: task-30
 ---
 
-<!-- (Audio) Sarah: I see what you mean. I strongly feel that Agile aligns with our team's strengths, though. I think we’ll have a greater chance of success with it. -->
+<!-- (Audio) Sarah: I see what you mean. I strongly feel that Agile aligns with our team's strengths, though. I think we'll have a greater chance of success with it. -->
 
 # --description--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617b674eb480b0c8d3d6031.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617b674eb480b0c8d3d6031.md
@@ -5,7 +5,7 @@ challengeType: 19
 dashedName: task-31
 ---
 
-<!-- (Audio) Sarah: I see what you mean. I strongly feel that Agile aligns with our team's strengths, though. I think we’ll have a greater chance of success with it. -->
+<!-- (Audio) Sarah: I see what you mean. I strongly feel that Agile aligns with our team's strengths, though. I think we'll have a greater chance of success with it. -->
 
 # --description--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617b81046e7b11287a7bef8.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617b81046e7b11287a7bef8.md
@@ -5,7 +5,7 @@ challengeType: 19
 dashedName: task-32
 ---
 
-<!-- (Audio) Sarah: I see what you mean. I strongly feel that Agile aligns with our team's strengths, though. I think we’ll have a greater chance of success with it. -->
+<!-- (Audio) Sarah: I see what you mean. I strongly feel that Agile aligns with our team's strengths, though. I think we'll have a greater chance of success with it. -->
 
 # --description--
 
@@ -27,7 +27,7 @@ Sarah expresses a strong belief in Agile's alignment with the team's strengths.
 
 ---
 
-She disagrees with using Agile and thinks it won’t be successful.
+She disagrees with using Agile and thinks it won't be successful.
 
 ### --feedback--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/658157d104bbc92a95147e45.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/658157d104bbc92a95147e45.md
@@ -5,7 +5,7 @@ challengeType: 19
 dashedName: task-32
 ---
 
-<!-- (Audio) Maria: Yeah, technical glitches are complicated and there’s not much we can do other than try to solve them. -->
+<!-- (Audio) Maria: Yeah, technical glitches are complicated and there's not much we can do other than try to solve them. -->
 
 # --description--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65fc9a04edb4d56c8390bc3a.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65fc9a04edb4d56c8390bc3a.md
@@ -5,7 +5,7 @@ challengeType: 22
 dashedName: task-31
 ---
 
-<!-- (Audio) Maria: Yeah, technical glitches are complicated and there’s not much we can do other than try to solve them. -->
+<!-- (Audio) Maria: Yeah, technical glitches are complicated and there's not much we can do other than try to solve them. -->
 
 # --description--
 
@@ -15,7 +15,7 @@ A `glitch` is a small problem that stops something from working right. Like when
 
 ## --sentence--
 
-`Yeah, technical BLANK are complicated and there’s not much we can do other than BLANK to solve them.`
+`Yeah, technical BLANK are complicated and there's not much we can do other than BLANK to solve them.`
 
 ## --blanks--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65fc9ab3635ebc6d167f86e6.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65fc9ab3635ebc6d167f86e6.md
@@ -5,7 +5,7 @@ challengeType: 19
 dashedName: task-33
 ---
 
-<!-- (Audio) Maria: Yeah, technical glitches are complicated and there’s not much we can do other than try to solve them. -->
+<!-- (Audio) Maria: Yeah, technical glitches are complicated and there's not much we can do other than try to solve them. -->
 
 # --description--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bd968e52c34220164de8d.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bd968e52c34220164de8d.md
@@ -5,7 +5,7 @@ challengeType: 19
 dashedName: task-32
 ---
 
-<!-- (Audio) Sarah: No problem, Tom. I noticed the issue you mentioned, and I’ve already tried a few things to solve it. -->
+<!-- (Audio) Sarah: No problem, Tom. I noticed the issue you mentioned, and I've already tried a few things to solve it. -->
 
 # --description--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65a84dad1595bbbc2e9cd895.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65a84dad1595bbbc2e9cd895.md
@@ -5,11 +5,11 @@ challengeType: 22
 dashedName: task-34
 ---
 
-<!-- (Audio) Sarah: No problem, Tom. I noticed the issue you mentioned, and I’ve already tried a few things to solve it. -->
+<!-- (Audio) Sarah: No problem, Tom. I noticed the issue you mentioned, and I've already tried a few things to solve it. -->
 
 # --description--
 
-People often use `have already` to talk about something they have done before now, and `have never` to talk about something they have not done at any time in the past. Let’s practice using these phrases.
+People often use `have already` to talk about something they have done before now, and `have never` to talk about something they have not done at any time in the past. Let's practice using these phrases.
 
 # --fillInTheBlank--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65a84e922382a7bd112057ad.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65a84e922382a7bd112057ad.md
@@ -5,7 +5,7 @@ challengeType: 19
 dashedName: task-35
 ---
 
-<!-- (Audio) Sarah: No problem, Tom. I noticed the issue you mentioned, and I’ve already tried a few things to solve it. -->
+<!-- (Audio) Sarah: No problem, Tom. I noticed the issue you mentioned, and I've already tried a few things to solve it. -->
 
 # --description--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65a85090914872be8ca97793.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65a85090914872be8ca97793.md
@@ -19,7 +19,7 @@ What is Tom asking Sarah about?
 
 ## --answers--
 
-Why she didn’t solve the issue
+Why she didn't solve the issue
 
 ### --feedback--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65a9457392dfd7d564bc940e.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65a9457392dfd7d564bc940e.md
@@ -27,7 +27,7 @@ It caused more problems, showing the current version is the issue.
 
 ### --feedback--
 
-Sarah said that going back didn’t solve the issue, not that it caused more problems.
+Sarah said that going back didn't solve the issue, not that it caused more problems.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65b28bbe803df52c4e76dd15.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65b28bbe803df52c4e76dd15.md
@@ -13,7 +13,7 @@ Modal verbs like `might` and `can` are used to express possibility and ability.
 
 `Might` is used for something that could happen or be true, like saying, `It might rain today`. 
 
-`Can` is used to talk about someone's ability to do something, like, `She can speak three languages`. Let’s practice using these words in sentences.
+`Can` is used to talk about someone's ability to do something, like, `She can speak three languages`. Let's practice using these words in sentences.
 
 # --fillInTheBlank--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65b28f840a0d962f2240e800.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65b28f840a0d962f2240e800.md
@@ -5,7 +5,7 @@ challengeType: 22
 dashedName: task-47
 ---
 
-<!-- (Audio) Sarah: Agreed. I’ll create a PR with the rollback and some additional logs for debugging. That may help us find what the problem is. -->
+<!-- (Audio) Sarah: Agreed. I'll create a PR with the rollback and some additional logs for debugging. That may help us find what the problem is. -->
 
 # --description--
 
@@ -15,7 +15,7 @@ In this task, you'll practice filling in key verbs and adjectives used in techni
 
 ## --sentence--
 
-`Agreed. I’ll BLANK a PR with the rollback and some BLANK logs for BLANK. That may help us find what the problem is.`
+`Agreed. I'll BLANK a PR with the rollback and some BLANK logs for BLANK. That may help us find what the problem is.`
 
 ## --blanks--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65b2af1545e34334b7573de9.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65b2af1545e34334b7573de9.md
@@ -5,7 +5,7 @@ challengeType: 19
 dashedName: task-48
 ---
 
-<!-- (Audio) Sarah: Agreed. I’ll create a PR with the rollback and some additional logs for debugging. That may help us find what the problem is. -->
+<!-- (Audio) Sarah: Agreed. I'll create a PR with the rollback and some additional logs for debugging. That may help us find what the problem is. -->
 
 # --description--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65b2b2781c59e837a5e0beb2.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65b2b2781c59e837a5e0beb2.md
@@ -5,7 +5,7 @@ challengeType: 19
 dashedName: task-51
 ---
 
-<!-- (Audio) Maria: Tom, I saw that you’ve fixed the issue on GitHub. Great job! -->
+<!-- (Audio) Maria: Tom, I saw that you've fixed the issue on GitHub. Great job! -->
 
 # --description--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65b2bb073ac8d03dfe507810.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65b2bb073ac8d03dfe507810.md
@@ -5,7 +5,7 @@ challengeType: 19
 dashedName: task-60
 ---
 
-<!-- (Audio) Tom: It happens to all of us, Maria. I’ll make sure to document this for future reference, so we won't run into the same problem again. -->
+<!-- (Audio) Tom: It happens to all of us, Maria. I'll make sure to document this for future reference, so we won't run into the same problem again. -->
 
 # --description--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/6620e51c36d18c137b887081.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/6620e51c36d18c137b887081.md
@@ -5,7 +5,7 @@ challengeType: 19
 dashedName: task-29
 ---
 
-<!-- (Audio) Tom: I see. So by explaining the complex parts with comments, I’ll help other people understand the code. Is that right? Sarah: Precisely. It's a form of documentation within the code. Great job grasping these concepts! -->
+<!-- (Audio) Tom: I see. So by explaining the complex parts with comments, I'll help other people understand the code. Is that right? Sarah: Precisely. It's a form of documentation within the code. Great job grasping these concepts! -->
 
 # --description--
 
@@ -27,7 +27,7 @@ Writing complex code without comments
 
 ### --feedback--
 
-Tom’s focus is on explaining complex code with comments, not writing it without comments.
+Tom's focus is on explaining complex code with comments, not writing it without comments.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/6622346c798d906ee4d31846.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/6622346c798d906ee4d31846.md
@@ -37,7 +37,7 @@ In this context, it refers to the final point Maria wants to make.
 
 ### --feedback--
 
-It describes the team’s nature of working together and helping each other.
+It describes the team's nature of working together and helping each other.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-read-and-understand-code-documentation/65fd5f2abfdbc510942d76f8.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-read-and-understand-code-documentation/65fd5f2abfdbc510942d76f8.md
@@ -35,7 +35,7 @@ Because it's a standard practice to read everything in order
 
 ### --feedback--
 
-The suggestion isn’t about reading everything in order but about finding specific information efficiently.
+The suggestion isn't about reading everything in order but about finding specific information efficiently.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/661005bbe1801e14c303a57a.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/661005bbe1801e14c303a57a.md
@@ -5,7 +5,7 @@ challengeType: 22
 dashedName: task-4
 ---
 
-<!-- (Audio) Bob: That's great, Sarah! I’ve also been pretty busy this week. I tested the new feature we added last week. It seems to be working well. And I found a few minor issues that we need to fix. -->
+<!-- (Audio) Bob: That's great, Sarah! I've also been pretty busy this week. I tested the new feature we added last week. It seems to be working well. And I found a few minor issues that we need to fix. -->
 
 # --description--
 
@@ -17,7 +17,7 @@ dashedName: task-4
 
 ## --sentence--
 
-`That's great, Sarah! I’ve also been BLANK busy this week. I tested the new BLANK we added last week. It BLANK to be working well. And I found a few BLANK issues that we need to fix.`
+`That's great, Sarah! I've also been BLANK busy this week. I tested the new BLANK we added last week. It BLANK to be working well. And I found a few BLANK issues that we need to fix.`
 
 ## --blanks--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/66100646290700150caff732.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/66100646290700150caff732.md
@@ -5,7 +5,7 @@ challengeType: 19
 dashedName: task-5
 ---
 
-<!-- (Audio) Bob: That's great, Sarah! I’ve also been pretty busy this week. I tested the new feature we added last week. It seems to be working well. And I found a few minor issues that we need to fix. -->
+<!-- (Audio) Bob: That's great, Sarah! I've also been pretty busy this week. I tested the new feature we added last week. It seems to be working well. And I found a few minor issues that we need to fix. -->
 
 # --description--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/661216bbf6d9a51b409172a8.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/661216bbf6d9a51b409172a8.md
@@ -5,7 +5,7 @@ challengeType: 19
 dashedName: task-7
 ---
 
-<!-- (Audio) Sarah: Thanks for catching those. As for me, I also finished the market research report. I presented it to the team yesterday. We’ve gathered valuable data that will help us make informed decisions. -->
+<!-- (Audio) Sarah: Thanks for catching those. As for me, I also finished the market research report. I presented it to the team yesterday. We've gathered valuable data that will help us make informed decisions. -->
 
 # --description--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/661256fe823f142fb9858beb.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/661256fe823f142fb9858beb.md
@@ -5,7 +5,7 @@ challengeType: 19
 dashedName: task-22
 ---
 
-<!-- (Audio) Brian: Of course. By the end of the quarter, I plan to have the documentation I’m working on fully updated, and I intend to improve our customer support process based on the training I received. -->
+<!-- (Audio) Brian: Of course. By the end of the quarter, I plan to have the documentation I'm working on fully updated, and I intend to improve our customer support process based on the training I received. -->
 
 # --description--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/66126744e24b0a31255718a7.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/66126744e24b0a31255718a7.md
@@ -5,7 +5,7 @@ challengeType: 19
 dashedName: task-23
 ---
 
-<!-- (Audio) Brian: Of course. By the end of the quarter, I plan to have the documentation I’m working on fully updated, and I intend to improve our customer support process based on the training I received. -->
+<!-- (Audio) Brian: Of course. By the end of the quarter, I plan to have the documentation I'm working on fully updated, and I intend to improve our customer support process based on the training I received. -->
 
 # --description--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-your-progress-in-weekly-stand-up-meetings/6579cf81a9cec6d21f872959.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-your-progress-in-weekly-stand-up-meetings/6579cf81a9cec6d21f872959.md
@@ -9,7 +9,7 @@ dashedName: task-6
 
 # --description--
 
-The phrase `a fresh pair of eyes` is an idiomatic expression meaning to have someone new look at something to offer a different perspective. It’s often used when someone has been working on a problem for a long time and needs an outside opinion. The modal verb `may` suggests possibility or likelihood but not certainty.
+The phrase `a fresh pair of eyes` is an idiomatic expression meaning to have someone new look at something to offer a different perspective. It's often used when someone has been working on a problem for a long time and needs an outside opinion. The modal verb `may` suggests possibility or likelihood but not certainty.
 
 # --fillInTheBlank--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-your-progress-in-weekly-stand-up-meetings/6579d002683211d5c7d13ef3.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-your-progress-in-weekly-stand-up-meetings/6579d002683211d5c7d13ef3.md
@@ -9,7 +9,7 @@ dashedName: task-8
 
 # --description--
 
-Sophie implies, or suggests without directly stating, that she needs help with her coding problem. To 'imply' something means to suggest it in an indirect way. For example, saying 'It’s getting late' can imply that it's time to leave, without saying it directly.
+Sophie implies, or suggests without directly stating, that she needs help with her coding problem. To 'imply' something means to suggest it in an indirect way. For example, saying 'It's getting late' can imply that it's time to leave, without saying it directly.
 
 # --questions--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-your-progress-in-weekly-stand-up-meetings/6579d4ca0578b4e95f1df60e.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-your-progress-in-weekly-stand-up-meetings/6579d4ca0578b4e95f1df60e.md
@@ -35,7 +35,7 @@ She should wait until the next meeting
 
 ### --feedback--
 
-Bob’s offer to help is immediate, contingent on Sophie sharing the code, not waiting until the next meeting.
+Bob's offer to help is immediate, contingent on Sophie sharing the code, not waiting until the next meeting.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-your-progress-in-weekly-stand-up-meetings/6579d539b1e5c2ec64484e49.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-your-progress-in-weekly-stand-up-meetings/6579d539b1e5c2ec64484e49.md
@@ -43,7 +43,7 @@ He doesn't think the problem can be solved
 
 ### --feedback--
 
-Bob’s statement implies he believes there are possible solutions, not that it's unsolvable.
+Bob's statement implies he believes there are possible solutions, not that it's unsolvable.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-your-progress-in-weekly-stand-up-meetings/6579d827ebd50afcacb829fe.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-your-progress-in-weekly-stand-up-meetings/6579d827ebd50afcacb829fe.md
@@ -44,7 +44,7 @@ He is asking for a break from the meeting
 
 ### --feedback--
 
-Bob’s statement is about making a suggestion, not about taking a break from the meeting.
+Bob's statement is about making a suggestion, not about taking a break from the meeting.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-your-progress-in-weekly-stand-up-meetings/6579dbf6a3e8a5161a592169.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-your-progress-in-weekly-stand-up-meetings/6579dbf6a3e8a5161a592169.md
@@ -5,7 +5,7 @@ challengeType: 19
 dashedName: task-31
 ---
 
-<!-- (Audio) Bob: I’m sure we'll gain some valuable insights from our discussion. -->
+<!-- (Audio) Bob: I'm sure we'll gain some valuable insights from our discussion. -->
 
 # --description--
 
@@ -43,7 +43,7 @@ He is unsure about the usefulness of the discussion
 
 ### --feedback--
 
-Bob’s statement `I'm sure` shows confidence in the usefulness of the discussion.
+Bob's statement `I'm sure` shows confidence in the usefulness of the discussion.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-your-progress-in-weekly-stand-up-meetings/6579ddc94db61d2463022da3.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-your-progress-in-weekly-stand-up-meetings/6579ddc94db61d2463022da3.md
@@ -35,7 +35,7 @@ Sophie specifically mentions a coding issue she's been working on, not a differe
 
 ---
 
-She requests Bob’s help on a coding issue she's struggling with
+She requests Bob's help on a coding issue she's struggling with
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-your-progress-in-weekly-stand-up-meetings/6579de040244fb274179f001.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-your-progress-in-weekly-stand-up-meetings/6579de040244fb274179f001.md
@@ -31,7 +31,7 @@ It means to give someone access to something, here referring to the code.
 
 ### --feedback--
 
-It suggests starting something with enthusiasm, indicating Bob’s readiness to examine the code closely.
+It suggests starting something with enthusiasm, indicating Bob's readiness to examine the code closely.
 
 # --scene--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-your-progress-in-weekly-stand-up-meetings/6579e17ff05c5d451c2e4f35.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-your-progress-in-weekly-stand-up-meetings/6579e17ff05c5d451c2e4f35.md
@@ -5,7 +5,7 @@ challengeType: 19
 dashedName: task-56
 ---
 
-<!-- (Audio) Sophie: Yeah, consistency is essential. I’ll go ahead and start with defining those coding standards. -->
+<!-- (Audio) Sophie: Yeah, consistency is essential. I'll go ahead and start with defining those coding standards. -->
 
 # --description--
 
@@ -23,7 +23,7 @@ To wait for further instructions about coding standards
 
 ### --feedback--
 
-Sophie’s statement shows she is ready to start working on the standards, not waiting for instructions.
+Sophie's statement shows she is ready to start working on the standards, not waiting for instructions.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-a-typical-workday-and-tasks/657e0868da73165e32763679.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-a-typical-workday-and-tasks/657e0868da73165e32763679.md
@@ -39,7 +39,7 @@ Which sentence correctly uses the word `most`?
 
 ### --feedback--
 
-This sentence doesn’t use `most`
+This sentence doesn't use `most`
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-a-typical-workday-and-tasks/657e15f175ecdf90b583ed01.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-a-typical-workday-and-tasks/657e15f175ecdf90b583ed01.md
@@ -19,7 +19,7 @@ What is Tom asking Sophie about?
 
 ## --answers--
 
-Sophie’s opinion on work.
+Sophie's opinion on work.
 
 ### --feedback--
 
@@ -39,7 +39,7 @@ The focus is on breaks during work, not after work.
 
 ---
 
-Sophie’s favorite coffee.
+Sophie's favorite coffee.
 
 ### --feedback--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-a-typical-workday-and-tasks/657e1c10bc3f2ea8e1c1d7f7.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-a-typical-workday-and-tasks/657e1c10bc3f2ea8e1c1d7f7.md
@@ -7,7 +7,7 @@ dashedName: task-22
 
 # --description--
 
-Understanding someone’s routine, like their lunch habits, involves paying attention to specific details in the conversation. 
+Understanding someone's routine, like their lunch habits, involves paying attention to specific details in the conversation. 
 
 # --questions--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-a-typical-workday-and-tasks/657e31b82090130535456f65.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-a-typical-workday-and-tasks/657e31b82090130535456f65.md
@@ -33,7 +33,7 @@ For helping him with a project.
 
 ### --feedback--
 
-Helping with a project isn’t mentioned in this context.
+Helping with a project isn't mentioned in this context.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-a-typical-workday-and-tasks/657e358a40dd95143df6fe26.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-a-typical-workday-and-tasks/657e358a40dd95143df6fe26.md
@@ -41,7 +41,7 @@ His favorite security equipment.
 
 ### --feedback--
 
-Equipment isn’t mentioned in Sophie's question.
+Equipment isn't mentioned in Sophie's question.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-a-typical-workday-and-tasks/657e3dfda31b534042d06e39.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-a-typical-workday-and-tasks/657e3dfda31b534042d06e39.md
@@ -27,7 +27,7 @@ Company rules suggest an external obligation, more suited to `have to`.
 
 ---
 
-`I have to make sure the security cameras work because I believe it’s crucial.`
+`I have to make sure the security cameras work because I believe it's crucial.`
 
 ### --feedback--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-a-typical-workday-and-tasks/657e4e482e3a38992b212c6f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-a-typical-workday-and-tasks/657e4e482e3a38992b212c6f.md
@@ -9,7 +9,7 @@ dashedName: task-77
 
 A `policy` (in the plural, `policies`) is a principle or rule to guide decisions and achieve rational outcomes. Policies are often adopted by an organization to guide employees. 
 
-For instance, `The company’s privacy policy protects client information.`
+For instance, `The company's privacy policy protects client information.`
 
 # --questions--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-a-typical-workday-and-tasks/657e50dd1f6ff2a9873f9ff0.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-a-typical-workday-and-tasks/657e50dd1f6ff2a9873f9ff0.md
@@ -44,7 +44,7 @@ Deciding what tasks to do.
 
 ### --feedback--
 
-It’s about following set tasks, not personal choice.
+It's about following set tasks, not personal choice.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-a-typical-workday-and-tasks/657e5c296bdba2ea26c67ca0.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-a-typical-workday-and-tasks/657e5c296bdba2ea26c67ca0.md
@@ -15,7 +15,7 @@ Listen to the audio to answer the question below.
 
 ## --text--
 
-What is the meaning of Linda’s question?
+What is the meaning of Linda's question?
 
 ## --answers--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657e76356b6af6c07fe338c1.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657e76356b6af6c07fe338c1.md
@@ -5,7 +5,7 @@ challengeType: 22
 dashedName: task-28
 ---
 
-<!-- (Audio) Linda: I've been a cyclist for more than 15 years. It's a love that hasn’t disappeared with time. -->
+<!-- (Audio) Linda: I've been a cyclist for more than 15 years. It's a love that hasn't disappeared with time. -->
 
 # --description--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657e786b51f7eac240e92bcc.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657e786b51f7eac240e92bcc.md
@@ -40,7 +40,7 @@ This sentence is not correct. A correct usage would be `Would you like me to mak
 
 ### --feedback--
 
-In this context, `like` doesn’t require the ending `-s` The correct form is `Would you like a glass of water?`
+In this context, `like` doesn't require the ending `-s` The correct form is `Would you like a glass of water?`
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657fff7dabba2ff23993b08c.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657fff7dabba2ff23993b08c.md
@@ -31,7 +31,7 @@ Partial acceptance
 
 ### --feedback--
 
-It suggests agreeing partially, which doesn’t fit the intention of the phrase.
+It suggests agreeing partially, which doesn't fit the intention of the phrase.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/658010478daa16fe79d8113a.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/658010478daa16fe79d8113a.md
@@ -35,7 +35,7 @@ She's hesitant to include Brian.
 
 ### --feedback--
 
-Sophie's tone doesn’t suggest hesitation, but rather openness and enthusiasm for his participation.
+Sophie's tone doesn't suggest hesitation, but rather openness and enthusiasm for his participation.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6613d3fe6615374be0d10008.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6613d3fe6615374be0d10008.md
@@ -5,7 +5,7 @@ challengeType: 19
 dashedName: task-5
 ---
 
-<!-- (Audio) Brian: Well, we’re going to use a framework for the front-end, probably React. It's the technology we're most comfortable with, and it will make development faster. -->
+<!-- (Audio) Brian: Well, we're going to use a framework for the front-end, probably React. It's the technology we're most comfortable with, and it will make development faster. -->
 
 # --description--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6613d46936e9374c24cfaaab.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6613d46936e9374c24cfaaab.md
@@ -11,7 +11,7 @@ dashedName: task-6
 
 `Going to` can also be used when you have some evidence in the present that something will happen in the future.  
 
-For example, `Look at those numbers! It's going to be a hard day.` or `They are going to feel upset if we don’t invite them to the meeting.`
+For example, `Look at those numbers! It's going to be a hard day.` or `They are going to feel upset if we don't invite them to the meeting.`
 
 # --fillInTheBlank--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6613d550a08c194cd27607ec.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6613d550a08c194cd27607ec.md
@@ -5,7 +5,7 @@ challengeType: 19
 dashedName: task-8
 ---
 
-<!-- (Audio) Brian: Absolutely. And as for the back-end, I think we’ll use Node.js. -->
+<!-- (Audio) Brian: Absolutely. And as for the back-end, I think we'll use Node.js. -->
 
 # --description--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6613d6c3e74a984d6fcbd013.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6613d6c3e74a984d6fcbd013.md
@@ -5,7 +5,7 @@ challengeType: 19
 dashedName: task-10
 ---
 
-<!-- (Audio) Brian: Absolutely. And as for the back-end, I think we’ll use Node.js. It's a solid choice, and it will allow us to scale the application effectively. -->
+<!-- (Audio) Brian: Absolutely. And as for the back-end, I think we'll use Node.js. It's a solid choice, and it will allow us to scale the application effectively. -->
 
 # --description--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6614ad58c102e15df06c96d5.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6614ad58c102e15df06c96d5.md
@@ -5,7 +5,7 @@ challengeType: 22
 dashedName: task-15
 ---
 
-<!-- (Audio) Sophie: I think we’re going to focus on social media marketing. It's cost-effective, and it will reach a broader audience. -->
+<!-- (Audio) Sophie: I think we're going to focus on social media marketing. It's cost-effective, and it will reach a broader audience. -->
 
 # --description--
 
@@ -21,7 +21,7 @@ An `audience` refers to the group of people who watch, read, or listen to someth
 
 ## --sentence--
 
-`I think we’re going to focus on social media marketing. It's BLANK, and it will BLANK a BLANK audience.`
+`I think we're going to focus on social media marketing. It's BLANK, and it will BLANK a BLANK audience.`
 
 ## --blanks--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6614ae3e02cc465ebee68851.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6614ae3e02cc465ebee68851.md
@@ -5,7 +5,7 @@ challengeType: 19
 dashedName: task-16
 ---
 
-<!-- (Audio) Sophie: I think we’re going to focus on social media marketing. It's cost-effective, and it will reach a broader audience. -->
+<!-- (Audio) Sophie: I think we're going to focus on social media marketing. It's cost-effective, and it will reach a broader audience. -->
 
 # --description--
 
@@ -19,7 +19,7 @@ Which part of Sophie's sentence indicates that she is considering focusing on so
 
 ## --answers--
 
-`I think we’re going to focus on social media marketing.`
+`I think we're going to focus on social media marketing.`
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6614b1f8ee220c5f79df89b8.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6614b1f8ee220c5f79df89b8.md
@@ -5,7 +5,7 @@ challengeType: 19
 dashedName: task-17
 ---
 
-<!-- (Audio) Sophie: I think we’re going to focus on social media marketing. It's cost-effective, and it will reach a broader audience. -->
+<!-- (Audio) Sophie: I think we're going to focus on social media marketing. It's cost-effective, and it will reach a broader audience. -->
 
 # --description--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6614b3e52a6aca60bc3417fb.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6614b3e52a6aca60bc3417fb.md
@@ -5,7 +5,7 @@ challengeType: 19
 dashedName: task-20
 ---
 
-<!-- (Audio) Sophie: I think we’re going to focus on social media marketing. It's cost-effective, and it will reach a broader audience. Brian: That sounds good. I suggest that we also invest in email marketing. It's more targeted, and it will allow us to engage with our subscribers directly. -->
+<!-- (Audio) Sophie: I think we're going to focus on social media marketing. It's cost-effective, and it will reach a broader audience. Brian: That sounds good. I suggest that we also invest in email marketing. It's more targeted, and it will allow us to engage with our subscribers directly. -->
 
 # --description--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-basic-programming-vocabulary-in-conversations/6629ce1a4f6581a7266d6ca9.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-basic-programming-vocabulary-in-conversations/6629ce1a4f6581a7266d6ca9.md
@@ -11,7 +11,7 @@ dashedName: task-3
 
 The **Present Perfect Continuous tense** is used talk about actions or situations that started in the past and are still happening now. It is very useful when you want to emphasize the duration of an activity or that it is an ongoing process.
 
-Here’s how to form the **Present Perfect Continuous**: Subject + `has/have been` + `-ing` form of the verb. This tense is often used with expressions of time such as `for` and `since`. `For` is used with a period of time like two years or six months, while `since` is used with a specific point in time, like 2018 or this morning.
+Here's how to form the **Present Perfect Continuous**: Subject + `has/have been` + `-ing` form of the verb. This tense is often used with expressions of time such as `for` and `since`. `For` is used with a period of time like two years or six months, while `since` is used with a specific point in time, like 2018 or this morning.
 
 Examples:
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-basic-programming-vocabulary-in-conversations/662a2779b2aeb80c10508bf2.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-basic-programming-vocabulary-in-conversations/662a2779b2aeb80c10508bf2.md
@@ -23,7 +23,7 @@ She complains about the difficulty of learning them.
 
 ### --feedback--
 
-Sophie doesn’t mention any difficulty; she only expresses surprise at the number of programming languages.
+Sophie doesn't mention any difficulty; she only expresses surprise at the number of programming languages.
 
 ---
 
@@ -43,7 +43,7 @@ She ignores the comment and changes the subject.
 
 ### --feedback--
 
-Sophie directly responds to Brian’s observation by pointing out an interesting fact about programming languages.
+Sophie directly responds to Brian's observation by pointing out an interesting fact about programming languages.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-basic-programming-vocabulary-in-conversations/662a2b1f0c9314142ae87955.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-basic-programming-vocabulary-in-conversations/662a2b1f0c9314142ae87955.md
@@ -43,7 +43,7 @@ Who she was with when she spent the time
 
 ### --feedback--
 
-Brian’s question is specifically about the amount of time, not about who was with her.
+Brian's question is specifically about the amount of time, not about who was with her.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-basic-programming-vocabulary-in-conversations/662a304552f2631d63aa7cab.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-basic-programming-vocabulary-in-conversations/662a304552f2631d63aa7cab.md
@@ -35,7 +35,7 @@ Sophie actually indicates she has free time and chooses to spend much of it on a
 
 ---
 
-She doesn’t enjoy what she does in her free time.
+She doesn't enjoy what she does in her free time.
 
 ### --feedback--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-basic-programming-vocabulary-in-conversations/662b74055c06e60af4f9b976.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-basic-programming-vocabulary-in-conversations/662b74055c06e60af4f9b976.md
@@ -23,7 +23,7 @@ Brian needs help finding Python, the snake.
 
 ### --feedback--
 
-Brian’s question is about Python the programming language, not a snake.
+Brian's question is about Python the programming language, not a snake.
 
 ---
 
@@ -35,7 +35,7 @@ Brian is looking for someone to teach him Python next week.
 
 ### --feedback--
 
-Brian’s request implies an immediate need for clarification on a specific question, not seeking a teacher for future lessons.
+Brian's request implies an immediate need for clarification on a specific question, not seeking a teacher for future lessons.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-basic-programming-vocabulary-in-conversations/662b8975b11107146a49ec58.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-basic-programming-vocabulary-in-conversations/662b8975b11107146a49ec58.md
@@ -35,7 +35,7 @@ Sarah needs help installing her code.
 
 ### --feedback--
 
-The audio does not mention installation issues; it focuses on trouble with existing code and understanding what’s wrong.
+The audio does not mention installation issues; it focuses on trouble with existing code and understanding what's wrong.
 
 ---
 
@@ -43,7 +43,7 @@ Sarah is confident about fixing the code herself.
 
 ### --feedback--
 
-Sarah’s description of not being able to figure out the issue suggests she is not confident about resolving it on her own.
+Sarah's description of not being able to figure out the issue suggests she is not confident about resolving it on her own.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-basic-programming-vocabulary-in-conversations/662f074021418e2b24937af7.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-basic-programming-vocabulary-in-conversations/662f074021418e2b24937af7.md
@@ -5,7 +5,7 @@ challengeType: 22
 dashedName: task-53
 ---
 
-<!-- (Audio) Tom: Depending on the IDE that you’re using, there are many extensions and plugins to use. -->
+<!-- (Audio) Tom: Depending on the IDE that you're using, there are many extensions and plugins to use. -->
 
 # --description--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-basic-programming-vocabulary-in-conversations/662f0d350c37f42de48847fe.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-basic-programming-vocabulary-in-conversations/662f0d350c37f42de48847fe.md
@@ -5,7 +5,7 @@ challengeType: 19
 dashedName: task-57
 ---
 
-<!-- (Audio) Tom: There are many debugging tools you can use. Depending on the IDE that you’re using, there are many extensions and plugins to use. They are super helpful. Sarah: I'll keep that in mind. Thanks, Tom. -->
+<!-- (Audio) Tom: There are many debugging tools you can use. Depending on the IDE that you're using, there are many extensions and plugins to use. They are super helpful. Sarah: I'll keep that in mind. Thanks, Tom. -->
 
 # --description--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-basic-programming-vocabulary-in-conversations/662f2e4b96f60636d44eb7db.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-basic-programming-vocabulary-in-conversations/662f2e4b96f60636d44eb7db.md
@@ -5,7 +5,7 @@ challengeType: 22
 dashedName: task-66
 ---
 
-<!-- (Audio) Tom: I understand that there are classes and methods, but I’ve never used them in my code. -->
+<!-- (Audio) Tom: I understand that there are classes and methods, but I've never used them in my code. -->
 
 # --description--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-basic-programming-vocabulary-in-conversations/662f31024608f337c0bf53a9.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-basic-programming-vocabulary-in-conversations/662f31024608f337c0bf53a9.md
@@ -5,7 +5,7 @@ challengeType: 19
 dashedName: task-67
 ---
 
-<!-- (Audio) Sarah: Object-oriented programming is used in many modern languages. How much do you know about it so far? Tom: Not much, really. I understand there are classes and methods, but I’ve never used them in my code. -->
+<!-- (Audio) Sarah: Object-oriented programming is used in many modern languages. How much do you know about it so far? Tom: Not much, really. I understand there are classes and methods, but I've never used them in my code. -->
 
 # --description--
 
@@ -31,11 +31,11 @@ Tom knows some things but hasn't tried them yet.
 
 ---
 
-Tom knows a lot about it but hasn’t used it.
+Tom knows a lot about it but hasn't used it.
 
 ### --feedback--
 
-Tom mentions understanding basic ideas like classes and methods, but he hasn’t used them, showing he knows a bit but not a lot.
+Tom mentions understanding basic ideas like classes and methods, but he hasn't used them, showing he knows a bit but not a lot.
 
 ---
 
@@ -43,7 +43,7 @@ Tom doesn't know anything about it.
 
 ### --feedback--
 
-Tom does know something because he talks about classes and methods, so he isn’t completely unfamiliar.
+Tom does know something because he talks about classes and methods, so he isn't completely unfamiliar.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-basic-programming-vocabulary-in-conversations/662f3450de7c2139809fb72b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-basic-programming-vocabulary-in-conversations/662f3450de7c2139809fb72b.md
@@ -33,7 +33,7 @@ A coworker asks for a report urgently and you reply, `No worries`, without provi
 
 ### --feedback--
 
-This use might imply indifference or dismissal without addressing the coworker’s urgent need, which is not appropriate.
+This use might imply indifference or dismissal without addressing the coworker's urgent need, which is not appropriate.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657b400653813a1caa228aca.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657b400653813a1caa228aca.md
@@ -19,7 +19,7 @@ Sentences with the verb `to be` are often used to describe feelings and emotions
 
 ## --text--
 
-What does the expression `I’m happy` indicate in the present simple tense?
+What does the expression `I'm happy` indicate in the present simple tense?
 
 ## --answers--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657b68caf6debb2975503948.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657b68caf6debb2975503948.md
@@ -12,7 +12,7 @@ It's nice to have you here, Alice.
 
 # --description--
 
-`It’s nice to` is used to express a positive sentiment or feeling about something or someone. 
+`It's nice to` is used to express a positive sentiment or feeling about something or someone. 
 
 # --questions--
 
@@ -22,7 +22,7 @@ What is Bob expressing in his sentence?
 
 ## --answers--
 
-A negative opinion about Alice’s presence
+A negative opinion about Alice's presence
 
 ### --feedback--
 
@@ -30,7 +30,7 @@ Think about how the phrase `nice to` usually conveys positive feelings.
 
 ---
 
-A neutral statement about Alice’s presence
+A neutral statement about Alice's presence
 
 ### --feedback--
 
@@ -38,7 +38,7 @@ Consider the warmth usually conveyed by the phrase `nice to`.
 
 ---
 
-An apology for Alice’s presence
+An apology for Alice's presence
 
 ### --feedback--
 
@@ -46,7 +46,7 @@ Reflect on the purpose of the phrase `nice to` in welcoming contexts.
 
 ---
 
-A positive and welcoming sentiment about Alice’s presence
+A positive and welcoming sentiment about Alice's presence
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657ca50a95d1c3828ee5a991.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657ca50a95d1c3828ee5a991.md
@@ -33,7 +33,7 @@ He is pleased with the current team members.
 
 ### --feedback--
 
-While this might be true, it doesn’t directly relate to the phrase about new members.
+While this might be true, it doesn't directly relate to the phrase about new members.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657caa4012f1cf846dcaa619.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657caa4012f1cf846dcaa619.md
@@ -6,7 +6,7 @@ dashedName: task-33
 ---
 <!--
 AUDIO REFERENCE:
-This is John, the database administrator. He’s been here for three years. He makes sure our data is secure and efficient.
+This is John, the database administrator. He's been here for three years. He makes sure our data is secure and efficient.
 -->
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657cad90d6745e85569cdc06.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657cad90d6745e85569cdc06.md
@@ -6,7 +6,7 @@ dashedName: task-34
 ---
 <!--
 AUDIO REFERENCE:
-This is John, the database administrator. He’s been here for three years. He makes sure our data is secure and efficient.
+This is John, the database administrator. He's been here for three years. He makes sure our data is secure and efficient.
 -->
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657caec5163c6c85e5b31284.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657caec5163c6c85e5b31284.md
@@ -6,7 +6,7 @@ dashedName: task-35
 ---
 <!--
 AUDIO REFERENCE:
-This is John, the database administrator. He’s been here for three years.
+This is John, the database administrator. He's been here for three years.
 -->
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657cafc142a867006734c3ed.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657cafc142a867006734c3ed.md
@@ -6,7 +6,7 @@ dashedName: task-36
 ---
 <!--
 AUDIO REFERENCE:
-This is John, the database administrator. He’s been here for three years.
+This is John, the database administrator. He's been here for three years.
 -->
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657ccfa7eeb47305177d4a45.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657ccfa7eeb47305177d4a45.md
@@ -6,7 +6,7 @@ dashedName: task-42
 ---
 <!--
 AUDIO REFERENCE:
-Everybody, let’s welcome Alice to the team.
+Everybody, let's welcome Alice to the team.
 -->
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657cd816f3caf509f85e4d4a.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657cd816f3caf509f85e4d4a.md
@@ -7,7 +7,7 @@ dashedName: task-50
 
 <!--
 AUDIO REFERENCE:
-I'd like to introduce Lisa. She’s our new front-end developer.
+I'd like to introduce Lisa. She's our new front-end developer.
 -->
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657ce387f809d60eb54f06d6.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657ce387f809d60eb54f06d6.md
@@ -7,7 +7,7 @@ dashedName: task-58
 
 <!--
 AUDIO REFERENCE:
-Bob: Is there any specific area of design or development you're interested in? He’s your go-to guy for that.
+Bob: Is there any specific area of design or development you're interested in? He's your go-to guy for that.
 -->
 
 # --description--
@@ -20,7 +20,7 @@ For example, `He's the go-to guy for computer problems` means he is the person b
 
 ## --sentence--
 
-`Is there any BLANK area of design or development you're interested in? He’s your BLANK-to BLANK for that.`
+`Is there any BLANK area of design or development you're interested in? He's your BLANK-to BLANK for that.`
 
 ## --blanks--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657ce691d6c57c107e650c5e.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657ce691d6c57c107e650c5e.md
@@ -7,7 +7,7 @@ dashedName: task-61
 
 <!--
 AUDIO REFERENCE:
-Bob: This is Tom, our new graphic designer. Is there any specific area of design or development you're interested in? He’s your go-to guy for that.
+Bob: This is Tom, our new graphic designer. Is there any specific area of design or development you're interested in? He's your go-to guy for that.
 -->
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657daa5ab8505427a5b99cd2.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657daa5ab8505427a5b99cd2.md
@@ -7,7 +7,7 @@ dashedName: task-64
 
 <!--
 AUDIO REFERENCE:
-Bob: And I’m Bob, the team’s project manager.
+Bob: And I'm Bob, the team's project manager.
 -->
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657dab674b9de728828aa020.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657dab674b9de728828aa020.md
@@ -7,7 +7,7 @@ dashedName: task-66
 
 <!--
 AUDIO REFERENCE:
-Bob: And I’m Bob, the team’s project manager. I’m the person you always need to talk to if you have any questions about the team’s goals and schedule.
+Bob: And I'm Bob, the team's project manager. I'm the person you always need to talk to if you have any questions about the team's goals and schedule.
 -->
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657dadfc7d21eb294c9f057e.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657dadfc7d21eb294c9f057e.md
@@ -7,7 +7,7 @@ dashedName: task-67
 
 <!--
 AUDIO REFERENCE:
-Bob: And I’m Bob, the team’s project manager. I’m the person you always need to talk to if you have any questions about the team’s goals and schedule.
+Bob: And I'm Bob, the team's project manager. I'm the person you always need to talk to if you have any questions about the team's goals and schedule.
 -->
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657daf702ed04a29ee42de69.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657daf702ed04a29ee42de69.md
@@ -7,7 +7,7 @@ dashedName: task-68
 
 <!--
 AUDIO REFERENCE:
-Lisa: Hi, Bob. It’s great to meet you too.
+Lisa: Hi, Bob. It's great to meet you too.
 -->
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657df21cc45b1f66112fb8fc.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657df21cc45b1f66112fb8fc.md
@@ -7,7 +7,7 @@ dashedName: task-69
 
 <!--
 AUDIO REFERENCE:
-Bob: Excellent! Lisa, it’s great to have you join our team, even if just online.
+Bob: Excellent! Lisa, it's great to have you join our team, even if just online.
 -->
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657df2b22d7649667734d71e.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657df2b22d7649667734d71e.md
@@ -7,7 +7,7 @@ dashedName: task-70
 
 <!--
 AUDIO REFERENCE:
-Bob: Excellent! Lisa, it’s great to have you join our team, even if just online.
+Bob: Excellent! Lisa, it's great to have you join our team, even if just online.
 -->
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657df5d14291b56887825276.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657df5d14291b56887825276.md
@@ -7,7 +7,7 @@ dashedName: task-74
 
 <!--
 AUDIO REFERENCE:
-James: Good morning. I’m James and I’m here to help you with your training.
+James: Good morning. I'm James and I'm here to help you with your training.
 -->
 
 # --description--
@@ -18,7 +18,7 @@ Listen to the audio and fill in the missing words.
 
 ## --sentence--
 
-`I’m James and I’m BLANK to BLANK you with your BLANK.`
+`I'm James and I'm BLANK to BLANK you with your BLANK.`
 
 ## --blanks--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657df6018a70e468f5dc016a.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657df6018a70e468f5dc016a.md
@@ -7,7 +7,7 @@ dashedName: task-75
 
 <!--
 AUDIO REFERENCE:
-James: Good morning. I’m James and I’m here to help you with your training.
+James: Good morning. I'm James and I'm here to help you with your training.
 -->
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657e4b7d381d567e8d97967c.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657e4b7d381d567e8d97967c.md
@@ -7,7 +7,7 @@ dashedName: task-88
 
 <!--
 AUDIO REFERENCE:
-I'm Maria, the lead developer. I’m responsible for the technical aspects of the project. This is Bob, the project manager. He’s responsible for coordinating our efforts to meet your needs.
+I'm Maria, the lead developer. I'm responsible for the technical aspects of the project. This is Bob, the project manager. He's responsible for coordinating our efforts to meet your needs.
 -->
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657e4c1f0bd3e97ef2d46644.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657e4c1f0bd3e97ef2d46644.md
@@ -7,7 +7,7 @@ dashedName: task-89
 
 <!--
 AUDIO REFERENCE:
-I'm Maria, the lead developer. I’m responsible for the technical aspects of the project. This is Bob, the project manager. He’s responsible for coordinating our efforts to meet your needs.
+I'm Maria, the lead developer. I'm responsible for the technical aspects of the project. This is Bob, the project manager. He's responsible for coordinating our efforts to meet your needs.
 -->
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657e4cd7f87d4f7f6954446d.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657e4cd7f87d4f7f6954446d.md
@@ -7,7 +7,7 @@ dashedName: task-90
 
 <!--
 AUDIO REFERENCE:
-I'm Maria, the lead developer. I’m responsible for the technical aspects of the project. This is Bob, the project manager. He’s responsible for coordinating our efforts to meet your needs.
+I'm Maria, the lead developer. I'm responsible for the technical aspects of the project. This is Bob, the project manager. He's responsible for coordinating our efforts to meet your needs.
 -->
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657e4db2e3fc8d7fb41b8b85.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657e4db2e3fc8d7fb41b8b85.md
@@ -7,7 +7,7 @@ dashedName: task-91
 
 <!--
 AUDIO REFERENCE:
-David: Hey, Bob. How’s it going?
+David: Hey, Bob. How's it going?
 -->
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657e4fd2ecf31280ef673f0d.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657e4fd2ecf31280ef673f0d.md
@@ -7,7 +7,7 @@ dashedName: task-94
 
 <!--
 AUDIO REFERENCE:
-Maria: And this is Linda, she’s our UX/UI designer. She works in user experience and she creates our interface design.
+Maria: And this is Linda, she's our UX/UI designer. She works in user experience and she creates our interface design.
 -->
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657e539471b4aa82c7402c15.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657e539471b4aa82c7402c15.md
@@ -8,7 +8,7 @@ dashedName: task-97
 <!--
 AUDIO REFERENCE:
 
-David: I’ll be your point of contact and I’ll help make sure our collaboration is great.
+David: I'll be your point of contact and I'll help make sure our collaboration is great.
 
 -->
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657e5477269b94834908826f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657e5477269b94834908826f.md
@@ -8,7 +8,7 @@ dashedName: task-98
 <!--
 AUDIO REFERENCE:
 
-David: I’ll be your point of contact and I’ll help make sure our collaboration is great.
+David: I'll be your point of contact and I'll help make sure our collaboration is great.
 
 -->
 
@@ -20,7 +20,7 @@ David: I’ll be your point of contact and I’ll help make sure our collaborati
 
 ## --sentence--
 
-`I'll be your BLANK of contact and I’ll help make sure our BLANK is great.`
+`I'll be your BLANK of contact and I'll help make sure our BLANK is great.`
 
 ## --blanks--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657e54f51fe1c983d840cb70.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657e54f51fe1c983d840cb70.md
@@ -8,7 +8,7 @@ dashedName: task-99
 <!--
 AUDIO REFERENCE:
 
-David: I’ll be your point of contact and I’ll help make sure our collaboration is great.
+David: I'll be your point of contact and I'll help make sure our collaboration is great.
 
 -->
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657e55e612fac9847dc7ce03.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657e55e612fac9847dc7ce03.md
@@ -8,7 +8,7 @@ dashedName: task-100
 <!--
 AUDIO REFERENCE:
 
-"We’re excited about this project. I’m confident that we can achieve great results."
+"We're excited about this project. I'm confident that we can achieve great results."
 
 -->
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657e56e7034d2d858b6e9e00.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657e56e7034d2d858b6e9e00.md
@@ -8,7 +8,7 @@ dashedName: task-101
 <!--
 AUDIO REFERENCE:
 
-David: Wonderful to meet you all. I'm David, the project manager from FCC Corp. I’ll be your point of contact and I’ll help make sure our collaboration is great. We’re excited about this project. I’m confident that we can achieve great results.
+David: Wonderful to meet you all. I'm David, the project manager from FCC Corp. I'll be your point of contact and I'll help make sure our collaboration is great. We're excited about this project. I'm confident that we can achieve great results.
 
 -->
 


### PR DESCRIPTION
I’ve replaced all curved backticks with straight ones to ensure the formatting aligns with fCC standards. This PR is just for the A2 curriculum. There's another one for B1. https://github.com/freeCodeCamp/freeCodeCamp/pull/57567
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
