### PR TITLE
fix(client): profile image overlapping privacy settings callout

### DIFF
--- a/client/src/components/profile/profile.tsx
+++ b/client/src/components/profile/profile.tsx
@@ -45,7 +45,7 @@ const UserMessage = ({ t }: Pick<MessageProps, 't'>) => {
   return (
     <FullWidthRow>
       <Alert variant='info'>{t('profile.you-change-privacy')}</Alert>
-      <Spacer size='m' />
+      <Spacer size='xl' />
     </FullWidthRow>
   );
 };


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR fixes an issue on the profile page, in that the profile image is overlapping privacy settings callout. 

The issue happens because the image has `position: absolute` and `top: -160px` set, so the fix is to increase the space between the callout and the div that the image anchors on, to accommodate for the space the image needs to take.

| Before | After |
| --- | --- |
| <img width="782" alt="Screenshot 2025-01-10 at 05 39 16" src="https://github.com/user-attachments/assets/06904189-329b-4f03-98a5-13f184be7eb4" /> | <img width="787" alt="Screenshot 2025-01-10 at 05 38 43" src="https://github.com/user-attachments/assets/04505fc1-ab27-446a-bf16-96529a7051ae" /> |

<!-- Feel free to add any additional description of changes below this line -->
