### PR TITLE
chore(curriculum): change challengeType for Plant Nursery Catalog

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/673339d96c56d36e963e888e.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/673339d96c56d36e963e888e.md
@@ -1,7 +1,7 @@
 ---
 id: 673339d96c56d36e963e888e
 title: Step 1
-challengeType: 0
+challengeType: 1
 dashedName: step-1
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/6733b5632fb854bc6c58dc0d.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/6733b5632fb854bc6c58dc0d.md
@@ -1,7 +1,7 @@
 ---
 id: 6733b5632fb854bc6c58dc0d
 title: Step 2
-challengeType: 0
+challengeType: 1
 dashedName: step-2
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/6733b5e6f210c1bd1afdf8b3.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/6733b5e6f210c1bd1afdf8b3.md
@@ -1,7 +1,7 @@
 ---
 id: 6733b5e6f210c1bd1afdf8b3
 title: Step 3
-challengeType: 0
+challengeType: 1
 dashedName: step-3
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/67349ba230cff237c0f2bdf2.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/67349ba230cff237c0f2bdf2.md
@@ -1,7 +1,7 @@
 ---
 id: 67349ba230cff237c0f2bdf2
 title: Step 4
-challengeType: 0
+challengeType: 1
 dashedName: step-4
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/67349d6e726b2c3c7f7301e8.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/67349d6e726b2c3c7f7301e8.md
@@ -1,7 +1,7 @@
 ---
 id: 67349d6e726b2c3c7f7301e8
 title: Step 5
-challengeType: 0
+challengeType: 1
 dashedName: step-5
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/6734a13a29acdf47f2b8e161.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/6734a13a29acdf47f2b8e161.md
@@ -1,7 +1,7 @@
 ---
 id: 6734a13a29acdf47f2b8e161
 title: Step 6
-challengeType: 0
+challengeType: 1
 dashedName: step-6
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/6734a2385c52c54d916a8b86.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/6734a2385c52c54d916a8b86.md
@@ -1,7 +1,7 @@
 ---
 id: 6734a2385c52c54d916a8b86
 title: Step 7
-challengeType: 0
+challengeType: 1
 dashedName: step-7
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/6734a606e5968a5a19b77171.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/6734a606e5968a5a19b77171.md
@@ -1,7 +1,7 @@
 ---
 id: 6734a606e5968a5a19b77171
 title: Step 8
-challengeType: 0
+challengeType: 1
 dashedName: step-8
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/6734a772196245601e4b80e0.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/6734a772196245601e4b80e0.md
@@ -1,7 +1,7 @@
 ---
 id: 6734a772196245601e4b80e0
 title: Step 10
-challengeType: 0
+challengeType: 1
 dashedName: step-10
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/6734ab61e916486c80c490d1.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/6734ab61e916486c80c490d1.md
@@ -1,7 +1,7 @@
 ---
 id: 6734ab61e916486c80c490d1
 title: Step 11
-challengeType: 0
+challengeType: 1
 dashedName: step-11
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/6734b36f1a3ce17e73327f24.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/6734b36f1a3ce17e73327f24.md
@@ -1,7 +1,7 @@
 ---
 id: 6734b36f1a3ce17e73327f24
 title: Step 9
-challengeType: 0
+challengeType: 1
 dashedName: step-9
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/6734bbc0bd741598f942352e.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/6734bbc0bd741598f942352e.md
@@ -1,7 +1,7 @@
 ---
 id: 6734bbc0bd741598f942352e
 title: Step 12
-challengeType: 0
+challengeType: 1
 dashedName: step-12
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/6734c10a327760a665b7d5b9.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/6734c10a327760a665b7d5b9.md
@@ -1,7 +1,7 @@
 ---
 id: 6734c10a327760a665b7d5b9
 title: Step 13
-challengeType: 0
+challengeType: 1
 dashedName: step-13
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/6734eee1f9498cd90f9ae340.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/6734eee1f9498cd90f9ae340.md
@@ -1,7 +1,7 @@
 ---
 id: 6734eee1f9498cd90f9ae340
 title: Step 14
-challengeType: 0
+challengeType: 1
 dashedName: step-14
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/6734f0ae9d1cf4dfd43a7805.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/6734f0ae9d1cf4dfd43a7805.md
@@ -1,7 +1,7 @@
 ---
 id: 6734f0ae9d1cf4dfd43a7805
 title: Step 15
-challengeType: 0
+challengeType: 1
 dashedName: step-15
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/6734f6290ebd5cfbc75996af.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/6734f6290ebd5cfbc75996af.md
@@ -1,7 +1,7 @@
 ---
 id: 6734f6290ebd5cfbc75996af
 title: Step 16
