### PR TITLE
fix(curriculum): changed Build a checkout page instruction tab-index

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-checkout-page/66da326c02141df538f29ba5.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-checkout-page/66da326c02141df538f29ba5.md
@@ -21,7 +21,7 @@ Fulfill the user stories below and get all the tests to pass to complete the lab
 1. You should have an input with an `id` and `name` of `card-name` within your form and a `label` associated with it.
 1. You should have an input with an `id` and `name` of `card-number` within your form and a `label` associated with it.
 1. At least two of your input elements should be required and have an `aria-required` attribute set to `true`.
-1. You should use `tab-index` at least once.
+1. You should use `tabindex` at least once.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #57809

<!-- Feel free to add any additional description of changes below this line -->
The instruction included the attribute "tab-index" which was confusing for the users as the attribute "tabindex" was meant to used
