### PR TITLE
fix(curriculum): Create greyscale CSS filter property

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-transforms-overflow-and-filters/672bccebe1fc82d911c3f078.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-transforms-overflow-and-filters/672bccebe1fc82d911c3f078.md
@@ -18,7 +18,7 @@ Which of the following CSS rules would make an image completely grayscale?
 
 ## --answers--
 
-`filter: grayscale(1);`
+`filter: grayscale(100%);`
 
 ---
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #58031

<!-- Feel free to add any additional description of changes below this line -->

PR updates the grayscale filter value in the CSS filter property challenge to use percentage notation (100%) instead of decimal notation (1) to better align with the video content.
