### PR TITLE
fix(curriculum): Corrected wrong example and updated task format

### DIFF
--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/6556bc95e6ce5d850d37dd07.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/6556bc95e6ce5d850d37dd07.md
@@ -7,24 +7,23 @@ dashedName: task-3
 
 # --description--
 
-Adjectives are words that describe or give more information about nouns or pronouns. For example, in the phrase `the blue sky`, `blue` is an adjective describing the sky. 
+Adjectives describe or provide more information about nouns or pronouns. They usually come before the noun they modify. For example:
 
-Notice how the adjective comes before the noun. It is `blue sky` not `sky blue`.
+- `The blue sky` - Here, `blue` is an adjective describing the noun `sky`. Notice how the adjective `blue` comes before the noun.
 
-Expressive language can include idiomatic expressions or descriptive adjectives to communicate strong feelings or vivid ideas, like saying `sparkling eyes` to describe someone's bright, lively eyes.
+- `She enjoys early mornings.` - The adjective `early` describes the type of mornings she enjoys.
 
-Instead of saying `It seems like you have a ton of energy this morning`, James could say something like `You look energetic this morning` to convey the same idea. `Energetic` is the adjective to represent someone who has a lot of energy. 
+- `He has a quick shower in the morning.` - The adjective `quick` describes how short the shower is.
 
-Here are some more examples:
+Adjectives can also make language more expressive by giving details about a person, place, or thing. For example:
 
-* `She wakes up early every day` - `Early` describes the time of her waking up.
-* `He has a quick shower in the morning` - `Quick` describes the short duration of the shower.
+Instead of saying `It seems like you have a lot of energy this morning`, you could say `You look energetic this morning`. Here, the adjective `energetic` is more concise and expressive, showing that someone has a lot of energy in a positive way.
 
 # --questions--
 
 ## --text--
 
-What does the adjective `energetic` imply about someone?
+In the sentence `You look energetic this morning`, what does `energetic` suggest about the person?
 
 ## --answers--
 
@@ -32,7 +31,7 @@ That the person is feeling unwell.
 
 ### --feedback--
 
-`Energetic` is generally used to express a positive feeling about a person, not that they are feeling unwell..
+Does `energetic` usually describe someone who feels negative or unwell? Think about how we use it to describe someone's energy level.
 
 ---
 
@@ -44,7 +43,7 @@ That the person is uncomfortable.
 
 ### --feedback--
 
-`Energetic` is generally used to express how dynamic the person looks, not how comfortable they are.
+Does `energetic` describe someone's comfort level, or does it describe something more related to activity or energy? 
 
 ---
 
@@ -52,7 +51,7 @@ That the person is late.
 
 ### --feedback--
 
-The adjective `energetic` does not relate to time or punctuality.
+Does `energetic` have any connection to time or being late? Reflect on its meaning in the description.
 
 ## --video-solution--
 


### PR DESCRIPTION
A camper noticed that one of the examples of this task was using an adverb instead of an adjective. I've took the opportunity and also updated the entire task to be better aligned with our current standards for tasks. 
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
