### PR TITLE
fix(client): only play scene when ready

### DIFF
--- a/client/src/templates/Challenges/components/scene/scene.tsx
+++ b/client/src/templates/Challenges/components/scene/scene.tsx
@@ -125,7 +125,7 @@ export function Scene({
       // TODO: if we manage the playing state in another module, we should not
       // need the early return here. It should not be possible for this to be
       // called at all if the scene is already playing.
-      if (isPlaying) return;
+      if (isPlaying || !sceneIsReady) return;
       setIsPlaying(true);
       setShowDialogue(true);
 
@@ -238,6 +238,7 @@ export function Scene({
     isPlaying,
     duration,
     sceneSubject,
+    sceneIsReady,
     commands,
     audio,
     hasTimestamps,


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

In principle someone could try to play the scene via the keyboard before it's loaded. This ignore those attempts.

For most people this should not matter, since it's likely that the audio loads before they get a chance to trigger the scene. It's just to ensure smooth playback in the edge-case where the audio is slow to load (for whatever reason).

<!-- Feel free to add any additional description of changes below this line -->
