### PR TITLE
fix(curriculum): Update question and distractors in question 8 of the CSS Typography Quiz

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/quiz-css-typography/66ed9010f45ce3ece4053eb8.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-css-typography/66ed9010f45ce3ece4053eb8.md
@@ -171,7 +171,7 @@ It allows you to use custom fonts by importing them
 
 #### --text--
 
-Which service offers a large selection of free fonts for use on websites?
+Which service offers a large selection of free fonts that can be easily integrated directly into websites?
 
 #### --distractors--
 
@@ -183,7 +183,7 @@ Adobe Fonts
 
 ---
 
-Font Squirrel
+Font Universe
 
 #### --answer--
 


### PR DESCRIPTION
Changed the question and distractors in question 8 of CSS Typography Quiz. 

Earlier version -: 

```
### --question--

#### --text--

Which service offers a large selection of free fonts for use on websites?

#### --distractors--

Typekit

---

Adobe Fonts

---

Font Squirrel

#### --answer--

Google Fonts

```

Updated Version -:

```
#### --text--

Which service offers a large selection of free fonts that can be easily integrated directly into websites?

#### --distractors--

Typekit

---

Adobe Fonts

---

Font Universe

#### --answer--

Google Fonts
```

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #57940

<!-- Feel free to add any additional description of changes below this line -->
