### PR TITLE
fix(client): show icons on coming soon chapters

### DIFF
--- a/client/src/templates/Introduction/components/super-block-accordion.tsx
+++ b/client/src/templates/Introduction/components/super-block-accordion.tsx
@@ -130,7 +130,7 @@ const ComingSoon = ({ children }: { children: ReactNode }) => {
   const { t } = useTranslation();
   return (
     <li className='coming-soon'>
-      <span className='badge'>{t('misc.coming-soon')}</span> {children}
+      {children} <span className='badge'>{t('misc.coming-soon')}</span>
     </li>
   );
 };
@@ -196,9 +196,17 @@ export const SuperBlockAccordion = ({
         // show coming soon on production, and all the challenges in dev
         if (chapter.comingSoon && !showUpcomingChanges) {
           return (
-            <ComingSoon key={chapter.name}>
-              {t(`intro:full-stack-developer.chapters.${chapter.name}`)}
-            </ComingSoon>
+            <>
+              <ComingSoon key={chapter.name}>
+                {Object.values(FsdChapters).includes(chapter.name) && (
+                  <ChapterIcon
+                    className='map-icon'
+                    chapter={chapter.name as FsdChapters}
+                  />
+                )}
+                {t(`intro:full-stack-developer.chapters.${chapter.name}`)}
+              </ComingSoon>
+            </>
           );
         }
 


### PR DESCRIPTION
This shows the icons on the coming soon chapters and movies the "coming soon" to the right of anything coming soon...

<details><summary>image</summary>

<img width="543" alt="Screenshot 2024-12-18 at 8 51 26 PM" src="https://github.com/user-attachments/assets/a0b3f675-bf15-443a-83e8-c6afc321ef66" />

</details>

I think it looks pretty good 👍 Hopefully it's a little easier to differentiate the coming soon stuff from the available stuff as well.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
