### PR TITLE
fix(curriculum): fix grammatical error in CSS Grid Review

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/review-css-grid/671a99394bedfb9a5bc687c4.md
+++ b/curriculum/challenges/english/25-front-end-development/review-css-grid/671a99394bedfb9a5bc687c4.md
@@ -11,7 +11,7 @@ Review the concepts below to prepare for the upcoming quiz.
 
 ## CSS Grid Basics 
 
-- **Definition**: CSS Grid is a two dimensional layout system used to create complex layouts in web pages. Grids will have rows and columns with gaps between them. To defined a grid layout, you would set the `display` property to `grid`. 
+- **Definition**: CSS Grid is a two dimensional layout system used to create complex layouts in web pages. Grids will have rows and columns with gaps between them. To define a grid layout, you would set the `display` property to `grid`.
 
 ```css
 .container {

--- a/curriculum/challenges/english/25-front-end-development/review-css/671a9a0a140c2b9d6a75629f.md
+++ b/curriculum/challenges/english/25-front-end-development/review-css/671a9a0a140c2b9d6a75629f.md
@@ -469,7 +469,7 @@ Review the concepts below to prepare for the upcoming exam.
 
 ## CSS Grid Basics 
 
-- **Definition**: CSS Grid is a two dimensional layout system used to create complex layouts in web pages. Grids will have rows and columns with gaps between them. To defined a grid layout, you would set the `display` property to `grid`. 
+- **Definition**: CSS Grid is a two dimensional layout system used to create complex layouts in web pages. Grids will have rows and columns with gaps between them. To define a grid layout, you would set the `display` property to `grid`.
 - **The `fr` (Fractional) Unit**: This unit represents a fraction of the space within the grid container. You can use the `fr` unit to create flexible grids.
 - **Creating Gaps Between Tracks**: There are three ways to create gaps between tracks in CSS grid. You can use the `column-gap` property to create gaps between columns. You can use the `row-gap` property to create gaps between rows. Or you can use the `gap` shorthand property to create gaps between both rows and columns.
 - **`repeat()` Function**: This function is used to repeat sections in the track listing. Instead of writing `grid-template-columns: 1fr 1fr 1fr;` you can use the `repeat()` function instead. 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #58037

<!-- Feel free to add any additional description of changes below this line -->
Fix grammatical error in CSS Grid Review. I also find and fix the same sentence in the CSS Review.

Before
To **defined** a grid layout, you would set the display property to grid.
After
To **define** a grid layout, you would set the display property to grid.

https://www.freecodecamp.org/learn/full-stack-developer/review-css-grid/review-css-grid
![prCapture1](https://github.com/user-attachments/assets/af09d256-824e-4741-8da7-0bc601c37da2)
https://www.freecodecamp.org/learn/full-stack-developer/review-css/review-css
![prCapture2](https://github.com/user-attachments/assets/62bbf0b4-c10f-4486-96d9-2dc3a4c396c3)

