### PR TITLE
fix(curriculum) : Clarify book catalog lab instructions 

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-book-catalog-table/66ec4c8e9878d8441956516f.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-book-catalog-table/66ec4c8e9878d8441956516f.md
@@ -18,7 +18,7 @@ Fulfill the user stories below and get all the tests to pass to complete the lab
 1. Your table should have a table body element with at least five rows in it.
 1. Each row in your table body should have four table data elements that display the book's Title, Author, Genre, and Publication Year.
 1. Your table should have a table footer element with one row in it.
-1. The row in your table footer element should have a table data element that spans four columns and has the text `Total Books: [number of books in your table]`.
+1. The row in your table footer element should have a table data element that spans four columns and has the text `Total Books: N` where `N` should be replaced by the number of books in your table.
 
 # --hints--
 


### PR DESCRIPTION
Updated `curriculum/challenges/english/25-front-end-development/lab-book-catalog-table/66ec4c8e9878d8441956516f.md` 

Earlier version was -: 

`The row in your table footer element should have a table data element that spans four columns and has the text Total Books: [number of books in your table].`

New version is -: 

`The row in your table footer element should have a table data element that spans four columns and has the text Total Books: N where N should be replaced by the number of books in your table.`

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #57869
<!-- Feel free to add any additional description of changes below this line -->
