### PR TITLE
fix(curriculum): typo in Euler Problem 462

### DIFF
--- a/curriculum/challenges/english/18-project-euler/project-euler-problems-401-to-480/problem-462-permutation-of-3-smooth-numbers.md
+++ b/curriculum/challenges/english/18-project-euler/project-euler-problems-401-to-480/problem-462-permutation-of-3-smooth-numbers.md
@@ -22,14 +22,14 @@ This is not a valid permutation because 12 comes before its divisor 6.
 
 We can verify that $F(6) = 5$, $F(8) = 9$, $F(20) = 450$ and $F(1000) ≈ 8.8521816557e\\,21$.
 
-Find $F({10}^{18})$. Give as your answer as a string in its scientific notation rounded to ten digits after the decimal point. When giving your answer, use a lowercase `e` to separate mantissa and exponent. E.g. if the answer is $112\\,233\\,445\\,566\\,778\\,899$ then the answer format would be `1.1223344557e17`.
+Find $F({10}^{18})$. Give your answer as a string in scientific notation rounded to ten digits after the decimal point. When giving your answer, use a lowercase `e` to separate mantissa and exponent. E.g. if the answer is $112\\,233\\,445\\,566\\,778\\,899$ then the answer format would be `1.1223344557e17`.
 
 # --hints--
 
 `permutationOf3SmoothNumbers()` should return a string.
 
 ```js
-assert.strictEqual(typeof permutationOf3SmoothNumbers() === 'string');
+assert.strictEqual(typeof permutationOf3SmoothNumbers(), 'string');
 ```
 
 `permutationOf3SmoothNumbers()` should return the string `5.5350769703e1512`.


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Closes #57724 

Description:

Replaced the === operator with ','
Also fixed the typo 
"Give as your answer as a string in its scientific notation" was changed to "Give your answer as a string in scientific notation".