### PR TITLE
fix(client): cursor on privacy settings

### DIFF
--- a/client/src/components/settings/toggle-radio-setting.tsx
+++ b/client/src/components/settings/toggle-radio-setting.tsx
@@ -40,7 +40,7 @@ export default function ToggleRadioSetting({
         {explain ? <p id={`desc${flagName}`}>{explain}</p> : null}
       </div>
       <div className='toggle-radio-group'>
-        <label htmlFor={firstRadioId}>
+        <label className={!flag ? 'not-checked' : ''} htmlFor={firstRadioId}>
           <input
             id={firstRadioId}
             type='radio'
@@ -52,7 +52,7 @@ export default function ToggleRadioSetting({
           <span className='custom-circle'></span>
           <span>{onLabel}</span>
         </label>
-        <label htmlFor={secondRadioId}>
+        <label className={flag ? 'not-checked' : ''} htmlFor={secondRadioId}>
           <input
             id={secondRadioId}
             type='radio'

--- a/client/src/components/settings/toggle-setting.css
+++ b/client/src/components/settings/toggle-setting.css
@@ -75,6 +75,10 @@
   margin-inline-start: 2rem;
 }
 
+.toggle-radio-group label.not-checked {
+  cursor: pointer;
+}
+
 .toggle-radio-group input {
   position: absolute;
   left: -9999px;


### PR DESCRIPTION
This sets the cursor to `pointer` on the `public`/`private` toggle buttons in the privacy settings on the [settings page.](https://www.freecodecamp.org/settings) Right now, it's always just the default cursor.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
