### PR TITLE
fix(api): /showCert not returning user full name

### DIFF
--- a/api/src/routes/public/certificate.test.ts
+++ b/api/src/routes/public/certificate.test.ts
@@ -244,13 +244,9 @@ describe('certificate routes', () => {
           }
         );
 
-        expect(response.body).toEqual({
-          certSlug: 'javascript-algorithms-and-data-structures',
-          certTitle: 'Legacy JavaScript Algorithms and Data Structures',
-          username: 'foobar',
-          date: DATE_NOW,
-          completionTime: 300
-        });
+        // TODO: delete this assertion once there's only one status 200 response
+        expect(response.body).toHaveProperty('username', 'foobar');
+        expect(response.body).not.toHaveProperty('name');
         expect(response.status).toBe(200);
       });
 
@@ -281,14 +277,7 @@ describe('certificate routes', () => {
           }
         );
 
-        expect(response.body).toEqual({
-          certSlug: 'javascript-algorithms-and-data-structures',
-          certTitle: 'Legacy JavaScript Algorithms and Data Structures',
-          username: 'foobar',
-          name: 'foobar',
-          date: DATE_NOW,
-          completionTime: 300
-        });
+        expect(response.body).toHaveProperty('name', 'foobar');
         expect(response.status).toBe(200);
       });
 

--- a/api/src/schemas/certificate/cert-slug.ts
+++ b/api/src/schemas/certificate/cert-slug.ts
@@ -85,14 +85,7 @@ export const certSlug = {
         certSlug: Type.Enum(Certification),
         certTitle: Type.String(),
         username: Type.String(),
-        date: Type.Number(),
-        completionTime: Type.Number()
-      }),
-      Type.Object({
-        certSlug: Type.Enum(Certification),
-        certTitle: Type.String(),
-        username: Type.String(),
-        name: Type.String(),
+        name: Type.Optional(Type.String()),
         date: Type.Number(),
         completionTime: Type.Number()
       }),


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR:
- Corrects the return values of the `/certificate/showCert` endpoint (it's currently not returning the `name` property)
- Adds some tests for the response of endpoint
- Closes #57616

## Investigation notes

If `showName` is `true`, the endpoint will return both user's `name` and `username`. Otherwise, it will only return `username`.

https://github.com/freeCodeCamp/freeCodeCamp/blob/2563c61b2eab703210db99327f6ec33cff8d2965/api/src/routes/public/certificate.ts#L213-L232

I went to https://www.freecodecamp.dev/certification/fccf064ea61-53d7-44b7-9051-7f4bc75e2702/responsive-web-design (the page that Yoko was testing with) and checked the API responses.
- /get-public-profile returns:
  ```js
  {
    profileUI: {
      showName: true
    }
  }
  ```
- But `/certificate/showCert` doesn't return the `name` property:
  
  <img width="1420" alt="Screenshot 2024-12-21 at 17 03 12" src="https://github.com/user-attachments/assets/9eb0d9ee-52a0-451d-9cdf-2a86516feeaf" />

---
I don't really understand why, but I could fix the issue by changing the schema from:

```js
Type.Union([
  {
    a: Type.String(),
  },
  {
    a: Type.String(),
    b: Type.String(),  
  }
])
```

to:

```js
{
  a: Type.String(),
  b: Type.Optional(Type.String()),  
}
```

<!-- Feel free to add any additional description of changes below this line -->
