### PR TITLE
fix(curriculum): use variable names not defined automatically by browser in Recipe Ingredient Converter

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-recipe-ingredient-converter/67353fb237ffbd01af3be1cc.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-recipe-ingredient-converter/67353fb237ffbd01af3be1cc.md
@@ -7,58 +7,56 @@ dashedName: step-14
 
 # --description--
 
-You can finally start hooking your logic into the user interface. You'll need to query the DOM to get a few elements by ID. Get the elements with the `ingredient`, `quantity`, `unit`, `servings`, `recipe-form`, and `result-list` IDs, and assign each to a variable name that matches the ID.
-
-Remember to use camelCase!
+You can finally start hooking your logic into the user interface. You'll need to query the DOM to get a few elements by ID. Get the elements with the `ingredient`, `quantity`, `unit`, `servings`, `recipe-form`, and `result-list` IDs, and assign them to `ingredientName`, `quantityInUnit`, `unitToConvert`, `numberOfServings`, `recipeForm`, `resultList` variables respectively.
 
 # --hints--
 
-You should define an `ingredient` variable.
+You should define an `ingredientName` variable.
 
 ```js
-assert.isDefined(ingredient);
+assert.isDefined(ingredientName);
 ```
 
-Your `ingredient` variable should be the element returned from `.getElementById()` with the `ingredient` ID.
+Your `ingredientName` variable should be the element returned from `.getElementById()` with the `ingredient` ID.
 
 ```js
-assert.match(code, /(?:let|const|var)\s+ingredient\s*=\s*document\s*\.\s*(?:querySelector\s*\(\s*('|")#ingredient\1\s*\)|getElementById\s*\(\s*('|")ingredient\2\s*\))\s*;?/);
+assert.strictEqual(ingredientName, document.getElementById('ingredient'));
 ```
 
-You should define a `quantity` variable.
+You should define a `quantityInUnit` variable.
 
 ```js
-assert.isDefined(quantity);
+assert.isDefined(quantityInUnit);
 ```
 
-Your `quantity` variable should be the element returned from `.getElementById()` with the `quantity` ID.
+Your `quantityInUnit` variable should be the element returned from `.getElementById()` with the `quantity` ID.
 
 ```js
-assert.match(code, /(?:let|const|var)\s+quantity\s*=\s*document\s*\.\s*(?:querySelector\s*\(\s*('|")#quantity\1\s*\)|getElementById\s*\(\s*('|")quantity\2\s*\))\s*;?/);
+assert.strictEqual(quantityInUnit, document.getElementById('quantity'));
 ```
 
-You should define a `unit` variable.
+You should define a `unitToConvert` variable.
 
 ```js
-assert.isDefined(unit);
+assert.isDefined(unitToConvert);
 ```
 
-Your `unit` variable should be the element returned from `.getElementById()` with the `unit` ID.
+Your `unitToConvert` variable should be the element returned from `.getElementById()` with the `unit` ID.
 
 ```js
-assert.match(code, /(?:let|const|var)\s+unit\s*=\s*document\s*\.\s*(?:querySelector\s*\(\s*('|")#unit\1\s*\)|getElementById\s*\(\s*('|")unit\2\s*\))\s*;?/);
+assert.strictEqual(unitToConvert, document.getElementById('unit'));
 ```
 
-You should define a `servings` variable.
+You should define a `numberOfServings` variable.
 
 ```js
-assert.isDefined(servings);
+assert.isDefined(numberOfServings);
 ```
 
-Your `servings` variable should be the element returned from `.getElementById()` with the `servings` ID.
+Your `numberOfServings` variable should be the element returned from `.getElementById()` with the `servings` ID.
 
 ```js
-assert.match(code, /(?:let|const|var)\s+servings\s*=\s*document\s*\.\s*(?:querySelector\s*\(\s*('|")#servings\1\s*\)|getElementById\s*\(\s*('|")servings\2\s*\))\s*;?/);
+assert.strictEqual(numberOfServings, document.getElementById('servings'));
 ```
 
 You should define a `recipeForm` variable.

