### PR TITLE
fix: remove extra height of scrollable anchors

### DIFF
--- a/client/src/templates/Introduction/intro.css
+++ b/client/src/templates/Introduction/intro.css
@@ -12,7 +12,7 @@
 }
 
 .hide-scrollable-anchor {
-  display: inline-block;
+  display: block;
   max-height: 0px;
 }
 


### PR DESCRIPTION

<details><summary>images</summary>

| Before | After |
|--------|-------|
| <img width="696" alt="Screenshot 2025-01-03 at 9 07 44 AM" src="https://github.com/user-attachments/assets/6cca6a03-e912-412c-bea5-3beb81600e2f" /> | <img width="696" alt="Screenshot 2025-01-03 at 9 07 29 AM" src="https://github.com/user-attachments/assets/bd77623f-c673-454e-ba9e-82220ce5228f" /> |
| ^ notice the "padding" at the top of each block title | |

</details>

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
