### PR TITLE
fix(curriculum): remove the word "showing"

### DIFF
--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c6193e7546c4e51cbf64c9.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c6193e7546c4e51cbf64c9.md
@@ -16,7 +16,7 @@ Listen to the audio and complete the sentence below.
 
 ## --sentence--
 
-`And in Eclipse, BLANK BLANK showing the Git tools.`
+`And in Eclipse, BLANK BLANK the Git tools.`
 
 ## --blanks--
 


### PR DESCRIPTION
Checklist:

- [ x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ x] My pull request targets the `main` branch of freeCodeCamp.
- [x ] I have tested these changes either locally on my machine, or GitPod.

Closes #57736

Removed the word showing from the sentence: [freeCodeCamp/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c6193e7546c4e51cbf64c9.md](https://github.com/freeCodeCamp/freeCodeCamp/blob/94b07766f5c91e7c8d88e797ab56c01101af3f4d/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66c6193e7546c4e51cbf64c9.md?plain=1#L19)