### PR TITLE
refactor: simplify client Dockerfile

### DIFF
--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -29,14 +29,9 @@ ARG SHOW_UPCOMING_CHANGES
 ARG GROWTHBOOK_URI
 ARG FREECODECAMP_NODE_ENV
 
-# We're installing specific packages even though it is not strictly necessary -
-# pnpm install would work. The idea is to make the dependencies explicit and
-# keep them under our control.
-RUN pnpm config set dedupe-peer-dependents false
-# Scripts need to be run at this stage (--ignore-scripts cannot be used) because
-# without them, Gatsby will not install sharp.
-RUN pnpm install -F=shared -F=client -F=ui -F=browser-scripts -F=challenge-parser \
-  --frozen-lockfile
+# For simplicity and because node_modules do not make it into the final image,
+# we can just install all dependencies here.
+RUN pnpm install --frozen-lockfile
 RUN pnpm build:client
 
 FROM node:20-alpine


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Originally I wanted to use the fact we only install a subset of the workspaces as a way of keeping them modular. On reflection, I think all this achieved was making the Dockerfile more complicated.

<!-- Feel free to add any additional description of changes below this line -->
