### PR TITLE
fix(curriculum): rename variables in Music Instrument Filter

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-music-instrument-filter/672137c47fa88d6f753f6d0b.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-music-instrument-filter/672137c47fa88d6f753f6d0b.md
@@ -142,7 +142,7 @@ assert.isEmpty(instrArr);
 ## --after-user-code-- 
 
 ```js
-const allInstrmnts = [
+const allInstruments = [
   { category: "woodwinds", instrument: "Flute", price: 500 },
   { category: "woodwinds", instrument: "Clarinet", price: 200 },
   { category: "woodwinds", instrument: "Oboe", price: 4000 },
@@ -157,8 +157,8 @@ const allInstrmnts = [
 function getInstrumentsArr(instrumentCategory) {
   const instruments =
     instrumentCategory === "all"
-      ? JSON.parse(JSON.stringify(allInstrmnts))
-      : allInstrmnts.filter(
+      ? JSON.parse(JSON.stringify(allInstruments))
+      : allInstruments.filter(
           ({ category }) => category === instrumentCategory
         );
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-music-instrument-filter/67213ce0a2ba1278a38df3a5.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-music-instrument-filter/67213ce0a2ba1278a38df3a5.md
@@ -64,7 +64,7 @@ try {
 ## --after-user-code-- 
 
 ```js
-const allInstrmnts = [
+const allInstruments = [
   { category: "woodwinds", instrument: "Flute", price: 500 },
   { category: "woodwinds", instrument: "Clarinet", price: 200 },
   { category: "woodwinds", instrument: "Oboe", price: 4000 },
@@ -77,14 +77,14 @@ const allInstrmnts = [
   { category: "percussion", instrument: "Marimba", price: 3000 }
 ]
 function getCardsArr(family) {
-  const instrmnts =
+  const instruments =
     family === "all"
-      ? allInstrmnts
-      : allInstrmnts.filter(
+      ? allInstruments
+      : allInstruments.filter(
           ({ category }) => category === family
         );
 
-  return instrmnts
+  return instruments
     .map(({ instrument, price }) => {
       return `
           <div class="card">

--- a/curriculum/challenges/english/25-front-end-development/workshop-music-instrument-filter/672146dde7104896adb274ae.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-music-instrument-filter/672146dde7104896adb274ae.md
@@ -48,7 +48,7 @@ assert(productsContainer.isEqualNode(testDiv))
 ## --after-user-code-- 
 
 ```js
-const allInstrmnts = [
+const allInstruments = [
   { category: "woodwinds", instrument: "Flute", price: 500 },
   { category: "woodwinds", instrument: "Clarinet", price: 200 },
   { category: "woodwinds", instrument: "Oboe", price: 4000 },
@@ -61,14 +61,14 @@ const allInstrmnts = [
   { category: "percussion", instrument: "Marimba", price: 3000 }
 ]
 function getCardsArr(family) {
-  const instrmnts =
+  const instruments =
     family === "all"
-      ? allInstrmnts
-      : allInstrmnts.filter(
+      ? allInstruments
+      : allInstruments.filter(
           ({ category }) => category === family
         );
 
-  return instrmnts
+  return instruments
     .map(({ instrument, price }) => {
       return `
           <div class="card">


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR:
- Renames `allInstrmnts` to `allInstruments`
- Renames `instrmnts` to `instruments`

(The terms differ by only two characters so I assume these are typos rather than an attempt to shorten the variable names.)

<!-- Feel free to add any additional description of changes below this line -->
