### PR TITLE
fix(curriculum): update requirement from height to min-height on event flyer page

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-event-flyer-page/66e45c8140f9fda5c105ae26.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-event-flyer-page/66e45c8140f9fda5c105ae26.md
@@ -20,7 +20,7 @@ Fulfill the user stories below and get all the tests to pass to complete the lab
 1. Your body should have a top and bottom padding of `50px`.
 1. Your body should have a top and bottom margin of `0`, and a left and right margin that centers itself.
 1. Your body should have a width set relative to the width of the viewport.
-1. Your body should use the `calc` function to set its min-height to 100% of the viewport's height minus all padding applied to the top and bottom of the body.
+1. Your body should use the `calc` function to set its `min-height` property to 100% of the viewport's height minus all padding applied to the top and bottom of the body.
 1. You should have at least one `hr` within your flyer.
 1. You should set the `width` of all `hr` and `section` elements to a percent value relative to its parent.
 

--- a/curriculum/challenges/english/25-front-end-development/lab-event-flyer-page/66e45c8140f9fda5c105ae26.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-event-flyer-page/66e45c8140f9fda5c105ae26.md
@@ -20,7 +20,7 @@ Fulfill the user stories below and get all the tests to pass to complete the lab
 1. Your body should have a top and bottom padding of `50px`.
 1. Your body should have a top and bottom margin of `0`, and a left and right margin that centers itself.
 1. Your body should have a width set relative to the width of the viewport.
-1. Your body should use the `calc` function to set its height to 100% of the viewport's min-height minus all padding applied to the top and bottom of the body.
+1. Your body should use the `calc` function to set its min-height to 100% of the viewport's height minus all padding applied to the top and bottom of the body.
 1. You should have at least one `hr` within your flyer.
 1. You should set the `width` of all `hr` and `section` elements to a percent value relative to its parent.
 

--- a/curriculum/challenges/english/25-front-end-development/lab-event-flyer-page/66e45c8140f9fda5c105ae26.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-event-flyer-page/66e45c8140f9fda5c105ae26.md
@@ -20,7 +20,7 @@ Fulfill the user stories below and get all the tests to pass to complete the lab
 1. Your body should have a top and bottom padding of `50px`.
 1. Your body should have a top and bottom margin of `0`, and a left and right margin that centers itself.
 1. Your body should have a width set relative to the width of the viewport.
-1. Your body should use the `calc` function to set its height to 100% of the viewport's height minus all padding applied to the top and bottom of the body.
+1. Your body should use the `calc` function to set its height to 100% of the viewport's min-height minus all padding applied to the top and bottom of the body.
 1. You should have at least one `hr` within your flyer.
 1. You should set the `width` of all `hr` and `section` elements to a percent value relative to its parent.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #57913

<!-- Feel free to add any additional description of changes below this line -->
Updated a requirement on Event Flyer Page.

From
9. Your body should use the `calc` function to set its height to 100% of the viewport's **height** minus all padding applied to the top and bottom of the body.

To
(Updated) 9. Your body should use the `calc` function to set its `min-height` property to 100% of the viewport's height minus all padding applied to the top and bottom of the body.

![efCapture](https://github.com/user-attachments/assets/b109eda8-d1bc-4ceb-be25-2c610fba10dd)