### PR TITLE
fix/typo in sentence analyzer workshop steps

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -2336,7 +2336,7 @@
       "lab-tribute-page": {
         "title": "Build a Tribute Page",
         "intro": [
-          "in this lab, you'll build a tribute page for a subject of your choosing, fictional or real."
+          "In this lab, you'll build a tribute page for a subject of your choosing, fictional or real."
         ]
       },
       "review-css-accessibility": {

--- a/curriculum/challenges/english/25-front-end-development/workshop-music-instrument-filter/67213641373a23696b74424b.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-music-instrument-filter/67213641373a23696b74424b.md
@@ -9,7 +9,7 @@ dashedName: step-11
 
 Within your new function, you need to filter the instruments depending on the selected category.
 
-Filter out items from `instrumentsArr` and make your function return an array containing the instrument objects with the the same category of `instrumentCategory`. If `instrumentCategory` is equal to `all`, return the whole `instrumentsArr` array.
+Filter out items from `instrumentsArr` and make your function return an array containing the instrument objects with the same category of `instrumentCategory`. If `instrumentCategory` is equal to `all`, return the whole `instrumentsArr` array.
 
 Then, remove the `console.log` from the callback of your event listener and log the result of calling `instrumentCards` with the selected option from the dropdown menu as argument so you can test your function selecting different category options.
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-sentence-analyzer/66e2df8c5676fe51cead8ec8.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-sentence-analyzer/66e2df8c5676fe51cead8ec8.md
@@ -11,7 +11,7 @@ Now it is time to test your `getVowelCount` function.
 
 Create a `vowelCount` variable and assign it the result of calling the `getVowelCount` function with the argument of `"Apples are tasty fruits"`
 
-After that, log the following to the console: `"Vowel Count: [vowel count goes here]"`. Replace  `[vowel count goes here]` with the the actual variable name. You can choose to use template strings or string concatenation with the `+` operator here.
+After that, log the following to the console: `"Vowel Count: [vowel count goes here]"`. Replace  `[vowel count goes here]` with the actual variable name. You can choose to use template strings or string concatenation with the `+` operator here.
 
 # --hints--
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-sentence-analyzer/66e2e99caa0cb3570f4822b4.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-sentence-analyzer/66e2e99caa0cb3570f4822b4.md
@@ -11,7 +11,7 @@ Now it is time to test your `getConsonantCount` function.
 
 Create a `consonantCount` variable and assign it the result of calling the `getConsonantCount` function with the argument of `"Coding is fun"`
 
-After that, log the following to the console: `"Consonant Count: [Consonant count goes here]"`. Replace  `[Consonant count goes here]` with the the actual variable name. You can choose to use template strings or string concatenation with the `+` operator here.
+After that, log the following to the console: `"Consonant Count: [Consonant count goes here]"`. Replace  `[Consonant count goes here]` with the actual variable name. You can choose to use template strings or string concatenation with the `+` operator here.
 
 # --hints--
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-sentence-analyzer/66e2edb23013ca596f8d9568.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-sentence-analyzer/66e2edb23013ca596f8d9568.md
@@ -11,7 +11,7 @@ Now it is time to test your `getPunctuationCount` function.
 
 Create a `punctuationCount` variable and assign it the result of calling the `getPunctuationCount` function with the argument of `"WHAT?!?!?!?!?"`
 
-After that, log the following to the console: `"Punctuation Count: [Punctuation count goes here]"`. Replace  `[Punctuation count goes here]` with the the actual variable name. You can choose to use template strings or string concatenation with the `+` operator here.
+After that, log the following to the console: `"Punctuation Count: [Punctuation count goes here]"`. Replace  `[Punctuation count goes here]` with the actual variable name. You can choose to use template strings or string concatenation with the `+` operator here.
 
 # --hints--
 
@@ -27,7 +27,7 @@ Your `punctuationCount` variable should be set to the result of `getPunctuationC
 assert.equal(punctuationCount, getPunctuationCount("WHAT?!?!?!?!?"));
 ```
 
-You should log the following to the console: `"Punctuation Count: [Punctuation count goes here]"`. Replace  `[Punctuation count goes here]` with the the actual variable name. Make sure to use proper string concatenation syntax here.
+You should log the following to the console: `"Punctuation Count: [Punctuation count goes here]"`. Replace  `[Punctuation count goes here]` with the actual variable name. Make sure to use proper string concatenation syntax here.
 
 ```js
 assert.match(code, /console\.log\((?:('|"|`)Punctuation\s+Count:\s+('|"|`)\s+\+\s+punctuationCount|`Punctuation\s+Count:\s+\${punctuationCount}`)\);?/)

--- a/curriculum/challenges/english/25-front-end-development/workshop-sentence-analyzer/66e2f376df6f315ee81de81a.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-sentence-analyzer/66e2f376df6f315ee81de81a.md
@@ -9,7 +9,7 @@ dashedName: step-8
 
 Test your `getWordCount` by creating a `wordCount` variable set to the calling of the `getWordCount` function with the sentence `"I love freeCodeCamp"`.
 
-After that, log the following to the console: `"Word Count: [Word count goes here]"`. Replace  `[Word count goes here]` with the the actual variable name. You can choose to use template strings or string concatenation with the `+` operator here.
+After that, log the following to the console: `"Word Count: [Word count goes here]"`. Replace  `[Word count goes here]` with the actual variable name. You can choose to use template strings or string concatenation with the `+` operator here.
 
 With that, your sentence analyzer project is done!
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #58107

<!-- Feel free to add any additional description of changes below this line -->

Noticed and updated the same typo on one other page: workshop music instrument filter 
