### PR TITLE
fix(curriculum): restore bob in present perfect english task 

### DIFF
--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/67278e07d5544c1a93f7f113.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/67278e07d5544c1a93f7f113.md
@@ -63,7 +63,7 @@ These are the characteristics or functions of something.
     "background": "company2-boardroom.png",
     "characters": [
       {
-        "character": "James",
+        "character": "Bob",
         "position": {
           "x": 50,
           "y": 15,
@@ -81,12 +81,12 @@ These are the characteristics or functions of something.
   },
   "commands": [
     {
-      "character": "James",
+      "character": "Bob",
       "opacity": 1,
       "startTime": 0
     },
     {
-      "character": "James",
+      "character": "Bob",
       "startTime": 1,
       "finishTime": 4.3,
       "dialogue": {
@@ -95,7 +95,7 @@ These are the characteristics or functions of something.
       }
     },
     {
-      "character": "James",
+      "character": "Bob",
       "opacity": 0,
       "startTime": 4.8
     }

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/67278fa39133d120afee631c.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/67278fa39133d120afee631c.md
@@ -61,7 +61,7 @@ The `Present Perfect Continuous` tense (`have been working`) indicates an action
     "background": "company2-boardroom.png",
     "characters": [
       {
-        "character": "James",
+        "character": "Bob",
         "position": {
           "x": 50,
           "y": 15,
@@ -79,12 +79,12 @@ The `Present Perfect Continuous` tense (`have been working`) indicates an action
   },
   "commands": [
     {
-      "character": "James",
+      "character": "Bob",
       "opacity": 1,
       "startTime": 0
     },
     {
-      "character": "James",
+      "character": "Bob",
       "startTime": 1,
       "finishTime": 4.3,
       "dialogue": {
@@ -93,7 +93,7 @@ The `Present Perfect Continuous` tense (`have been working`) indicates an action
       }
     },
     {
-      "character": "James",
+      "character": "Bob",
       "opacity": 0,
       "startTime": 4.8
     }

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672836d6ec0ae23f4724ccb1.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672836d6ec0ae23f4724ccb1.md
@@ -88,7 +88,7 @@ Linda's statement indicates that the action of testing started at the time of th
       "startTime": 1,
       "finishTime": 3.62,
       "dialogue": {
-        "text": "Yes, I've been testing them since the latest software update",
+        "text": "Yes, I've been testing them since the latest software update.",
         "align": "center"
       }
     },

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/6728378c94eaf541fce8f334.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/6728378c94eaf541fce8f334.md
@@ -78,7 +78,7 @@ This term refers to errors in software that need to be resolved. It's plural for
       "startTime": 1,
       "finishTime": 4.36,
       "dialogue": {
-        "text": "We've had some positive feedback, but there are still a few bugs to fix",
+        "text": "We've had some positive feedback, but there are still a few bugs to fix.",
         "align": "center"
       }
     },

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/67289c4908f407948ef08a55.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/67289c4908f407948ef08a55.md
@@ -88,7 +88,7 @@ Linda's statement highlights that although they have received good responses fro
       "startTime": 1,
       "finishTime": 4.36,
       "dialogue": {
-        "text": "We've had some positive feedback, but there are still a few bugs to fix",
+        "text": "We've had some positive feedback, but there are still a few bugs to fix.",
         "align": "center"
       }
     },


### PR DESCRIPTION
…punctuation

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #57753

<!-- Feel free to add any additional description of changes below this line -->
I also updated the punctuation  where appropriate. 