### PR TITLE
fix(curriculum): fix typo for the word 'remaining' in the curriculum

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/6734a606e5968a5a19b77171.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/6734a606e5968a5a19b77171.md
@@ -7,7 +7,7 @@ dashedName: step-8
 
 # --description--
 
-Keep adding the remaing plants to your catalog as you did in the previous steps.
+Keep adding the remaining plants to your catalog as you did in the previous steps.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Closes #57651

Fixed the typo for the word `remaining` which was spelt as `remaing`. 