### PR TITLE
fix(curriculum):  fix typo for hint in meta description video 

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lecture-html-fundamentals/67083952f800051a8a21fcfd.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-html-fundamentals/67083952f800051a8a21fcfd.md
@@ -94,7 +94,7 @@ Inside the `figure` element.
 
 ### --feedback--
 
-Refer back to the middle of the video where there are examples showing where the page's descriptions typically shows up.
+Refer back to the middle of the video where there are examples showing where the page's descriptions typically show up.
 
 ---
 
@@ -102,7 +102,7 @@ Inside the `footer` element.
 
 ### --feedback--
 
-Refer back to the middle of the video where there are examples showing where the page's descriptions typically shows up.
+Refer back to the middle of the video where there are examples showing where the page's descriptions typically show up.
 
 ---
 
@@ -114,7 +114,7 @@ In a popup alert message.
 
 ### --feedback--
 
-Refer back to the middle of the video where there are examples showing where the page's descriptions typically shows up.
+Refer back to the middle of the video where there are examples showing where the page's descriptions typically show up.
 
 ## --video-solution--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #57771

Change the text as below:

`Refer back to the middle of the video where there are examples showing where the page's descriptions typically show up.
`

<!-- Feel free to add any additional description of changes below this line -->
