### PR TITLE
fix(curriculum): feedback in replaced elements lecture changed

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-media/6716743531fc9a797351c21e.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-media/6716743531fc9a797351c21e.md
@@ -94,7 +94,7 @@ Which of these is a replaced element?
 
 ### --feedback--
 
-A separate website is an external object.
+Review the first minute of the video where examples of replaced elements were discussed. 
 
 ---
 
@@ -102,7 +102,7 @@ A separate website is an external object.
 
 ### --feedback--
 
-A separate website is an external object.
+Review the first minute of the video where examples of replaced elements were discussed. 
 
 ---
 
@@ -114,7 +114,7 @@ A separate website is an external object.
 
 ### --feedback--
 
-A separate website is an external object.
+Review the first minute of the video where examples of replaced elements were discussed. 
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-media/67168278ac6df6a799555db5.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-media/67168278ac6df6a799555db5.md
@@ -22,7 +22,7 @@ What attribute allows the audio to start in a muted state?
 
 ### --feedback--
 
-Remember the attribute that specifically controls the sound state when the audio starts?
+Remember the attribute that specifically controls the sound state when the audio starts.
 
 ---
 
@@ -30,7 +30,7 @@ Remember the attribute that specifically controls the sound state when the audio
 
 ### --feedback--
 
-Remember the attribute that specifically controls the sound state when the audio starts?
+Remember the attribute that specifically controls the sound state when the audio starts.
 
 ---
 
@@ -38,7 +38,7 @@ Remember the attribute that specifically controls the sound state when the audio
 
 ### --feedback--
 
-Remember the attribute that specifically controls the sound state when the audio starts?
+Remember the attribute that specifically controls the sound state when the audio starts.
 
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-media/67168278ac6df6a799555db5.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-media/67168278ac6df6a799555db5.md
@@ -22,7 +22,7 @@ What attribute allows the audio to start in a muted state?
 
 ### --feedback--
 
-Remember the attribute that specifically controls the sound state when the audio starts.
+Remember the attribute that specifically controls the sound state when the audio starts?
 
 ---
 
@@ -30,7 +30,7 @@ Remember the attribute that specifically controls the sound state when the audio
 
 ### --feedback--
 
-Remember the attribute that specifically controls the sound state when the audio starts.
+Remember the attribute that specifically controls the sound state when the audio starts?
 
 ---
 
@@ -38,7 +38,7 @@ Remember the attribute that specifically controls the sound state when the audio
 
 ### --feedback--
 
-Remember the attribute that specifically controls the sound state when the audio starts.
+Remember the attribute that specifically controls the sound state when the audio starts?
 
 ---
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #57772


<!-- Feel free to add any additional description of changes below this line -->

The hint of the last question changed to a more helpful hint.
Hint before: A separate website is an external object.
Hint after: Review the first minute of the video where examples of replaced elements were discussed. 



![Screenshot 1 (issue 57772)](https://github.com/user-attachments/assets/8af7fe99-75f6-4a1c-aca5-56707c48f06a)

![Screenshot 2 (issue 57772)](https://github.com/user-attachments/assets/ec1e6344-a5ec-4286-bac9-c2397a6110ac)
