### PR TITLE
fix(curriculum): markdown lab check syntax multiple times

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-markdown-to-html-converter/66f55eac933ff64ce654ca74.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-markdown-to-html-converter/66f55eac933ff64ce654ca74.md
@@ -134,6 +134,20 @@ const testH1 = testDiv.querySelector("h1")
 assert.notExists(testH1);
 ```
 
+When the value of `#markdown-input` is `# title 1\n# alternate title`, `convertMarkdown()` should return `<h1>title 1</h1><h1>alternate title</h1>`.
+
+```js
+const input = document.querySelector("#markdown-input");
+input.value = "# title 1\n# alternate title";
+const testDiv = document.createElement("div");
+testDiv.innerHTML = convertMarkdown();
+const headings = testDiv.querySelectorAll("h1");
+assert.lengthOf(headings, 2);
+assert.lengthOf(testDiv.children, 2);
+assert.equal(headings[0].innerText, "title 1");
+assert.equal(headings[1].innerText, "alternate title");
+```
+
 When the value of `#markdown-input` is `## title 2`, `convertMarkdown()` should return `<h2>title 2</h2>`.
 
 ```js
@@ -184,6 +198,20 @@ const testDiv = document.createElement("div");
 testDiv.innerHTML = convertMarkdown();
 const testH2 = testDiv.querySelector("h2")
 assert.notExists(testH2);
+```
+
+When the value of `#markdown-input` is `## title 2\n## title 2 alt`, `convertMarkdown()` should return `<h2>title 2</h2><h2>title 2 alt</h2>`.
+
+```js
+const input = document.querySelector("#markdown-input");
+input.value = "## title 2\n## title 2 alt";
+const testDiv = document.createElement("div");
+testDiv.innerHTML = convertMarkdown();
+const headings = testDiv.querySelectorAll("h2");
+assert.lengthOf(headings, 2);
+assert.lengthOf(testDiv.children, 2);
+assert.equal(headings[0].innerText, "title 2");
+assert.equal(headings[1].innerText, "title 2 alt");
 ```
 
 When the value of `#markdown-input` is `### title 3`, `convertMarkdown()` should return `<h3>title 3</h3>`.
@@ -238,6 +266,20 @@ const testH3 = testDiv.querySelector("h3")
 assert.notExists(testH3);
 ```
 
+When the value of `#markdown-input` is `### title 3\n### third title`, `convertMarkdown()` should return `<h3>title 3</h3><h3>third title</h3>`.
+
+```js
+const input = document.querySelector("#markdown-input");
+input.value = "### title 3\n### third title";
+const testDiv = document.createElement("div");
+testDiv.innerHTML = convertMarkdown();
+const headings = testDiv.querySelectorAll("h3");
+assert.lengthOf(headings, 2);
+assert.lengthOf(testDiv.children, 2);
+assert.equal(headings[0].innerText, "title 3");
+assert.equal(headings[1].innerText, "third title");
+```
+
 When the value of `#markdown-input` is `**this is bold**`, `convertMarkdown()` should return `<strong>this is bold</strong>`.
 
 ```js
@@ -279,17 +321,18 @@ assert.lengthOf(preview.children, 1)
 assert.equal(strongs[0].innerText, "this is bold");
 ```
 
-When the value of `#markdown-input` is `__this is bold__`, `convertMarkdown()` should return `<strong>this is bold</strong>`.
+When the value of `#markdown-input` is `**this is bold**\n**this is also bold**`, `convertMarkdown()` should return `<strong>this is bold</strong><strong>this is also bold</strong>`.
 
 ```js
 const input = document.querySelector("#markdown-input");
-input.value = "__this is bold__";
+input.value = "**this is bold**\n**this is also bold**";
 const testDiv = document.createElement("div");
 testDiv.innerHTML = convertMarkdown();
 const strongs = testDiv.querySelectorAll("strong");
-assert.lengthOf(strongs, 1);
-assert.lengthOf(testDiv.children, 1);
+assert.lengthOf(strongs, 2);
+assert.lengthOf(testDiv.children, 2);
 assert.equal(strongs[0].innerText, "this is bold");
+assert.equal(strongs[1].innerText, "this is also bold");
 ```
 
 When the value of `#markdown-input` is `__this is bold__`, `<strong>this is bold</strong>` should be displayed inside `#html-output`.
@@ -318,6 +361,20 @@ const strongs = preview.querySelectorAll("strong");
 assert.lengthOf(strongs, 1);
 assert.lengthOf(preview.children, 1)
 assert.equal(strongs[0].innerText, "this is bold");
+```
+
+When the value of `#markdown-input` is `__this is bold__\n__this is also bold__`, `convertMarkdown()` should return `<strong>this is bold</strong><strong>this is also bold</strong>`.
+
+```js
+const input = document.querySelector("#markdown-input");
+input.value = "__this is bold__\n__this is also bold__";
+const testDiv = document.createElement("div");
+testDiv.innerHTML = convertMarkdown();
+const strongs = testDiv.querySelectorAll("strong");
+assert.lengthOf(strongs, 2);
+assert.lengthOf(testDiv.children, 2);
+assert.equal(strongs[0].innerText, "this is bold");
+assert.equal(strongs[1].innerText, "this is also bold");
 ```
 
 When the value of `#markdown-input` is `*this is italic*`, `convertMarkdown()` should return `<em>this is italic</em>`.
