### PR TITLE
fix(curriculum): inconsistent logging in final step

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-shopping-list/66c748ffdfbe4f2ede268be2.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-shopping-list/66c748ffdfbe4f2ede268be2.md
@@ -13,10 +13,10 @@ And with this last step your grocery list is complete!
 
 # --hints--
 
-You should log the `shoppingList` array to the console.
+You should call the `getShoppingListMsg` function inside of the `console.log`.
 
 ```js
-assert.match(code, /console\.log\(\s*shoppingList\s*\)/);
+assert.lengthOf(code.match(/console\.log\(\s*getShoppingListMsg\(\)\s*\)/g), 7);
 ```
 
 # --seed--
@@ -112,5 +112,5 @@ console.log("On second thought, maybe we should be more health conscious.");
 shoppingList.shift();
 shoppingList[0] = "Canola Oil";
 
-console.log(shoppingList);
+console.log(getShoppingListMsg());
 ```


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

- - -
- In multiple earlier steps every time there was mentioned logging of the shopping list, the usage of `getShoppingListMsg` function was expected.
- This change makes the final step consistent with that.