### PR TITLE
fix(curriculum): clarify leap year in user story

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-leap-year-calculator/66c06fad3475cd92421b9ac2.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-leap-year-calculator/66c06fad3475cd92421b9ac2.md
@@ -15,12 +15,12 @@ Fulfill the user stories below and get all the tests to pass to complete the lab
 
 1. Define a function called `isLeapYear` that takes a number as an argument.
 2. Outside the function, declare a variable `year` that stores the value of the year you want to check.
-3. Inside the function, use an `if/ else` statement or a ternary operator to check if the year is a leap year. 
-4. To check if the year is a leap year, fulfill the following conditions: 
+3. Inside the function, use an `if/ else` statement or a ternary operator to check if the year is a leap year.
+4. To check if the year is a leap year, fulfill the following conditions:
 
    - If the year is divisible by `4`, then it is a leap year.
-   - If the year is divisible by `100`, then it is not a leap year.
-   - If the year is divisible by `400`, then it is a leap year.
+   - Unless the year is also divisible by `100`, then it is not a leap year.
+   - Unless the year is also divisible by `400`, then it is a leap year.
 
 5. If the year is a leap year, return `[year] is a leap year.`. Otherwise, return `[year] is not a leap year.`. You will replace `[year]` with the parameter defined in the `isLeapYear` function.
 6. You should call the `isLeapYear` function with `year` as the argument and assign the result to a variable named `result`.


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

- - -
- Clarifies leap year in user story, to show dependency on the other divisibility.