### PR TITLE
fix(client): update exam token return type

### DIFF
--- a/client/src/components/settings/exam-token.tsx
+++ b/client/src/components/settings/exam-token.tsx
@@ -20,9 +20,7 @@ function ExamToken(): JSX.Element {
       const response = await generateExamToken();
 
       const {
-        data: {
-          data: { examEnvironmentAuthorizationToken }
-        }
+        data: { examEnvironmentAuthorizationToken }
       } = response;
       setExamToken(examEnvironmentAuthorizationToken);
       setExamTokenError('');

--- a/client/src/redux/prop-types.ts
+++ b/client/src/redux/prop-types.ts
@@ -468,9 +468,7 @@ export interface GenerateExamResponseWithData {
 }
 
 export interface ExamTokenResponse {
-  data: {
-    examEnvironmentAuthorizationToken: string;
-  };
+  examEnvironmentAuthorizationToken: string;
 }
 // User Exam (null until they answer the question)
 interface UserExamAnswer {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Hopefully, one day, we can use something like `openapi-typescript` on the client to avoid this sort of divergence between the API and the client.