### PR TITLE
fix(curriculum): tests in availability table lab

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-availability-table/66b36358ed4f261d64840c24.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-availability-table/66b36358ed4f261d64840c24.md
@@ -62,8 +62,9 @@ assert.isAtLeast(document.querySelectorAll('tr:first-child>th').length, 3)
 The first row in your table should not contain `td` elements.
 
 ```js
-assert.isNotNull(document.querySelector('tr:first-child'));
-assert.isEmpty(document.querySelectorAll('tr:first-child>td'));
+const firstRow = document.querySelector('tr');
+assert.isNotNull(firstRow);
+assert.isEmpty(firstRow.querySelectorAll('td'));
 ```
 
 You should have at least two rows with the class of `sharp`.
@@ -289,8 +290,12 @@ You should use two color-stops (expressed in percentage) to make the transition 
 
 ```js
 const legendGradient = new __helpers.CSSHelp(document).getStyle('#legend-gradient');
-assert.exists(legendGradient); 
-assert.lengthOf(legendGradient.backgroundImage.match(/var\(\s*--color[0-5]\s*\)\s+\d+%\s+\d+%/g), 6)
+assert.exists(legendGradient);
+const matched = legendGradient.backgroundImage.match(/var\(\s*--color[0-5]\s*\)\s+\d+%(\s+\d+%)?/g);
+assert.lengthOf(matched, 6);
+matched.forEach((arg, i) => {
+  if (i !== 0 && i !== 5) assert.lengthOf(arg.match(/%/g), 2);
+})
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
- Fixed test to select correct `tr` no matter you use `thead`, `tbody` or neither of them. See [this](https://forum.freecodecamp.org/t/full-stack-dev-build-an-availability-table-test-bug/729199) for context.
- Allow first and last var argument of `linear-gradient` to have a single color stop.