### PR TITLE
feat(tools): allow json in challenges

### DIFF
--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -188,6 +188,7 @@ const modeMap = {
   css: 'css',
   html: 'html',
   js: 'javascript',
+  json: 'json',
   jsx: 'javascript',
   ts: 'typescript',
   py: 'python',

--- a/client/src/templates/Challenges/classic/multifile-editor.tsx
+++ b/client/src/templates/Challenges/classic/multifile-editor.tsx
@@ -18,6 +18,7 @@ export type VisibleEditors = {
   indexjsx?: boolean;
   stylescss?: boolean;
   scriptjs?: boolean;
+  datajson?: boolean;
   indexts?: boolean;
   mainpy?: boolean;
 };
@@ -76,6 +77,7 @@ const MultifileEditor = (props: MultifileEditorProps) => {
       stylescss,
       indexhtml,
       scriptjs,
+      datajson,
       indexts,
       indexjsx,
       mainpy
@@ -105,6 +107,7 @@ const MultifileEditor = (props: MultifileEditorProps) => {
   if (indexjsx) editorKeys.push('indexjsx');
   if (mainpy) editorKeys.push('mainpy');
   if (indexts) editorKeys.push('indexts');
+  if (datajson) editorKeys.push('datajson');
 
   const editorAndSplitterKeys = editorKeys.reduce((acc: string[] | [], key) => {
     if (acc.length === 0) {

--- a/client/utils/__fixtures__/challenges.ts
+++ b/client/utils/__fixtures__/challenges.ts
@@ -70,5 +70,19 @@ export const challengeFiles: ChallengeFile[] = [
     tail: '',
     editableRegionBoundaries: [],
     usesMultifileEditor: true,
+  },
+  {
+    id: '5',
+    contents: 'some json',
+    error: null,
+    ext: 'json',
+    head: '',
+    history: ['data.json'],
+    fileKey: 'datajson',
+    name: 'data',
+    seed: 'some json',
+    tail: '',
+    editableRegionBoundaries: [],
+    usesMultifileEditor: true,
   }
 ]

--- a/client/utils/sort-challengefiles.js
+++ b/client/utils/sort-challengefiles.js
@@ -11,6 +11,8 @@ exports.sortChallengeFiles = function sortChallengeFiles(challengeFiles) {
     if (b.history[0] === 'script.js') return 1;
     if (a.history[0] === 'index.ts') return -1;
     if (b.history[0] === 'index.ts') return 1;
+    if (a.history[0] === 'data.json') return -1;
+    if (b.history[0] === 'data.json') return 1;
     return 0;
   });
   return xs;

--- a/client/utils/sort-challengefiles.test.js
+++ b/client/utils/sort-challengefiles.test.js
@@ -14,7 +14,7 @@ describe('sort-files', () => {
       expect(sorted.length).toEqual(expected.length);
     });
 
-    it('should sort the objects into html, css, jsx, js, ts order', () => {
+    it('should sort the objects into html, css, jsx, js, ts, json order', () => {
       const sorted = sortChallengeFiles(challengeFiles);
       const sortedKeys = sorted.map(({ fileKey }) => fileKey);
       const expected = [
@@ -22,7 +22,8 @@ describe('sort-files', () => {
         'stylescss',
         'indexjsx',
         'scriptjs',
-        'indexts'
+        'indexts',
+        'datajson'
       ];
       expect(sortedKeys).toStrictEqual(expected);
     });

--- a/shared/utils/polyvinyl.ts
+++ b/shared/utils/polyvinyl.ts
@@ -1,7 +1,7 @@
 // originally based off of https://github.com/gulpjs/vinyl
 import invariant from 'invariant';
 
-export type Ext = 'js' | 'html' | 'css' | 'jsx' | 'ts';
+export type Ext = 'js' | 'html' | 'css' | 'jsx' | 'ts' | 'json';
 
 export type ChallengeFile = {
   fileKey: string;

--- a/tools/challenge-parser/parser/plugins/utils/get-file-visitor.js
+++ b/tools/challenge-parser/parser/plugins/utils/get-file-visitor.js
@@ -8,7 +8,7 @@ const keyToSection = {
   head: 'before-user-code',
   tail: 'after-user-code'
 };
-const supportedLanguages = ['js', 'css', 'html', 'jsx', 'py', 'ts'];
+const supportedLanguages = ['js', 'css', 'html', 'jsx', 'py', 'ts', 'json'];
 const longToShortLanguages = {
   javascript: 'js',
   typescript: 'ts',


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related to #57921

<!-- Feel free to add any additional description of changes below this line -->
This allows `json` files to actually be used in the editor. A test has been added to make sure the files display in the right editor and as a result a test has been added. 