### PR TITLE
fix(curriculum): remove duplicate 'to make' in lightbox viewer hint

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-lightbox-viewer/66db57ad34c7089b9b41bfd6.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-lightbox-viewer/66db57ad34c7089b9b41bfd6.md
@@ -151,7 +151,7 @@ Your `.lightbox` element should be hidden initially.
 assert.equal(new __helpers.CSSHelp(document).getStyle('.lightbox')?.display, 'none');
 ```
 
-When you click one of your `.gallery-item` elements, the `.lightbox` element's `display` property should be set to `flex` to make to make `.lightbox` and the two elements within it visible.
+When you click one of your `.gallery-item` elements, the `.lightbox` element's `display` property should be set to `flex` to make `.lightbox` and the two elements within it visible.
 
 ```js
 // Get the lightbox element


### PR DESCRIPTION
Fixes the issue described in **#58149** by removing the redundant phrase "to make" in the hint text of the lightbox viewer lab. The original sentence contained a repeated phrase, making the instruction unclear.

Original:
```
When you click one of your `.gallery-item` elements, the `.lightbox` element's `display` property should be set to `flex` to make to make `.lightbox` and the two elements within it visible.
```

Corrected:
```
When you click one of your `.gallery-item` elements, the `.lightbox` element's `display` property should be set to `flex` to make `.lightbox` and the two elements within it visible.
```

Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine.

Closes #58149