### PR TITLE
fix: no  block prompt on fcc10

### DIFF
--- a/client/src/redux/donation-saga.js
+++ b/client/src/redux/donation-saga.js
@@ -45,13 +45,18 @@ const updateCardErrorMessage = i18next.t('donate.error-3');
 
 function* showDonateModalSaga() {
   let shouldRequestDonation = yield select(shouldRequestDonationSelector);
+  const recentlyClaimedBlock = yield select(recentlyClaimedBlockSelector);
   const MODAL_SHOWN_KEY = 'modalShownTimestamp';
   const modalShownTimestamp = sessionStorage.getItem(MODAL_SHOWN_KEY);
   const isModalRecentlyShown = Date.now() - modalShownTimestamp < 20000;
-
-  if (shouldRequestDonation || isModalRecentlyShown) {
+  if (
+    shouldRequestDonation &&
+    recentlyClaimedBlock &&
+    recentlyClaimedBlock.superBlock == 'full-stack-developer'
+  ) {
+    yield put(preventBlockDonationRequests());
+  } else if (shouldRequestDonation || isModalRecentlyShown) {
     yield delay(200);
-    const recentlyClaimedBlock = yield select(recentlyClaimedBlockSelector);
     yield put(openDonationModal());
     sessionStorage.setItem(MODAL_SHOWN_KEY, Date.now());
     yield take(appTypes.closeDonationModal);


### PR DESCRIPTION
This pr will stops the block donation modals from appearing on fcc10.
In case https://github.com/freeCodeCamp/freeCodeCamp/pull/57583 does not get finalized before the release, we can get this in to make sure users are not interrupted too much.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
