### PR TITLE
fix(curriculum): Update step 20 incorrect html

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-basic-css-by-building-a-cafe-menu/5f356ed6cf6eab5f15f5cfe6.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-basic-css-by-building-a-cafe-menu/5f356ed6cf6eab5f15f5cfe6.md
@@ -37,7 +37,7 @@ Your `div` tag should be nested in the `body`.
 assert.equal(document.querySelector('div')?.parentElement?.tagName, 'BODY');
 ```
 
-Move all the other elements inside the new `div`.
+You should move all the other elements inside the new `div`.
 
 ```js
 assert.lengthOf(document.querySelector('body > div#menu > main')?.children, 3);

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-basic-css-by-building-a-cafe-menu/5f356ed6cf6eab5f15f5cfe6.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-basic-css-by-building-a-cafe-menu/5f356ed6cf6eab5f15f5cfe6.md
@@ -37,6 +37,12 @@ Your `div` tag should be nested in the `body`.
 assert.equal(document.querySelector('div')?.parentElement?.tagName, 'BODY');
 ```
 
+Move all the other elements inside the new `div`.
+
+```js
+assert.lengthOf(document.querySelector('body > div#menu > main')?.children, 3);
+```
+
 
 # --seed--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #57857

<!-- Feel free to add any additional description of changes below this line -->


With this `querySelector` `body > div#menu > main` we can assert that indeed `div#menu` is inside body and `main` is inside the new `div#menu` with all other 3 elements from the original code
