### PR TITLE
fix(curriculum): Removed "received"

### DIFF
--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-activities/66c8ffb7c913438ad893dcf2.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-activities/66c8ffb7c913438ad893dcf2.md
@@ -14,7 +14,7 @@ Listen to the audio and complete the sentence below.
 
 ## --sentence--
 
-`BLANK received any detailed reports from users about this issue?`
+`BLANK any detailed reports from users about this issue?`
 
 ## --blanks--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #57737 

<!-- Feel free to add any additional description of changes below this line -->

As per the issue raised , the additional word "recieved " from the sentence has been removed.

![image](https://github.com/user-attachments/assets/42765362-7a73-4ea0-9bb8-a2f71e6d2182)
