### PR TITLE
fix(curriculum): update the distractors of Basic CSS Quiz No 14

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/quiz-basic-css/66ed8fa2f45ce3ece4053eab.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-basic-css/66ed8fa2f45ce3ece4053eab.md
@@ -307,19 +307,19 @@ Given the following selectors, which has the lowest specificity?
 
 #### --distractors--
 
-`h1`
-
----
-
 `#id`
 
 ---
 
-`p`
+`.class`
+
+---
+
+`div h1`
 
 #### --answer--
 
-`div`
+`h1`
 
 ### --question--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #57934

<!-- Feel free to add any additional description of changes below this line -->
Updated distractors of this quiz by suggestion.

14. Given the following selectors, which has the lowest specificity?

Current
p
h1
#id
div

Updated
#id
.class
div h1
h1

