### PR TITLE
fix(curriculum): fixed typo 'targerts' in workshop card

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-greeting-card/67333aa0e231d43e7556c644.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-greeting-card/67333aa0e231d43e7556c644.md
@@ -7,7 +7,7 @@ dashedName: step-22
 
 # --description--
 
-Add a new selector that targerts the `.card-links a` elements when they are active. Set the `background-color` to `midnightblue`.
+Add a new selector that targets the `.card-links a` elements when they are active. Set the `background-color` to `midnightblue`.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ x] My pull request targets the `main` branch of freeCodeCamp.
- [ x] I have tested these changes either locally on my machine, or GitPod.



Closes #58001

A very simple fix for changing typo 'targerts' to targets