--- a/curriculum/challenges/english/25-front-end-development/workshop-recipe-ingredient-converter/67353fb237ffbd01af3be1cc.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-recipe-ingredient-converter/67353fb237ffbd01af3be1cc.md
@@ -22,7 +22,7 @@ assert.isDefined(ingredient);
 Your `ingredient` variable should be the element returned from `.getElementById()` with the `ingredient` ID.
 
 ```js
-assert.strictEqual(ingredient, document.getElementById("ingredient"));
+assert.match(code, /(?:let|const|var)\s+ingredient\s*=\s*document\s*\.\s*(?:querySelector\s*\(\s*('|")#ingredient\1\s*\)|getElementById\s*\(\s*('|")ingredient\2\s*\))\s*;?/);
 ```
 
 You should define a `quantity` variable.
@@ -34,7 +34,7 @@ assert.isDefined(quantity);
 Your `quantity` variable should be the element returned from `.getElementById()` with the `quantity` ID.
 
 ```js
-assert.strictEqual(quantity, document.getElementById("quantity"));
+assert.match(code, /(?:let|const|var)\s+quantity\s*=\s*document\s*\.\s*(?:querySelector\s*\(\s*('|")#quantity\1\s*\)|getElementById\s*\(\s*('|")quantity\2\s*\))\s*;?/);
 ```
 
 You should define a `unit` variable.
@@ -46,7 +46,7 @@ assert.isDefined(unit);
 Your `unit` variable should be the element returned from `.getElementById()` with the `unit` ID.
 
 ```js
-assert.strictEqual(unit, document.getElementById("unit"));
+assert.match(code, /(?:let|const|var)\s+unit\s*=\s*document\s*\.\s*(?:querySelector\s*\(\s*('|")#unit\1\s*\)|getElementById\s*\(\s*('|")unit\2\s*\))\s*;?/);
 ```
 
 You should define a `servings` variable.
@@ -58,7 +58,7 @@ assert.isDefined(servings);
 Your `servings` variable should be the element returned from `.getElementById()` with the `servings` ID.
 
 ```js
-assert.strictEqual(servings, document.getElementById("servings"));
+assert.match(code, /(?:let|const|var)\s+servings\s*=\s*document\s*\.\s*(?:querySelector\s*\(\s*('|")#servings\1\s*\)|getElementById\s*\(\s*('|")servings\2\s*\))\s*;?/);
 ```
 
 You should define a `recipeForm` variable.

--- a/curriculum/challenges/english/25-front-end-development/workshop-recipe-ingredient-converter/67353fb237ffbd01af3be1cc.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-recipe-ingredient-converter/67353fb237ffbd01af3be1cc.md
@@ -23,16 +23,16 @@ Your `ingredientName` variable should be the element returned from `.getElementB
 assert.strictEqual(ingredientName, document.getElementById('ingredient'));
 ```
 
-You should define a `quantityInUnit` variable.
+You should define a `ingredientQuantity` variable.
 
 ```js
-assert.isDefined(quantityInUnit);
+assert.isDefined(ingredientQuantity);
 ```
 
-Your `quantityInUnit` variable should be the element returned from `.getElementById()` with the `quantity` ID.
+Your `ingredientQuantity` variable should be the element returned from `.getElementById()` with the `quantity` ID.
 
 ```js
-assert.strictEqual(quantityInUnit, document.getElementById('quantity'));
+assert.strictEqual(ingredientQuantity, document.getElementById('quantity'));
 ```
 
 You should define a `unitToConvert` variable.

--- a/curriculum/challenges/english/25-front-end-development/workshop-recipe-ingredient-converter/67353fb237ffbd01af3be1cc.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-recipe-ingredient-converter/67353fb237ffbd01af3be1cc.md
@@ -7,7 +7,7 @@ dashedName: step-14
 
 # --description--
 
