### PR TITLE
fix(curriculum): fix fade in on first audioplay

### DIFF
--- a/client/src/templates/Challenges/components/scene/scene.tsx
+++ b/client/src/templates/Challenges/components/scene/scene.tsx
@@ -49,8 +49,10 @@ export function Scene({
     const { current } = audioRef;
 
     if (current) {
+      current.volume = 1;
       current.addEventListener('canplaythrough', audioLoaded);
       current.src = `${sounds}/${audio.filename}${audioTimestamp}`;
+      current.preload = 'auto';
       current.load();
     }
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

I tested some small changes locally with this PR and apparently this solves the audio fade in issue which happens on the first time the audio is loaded on challenges with scenes, like those from the English Curriculum.