### PR TITLE
fix(curriculum): restore Array.prototype.sort after test

### DIFF
--- a/curriculum/challenges/english/10-coding-interview-prep/algorithms/implement-bubble-sort.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/algorithms/implement-bubble-sort.md
@@ -82,7 +82,7 @@ assert.sameMembers(
 `bubbleSort` should not use the built-in `.sort()` method.
 
 ```js
-assert(isBuiltInSortUsed());
+assert.isFalse(isBuiltInSortUsed());
 ```
 
 # --seed--
@@ -99,9 +99,14 @@ function isSorted(a){
 
 function isBuiltInSortUsed(){
   let sortUsed = false;
+  const temp = Array.prototype.sort;
   Array.prototype.sort = () => sortUsed = true;
-  bubbleSort([0, 1]);
-  return !sortUsed;
+  try {
+    bubbleSort([0, 1]);
+  } finally {
+    Array.prototype.sort = temp;
+  }
+  return sortUsed;
 }
 ```
 

--- a/curriculum/challenges/english/10-coding-interview-prep/algorithms/implement-insertion-sort.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/algorithms/implement-insertion-sort.md
@@ -84,7 +84,7 @@ assert.deepEqual(insertionSort([5, 4, 33, 2, 8]), [2, 4, 5, 8, 33])
 `insertionSort` should not use the built-in `.sort()` method.
 
 ```js
-assert(isBuiltInSortUsed());
+assert.isFalse(isBuiltInSortUsed());
 ```
 
 # --seed--
@@ -101,9 +101,14 @@ function isSorted(a){
 
 function isBuiltInSortUsed(){
   let sortUsed = false;
+  const temp = Array.prototype.sort;
   Array.prototype.sort = () => sortUsed = true;
-  insertionSort([0, 1]);
-  return !sortUsed;
+  try {
+    insertionSort([0, 1]);
+  } finally {
+    Array.prototype.sort = temp;
+  }
+  return sortUsed;
 }
 ```
 

--- a/curriculum/challenges/english/10-coding-interview-prep/algorithms/implement-merge-sort.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/algorithms/implement-merge-sort.md
@@ -31,13 +31,6 @@ assert.isFunction(mergeSort);
 `mergeSort` should return a sorted array (least to greatest).
 
 ```js
-function isSorted(a){
-  for(let i = 0; i < a.length - 1; i++)
-    if(a[i] > a[i + 1])
-      return false;
-  return true;
-}
-
 assert.isTrue(
   isSorted(
     mergeSort([
@@ -93,16 +86,33 @@ assert.sameMembers(
 `mergeSort` should not use the built-in `.sort()` method.
 
 ```js
-function isBuiltInSortUsed(){
-  let sortUsed = false;
-  Array.prototype.sort = () => sortUsed = true;
-  mergeSort([0, 1]);
-  return sortUsed;
-}
 assert.isFalse(isBuiltInSortUsed());
 ```
 
 # --seed--
+
+## --after-user-code--
+
+```js
+function isSorted(a){
+  for(let i = 0; i < a.length - 1; i++)
+    if(a[i] > a[i + 1])
+      return false;
+  return true;
+}
+
+function isBuiltInSortUsed(){
+  let sortUsed = false;
+  const temp = Array.prototype.sort;
+  Array.prototype.sort = () => sortUsed = true;
+  try {
+    mergeSort([0, 1]);
+  } finally {
+    Array.prototype.sort = temp;
+  }
+  return sortUsed;
+}
+```
 
 ## --seed-contents--
 

--- a/curriculum/challenges/english/10-coding-interview-prep/algorithms/implement-quick-sort.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/algorithms/implement-quick-sort.md
@@ -80,7 +80,7 @@ assert.sameMembers(
 `quickSort` should not use the built-in `.sort()` method.
 
 ```js
-assert(isBuiltInSortUsed());
+assert.isFalse(isBuiltInSortUsed());
 ```
 
 # --seed--
@@ -97,9 +97,14 @@ function isSorted(a){
 
 function isBuiltInSortUsed(){
   let sortUsed = false;
+  const temp = Array.prototype.sort;
   Array.prototype.sort = () => sortUsed = true;
-  quickSort([0, 1]);
-  return !sortUsed;
+  try {
+    quickSort([0, 1]);
+  } finally {
+    Array.prototype.sort = temp;
+  }
+  return sortUsed;
 }
 ```
 

--- a/curriculum/challenges/english/10-coding-interview-prep/algorithms/implement-selection-sort.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/algorithms/implement-selection-sort.md
@@ -78,7 +78,7 @@ assert.sameMembers(
 `selectionSort` should not use the built-in `.sort()` method.
 
 ```js
-assert(isBuiltInSortUsed());
+assert.isFalse(isBuiltInSortUsed());
 ```
 
 # --seed--
@@ -95,9 +95,14 @@ function isSorted(a){
 
 function isBuiltInSortUsed(){
   let sortUsed = false;
+  const temp = Array.prototype.sort;
   Array.prototype.sort = () => sortUsed = true;
-  selectionSort([0, 1]);
-  return !sortUsed;
+  try {
+    selectionSort([0, 1]);
+  } finally {
+    Array.prototype.sort = temp;
+  }
+  return sortUsed;
 }
 ```
 


### PR DESCRIPTION
While this is not having any impact on production, modifying a standard function like Array.prototype.sort is not promising great things in the long term.

This commit restores the original sort function once test is done.

It also align practices with `--after-user-code--` in `implement-merge-sort.md` (just like all other challenges about sorting)

Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Remark:

This will obviously have to be done as well on all translations in https://github.com/freeCodeCamp/i18n-curriculum/ ; I can work on a PR there as well once this one is approved.