### PR TITLE
fix(challenges): Remove duplicate 'to make' in Lightbox Viewer challenge

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-lightbox-viewer/66db57ad34c7089b9b41bfd6.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-lightbox-viewer/66db57ad34c7089b9b41bfd6.md
@@ -151,7 +151,7 @@ Your `.lightbox` element should be hidden initially.
 assert.equal(new __helpers.CSSHelp(document).getStyle('.lightbox')?.display, 'none');
 ```
 
-When you click one of your `.gallery-item` elements, the `.lightbox` element's `display` property should be set to `flex` to make to make `.lightbox` and the two elements within it visible.
+When you click one of your `.gallery-item` elements, the `.lightbox` element's `display` property should be set to `flex` to make `.lightbox` and the two elements within it visible.
 
 ```js
 // Get the lightbox element


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #58149

<!-- Feel free to add any additional description of changes below this line -->

Description:
This pull request addresses a small typo found in the challenge instructions for the Lightbox Viewer module. Specifically, the phrase "to make" was duplicated in the text, which could potentially confuse learners or detract from the professional quality of the content.

Changes Made:
Removed the duplicated phrase "to make" from the instruction text
