### PR TITLE
feat(tools): add a seed verification section to the template

### DIFF
--- a/tools/challenge-helper-scripts/helpers/get-challenge-template.ts
+++ b/tools/challenge-helper-scripts/helpers/get-challenge-template.ts
@@ -57,6 +57,14 @@ Test 1
 
 \`\`\`
 
+# --seed-verification--
+
+Verifier 1
+
+\`\`\`js
+
+\`\`\`
+
 # --seed--
 
 \`\`\`js

--- a/tools/challenge-helper-scripts/helpers/get-step-template.test.ts
+++ b/tools/challenge-helper-scripts/helpers/get-step-template.test.ts
@@ -24,6 +24,14 @@ Test 1
 
 \`\`\`
 
+# --seed-verification--
+
+Verifier 1
+
+\`\`\`js
+
+\`\`\`
+
 # --seed--
 
 ## --seed-contents--

--- a/tools/challenge-helper-scripts/helpers/get-step-template.ts
+++ b/tools/challenge-helper-scripts/helpers/get-step-template.ts
@@ -92,6 +92,11 @@ ${stepDescription}
 Test 1
 
 ${getCodeBlock('js')}
+# --seed-verification--
+
+Verifier 1
+
+${getCodeBlock('js')}
 # --seed--` +
     seedChallengeSection +
     seedHeadSection +

--- a/tools/challenge-parser/parser/__fixtures__/with-broken-seed-tests.md
+++ b/tools/challenge-parser/parser/__fixtures__/with-broken-seed-tests.md
@@ -22,29 +22,21 @@ First hint
 // test code
 ```
 
+
 Second hint with <code>code</code>
 
 ```js
 // more test code
 ```
 
-Third *hint* with <code>code</code> and `inline code`
-
-```js
-// more test code
-if(let x of xs) {
-  console.log(x);
-}
-```
-
 # --seed-verification--
-
-First hint
 
 ```js
 // test code
 ```
 
+First hint
+
 Second hint with <code>code</code>
 
 ```js
@@ -53,16 +45,8 @@ Second hint with <code>code</code>
 
 Third *hint* with <code>code</code> and `inline code`
 
-```js
-// more test code
-if(let x of xs) {
-  console.log(x);
-}
-```
 
 # --seed--
