### PR TITLE
fix(client): cursor type in challenge explanation

### DIFF
--- a/client/src/templates/Challenges/components/challenge-explanation.css
+++ b/client/src/templates/Challenges/components/challenge-explanation.css
@@ -1,3 +1,3 @@
-.explanation {
+.challenge-summary {
   cursor: pointer;
 }

--- a/client/src/templates/Challenges/components/challenge-explanation.tsx
+++ b/client/src/templates/Challenges/components/challenge-explanation.tsx
@@ -16,8 +16,10 @@ function ChallengeExplanation({
 
   return (
     <>
-      <details className='explanation'>
-        <summary>{t('learn.explanation')}</summary>
+      <details>
+        <summary className='challenge-summary'>
+          {t('learn.explanation')}
+        </summary>
         <Spacer size='m' />
         <PrismFormatted className={'line-numbers'} text={explanation} />
       </details>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

I was testing a couple of B1 English challenges, and noticed that explanation component has the mouse cursor changed to pointer, even for the text content.

I'm updating the CSS so that the pointer type only applies to the `summary` element.

<!-- Feel free to add any additional description of changes below this line -->
