### PR TITLE
fix(client): cursor in challenge transcripts

### DIFF
--- a/client/src/templates/Challenges/components/challenge-transcript.css
+++ b/client/src/templates/Challenges/components/challenge-transcript.css
@@ -1,3 +1,3 @@
-.challenge-transcript {
+.challenge-transcript-heading {
   cursor: pointer;
 }

--- a/client/src/templates/Challenges/components/challenge-transcript.tsx
+++ b/client/src/templates/Challenges/components/challenge-transcript.tsx
@@ -16,8 +16,10 @@ function ChallengeTranscript({
 
   return (
     <>
-      <details className='challenge-transcript'>
-        <summary>{t('learn.transcript')}</summary>
+      <details>
+        <summary className='challenge-transcript-heading'>
+          {t('learn.transcript')}
+        </summary>
         <Spacer size='m' />
         <PrismFormatted className={'line-numbers'} text={transcript} />
       </details>


### PR DESCRIPTION
ref: https://github.com/freeCodeCamp/freeCodeCamp/pull/58133#pullrequestreview-2553993178

The `cursor: pointer` was applied to the whole transcript when it was expanded. This makes it only the pointer on the heading, which is the only clickable part.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