-challengeType: 0
+challengeType: 1
 dashedName: step-16
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/6734fa225c6667121e589f7e.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/6734fa225c6667121e589f7e.md
@@ -1,7 +1,7 @@
 ---
 id: 6734fa225c6667121e589f7e
 title: Step 17
-challengeType: 0
+challengeType: 1
 dashedName: step-17
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/67350acfd2006f2777295b96.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/67350acfd2006f2777295b96.md
@@ -1,7 +1,7 @@
 ---
 id: 67350acfd2006f2777295b96
 title: Step 19
-challengeType: 0
+challengeType: 1
 dashedName: step-19
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/67351225403acd3d6f70ed6d.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/67351225403acd3d6f70ed6d.md
@@ -1,7 +1,7 @@
 ---
 id: 67351225403acd3d6f70ed6d
 title: Step 20
-challengeType: 0
+challengeType: 1
 dashedName: step-20
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/6735145b0ee741461bdbaa49.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/6735145b0ee741461bdbaa49.md
@@ -1,7 +1,7 @@
 ---
 id: 6735145b0ee741461bdbaa49
 title: Step 21
-challengeType: 0
+challengeType: 1
 dashedName: step-21
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/673521668be7905059b2d555.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/673521668be7905059b2d555.md
@@ -1,7 +1,7 @@
 ---
 id: 673521668be7905059b2d555
 title: Step 22
-challengeType: 0
+challengeType: 1
 dashedName: step-22
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/673529d08c0d9c5a4193a465.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/673529d08c0d9c5a4193a465.md
@@ -1,7 +1,7 @@
 ---
 id: 673529d08c0d9c5a4193a465
 title: Step 23
-challengeType: 0
+challengeType: 1
 dashedName: step-23
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/673762590f4bc1771c3a1e97.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/673762590f4bc1771c3a1e97.md
@@ -1,7 +1,7 @@
 ---
 id: 673762590f4bc1771c3a1e97
 title: Step 18
-challengeType: 0
+challengeType: 1
 dashedName: step-18
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/673788448f390305b34aa814.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/673788448f390305b34aa814.md
@@ -1,7 +1,7 @@
 ---
 id: 673788448f390305b34aa814
 title: Step 24
-challengeType: 0
+challengeType: 1
 dashedName: step-24
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/6737a1a073a0d14c6544d301.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/6737a1a073a0d14c6544d301.md
@@ -1,7 +1,7 @@
 ---
 id: 6737a1a073a0d14c6544d301
 title: Step 25
-challengeType: 0
+challengeType: 1
 dashedName: step-25
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/6737a5058ff3015829ce3265.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/6737a5058ff3015829ce3265.md
@@ -1,7 +1,7 @@
 ---
 id: 6737a5058ff3015829ce3265
 title: Step 26
-challengeType: 0
+challengeType: 1
 dashedName: step-26
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/6737a95d5b431860f96ca7bb.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/6737a95d5b431860f96ca7bb.md
@@ -1,7 +1,7 @@
 ---
 id: 6737a95d5b431860f96ca7bb
 title: Step 27
-challengeType: 0
+challengeType: 1
 dashedName: step-27
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/6737ac8e4fe7ae6b91c806bd.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/6737ac8e4fe7ae6b91c806bd.md
@@ -1,7 +1,7 @@
 ---
 id: 6737ac8e4fe7ae6b91c806bd
 title: Step 28
-challengeType: 0
+challengeType: 1
 dashedName: step-28
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/6737c6d5d66b5cc3dac09c7b.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/6737c6d5d66b5cc3dac09c7b.md
@@ -1,7 +1,7 @@
 ---
 id: 6737c6d5d66b5cc3dac09c7b
 title: Step 29
-challengeType: 0
+challengeType: 1
 dashedName: step-29
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/6738a5c704680355e29e077c.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/6738a5c704680355e29e077c.md
@@ -1,7 +1,7 @@
 ---
 id: 6738a5c704680355e29e077c
 title: Step 30
-challengeType: 0
+challengeType: 1
 dashedName: step-30
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/6738a8035efec45acd8fdbf9.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/6738a8035efec45acd8fdbf9.md
@@ -1,7 +1,7 @@
 ---
 id: 6738a8035efec45acd8fdbf9
 title: Step 31
-challengeType: 0
+challengeType: 1
 dashedName: step-31
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/6738ad2fd11775752d23ddc2.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/6738ad2fd11775752d23ddc2.md
@@ -1,7 +1,7 @@
 ---
 id: 6738ad2fd11775752d23ddc2
 title: Step 32
-challengeType: 0
+challengeType: 1
 dashedName: step-32
 ---
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

- - -
- challengeType 1 is consistent with other JS workshops that don't have any HTML or CSS code.
- What actually this change means is that preview buttons will be gone, and console will be open by default.