### PR TITLE
Correct use of CSS variable in quiz

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-basic-css-by-building-a-cafe-menu/5f33294a6af5e9188dbdb8f3.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-basic-css-by-building-a-cafe-menu/5f33294a6af5e9188dbdb8f3.md
@@ -44,7 +44,7 @@ assert(main.parentElement.tagName === 'BODY');
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="utf-8" />
+    <meta charset="utf-8">
     <title>Cafe Menu</title>
   </head>
 --fcc-editable-region--

--- a/curriculum/challenges/english/25-front-end-development/quiz-css-colors/66ed8fe1f45ce3ece4053eb1.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-css-colors/66ed8fe1f45ce3ece4053eb1.md
@@ -493,11 +493,11 @@ body {
 
 ```css
 :root {
-  --primary-color: blue;
+  --primary: blue;
 }
 
 .element1, .element2 {
-  color: var(--primary-color);
+  color: var(--primary);
 }
-```
+
 


### PR DESCRIPTION
This pull request fixes the issue with the use of CSS variables in the quiz.
Specifically, the --primary variable definition and its usage were corrected.
This change ensures that the correct solution is shown, which was previously listed as a distractor.