-
-## --seed-contents--
 
 ```html
 <html>

--- a/tools/challenge-parser/parser/__fixtures__/with-missing-verifier.md
+++ b/tools/challenge-parser/parser/__fixtures__/with-missing-verifier.md
@@ -1,0 +1,5 @@
+# --seed-verification--
+
+First hint
+
+Whoops, this should have been a test code block

--- a/tools/challenge-parser/parser/plugins/__snapshots__/add-seed-verification.test.js.snap
+++ b/tools/challenge-parser/parser/plugins/__snapshots__/add-seed-verification.test.js.snap
@@ -2,11 +2,27 @@
 
 exports[`add-seed-verification plugin should have an output to match the snapshot 1`] = `
 {
-  "tests": [],
+  "tests": [
+    {
+      "testString": "// test code",
+      "text": "<p>First hint</p>",
+    },
+    {
+      "testString": "// more test code",
+      "text": "<p>Second hint with <code>code</code></p>",
+    },
+    {
+      "testString": "// more test code
+if(let x of xs) {
+  console.log(x);
+}",
+      "text": "<p>Third <em>hint</em> with <code>code</code> and <code>inline code</code></p>",
+    },
+  ],
 }
 `;
 
-exports[`add-seed-verification plugin should have an output to match the snapshot 1`] = `
+exports[`add-tests plugin should have an output to match the snapshot 1`] = `
 {
   "tests": [
     {

--- a/tools/challenge-parser/parser/plugins/__snapshots__/add-seed-verification.test.js.snap
+++ b/tools/challenge-parser/parser/plugins/__snapshots__/add-seed-verification.test.js.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`add-seed-verification plugin should have an output to match the snapshot 1`] = `
+{
+  "tests": [],
+}
+`;
+
+exports[`add-seed-verification plugin should have an output to match the snapshot 1`] = `
+{
+  "tests": [
+    {
+      "testString": "// test code",
+      "text": "<p>First hint</p>",
+    },
+    {
+      "testString": "// more test code",
+      "text": "<p>Second hint with <code>code</code></p>",
+    },
+    {
+      "testString": "// more test code
+if(let x of xs) {
+  console.log(x);
+}",
+      "text": "<p>Third <em>hint</em> with <code>code</code> and <code>inline code</code></p>",
+    },
+  ],
+}
+`;

--- a/tools/challenge-parser/parser/plugins/add-seed-verification.js
+++ b/tools/challenge-parser/parser/plugins/add-seed-verification.js
@@ -1,0 +1,32 @@
+const chunk = require('lodash/chunk');
+const { getSection } = require('./utils/get-section');
+const mdastToHtml = require('./utils/mdast-to-html');
+
+function plugin() {
+  return transformer;
+
+  function transformer(tree, file) {
+    const hintNodes = getSection(tree, '--seed-verification--');
+    if (hintNodes.length % 2 !== 0)
+      throw Error('Verifiers must be in (text, ```testString```) order');
+
+    const tests = chunk(hintNodes, 2).map(getTest);
+    file.data.tests = tests;
+  }
+}
+
+function getTest(hintNodes) {
+  const [textNode, testStringNode] = hintNodes;
+  const text = mdastToHtml([textNode]);
+  const testString = testStringNode.value;
+
+  if (!text) throw Error('text is missing from seed verifier');
+  // stub tests (i.e. text, but no testString) are allowed, but the md must
+  // have a code block, even if it is empty.
+  if (!testString && testString !== '')
+    throw Error('testString (code block) is missing from seed verifier');
+
+  return { text, testString };
+}
+
+module.exports = plugin;

--- a/tools/challenge-parser/parser/plugins/add-seed-verification.test.js
+++ b/tools/challenge-parser/parser/plugins/add-seed-verification.test.js
@@ -1,0 +1,82 @@
+const parseFixture = require('../__fixtures__/parse-fixture');
+const addTests = require('./add-seed-verification');
+
+describe('add-tests plugin', () => {
+  let brokenHintsAST, simpleAST, missingTestStringAST;
+  const plugin = addTests();
+  let file = { data: {} };
+
+  beforeAll(async () => {
+    simpleAST = await parseFixture('simple.md');
+    brokenHintsAST = await parseFixture('with-broken-seed-tests.md');
+    missingTestStringAST = await parseFixture('with-missing-verifier.md');
+  });
+
+  beforeEach(() => {
+    file = { data: {} };
+  });
+
+  it('returns a function', () => {
+    expect(typeof plugin).toEqual('function');
+  });
+
+  it('adds a `tests` property to `file.data`', () => {
+    plugin(simpleAST, file);
+
+    expect('tests' in file.data).toBe(true);
+  });
+
+  it('adds test objects to the tests array following a schema', () => {
+    expect.assertions(5);
+    plugin(simpleAST, file);
+    const testObject = file.data.tests[0];
+    expect(Object.keys(testObject).length).toBe(2);
+    expect(testObject).toHaveProperty('testString');
+    expect(typeof testObject.testString).toBe('string');
+    expect(testObject).toHaveProperty('text');
+    expect(typeof testObject.text).toBe('string');
+  });
+
+  // TODO: make this a bit more robust and informative
+  it('should throw if a test pair is out of order', () => {
+    // TODO: update the markdown so it makes this error
+    expect(() => plugin(brokenHintsAST, file)).toThrow(
+      'Verifiers must be in (text, ```testString```) order'
+    );
+  });
+
+  it('should throw if a verification string is not found', () => {
+    expect(() => plugin(missingTestStringAST, file)).toThrow(
+      'testString (code block) is missing from seed verifier'
+    );
+  });
+
+  it('preserves code whitespace in testStrings', () => {
+    plugin(simpleAST, file);
+    const testObject = file.data.tests[2];
+    expect(testObject.testString).toBe(`// more test code
+if(let x of xs) {
+  console.log(x);
+}`);
+  });
+
+  it('does not encode html', () => {
+    plugin(simpleAST, file);
+    const testObject = file.data.tests[1];
+    expect(testObject.text).toBe('<p>Second hint with <code>code</code></p>');
+  });
+
+  it('converts test text from md to html', () => {
+    plugin(simpleAST, file);
+    const testObject = file.data.tests[2];
+    expect(testObject.text).toBe(
+      '<p>Third <em>hint</em> with <code>code</code>' +
+        ' and <code>inline code</code></p>'
+    );
+  });
+
+  it('should have an output to match the snapshot', () => {
+    plugin(simpleAST, file);
+    expect(file.data).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #55570

<!-- Feel free to add any additional description of changes below this line -->
I chose solution number 3, which was a new section for tests that explicitly make sure the seed passes. This section is called `seed-verification`. I believe I still have to 


I think I might want some help with making sure the snapshot is right and triple checking things. As is I need to add some entries into the template list so we know the numbers are reserved.  

There's also the matter of integrating it into the test-runner I need to resolve.    