### PR TITLE
fix(curriculum): intiialize mathjax in classic challenge editor

### DIFF
--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -65,7 +65,7 @@ import {
   makePrismCollapsible,
   setScrollbarArrowStyles
 } from '../utils/index';
-import { initializeMathJax } from '../../../utils/math-jax';
+import { initializeMathJax, isMathJaxAllowed } from '../../../utils/math-jax';
 import { getScrollbarWidth } from '../../../utils/scrollbar-width';
 import { isProjectBased } from '../../../utils/curriculum-layout';
 import LowerJaw from './lower-jaw';
@@ -404,7 +404,9 @@ const Editor = (props: EditorProps): JSX.Element => {
       addContentChangeListener();
       resetAttempts();
       showEditableRegion(editor);
-      initializeMathJax();
+      if (isMathJaxAllowed(props.superBlock)) {
+        initializeMathJax();
+      }
     }
 
     const storedAccessibilityMode = () => {
@@ -768,6 +770,9 @@ const Editor = (props: EditorProps): JSX.Element => {
     const desc = document.createElement('div');
     const descContainer = document.createElement('div');
     descContainer.classList.add('description-container');
+    if (isMathJaxAllowed(props.superBlock)) {
+      descContainer.classList.add('mathjax-support');
+    }
     domNode.classList.add('editor-upper-jaw');
     domNode.appendChild(descContainer);
     if (isMobileLayout) descContainer.appendChild(createBreadcrumb());


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #58082

<!-- Feel free to add any additional description of changes below this line -->
I dynamically added the mathjax support if the superblock allows it. This fixes our issue with the mathjax not showing up. 