### PR TITLE
Fix #57655 Wrap the id value in backticks to resolve formatting issue…

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-higher-order-functions-and-callbacks/673362cbb475e21eab726506.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-higher-order-functions-and-callbacks/673362cbb475e21eab726506.md
@@ -1,5 +1,5 @@
 ---
-id: 673362cbb475e21eab726506
+id:  `673362cbb475e21eab726506`
 title: What Is Method Chaining, and How Does It Work?
 challengeType: 11
 videoId: nVAaxZ34khk
@@ -11,7 +11,6 @@ dashedName: what-is-method-chaining-and-how-does-it-work
 Watch the lecture video and answer the questions below.
 
 # --questions--
-
 ## --text--
 
 What will be the output of the following code?


### PR DESCRIPTION
This commit addresses a formatting issue in the "What Is Method Chaining, and How Does It Work?" lecture quiz. The ID value 673362cbb475e21eab726506 was previously missing backticks, which could have led to rendering or parsing issues. The commit wraps the ID value in backticks to ensure proper formatting and resolve the issue.

By adding backticks around the ID, we maintain consistency with how identifiers should be displayed and prevent potential issues in the system's handling of the data.