### PR TITLE
fix(client): replace apple quotes in fill in the blanks before testing

### DIFF
--- a/client/src/templates/Challenges/fill-in-the-blank/show.tsx
+++ b/client/src/templates/Challenges/fill-in-the-blank/show.tsx
@@ -33,6 +33,7 @@ import Scene from '../components/scene/scene';
 import { SceneSubject } from '../components/scene/scene-subject';
 import { getChallengePaths } from '../utils/challenge-paths';
 import { isChallengeCompletedSelector } from '../redux/selectors';
+import { replaceAppleQuotes } from '../../../utils/replace-apple-quotes';
 
 import './show.css';
 
@@ -133,7 +134,9 @@ const ShowFillInTheBlank = ({
     const blankAnswers = fillInTheBlank.blanks.map(b => b.answer);
 
     const newAnswersCorrect = userAnswers.map(
-      (userAnswer, i) => !!userAnswer && userAnswer.trim() === blankAnswers[i]
+      (userAnswer, i) =>
+        !!userAnswer &&
+        replaceAppleQuotes(userAnswer.trim()) === blankAnswers[i]
     );
     setAnswersCorrect(newAnswersCorrect);
     const hasWrongAnswer = newAnswersCorrect.some(a => a === false);

--- a/client/src/utils/replace-apple-quotes.test.ts
+++ b/client/src/utils/replace-apple-quotes.test.ts
@@ -1,0 +1,13 @@
+import { replaceAppleQuotes } from './replace-apple-quotes';
+
+describe('replaceAppleQuotes()', () => {
+  it('replaces apple quotes with regular quotes', () => {
+    expect(replaceAppleQuotes('“double” quotes and ‘single’ quotes')).toBe(
+      `"double" quotes 'single' quotes`
+    );
+  });
+
+  it('returns the original string if there are no smart quotes', () => {
+    expect(replaceAppleQuotes('No quotes')).toBe('No smart quotes here!');
+  });
+});

--- a/client/src/utils/replace-apple-quotes.test.ts
+++ b/client/src/utils/replace-apple-quotes.test.ts
@@ -3,11 +3,11 @@ import { replaceAppleQuotes } from './replace-apple-quotes';
 describe('replaceAppleQuotes()', () => {
   it('replaces apple quotes with regular quotes', () => {
     expect(replaceAppleQuotes('“double” quotes and ‘single’ quotes')).toBe(
-      `"double" quotes 'single' quotes`
+      `"double" quotes and 'single' quotes`
     );
   });
 
   it('returns the original string if there are no smart quotes', () => {
-    expect(replaceAppleQuotes('No quotes')).toBe('No smart quotes here!');
+    expect(replaceAppleQuotes('No quotes')).toBe('No quotes');
   });
 });

--- a/client/src/utils/replace-apple-quotes.ts
+++ b/client/src/utils/replace-apple-quotes.ts
@@ -1,0 +1,5 @@
+export function replaceAppleQuotes(text: string): string {
+  return typeof text !== 'string'
+    ? text
+    : text.replace(/[“”]/g, '"').replace(/[‘’]/g, "'");
+}


### PR DESCRIPTION
Reported in chat: "iphone default apostrophe is curly, not straight." Making it so it doesn't pass when used in the fill in the blank challenges. 

Verify by pasting one of the quotes: `‘`, `‘` into [the first fill in the blank challenge.](https://www.freecodecamp.org/learn/a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/task-1) I also verified on my iphone.

This replaces those curly before testing.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
