### PR TITLE
fix: improve tests in travel agency lab

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-travel-agency-page/669e2f60e83c011754f711f9.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-travel-agency-page/669e2f60e83c011754f711f9.md
@@ -142,7 +142,7 @@ assert.strictEqual(
 You should have two items in your unordered list.
 
 ```js
-assert.lengthOf(document.querySelectorAll('li'), 2);
+assert.lengthOf(document.querySelectorAll('p + ul li'), 2);
 ```
 
 Both your list items should contain an anchor element.
@@ -205,8 +205,16 @@ Each `figure` element should contain a `figcaption` element as its second child.
 const figures = document.querySelectorAll('figure');
 assert.isNotEmpty(figures);
 for (let figure of figures) {
-  assert.equal(figure.children[1].tagName, 'FIGCAPTION');
+  assert.equal(figure.children[1]?.tagName, 'FIGCAPTION');
 }
+```
+
+Each `figcaption` should contain some text.
+
+```js
+const figcaptionEls = document.querySelectorAll('figcaption');
+assert.isNotEmpty(figcaptionEls);
+figcaptionEls.forEach((figcaption => assert.isNotEmpty(figcaption.innerText)));
 ```
 
 Each of the `a` elements that are children of your `figure` elements should contain an image.
@@ -215,7 +223,7 @@ Each of the `a` elements that are children of your `figure` elements should cont
 const anchors = document.querySelectorAll('figure > a');
 assert.isNotEmpty(anchors);
 for (let anchor of anchors) {
-  assert.equal(anchor.children[0].tagName, 'IMG');
+  assert.equal(anchor.children[0]?.tagName, 'IMG');
 }
 ```
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

I have
- added optional chaining in two places to avoid errors in the console of not being able to read a property of undefined
- added a test to check that there is text in the `figcaption` elements
- changed a test so that it counts `li` elements only if they are in an `ul` element