### PR TITLE
fix(client): only show live certifications

### DIFF
--- a/client/src/templates/Introduction/super-block-intro.tsx
+++ b/client/src/templates/Introduction/super-block-intro.tsx
@@ -25,7 +25,8 @@ import {
   signInLoadingSelector
 } from '../../redux/selectors';
 import type { ChallengeNode, User } from '../../redux/prop-types';
-import { CertTitle } from '../../../config/cert-and-project-map';
+import { CertTitle, liveCerts } from '../../../config/cert-and-project-map';
+import { superBlockToCertMap } from '../../../../shared/config/certification-settings';
 import Block from './components/block';
 import CertChallenge from './components/cert-challenge';
 import LegacyLinks from './components/legacy-links';
@@ -187,15 +188,9 @@ const SuperBlockIntroductionPage = (props: SuperBlockProp) => {
 
   const i18nTitle = getSuperBlockTitleForMap(superBlock);
 
-  const superblockWithoutCert = [
-    SuperBlocks.RespWebDesign,
-    SuperBlocks.CodingInterviewPrep,
-    SuperBlocks.TheOdinProject,
-    SuperBlocks.ProjectEuler,
-    SuperBlocks.A2English,
-    SuperBlocks.RosettaCode,
-    SuperBlocks.PythonForEverybody
-  ];
+  const showCertification = liveCerts.some(
+    cert => superBlockToCertMap[superBlock] === cert.certSlug
+  );
 
   const superBlockWithAccordionView = [SuperBlocks.FullStackDeveloper];
   const chosenBlock = getChosenBlock();
@@ -255,7 +250,7 @@ const SuperBlockIntroductionPage = (props: SuperBlockProp) => {
                       />
                     );
                   })}
-                  {!superblockWithoutCert.includes(superBlock) && (
+                  {showCertification && (
                     <CertChallenge
                       certification={certification}
                       superBlock={superBlock}

--- a/shared/config/certification-settings.ts
+++ b/shared/config/certification-settings.ts
@@ -250,6 +250,34 @@ export const certTypeTitleMap = {
     'JavaScript Algorithms and Data Structures (Beta)'
 };
 
+export const superBlockToCertMap: {
+  [key in SuperBlocks]: Certification | null;
+} = {
+  [SuperBlocks.RespWebDesign]: Certification.RespWebDesign,
+  [SuperBlocks.JsAlgoDataStructNew]: Certification.JsAlgoDataStructNew,
+  [SuperBlocks.FrontEndDevLibs]: Certification.FrontEndDevLibs,
+  [SuperBlocks.DataVis]: Certification.DataVis,
+  [SuperBlocks.RelationalDb]: Certification.RelationalDb,
+  [SuperBlocks.BackEndDevApis]: Certification.BackEndDevApis,
+  [SuperBlocks.QualityAssurance]: Certification.QualityAssurance,
+  [SuperBlocks.SciCompPy]: Certification.SciCompPy,
+  [SuperBlocks.DataAnalysisPy]: Certification.DataAnalysisPy,
+  [SuperBlocks.InfoSec]: Certification.InfoSec,
+  [SuperBlocks.MachineLearningPy]: Certification.MachineLearningPy,
+  [SuperBlocks.CollegeAlgebraPy]: Certification.CollegeAlgebraPy,
+  [SuperBlocks.FoundationalCSharp]: Certification.FoundationalCSharp,
+  [SuperBlocks.RespWebDesignNew]: Certification.RespWebDesign,
+  [SuperBlocks.JsAlgoDataStruct]: Certification.JsAlgoDataStruct,
+  [SuperBlocks.FullStackDeveloper]: Certification.FullStackDeveloper,
+  [SuperBlocks.A2English]: Certification.A2English,
+  [SuperBlocks.B1English]: Certification.B1English,
+  [SuperBlocks.PythonForEverybody]: null,
+  [SuperBlocks.CodingInterviewPrep]: null,
+  [SuperBlocks.ProjectEuler]: null,
+  [SuperBlocks.TheOdinProject]: null,
+  [SuperBlocks.RosettaCode]: null
+};
+
 export type CertSlug = (typeof Certification)[keyof typeof Certification];
 
 export const linkedInCredentialIds = {


### PR DESCRIPTION
The intro can only show a certification if it's live, so we can use that list to determine if the button appears. It should be the single source of truth.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
