### PR TITLE
fix(curriculum): separate empty string test in Sentence Analyzer

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-sentence-analyzer/66e2f06b191e305c00574e4d.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-sentence-analyzer/66e2f06b191e305c00574e4d.md
@@ -54,7 +54,13 @@ Your `getWordCount` function should return the correct punctuation count for any
 assert.strictEqual(getWordCount("freeCodeCamp has a great community of kind people"), 8);
 assert.strictEqual(getWordCount("The freeCodeCamp curriculum is constantly updated"), 6);
 assert.strictEqual(getWordCount("freeCodeCamp teaches both frontend and backend development"), 7);
+```
+
+Your `getWordCount` function should return the correct word count for empty string, or string only with spaces.
+
+```js
 assert.strictEqual(getWordCount(""), 0);
+assert.strictEqual(getWordCount("   "), 0);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-sentence-analyzer/66e2f06b191e305c00574e4d.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-sentence-analyzer/66e2f06b191e305c00574e4d.md
@@ -56,7 +56,7 @@ assert.strictEqual(getWordCount("The freeCodeCamp curriculum is constantly updat
 assert.strictEqual(getWordCount("freeCodeCamp teaches both frontend and backend development"), 7);
 ```
 
-Your `getWordCount` function should return the correct word count for empty string, or string only with spaces.
+Your `getWordCount` function should return the correct word count for an empty string, or a string only with spaces.
 
 ```js
 assert.strictEqual(getWordCount(""), 0);


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

- - -
- Creates separate test for checking `getWordsCount` with _empty_ strings.
- While it falls under the _function should return the correct word count for any sentence_ case, edge case with _empty_ strings is not obvious from it.