### PR TITLE
fix(client): multiple choice question feedback display

### DIFF
--- a/client/src/templates/Challenges/components/multiple-choice-questions.tsx
+++ b/client/src/templates/Challenges/components/multiple-choice-questions.tsx
@@ -83,12 +83,13 @@ function MultipleChoiceQuestions({
                     <div
                       className={`video-quiz-option-label mcq-feedback ${isCorrect ? 'mcq-correct' : 'mcq-incorrect'}`}
                     >
-                      {isCorrect
-                        ? t('learn.quiz.correct-answer')
-                        : t('learn.quiz.incorrect-answer')}
+                      <p>
+                        {isCorrect
+                          ? t('learn.quiz.correct-answer')
+                          : t('learn.quiz.incorrect-answer')}
+                      </p>
                       {feedback && (
-                        <>
-                          <span>&nbsp;</span>
+                        <p>
                           <PrismFormatted
                             className={
                               isCorrect
@@ -99,7 +100,7 @@ function MultipleChoiceQuestions({
                             useSpan
                             noAria
                           />
-                        </>
+                        </p>
                       )}
                     </div>
                   )}

--- a/client/src/templates/Challenges/video.css
+++ b/client/src/templates/Challenges/video.css
@@ -139,6 +139,7 @@ input:focus-visible + .video-quiz-input-visible {
 
 .mcq-feedback {
   border-top: none;
+  display: block;
 }
 
 .mcq-prism-correct code {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Fixes the display of feedback in multiple choice questions.

| Before | After |
| --- | --- |
| <img width="783" alt="Screenshot 2024-12-24 at 19 20 07" src="https://github.com/user-attachments/assets/5b88f28a-a530-459c-bd7d-f5f340899b77" /> | <img width="781" alt="Screenshot 2024-12-24 at 19 15 43" src="https://github.com/user-attachments/assets/f3881c52-7d22-43da-99f5-be8c7a413462" /> |

Note: This is just a temporary fix, and we would want to update the MCQ component to use the QuizQuestion component from `freecodecamp/ui` instead. 

Here is how QuizQuestion displays feedback: https://opensource.freecodecamp.org/ui/?path=/story/components-quizquestion--incorrect-with-answer-feedback&globals=backgrounds.value:!hex(1b1b32).


<!-- Feel free to add any additional description of changes below this line -->
