### PR TITLE
fix(curriculum): specify elements order in video compilation lab user stories

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-video-compilation-page/669e81368e52b3a5c35a2dc5.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-video-compilation-page/669e81368e52b3a5c35a2dc5.md
@@ -13,10 +13,11 @@ Fulfill the user stories below and get all the tests to pass to complete the lab
 
 **User Stories:**
 
-1. You should have a `main` element.
+1. You should have a `main` element as the only child of the `body` element.
 1. You should have an `h1` element with the topic of your page.
 1. You should have a paragraph introducing the topic of your page below your `h1` element.
-1. You should have three `section` elements, each containing an `h2` element, a paragraph, and an `iframe` element.
+1. You should have three `section` elements below your first paragraph.
+1. Each section should contain an `h2` element, a paragraph, and an `iframe` element, in this order.
 1. The three `iframe` elements should have a `src` attribute set to a valid video.
 1. Each `iframe` element should also have a `title` attribute to describe the embedded content, and a `height` attribute and a `width` attribute to set the element to a proper size.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
The order of some elements is specified in hints but not in user stories. This is to provide that information from the beginning.
