### PR TITLE
fix(curriculum): Update CSS variable fallback syntax question in CSS Colors Quiz

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/quiz-css-colors/66ed8fe1f45ce3ece4053eb1.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-css-colors/66ed8fe1f45ce3ece4053eb1.md
@@ -419,7 +419,7 @@ Which of the following is the correct syntax to create a CSS variable with a fal
 
 ```css
 .element {
-  color: var(--main-color, red);
+  color: var(--main-color; red);
 }
 ```
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ X ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ X ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ X ] My pull request targets the `main` branch of freeCodeCamp.
- [ X ] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #57878

<!-- Feel free to add any additional description of changes below this line -->

The PR fixes a duplication issue in Question 19 of the CSS Colors Quiz. One of the distractors was identical to the correct answer. The duplicate option has been replaced with the following distractor:

`.element {
  color: var(--main-color; red);
}`

Related Issue
Fixes #57878


<img width="1117" alt="Screenshot 2025-01-03 at 21 37 09" src="https://github.com/user-attachments/assets/52d0a89b-8a21-4a25-a420-7f84b6e53a39" />

