### PR TITLE
fix: typos from your to you in challenges (#57713)

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-intermediate-css-by-building-a-cat-painting/646c48df8674cf2b91020ecc.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-intermediate-css-by-building-a-cat-painting/646c48df8674cf2b91020ecc.md
@@ -11,7 +11,7 @@ Add a `link` element within your `head` element. For that `link` element, set th
 
 # --hints--
 
-Your should have a `link` element.
+You should have a `link` element.
 
 ```js
 assert.match(code, /<link/)

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-asynchronous-programming-by-building-an-fcc-forum-leaderboard/644b6d20eabd7e0149383254.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-asynchronous-programming-by-building-an-fcc-forum-leaderboard/644b6d20eabd7e0149383254.md
@@ -17,7 +17,7 @@ You should use `let` to declare a variable named `selectedCategory`.
 assert.match(code, /\s*let\s+selectedCategory\s*/);
 ```
 
-Your should assign an empty object to the `selectedCategory` variable.
+You should assign an empty object to the `selectedCategory` variable.
 
 ```js
 assert.match(code, /\s*let\s+selectedCategory\s*=\s*{\s*}\s*/);

--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646c48df8674cf2b91020ecc.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646c48df8674cf2b91020ecc.md
@@ -12,7 +12,7 @@ You have been provided with a basic boilerplate. Begin by adding a `link` elemen
 
 # --hints--
 
-Your should have a `link` element.
+You should have a `link` element.
 
 ```js
 assert.exists(document.querySelector("head>link"));

--- a/curriculum/challenges/english/25-front-end-development/workshop-music-player/6758a61fc7e949923716ec41.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-music-player/6758a61fc7e949923716ec41.md
@@ -19,7 +19,7 @@ You should have a variable named `songs`.
 assert.isDefined(songs);
 ```
 
-Your should assign the collection of all `.playlist-song` elements to your `songs` variable.
+You should assign the collection of all `.playlist-song` elements to your `songs` variable.
 
 ```js
 assert.deepEqual(songs, document.querySelectorAll(".playlist-song"));

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6745d9df333efe2543a1f457.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6745d9df333efe2543a1f457.md
@@ -17,13 +17,13 @@ You should create a `ul` element inside your third `li` element.
 assert(document.querySelector('li ul'));
 ```
 
-Your should set the `className` attribute of your `ul` element to `sub-menu`.
+You should set the `className` attribute of your `ul` element to `sub-menu`.
 
 ```js
 assert.equal(document.querySelector('li ul')?.getAttribute('class'), 'sub-menu');
 ```
 
-Your should set the `aria-label` attribute of your `ul` element to `Apps`.
+You should set the `aria-label` attribute of your `ul` element to `Apps`.
 
 ```js
 assert.equal(document.querySelector('li ul')?.getAttribute('aria-label'), 'Apps');


### PR DESCRIPTION
Checklist:
 I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org/).
 I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
 My pull request targets the main branch of freeCodeCamp.
 I have tested these changes either locally on my machine, or GitPod.
<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. -->
Closes #57713

<!-- Feel free to add any additional description of changes below this line -->
This pull request fixes a typo by replacing 'Your' with 'You' in several curriculum challenge files as per issue #57713.
