### PR TITLE
fix(curriculum): job-application-form label input test

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-job-application-form/66faac4139dbbd5dd632c860.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-job-application-form/66faac4139dbbd5dd632c860.md
@@ -128,7 +128,8 @@ You should use the `:checked` pseudo-class on radio buttons to change the text c
 const els = document.querySelectorAll('input[type="radio"]');
 assert.isNotEmpty(els);
 els.forEach(input => {
-  const label = document.querySelector(`label[for="${input.id}"]`);
+  const label = document.querySelector(`label[for="${input.id}"]`) || input.parentElement;
+  assert.equal(label.tagName, "LABEL");
   input.checked = false;
   const colorBefore = getComputedStyle(label).color;
   input.checked = true;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

A `label` does not need a `for` attribute when its associated `input` is an only child:

```html
<label>
  Full-Type
  <input type="radio" name="availability" />
</label>
<label>
  Part-Time
  <input type="radio" name="availability" />
</label>
```