### PR TITLE
fix(curriculum): change travel agency lab test to allow different solution

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-travel-agency-page/669e2f60e83c011754f711f9.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-travel-agency-page/669e2f60e83c011754f711f9.md
@@ -159,13 +159,13 @@ for (let e of listItems) {
 The anchor element of your first list item should wrap the text `Group Travels`.
 
 ```js
-assert.equal(document.querySelectorAll('a')[0]?.innerText, 'Group Travels');
+assert.equal(document.querySelectorAll('li>a')[0]?.innerText, 'Group Travels');
 ```
 
 The anchor element of your second list item should wrap the text `Private Tours`.
 
 ```js
-assert.equal(document.querySelectorAll('a')[1]?.innerText, 'Private Tours');
+assert.equal(document.querySelectorAll('li>a')[1]?.innerText, 'Private Tours');
 ```
 
 You should have an `h2` element after your unordered list.

--- a/curriculum/challenges/english/25-front-end-development/lab-travel-agency-page/669e2f60e83c011754f711f9.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-travel-agency-page/669e2f60e83c011754f711f9.md
@@ -159,13 +159,13 @@ for (let e of listItems) {
 The anchor element of your first list item should wrap the text `Group Travels`.
 
 ```js
-assert.equal(document.querySelectorAll('li>a')[0]?.innerText, 'Group Travels');
+assert.equal(document.querySelectorAll('li > a')[0]?.innerText, 'Group Travels');
 ```
 
 The anchor element of your second list item should wrap the text `Private Tours`.
 
 ```js
-assert.equal(document.querySelectorAll('li>a')[1]?.innerText, 'Private Tours');
+assert.equal(document.querySelectorAll('li > a')[1]?.innerText, 'Private Tours');
 ```
 
 You should have an `h2` element after your unordered list.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

This changes two tests that assume that the first two anchors would be within the unordered list even though it's not required.

See [this post] (https://forum.freecodecamp.org/t/build-a-travel-agency-page-build-a-travel-agency-page/727881) for context. 
