### PR TITLE
feat(curriculum): test clearing of previous arrays in Sorting Visualizer

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-sorting-visualizer/6716249b5405164036fd0b0d.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-sorting-visualizer/6716249b5405164036fd0b0d.md
@@ -26,8 +26,7 @@ Fulfill the user stories below and get all the tests to pass to complete the lab
 1. The `swapElements` function should modify the array in place by swapping the element at the passed index and the following element if `isOrdered` returns `false`.
 1. You should have a function named `highlightCurrentEls` that takes an HTML element and a numeric index.
 1. The `highlightCurrentEls` function should set the `border` of the given element's child at the given index, and the child immediately after the index, to have a `dashed` style, a `red` color, and a width of your choice.
-1. When you click `#generate-btn` you should use the `fillArrContainer` function to fill `#starting-array` with five `span` elements, each with a random number as its text.
-1. When you click `#generate-btn` the `#array-container` should contain `#starting-array` with generated numbers. Other elements should be removed from `#array-container`.
+1. When you click `#generate-btn` you should use the `fillArrContainer` function to fill `#starting-array` with five `span` elements, each with a random number as its text. If present, other elements should be removed from `#array-container`.
 1. You should implement the Bubble Sort algorithm so that after you click `#sort-btn`, `#array-container` contains a `div` element for each of the steps required by the Bubble Sort algorithm to sort the starting array, including the `div` representing the starting array and a `div` representing the sorted array. The functions you have created so far can be useful here.
 1. Each `div` should contain five `span` elements, representing the array in its current state of being sorted.
 1. After you click `#sort-btn`, `#starting-array` should represent the starting step with the initial array and the first two integers highlighted.
@@ -208,7 +207,7 @@ Array.from(children).forEach(el => {
 })
 ```
 
-When `#starting-array` already contains generated array, or `#array-container` contains sorted array, clicking the `#generate-btn` should remove other elements in the `#array-container`, leaving only `#starting-array` with newly generated numbers.
+When `#starting-array` already contains a generated array, or `#array-container` contains the sorted array, clicking the `#generate-btn` should remove other elements in the `#array-container`, leaving only `#starting-array` with newly generated numbers.
 
 ```js
 const genBtn = document.querySelector("#generate-btn");

--- a/curriculum/challenges/english/25-front-end-development/lab-sorting-visualizer/6716249b5405164036fd0b0d.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-sorting-visualizer/6716249b5405164036fd0b0d.md
@@ -27,6 +27,7 @@ Fulfill the user stories below and get all the tests to pass to complete the lab
 1. You should have a function named `highlightCurrentEls` that takes an HTML element and a numeric index.
 1. The `highlightCurrentEls` function should set the `border` of the given element's child at the given index, and the child immediately after the index, to have a `dashed` style, a `red` color, and a width of your choice.
 1. When you click `#generate-btn` you should use the `fillArrContainer` function to fill `#starting-array` with five `span` elements, each with a random number as its text.
+1. When you click `#generate-btn` the `#array-container` should contain `#starting-array` with generated numbers. Other elements should be removed from `#array-container`.
 1. You should implement the Bubble Sort algorithm so that after you click `#sort-btn`, `#array-container` contains a `div` element for each of the steps required by the Bubble Sort algorithm to sort the starting array, including the `div` representing the starting array and a `div` representing the sorted array. The functions you have created so far can be useful here.
 1. Each `div` should contain five `span` elements, representing the array in its current state of being sorted.
 1. After you click `#sort-btn`, `#starting-array` should represent the starting step with the initial array and the first two integers highlighted.
@@ -205,6 +206,25 @@ Array.from(children).forEach(el => {
     assert.isAtMost(num, 100);
     assert.isAtLeast(num, 1);
 })
+```
+
+When `#starting-array` already contains generated array, or `#array-container` contains sorted array, clicking the `#generate-btn` should remove other elements in the `#array-container`, leaving only `#starting-array` with newly generated numbers.
+
+```js
+const genBtn = document.querySelector("#generate-btn");
+const sortBtn = document.querySelector("#sort-btn");
+genBtn.dispatchEvent(new Event("click"));
+
+const prevNumbers = Array.from(document.querySelector("#starting-array").querySelectorAll("span")).map(el => Number(el.innerText));
+
+sortBtn.dispatchEvent(new Event("click"));
+genBtn.dispatchEvent(new Event("click"));
+
+const container = document.querySelector("#array-container");
+assert.lengthOf(container.children, 1);
+const numbers = Array.from(document.querySelector("#starting-array").querySelectorAll("span")).map(el => Number(el.innerText));
+assert.lengthOf(numbers, 5);
+assert.isTrue(prevNumbers.some((num, index) => num !== numbers[index]))
 ```
 
 After you click `#sort-btn`, `#array-container` should contain as many `div` elements as the steps required by the Bubble Sort algorithm to sort the starting array, including the `div` representing the starting array and a `div` representing the sorted array.


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

- - -
- Adds test for clearing previously generated numbers and/or sorted arrays.
- This gives better (specific) indication why different test might be failing, while _everything_ appear to be working fine.
- Without such feature implemented in camper solution, currently fails only one test, which in this case does not give any hints regarding the issue:
  > After you click `#sort-btn`, each `div` within `#array-container` should contain five `span`, each with a number as its text, and arranged to represent the steps required by Bubble Sort algorithm to sort the starting array.