### PR TITLE
fix(curriculum): match literal dot

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-calorie-counter/63b61490e633a22b4593e62f.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-calorie-counter/63b61490e633a22b4593e62f.md
@@ -65,7 +65,7 @@ You should assign the `#output` element to `output`.
 ```js
 // assert.deepEqual(output, document.getElementById('output')); cannot be used,
 // as browser defines `output` variable on it own for `#output`.
-assert.match(code, /const\s+output\s*=\s*document.getElementById\(('|")output\1\)/);
+assert.match(code, /const\s+output\s*=\s*document\.getElementById\(('|")output\1\)/);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-calorie-counter/660404511dbf1b90eb23b617.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-calorie-counter/660404511dbf1b90eb23b617.md
@@ -18,13 +18,13 @@ Open up the console to see the result. In the next step, you will learn more abo
 You should have a `console.log` below your `isInvalidInput` function.
 
 ```js
-assert.match(code, /console.log\(/);
+assert.match(code, /console\.log\(/);
 ```
 
 Your console statement should have the value of `isInvalidInput("1e3")`.
 
 ```js
-assert.match(code, /console.log\(isInvalidInput\(('|")1e3\s*\1\);?\)/);
+assert.match(code, /console\.log\(isInvalidInput\(('|")1e3\s*\1\);?\)/);
 
 ```
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-calorie-counter/6604080b66ff6e942d8225b1.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-calorie-counter/6604080b66ff6e942d8225b1.md
@@ -31,13 +31,13 @@ Open up the console to see the result. You will learn more about what this resul
 You should have a `console.log` below your `isInvalidInput` function.
 
 ```js
-assert.match(code, /console.log\(/);
+assert.match(code, /console\.log\(/);
 ```
 
 Your console statement should have the value of `isInvalidInput("10")`.
 
 ```js
-assert.match(code, /console.log\(isInvalidInput\(('|")10\s*\1\);?\)/);
+assert.match(code, /console\.log\(isInvalidInput\(('|")10\s*\1\);?\)/);
 
 ```
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-calorie-counter/66040ae710de0e96c26a0201.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-calorie-counter/66040ae710de0e96c26a0201.md
@@ -18,7 +18,7 @@ Now that you have finished testing your `isInvalidInput` function, you can remov
 You should remove your `console.log(isInvalidInput("10"));`.
 
 ```js
-assert.notMatch(code, /console.log\(isInvalidInput\("10"\)\);?/g)
+assert.notMatch(code, /console\.log\(isInvalidInput\("10"\)\);?/g)
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

- - -
- Few cases of regex missing escape for dot.