-You can finally start hooking your logic into the user interface. You'll need to query the DOM to get a few elements by ID. Get the elements with the `ingredient`, `quantity`, `unit`, `servings`, `recipe-form`, and `result-list` IDs, and assign them to `ingredientName`, `quantityInUnit`, `unitToConvert`, `numberOfServings`, `recipeForm`, `resultList` variables respectively.
+You can finally start hooking your logic into the user interface. You'll need to query the DOM to get a few elements by ID. Get the elements with the `ingredient`, `quantity`, `unit`, `servings`, `recipe-form`, and `result-list` IDs, and assign them to the variables `ingredientName`, `ingredientQuantity`, `unitToConvert`, `numberOfServings`, `recipeForm`, and `resultList`, respectively.
 
 # --hints--
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-recipe-ingredient-converter/673540f6e49ae33d6a235c20.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-recipe-ingredient-converter/673540f6e49ae33d6a235c20.md
@@ -218,10 +218,10 @@ const processIngredient = (baseQuantity, baseUnit, newUnit, newServings) => {
   return convertedQuantity.toFixed(2);
 };
 
-const ingredient = document.getElementById("ingredient");
-const quantity = document.getElementById("quantity");
-const unit = document.getElementById("unit");
-const servings = document.getElementById("servings");
+const ingredientName = document.getElementById("ingredient");
+const quantityInUnit = document.getElementById("quantity");
+const unitToConvert = document.getElementById("unit");
+const numberOfServings = document.getElementById("servings");
 const recipeForm = document.getElementById("recipe-form");
 const resultList = document.getElementById("result-list");
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-recipe-ingredient-converter/673540f6e49ae33d6a235c20.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-recipe-ingredient-converter/673540f6e49ae33d6a235c20.md
@@ -219,7 +219,7 @@ const processIngredient = (baseQuantity, baseUnit, newUnit, newServings) => {
 };
 
 const ingredientName = document.getElementById("ingredient");
-const quantityInUnit = document.getElementById("quantity");
+const ingredientQuantity = document.getElementById("quantity");
 const unitToConvert = document.getElementById("unit");
 const numberOfServings = document.getElementById("servings");
 const recipeForm = document.getElementById("recipe-form");

--- a/curriculum/challenges/english/25-front-end-development/workshop-recipe-ingredient-converter/673542088e459b6def5d6e56.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-recipe-ingredient-converter/673542088e459b6def5d6e56.md
@@ -192,7 +192,7 @@ const processIngredient = (baseQuantity, baseUnit, newUnit, newServings) => {
 };
 
 const ingredientName = document.getElementById("ingredient");
-const quantityInUnit = document.getElementById("quantity");
+const ingredientQuantity = document.getElementById("quantity");
 const unitToConvert = document.getElementById("unit");
 const numberOfServings = document.getElementById("servings");
 const recipeForm = document.getElementById("recipe-form");

--- a/curriculum/challenges/english/25-front-end-development/workshop-recipe-ingredient-converter/673542088e459b6def5d6e56.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-recipe-ingredient-converter/673542088e459b6def5d6e56.md
@@ -191,10 +191,10 @@ const processIngredient = (baseQuantity, baseUnit, newUnit, newServings) => {
   return convertedQuantity.toFixed(2);
 };
 
-const ingredient = document.getElementById("ingredient");
-const quantity = document.getElementById("quantity");
-const unit = document.getElementById("unit");
-const servings = document.getElementById("servings");
+const ingredientName = document.getElementById("ingredient");
+const quantityInUnit = document.getElementById("quantity");
+const unitToConvert = document.getElementById("unit");
+const numberOfServings = document.getElementById("servings");
 const recipeForm = document.getElementById("recipe-form");
 const resultList = document.getElementById("result-list");
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-recipe-ingredient-converter/6735424ecfeb557d81dcc9d1.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-recipe-ingredient-converter/6735424ecfeb557d81dcc9d1.md
@@ -7,7 +7,7 @@ dashedName: step-17
 
 # --description--
 
-Now you need to iterate through your `units` array. With each value in that array, check if the current value is **not** equal to the current unit (found in `unit.value`).
+Now you need to iterate through your `units` array. With each value in that array, check if the current value is **not** equal to the current unit (found in `unitToConvert.value`).
 
 If so, you will need to convert the existing unit to your current unit, and append a list item to `resultList` with the following format:
 
@@ -20,10 +20,10 @@ For example, a conversion result of five grams for flour should look like `Flour
 Your `updateResultsList` function should properly update the DOM.
 
 ```js
