### PR TITLE
Fix typo in getPerformanceStatistics function

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/quiz-web-performance/66f1adcf97e3e4c1bd89ebf5.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-web-performance/66f1adcf97e3e4c1bd89ebf5.md
@@ -285,7 +285,7 @@ Which Web API is effective for measuring performance in JavaScript?
 
 #### --distractors--
 
-`window.getPerformaceStatistics()`
+`window.getPerformanceStatistics()`
 
 ---
 


### PR DESCRIPTION
Closes #58207


I have fixed a typo in the function name in the file freeCodeCamp/curriculum/challenges/english/25-front-end-development/quiz-web-performance/66f1adcf97e3e4c1bd89ebf5.md. 

The function window.getPerformaceStatistics() was corrected to window.getPerformanceStatistics().