### PR TITLE
fix: use optional chaining to avoid errors

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/build-a-cash-register-project/build-a-cash-register.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/build-a-cash-register-project/build-a-cash-register.md
@@ -111,7 +111,7 @@ cashInput.dispatchEvent(new Event('change'));
 purchaseBtn.click();
 assert.strictEqual(
   alertMessage
-    .trim()
+    ?.trim()
     .replace(/[.,?!]+$/g, '')
     .toLowerCase(),
   'customer does not have enough money to purchase the item'
@@ -148,7 +148,7 @@ cashInput.dispatchEvent(new Event('change'));
 purchaseBtn.click();
 assert.strictEqual(
   alertMessage
-    .trim()
+    ?.trim()
     .replace(/[.,?!]+$/g, '')
     .toLowerCase(),
   'customer does not have enough money to purchase the item'

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/build-a-palindrome-checker-project/build-a-palindrome-checker.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/build-a-palindrome-checker-project/build-a-palindrome-checker.md
@@ -70,7 +70,7 @@ window.alert = (message) => alertMessage = message; // Override alert and store 
 inputEl.value = '';
 inputEl.dispatchEvent(new Event('change'))
 checkBtn.click();
-assert.strictEqual(alertMessage.trim().replace(/[.,?!]+$/g, '').toLowerCase(), 'please input a value');
+assert.strictEqual(alertMessage?.trim().replace(/[.,?!]+$/g, '').toLowerCase(), 'please input a value');
 ```
 
 When the `#text-input` element only contains the letter `A` and the `#check-btn` element is clicked, the `#result` element should contain the text `"A is a palindrome"`.

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/build-a-pokemon-search-app-project/build-a-pokemon-search-app.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/build-a-pokemon-search-app-project/build-a-pokemon-search-app.md
@@ -153,7 +153,7 @@ async () => {
     if (!res.ok) {
       await new Promise(resolve => setTimeout(resolve, 1000)); // Additional delay to allow the alert to trigger
 
-      assert.include(['pokémon not found', 'pokemon not found'], alertMessage.trim().replace(/[.,?!]+$/g, '').toLowerCase());
+      assert.include(['pokémon not found', 'pokemon not found'], alertMessage?.trim().replace(/[.,?!]+$/g, '').toLowerCase());
     }
   } catch (err) {
     throw new Error(err);
@@ -375,7 +375,7 @@ async () => {
     if (!res.ok) {
       await new Promise(resolve => setTimeout(resolve, 2000)); // Additional delay to allow the alert to trigger
 
-      assert.include(['pokémon not found', 'pokemon not found'], alertMessage.trim().replace(/[.,?!]+$/g, '').toLowerCase());
+      assert.include(['pokémon not found', 'pokemon not found'], alertMessage?.trim().replace(/[.,?!]+$/g, '').toLowerCase());
     }
   } catch (err) {
     throw new Error(err);

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/build-a-telephone-number-validator-project/build-a-telephone-number-validator.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/build-a-telephone-number-validator-project/build-a-telephone-number-validator.md
@@ -103,7 +103,7 @@ window.alert = (message) => alertMessage = message; // Override alert and store 
 
 userInput.value = '';
 checkBtn.click();
-assert.strictEqual(alertMessage.trim().replace(/[.,?!]+$/g, '').toLowerCase(), 'please provide a phone number');
+assert.strictEqual(alertMessage?.trim().replace(/[.,?!]+$/g, '').toLowerCase(), 'please provide a phone number');
 ```
 
 When you click on the `#clear-btn` element, the content within the `#results-div` element should be removed.

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-recursion-by-building-a-decimal-to-binary-converter/64475c0b61cddb6feaab4e2e.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-recursion-by-building-a-decimal-to-binary-converter/64475c0b61cddb6feaab4e2e.md
@@ -31,7 +31,7 @@ window.alert = (message) => alertMessage = message; // Override alert and store 
 numberInput.value = '';
 checkUserInput();
 
-assert.strictEqual(alertMessage.trim().replace(/[.,?!]+$/g, '').toLowerCase(), 'please provide a decimal number greater than or equal to 0');
+assert.strictEqual(alertMessage?.trim().replace(/[.,?!]+$/g, '').toLowerCase(), 'please provide a decimal number greater than or equal to 0');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/lab-palindrome-checker/657bdc55a322aae1eac3838f.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-palindrome-checker/657bdc55a322aae1eac3838f.md
@@ -68,7 +68,7 @@ window.alert = (message) => alertMessage = message; // Override alert and store 
 inputEl.value = '';
 inputEl.dispatchEvent(new Event('change'))
 checkBtn.click();
-assert.strictEqual(alertMessage.trim().replace(/[.,?!]+$/g, '').toLowerCase(), 'please input a value');
+assert.strictEqual(alertMessage?.trim().replace(/[.,?!]+$/g, '').toLowerCase(), 'please input a value');
 ```
 
 When the `#text-input` element only contains the letter `A` and the `#check-btn` element is clicked, the `#result` element should contain the text `"A is a palindrome"`.

--- a/curriculum/challenges/english/25-front-end-development/workshop-decimal-to-binary-converter/64475c0b61cddb6feaab4e2e.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-decimal-to-binary-converter/64475c0b61cddb6feaab4e2e.md
@@ -31,7 +31,7 @@ window.alert = (message) => alertMessage = message; // Override alert and store 
 numberInput.value = '';
 checkUserInput();
 
-assert.strictEqual(alertMessage.trim().replace(/[.,?!]+$/g, '').toLowerCase(), 'please provide a decimal number greater than or equal to 0');
+assert.strictEqual(alertMessage?.trim().replace(/[.,?!]+$/g, '').toLowerCase(), 'please provide a decimal number greater than or equal to 0');
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

In these challenges, as `alert` gives a value to `alertMessage`, if `alert` is not implement in the user code, it gives an error that `alertMessage` is `undefined`. Now, this should not happen.