### PR TITLE
fix: inconsistent requirement in light box viewer test

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-lightbox-viewer/66db57ad34c7089b9b41bfd6.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-lightbox-viewer/66db57ad34c7089b9b41bfd6.md
@@ -222,7 +222,7 @@ function getComputedDisplay(element) {
 }
 
 // Make sure the lightbox is visible initially
-assert.strictEqual(getComputedDisplay(lightbox), 'flex');
+lightbox.style.display="flex";
 
 // Simulate a click outside the lightbox
 background.dispatchEvent(new Event('click'));
@@ -246,7 +246,7 @@ function getComputedDisplay(element) {
 }
 
 // Make sure the lightbox is visible initially
-assert.strictEqual(getComputedDisplay(lightbox), 'flex');
+lightbox.style.display="flex";
 
 // Simulate a click inside the lightbox
 lightbox.dispatchEvent(new Event('click'));

--- a/curriculum/challenges/english/25-front-end-development/lab-lightbox-viewer/66db57ad34c7089b9b41bfd6.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-lightbox-viewer/66db57ad34c7089b9b41bfd6.md
@@ -209,7 +209,7 @@ galleryItems.forEach((item) => {
 
 ```
 
-When your `.lightbox` element is visible and you click the #close button or .lightbox element, the `.lightbox` elements `display` should be set back to `none`.
+When your `.lightbox` element is visible and you click the `#close` button or `.lightbox` element, the `.lightbox` elements `display` should be set back to `none`.
 
 ```js
 // Get the lightbox and a background element (or the document) for simulating clicks outside

--- a/curriculum/challenges/english/25-front-end-development/lab-lightbox-viewer/66db57ad34c7089b9b41bfd6.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-lightbox-viewer/66db57ad34c7089b9b41bfd6.md
@@ -209,7 +209,7 @@ galleryItems.forEach((item) => {
 
 ```
 
-When your `.lightbox` element is visible and you click anywhere outside the image, the `.lightbox` elements `display` should be set back to `none`.
+When your `.lightbox` element is visible and you click the #close button or .lightbox element, the `.lightbox` elements `display` should be set back to `none`.
 
 ```js
 // Get the lightbox and a background element (or the document) for simulating clicks outside

--- a/curriculum/challenges/english/25-front-end-development/lab-lightbox-viewer/66db57ad34c7089b9b41bfd6.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-lightbox-viewer/66db57ad34c7089b9b41bfd6.md
@@ -233,6 +233,7 @@ background.dispatchEvent(new Event('click'));
 // Assert that the lightbox is hidden after clicking outside
 assert.strictEqual(getComputedDisplay(lightbox), 'none');
 ```
+
 When your `.lightbox` element is visible and you click the `.lightbox` element, the `.lightbox` elements `display` should be set back to `none`.
 
 ```js

--- a/curriculum/challenges/english/25-front-end-development/lab-lightbox-viewer/66db57ad34c7089b9b41bfd6.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-lightbox-viewer/66db57ad34c7089b9b41bfd6.md
@@ -246,7 +246,7 @@ function getComputedDisplay(element) {
 }
 
 // Make sure the lightbox is visible initially
-lightbox.style.display="flex";
+lightbox.style.display = "flex";
 
 // Simulate a click inside the lightbox
 lightbox.dispatchEvent(new Event('click'));

--- a/curriculum/challenges/english/25-front-end-development/lab-lightbox-viewer/66db57ad34c7089b9b41bfd6.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-lightbox-viewer/66db57ad34c7089b9b41bfd6.md
@@ -222,7 +222,7 @@ function getComputedDisplay(element) {
 }
 
 // Make sure the lightbox is visible initially
-lightbox.style.display="flex";
+lightbox.style.display = "flex";
 
 // Simulate a click outside the lightbox
 background.dispatchEvent(new Event('click'));

--- a/curriculum/challenges/english/25-front-end-development/lab-lightbox-viewer/66db57ad34c7089b9b41bfd6.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-lightbox-viewer/66db57ad34c7089b9b41bfd6.md
@@ -209,7 +209,7 @@ galleryItems.forEach((item) => {
 
 ```
 
-When your `.lightbox` element is visible and you click the `#close` button or `.lightbox` element, the `.lightbox` elements `display` should be set back to `none`.
+When your `.lightbox` element is visible and you click the `#close` button, the `.lightbox` elements `display` should be set back to `none`.
 
 ```js
 // Get the lightbox and a background element (or the document) for simulating clicks outside
@@ -226,6 +226,29 @@ assert.strictEqual(getComputedDisplay(lightbox), 'flex');
 
 // Simulate a click outside the lightbox
 background.dispatchEvent(new Event('click'));
+
+// Wait for any async operations if needed
+// await new Promise(resolve => setTimeout(resolve, 100)); // Adjust timeout as needed
+
+// Assert that the lightbox is hidden after clicking outside
+assert.strictEqual(getComputedDisplay(lightbox), 'none');
+```
+When your `.lightbox` element is visible and you click the `.lightbox` element, the `.lightbox` elements `display` should be set back to `none`.
+
+```js
+// Get the lightbox element for simulating clicks outside
+const lightbox = document.querySelector(".lightbox");
+
+// Function to get the computed display property
+function getComputedDisplay(element) {
+  return window.getComputedStyle(element).display;
+}
+
+// Make sure the lightbox is visible initially
+assert.strictEqual(getComputedDisplay(lightbox), 'flex');
+
+// Simulate a click inside the lightbox
+lightbox.dispatchEvent(new Event('click'));
 
 // Wait for any async operations if needed
 // await new Promise(resolve => setTimeout(resolve, 100)); // Adjust timeout as needed


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ x] My pull request targets the `main` branch of freeCodeCamp.
- [ x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #58117

<!-- Feel free to add any additional description of changes below this line -->
There was a conflict in hint given and what test was actually conducted. I modified the hint text so that it resembles actual test
