### PR TITLE
fix(curriculum): Basic CSS Quiz - question 10 precise sibling element location

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/quiz-basic-css/66ed8fa2f45ce3ece4053eab.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-basic-css/66ed8fa2f45ce3ece4053eab.md
@@ -215,7 +215,7 @@ Which selector is correct to target the next sibling of an `img`?
 
 #### --text--
 
-Which selector is correct to target all siblings of an `img`?
+Which selector is correct to target all siblings preceded by an `img` element?
 
 #### --distractors--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #57933

<!-- Feel free to add any additional description of changes below this line -->

The question previously misrepresented the behavior of the ~ selector, stating it targets all siblings of an img element, when it actually targets only subsequent siblings. The updated question now asks, "Which selector is correct to target all siblings preceded by an img element?" ensuring clarity and accuracy.
