### PR TITLE
fix(curriculum): more lenient border width for legacy css

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/add-borders-around-your-elements.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/add-borders-around-your-elements.md
@@ -50,6 +50,9 @@ assert.isTrue(document.querySelector('img').classList.contains('thick-green-bord
 Your image should have a border width of `10px`.
 
 ```js
+// Note: to any future maintainers, the read width of the border is dependent on 
+// the zoom. For example we cannot match 10px exactly because if a campers set the zoom to 110% 
+// it will be read as 9~px. 
 const image = document.querySelector('img'); 
 const imageBorderTopWidth = window.getComputedStyle(image)["border-top-width"]; 
 const widthNumber = parseInt(imageBorderTopWidth.replace("px",""));

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/add-borders-around-your-elements.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/add-borders-around-your-elements.md
@@ -55,9 +55,9 @@ Your image should have a border width of `10px`.
 // it will be read as 9~px. 
 const image = document.querySelector('img'); 
 const imageBorderTopWidth = window.getComputedStyle(image)["border-top-width"]; 
-const widthNumber = parseInt(imageBorderTopWidth.replace("px",""));
-assert.isAtLeast(widthNumber,8);
-assert.isAtMost(widthNumber,12);
+const widthNumber = parseInt(imageBorderTopWidth);
+assert.isAtLeast(widthNumber, 8);
+assert.isAtMost(widthNumber, 12);
 ```
 
 Your image should have a border style of `solid`.

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/add-borders-around-your-elements.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/add-borders-around-your-elements.md
@@ -52,8 +52,9 @@ Your image should have a border width of `10px`.
 ```js
 const image = document.querySelector('img'); 
 const imageBorderTopWidth = window.getComputedStyle(image)["border-top-width"]; 
-
-assert.strictEqual(imageBorderTopWidth, "10px")
+const widthNumber = parseInt(imageBorderTopWidth.replace("px",""));
+assert.isAtLeast(widthNumber,8);
+assert.isAtMost(widthNumber,12);
 ```
 
 Your image should have a border style of `solid`.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Follow up to https://github.com/freeCodeCamp/freeCodeCamp/pull/57139

Unfortunately, while I had no idea at the time, zoom actually controls how the border width is picked up by the tests. This should fix the challenge. 