-ingredient.value = "Flour";
-quantity.value = 5;
-servings.value = 5;
-unit.value = "gram";
+ingredientName.value = "Flour";
+quantityInUnit.value = 5;
+numberOfServings.value = 5;
+unitToConvert.value = "gram";
 updateResultsList();
 assert.include(resultList.innerHTML, "<li>Flour: 0.10 cup</li>");
 assert.include(resultList.innerHTML, "<li>Flour: 0.88 ounce</li>");
@@ -193,10 +193,10 @@ const processIngredient = (baseQuantity, baseUnit, newUnit, newServings) => {
   return convertedQuantity.toFixed(2);
 };
 
-const ingredient = document.getElementById("ingredient");
-const quantity = document.getElementById("quantity");
-const unit = document.getElementById("unit");
-const servings = document.getElementById("servings");
+const ingredientName = document.getElementById("ingredient");
+const quantityInUnit = document.getElementById("quantity");
+const unitToConvert = document.getElementById("unit");
+const numberOfServings = document.getElementById("servings");
 const recipeForm = document.getElementById("recipe-form");
 const resultList = document.getElementById("result-list");
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-recipe-ingredient-converter/6735424ecfeb557d81dcc9d1.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-recipe-ingredient-converter/6735424ecfeb557d81dcc9d1.md
@@ -21,7 +21,7 @@ Your `updateResultsList` function should properly update the DOM.
 
 ```js
 ingredientName.value = "Flour";
-quantityInUnit.value = 5;
+ingredientQuantity.value = 5;
 numberOfServings.value = 5;
 unitToConvert.value = "gram";
 updateResultsList();
@@ -194,7 +194,7 @@ const processIngredient = (baseQuantity, baseUnit, newUnit, newServings) => {
 };
 
 const ingredientName = document.getElementById("ingredient");
-const quantityInUnit = document.getElementById("quantity");
+const ingredientQuantity = document.getElementById("quantity");
 const unitToConvert = document.getElementById("unit");
 const numberOfServings = document.getElementById("servings");
 const recipeForm = document.getElementById("recipe-form");

--- a/curriculum/challenges/english/25-front-end-development/workshop-recipe-ingredient-converter/673543d867b44ac7580610a2.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-recipe-ingredient-converter/673543d867b44ac7580610a2.md
@@ -19,7 +19,7 @@ Your `recipeForm` should call `updateResultsList` when submitted.
 
 ```js
 ingredientName.value = "Flour";
-quantityInUnit.value = 5;
+ingredientQuantity.value = 5;
 numberOfServings.value = 5;
 unitToConvert.value = "gram";
 const submit = new Event("submit");
@@ -193,7 +193,7 @@ const processIngredient = (baseQuantity, baseUnit, newUnit, newServings) => {
 };
 
 const ingredientName = document.getElementById("ingredient");
-const quantityInUnit = document.getElementById("quantity");
+const ingredientQuantity = document.getElementById("quantity");
 const unitToConvert = document.getElementById("unit");
 const numberOfServings = document.getElementById("servings");
 const recipeForm = document.getElementById("recipe-form");
