### PR TITLE
fix(curriculum): update step 46 hanoi tower comment

### DIFF
--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-recursion-by-solving-the-tower-of-hanoi-puzzle/64df45a3ad4f8719e5355244.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-recursion-by-solving-the-tower-of-hanoi-puzzle/64df45a3ad4f8719e5355244.md
@@ -16,7 +16,19 @@ For now, each recursive call prints the `rods` dictionary without performing any
 You should remove the last element from the `rods[source]` list and append it to the `rods[target]` list before the `print` call.
 
 ```js
-({ test: () => assert(runPython(`_Node(_code).find_function("move").find_body().find_if("n > 0").find_bodies()[0].find_calls("append")[0].is_equivalent("rods[target].append(rods[source].pop())")`)) })
+({ test: () => assert.isTrue(runPython(`
+old_rods = rods
+rods2 = {
+    'A': list(range(5, 0, -1)),
+    'B': [],
+    'C': []
+}
+rods = rods2
+print(rods)
+move(5, 'A', 'B', 'C')
+rods = old_rods
+rods2['A'] == [] and rods2['C'] == list(range(1, 6))
+`))})
 ```
 
 # --seed--

--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-recursion-by-solving-the-tower-of-hanoi-puzzle/64df45a3ad4f8719e5355244.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-recursion-by-solving-the-tower-of-hanoi-puzzle/64df45a3ad4f8719e5355244.md
@@ -17,6 +17,13 @@ You should remove the last element from the `rods[source]` list and append it to
 
 ```js
 ({ test: () => assert.isTrue(runPython(`
+_log = []
+def capture_print(*args):
+    _log.append(repr(args))
+
+old_print = print
+print = capture_print
+
 old_rods = rods
 rods2 = {
     'A': list(range(5, 0, -1)),
@@ -24,10 +31,26 @@ rods2 = {
     'C': []
 }
 rods = rods2
-print(rods)
+
 move(5, 'A', 'B', 'C')
 rods = old_rods
-rods2['A'] == [] and rods2['C'] == list(range(1, 6))
+print = old_print
+
+_expected_prints = [
+r"({'A': [5, 4, 3, 2], 'B': [], 'C': [1]}, '\\n')",
+r"({'A': [5, 4, 3], 'B': [], 'C': [1, 2]}, '\\n')",
+r"({'A': [5, 4], 'B': [], 'C': [1, 2, 3]}, '\\n')",
+r"({'A': [5], 'B': [], 'C': [1, 2, 3, 4]}, '\\n')",
+r"({'A': [], 'B': [], 'C': [1, 2, 3, 4, 5]}, '\\n')",
+]
+
+for args in _log:
+    if not _expected_prints:
+        break
+    if args == _expected_prints[0]:
+        _expected_prints.pop(0)
+
+not rods2['A'] and rods2['C'] == list(range(1, 6)) and not _expected_prints
 `))})
 ```
 

--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-recursion-by-solving-the-tower-of-hanoi-puzzle/64df45a3ad4f8719e5355244.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-recursion-by-solving-the-tower-of-hanoi-puzzle/64df45a3ad4f8719e5355244.md
@@ -16,7 +16,7 @@ For now, each recursive call prints the `rods` dictionary without performing any
 You should remove the last element from the `rods[source]` list and append it to the `rods[target]` list before the `print` call.
 
 ```js
-({ test: () => assert.match(code, /move\(\s*n\s*-\s*1\s*,\s*source\s*,\s*auxiliary\s*,\s*target\s*\)\s+rods\s*\[\s*target\s*\]\s*\.append\(\s*rods\s*\[\s*source\s*\]\s*\.pop\(\s*\)\s*\)/) })
+({ test: () => assert(runPython(`_Node(_code).find_function("move").find_body().find_if("n > 0").find_bodies()[0].find_calls("append")[0].is_equivalent("rods[target].append(rods[source].pop())")`)) })
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #58170

<!-- Feel free to add any additional description of changes below this line -->
I have chosen to write an equivalent method using the AST helpers. If I knew that we can (and how) to check that the rods' value was changed, I would have gone with that instead. 