### PR TITLE
fix(curriculum): Corrected typo of "emgine" to "engine" in Basic CSS quiz

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/quiz-basic-css/66ed8fa2f45ce3ece4053eab.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-basic-css/66ed8fa2f45ce3ece4053eab.md
@@ -381,7 +381,7 @@ Gives animations to the page.
 
 ---
 
-Improves Search Emgine Optimization (SEO).
+Improves Search Engine Optimization (SEO).
 
 #### --answer--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #58145 

<!-- Feel free to add any additional description of changes below this line -->

Changes Made:
Fixed the type of "Emgine" at line 384 to "Engine" in the Basic css quiz file.

Reason for change:
It is a typo

Affected File
freeCodeCamp/curriculum/challenges/english/25-front-end-development/quiz-basic-css/66ed8fa2f45ce3ece4053eab.md

