### PR TITLE
fix(client): fsd scroll issue

### DIFF
--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -336,7 +336,10 @@ class Block extends Component<BlockProps> {
      * so we can play with it without affecting the existing block layouts.
      */
     const ChallengeListBlock = (
-      <ScrollableAnchor id={block}>
+      <>
+        <ScrollableAnchor id={block}>
+          <span className='hide-scrollable-anchor'></span>
+        </ScrollableAnchor>
         <div
           className={`block block-grid challenge-list-block ${isExpanded ? 'open' : ''}`}
         >
@@ -371,7 +374,7 @@ class Block extends Component<BlockProps> {
             </div>
           )}
         </div>
-      </ScrollableAnchor>
+      </>
     );
 
     /**
@@ -381,7 +384,10 @@ class Block extends Component<BlockProps> {
      * so we can play with it without affecting the existing block layouts.
      */
     const LinkBlock = (
-      <ScrollableAnchor id={block}>
+      <>
+        <ScrollableAnchor id={block}>
+          <span className='hide-scrollable-anchor'></span>
+        </ScrollableAnchor>
         <div className='block block-grid grid-project-block grid-project-block-no-margin'>
           <div className='tags-wrapper'>
             {!isAudited && (
@@ -415,7 +421,7 @@ class Block extends Component<BlockProps> {
           </div>
           <BlockIntros intros={blockIntroArr} />
         </div>
-      </ScrollableAnchor>
+      </>
     );
 
     /**
@@ -423,7 +429,10 @@ class Block extends Component<BlockProps> {
      * This layout is specifically used for the new Full Stack Developer Certification.
      */
     const ChallengeGridBlock = (
-      <ScrollableAnchor id={block}>
+      <>
+        <ScrollableAnchor id={block}>
+          <span className='hide-scrollable-anchor'></span>
+        </ScrollableAnchor>
         <div
           className={`block block-grid challenge-grid-block ${isExpanded ? 'open' : ''}`}
         >
@@ -460,7 +469,7 @@ class Block extends Component<BlockProps> {
             </div>
           )}
         </div>
-      </ScrollableAnchor>
+      </>
     );
 
     const layoutToComponent = {

--- a/client/src/templates/Introduction/intro.css
+++ b/client/src/templates/Introduction/intro.css
@@ -11,6 +11,11 @@
   overflow-wrap: break-word;
 }
 
+.hide-scrollable-anchor {
+  display: inline-block;
+  max-height: 0px;
+}
+
 .block-label {
   align-self: center;
   height: fit-content;


### PR DESCRIPTION
I noticed an issue with scrolling on the FSD superblock page.

To reproduce... 
1. Go to the FSD superblock page where the URL includes one of the scrollable anchor hashes, e.g: `http://localhost:8000/learn/full-stack-developer/#lecture-welcome-to-freecodecamp`
2. Scroll down until just **before** the hash in the URL is removed
3. Expand one of the other chapters/modules
4. Get auto-scrolled back to the top of the block with the hash

<details><summary>gif</summary>

![Dec-20-2024 12-01-46](https://github.com/user-attachments/assets/77d3eb14-3965-40da-8150-306a27e56495)

</details>

If the hash isn't in the URL, it works fine. This is a bit of a hack, but I changed the layout on all the new block layouts for the FSD so that the scrollable anchor only contains one element that doesn't have any height (old block layouts didn't change). So you won't ever see the hash in the URL when scrolling down the superblock page, but you can still go to a URL with a hash and get taken to the block. e.g: open `http://localhost:8000/learn/full-stack-developer/#lecture-welcome-to-freecodecamp` and it will take you to the `lecture-welcome-to-freecodecamp` block, and the URL immediately changes to `http://localhost:8000/learn/full-stack-developer/` - so expanding something else won't scroll you away.

Not sure if it's the best solution, but it fixes some pretty annoying behavior.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
