### PR TITLE
fix(curriculum): allow variables in lab trivia bot

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-javascript-trivia-bot/66ed41f912d0bb1dc62da5dd.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-javascript-trivia-bot/66ed41f912d0bb1dc62da5dd.md
@@ -72,7 +72,7 @@ You should use `let` to declare a new variable `codingFact`.
 
 ```js
 const codeWithoutComments = __helpers.removeJSComments(code);
-const [first, second, third] = codeWithoutComments.match(/(let )?\s*codingFact\s*=\s*("|').+?\2\s*\+\s*favoriteLanguage/g)
+const [first, second, third] = codeWithoutComments.match(/(let )?\s*codingFact\s*=\s*("|'|).+?\2\s*\+\s*favoriteLanguage/g)
 assert.match(code, /let\s+codingFact/)
 assert.include(first, 'let');
 assert.exists(first);
@@ -82,10 +82,11 @@ You should give `codingFact` a value  that includes `favoriteLanguage` using con
 
 ```js
 const codeWithoutComments = __helpers.removeJSComments(code);
-const [first, second, third] = codeWithoutComments.match(/(let )?\s*codingFact\s*=\s*("|').+?\2\s*\+\s*favoriteLanguage/g)
-assert.match(code, /let\scodingFact\s*=\s*("|').+?\1\s*\+\s*favoriteLanguage/)
+const [first, second, third] = codeWithoutComments.match(/(let )?\s*codingFact\s*=\s*("|')?.+?\2?\s*\+\s*favoriteLanguage/g)
+assert.match(code, /let\scodingFact\s*=\s*("|')?.+?\1?\s*\+\s*favoriteLanguage/)
 assert.include(first, 'let');
 assert.exists(first);
+assert.isNotEmpty(codingFact); 
 ```
 
 You should log `codingFact` to the console.
@@ -102,11 +103,12 @@ You should assign a new value to `codingFact` that also contains `favoriteLangua
 ```js
 const codeWithoutComments = __helpers.removeJSComments(code);
 const loggingCodingFacts = codeWithoutComments.match(/console\.log\(\s*codingFact\s*\)/g)
-const [first, second, third] = codeWithoutComments.match(/(let )?\s*codingFact\s*=\s*("|').+?\2\s*\+\s*favoriteLanguage/g)
+const [first, second, third] = codeWithoutComments.match(/(let )?\s*codingFact\s*=\s*("|')?.+?\2?\s*\+\s*favoriteLanguage/g)
 assert.include(output[4], favoriteLanguage);
 assert.notEqual(output[4], output[3]);
 assert.isAtLeast(loggingCodingFacts.length, 2);
 assert.exists(second);
+assert.isNotEmpty(codingFact); 
 ```
 
 You should assign a value to `codingFact` for the third time that also contains `favoriteLanguage`, and log it to the console.
@@ -114,12 +116,13 @@ You should assign a value to `codingFact` for the third time that also contains 
 ```js
 const codeWithoutComments = __helpers.removeJSComments(code);
 const loggingCodingFacts = codeWithoutComments.match(/console\.log\(\s*codingFact\s*\)/g)
-const [first, second, third] = codeWithoutComments.match(/(let )?\s*codingFact\s*=\s*("|').+?\2\s*\+\s*favoriteLanguage/g)
+const [first, second, third] = codeWithoutComments.match(/(let )?\s*codingFact\s*=\s*("|')?.+?\2?\s*\+\s*favoriteLanguage/g)
 assert.include(output[5], favoriteLanguage);
 assert.notEqual(output[5], output[4]);
 assert.equal(output[5], codingFact);
 assert.lengthOf(loggingCodingFacts, 3);
 assert.exists(third);
+assert.isNotEmpty(codingFact); 
 ```
 
 You should log to the console `"It was fun sharing these facts with you. Goodbye! - (botName) from (botLocation)."` using concatenation to add the values of the variables.

--- a/curriculum/challenges/english/25-front-end-development/lab-javascript-trivia-bot/66ed41f912d0bb1dc62da5dd.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-javascript-trivia-bot/66ed41f912d0bb1dc62da5dd.md
@@ -72,10 +72,7 @@ You should use `let` to declare a new variable `codingFact`.
 
 ```js
 const codeWithoutComments = __helpers.removeJSComments(code);
-const [first, second, third] = codeWithoutComments.match(/(let )?\s*codingFact\s*=\s*("|'|).+?\2\s*\+\s*favoriteLanguage/g)
 assert.match(code, /let\s+codingFact/)
-assert.include(first, 'let');
-assert.exists(first);
 ```
 
 You should give `codingFact` a value  that includes `favoriteLanguage` using concatenation.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #57755

<!-- Feel free to add any additional description of changes below this line -->
I did my best to make this optional. I also added an `isNotEmpty` assertion to try to make sure valid JavaScript is involved. I can remove the added assertions if we want.  