### PR TITLE
feat(client): add transcript option in fill in the blank challenges

### DIFF
--- a/client/src/templates/Challenges/fill-in-the-blank/show.tsx
+++ b/client/src/templates/Challenges/fill-in-the-blank/show.tsx
@@ -21,6 +21,7 @@ import ChallegeExplanation from '../components/challenge-explanation';
 import CompletionModal from '../components/completion-modal';
 import HelpModal from '../components/help-modal';
 import FillInTheBlanks from '../components/fill-in-the-blanks';
+import ChallengeTranscript from '../components/challenge-transcript';
 import PrismFormatted from '../components/prism-formatted';
 import {
   challengeMounted,
@@ -80,6 +81,7 @@ const ShowFillInTheBlank = ({
         description,
         instructions,
         explanation,
+        transcript,
         superBlock,
         block,
         translationPending,
@@ -209,6 +211,8 @@ const ShowFillInTheBlank = ({
             {scene && <Scene scene={scene} sceneSubject={sceneSubject} />}
 
             <Col md={8} mdOffset={2} sm={10} smOffset={1} xs={12}>
+              {transcript && <ChallengeTranscript transcript={transcript} />}
+
               {instructions && (
                 <>
                   <PrismFormatted text={instructions} />
@@ -290,6 +294,7 @@ export const query = graphql`
             feedback
           }
         }
+        transcript
         scene {
           setup {
             background


### PR DESCRIPTION
This allows transcripts to be added to fill in the blank challenges. Add this in the challenge to see:

```
# --transcript--

Here's the transcript
```

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
