### PR TITLE
Fixed(Curriculum) - Typo in the type and placeholder attributes.

### DIFF
--- a/6729974ec29be33cb00eb54d.md
+++ b/6729974ec29be33cb00eb54d.md
@@ -1,0 +1,1 @@
+Fixing a typo in type and placeholder attribute


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

I changed the Feedback typo where type and placeholder attributes occurs.

I replaced the typo in type attribute as "Refer back to the beginning of the video where the example shows a valid value for the `type` attribute." and the typo in placeholder attribute as "Review the end of the video where the `placeholder` attribute was discussed. " as it is mentioned in the issue.

Closes #57820

<!-- Feel free to add any additional description of changes below this line -->
