### PR TITLE
fix(client): share buttons in lower jaw

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -107,6 +107,7 @@
     "confirm-amount": "Confirm amount",
     "play-scene": "Press Play",
     "closed-caption": "Closed caption",
+    "share-on-x": "Share on X",
     "share-on-bluesky": "Share on BlueSky",
     "share-on-threads": "Share on Threads"
   },

--- a/client/src/components/share/share-template.test.tsx
+++ b/client/src/components/share/share-template.test.tsx
@@ -14,7 +14,7 @@ describe('Share Template Testing', () => {
   );
   test('Testing share template Click Redirect Event', () => {
     const twitterLink = screen.queryByRole('link', {
-      name: 'buttons.tweet aria.opens-new-window'
+      name: 'buttons.share-on-x aria.opens-new-window'
     });
 
     expect(twitterLink).toBeInTheDocument();

--- a/client/src/components/share/share-template.tsx
+++ b/client/src/components/share/share-template.tsx
@@ -15,7 +15,7 @@ export const ShareTemplate: React.ComponentType<ShareRedirectProps> = ({
 }) => {
   const { t } = useTranslation();
   return (
-    <div>
+    <>
       <a
         data-testid='ShareTemplateWrapperTestID'
         className='btn fade-in'
@@ -29,7 +29,7 @@ export const ShareTemplate: React.ComponentType<ShareRedirectProps> = ({
           aria-label='twitterIcon'
           aria-hidden='true'
         />
-        {t('buttons.tweet')}
+        {t('buttons.share-on-x')}
         <span className='sr-only'>{t('aria.opens-new-window')}</span>
       </a>
       <a
@@ -64,6 +64,6 @@ export const ShareTemplate: React.ComponentType<ShareRedirectProps> = ({
         {t('buttons.share-on-threads')}
         <span className='sr-only'>{t('aria.opens-new-window')}</span>
       </a>
-    </div>
+    </>
   );
 };

--- a/client/src/templates/Challenges/classic/editor.css
+++ b/client/src/templates/Challenges/classic/editor.css
@@ -235,16 +235,6 @@ textarea.inputarea {
   gap: 20px;
 }
 
-.utility-bar button {
-  display: flex;
-  width: 50%;
-  padding-top: 0.375rem;
-  padding-bottom: 0.375rem;
-  justify-content: center;
-  align-items: center;
-  gap: 0.3rem;
-}
-
 .utility-bar .utility-bar-top {
   width: 100%;
   display: flex;
@@ -264,6 +254,16 @@ textarea.inputarea {
   width: 100%;
   display: flex;
   gap: 0.75rem;
+}
+
+.utility-bar .utility-bar-bottom button {
+  display: flex;
+  width: 50%;
+  padding-top: 0.375rem;
+  padding-bottom: 0.375rem;
+  justify-content: center;
+  align-items: center;
+  gap: 0.3rem;
 }
 
 .progress-bar-container {

--- a/client/src/templates/Challenges/classic/editor.css
+++ b/client/src/templates/Challenges/classic/editor.css
@@ -229,18 +229,41 @@ textarea.inputarea {
 }
 
 .utility-bar {
-  display: grid;
-  /* 8rem is a safe default for all currently supported languages. Will need to be increased if a new language has longer words for Reset/Help. */
-  grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));
-  gap: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
 }
 
-.utility-bar > * {
+.utility-bar button {
   display: flex;
-  align-items: center;
+  width: 50%;
+  padding-top: 0.375rem;
+  padding-bottom: 0.375rem;
   justify-content: center;
+  align-items: center;
   gap: 0.3rem;
-  padding: 6px 0;
+}
+
+.utility-bar .utility-bar-top {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+}
+
+.utility-bar .utility-bar-top a {
+  width: 30%;
+}
+
+.utility-bar .utility-bar-top svg {
+  display: block;
+  margin: 0 auto;
+}
+
+.utility-bar .utility-bar-bottom {
+  width: 100%;
+  display: flex;
+  gap: 0.75rem;
 }
 
 .progress-bar-container {

--- a/client/src/templates/Challenges/classic/lower-jaw.tsx
+++ b/client/src/templates/Challenges/classic/lower-jaw.tsx
@@ -96,26 +96,33 @@ const LowerButtonsPanel = ({
     <>
       <hr />
       <div className='utility-bar'>
-        <Button
-          data-playwright-test-label='lowerJaw-reset-button'
-          className='fade-in'
-          onClick={resetButtonEvent}
-        >
-          <Reset />
-          {resetButtonText}
-        </Button>
-        {showShareButton && <Share superBlock={superBlock} block={block} />}
-
-        {hideHelpButton && (
-          <Button
-            className='fade-in'
-            id='get-help-button'
-            onClick={helpButtonEvent}
-          >
-            <Help />
-            {helpButtonText}
-          </Button>
+        {showShareButton && (
+          <div className='utility-bar-top'>
+            <Share superBlock={superBlock} block={block} />
+          </div>
         )}
+
+        <div className='utility-bar-bottom'>
+          <Button
+            data-playwright-test-label='lowerJaw-reset-button'
+            className='fade-in'
+            onClick={resetButtonEvent}
+          >
+            <Reset />
+            {resetButtonText}
+          </Button>
+
+          {hideHelpButton && (
+            <Button
+              className='fade-in'
+              id='get-help-button'
+              onClick={helpButtonEvent}
+            >
+              <Help />
+              {helpButtonText}
+            </Button>
+          )}
+        </div>
       </div>
     </>
   );


### PR DESCRIPTION
| Before | After |
| - | - |
| <img width="571" alt="Screenshot 2024-12-23 at 7 04 19 PM" src="https://github.com/user-attachments/assets/4ba6630c-3061-4f96-806e-2335cfdf1eaa" /> | <img width="631" alt="Screenshot 2024-12-23 at 7 55 20 PM" src="https://github.com/user-attachments/assets/1f9a0a53-46fe-4574-b161-ee7fad29d52c" /> |
| <img width="615" alt="Screenshot 2024-12-23 at 8 08 37 PM" src="https://github.com/user-attachments/assets/995bcea6-65e7-4bd3-bead-ca94c83b282e" /> | <img width="617" alt="Screenshot 2024-12-23 at 8 01 13 PM" src="https://github.com/user-attachments/assets/e991d182-8f7c-411e-9f4a-56f7ab3a36a1" /> |

The share buttons show up when you complete an entire workshop - or step based project I think?

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
