### PR TITLE
feat(challenge-parser): add transcript to challenge parser

### DIFF
--- a/client/gatsby-node.js
+++ b/client/gatsby-node.js
@@ -305,6 +305,7 @@ exports.createSchemaCustomization = ({ actions }) => {
       msTrophyId: String
       fillInTheBlank: FillInTheBlank
       scene: Scene
+      transcript: String
       quizzes: [Quiz]
     }
     type FileContents {

--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -428,6 +428,7 @@
     "questions": "Questions",
     "answered-mcq": "You have unanswered questions and/or incorrect answers.",
     "explanation": "Explanation",
+    "transcript": "Read a transcript of this video",
     "solution-link": "Solution Link",
     "source-code-link": "Source Code Link",
     "ms-link": "Microsoft Link",

--- a/client/src/redux/prop-types.ts
+++ b/client/src/redux/prop-types.ts
@@ -221,6 +221,7 @@ export type ChallengeNode = {
     template: string;
     tests: Test[];
     title: string;
+    transcript: string;
     translationPending: boolean;
     url: string;
     usesMultifileEditor: boolean;

--- a/client/src/templates/Challenges/components/challenge-transcript.css
+++ b/client/src/templates/Challenges/components/challenge-transcript.css
@@ -1,0 +1,3 @@
+.challenge-transcript {
+  cursor: pointer;
+}

--- a/client/src/templates/Challenges/components/challenge-transcript.tsx
+++ b/client/src/templates/Challenges/components/challenge-transcript.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Spacer } from '@freecodecamp/ui';
+import PrismFormatted from './prism-formatted';
+
+import './challenge-transcript.css';
+
+interface ChallengeTranscriptProps {
+  transcript: string;
+}
+
+function ChallengeTranscript({
+  transcript
+}: ChallengeTranscriptProps): JSX.Element {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <details className='challenge-transcript'>
+        <summary>{t('learn.transcript')}</summary>
+        <Spacer size='m' />
+        <PrismFormatted className={'line-numbers'} text={transcript} />
+      </details>
+      <Spacer size='m' />
+    </>
+  );
+}
+
+ChallengeTranscript.displayName = 'ChallengeTranscript';
+
+export default ChallengeTranscript;

--- a/client/src/templates/Challenges/components/video-player.tsx
+++ b/client/src/templates/Challenges/components/video-player.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import YouTube from 'react-youtube';
+import { Spacer } from '@freecodecamp/ui';
 
 import Loader from '../../../components/helpers/loader';
 import envData from '../../../../config/env.json';
@@ -79,6 +80,7 @@ function VideoPlayer({
           videoId={videoId}
         />
       )}
+      <Spacer size='m' />
     </div>
   );
 }

--- a/client/src/templates/Challenges/components/video-player.tsx
+++ b/client/src/templates/Challenges/components/video-player.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import YouTube from 'react-youtube';
-import { Spacer } from '@freecodecamp/ui';
 
 import Loader from '../../../components/helpers/loader';
 import envData from '../../../../config/env.json';
@@ -80,7 +79,6 @@ function VideoPlayer({
           videoId={videoId}
         />
       )}
-      <Spacer size='m' />
     </div>
   );
 }

--- a/client/src/templates/Challenges/generic/show.tsx
+++ b/client/src/templates/Challenges/generic/show.tsx
@@ -28,6 +28,7 @@ import { getChallengePaths } from '../utils/challenge-paths';
 import Scene from '../components/scene/scene';
 import MultipleChoiceQuestions from '../components/multiple-choice-questions';
 import ChallengeExplanation from '../components/challenge-explanation';
+import ChallengeTranscript from '../components/challenge-transcript';
 import HelpModal from '../components/help-modal';
 import { SceneSubject } from '../components/scene/scene-subject';
 
@@ -82,6 +83,7 @@ const ShowGeneric = ({
         instructions,
         questions,
         title,
+        transcript,
         translationPending,
         scene,
         superBlock,
@@ -204,6 +206,8 @@ const ShowGeneric = ({
               {title}
             </ChallengeTitle>
 
+            <Spacer size='m' />
+
             {description && (
               <Col md={8} mdOffset={2} sm={10} smOffset={1} xs={12}>
                 <ChallengeDescription
@@ -216,28 +220,34 @@ const ShowGeneric = ({
 
             <Col lg={10} lgOffset={1} md={10} mdOffset={1}>
               {videoId && (
-                <VideoPlayer
-                  bilibiliIds={bilibiliIds}
-                  onVideoLoad={handleVideoIsLoaded}
-                  title={title}
-                  videoId={videoId}
-                  videoIsLoaded={videoIsLoaded}
-                  videoLocaleIds={videoLocaleIds}
-                />
+                <>
+                  <VideoPlayer
+                    bilibiliIds={bilibiliIds}
+                    onVideoLoad={handleVideoIsLoaded}
+                    title={title}
+                    videoId={videoId}
+                    videoIsLoaded={videoIsLoaded}
+                    videoLocaleIds={videoLocaleIds}
+                  />
+                  <Spacer size='m' />
+                </>
               )}
             </Col>
 
             {scene && <Scene scene={scene} sceneSubject={sceneSubject} />}
 
             <Col md={8} mdOffset={2} sm={10} smOffset={1} xs={12}>
-              {instructions && (
-                <ChallengeDescription
-                  instructions={instructions}
-                  superBlock={superBlock}
-                />
-              )}
+              {transcript && <ChallengeTranscript transcript={transcript} />}
 
-              <Spacer size='m' />
+              {instructions && (
+                <>
+                  <ChallengeDescription
+                    instructions={instructions}
+                    superBlock={superBlock}
+                  />
+                  <Spacer size='m' />
+                </>
+              )}
 
               {assignments.length > 0 && (
                 <Assignments
@@ -362,6 +372,7 @@ export const query = graphql`
         }
         superBlock
         title
+        transcript
         translationPending
         videoId
         videoId

--- a/curriculum/schema/challenge-schema.js
+++ b/curriculum/schema/challenge-schema.js
@@ -287,6 +287,10 @@ const schema = Joi.object()
       .required(),
     template: Joi.string().allow(''),
     title: Joi.string().required(),
+    transcript: Joi.when('challengeType', {
+      is: [challengeTypes.generic, challengeTypes.video],
+      then: Joi.string()
+    }),
     translationPending: Joi.bool().required(),
     url: Joi.when('challengeType', {
       is: [challengeTypes.codeAllyPractice, challengeTypes.codeAllyCert],

--- a/tools/challenge-parser/parser/index.js
+++ b/tools/challenge-parser/parser/index.js
@@ -53,7 +53,13 @@ const processor = unified()
   .use(addScene)
   .use(addQuizzes)
   .use(addTests)
-  .use(addText, ['description', 'instructions', 'notes', 'explanation']);
+  .use(addText, [
+    'description',
+    'instructions',
+    'notes',
+    'explanation',
+    'transcript'
+  ]);
 
 exports.parseMD = function parseMD(filename) {
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
This adds an option to add a `# --transcript--` heading to challenges, which shows up below the videos.

<details><summary>image</summary>

<img width="793" alt="Screenshot 2025-01-06 at 3 22 11 PM" src="https://github.com/user-attachments/assets/ddf7ba61-e002-4a21-a9db-0c981686162c" />

</details>

To test:
Add a `# --transcript--` heading to any video challenge with some text.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
