### PR TITLE
fix(curriculum): confirm not using `unshift` in Shopping List

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-shopping-list/66c742d045c9fc2e09fa64b1.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-shopping-list/66c742d045c9fc2e09fa64b1.md
@@ -29,6 +29,7 @@ You should update the first item in the `shoppingList` array to be `"Canola Oil"
 
 ```js
 assert.equal(shoppingList[0], "Canola Oil");
+assert.notEqual(shoppingList[1], "Vegetable Oil");
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

- - -
- Test would pass with using `unshift` method, while step asks to update element with the `0` index.