### PR TITLE
fix(curriculum): correct typo from 'cick' to 'click'

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-storytelling-app/671fafbae959c048d82bac8d.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-storytelling-app/671fafbae959c048d82bac8d.md
@@ -13,7 +13,7 @@ With this, you have successfully completed the workshop.
 
 # --hints--
 
-When you cick the `scaryStoryBtn`, the `result` paragraph should display the scary story `"In the dark woods, a group of friends stumbled upon an old, abandoned cabin. They enter the cabin and awaken something malevolent that had been dormant for centuries."` with a border color of `#ee4b2b`.
+When you click the `scaryStoryBtn`, the `result` paragraph should display the scary story `"In the dark woods, a group of friends stumbled upon an old, abandoned cabin. They enter the cabin and awaken something malevolent that had been dormant for centuries."` with a border color of `#ee4b2b`.
 
 ```js
 scaryStoryBtn.click();
@@ -36,7 +36,7 @@ assert.equal(hexColor.toLowerCase(), "#ee4b2b");
 assert.equal(result.textContent.replace(/\s+/g, ' '), expectedStory);
 ```
 
-When you cick the `funnyStoryBtn`, the `result` paragraph should display the funny story with a border color of `#f1be32`.
+When you click the `funnyStoryBtn`, the `result` paragraph should display the funny story with a border color of `#f1be32`.
 
 ```js
 funnyStoryBtn.click();
@@ -59,7 +59,7 @@ assert.equal(hexColor.toLowerCase(), "#f1be32");
 assert.equal(result.textContent.replace(/\s+/g, ' '), expectedFunnyStory);
 ```
 
-When you cick the `adventureStoryBtn`, the `result` paragraph should display the adventure story with a border color of `#acd157`.
+When you click the `adventureStoryBtn`, the `result` paragraph should display the adventure story with a border color of `#acd157`.
 
 ```js
 adventureStoryBtn.click();


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #57653

<!-- Feel free to add any additional description of changes below this line -->
This PR corrects a typo in the `freeCodeCamp\curriculum\challenges\english\25-front-end-development\workshop-storytelling-app\671fafbae959c048d82bac8d.md` file, changing "cick" to "click". 
