### PR TITLE
fix(curriculum): removed global variable ab(use) in lunch picker

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-lunch-picker-program/66db529d37ad966480ebb633.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-lunch-picker-program/66db529d37ad966480ebb633.md
@@ -21,9 +21,9 @@ In this lab, you'll build a program that helps in managing lunch options. You'll
     - Return the updated array.
 
 3. You should create a function `addLunchToStart` that takes an array as the first argument and a string as the second argument. The function should:
-    - add the string to the start of the array
-    - log the string `"[Lunch Item] added to the start of the lunch menu."` to the console
-    - return the updated array
+    - Add the string to the start of the array.
+    - Log the string `"[Lunch Item] added to the start of the lunch menu."` to the console.
+    - Return the updated array.
 
 4. You should create a function `removeLastLunch` that takes an array as its argument. The function should:
    - Remove the last lunch item from the array.
@@ -86,8 +86,8 @@ try {
 `addLunchToEnd(["Pizza", "Tacos"], "Burger")` should return `["Pizza", "Tacos", "Burger"]`.
 
 ```js
-lunches = ["Fries"]
-assert.deepStrictEqual(addLunchToEnd(lunches, "Tacos"), ["Fries", "Tacos"]);
+assert.deepStrictEqual(addLunchToEnd(["Pizza", "Tacos"], "Burger"), ["Pizza", "Tacos", "Burger"]);
+assert.deepStrictEqual(addLunchToEnd(["Fries"], "Tacos"), ["Fries", "Tacos"]);
 ```
 
 You should define a function `addLunchToStart`.
@@ -106,21 +106,24 @@ assert.lengthOf(addLunchToStart, 2);
 
 ```js
 const tempArr = [];
+const testLunches = [];
 const temp = console.log;
 try {
   console.log = obj => tempArr.push(obj);
-  addLunchToStart(lunches, "Burger");
-  assert.strictEqual(tempArr[0], "Burger added to the start of the lunch menu.");
+  addLunchToStart(testLunches, "Sushi");
+  assert.strictEqual(tempArr[0], "Sushi added to the start of the lunch menu.");  
+  addLunchToStart(testLunches, "Burger");
+  assert.strictEqual(tempArr[1], "Burger added to the start of the lunch menu.");
 } finally {
   console.log = temp;
 }
 ```
 
-The function `addLunchToStart` should return the correct array.
+`addLunchToStart(["Burger", "Sushi"], "Pizza")` should return `["Pizza", "Burger", "Sushi"]`.
 
 ```js
-lunches = ["Noodles"]
-assert.deepStrictEqual(addLunchToStart(lunches, "Sushi"), ["Sushi", "Noodles"]);
+assert.deepStrictEqual(addLunchToStart(["Burger", "Sushi"], "Pizza"), ["Pizza", "Burger", "Sushi"]);
+assert.deepStrictEqual(addLunchToStart(["Noodles"], "Sushi"), ["Sushi", "Noodles"]);
 ```
 
 You should define a function `removeLastLunch`.
@@ -138,12 +141,12 @@ assert.lengthOf(removeLastLunch, 1);
 When the input array is empty, the function `removeLastLunch` should log the string `"No lunches to remove."` to the console.
 
 ```js
-lunches = [];
+const testLunches = [];
 const tempArr = [];
 const temp = console.log;
 try {
   console.log = obj => tempArr.push(obj);
-  removeLastLunch(lunches);
+  removeLastLunch(testLunches);
   assert.strictEqual(tempArr[0], "No lunches to remove.");
 } finally {
   console.log = temp;
@@ -153,23 +156,26 @@ try {
 When `lunches = ["Stew", "Soup", "Toast"]`, `removeLastLunch(lunches)` should log the string `"Toast removed from the end of the lunch menu."` to the console.
 
 ```js
-lunches = ["Fries", "Tacos", "Noodles"];
+let testLunches = ["Stew", "Soup", "Toast"];
 const tempArr = [];
 const temp = console.log;
 try {
   console.log = obj => tempArr.push(obj);
-  removeLastLunch(lunches);
-  assert.strictEqual(tempArr[0], "Noodles removed from the end of the lunch menu.");
+  removeLastLunch(testLunches);
+  assert.strictEqual(tempArr[0], "Toast removed from the end of the lunch menu.");
+  testLunches = ["Rice", "Pizza"];
+  removeLastLunch(testLunches);
+  assert.strictEqual(tempArr[1], "Pizza removed from the end of the lunch menu.");
 } finally {
   console.log = temp;
 }
 ```
 
-The function `removeLastLunch` should return the correct array.
+`removeLastLunch(["Sushi", "Pizza", "Noodles"])` should return `["Sushi", "Pizza"]`.
 
 ```js
-lunches = ["Pizza", "Burger"];
-assert.deepStrictEqual(removeLastLunch(lunches), ["Pizza"]);
+assert.deepStrictEqual(removeLastLunch(["Sushi", "Pizza", "Noodles"]), ["Sushi", "Pizza"]);
+assert.deepStrictEqual(removeLastLunch(["Pizza", "Burger"]), ["Pizza"]);
 ```
 
 You should define a function `removeFirstLunch`.
@@ -187,12 +193,12 @@ assert.lengthOf(removeFirstLunch, 1);
 When the input array is empty, the function `removeFirstLunch` should log the string `"No lunches to remove."` to the console.
 
 ```js
-lunches = [];
+const testLunches = [];
 const tempArr = [];
 const temp = console.log;
 try {
   console.log = obj => tempArr.push(obj);
-  removeFirstLunch(lunches);
+  removeFirstLunch(testLunches);
   assert.strictEqual(tempArr[0], "No lunches to remove.");
 } finally {
   console.log = temp;
@@ -202,23 +208,26 @@ try {
 When `lunches = ["Salad", "Eggs", "Cheese"]`, `removeFirstLunch(lunches)` should log the string `"Salad removed from the start of the lunch menu."` to the console.
 
 ```js
-lunches = ["Stew", "Soup", "Toast"];
+let testLunches = ["Salad", "Eggs", "Cheese"];
 const tempArr = [];
 const temp = console.log;
 try {
   console.log = obj => tempArr.push(obj);
-  removeFirstLunch(lunches);
-  assert.strictEqual(tempArr[0], "Stew removed from the start of the lunch menu.");
+  removeFirstLunch(testLunches);
+  assert.strictEqual(tempArr[0], "Salad removed from the start of the lunch menu.");
+  testLunches = ["Stew", "Soup", "Toast"]
+  removeFirstLunch(testLunches);
+  assert.strictEqual(tempArr[1], "Stew removed from the start of the lunch menu.");
 } finally {
   console.log = temp;
 }
 ```
 
-The function `removeFirstLunch` should return the correct array.
+`removeFirstLunch(["Sushi", "Pizza", "Burger"])` should return `["Pizza", "Burger"]`.
 
 ```js
-lunches = ["Pizza", "Burger"];
-assert.deepStrictEqual(removeFirstLunch(lunches), ["Burger"]);
+assert.deepStrictEqual(removeFirstLunch(["Sushi", "Pizza", "Burger"]), ["Pizza", "Burger"]);
+assert.deepStrictEqual(removeFirstLunch(["Pizza", "Burger"]), ["Burger"]);
 ```
 
 You should define a function `getRandomLunch`.
@@ -236,12 +245,12 @@ assert.lengthOf(getRandomLunch, 1);
 When the input array is empty, the function `getRandomLunch` should log the string `"No lunches available."` to the console.
 
 ```js
-lunches = [];
+const testLunches = [];
 const tempArr = [];
 const temp = console.log;
 try {
   console.log = obj => tempArr.push(obj);
-  getRandomLunch(lunches);
+  getRandomLunch(testLunches);
   assert.strictEqual(tempArr[0], "No lunches available.");
 } finally {
   console.log = temp;
@@ -251,7 +260,7 @@ try {
 When `lunches = ["Fish", "Fries", "Roast"]`, the function `getRandomLunch` should log a string in the format `"Randomly selected lunch: [Lunch Item]"` to the console.
 
 ```js
-lunches = ["Salad", "Eggs", "Cheese"];
+const testLunches = ["Fish", "Fries", "Roast"];
 const tempRandom = Math.random;
 const tempArr = [];
 const temp = console.log;
@@ -261,18 +270,18 @@ try {
 
   // check that it correctly outputs the first item
   Math.random = () => 0;
-  getRandomLunch(lunches);
-  assert.strictEqual(tempArr[0], `Randomly selected lunch: ${lunches[0]}`);
+  getRandomLunch(testLunches);
+  assert.strictEqual(tempArr[0], `Randomly selected lunch: ${testLunches[0]}`);
 
   // second item
   Math.random = () => 0.4;
-  getRandomLunch(lunches);
-  assert.strictEqual(tempArr[1], `Randomly selected lunch: ${lunches[1]}`);
+  getRandomLunch(testLunches);
+  assert.strictEqual(tempArr[1], `Randomly selected lunch: ${testLunches[1]}`);
 
   // third item
   Math.random = () => 0.8;
-  getRandomLunch(lunches);
-  assert.strictEqual(tempArr[2], `Randomly selected lunch: ${lunches[2]}`);
+  getRandomLunch(testLunches);
+  assert.strictEqual(tempArr[2], `Randomly selected lunch: ${testLunches[2]}`);
 
 } finally {
   // restore Math.random
@@ -296,12 +305,12 @@ assert.lengthOf(showLunchMenu, 1);
 When the input array is empty, the function `showLunchMenu` should log the string `"The menu is empty."` to the console.
 
 ```js
-lunches = [];
+const testLunches = [];
 const tempArr = [];
 const temp = console.log;
 try {
   console.log = obj => tempArr.push(obj);
-  showLunchMenu(lunches);
+  showLunchMenu(testLunches);
   assert.strictEqual(tempArr[0], "The menu is empty.");
 } finally {
   console.log = temp;
@@ -311,13 +320,16 @@ try {
 When `lunches = ["Greens", "Corns", "Beans"]`, the function `showLunchMenu` should log a string in the format `"Menu items: Greens, Corns, Beans"` to the console.
 
 ```js
-lunches = ["Pizza", "Burger", "Fries"];
+let testLunches = ["Greens", "Corns", "Beans"];
 const tempArr = [];
 const temp = console.log;
 try {
   console.log = obj => tempArr.push(obj);
-  showLunchMenu(lunches);
-  assert.strictEqual(tempArr[0], "Menu items: Pizza, Burger, Fries");
+  showLunchMenu(testLunches);
+  assert.strictEqual(tempArr[0], "Menu items: Greens, Corns, Beans");
+  testLunches = ["Pizza", "Burger", "Fries"]
+  showLunchMenu(testLunches);
+  assert.strictEqual(tempArr[1], "Menu items: Pizza, Burger, Fries");
 } finally {
   console.log = temp;
 }

--- a/curriculum/challenges/english/25-front-end-development/lab-lunch-picker-program/66db529d37ad966480ebb633.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-lunch-picker-program/66db529d37ad966480ebb633.md
@@ -254,6 +254,22 @@ try {
 }
 ```
 
+`addLunchToEnd`, `addLunchToStart`, `removeLastLunch`, and `removeFirstLunch` should return the same array passed as an argument after updating it.
+
+```js
+const temp = console.log;
+console.log = () => {}
+const testLunches = ["Spam"];
+try {
+  assert.equal(addLunchToEnd(testLunches, "Pizza"), testLunches);
+  assert.equal(addLunchToStart(testLunches, "Caviar"), testLunches);
+  assert.equal(removeLastLunch(testLunches), testLunches);
+  assert.equal(removeFirstLunch(testLunches), testLunches);
+} finally {
+  console.log = temp;
+}
+```
+
 You should define a function `getRandomLunch`.
 
 ```js

--- a/curriculum/challenges/english/25-front-end-development/lab-lunch-picker-program/66db529d37ad966480ebb633.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-lunch-picker-program/66db529d37ad966480ebb633.md
@@ -60,7 +60,7 @@ You should define a function `addLunchToEnd`.
 assert.isFunction(addLunchToEnd);
 ```
 
-The function `addLunchToEnd` should take two arguments.
+The function `addLunchToEnd` should have two parameters.
 
 ```js
 assert.lengthOf(addLunchToEnd, 2);
@@ -96,7 +96,7 @@ You should define a function `addLunchToStart`.
 assert.isFunction(addLunchToStart);
 ```
 
-The function `addLunchToStart` should take two arguments.
+The function `addLunchToStart` should have two parameters.
 
 ```js
 assert.lengthOf(addLunchToStart, 2);
@@ -132,7 +132,7 @@ You should define a function `removeLastLunch`.
 assert.isFunction(removeLastLunch)
 ```
 
-The function `removeLastLunch` should take one argument.
+The function `removeLastLunch` should have one parameter.
 
 ```js
 assert.lengthOf(removeLastLunch, 1);
@@ -184,7 +184,7 @@ You should define a function `removeFirstLunch`.
 assert.isFunction(removeFirstLunch);
 ```
 
-The function `removeFirstLunch` should take a single argument.
+The function `removeFirstLunch` should have a single parameter.
 
 ```js
 assert.lengthOf(removeFirstLunch, 1);
@@ -236,7 +236,7 @@ You should define a function `getRandomLunch`.
 assert.isFunction(getRandomLunch);
 ```
 
-The function `getRandomLunch` should take a single argument.
+The function `getRandomLunch` should have a single parameter.
 
 ```js
 assert.lengthOf(getRandomLunch, 1);
@@ -296,7 +296,7 @@ You should define a function `showLunchMenu`.
 assert.isFunction(showLunchMenu);
 ```
 
-The function `showLunchMenu` should take a single argument.
+The function `showLunchMenu` should have a single parameter.
 
 ```js
 assert.lengthOf(showLunchMenu, 1);

--- a/curriculum/challenges/english/25-front-end-development/lab-lunch-picker-program/66db529d37ad966480ebb633.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-lunch-picker-program/66db529d37ad966480ebb633.md
@@ -71,11 +71,11 @@ assert.lengthOf(addLunchToEnd, 2);
 ```js
 const tempArr = [];
 const temp = console.log;
-try{
+try {
   console.log = obj => tempArr.push(obj);
   addLunchToEnd(lunches, "Pizza");
   assert.strictEqual(tempArr[0], "Pizza added to the end of the lunch menu.");
-}finally{
+} finally {
   console.log = temp;
 }
 ```
@@ -104,11 +104,11 @@ assert.lengthOf(addLunchToStart, 2);
 ```js
 const tempArr = [];
 const temp = console.log;
-try{
+try {
   console.log = obj => tempArr.push(obj);
   addLunchToStart(lunches, "Burger");
   assert.strictEqual(tempArr[0], "Burger added to the start of the lunch menu.");
-}finally{
+} finally {
   console.log = temp;
 }
 ```
@@ -138,11 +138,11 @@ When the input array is empty, the function `removeLastLunch` should log the str
 lunches = [];
 const tempArr = [];
 const temp = console.log;
-try{
+try {
   console.log = obj => tempArr.push(obj);
   removeLastLunch(lunches);
   assert.strictEqual(tempArr[0], "No lunches to remove.");
-}finally{
+} finally {
   console.log = temp;
 }
 ```
@@ -153,11 +153,11 @@ When `lunches = ["Stew", "Soup", "Toast"]`, `removeLastLunch(lunches)` should lo
 lunches = ["Fries", "Tacos", "Noodles"];
 const tempArr = [];
 const temp = console.log;
-try{
+try {
   console.log = obj => tempArr.push(obj);
   removeLastLunch(lunches);
   assert.strictEqual(tempArr[0], "Noodles removed from the end of the lunch menu.");
-}finally{
+} finally {
   console.log = temp;
 }
 ```
@@ -187,11 +187,11 @@ When the input array is empty, the function `removeFirstLunch` should log the st
 lunches = [];
 const tempArr = [];
 const temp = console.log;
-try{
+try {
   console.log = obj => tempArr.push(obj);
   removeFirstLunch(lunches);
   assert.strictEqual(tempArr[0], "No lunches to remove.");
-}finally{
+} finally {
   console.log = temp;
 }
 ```
@@ -202,11 +202,11 @@ When `lunches = ["Salad", "Eggs", "Cheese"]`, `removeFirstLunch(lunches)` should
 lunches = ["Stew", "Soup", "Toast"];
 const tempArr = [];
 const temp = console.log;
-try{
+try {
   console.log = obj => tempArr.push(obj);
   removeFirstLunch(lunches);
   assert.strictEqual(tempArr[0], "Stew removed from the start of the lunch menu.");
-}finally{
+} finally {
   console.log = temp;
 }
 ```
@@ -236,11 +236,11 @@ When the input array is empty, the function `getRandomLunch` should log the stri
 lunches = [];
 const tempArr = [];
 const temp = console.log;
-try{
+try {
   console.log = obj => tempArr.push(obj);
   getRandomLunch(lunches);
   assert.strictEqual(tempArr[0], "No lunches available.");
-}finally{
+} finally {
   console.log = temp;
 }
 ```
@@ -253,7 +253,7 @@ const tempRandom = Math.random;
 const tempArr = [];
 const temp = console.log;
 
-try{
+try {
   console.log = obj => tempArr.push(obj);
 
   // check that it correctly outputs the first item
@@ -271,7 +271,7 @@ try{
   getRandomLunch(lunches);
   assert.strictEqual(tempArr[2], `Randomly selected lunch: ${lunches[2]}`);
 
-}finally{
+} finally {
   // restore Math.random
   Math.random = tempRandom;
   console.log = temp;
@@ -296,11 +296,11 @@ When the input array is empty, the function `showLunchMenu` should log the strin
 lunches = [];
 const tempArr = [];
 const temp = console.log;
-try{
+try {
   console.log = obj => tempArr.push(obj);
   showLunchMenu(lunches);
   assert.strictEqual(tempArr[0], "The menu is empty.");
-}finally{
+} finally {
   console.log = temp;
 }
 ```
@@ -311,11 +311,11 @@ When `lunches = ["Greens", "Corns", "Beans"]`, the function `showLunchMenu` shou
 lunches = ["Pizza", "Burger", "Fries"];
 const tempArr = [];
 const temp = console.log;
-try{
+try {
   console.log = obj => tempArr.push(obj);
   showLunchMenu(lunches);
   assert.strictEqual(tempArr[0], "Menu items: Pizza, Burger, Fries");
-}finally{
+} finally {
   console.log = temp;
 }
 ```

--- a/curriculum/challenges/english/25-front-end-development/lab-lunch-picker-program/66db529d37ad966480ebb633.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-lunch-picker-program/66db529d37ad966480ebb633.md
@@ -13,31 +13,42 @@ In this lab, you'll build a program that helps in managing lunch options. You'll
 
 **User Stories:**
 
-1. You should create a `lunches` variable and assign it an empty array that will be used to store lunch items.
+1. You should create a mutable `lunches` variable and assign it an empty array that will be used to store lunch items.
 
-2. You should create a function `addLunchToEnd` that takes a string parameter and adds it to the end of the `lunches` array and returns a string in the format: `"[Lunch Item] added to the end of the lunch menu."`
+2. You should create a function `addLunchToEnd` that takes an array as the first parameter and a string as the second parameter. The function should:
+    - add the string to the end of the array
+    - log the string `"[Lunch Item] added to the end of the lunch menu."`  to the console
+    - return the updated array
 
-3. You should create a function `addLunchToStart` that takes a string parameter and adds it to the start of the `lunches` array and returns a string in the format: `"[Lunch Item] added to the start of the lunch menu."`
+3. You should create a function `addLunchToStart` that takes an array as the first parameter and a string as the second parameter. The function should:
+    - add the string to the start of the array
+    - log the string `"[Lunch Item] added to the start of the lunch menu."` to the console
+    - return the updated array
 
-4. You should create a function `removeLastLunch` that removes the last lunch item from the `lunches` array and:
-   - If successful, returns a string in the format: `"[Lunch Item] removed from the end of the lunch menu."`
-   - If the `lunches` array is empty, returns a string: `"No lunches to remove."`
+4. You should create a function `removeLastLunch` that takes an array parameter and:
+   - removes the last lunch item from the array
+   - If successful, log the string `"[Lunch Item] removed from the end of the lunch menu."` to the console
+   - If the array is empty, log the string `"No lunches to remove."` to the console
+   - return the updated array
 
-5. You should create a function `removeFirstLunch` that removes the first lunch item from the `lunches` array and:
-   - If successful, returns a string in the format: `"[Lunch Item] removed from the start of the lunch menu."`
-   - If the `lunches` array is empty, returns a string: `"No lunches to remove."`
+5. You should create a function `removeFirstLunch` that takes an array parameter and:
+   - removes the first lunch item from the array
+   - If successful, log the string `"[Lunch Item] removed from the start of the lunch menu."` to the console
+   - If the array is empty, log the string `"No lunches to remove."` to the console
+   - return the updated array
 
-6. You should create a function `getRandomLunch` that selects a random lunch item from the `lunches` array and:
-   - If successful, returns a string in the format: `"Randomly selected lunch: [Lunch Item]"`
-   - If the `lunches` array is empty, returns a string: `"No lunches available."`
+6. You should create a function `getRandomLunch` that takes an array parameter and:
+   - selects a random lunch item from the array
+   - If successful, log the string `"Randomly selected lunch: [Lunch Item]"` to the console
+   - If the array is empty, log the string `"No lunches available."` to the console
 
-7. You should create a function `showLunchMenu` that:
-   - If there are items in the `lunches` array, returns a string in the format: `"Menu items: [Lunch Item], [Lunch Item]...`
-   - If the `lunches` array is empty, returns a string: `"The menu is empty."`
+7. You should create a function `showLunchMenu` that takes an array parameter and:
+   - If there are lunch items in the array, log the string `"Menu items: [Lunch Item], [Lunch Item]...` to the console
+   - If the array is empty, log the string `"The menu is empty."` to the console
 
 # --hints--
 
-You should declare a variable `lunches` and assign it an empty array to store the lunch items.
+You should declare a mutable variable `lunches` and assign it an empty array to store the lunch items.
 
 ```js
 assert.isArray(lunches);
@@ -49,20 +60,31 @@ You should define a function `addLunchToEnd`.
 assert.isFunction(addLunchToEnd);
 ```
 
-The function `addLunchToEnd` should take a single argument.
+The function `addLunchToEnd` should take 2 arguments.
 
 ```js
-assert.lengthOf(addLunchToEnd, 1);
+assert.lengthOf(addLunchToEnd, 2);
 ```
 
-`addLunchToEnd("Tacos")` should return the string `"Tacos added to the end of the lunch menu."`.
+`addLunchToEnd(lunches, "Tacos")` should log the string `"Tacos added to the end of the lunch menu."`.
 
 ```js
-assert.strictEqual(addLunchToEnd("Tacos"), "Tacos added to the end of the lunch menu.");
+const tempArr = [];
+const temp = console.log;
+try{
+  console.log = obj => tempArr.push(obj);
+  addLunchToEnd(lunches, "Pizza");
+  assert.strictEqual(tempArr[0], "Pizza added to the end of the lunch menu.");
+}finally{
+  console.log = temp;
+}
+```
 
-// prevent hardcoding
-assert.strictEqual(addLunchToEnd("Pizza"), "Pizza added to the end of the lunch menu.");
-assert.strictEqual(addLunchToEnd("Burger"), "Burger added to the end of the lunch menu.");
+The function `addLunchToEnd` should return the correct array.
+
+```js
+lunches = ["Fries"]
+assert.deepStrictEqual(addLunchToEnd(lunches, "Tacos"), ["Fries", "Tacos"]);
 ```
 
 You should define a function `addLunchToStart`.
@@ -71,20 +93,31 @@ You should define a function `addLunchToStart`.
 assert.isFunction(addLunchToStart);
 ```
 
-The function `addLunchToStart` should take a single argument.
+The function `addLunchToStart` should take two arguments.
 
 ```js
-assert.lengthOf(addLunchToStart, 1);
+assert.lengthOf(addLunchToStart, 2);
 ```
 
-`addLunchToStart("Sushi")` should return the string `"Sushi added to the start of the lunch menu."`.
+`addLunchToStart(lunches, "Sushi")` should log the string `"Sushi added to the start of the lunch menu."`.
 
 ```js
-assert.strictEqual(addLunchToStart("Sushi"), "Sushi added to the start of the lunch menu.");
+const tempArr = [];
+const temp = console.log;
+try{
+  console.log = obj => tempArr.push(obj);
+  addLunchToStart(lunches, "Burger");
+  assert.strictEqual(tempArr[0], "Burger added to the start of the lunch menu.");
+}finally{
+  console.log = temp;
+}
+```
 
-// prevent hardcoding
-assert.strictEqual(addLunchToStart("Salad"), "Salad added to the start of the lunch menu.");
-assert.strictEqual(addLunchToStart("Pasta"), "Pasta added to the start of the lunch menu.");
+The function `addLunchToStart` should return the correct array.
+
+```js
+lunches = ["Noodles"]
+assert.deepStrictEqual(addLunchToStart(lunches, "Sushi"), ["Sushi", "Noodles"]);
 ```
 
 You should define a function `removeLastLunch`.
@@ -93,40 +126,96 @@ You should define a function `removeLastLunch`.
 assert.isFunction(removeLastLunch)
 ```
 
-When the `lunches` array is empty, the function `removeLastLunch` should return the string `"No lunches to remove."`.
+The function `removeLastLunch` should take one argument.
+
+```js
+assert.lengthOf(removeLastLunch, 1);
+```
+
+When the input array is empty, the function `removeLastLunch` should log the string `"No lunches to remove."`.
 
 ```js
 lunches = [];
-assert.strictEqual(removeLastLunch(), "No lunches to remove.");
+const tempArr = [];
+const temp = console.log;
+try{
+  console.log = obj => tempArr.push(obj);
+  removeLastLunch(lunches);
+  assert.strictEqual(tempArr[0], "No lunches to remove.");
+}finally{
+  console.log = temp;
+}
 ```
 
-When `lunches = ["Stew", "Soup", "Toast"]`, the function `removeLastLunch` should return the string `"Toast removed from the end of the lunch menu."`.
+When `lunches = ["Stew", "Soup", "Toast"]`, `removeLastLunch(lunches)` should log the string `"Toast removed from the end of the lunch menu."`.
+
+```js
+lunches = ["Fries", "Tacos", "Noodles"];
+const tempArr = [];
+const temp = console.log;
+try{
+  console.log = obj => tempArr.push(obj);
+  removeLastLunch(lunches);
+  assert.strictEqual(tempArr[0], "Noodles removed from the end of the lunch menu.");
+}finally{
+  console.log = temp;
+}
+```
+
+The function `removeLastLunch` should return the correct array.
+
+```js
+lunches = ["Pizza", "Burger"];
+assert.deepStrictEqual(removeLastLunch(lunches), ["Pizza"]);
+```
+
+You should define a function `removeFirstLunch`.
+
+```js
+assert.isFunction(removeFirstLunch)
+```
+
+The function `removeFirstLunch` should take one argument.
+
+```js
+assert.lengthOf(removeFirstLunch, 1);
+```
+
+When the input array is empty, the function `removeFirstLunch` should log the string `"No lunches to remove."`.
+
+```js
+lunches = [];
+const tempArr = [];
+const temp = console.log;
+try{
+  console.log = obj => tempArr.push(obj);
+  removeFirstLunch(lunches);
+  assert.strictEqual(tempArr[0], "No lunches to remove.");
+}finally{
+  console.log = temp;
+}
+```
+
+When `lunches = ["Salad", "Eggs", "Cheese"]`, `removeFirstLunch(lunches)` should log the string `"Salad removed from the start of the lunch menu."`.
 
 ```js
 lunches = ["Stew", "Soup", "Toast"];
-assert.strictEqual(removeLastLunch(), "Toast removed from the end of the lunch menu.");
-
-// prevent hardcoding
-assert.strictEqual(removeLastLunch(), "Soup removed from the end of the lunch menu.");
-assert.strictEqual(removeLastLunch(), "Stew removed from the end of the lunch menu.");
+const tempArr = [];
+const temp = console.log;
+try{
+  console.log = obj => tempArr.push(obj);
+  removeFirstLunch(lunches);
+  assert.strictEqual(tempArr[0], "Stew removed from the start of the lunch menu.");
+}finally{
+  console.log = temp;
+}
 ```
 
-When the `lunches` array is empty, the function `removeFirstLunch` should return the string `"No lunches to remove."`.
+The function `removeFirstLunch` should return the correct array.
 
 ```js
-lunches = [];
-assert.strictEqual(removeFirstLunch(), "No lunches to remove.");
-```
-
-When `lunches = ["Salad", "Eggs", "Cheese"]`, the function `removeFirstLunch` should return the string `"Salad removed from the start of the lunch menu."`.
-
-```js
-lunches = ["Salad", "Eggs", "Cheese"];
-assert.strictEqual(removeFirstLunch(), "Salad removed from the start of the lunch menu.");
-
-// prevent hardcoding
-assert.strictEqual(removeFirstLunch(), "Eggs removed from the start of the lunch menu.");
-assert.strictEqual(removeFirstLunch(), "Cheese removed from the start of the lunch menu.");
+lunches = ["Pizza", "Burger"];
+assert.deepStrictEqual(removeFirstLunch(lunches), ["Burger"]);
 ```
 
 You should define a function `getRandomLunch`.
@@ -135,34 +224,58 @@ You should define a function `getRandomLunch`.
 assert.isFunction(getRandomLunch);
 ```
 
-When the `lunches` array is empty, the function `getRandomLunch` should return the string `"No lunches available."`.
+The function `getRandomLunch` should take one argument.
+
+```js
+assert.lengthOf(getRandomLunch, 1);
+```
+
+When the input array is empty, the function `getRandomLunch` should log the string `"No lunches available."`.
 
 ```js
 lunches = [];
-assert.strictEqual(getRandomLunch(), "No lunches available.");
+const tempArr = [];
+const temp = console.log;
+try{
+  console.log = obj => tempArr.push(obj);
+  getRandomLunch(lunches);
+  assert.strictEqual(tempArr[0], "No lunches available.");
+}finally{
+  console.log = temp;
+}
 ```
 
-When `lunches = ["Fish", "Fries", "Roast"]`, the function `getRandomLunch` should return a string in the format `"Randomly selected lunch: [Lunch Item]"`.
+When `lunches = ["Fish", "Fries", "Roast"]`, the function `getRandomLunch` should log a string in the format `"Randomly selected lunch: [Lunch Item]"`.
 
 ```js
-const temp = Math.random;
+lunches = ["Salad", "Eggs", "Cheese"];
+const tempRandom = Math.random;
+const tempArr = [];
+const temp = console.log;
 
-lunches = ["Fish", "Fries", "Roast"];
+try{
+  console.log = obj => tempArr.push(obj);
 
-// check that it correctly outputs the first item
-Math.random = () => 0;
-assert.equal(getRandomLunch(), `Randomly selected lunch: ${lunches[0]}`);
+  // check that it correctly outputs the first item
+  Math.random = () => 0;
+  getRandomLunch(lunches);
+  assert.strictEqual(tempArr[0], `Randomly selected lunch: ${lunches[0]}`);
 
-// second item
-Math.random = () => 0.4;
-assert.equal(getRandomLunch(), `Randomly selected lunch: ${lunches[1]}`);
+  // second item
+  Math.random = () => 0.4;
+  getRandomLunch(lunches);
+  assert.strictEqual(tempArr[1], `Randomly selected lunch: ${lunches[1]}`);
 
-// third item
-Math.random = () => 0.8;
-assert.equal(getRandomLunch(), `Randomly selected lunch: ${lunches[2]}`);
+  // third item
+  Math.random = () => 0.8;
+  getRandomLunch(lunches);
+  assert.strictEqual(tempArr[2], `Randomly selected lunch: ${lunches[2]}`);
 
-// restore Math.random
-Math.random = temp;
+}finally{
+  // restore Math.random
+  Math.random = tempRandom;
+  console.log = temp;
+}
 ```
 
 You should define a function `showLunchMenu`.
@@ -171,21 +284,40 @@ You should define a function `showLunchMenu`.
 assert.isFunction(showLunchMenu);
 ```
 
-When the `lunches` array is empty, the function `showLunchMenu` should return the string `"The menu is empty."`.
+The function `showLunchMenu` should take one argument.
+
+```js
+assert.lengthOf(showLunchMenu, 1);
+```
+
+When the input array is empty, the function `showLunchMenu` should log the string `"The menu is empty."`.
 
 ```js
 lunches = [];
-assert.strictEqual(showLunchMenu(), "The menu is empty.");
+const tempArr = [];
+const temp = console.log;
+try{
+  console.log = obj => tempArr.push(obj);
+  showLunchMenu(lunches);
+  assert.strictEqual(tempArr[0], "The menu is empty.");
+}finally{
+  console.log = temp;
+}
 ```
 
-When `lunches = ["Greens", "Corns", "Beans"]`, the function `showLunchMenu` should return a string in the format `"Menu items: Greens, Corns, Beans"`.
+When `lunches = ["Greens", "Corns", "Beans"]`, the function `showLunchMenu` should log a string in the format `"Menu items: Greens, Corns, Beans"`.
 
 ```js
-lunches = ["Greens", "Corns", "Beans"];
-assert.strictEqual(showLunchMenu(), "Menu items: Greens, Corns, Beans");
-
 lunches = ["Pizza", "Burger", "Fries"];
-assert.strictEqual(showLunchMenu(), "Menu items: Pizza, Burger, Fries");
+const tempArr = [];
+const temp = console.log;
+try{
+  console.log = obj => tempArr.push(obj);
+  showLunchMenu(lunches);
+  assert.strictEqual(tempArr[0], "Menu items: Pizza, Burger, Fries");
+}finally{
+  console.log = temp;
+}
 ```
 
 # --seed--
@@ -199,63 +331,71 @@ assert.strictEqual(showLunchMenu(), "Menu items: Pizza, Burger, Fries");
 # --solutions--
 
 ```js
-const lunches = [];
+let lunches = [];
 
-// Add a new lunch to the list (at the end)
-function addLunchToEnd(newLunch) {
+// Add a new lunch to the end of the list
+function addLunchToEnd(lunches, newLunch) {
   lunches.push(newLunch);
-  return `${newLunch} added to the end of the lunch menu.`;
+  console.log(`${newLunch} added to the end of the lunch menu.`);
+  return lunches;
 }
 
 // Add a new lunch to the start of the list
-function addLunchToStart(newLunch) {
+function addLunchToStart(lunches, newLunch) {
   lunches.unshift(newLunch);
-  return `${newLunch} added to the start of the lunch menu.`;
+  console.log(`${newLunch} added to the start of the lunch menu.`);
+  return lunches;
 }
 
 // Remove the last lunch from the list
-function removeLastLunch() {
+function removeLastLunch(lunches) {
   const removedLunch = lunches.pop();
   if (removedLunch) {
-    return `${removedLunch} removed from the end of the lunch menu.`;
+    console.log(`${removedLunch} removed from the end of the lunch menu.`);
   } else {
-    return "No lunches to remove.";
+    console.log("No lunches to remove.");
   }
+  return lunches;
 }
 
 // Remove the first lunch from the list
-function removeFirstLunch() {
+function removeFirstLunch(lunches) {
   const removedLunch = lunches.shift();
   if (removedLunch) {
-    return `${removedLunch} removed from the start of the lunch menu.`;
+    console.log(`${removedLunch} removed from the start of the lunch menu.`);
   } else {
-    return "No lunches to remove.";
+    console.log("No lunches to remove.");
   }
+  return lunches;
 }
 
 // Function to get a random lunch from the list
-function getRandomLunch() {
+function getRandomLunch(lunches) {
   if (lunches.length === 0) {
-    return "No lunches available.";
+    console.log("No lunches available.");
   }
-  const randomIndex = Math.floor(Math.random() * lunches.length);
-  const randomLunch = lunches[randomIndex];
-  return `Randomly selected lunch: ${randomLunch}`;
+  else {
+    const randomIndex = Math.floor(Math.random() * lunches.length);
+    const randomLunch = lunches[randomIndex];
+    console.log(`Randomly selected lunch: ${randomLunch}`);
+  }
 }
 
-// New function to display the lunches as a numbered menu using a for loop
-function showLunchMenu() {
+// Function to display all the lunches in the list
+function showLunchMenu(lunches) {
   if (lunches.length === 0) {
-    return "The menu is empty.";
+    console.log("The menu is empty.");
   }
-  return `Menu items: ${lunches.join(', ')}`;
+  else {
+    console.log(`Menu items: ${lunches.join(', ')}`);
+  }
 }
 
-addLunchToEnd("Tacos");
-addLunchToStart("Sushi");
-removeLastLunch();
-removeFirstLunch();
-getRandomLunch();
-showLunchMenu();
+lunches = addLunchToEnd(lunches, "Tacos");
+lunches = addLunchToStart(lunches, "Sushi");
+lunches = removeLastLunch(lunches);
+lunches = removeFirstLunch(lunches);
+getRandomLunch(lunches);
+showLunchMenu(lunches);
 
 ```

--- a/curriculum/challenges/english/25-front-end-development/lab-lunch-picker-program/66db529d37ad966480ebb633.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-lunch-picker-program/66db529d37ad966480ebb633.md
@@ -86,8 +86,14 @@ try {
 `addLunchToEnd(["Pizza", "Tacos"], "Burger")` should return `["Pizza", "Tacos", "Burger"]`.
 
 ```js
-assert.deepStrictEqual(addLunchToEnd(["Pizza", "Tacos"], "Burger"), ["Pizza", "Tacos", "Burger"]);
-assert.deepStrictEqual(addLunchToEnd(["Fries"], "Tacos"), ["Fries", "Tacos"]);
+const temp = console.log;
+console.log = () => {}
+try {
+  assert.deepStrictEqual(addLunchToEnd(["Pizza", "Tacos"], "Burger"), ["Pizza", "Tacos", "Burger"]);
+  assert.deepStrictEqual(addLunchToEnd(["Fries"], "Tacos"), ["Fries", "Tacos"]);
+} finally {
+  console.log = temp;
+}
 ```
 
 You should define a function `addLunchToStart`.
@@ -122,8 +128,14 @@ try {
 `addLunchToStart(["Burger", "Sushi"], "Pizza")` should return `["Pizza", "Burger", "Sushi"]`.
 
 ```js
-assert.deepStrictEqual(addLunchToStart(["Burger", "Sushi"], "Pizza"), ["Pizza", "Burger", "Sushi"]);
-assert.deepStrictEqual(addLunchToStart(["Noodles"], "Sushi"), ["Sushi", "Noodles"]);
+const temp = console.log;
+console.log = () => {}
+try {
+  assert.deepStrictEqual(addLunchToStart(["Burger", "Sushi"], "Pizza"), ["Pizza", "Burger", "Sushi"]);
+  assert.deepStrictEqual(addLunchToStart(["Noodles"], "Sushi"), ["Sushi", "Noodles"]);
+} finally {
+  console.log = temp;
+}
 ```
 
 You should define a function `removeLastLunch`.
@@ -153,7 +165,7 @@ try {
 }
 ```
 
-When `lunches = ["Stew", "Soup", "Toast"]`, `removeLastLunch(lunches)` should log the string `"Toast removed from the end of the lunch menu."` to the console.
+`removeLastLunch(["Stew", "Soup", "Toast"])` should log the string `"Toast removed from the end of the lunch menu."` to the console.
 
 ```js
 let testLunches = ["Stew", "Soup", "Toast"];
@@ -174,8 +186,14 @@ try {
 `removeLastLunch(["Sushi", "Pizza", "Noodles"])` should return `["Sushi", "Pizza"]`.
 
 ```js
-assert.deepStrictEqual(removeLastLunch(["Sushi", "Pizza", "Noodles"]), ["Sushi", "Pizza"]);
-assert.deepStrictEqual(removeLastLunch(["Pizza", "Burger"]), ["Pizza"]);
+const temp = console.log;
+console.log = () => {}
+try {
+  assert.deepStrictEqual(removeLastLunch(["Sushi", "Pizza", "Noodles"]), ["Sushi", "Pizza"]);
+  assert.deepStrictEqual(removeLastLunch(["Pizza", "Burger"]), ["Pizza"]);
+} finally {
+  console.log = temp;
+}
 ```
 
 You should define a function `removeFirstLunch`.
@@ -205,7 +223,7 @@ try {
 }
 ```
 
-When `lunches = ["Salad", "Eggs", "Cheese"]`, `removeFirstLunch(lunches)` should log the string `"Salad removed from the start of the lunch menu."` to the console.
+`removeFirstLunch(["Salad", "Eggs", "Cheese"])` should log the string `"Salad removed from the start of the lunch menu."` to the console.
 
 ```js
 let testLunches = ["Salad", "Eggs", "Cheese"];
@@ -226,8 +244,14 @@ try {
 `removeFirstLunch(["Sushi", "Pizza", "Burger"])` should return `["Pizza", "Burger"]`.
 
 ```js
-assert.deepStrictEqual(removeFirstLunch(["Sushi", "Pizza", "Burger"]), ["Pizza", "Burger"]);
-assert.deepStrictEqual(removeFirstLunch(["Pizza", "Burger"]), ["Burger"]);
+const temp = console.log;
+console.log = () => {}
+try {
+  assert.deepStrictEqual(removeFirstLunch(["Sushi", "Pizza", "Burger"]), ["Pizza", "Burger"]);
+  assert.deepStrictEqual(removeFirstLunch(["Pizza", "Burger"]), ["Burger"]);
+} finally {
+  console.log = temp;
+}
 ```
 
 You should define a function `getRandomLunch`.
@@ -257,7 +281,7 @@ try {
 }
 ```
 
-When `lunches = ["Fish", "Fries", "Roast"]`, the function `getRandomLunch` should log a string in the format `"Randomly selected lunch: [Lunch Item]"` to the console.
+When the input array is not empty, the function `getRandomLunch` should log a string in the format `"Randomly selected lunch: [Lunch Item]"` to the console.
 
 ```js
 const testLunches = ["Fish", "Fries", "Roast"];
@@ -317,7 +341,7 @@ try {
 }
 ```
 
-When `lunches = ["Greens", "Corns", "Beans"]`, the function `showLunchMenu` should log a string in the format `"Menu items: Greens, Corns, Beans"` to the console.
+`showLunchMenu(["Greens", "Corns", "Beans"])` should log `"Menu items: Greens, Corns, Beans"` to the console.
 
 ```js
 let testLunches = ["Greens", "Corns", "Beans"];

--- a/curriculum/challenges/english/25-front-end-development/lab-lunch-picker-program/66db529d37ad966480ebb633.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-lunch-picker-program/66db529d37ad966480ebb633.md
@@ -17,33 +17,33 @@ In this lab, you'll build a program that helps in managing lunch options. You'll
 
 2. You should create a function `addLunchToEnd` that takes an array as the first argument and a string as the second argument. The function should:
     - Add the string to the end of the array.
-    - Log the string `"[Lunch Item] added to the end of the lunch menu."` to the console.
+    - Log the string `"[Lunch Item] added to the end of the lunch menu."` to the console, where `[Lunch Item]` is the string passed to the function.
     - Return the updated array.
 
 3. You should create a function `addLunchToStart` that takes an array as the first argument and a string as the second argument. The function should:
     - Add the string to the start of the array.
-    - Log the string `"[Lunch Item] added to the start of the lunch menu."` to the console.
+    - Log the string `"[Lunch Item] added to the start of the lunch menu."` to the console, where `[Lunch Item]` is the string passed to the function.
     - Return the updated array.
 
 4. You should create a function `removeLastLunch` that takes an array as its argument. The function should:
    - Remove the last lunch item from the array.
-   - If  the removal is successful, log the string `"[Lunch Item] removed from the end of the lunch menu."` to the console.
+   - If  the removal is successful, log the string `"[Lunch Item] removed from the end of the lunch menu."` to the console, where `[Lunch Item]` is the element removed from the array.
    - If the array is empty, log the string `"No lunches to remove."` to the console.
    - Return the updated array.
 
 5. You should create a function `removeFirstLunch` that takes an array as its argument. The function should:
    - Remove the first lunch item from the array.
-   - If the removal is successful, log the string `"[Lunch Item] removed from the start of the lunch menu."` to the console.
+   - If the removal is successful, log the string `"[Lunch Item] removed from the start of the lunch menu."` to the console, where `[Lunch Item]` is the element removed from the array.
    - If the array is empty, log the string `"No lunches to remove."` to the console.
    - Return the updated array.
 
 6. You should create a function `getRandomLunch` that takes an array as its argument. The function should:
-   - Select a random lunch item from the array.
-   - If successful, log the string `"Randomly selected lunch: [Lunch Item]"` to the console.
+   - Select a random element from the array.
+   - If successful, log the string `"Randomly selected lunch: [Lunch Item]"` to the console, where `[Lunch Item]` is a random element in the array.
    - If the array is empty, log the string `"No lunches available."` to the console.
 
 7. You should create a function `showLunchMenu` that takes an array as its argument and:
-   - If there are lunch items in the array, logs the string `"Menu items: [Lunch Item], [Lunch Item]...` to the console.
+   - If there are elements in the array, logs the string `"Menu items: [Lunch Item], [Lunch Item]...` to the console, where each `[Lunch item]` is one of the elements in the array, in order.
    - If the array is empty, logs the string `"The menu is empty."` to the console.
 
 # --hints--

--- a/curriculum/challenges/english/25-front-end-development/lab-lunch-picker-program/66db529d37ad966480ebb633.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-lunch-picker-program/66db529d37ad966480ebb633.md
@@ -13,7 +13,7 @@ In this lab, you'll build a program that helps in managing lunch options. You'll
 
 **User Stories:**
 
-1. You should create a mutable `lunches` variable and assign it an empty array that will be used to store lunch items.
+1. You should create a `lunches` variable and assign it an empty array that will be used to store lunch items.
 
 2. You should create a function `addLunchToEnd` that takes an array as the first parameter and a string as the second parameter. The function should:
     - add the string to the end of the array
@@ -48,7 +48,7 @@ In this lab, you'll build a program that helps in managing lunch options. You'll
 
 # --hints--
 
-You should declare a mutable variable `lunches` and assign it an empty array to store the lunch items.
+You should declare a variable `lunches` and assign it an empty array to store the lunch items.
 
 ```js
 assert.isArray(lunches);
@@ -331,7 +331,7 @@ try {
 # --solutions--
 
 ```js
-let lunches = [];
+const lunches = [];
 
 // Add a new lunch to the end of the list
 function addLunchToEnd(lunches, newLunch) {
@@ -391,10 +391,10 @@ function showLunchMenu(lunches) {
   }
 }
 
-lunches = addLunchToEnd(lunches, "Tacos");
-lunches = addLunchToStart(lunches, "Sushi");
-lunches = removeLastLunch(lunches);
-lunches = removeFirstLunch(lunches);
+addLunchToEnd(lunches, "Tacos");
+addLunchToStart(lunches, "Sushi");
+removeLastLunch(lunches);
+removeFirstLunch(lunches);
 getRandomLunch(lunches);
 showLunchMenu(lunches);
 

--- a/curriculum/challenges/english/25-front-end-development/lab-lunch-picker-program/66db529d37ad966480ebb633.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-lunch-picker-program/66db529d37ad966480ebb633.md
@@ -26,13 +26,13 @@ In this lab, you'll build a program that helps in managing lunch options. You'll
     - Return the updated array.
 
 4. You should create a function `removeLastLunch` that takes an array as its argument. The function should:
-   - Remove the last lunch item from the array.
+   - Remove the last element from the array.
    - If  the removal is successful, log the string `"[Lunch Item] removed from the end of the lunch menu."` to the console, where `[Lunch Item]` is the element removed from the array.
    - If the array is empty, log the string `"No lunches to remove."` to the console.
    - Return the updated array.
 
 5. You should create a function `removeFirstLunch` that takes an array as its argument. The function should:
-   - Remove the first lunch item from the array.
+   - Remove the first element from the array.
    - If the removal is successful, log the string `"[Lunch Item] removed from the start of the lunch menu."` to the console, where `[Lunch Item]` is the element removed from the array.
    - If the array is empty, log the string `"No lunches to remove."` to the console.
    - Return the updated array.

--- a/curriculum/challenges/english/25-front-end-development/lab-lunch-picker-program/66db529d37ad966480ebb633.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-lunch-picker-program/66db529d37ad966480ebb633.md
@@ -15,36 +15,36 @@ In this lab, you'll build a program that helps in managing lunch options. You'll
 
 1. You should create a `lunches` variable and assign it an empty array that will be used to store lunch items.
 
-2. You should create a function `addLunchToEnd` that takes an array as the first parameter and a string as the second parameter. The function should:
-    - add the string to the end of the array
-    - log the string `"[Lunch Item] added to the end of the lunch menu."`  to the console
-    - return the updated array
+2. You should create a function `addLunchToEnd` that takes an array as the first argument and a string as the second argument. The function should:
+    - Add the string to the end of the array.
+    - Log the string `"[Lunch Item] added to the end of the lunch menu."` to the console.
+    - Return the updated array.
 
-3. You should create a function `addLunchToStart` that takes an array as the first parameter and a string as the second parameter. The function should:
+3. You should create a function `addLunchToStart` that takes an array as the first argument and a string as the second argument. The function should:
     - add the string to the start of the array
     - log the string `"[Lunch Item] added to the start of the lunch menu."` to the console
     - return the updated array
 
-4. You should create a function `removeLastLunch` that takes an array parameter and:
-   - removes the last lunch item from the array
-   - If successful, log the string `"[Lunch Item] removed from the end of the lunch menu."` to the console
-   - If the array is empty, log the string `"No lunches to remove."` to the console
-   - return the updated array
+4. You should create a function `removeLastLunch` that takes an array as its argument. The function should:
+   - Remove the last lunch item from the array.
+   - If  the removal is successful, log the string `"[Lunch Item] removed from the end of the lunch menu."` to the console.
+   - If the array is empty, log the string `"No lunches to remove."` to the console.
+   - Return the updated array.
 
-5. You should create a function `removeFirstLunch` that takes an array parameter and:
-   - removes the first lunch item from the array
-   - If successful, log the string `"[Lunch Item] removed from the start of the lunch menu."` to the console
-   - If the array is empty, log the string `"No lunches to remove."` to the console
-   - return the updated array
+5. You should create a function `removeFirstLunch` that takes an array as its argument. The function should:
+   - Remove the first lunch item from the array.
+   - If the removal is successful, log the string `"[Lunch Item] removed from the start of the lunch menu."` to the console.
+   - If the array is empty, log the string `"No lunches to remove."` to the console.
+   - Return the updated array.
 
-6. You should create a function `getRandomLunch` that takes an array parameter and:
-   - selects a random lunch item from the array
-   - If successful, log the string `"Randomly selected lunch: [Lunch Item]"` to the console
-   - If the array is empty, log the string `"No lunches available."` to the console
+6. You should create a function `getRandomLunch` that takes an array as its argument. The function should:
+   - Select a random lunch item from the array.
+   - If successful, log the string `"Randomly selected lunch: [Lunch Item]"` to the console.
+   - If the array is empty, log the string `"No lunches available."` to the console.
 
-7. You should create a function `showLunchMenu` that takes an array parameter and:
-   - If there are lunch items in the array, log the string `"Menu items: [Lunch Item], [Lunch Item]...` to the console
-   - If the array is empty, log the string `"The menu is empty."` to the console
+7. You should create a function `showLunchMenu` that takes an array as its argument and:
+   - If there are lunch items in the array, logs the string `"Menu items: [Lunch Item], [Lunch Item]...` to the console.
+   - If the array is empty, logs the string `"The menu is empty."` to the console.
 
 # --hints--
 
@@ -60,27 +60,30 @@ You should define a function `addLunchToEnd`.
 assert.isFunction(addLunchToEnd);
 ```
 
-The function `addLunchToEnd` should take 2 arguments.
+The function `addLunchToEnd` should take two arguments.
 
 ```js
 assert.lengthOf(addLunchToEnd, 2);
 ```
 
-`addLunchToEnd(lunches, "Tacos")` should log the string `"Tacos added to the end of the lunch menu."`.
+`addLunchToEnd(lunches, "Tacos")` should log the string `"Tacos added to the end of the lunch menu."` to the console.
 
 ```js
 const tempArr = [];
 const temp = console.log;
+const testLunches = []
 try {
   console.log = obj => tempArr.push(obj);
-  addLunchToEnd(lunches, "Pizza");
-  assert.strictEqual(tempArr[0], "Pizza added to the end of the lunch menu.");
+  addLunchToEnd(testLunches, "Tacos");
+  assert.strictEqual(tempArr[0], "Tacos added to the end of the lunch menu.");
+  addLunchToEnd(testLunches, "Pizza");
+  assert.strictEqual(tempArr[1], "Pizza added to the end of the lunch menu.");
 } finally {
   console.log = temp;
 }
 ```
 
-The function `addLunchToEnd` should return the correct array.
+`addLunchToEnd(["Pizza", "Tacos"], "Burger")` should return `["Pizza", "Tacos", "Burger"]`.
 
 ```js
 lunches = ["Fries"]
@@ -99,7 +102,7 @@ The function `addLunchToStart` should take two arguments.
 assert.lengthOf(addLunchToStart, 2);
 ```
 
-`addLunchToStart(lunches, "Sushi")` should log the string `"Sushi added to the start of the lunch menu."`.
+`addLunchToStart(lunches, "Sushi")` should log the string `"Sushi added to the start of the lunch menu."` to the console.
 
 ```js
 const tempArr = [];
@@ -132,7 +135,7 @@ The function `removeLastLunch` should take one argument.
 assert.lengthOf(removeLastLunch, 1);
 ```
 
-When the input array is empty, the function `removeLastLunch` should log the string `"No lunches to remove."`.
+When the input array is empty, the function `removeLastLunch` should log the string `"No lunches to remove."` to the console.
 
 ```js
 lunches = [];
@@ -147,7 +150,7 @@ try {
 }
 ```
 
-When `lunches = ["Stew", "Soup", "Toast"]`, `removeLastLunch(lunches)` should log the string `"Toast removed from the end of the lunch menu."`.
+When `lunches = ["Stew", "Soup", "Toast"]`, `removeLastLunch(lunches)` should log the string `"Toast removed from the end of the lunch menu."` to the console.
 
 ```js
 lunches = ["Fries", "Tacos", "Noodles"];
@@ -172,16 +175,16 @@ assert.deepStrictEqual(removeLastLunch(lunches), ["Pizza"]);
 You should define a function `removeFirstLunch`.
 
 ```js
-assert.isFunction(removeFirstLunch)
+assert.isFunction(removeFirstLunch);
 ```
 
-The function `removeFirstLunch` should take one argument.
+The function `removeFirstLunch` should take a single argument.
 
 ```js
 assert.lengthOf(removeFirstLunch, 1);
 ```
 
-When the input array is empty, the function `removeFirstLunch` should log the string `"No lunches to remove."`.
+When the input array is empty, the function `removeFirstLunch` should log the string `"No lunches to remove."` to the console.
 
 ```js
 lunches = [];
@@ -196,7 +199,7 @@ try {
 }
 ```
 
-When `lunches = ["Salad", "Eggs", "Cheese"]`, `removeFirstLunch(lunches)` should log the string `"Salad removed from the start of the lunch menu."`.
+When `lunches = ["Salad", "Eggs", "Cheese"]`, `removeFirstLunch(lunches)` should log the string `"Salad removed from the start of the lunch menu."` to the console.
 
 ```js
 lunches = ["Stew", "Soup", "Toast"];
@@ -224,13 +227,13 @@ You should define a function `getRandomLunch`.
 assert.isFunction(getRandomLunch);
 ```
 
-The function `getRandomLunch` should take one argument.
+The function `getRandomLunch` should take a single argument.
 
 ```js
 assert.lengthOf(getRandomLunch, 1);
 ```
 
-When the input array is empty, the function `getRandomLunch` should log the string `"No lunches available."`.
+When the input array is empty, the function `getRandomLunch` should log the string `"No lunches available."` to the console.
 
 ```js
 lunches = [];
@@ -245,7 +248,7 @@ try {
 }
 ```
 
-When `lunches = ["Fish", "Fries", "Roast"]`, the function `getRandomLunch` should log a string in the format `"Randomly selected lunch: [Lunch Item]"`.
+When `lunches = ["Fish", "Fries", "Roast"]`, the function `getRandomLunch` should log a string in the format `"Randomly selected lunch: [Lunch Item]"` to the console.
 
 ```js
 lunches = ["Salad", "Eggs", "Cheese"];
@@ -284,13 +287,13 @@ You should define a function `showLunchMenu`.
 assert.isFunction(showLunchMenu);
 ```
 
-The function `showLunchMenu` should take one argument.
+The function `showLunchMenu` should take a single argument.
 
 ```js
 assert.lengthOf(showLunchMenu, 1);
 ```
 
-When the input array is empty, the function `showLunchMenu` should log the string `"The menu is empty."`.
+When the input array is empty, the function `showLunchMenu` should log the string `"The menu is empty."` to the console.
 
 ```js
 lunches = [];
@@ -305,7 +308,7 @@ try {
 }
 ```
 
-When `lunches = ["Greens", "Corns", "Beans"]`, the function `showLunchMenu` should log a string in the format `"Menu items: Greens, Corns, Beans"`.
+When `lunches = ["Greens", "Corns", "Beans"]`, the function `showLunchMenu` should log a string in the format `"Menu items: Greens, Corns, Beans"` to the console.
 
 ```js
 lunches = ["Pizza", "Burger", "Fries"];


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #57970 

<!-- Feel free to add any additional description of changes below this line -->
Work done:
- Fixed the direct use of global `lunches` variable.
- Updated the user story
- Updated the hints
- Added extra tests to check:
  - Correct number of parameters
  - Console log
  - Correct return array
- Updated the solution