### PR TITLE
fix(client): ignore capitalization in fill in the blanks

### DIFF
--- a/client/src/templates/Challenges/fill-in-the-blank/show.tsx
+++ b/client/src/templates/Challenges/fill-in-the-blank/show.tsx
@@ -138,7 +138,8 @@ const ShowFillInTheBlank = ({
     const newAnswersCorrect = userAnswers.map(
       (userAnswer, i) =>
         !!userAnswer &&
-        replaceAppleQuotes(userAnswer.trim()) === blankAnswers[i]
+        replaceAppleQuotes(userAnswer.trim()).toLowerCase() ===
+          blankAnswers[i].toLowerCase()
     );
     setAnswersCorrect(newAnswersCorrect);
     const hasWrongAnswer = newAnswersCorrect.some(a => a === false);


### PR DESCRIPTION
Some phones auto-capitalize the first letter when typing in a blank - which is quite annoying. The English team decided that we are fine to ignore the case.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
