### PR TITLE
fix(curriculum): ensure empty array doesn't pass tests in Quiz Game

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-quiz-game/66f17db06803d11a1bd19a20.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-quiz-game/66f17db06803d11a1bd19a20.md
@@ -43,12 +43,14 @@ questions.forEach(question => {
 The `category` key should have the value of a string representing a question category.
 
 ```js
+assert.isNotEmpty(questions);
 questions.forEach(({category}) => assert.isString(category));
 ```
 
 The `question` key should have the value of a string representing a question.
 
 ```js
+assert.isNotEmpty(questions);
 questions.forEach(({question}) => {
     assert.isString(question);
     assert.include(question, '?');
@@ -58,6 +60,7 @@ questions.forEach(({question}) => {
 The `choices` key should have the value of an array containing three strings.
 
 ```js
+assert.isNotEmpty(questions);
 questions.forEach(({choices}) => {
     assert.isArray(choices);
     assert.lengthOf(choices, 3);
@@ -68,12 +71,14 @@ questions.forEach(({choices}) => {
 The `answer` key should have the value of a string.
 
 ```js
+assert.isNotEmpty(questions);
 questions.forEach(({answer}) => assert.isString(answer));
 ```
 
 The value of `answer` should be included in the `choices` array.
 
 ```js
+assert.isNotEmpty(questions);
 questions.forEach(({answer, choices}) => assert.oneOf(answer, choices));
 ```
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

- - -
- Adds check for non-empty array in few tests. Otherwise they'd pass when `questions` array is empty. This would not cause whole lab to pass, as there is other test checking if there's five elements in `questions`. This change prevents tests passing too early from misrepresenting the job that still needs to be done in lab.