### PR TITLE
fix(curriculum): don't require specific `num` value in Factorial Calculator

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-factorial-calculator/66c07238b01053abaf812065.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-factorial-calculator/66c07238b01053abaf812065.md
@@ -92,7 +92,7 @@ assert.strictEqual(factorialCalculator(9), 362880);
 assert.strictEqual(factorialCalculator(11), 39916800);
 ```
 
-Your `resultMsg` should contain string in a format `Factorial of [num] is [factorial]`.
+Your `resultMsg` should contain a string in a format `Factorial of [num] is [factorial]`.
 
 ```js
 assert.strictEqual(resultMsg, `Factorial of ${num} is ${factorialCalculator(num)}`);

--- a/curriculum/challenges/english/25-front-end-development/lab-factorial-calculator/66c07238b01053abaf812065.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-factorial-calculator/66c07238b01053abaf812065.md
@@ -71,12 +71,6 @@ The factorial of `7` should return `5040`.
 assert.strictEqual(factorialCalculator(7), 5040);
 ```
 
-For `5`, the `resultMsg` should contain `Factorial of 5 is 120`.
-
-```js
-assert.strictEqual(resultMsg, 'Factorial of 5 is 120');
-```
-
 You should call your `factorialCalculator` function with the `num` variable as the argument.
 
 ```js
@@ -96,6 +90,13 @@ Your `factorialCalculator` should produce the correct result.
 assert.strictEqual(factorialCalculator(6), 720);
 assert.strictEqual(factorialCalculator(9), 362880);
 assert.strictEqual(factorialCalculator(11), 39916800);
+```
+
+Your `resultMsg` should contain string in a format `Factorial of [num] is [factorial]`.
+
+```js
+assert.strictEqual(resultMsg, `Factorial of ${num} is ${factorialCalculator(num)}`);
+assert.notMatch(__helpers.removeJSComments(code), /Factorial of \d{1,2} is \d+/);
 ```
 
 You should output the value of `resultMsg` to the console.


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

- - -
- User story and other test seemingly allowed `num` to be between `1` and `20`, but changed test was not passing unless `num` was `5`.
- Test checks `resultMsg` against the message using actual `num` and the `factorialCalculator` result for that `num`. Additionally there's check for hardcoding the `Factorial [num] is [factorial]`.
- Test was moved further, after other things `resultMsg` depends on are tested.