@@ -207,7 +207,7 @@ const updateResultsList = () => {
   units.forEach((newUnit) => {
     if (newUnit !== unitToConvert.value) {
       const convertedQuantity = processIngredient(
-        parseFloat(quantityInUnit.value),
+        parseFloat(ingredientQuantity.value),
         unitToConvert.value,
         newUnit,
         parseFloat(numberOfServings.value)
@@ -385,7 +385,7 @@ const processIngredient = (baseQuantity, baseUnit, newUnit, newServings) => {
 };
 
 const ingredientName = document.getElementById("ingredient");
-const quantityInUnit = document.getElementById("quantity");
+const ingredientQuantity = document.getElementById("quantity");
 const unitToConvert = document.getElementById("unit");
 const numberOfServings = document.getElementById("servings");
 const recipeForm = document.getElementById("recipe-form");
@@ -399,7 +399,7 @@ const updateResultsList = () => {
   units.forEach((newUnit) => {
     if (newUnit !== unitToConvert.value) {
       const convertedQuantity = processIngredient(
-        parseFloat(quantityInUnit.value),
+        parseFloat(ingredientQuantity.value),
         unitToConvert.value,
         newUnit,
         parseFloat(numberOfServings.value)

--- a/curriculum/challenges/english/25-front-end-development/workshop-recipe-ingredient-converter/673543d867b44ac7580610a2.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-recipe-ingredient-converter/673543d867b44ac7580610a2.md
@@ -18,10 +18,10 @@ Once that's done, take some time to experiment with different values in the form
 Your `recipeForm` should call `updateResultsList` when submitted.
 
 ```js
-ingredient.value = "Flour";
-quantity.value = 5;
-servings.value = 5;
-unit.value = "gram";
+ingredientName.value = "Flour";
+quantityInUnit.value = 5;
+numberOfServings.value = 5;
+unitToConvert.value = "gram";
 const submit = new Event("submit");
 recipeForm.dispatchEvent(submit);
 assert.include(resultList.innerHTML, "<li>Flour: 0.10 cup</li>");
@@ -192,10 +192,10 @@ const processIngredient = (baseQuantity, baseUnit, newUnit, newServings) => {
   return convertedQuantity.toFixed(2);
 };
 
-const ingredient = document.getElementById("ingredient");
-const quantity = document.getElementById("quantity");
-const unit = document.getElementById("unit");
-const servings = document.getElementById("servings");
+const ingredientName = document.getElementById("ingredient");
+const quantityInUnit = document.getElementById("quantity");
+const unitToConvert = document.getElementById("unit");
+const numberOfServings = document.getElementById("servings");
 const recipeForm = document.getElementById("recipe-form");
 const resultList = document.getElementById("result-list");
 
@@ -205,15 +205,15 @@ const updateResultsList = () => {
   resultList.innerHTML = "";
 
   units.forEach((newUnit) => {
-    if (newUnit !== unit.value) {
+    if (newUnit !== unitToConvert.value) {
       const convertedQuantity = processIngredient(
-        parseFloat(quantity.value),
-        unit.value,
+        parseFloat(quantityInUnit.value),
+        unitToConvert.value,
         newUnit,
-        parseFloat(servings.value)
+        parseFloat(numberOfServings.value)
       );
 
-      resultList.innerHTML += `<li>${ingredient.value}: ${convertedQuantity} ${newUnit}</li>`;
+      resultList.innerHTML += `<li>${ingredientName.value}: ${convertedQuantity} ${newUnit}</li>`;
     }
   });
 }
@@ -384,10 +384,10 @@ const processIngredient = (baseQuantity, baseUnit, newUnit, newServings) => {
   return convertedQuantity.toFixed(2);
 };
 
-const ingredient = document.getElementById("ingredient");
-const quantity = document.getElementById("quantity");
-const unit = document.getElementById("unit");
-const servings = document.getElementById("servings");
+const ingredientName = document.getElementById("ingredient");
+const quantityInUnit = document.getElementById("quantity");
+const unitToConvert = document.getElementById("unit");
+const numberOfServings = document.getElementById("servings");
 const recipeForm = document.getElementById("recipe-form");
 const resultList = document.getElementById("result-list");
 
@@ -397,15 +397,15 @@ const updateResultsList = () => {
   resultList.innerHTML = "";
 
   units.forEach((newUnit) => {
-    if (newUnit !== unit.value) {
+    if (newUnit !== unitToConvert.value) {
       const convertedQuantity = processIngredient(
-        parseFloat(quantity.value),
-        unit.value,
+        parseFloat(quantityInUnit.value),
+        unitToConvert.value,
         newUnit,
-        parseFloat(servings.value)
+        parseFloat(numberOfServings.value)
       );
 
-      resultList.innerHTML += `<li>${ingredient.value}: ${convertedQuantity} ${newUnit}</li>`;
+      resultList.innerHTML += `<li>${ingredientName.value}: ${convertedQuantity} ${newUnit}</li>`;
     }
   });
 }


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

- - -
- Variables corresponding to the HTML elements with id are automatically defined (https://html.spec.whatwg.org/#named-access-on-the-window-object). Because of that unfortunately comparing variable to element does not confirm, that camper defined variable.
- Ie. element `#ingredient` element will be automatically accessible by `ingredient` variable.
- Ids containing `-` don't have such straightforward names to access, since `-` is not valid character for JS variable. (They can be accessed via `window['variable-name-with-dash']`.)
- _Affected_ variables were renamed.