### PR TITLE
fix: add video ids and transcript headings, and fix a couple of titles and slugs

### DIFF
--- a/curriculum/challenges/_meta/lecture-introduction-to-javascript-libraries-and-frameworks/meta.json
+++ b/curriculum/challenges/_meta/lecture-introduction-to-javascript-libraries-and-frameworks/meta.json
@@ -28,7 +28,7 @@
     },
     {
       "id": "6734e88cc46e6dc679420040",
-      "title": "What is Vite and How Can It Be Used to Set Up a New React Project?"
+      "title": "What is Vite, and How Can It Be Used to Set Up a New React Project?"
     }
   ],
   "helpCategory": "JavaScript"

--- a/curriculum/challenges/_meta/lecture-introduction-to-javascript-libraries-and-frameworks/meta.json
+++ b/curriculum/challenges/_meta/lecture-introduction-to-javascript-libraries-and-frameworks/meta.json
@@ -28,7 +28,7 @@
     },
     {
       "id": "6734e88cc46e6dc679420040",
-      "title": "What is Vite and How Can It Be Used to Setup a New React Project?"
+      "title": "What is Vite and How Can It Be Used to Set Up a New React Project?"
     }
   ],
   "helpCategory": "JavaScript"

--- a/curriculum/challenges/_meta/lecture-working-with-data-in-react/meta.json
+++ b/curriculum/challenges/_meta/lecture-working-with-data-in-react/meta.json
@@ -8,7 +8,7 @@
   "challengeOrder": [
     {
       "id": "6734e3ceee2da4b0301719b7",
-      "title": "How Do You Pass Props from Parent to Child Component in React?"
+      "title": "How Do You Pass Props from a Parent Component to a Child Component in React?"
     },
     {
       "id": "673500abfe36cd015b67b1b7",

--- a/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e3a9cc78faaf4248d335.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e3a9cc78faaf4248d335.md
@@ -8,7 +8,7 @@ dashedName: what-is-the-role-of-js-libraries-and-frameworks-and-why-are-they-use
 
 # --description--
 
-Watch the video and complete the assignment below.
+Watch the video and answer the questions below.
 
 # --transcript--
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e3a9cc78faaf4248d335.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e3a9cc78faaf4248d335.md
@@ -8,7 +8,9 @@ dashedName: what-is-the-role-of-js-libraries-and-frameworks-and-why-are-they-use
 
 # --description--
 
-The video for this lecture isn't available yet, one will be available soon. Here is a transcript of the lecture for now:
+Watch the video and complete the assignment below.
+
+# --transcript--
 
 JavaScript libraries and frameworks provide pre-built code that streamlines the development process.  While both libraries and frameworks serve to improve productivity and standardize coding practices, they differ in their approach and level of control they provide to developers.
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e3a9cc78faaf4248d335.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e3a9cc78faaf4248d335.md
@@ -2,7 +2,7 @@
 id: 6734e3a9cc78faaf4248d335
 title: What Is the Role of JS Libraries and Frameworks, and Why Are They Used in the Industry?
 challengeType: 19
-# videoId: nVAaxZ34khk
+videoId: AJMjp3NxnEA
 dashedName: what-is-the-role-of-js-libraries-and-frameworks-and-why-are-they-used-in-the-industry
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e3a9cc78faaf4248d335.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e3a9cc78faaf4248d335.md
@@ -12,19 +12,21 @@ Watch the video and answer the questions below.
 
 # --transcript--
 
+What is the role of JS libraries and frameworks, and why are they used in the industry?
+
 JavaScript libraries and frameworks provide pre-built code that streamlines the development process.  While both libraries and frameworks serve to improve productivity and standardize coding practices, they differ in their approach and level of control they provide to developers.
 
 Libraries are generally more focused on providing solutions to specific tasks, such as manipulating the DOM, handling events, or managing AJAX requests.
 
-An example of a JavaScript library is jQuery. 
+An example of a JavaScript library is jQuery.
 
 jQuery became very popular in the early 2010s and was widely used to simplify DOM manipulation, event handling, animations, effects, and more. This library also offered a rich ecosystem of plugins, which made it easy to build common web components like date pickers, sliders, and modal dialogs.
 
 Although jQuery is no longer as widely used as it once was, it significantly helped developers by making tasks that were complex in vanilla JavaScript much easier to implement.
 
-Frameworks, on the other hand, provide a more defined structure for building applications. They often come with a set of rules and conventions that developers need to follow. 
+Frameworks, on the other hand, provide a more defined structure for building applications. They often come with a set of rules and conventions that developers need to follow.
 
-For example, Angular encourages a component-based architecture with a set of conventions and tools that provide a structured approach to organizing and building applications. Angular gives developers clear guidelines on how to structure components, manage state, handle routing, and interact with services, making it a more opinionated framework. 
+For example, Angular encourages a component-based architecture with a set of conventions and tools that provide a structured approach to organizing and building applications. Angular gives developers clear guidelines on how to structure components, manage state, handle routing, and interact with services, making it a more opinionated framework.
 
 Other examples of frameworks include Remix and NextJS.
 
@@ -32,9 +34,9 @@ In contrast, React, a UI library, is more flexible and doesn't enforce any parti
 
 Although libraries and frameworks are used across projects of all sizes, the choice between using them often depends on the project's requirements. Libraries offer flexibility for specific functionalities, while frameworks provide a structured approach towards complex applications.
 
-In the industry, libraries and frameworks are widely used for several reasons. They significantly speed up development by providing quick solutions for common problems. 
+In the industry, libraries and frameworks are widely used for several reasons. They significantly speed up development by providing quick solutions for common problems.
 
-One common problem in JavaScript is working with dates and timezones. But there are libraries out there with built in solutions to help you with date manipulation, time zones, parsing and formatting of dates. 
+One common problem in JavaScript is working with dates and timezones. But there are libraries out there with built-in solutions to help you with date manipulation, time zones, parsing and formatting of dates.
 
 A lot of popular libraries and frameworks are well-tested and maintained by large communities. This means they're often more practical than building the same thing from scratch.
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e3a9cc78faaf4248d335.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e3a9cc78faaf4248d335.md
@@ -18,7 +18,7 @@ Libraries are generally more focused on providing solutions to specific tasks, s
 
 An example of a JavaScript library is jQuery. 
 
-jQuery became very popular in the early 2010s and was widely used to simplify DOM manipulation, event handling, animations, effects, and more. This library also offered a rich ecosystem of plugins, which made it easy to build common web components like datepickers, sliders, and modal dialogs.
+jQuery became very popular in the early 2010s and was widely used to simplify DOM manipulation, event handling, animations, effects, and more. This library also offered a rich ecosystem of plugins, which made it easy to build common web components like date pickers, sliders, and modal dialogs.
 
 Although jQuery is no longer as widely used as it once was, it significantly helped developers by making tasks that were complex in vanilla JavaScript much easier to implement.
 
@@ -30,11 +30,11 @@ Other examples of frameworks include Remix and NextJS.
 
 In contrast, React, a UI library, is more flexible and doesn't enforce any particular architectural pattern. React focuses primarily on the view layer and leaves a lot of the choices on application design up to the developers.
 
-Although libraries and frameworks are used across projects of all sizes, The choice between using them often depends on the project's requirements. Libraries offer flexibility for specific functionalities, while frameworks provide a structured approach towards complex applications.
+Although libraries and frameworks are used across projects of all sizes, the choice between using them often depends on the project's requirements. Libraries offer flexibility for specific functionalities, while frameworks provide a structured approach towards complex applications.
 
 In the industry, libraries and frameworks are widely used for several reasons. They significantly speed up development by providing quick solutions for common problems. 
 
-One common problem in JavaScript is working with dates and timezones. But there are libraries out there with built in solutions to help you with date manipulation, timezones, parsing and formatting of dates. 
+One common problem in JavaScript is working with dates and timezones. But there are libraries out there with built in solutions to help you with date manipulation, time zones, parsing and formatting of dates. 
 
 A lot of popular libraries and frameworks are well-tested and maintained by large communities. This means they're often more practical than building the same thing from scratch.
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e867bbf41cc5b11648c4.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e867bbf41cc5b11648c4.md
@@ -8,7 +8,7 @@ dashedName: what-are-single-page-applications-and-what-are-some-issues-surroundi
 
 # --description--
 
-Watch the video and complete the assignment below.
+Watch the video and answer the questions below.
 
 # --transcript--
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e867bbf41cc5b11648c4.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e867bbf41cc5b11648c4.md
@@ -2,7 +2,7 @@
 id: 6734e867bbf41cc5b11648c4
 title: What Are Single Page Applications, and What Are Some Issues Surrounding Them?
 challengeType: 19
-# videoId: nVAaxZ34khk
+videoId: pqTVIg2JTJc
 dashedName: what-are-single-page-applications-and-what-are-some-issues-surrounding-them
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e867bbf41cc5b11648c4.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e867bbf41cc5b11648c4.md
@@ -12,6 +12,8 @@ Watch the video and answer the questions below.
 
 # --transcript--
 
+What are single page applications, and what are some issues surrounding them?
+
 Unlike traditional multi-page websites, single page applications (SPAs) load only one HTML page and dynamically update the content as the user interacts with the app, without reloading the entire page. This approach can lead to faster, more responsive applications, but it also comes a set of challenges and considerations.
 
 SPAs heavily use JavaScript to manage the application's state and render content. Instead of requesting new HTML pages from the server, SPAs use JavaScript to manipulate the DOM and fetch data asynchronously. This is often done using libraries and frameworks like React, Vue, or Angular, which provide great tools for building complex user interfaces.
@@ -20,7 +22,7 @@ SPAs have some common issues. One significant issue is that screen readers may s
 
 Another challenge with SPAs is with navigation and browser history. Users expect the back and forward buttons to work as they do on traditional websites. This might not work properly in SPAs because technically, the URL of the web app doesn’t change. Since, the URL of the web app doesn’t change, they can’t bookmark any specific page. Refreshing the page might reset the application to its initial state, rather than maintaining the current view.
 
-SPAs can pose challenges for SEO optimization. Search engines like Google can have difficulty indexing dynamically loaded content because they may not execute JavaScript properly or may miss content that isn’t included in the initial HTML page. This can lead to pages not being indexed correctly. 
+SPAs can pose challenges for SEO optimization. Search engines like Google can have difficulty indexing dynamically loaded content because they may not execute JavaScript properly or may miss content that isn’t included in the initial HTML page. This can lead to pages not being indexed correctly.
 
 However, modern search engines have improved their ability to crawl SPAs, and there are techniques such as server-side rendering (SSR), pre-rendering, and the use of SEO-friendly URLs that can help mitigate these issues and improve SEO for SPAs.
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e867bbf41cc5b11648c4.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e867bbf41cc5b11648c4.md
@@ -20,11 +20,9 @@ SPAs have some common issues. One significant issue is that screen readers may s
 
 Another challenge with SPAs is with navigation and browser history. Users expect the back and forward buttons to work as they do on traditional websites. This might not work properly in SPAs because technically, the URL of the web app doesn’t change. Since, the URL of the web app doesn’t change, they can’t bookmark any specific page. Refreshing the page might reset the application to its initial state, rather than maintaining the current view.
 
-SPAs can pose challenges for SEO optimization. 
+SPAs can pose challenges for SEO optimization. Search engines like Google can have difficulty indexing dynamically loaded content because they may not execute JavaScript properly or may miss content that isn’t included in the initial HTML page. This can lead to pages not being indexed correctly. 
 
-Search engines like Google can have difficulty indexing dynamically loaded content because they may not execute JavaScript properly or may miss content that isn’t included in the initial HTML page. This can lead to pages not being indexed correctly. 
-
-However, modern search engines have improved their ability to crawl SPAs, and there are techniques such as server-side rendering (SSR), pre rendering, and the use of SEO-friendly URLs that can help mitigate these issues and improve SEO for SPAs.
+However, modern search engines have improved their ability to crawl SPAs, and there are techniques such as server-side rendering (SSR), pre-rendering, and the use of SEO-friendly URLs that can help mitigate these issues and improve SEO for SPAs.
 
 Performance is another consideration. SPAs load the entire application in one go, which means that if the loading time increases, users will be seeing a blank screen for a longer period of time. Now consider the scenario of users with slower internet speeds. Overall, the user experience will not be very pleasant.
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e867bbf41cc5b11648c4.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e867bbf41cc5b11648c4.md
@@ -8,7 +8,9 @@ dashedName: what-are-single-page-applications-and-what-are-some-issues-surroundi
 
 # --description--
 
-The video for this lecture isn't available yet, one will be available soon. Here is a transcript of the lecture for now:
+Watch the video and complete the assignment below.
+
+# --transcript--
 
 Unlike traditional multi-page websites, single page applications (SPAs) load only one HTML page and dynamically update the content as the user interacts with the app, without reloading the entire page. This approach can lead to faster, more responsive applications, but it also comes a set of challenges and considerations.
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e86f590727c5e7e9ec5e.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e86f590727c5e7e9ec5e.md
@@ -8,7 +8,7 @@ dashedName: what-is-react-and-what-is-it-commonly-used-for
 
 # --description--
 
-Watch the video and complete the assignment below.
+Watch the video and answer the questions below.
 
 # --transcript--
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e86f590727c5e7e9ec5e.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e86f590727c5e7e9ec5e.md
@@ -26,7 +26,7 @@ With React, you can easily track and update the state of components, ensuring th
 
 While there are many libraries within the JavaScript ecosystem, freeCodeCamp will mainly be focused on teaching React because of its wide spread use and demand in the industry.
 
-Over the next few lectures, we will dive deeper into building custom components, managing state, and more. 
+Our next few lectures will dive deeper into building custom components, managing state, and more.
 
 # --questions--
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e86f590727c5e7e9ec5e.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e86f590727c5e7e9ec5e.md
@@ -12,11 +12,13 @@ Watch the video and answer the questions below.
 
 # --transcript--
 
-React is one of the most popular JavaScript libraries for building user interfaces and web applications. Originally developed and maintained by Facebook, React has gained huge popularity in web development due to its efficiency, flexibility, and features. 
+What is React, and what is it commonly used for?
+
+React is one of the most popular JavaScript libraries for building user interfaces and web applications. Originally developed and maintained by Facebook, React has gained huge popularity in web development due to its efficiency, flexibility, and features.
 
 A fundamental concept in React is the creation of reusable UI components. These components, such as buttons, cards, and avatar components, can be easily reused throughout your application. You can nest these components inside each other to build more complex, dynamic interfaces.
 
-One of the key advantages of React is that these custom components can update and render independently as data changes. 
+One of the key advantages of React is that these custom components can update and render independently as data changes.
 
 Unlike traditional JavaScript, which requires direct manipulation of the DOM (Document Object Model), React uses a virtual DOM, which improves performance and efficiency. You’ll learn more about the virtual DOM and how it works in upcoming lecture videos.
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e86f590727c5e7e9ec5e.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e86f590727c5e7e9ec5e.md
@@ -2,7 +2,7 @@
 id: 6734e86f590727c5e7e9ec5e
 title: What Is React, and What Is It Commonly Used For?
 challengeType: 19
-# videoId: nVAaxZ34khk
+videoId: 1FGlfBVLSOA
 dashedName: what-is-react-and-what-is-it-commonly-used-for
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e86f590727c5e7e9ec5e.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e86f590727c5e7e9ec5e.md
@@ -8,7 +8,9 @@ dashedName: what-is-react-and-what-is-it-commonly-used-for
 
 # --description--
 
-The video for this lecture isn't available yet, one will be available soon. Here is a transcript of the lecture for now:
+Watch the video and complete the assignment below.
+
+# --transcript--
 
 React is one of the most popular JavaScript libraries for building user interfaces and web applications. Originally developed and maintained by Facebook, React has gained huge popularity in web development due to its efficiency, flexibility, and features. 
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e879c78ee6c61db25b90.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e879c78ee6c61db25b90.md
@@ -8,7 +8,13 @@ dashedName: what-are-components-in-react-and-how-do-they-work
 
 # --description--
 
-The video for this lecture isn't available yet, one will be available soon. Here is a transcript of the lecture for now:
+Watch the video and complete the assignment below.
+
+# --description--
+
+Watch the video and complete the assignment below.
+
+# --transcript--
 
 Components are the building blocks of React applications that allow developers to break down complex user interfaces into smaller, manageable pieces, making it easier to develop and maintain large-scale applications.
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e879c78ee6c61db25b90.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e879c78ee6c61db25b90.md
@@ -12,9 +12,11 @@ Watch the video and complete the assignment below.
 
 # --transcript--
 
+What are components in React, and how do they work?
+
 Components are the building blocks of React applications that allow developers to break down complex user interfaces into smaller, manageable pieces, making it easier to develop and maintain large-scale applications.
 
-The two types of components in React are functional and class based components. In modern React, developers will use functional components and all of the examples we look at today will be functional components. 
+The two types of components in React are functional and class based components. In modern React, developers will use functional components and all of the examples we look at today will be functional components.
 
 At a higher level, you can think of component like JavaScript functions that return elements describing the UI.
 
@@ -30,13 +32,13 @@ function Greeting() {
 }
 ```
 
-In this example, we've defined a component called Greeting. The curly braces `{}` inside the `h1` tags enable us to embed JavaScript expressions, allowing us to access the name variable within the `h1` element.
+In this example, we've defined a component called `Greeting`. The curly braces `{}` inside the `h1` tags enable us to embed JavaScript expressions, allowing us to access the `name` variable within the `h1` element.
 
-We are also applying a `className` called title to the `h1` element. 
+We are also applying a `className` called `title` to the `h1` element.
 
-But why are we using `className` instead of `class` like with regular HTML elements? 
+But why are we using `className` instead of `class` like with regular HTML elements?
 
-Well this is because in JavaScript, `class` is a reserved name. So, we need to use `className` instead. 
+Well, this is because in JavaScript, `class` is a reserved name. So, we need to use `className` instead.
 
 We are also using a comment in JSX showing what the result will be. It is important to note that you can use regular comment syntax like this but it needs to be wrapped in curly braces in order for it to work:
 
@@ -48,7 +50,7 @@ Another thing you might have noticed is that we are using a capital letter at th
 
 This is because React treats components with a capital letter as custom components, while elements with lowercase letters are considered built-in HTML elements.
 
-When React encounters a lowercase tag (like `<div>` or `<span>`), it assumes it's a standard HTML element. However, if the component name starts with a capital letter, React will treat it as a user-defined component and render it accordingly. This distinction helps React differentiate between native HTML tags and components that you create.
+When React encounters a lowercase tag, like `<div>` or `<span>`, it assumes it's a standard HTML element. However, if the component name starts with a capital letter, React will treat it as a user-defined component and render it accordingly. This distinction helps React differentiate between native HTML tags and components that you create.
 
 To use this `Greeting` component in our application, we would write something like this:
 
@@ -56,7 +58,7 @@ To use this `Greeting` component in our application, we would write something li
 <Greeting />
 ```
 
-This would render an `<h1>` element with the text `"Hello, John"` to the page. But take a closer look at the syntax here. When we use the component, it ends with a forward slash and then the greater than symbol.
+This would render an `h1` element with the text `Hello, John` to the page. But take a closer look at the syntax here. When we use the component, it ends with a forward slash and then the greater than symbol.
 
 When working with JSX, all tags and uses of components need to be explicitly closed. So if the component or tag does not have any children, then you need to explicitly close it like shown here:
 
@@ -64,7 +66,7 @@ When working with JSX, all tags and uses of components need to be explicitly clo
 <Greeting /> {/* /> is required */}
 ```
 
-So far we have only been looking at how to render a single `h1` element. But you can actually render multiple elements. 
+So far we have only been looking at how to render a single `h1` element. But you can actually render multiple elements.
 
 Let’s take a look at the following example code here:
 
@@ -77,15 +79,13 @@ function Greeting() {
 }
 ```
 
-We are trying to add another sentence of `"Nice to meet you"` but it is not rendering on the page correctly. 
+We are trying to add another sentence of `Nice to meet you` but it is not rendering on the page correctly.
 
-There seems to be an error message instead. The error message says `"Adjacent JSX elements must be wrapped in an enclosing tag."`
+There seems to be an error message instead. The error message says `Adjacent JSX elements must be wrapped in an enclosing tag.`
 
 The reason why you are getting that error message is because multiple sibling elements need to be wrapped in a parent element. While you could wrap the `h1` and `p` elements in a simple `div`, there is another way to silence the error.
 
-React `<Fragment>`s are used to group elements together.
-
-Here is what the revised example will look like:
+React fragments are used to group elements together. Here is what the revised example will look like:
 
 ```js
 function Greeting() {
@@ -99,7 +99,7 @@ function Greeting() {
 }
 ```
 
-You can also choose to use empty JSX tags which can serve as shorthand for `Fragments`. 
+You can also choose to use empty JSX tags which can serve as shorthand for fragments:
 
 ```js
 function Greeting() {

--- a/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e879c78ee6c61db25b90.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e879c78ee6c61db25b90.md
@@ -30,15 +30,15 @@ function Greeting() {
 }
 ```
 
-In this example, we've defined a component called Greeting. The curly braces `{}` inside the `h1` tags enable us to embed JavaScript expressions, allowing us to access the name variable within the h1 element.
+In this example, we've defined a component called Greeting. The curly braces `{}` inside the `h1` tags enable us to embed JavaScript expressions, allowing us to access the name variable within the `h1` element.
 
 We are also applying a `className` called title to the `h1` element. 
 
-But why are we using `className` instead of class like with regular HTML elements? 
+But why are we using `className` instead of `class` like with regular HTML elements? 
 
 Well this is because in JavaScript, `class` is a reserved name. So, we need to use `className` instead. 
 
-We are also using a comment in JSX showing what the result will be. It is important to note that you can use regular comment syntax like this but it needs to be wrapped in curly braces in order for it to work.
+We are also using a comment in JSX showing what the result will be. It is important to note that you can use regular comment syntax like this but it needs to be wrapped in curly braces in order for it to work:
 
 ```js
 {/* Block Comments */}
@@ -46,7 +46,7 @@ We are also using a comment in JSX showing what the result will be. It is import
 
 Another thing you might have noticed is that we are using a capital letter at the beginning of the component name. But why can’t we use all lower case letters?
 
-This is because React treats components with a capital letter as custom components, while elements with lowercase letters are considered built-in HTML elements. 
+This is because React treats components with a capital letter as custom components, while elements with lowercase letters are considered built-in HTML elements.
 
 When React encounters a lowercase tag (like `<div>` or `<span>`), it assumes it's a standard HTML element. However, if the component name starts with a capital letter, React will treat it as a user-defined component and render it accordingly. This distinction helps React differentiate between native HTML tags and components that you create.
 
@@ -58,14 +58,13 @@ To use this `Greeting` component in our application, we would write something li
 
 This would render an `<h1>` element with the text `"Hello, John"` to the page. But take a closer look at the syntax here. When we use the component, it ends with a forward slash and then the greater than symbol.
 
-When working with JSX, all tags and uses of components need to be explicitly closed. So if the component or tag does not have any children, then you need to explicitly close it like shown here
+When working with JSX, all tags and uses of components need to be explicitly closed. So if the component or tag does not have any children, then you need to explicitly close it like shown here:
 
 ```js
-<img />
-<MyComponent />
+<Greeting /> {/* /> is required */}
 ```
 
-So far we have only been looking at how to render a single h1 element. But you can actually render multiple elements. 
+So far we have only been looking at how to render a single `h1` element. But you can actually render multiple elements. 
 
 Let’s take a look at the following example code here:
 
@@ -82,7 +81,7 @@ We are trying to add another sentence of `"Nice to meet you"` but it is not rend
 
 There seems to be an error message instead. The error message says `"Adjacent JSX elements must be wrapped in an enclosing tag."`
 
-The reason why you are getting that error message is because multiple sibling elements need to be wrapped in a parent element. While you could wrap the h1 and p elements in a single div, there is another way to silence the error.
+The reason why you are getting that error message is because multiple sibling elements need to be wrapped in a parent element. While you could wrap the `h1` and `p` elements in a simple `div`, there is another way to silence the error.
 
 React `<Fragment>`s are used to group elements together.
 
@@ -100,10 +99,10 @@ function Greeting() {
 }
 ```
 
-You can also choose to use empty JSX tags which can serve as shorthand for Fragments. 
+You can also choose to use empty JSX tags which can serve as shorthand for `Fragments`. 
 
 ```js
- function Greeting() {
+function Greeting() {
   const name = "John";
   return (
     <>

--- a/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e879c78ee6c61db25b90.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e879c78ee6c61db25b90.md
@@ -8,10 +8,6 @@ dashedName: what-are-components-in-react-and-how-do-they-work
 
 # --description--
 
-Watch the video and answer the questions below.
-
-# --description--
-
 Watch the video and complete the assignment below.
 
 # --transcript--

--- a/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e879c78ee6c61db25b90.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e879c78ee6c61db25b90.md
@@ -8,7 +8,7 @@ dashedName: what-are-components-in-react-and-how-do-they-work
 
 # --description--
 
-Watch the video and complete the assignment below.
+Watch the video and answer the questions below.
 
 # --description--
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e879c78ee6c61db25b90.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e879c78ee6c61db25b90.md
@@ -2,7 +2,7 @@
 id: 6734e879c78ee6c61db25b90
 title: What Are Components in React, and How Do They Work?
 challengeType: 19
-# videoId: nVAaxZ34khk
+videoId: 0X9IvIhopZQ
 dashedName: what-are-components-in-react-and-how-do-they-work
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e88cc46e6dc679420040.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e88cc46e6dc679420040.md
@@ -12,7 +12,7 @@ Watch the video and answer the questions below.
 
 # --transcript--
 
-Unlike working with smaller vanilla HTML, CSS, and JavaScript projects, starting a new React project includes a few more steps to ensure that everything runs correctly. Instead of trying to set up of all of the necessary configurations by yourself, there are tools that will do that for you.  
+Unlike working with smaller vanilla HTML, CSS, and JavaScript projects, starting a new React project includes a few more steps to ensure that everything runs correctly. Instead of trying to set up of all of the necessary configurations by yourself, there are tools that will do that for you. 
 
 One of the most popular tools for setting up projects is Vite. Vite, which means "fast" in French, is a build tool that aims to provide a faster development experience for modern web projects. Vite can be used with React, as well as with other libraries and frameworks like Vue or Svelte. You can even use it with vanilla JavaScript projects.
 
@@ -28,9 +28,11 @@ This command creates a new React project named `my-react-app` using Vite's React
 
 You can then open up the new project and see the React boilerplate code that Vite has provided for you.
 
-The great thing about Vite is that it will only provide the files that are absolutely necessary to get started with your React project. 
+[Image showing the boilerplate Vite files and folders in a code editor, including the `public` and `src` folders, and the `.gitignore`, `eslint.config.js`, `index.html`, `package.json`, `README.md`, and `vite.config.js` files.]
 
-To actually run the project as is, you will need to install the dependencies using the following commands in the command line:
+The great thing about Vite is that it will only provide the files that are absolutely necessary to get started with your React project.
+
+To actually run the project as-is, you will need to install the dependencies using the following commands in the command line:
 
 ```bash
 cd my-react-app
@@ -39,23 +41,25 @@ npm install
 
 The `cd my-react-app` command ensures that you change to the correct directory where your project is located.
 
-The `npm install` command is used to install the dependencies needed to properly run your React project. Dependencies are libraries or packages that your React project requires in order to function correctly, such as React itself, ReactDOM, or other third-party packages that provide additional functionality. 
+The `npm install` command is used to install the dependencies needed to properly run your React project. Dependencies are libraries or packages that your React project requires in order to function correctly, such as React itself, ReactDOM, or other third-party packages that provide additional functionality.
 
 Running `npm install` will read the `package.json` file in your project directory and install all the dependencies listed there, allowing you to build and run your React app without missing any necessary components.
 
-The `package.json` file is a key configuration file in projects that contains metadata about your project, including its name, version, and dependencies. It also defines scripts, licensing information, and other settings that help manage the project and its dependencies. 
+The `package.json` file is a key configuration file in projects that contains metadata about your project, including its name, version, and dependencies. It also defines scripts, licensing information, and other settings that help manage the project and its dependencies.
 
-Once the dependencies are installed, you should notice a new folder in your project called `node_modules`. 
+Once the dependencies are installed, you should notice a new folder in your project called `node_modules`.
 
-The `node_modules` folder is where all the packages and libraries required by your project are stored. This folder contains the actual code for the dependencies listed in your package.json file, including both your project's direct dependencies and any dependencies of those dependencies.
+[Image showing the `node_modules` folder in the project directory in a code editor.]
 
-To run your project, run the `npm run dev` command and open up a new browser tab at `http://localhost:5173/`. 
+The `node_modules` folder is where all the packages and libraries required by your project are stored. This folder contains the actual code for the dependencies listed in your `package.json` file, including both your project's direct dependencies and any dependencies of those dependencies.
+
+To run your project, run the `npm run dev` command and open up a new browser tab at `http://localhost:5173/`.
 
 You should see the starter template that Vite has provided for you.
 
 If you need to stop the local server, press `CTRL + C` in the command line.
 
-To actually see the code for this starter template, you can go into your project inside the src folder and you should see the `App.jsx` file. 
+To actually see the code for this starter template, you can go into your project inside the `src` folder and you should see the `App.jsx` file.
 
 From there you can start to modify the file, save your changes and see the new changes display in the browser.
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e88cc46e6dc679420040.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e88cc46e6dc679420040.md
@@ -8,9 +8,11 @@ dashedName: what-is-vite-and-how-can-it-be-used-to-set-up-a-new-react-project
 
 # --description--
 
-The video for this lecture isn't available yet, one will be available soon. Here is a transcript of the lecture for now:
+Watch the video and complete the assignment below.
 
-Unlike working with smaller vanilla HTML, CSS, and JavaScript projects, starting a new React project includes a few more steps to ensure that everything runs correctly. Instead of trying to setup of all of the necessary configurations by yourself, there are tools that will do that for you.  
+# --transcript--
+
+Unlike working with smaller vanilla HTML, CSS, and JavaScript projects, starting a new React project includes a few more steps to ensure that everything runs correctly. Instead of trying to set up of all of the necessary configurations by yourself, there are tools that will do that for you.  
 
 One of the most popular tools for setting up projects is Vite. Vite, which means "fast" in French, is a build tool that aims to provide a faster development experience for modern web projects. Vite can be used with React, as well as with other libraries and frameworks like Vue or Svelte. You can even use it with vanilla JavaScript projects.
 
@@ -31,8 +33,8 @@ The great thing about Vite is that it will only provide the files that are absol
 To actually run the project as is, you will need to install the dependencies using the following commands in the command line:
 
 ```bash
-  cd my-react-app
-  npm install
+cd my-react-app
+npm install
 ```
 
 The `cd my-react-app` command ensures that you change to the correct directory where your project is located.

--- a/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e88cc46e6dc679420040.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e88cc46e6dc679420040.md
@@ -2,7 +2,7 @@
 id: 6734e88cc46e6dc679420040
 title: What is Vite and How Can It Be Used to Set Up a New React Project?
 challengeType: 19
-# videoId: nVAaxZ34khk
+videoId: lzU9WdGBjlw
 dashedName: what-is-vite-and-how-can-it-be-used-to-set-up-a-new-react-project
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e88cc46e6dc679420040.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e88cc46e6dc679420040.md
@@ -8,7 +8,7 @@ dashedName: what-is-vite-and-how-can-it-be-used-to-set-up-a-new-react-project
 
 # --description--
 
-Watch the video and complete the assignment below.
+Watch the video and answer the questions below.
 
 # --transcript--
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e88cc46e6dc679420040.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e88cc46e6dc679420040.md
@@ -1,6 +1,6 @@
 ---
 id: 6734e88cc46e6dc679420040
-title: What is Vite and How Can It Be Used to Set Up a New React Project?
+title: What is Vite, and How Can It Be Used to Set Up a New React Project?
 challengeType: 19
 videoId: lzU9WdGBjlw
 dashedName: what-is-vite-and-how-can-it-be-used-to-set-up-a-new-react-project
@@ -11,6 +11,8 @@ dashedName: what-is-vite-and-how-can-it-be-used-to-set-up-a-new-react-project
 Watch the video and answer the questions below.
 
 # --transcript--
+
+What is Vite, and how can it be used to set up a new React project?
 
 Unlike working with smaller vanilla HTML, CSS, and JavaScript projects, starting a new React project includes a few more steps to ensure that everything runs correctly. Instead of trying to set up of all of the necessary configurations by yourself, there are tools that will do that for you. 
 
@@ -24,7 +26,7 @@ Once you have the command line open, you can use the following command:
 npm create vite@latest my-react-app -- --template react
 ```
 
-This command creates a new React project named `my-react-app` using Vite's React template. 
+This command creates a new React project named `my-react-app` using Vite's React template.
 
 You can then open up the new project and see the React boilerplate code that Vite has provided for you.
 
@@ -48,8 +50,6 @@ Running `npm install` will read the `package.json` file in your project director
 The `package.json` file is a key configuration file in projects that contains metadata about your project, including its name, version, and dependencies. It also defines scripts, licensing information, and other settings that help manage the project and its dependencies.
 
 Once the dependencies are installed, you should notice a new folder in your project called `node_modules`.
-
-[Image showing the `node_modules` folder in the project directory in a code editor.]
 
 The `node_modules` folder is where all the packages and libraries required by your project are stored. This folder contains the actual code for the dependencies listed in your `package.json` file, including both your project's direct dependencies and any dependencies of those dependencies.
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e88cc46e6dc679420040.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e88cc46e6dc679420040.md
@@ -1,9 +1,9 @@
 ---
 id: 6734e88cc46e6dc679420040
-title: What is Vite and How Can It Be Used to Setup a New React Project?
+title: What is Vite and How Can It Be Used to Set Up a New React Project?
 challengeType: 19
 # videoId: nVAaxZ34khk
-dashedName: what-is-vite-and-how-can-it-be-used-to-setup-a-new-react-project
+dashedName: what-is-vite-and-how-can-it-be-used-to-set-up-a-new-react-project
 ---
 
 # --description--

--- a/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/674ba6876f7ada867135bb95.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/674ba6876f7ada867135bb95.md
@@ -12,7 +12,9 @@ Watch the video and answer the questions below.
 
 # --transcript--
 
-In earlier lecture videos you learned how to work with imports and exports in JavaScript. In this lecture, we will take a look at how to import and export components in React.
+How can you import and export components in React?
+
+In earlier lecture videos, you learned how to work with imports and exports in JavaScript. In this lecture, we will take a look at how to import and export components in React.
 
 In this example, we have a `Cat` component that belongs in a file called `Cat.jsx`. For the file extension, we are using the `.jsx` file extension because this file is mainly working with JSX.
 
@@ -31,8 +33,6 @@ function Cat() {
   );
 }
 ```
-
-[Image of three cats running in the grass towards the camera, and the sound of a cat meowing.]
 
 If we want to use our `Cat` component in another file, we need to first export it like this:
 
@@ -70,7 +70,7 @@ export default function Cat() {
 
 You can choose to import child components in other parent component files, or import them in the root component file. For this example, we will import the `Cat` component inside the root component file.
 
-Every React project will have a top-level component, typically called `App.jsx`. This file is usually located in the `src` directory of your project. You’ll learn more about common project layouts in a future lecture video.
+Every React project will have a top-level component, typically called `App.jsx`:
 
 ```js
 export default function App() {
@@ -79,6 +79,8 @@ export default function App() {
   );
 }
 ```
+
+This file is usually located in the `src` directory of your project. You’ll learn more about common project layouts in a future lecture video.
 
 To use the `Cat` component inside the root `App` component, you will need to import it like this:
 
@@ -105,8 +107,6 @@ export default function App() {
 ```
 
 As you continue building your own React projects, you’ll become more comfortable organizing components, importing them where needed, and creating sophisticated UIs by composing these modular components.
-
-[Image of a cat facing the camera with its left paw raised.]
 
 # --questions--
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/674ba6876f7ada867135bb95.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/674ba6876f7ada867135bb95.md
@@ -12,9 +12,11 @@ Watch the video and answer the questions below.
 
 # --transcript--
 
-In this lecture, we will take a look at how to import and export components in React.
+In earlier lecture videos you learned how to work with imports and exports in JavaScript. In this lecture, we will take a look at how to import and export components in React.
 
-In this example, we have a `Cat` component that belongs in a file called `Cat.jsx`. For the file extension, we are using the jsx file extension because this file is mainly working with JSX.
+In this example, we have a `Cat` component that belongs in a file called `Cat.jsx`. For the file extension, we are using the `.jsx` file extension because this file is mainly working with JSX.
+
+This `Cat` component returns a JSX markup with a title and image for a cat called Mr. Whiskers:
 
 ```js
 function Cat() {
@@ -30,7 +32,7 @@ function Cat() {
 }
 ```
 
-This `Cat` component returns a JSX markup with a title and image for a cat called Mr.Whiskers.
+[Image of three cats running in the grass towards the camera, and the sound of a cat meowing.]
 
 If we want to use our `Cat` component in another file, we need to first export it like this:
 
@@ -50,7 +52,7 @@ function Cat() {
 export default Cat;
 ```
 
-We are using the default keyword because this will be the default export from the module. You can also choose to export the component on the same line as the component definition like this:
+We are using the `default` keyword because this will be the default export from the module. You can also choose to export the component on the same line as the component definition like this:
 
 ```js
 export default function Cat() {
@@ -66,9 +68,9 @@ export default function Cat() {
 }
 ```
 
-You can choose to import child components in other parent component files. Or import them in the root component file. For this example, we will import the Cat component inside the root component file.
+You can choose to import child components in other parent component files, or import them in the root component file. For this example, we will import the `Cat` component inside the root component file.
 
-Every React project will have a top-level component, typically called `App.jsx`. This file is usually located in the src directory of your project. You’ll learn more about common project layouts in a future lecture video.
+Every React project will have a top-level component, typically called `App.jsx`. This file is usually located in the `src` directory of your project. You’ll learn more about common project layouts in a future lecture video.
 
 ```js
 export default function App() {
@@ -103,6 +105,8 @@ export default function App() {
 ```
 
 As you continue building your own React projects, you’ll become more comfortable organizing components, importing them where needed, and creating sophisticated UIs by composing these modular components.
+
+[Image of a cat facing the camera with its left paw raised.]
 
 # --questions--
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/674ba6876f7ada867135bb95.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/674ba6876f7ada867135bb95.md
@@ -8,7 +8,7 @@ dashedName: how-can-you-import-and-export-components-in-react
 
 # --description--
 
-Watch the video and complete the assignment below.
+Watch the video and answer the questions below.
 
 # --transcript--
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/674ba6876f7ada867135bb95.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/674ba6876f7ada867135bb95.md
@@ -2,7 +2,7 @@
 id: 674ba6876f7ada867135bb95
 title: How Can You Import and Export Components in React?
 challengeType: 19
-# videoId: nVAaxZ34khk
+videoId: XWvb9g1IjR4
 dashedName: how-can-you-import-and-export-components-in-react
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/674ba6876f7ada867135bb95.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/674ba6876f7ada867135bb95.md
@@ -8,7 +8,9 @@ dashedName: how-can-you-import-and-export-components-in-react
 
 # --description--
 
-The video for this lecture isn't available yet, one will be available soon. Here is a transcript of the lecture for now:
+Watch the video and complete the assignment below.
+
+# --transcript--
 
 In this lecture, we will take a look at how to import and export components in React.
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-in-react/6734e3ceee2da4b0301719b7.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-in-react/6734e3ceee2da4b0301719b7.md
@@ -1,9 +1,9 @@
 ---
 id: 6734e3ceee2da4b0301719b7
-title: How Do You Pass Props from Parent to Child Component in React?
+title: How Do You Pass Props from a Parent Component to a Child Component in React?
 challengeType: 19
 # videoId: nVAaxZ34khk
-dashedName: how-do-you-pass-props-from-parent-to-child-component-in-react
+dashedName: how-do-you-pass-props-from-a-parent-component-to-a-child-component-in-react
 ---
 
 # --description--

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-in-react/6734e3ceee2da4b0301719b7.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-in-react/6734e3ceee2da4b0301719b7.md
@@ -12,6 +12,8 @@ Watch the video and answer the questions below.
 
 # --transcript--
 
+How do you pass props from a parent component to a child component in react?
+
 In the previous lectures, we learned how to build small components in React like this:
 
 ```js
@@ -36,17 +38,9 @@ function Greeting() {
 
 While this code will run fine and display the result of `Hi Jessica!` on the screen, it is not that flexible of a component. 
 
-What if we wanted to display a different name like Naomi, Tom, or Oliver?
+What if we wanted to display a different name like Naomi, Tom, or Oliver? This is where React props comes in. Props, which is short for properties, is the way for parent components to pass data down to the child component. Props can be of any type: strings, numbers, booleans, objects, or arrays.
 
-[Image showing the text "Hi Naomi!", "Hi Tom!", "Hi Jessica!", and "Hi Oliver!" on the screen.]
-
-This is where React props comes in.
-
-Props, which is short for properties, is the way for parent components to pass data down to the child component. 
-
-Props can be of any type: strings, numbers, booleans, objects, or arrays.
-
-Let’s update our example from earlier to now accept a `name` prop:
+Let's update our example from earlier to now accept a `name` prop:
 
 ```js
 function App() {
@@ -61,11 +55,9 @@ function Greeting(props) {
 }
 ```
 
-For the child component called `Greeting` we are now using `props.name` instead of hardcoding the name `"Jessica"`. We are also logging props to the console which is showing as an object.
+For the child component called `Greeting` we are now using `props.name` instead of hardcoding the name `"Jessica"`. We are also logging `props` to the console which is showing as an object.
 
-Then inside of the parent `App` component, we are passing the value to the `name` prop so it can be passed down to the child.
-
-The result will be the same on the screen like earlier, but now we have created a more flexible component. 
+Then, inside of the parent `App` component, we are passing the value to the `name` prop so it can be passed down to the child. The result will be the same on the screen like earlier, but now we have created a more flexible component.
 
 Now we have the ability to reuse the child component several times and pass in different names each time:
 
@@ -82,11 +74,7 @@ function App() {
 }
 ```
 
-[Image showing the text "Hi Naomi!", "Hi Tom!", "Hi Jessica!", and "Hi Oliver!" rendered to the page.]
-
-You can also choose to use object destructuring in the props to make it more readable.
-
-Here's how you could rewrite the `Greeting` component:
+You can also choose to use object destructuring in the props to make it more readable. Here's how you could rewrite the `Greeting` component:
 
 ```js
 function Greeting({ name }) {

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-in-react/6734e3ceee2da4b0301719b7.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-in-react/6734e3ceee2da4b0301719b7.md
@@ -8,7 +8,9 @@ dashedName: how-do-you-pass-props-from-a-parent-component-to-a-child-component-i
 
 # --description--
 
-The video for this lecture isn't available yet, one will be available soon. Here is a transcript of the lecture for now:
+Watch the video and complete the assignment below.
+
+# --transcript--
 
 In the previous lectures, we learned how to build small components in React like this:
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-in-react/6734e3ceee2da4b0301719b7.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-in-react/6734e3ceee2da4b0301719b7.md
@@ -8,7 +8,7 @@ dashedName: how-do-you-pass-props-from-a-parent-component-to-a-child-component-i
 
 # --description--
 
-Watch the video and complete the assignment below.
+Watch the video and answer the questions below.
 
 # --transcript--
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-in-react/6734e3ceee2da4b0301719b7.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-in-react/6734e3ceee2da4b0301719b7.md
@@ -34,15 +34,17 @@ function Greeting() {
 }
 ```
 
-While this code will run fine and display the result of Hi Jessica! on the screen, it is not that flexible of a component. 
+While this code will run fine and display the result of `Hi Jessica!` on the screen, it is not that flexible of a component. 
 
 What if we wanted to display a different name like Naomi, Tom, or Oliver?
 
+[Image showing the text "Hi Naomi!", "Hi Tom!", "Hi Jessica!", and "Hi Oliver!" on the screen.]
+
 This is where React props comes in.
 
-Props, which is short for properties, is the way for Parent components to pass data down to the child component. 
+Props, which is short for properties, is the way for parent components to pass data down to the child component. 
 
-Props can be of any type: strings, numbers, booleans, objects, or arrays. 
+Props can be of any type: strings, numbers, booleans, objects, or arrays.
 
 Let’s update our example from earlier to now accept a `name` prop:
 
@@ -61,11 +63,11 @@ function Greeting(props) {
 
 For the child component called `Greeting` we are now using `props.name` instead of hardcoding the name `"Jessica"`. We are also logging props to the console which is showing as an object.
 
-Then inside of the parent App component, we are passing the value to the name prop so it can be passed down to the child.
+Then inside of the parent `App` component, we are passing the value to the `name` prop so it can be passed down to the child.
 
 The result will be the same on the screen like earlier, but now we have created a more flexible component. 
 
-Now we have the ability to reuse the child component several times and pass in different names each time.
+Now we have the ability to reuse the child component several times and pass in different names each time:
 
 ```js
 function App() {
@@ -80,7 +82,9 @@ function App() {
 }
 ```
 
-You can also choose to use object destructuring in the props to make it more readable. 
+[Image showing the text "Hi Naomi!", "Hi Tom!", "Hi Jessica!", and "Hi Oliver!" rendered to the page.]
+
+You can also choose to use object destructuring in the props to make it more readable.
 
 Here's how you could rewrite the `Greeting` component:
 
@@ -110,7 +114,7 @@ function DeveloperCard({ name, age, country }) {
 
 This `DeveloperCard` component accepts three props: `name`, `age`, and `country`. 
 
-In the parent `App` component, we can use the spread syntax to pass all the properties from an object as individual props to the child component.
+In the parent `App` component, we can use the spread syntax to pass all the properties from an object as individual props to the child component:
 
 ```js
 function App() {
@@ -130,9 +134,9 @@ function App() {
 
 This is particularly useful when working with arrays of objects and passing multiple sets of properties to child components. For example, you might have a list of developers where each object in the array has the same structure but represents a different person.
 
-You will learn more about how to render lists in React in future lectures.
+You will learn more about how to render lists in arrays in future lecture videos.
 
-Using props in React makes your components more flexible and reusable, allowing you to build more complex UIs. However, it's important to note that props are immutable, meaning they cannot be changed once passed to a component. If you need to handle user input and modify data, you should use state instead. You'll learn more about managing state in future lectures.
+Using props in React makes your components more flexible and reusable, allowing you to build more complex UIs. However, it's important to note that props are immutable, meaning they cannot be changed once passed to a component. If you need to handle user input and modify data, you should use state instead. You'll learn more about managing state in future lecture videos.
 
 # --questions--
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-in-react/6734e3ceee2da4b0301719b7.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-in-react/6734e3ceee2da4b0301719b7.md
@@ -2,7 +2,7 @@
 id: 6734e3ceee2da4b0301719b7
 title: How Do You Pass Props from a Parent Component to a Child Component in React?
 challengeType: 19
-# videoId: nVAaxZ34khk
+videoId: kUJ6yGagVtE
 dashedName: how-do-you-pass-props-from-a-parent-component-to-a-child-component-in-react
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-in-react/673500abfe36cd015b67b1b7.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-in-react/673500abfe36cd015b67b1b7.md
@@ -2,7 +2,7 @@
 id: 673500abfe36cd015b67b1b7
 title: How Does Conditional Rendering Work in React Components?
 challengeType: 19
-# videoId: nVAaxZ34khk
+videoId: jSwg6t4FOBc
 dashedName: how-does-conditional-rendering-work-in-react-components
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-in-react/673500abfe36cd015b67b1b7.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-in-react/673500abfe36cd015b67b1b7.md
@@ -12,13 +12,13 @@ Watch the video and answer the questions below.
 
 # --transcript--
 
+How does conditional rendering work in react components?
+
 Conditional rendering in React allows you to create dynamic user interfaces. It is used to show different content based on certain conditions or states within your application.
 
-The most common approaches of using conditional rendering includes using `if` statements, the ternary (`?:`) operator, and `logical AND (&&)` operator.
+The most common approaches of using conditional rendering includes using `if` statements, the ternary (`?:`) operator, and logical AND (`&&`) operator.
 
-The simplest form of conditional rendering uses an `if` statement. 
-
-Here's an example:
+The simplest form of conditional rendering uses an `if` statement. Here's an example:
 
 ```js
 function Greeting({ isLoggedIn }) {
@@ -29,7 +29,7 @@ function Greeting({ isLoggedIn }) {
 }
 ```
 
-In this example, the `Greeting` component checks the `isLoggedIn` prop. If it's true, it returns a welcome message, otherwise, it prompts the user to sign in.
+In this example, the `Greeting` component checks the `isLoggedIn` prop. If it's `true`, it returns a welcome message, otherwise, it prompts the user to sign in.
 
 Here is an example using the `Greeting` component inside of the parent `App` component:
 
@@ -53,7 +53,7 @@ function Greeting({ isLoggedIn }) {
 
 This code achieves the same result as the previous example but in a more compact form. The ternary operator checks `isLoggedIn` and renders the appropriate message.
 
-Another common pattern for conditional rendering is using the `logical AND (&&)` operator. This is particularly useful when you want to render something or nothing based on a condition:
+Another common pattern for conditional rendering is using the logical AND (`&&`) operator. This is particularly useful when you want to render something, or nothing, based on a condition:
 
 ```js
 function Notification({ message }) {
@@ -65,7 +65,7 @@ function Notification({ message }) {
 }
 ```
 
-In this example, the paragraph element with the message is only rendered if the `message` prop is truthy. If `message` is falsy (meaning it is an empty string, `null`, or `undefined`), nothing is rendered to the screen.
+In this example, the paragraph element with the message is only rendered if the `message` prop is truthy. If `message` is falsy - meaning it is an empty string, `null`, or `undefined`, nothing is rendered to the screen.
 
 By mastering these techniques of conditional rendering, you can build more interactive and user-friendly applications that adapt to changing data and user interactions.
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-in-react/673500abfe36cd015b67b1b7.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-in-react/673500abfe36cd015b67b1b7.md
@@ -8,7 +8,9 @@ dashedName: how-does-conditional-rendering-work-in-react-components
 
 # --description--
 
-The video for this lecture isn't available yet, one will be available soon. Here is a transcript of the lecture for now:
+Watch the video and complete the assignment below.
+
+# --transcript--
 
 Conditional rendering in React allows you to create dynamic user interfaces. It is used to show different content based on certain conditions or states within your application.
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-in-react/673500abfe36cd015b67b1b7.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-in-react/673500abfe36cd015b67b1b7.md
@@ -14,9 +14,9 @@ Watch the video and answer the questions below.
 
 Conditional rendering in React allows you to create dynamic user interfaces. It is used to show different content based on certain conditions or states within your application.
 
-The most common approaches of using Conditional rendering includes using if statements, the ternary operator, and `logical AND (&&)` operator. 
+The most common approaches of using conditional rendering includes using `if` statements, the ternary (`?:`) operator, and `logical AND (&&)` operator.
 
-The simplest form of conditional rendering uses an if statement. 
+The simplest form of conditional rendering uses an `if` statement. 
 
 Here's an example:
 
@@ -31,7 +31,7 @@ function Greeting({ isLoggedIn }) {
 
 In this example, the `Greeting` component checks the `isLoggedIn` prop. If it's true, it returns a welcome message, otherwise, it prompts the user to sign in.
 
-Here is an example using the Greeting component inside of the parent App component.
+Here is an example using the `Greeting` component inside of the parent `App` component:
 
 ```js
 function App() {
@@ -43,7 +43,7 @@ function App() {
 }
 ```
 
-For simpler conditions, the ternary operator (?) is often used directly within JSX. It allows for inline conditional rendering, which can make your code more concise:
+For simpler conditions, the ternary operator (`?:`) is often used directly within JSX. It allows for inline conditional rendering, which can make your code more concise:
 
 ```js
 function Greeting({ isLoggedIn }) {
@@ -51,7 +51,7 @@ function Greeting({ isLoggedIn }) {
 }
 ```
 
-This code achieves the same result as the previous example but in a more compact form. The ternary operator checks isLoggedIn and renders the appropriate message.
+This code achieves the same result as the previous example but in a more compact form. The ternary operator checks `isLoggedIn` and renders the appropriate message.
 
 Another common pattern for conditional rendering is using the `logical AND (&&)` operator. This is particularly useful when you want to render something or nothing based on a condition:
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-in-react/673500abfe36cd015b67b1b7.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-in-react/673500abfe36cd015b67b1b7.md
@@ -8,7 +8,7 @@ dashedName: how-does-conditional-rendering-work-in-react-components
 
 # --description--
 
-Watch the video and complete the assignment below.
+Watch the video and answer the questions below.
 
 # --transcript--
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-in-react/673500b41af8500191febedc.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-in-react/673500b41af8500191febedc.md
@@ -8,7 +8,7 @@ dashedName: how-do-you-render-lists-in-react
 
 # --description--
 
-Watch the video and complete the assignment below.
+Watch the video and answer the questions below.
 
 # --transcript--
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-in-react/673500b41af8500191febedc.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-in-react/673500b41af8500191febedc.md
@@ -12,7 +12,9 @@ Watch the video and answer the questions below.
 
 # --transcript--
 
-Rendering lists is a fundamental task in React web apps, and is used for displaying data to users. In React, the `map()` method is used to transform an array of data into an array of JSX elements that can be rendered in the UI.
+How do you render lists in React?
+
+Rendering lists is a fundamental task in React web apps, and is used for displaying data to users. In React, the `map` method is used to transform an array of data into an array of JSX elements that can be rendered in the UI.
 
 Here is an example of a component called `FruitList` that displays a list of fruits:
 
@@ -27,7 +29,7 @@ function FruitList() {
 }
 ```
 
-In this example, the `map()` function iterates over each item in the `fruits` array. For each fruit, it creates a new `<li>` element containing the fruit's name. The newly created array of `<li>` elements is then displayed inside the `<ul>` parent tags. 
+In this example, the `map` function iterates over each item in the `fruits` array. For each fruit, it creates a new `li` element containing the fruit's name. The newly created array of `li` elements is then displayed inside the `ul` parent tags.
 
 However, when rendering lists in React, it is important not to forget the `key` prop for each element in the list. The key must always be unique and it helps React identify which items have changed, been added, or been removed, which is essential for efficient rendering and updating the list. 
 
@@ -72,7 +74,7 @@ function UserList() {
 
 In this example, we're creating a more complex JSX structure for each user, displaying both their name and email address. We're using the user's `id` as the `key`, which is a good practice.
 
-In conclusion, rendering lists in React involves converting arrays of data into JSX elements, typically using the `map()` function.
+In conclusion, rendering lists in React involves converting arrays of data into JSX elements, typically using the `map` function.
 
 # --questions--
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-in-react/673500b41af8500191febedc.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-in-react/673500b41af8500191febedc.md
@@ -2,7 +2,7 @@
 id: 673500b41af8500191febedc
 title: How Do You Render Lists in React?
 challengeType: 19
-# videoId: nVAaxZ34khk
+videoId: EXuI5_x3tEM
 dashedName: how-do-you-render-lists-in-react
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-in-react/673500b41af8500191febedc.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-in-react/673500b41af8500191febedc.md
@@ -8,7 +8,9 @@ dashedName: how-do-you-render-lists-in-react
 
 # --description--
 
-The video for this lecture isn't available yet, one will be available soon. Here is a transcript of the lecture for now:
+Watch the video and complete the assignment below.
+
+# --transcript--
 
 Rendering lists is a fundamental task in React web apps, and is used for displaying data to users. In React, the `map()` method is used to transform an array of data into an array of JSX elements that can be rendered in the UI.
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-in-react/673500b41af8500191febedc.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-in-react/673500b41af8500191febedc.md
@@ -29,7 +29,7 @@ function FruitList() {
 
 In this example, the `map()` function iterates over each item in the `fruits` array. For each fruit, it creates a new `<li>` element containing the fruit's name. The newly created array of `<li>` elements is then displayed inside the `<ul>` parent tags. 
 
-However, when rendering lists in React, it is important not to forget the `key` prop to each element in the list. The key must always be unique and it helps React identify which items have changed, been added, or been removed, which is essential for efficient rendering and updating the list. 
+However, when rendering lists in React, it is important not to forget the `key` prop for each element in the list. The key must always be unique and it helps React identify which items have changed, been added, or been removed, which is essential for efficient rendering and updating the list. 
 
 Let's modify our example to include keys:
 
@@ -70,13 +70,9 @@ function UserList() {
 }
 ```
 
-In this example, we're creating a more complex JSX structure for each user, displaying both their name and email. We're using the user's `id` as the key, which is a good practice.
+In this example, we're creating a more complex JSX structure for each user, displaying both their name and email address. We're using the user's `id` as the `key`, which is a good practice.
 
-In conclusion, rendering lists in React involves converting arrays of data into JSX elements, typically using the `map()` function. 
-
-Always remember to provide a unique key for each list item to help React manage the updating and rendering roles. 
-
-With these techniques, you can create flexible, efficient, and dynamic lists in your React applications.
+In conclusion, rendering lists in React involves converting arrays of data into JSX elements, typically using the `map()` function.
 
 # --questions--
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-in-react/673500bfe1f41601c1ddb1a2.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-in-react/673500bfe1f41601c1ddb1a2.md
@@ -8,7 +8,9 @@ dashedName: how-do-inline-styles-work-in-react
 
 # --description--
 
-The video for this lecture isn't available yet, one will be available soon. Here is a transcript of the lecture for now:
+Watch the video and complete the assignment below.
+
+# --transcript--
 
 In React, inline styles are used to apply CSS styles directly to React elements within your JSX code instead of defining them in separate CSS files.
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-in-react/673500bfe1f41601c1ddb1a2.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-in-react/673500bfe1f41601c1ddb1a2.md
@@ -2,7 +2,7 @@
 id: 673500bfe1f41601c1ddb1a2
 title: How Do Inline Styles Work in React?
 challengeType: 19
-# videoId: nVAaxZ34khk
+videoId: SMnrYMHFvbA
 dashedName: how-do-inline-styles-work-in-react
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-in-react/673500bfe1f41601c1ddb1a2.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-in-react/673500bfe1f41601c1ddb1a2.md
@@ -8,7 +8,7 @@ dashedName: how-do-inline-styles-work-in-react
 
 # --description--
 
-Watch the video and complete the assignment below.
+Watch the video and answer the questions below.
 
 # --transcript--
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-in-react/673500bfe1f41601c1ddb1a2.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-in-react/673500bfe1f41601c1ddb1a2.md
@@ -36,9 +36,9 @@ function Button({ buttonText }) {
 }
 ```
 
-In this example, we define a style object called defaultStyles. We then apply these styles to a button element using the style attribute. React takes care of applying these styles to the element when it renders.
+In this example, we define a style object called `defaultStyles`. We then apply these styles to a button element using the `style` attribute. React takes care of applying these styles to the element when it renders.
 
-You can also choose to pass in an object directly to the style attribute. Here is what a revised example would look like:
+You can also choose to pass in an object directly to the `style` attribute. Here is what a revised example would look like:
 
 ```js
 function Button({ buttonText }) {
@@ -57,7 +57,7 @@ function Button({ buttonText }) {
 
 Sometimes you might want to pass in an object directly if there are only a few properties like shown here. Otherwise, passing in a name to an object would be better like in the first example.
 
-It's important to note that while CSS property names are typically written in kebab-case (like font-size), in React's inline styles, we use camelCase (like fontSize). This is because the style object is a JavaScript object, and kebab-case names are not valid as object keys in JavaScript without using quotes.
+It's important to note that while CSS property names are typically written in kebab-case (like `font-size`), in React's inline styles, we use camelCase (like `fontSize`). This is because the style object is a JavaScript object, and kebab-case names are not valid as object keys in JavaScript without using quotes.
 
 A great advantage of inline styles in React is that they support dynamic styling based on a component state or props. For example:
 
@@ -75,7 +75,7 @@ function DynamicButton({ isActive }) {
 }
 ```
 
-In this example, the button's background color changes based on the isActive prop. This kind of dynamic styling can be powerful for creating interactive and responsive user interfaces.
+In this example, the button's background color changes based on the `isActive` prop. This kind of dynamic styling can be powerful for creating interactive and responsive user interfaces.
 
 In summary, inline styles in React provide a powerful way to apply and manipulate styles directly within your components. They use JavaScript objects instead of CSS strings, require camelCased property names, and can easily incorporate dynamic values. They're an essential tool in a React developer's toolkit, especially for creating highly customized and interactive user interfaces.
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-in-react/673500bfe1f41601c1ddb1a2.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-in-react/673500bfe1f41601c1ddb1a2.md
@@ -12,9 +12,11 @@ Watch the video and answer the questions below.
 
 # --transcript--
 
+How do inline styles work in react?
+
 In React, inline styles are used to apply CSS styles directly to React elements within your JSX code instead of defining them in separate CSS files.
 
-React's approach to inline styles involves using JavaScript objects to define styles, rather than traditional CSS strings. This means that instead of writing styles as you would in a CSS file, you create a JavaScript object where the keys are camelCased versions of CSS property names, and the values are the strings of CSS values.
+React's approach to inline styles involves using JavaScript objects to define styles, rather than traditional CSS strings. This means that instead of writing styles as you would in a CSS file, you create a JavaScript object where the keys are camel cased versions of CSS property names, and the values are the strings of CSS values.
 
 Here is an example of how you can use inline styles for a `Button` component:
 
@@ -57,7 +59,7 @@ function Button({ buttonText }) {
 
 Sometimes you might want to pass in an object directly if there are only a few properties like shown here. Otherwise, passing in a name to an object would be better like in the first example.
 
-It's important to note that while CSS property names are typically written in kebab-case (like `font-size`), in React's inline styles, we use camelCase (like `fontSize`). This is because the style object is a JavaScript object, and kebab-case names are not valid as object keys in JavaScript without using quotes.
+It's important to note that while CSS property names are typically written in kebab case, like `font-size`, in React's inline styles, we use camel case, like `fontSize`. This is because the style object is a JavaScript object, and kebab case names are not valid as object keys in JavaScript without using quotes.
 
 A great advantage of inline styles in React is that they support dynamic styling based on a component state or props. For example:
 
@@ -77,7 +79,7 @@ function DynamicButton({ isActive }) {
 
 In this example, the button's background color changes based on the `isActive` prop. This kind of dynamic styling can be powerful for creating interactive and responsive user interfaces.
 
-In summary, inline styles in React provide a powerful way to apply and manipulate styles directly within your components. They use JavaScript objects instead of CSS strings, require camelCased property names, and can easily incorporate dynamic values. They're an essential tool in a React developer's toolkit, especially for creating highly customized and interactive user interfaces.
+In summary, inline styles in React provide a powerful way to apply and manipulate styles directly within your components. They use JavaScript objects instead of CSS strings, require camel cased property names, and can easily incorporate dynamic values. They're an essential tool in a React developer's toolkit, especially for creating highly customized and interactive user interfaces.
 
 # --questions--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related to:
- https://github.com/freeCodeCamp/fCC10/issues/50
- https://github.com/freeCodeCamp/freeCodeCamp/issues/57695

<!-- Feel free to add any additional description of changes below this line -->
The main changes in this PR are adding the video ids and adding transcript headers to lectures in the "Introduction to JavaScript Libraries and Frameworks" and "Working With Data in React" blocks.

Also, the following titles and slugs have been updated:

- What is Vite and How Can It Be Used to Setup a New React Project? (what-is-vite-and-how-can-it-be-used-to-setup-a-new-react-project) --> What is Vite and How Can It Be Used to Set Up a New React Project? (what-is-vite-and-how-can-it-be-used-to-set-up-a-new-react-project)

- How Do You Pass Props from Parent to Child Component in React? (how-do-you-pass-props-from-parent-to-child-component-in-react) --> How Do You Pass Props from a Parent Component to a Child Component in React? (how-do-you-pass-props-from-a-parent-component-to-a-child-component-in-react)

The updates to the titles were either to better match the title card in the video, or to fix minor grammatical errors.

If it's better to leave the slugs as-is, I can go in and revert those changes.