### PR TITLE
Fix: show name instead of username in certification

### DIFF
--- a/client/src/client-only-routes/show-certification.tsx
+++ b/client/src/client-only-routes/show-certification.tsx
@@ -218,7 +218,7 @@ const ShowCertification = (props: ShowCertificationProps): JSX.Element => {
 
   const {
     date,
-    name: userFullName = null,
+    name,
     username,
     certTitle,
     certSlug,
@@ -227,7 +227,7 @@ const ShowCertification = (props: ShowCertificationProps): JSX.Element => {
 
   const { user } = props;
 
-  const displayName = userFullName ?? username;
+  const displayName = name || username;
 
   const certDate = new Date(date);
   const certYear = certDate.getFullYear();


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #57616 

<!-- Feel free to add any additional description of changes below this line -->
Updated the ShowCertification component to correctly display the user's full name by using name (from the cert object) instead of cert.username. This ensures that users will see their real name (if set to public) on the certification page instead of their username.