@@ -361,6 +418,20 @@ assert.lengthOf(preview.children, 1);
 assert.equal(italics[0].innerText, "this is italic");
 ```
 
+When the value of `#markdown-input` is `*this is italic*\n*this is also italic*`, `convertMarkdown()` should return `<em>this is italic</em><em>this is also italic</em>`.
+
+```js
+const input = document.querySelector("#markdown-input");
+input.value = "*this is italic*\n*this is also italic*";
+const testDiv = document.createElement("div");
+testDiv.innerHTML = convertMarkdown();
+const italics = testDiv.querySelectorAll("em");
+assert.lengthOf(italics, 2);
+assert.lengthOf(testDiv.children, 2);
+assert.equal(italics[0].innerText, "this is italic");
+assert.equal(italics[1].innerText, "this is also italic");
+```
+
 When the value of `#markdown-input` is `_this is italic_`, `convertMarkdown()` should return `<em>this is italic</em>`.
 
 ```js
@@ -400,6 +471,20 @@ const italics = preview.querySelectorAll("em");
 assert.lengthOf(italics, 1);
 assert.lengthOf(preview.children, 1);
 assert.equal(italics[0].innerText, "this is italic");
+```
+
+When the value of `#markdown-input` is `_this is italic_\n_this is also italic_`, `convertMarkdown()` should return `<em>this is italic</em><em>this is also italic</em>`.
+
+```js
+const input = document.querySelector("#markdown-input");
+input.value = "_this is italic_\n_this is also italic_";
+const testDiv = document.createElement("div");
+testDiv.innerHTML = convertMarkdown();
+const italics = testDiv.querySelectorAll("em");
+assert.lengthOf(italics, 2);
+assert.lengthOf(testDiv.children, 2);
+assert.equal(italics[0].innerText, "this is italic");
+assert.equal(italics[1].innerText, "this is also italic");
 ```
 
 When the value of `#markdown-input` is either `# **title 1**` or `# __title 1__`, `convertMarkdown()` should return `<h1><strong>title 1</strong></h1>`.
@@ -529,6 +614,22 @@ assert.equal(imgs[0].alt, "alt-text");
 assert.isTrue(imgs[0].src.endsWith("image-source"));
 ```
 
+When the value of `#markdown-input` is `![alt-text](image-source)\n![alt-text-2](image-source-2)`, `convertMarkdown()` should return `<img alt="alt-text" src="image-source"><img alt="alt-text-2" src="image-source-2">`.
+
+```js
+const input = document.querySelector("#markdown-input");
+input.value = "!![alt-text](image-source)\n![alt-text-2](image-source-2)";
+const testDiv = document.createElement("div");
+testDiv.innerHTML = convertMarkdown();
+const imgs = testDiv.querySelectorAll("img");
+assert.lengthOf(testDiv.children, 2);
+assert.lengthOf(imgs, 2);
+assert.equal(imgs[0].alt, "alt-text");
+assert.isTrue(imgs[0].src.endsWith("image-source"));
+assert.equal(imgs[1].alt, "alt-text-2");
+assert.isTrue(imgs[1].src.endsWith("image-source-2"));
+```
+
 When the value of `#markdown-input` is `[link text](URL)`, `convertMarkdown()` should return `<a href="URL">link text</a>`.
 
 ```js
@@ -573,6 +674,22 @@ assert.isTrue(anchors[0].href.endsWith("URL"));
 assert.equal(anchors[0].innerText, "link text");
 ```
 
+When the value of `#markdown-input` is `[link text](URL)\n[link text 2](URL2)`, `convertMarkdown()` should return `<a href="URL">link text</a><a href="URL2">link text 2</a>`.
+
+```js
+const input = document.querySelector("#markdown-input");
+input.value = "[link text](URL)\n[link text 2](URL2)";
+const testDiv = document.createElement("div");
+testDiv.innerHTML = convertMarkdown();
+const anchors = testDiv.querySelectorAll("a");
+assert.lengthOf(testDiv.children, 2);
+assert.lengthOf(anchors, 2);
+assert.isTrue(anchors[0].href.endsWith("URL"));
+assert.equal(anchors[0].innerText, "link text");
+assert.isTrue(anchors[1].href.endsWith("URL2"));
+assert.equal(anchors[1].innerText, "link text 2");
+```
+
 When the value of `#markdown-input` is `> this is a quote`, `convertMarkdown()` should return `<blockquote>this is a quote</blockquote>`.
 
 ```js
@@ -613,6 +730,21 @@ assert.lengthOf(preview.children, 1);
 assert.lengthOf(quotes, 1);
 assert.equal(quotes[0].innerText, "this is a quote");
 ```
+
+When the value of `#markdown-input` is `> this is a quote\n> this is another quote`, `convertMarkdown()` should return `<blockquote>this is a quote</blockquote><blockquote>this is another quote</blockquote>`.
+
+```js
+const input = document.querySelector("#markdown-input");
+input.value = "> this is a quote\n> this is another quote";
+const testDiv = document.createElement("div");
+testDiv.innerHTML = convertMarkdown();
+const quotes = testDiv.querySelectorAll("blockquote");
+assert.lengthOf(testDiv.children, 2);
+assert.lengthOf(quotes, 2);
+assert.equal(quotes[0].innerText, "this is a quote");
+assert.equal(quotes[1].innerText, "this is another quote");
+```
+
 
 When the value of `#markdown-input` is `some text > not a quote anymore`, `convertMarkdown()` should not convert `> not a quote anymore` into a `blockquote` element.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #57673

<!-- Feel free to add any additional description of changes below this line -->
I tested for syntax instances multiple times. My logic was is that if *one* element was showing up that was correctly corrected, then if both are correctly converted; they both should show up. 