### PR TITLE
fix(client): prevent scene audio from stopping early

### DIFF
--- a/client/src/redux/prop-types.ts
+++ b/client/src/redux/prop-types.ts
@@ -130,8 +130,8 @@ interface SetupCharacter {
 interface SetupAudio {
   filename: string;
   startTime: number;
-  startTimestamp?: number;
-  finishTimestamp?: number;
+  startTimestamp: number | null;
+  finishTimestamp: number | null;
 }
 
 interface SceneSetup {

--- a/client/src/templates/Challenges/components/scene/scene.tsx
+++ b/client/src/templates/Challenges/components/scene/scene.tsx
@@ -42,7 +42,7 @@ export function Scene({
   // if there are timestamps, we use the difference between them as the duration
   // if not, we assume we're playing the whole audio file.
   const duration =
-    audio.startTimestamp !== undefined && audio.finishTimestamp !== undefined
+    audio.startTimestamp !== null && audio.finishTimestamp !== null
       ? sToMs(audio.finishTimestamp - audio.startTimestamp)
       : Infinity;
 

--- a/client/src/templates/Challenges/components/scene/scene.tsx
+++ b/client/src/templates/Challenges/components/scene/scene.tsx
@@ -188,8 +188,8 @@ export function Scene({
             const audioCurrentTime = sToMs(audioRef.current.currentTime);
             const remainingTime = endTimeStamp - audioCurrentTime;
             // For some reason, despite the setTimeout resolving at the right
-            // time, the currentTime is smaller than expected. That means that
-            // if we pause now it will cut off the last part.
+            // time, the currentTime can be smaller than expected. That means
+            // that if we pause now it will cut off the last part.
             if (remainingTime < 100) {
               // 100ms is arbitrary and may need to be adjusted if people still
               // notice the cut off

--- a/client/src/templates/Challenges/components/scene/scene.tsx
+++ b/client/src/templates/Challenges/components/scene/scene.tsx
@@ -109,8 +109,9 @@ export function Scene({
   const [dialogue, setDialogue] = useState(initDialogue);
   const [background, setBackground] = useState(initBackground);
   const startRef = useRef<number>(0);
-  const startTimerRef = useRef<number>(0);
-  const finishTimerRef = useRef<number>(Number.MAX_SAFE_INTEGER);
+  const startTimerRef = useRef<number>();
+  const finishTimerRef = useRef<number>();
+  const animationRef = useRef<number>();
 
   const [currentTime, setCurrentTime] = useState(0);
   // TODO: I'm using a ref so that the maybeStopAudio closure doesn't get stuck
@@ -155,8 +156,9 @@ export function Scene({
       const time = Date.now() - startRef.current;
       setCurrentTime(time);
 
-      if (isPlayingSceneRef.current)
-        window.requestAnimationFrame(updateCurrentTime);
+      if (isPlayingSceneRef.current) {
+        animationRef.current = window.requestAnimationFrame(updateCurrentTime);
+      }
     };
     // TODO: if we manage the playing state in another module, we should not
     // need the early return here. It should not be possible for this to be
@@ -214,8 +216,11 @@ export function Scene({
 
   useEffect(() => {
     return () => {
-      if (startTimerRef.current) clearTimeout(startTimerRef.current);
-      if (finishTimerRef.current) clearTimeout(finishTimerRef.current);
+      clearTimeout(startTimerRef.current);
+      clearTimeout(finishTimerRef.current);
+      // @ts-expect-error cancelAnimationFrame accepts undefined, but TS doesn't
+      // know that
+      window.cancelAnimationFrame(animationRef.current);
     };
   }, []);
 

--- a/client/src/templates/Challenges/components/scene/scene.tsx
+++ b/client/src/templates/Challenges/components/scene/scene.tsx
@@ -216,19 +216,7 @@ export function Scene({
     return () => {
       sceneSubject.detach(playScene);
     };
-  }, [
-    currentTime,
-    isPlaying,
-    duration,
-    sceneSubject,
-    sceneIsReady,
-    commands,
-    audio,
-    hasTimestamps,
-    initCharacters,
-    initBackground,
-    audioTimestamp
-  ]);
+  }, [isPlaying, duration, sceneSubject, sceneIsReady, audio, hasTimestamps]);
 
   useEffect(() => {
     return () => {

--- a/client/src/templates/Challenges/components/scene/scene.tsx
+++ b/client/src/templates/Challenges/components/scene/scene.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useRef, useMemo } from 'react'; //, ReactElement } from 'react';
 import { Col, Spacer } from '@freecodecamp/ui';
+import { isEmpty } from 'lodash-es';
 import { useTranslation } from 'react-i18next';
 import { FullScene } from '../../../../redux/prop-types';
 import { Loader } from '../../../../components/helpers';
@@ -223,6 +224,8 @@ export function Scene({
   }, []);
 
   useEffect(() => {
+    if (isEmpty(sortedCommands)) return;
+
     const resetScene = () => {
       const { current } = audioRef;
       usedCommandsRef.current.clear();

--- a/client/src/templates/Challenges/components/scene/scene.tsx
+++ b/client/src/templates/Challenges/components/scene/scene.tsx
@@ -121,7 +121,7 @@ export function Scene({
   const isPlayingSceneRef = useRef(false);
 
   // memoizing to prevent the useEffect from running on every render
-  const normalizedCommands = useMemo(() => {
+  const sortedCommands = useMemo(() => {
     const normalized = commands.flatMap(command => {
       const { startTime, finishTime, ...rest } = command;
 
@@ -242,7 +242,7 @@ export function Scene({
       setBackground(initBackground);
     };
 
-    normalizedCommands.forEach((command, commandIndex) => {
+    sortedCommands.forEach((command, commandIndex) => {
       // Start command timeout
       if (
         currentTime > command.time &&
@@ -275,8 +275,7 @@ export function Scene({
     });
 
     // an extra 500ms at the end to let the characters fade out (CSS transition
-    const resetTime =
-      normalizedCommands[normalizedCommands.length - 1].time + 500;
+    const resetTime = sortedCommands[sortedCommands.length - 1].time + 500;
 
     // TODO: this has to be _after_ the normalizedCommands.forEach, otherwise
     // the usedCommandsRef will be cleared and immediately refilled. This kind
@@ -288,7 +287,7 @@ export function Scene({
     currentTime,
     audio,
     audioTimestamp,
-    normalizedCommands,
+    sortedCommands,
     initCharacters,
     initBackground
   ]);

--- a/client/src/templates/Challenges/components/scene/scene.tsx
+++ b/client/src/templates/Challenges/components/scene/scene.tsx
@@ -112,6 +112,7 @@ export function Scene({
   const startTimerRef = useRef<number>();
   const finishTimerRef = useRef<number>();
   const animationRef = useRef<number>();
+  const usedCommandsRef = useRef(new Set<number>());
 
   const [currentTime, setCurrentTime] = useState(0);
   // TODO: I'm using a ref so that the maybeStopAudio closure doesn't get stuck
@@ -141,8 +142,6 @@ export function Scene({
 
   // an extra 500ms at the end to let the characters fade out (CSS transition
   const resetTime = sortedCommands.at(-1)!.time + 500;
-
-  const usedCommandsRef = useRef(new Set<number>());
 
   const audioLoaded = () => {
     setSceneIsReady(true);
@@ -264,14 +263,11 @@ export function Scene({
         });
       }
     });
-  }, [currentTime, sortedCommands]);
 
-  useEffect(() => {
-    // TODO: this has to be _after_ the normalizedCommands.forEach, otherwise
-    // the usedCommandsRef will be cleared and immediately refilled. This kind
-    // of temporal coupling is a bit fragile.
+    // resetScene only works if called AFTER the commands, otherwise the
+    // commands will undo the reset.
     if (currentTime >= resetTime) resetScene();
-  }, [currentTime, resetTime, resetScene]);
+  }, [currentTime, resetTime, sortedCommands, resetScene]);
 
   useEffect(() => {
     return () => {

--- a/client/src/templates/Challenges/components/scene/scene.tsx
+++ b/client/src/templates/Challenges/components/scene/scene.tsx
@@ -11,9 +11,7 @@ import { SceneSubject } from './scene-subject';
 
 import './scene.css';
 
-const sToMs = (n: number) => {
-  return n * 1000;
-};
+const sToMs = (n: number) => n * 1000;
 
 const loadImage = (src: string | null) => {
   if (src) new Image().src = src;

--- a/client/src/templates/Challenges/components/scene/scene.tsx
+++ b/client/src/templates/Challenges/components/scene/scene.tsx
@@ -241,8 +241,14 @@ export function Scene({
       setBackground(initBackground);
     };
 
-    // TODO: set each command once. Currently it only checks to see if the
-    // command should have started, not if another supercedes it.
+    // an extra 500ms at the end to let the characters fade out (CSS transition
+    const resetTime =
+      normalizedCommands[normalizedCommands.length - 1].time + 500;
+
+    if (currentTime >= resetTime) {
+      resetScene();
+    }
+
     normalizedCommands.forEach((command, commandIndex) => {
       // Start command timeout
       if (
@@ -272,17 +278,6 @@ export function Scene({
           });
           return newCharacters;
         });
-      }
-
-      // Last command timeout
-      // an extra 500ms at the end to let the characters fade out (CSS transition)
-      const resetTime = command.time + 500;
-
-      if (
-        currentTime >= resetTime &&
-        commandIndex === normalizedCommands.length - 1
-      ) {
-        resetScene();
       }
     });
   }, [

--- a/client/src/templates/Challenges/components/scene/scene.tsx
+++ b/client/src/templates/Challenges/components/scene/scene.tsx
@@ -236,6 +236,7 @@ export function Scene({
         current.currentTime = audio.startTimestamp || 0;
       }
 
+      setCurrentTime(0);
       setIsPlaying(false);
       isPlayingSceneRef.current = false;
       setShowDialogue(false);
@@ -243,14 +244,6 @@ export function Scene({
       setCharacters(initCharacters);
       setBackground(initBackground);
     };
-
-    // an extra 500ms at the end to let the characters fade out (CSS transition
-    const resetTime =
-      normalizedCommands[normalizedCommands.length - 1].time + 500;
-
-    if (currentTime >= resetTime) {
-      resetScene();
-    }
 
     normalizedCommands.forEach((command, commandIndex) => {
       // Start command timeout
@@ -283,6 +276,17 @@ export function Scene({
         });
       }
     });
+
+    // an extra 500ms at the end to let the characters fade out (CSS transition
+    const resetTime =
+      normalizedCommands[normalizedCommands.length - 1].time + 500;
+
+    // TODO: this has to be _after_ the normalizedCommands.forEach, otherwise
+    // the usedCommandsRef will be cleared and immediately refilled. This kind
+    // of temporal coupling is a bit fragile.
+    if (currentTime >= resetTime) {
+      resetScene();
+    }
   }, [
     currentTime,
     audio,

--- a/client/src/templates/Challenges/components/scene/scene.tsx
+++ b/client/src/templates/Challenges/components/scene/scene.tsx
@@ -275,7 +275,7 @@ export function Scene({
     });
 
     // an extra 500ms at the end to let the characters fade out (CSS transition
-    const resetTime = sortedCommands[sortedCommands.length - 1].time + 500;
+    const resetTime = sortedCommands.at(-1)!.time + 500;
 
     // TODO: this has to be _after_ the normalizedCommands.forEach, otherwise
     // the usedCommandsRef will be cleared and immediately refilled. This kind

--- a/client/src/templates/Challenges/components/scene/scene.tsx
+++ b/client/src/templates/Challenges/components/scene/scene.tsx
@@ -227,15 +227,9 @@ export function Scene({
     if (isEmpty(sortedCommands)) return;
 
     const resetScene = () => {
-      const { current } = audioRef;
       usedCommandsRef.current.clear();
       pause();
-      if (current) {
-        current.src = `${sounds}/${audio.filename}${audioTimestamp}`;
-        current.load();
-        current.currentTime = audio.startTimestamp || 0;
-      }
-
+      audioRef.current.currentTime = audio.startTimestamp || 0;
       setCurrentTime(0);
       setIsPlaying(false);
       isPlayingSceneRef.current = false;

--- a/client/src/templates/Challenges/components/scene/scene.tsx
+++ b/client/src/templates/Challenges/components/scene/scene.tsx
@@ -115,8 +115,6 @@ export function Scene({
   const finishTimerRef = useRef<number>(Number.MAX_SAFE_INTEGER);
 
   const [currentTime, setCurrentTime] = useState(0);
-  // TODO: can we avoid having both a ref and a state for currentTime?
-  const currentTimeRef = useRef(currentTime);
   // TODO: I'm using a ref so that the maybeStopAudio closure doesn't get stuck
   // with the initial value of isPlaying. Given that we also have a state,
   // isPlaying, it feels like there's a better way.
@@ -158,7 +156,6 @@ export function Scene({
     const updateCurrentTime = () => {
       const time = Date.now() - startRef.current;
       setCurrentTime(time);
-      currentTimeRef.current = time;
 
       if (isPlayingSceneRef.current)
         window.requestAnimationFrame(updateCurrentTime);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Okay, the plan was to roll the feature into this PR, but it's already quite a big change to how scene operates and (tentatively) fixes the bug where the audio could get cut off early. I'll finish the refactor, but I suspect this will be enough for one PR. Edit: yep, it was.

<!-- Feel free to add any additional description of changes below this line -->
