### PR TITLE
fix: changed cryptic typo

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/review-javascript/6723d3cfdd0717d3f1bf27e3.md
+++ b/curriculum/challenges/english/25-front-end-development/review-javascript/6723d3cfdd0717d3f1bf27e3.md
@@ -40,9 +40,9 @@ let pet = {
 In the example below, two symbols are created with the same description, but they are not equal.
 
 ```js
-const crytpicKey1= Symbol('saltNpepper');
-const crytpicKey2= Symbol('saltNpepper');
-console.log(crytpicKey1 === crytpicKey2); // false
+const crypticKey1= Symbol('saltNpepper');
+const crypticKey2= Symbol('saltNpepper');
+console.log(crypticKey1 === crypticKey2); // false
 ```
 
 - **BigInt**: When the number is too large for the `Number` data type, you can use the BigInt data type to represent integers of arbitrary length.


### PR DESCRIPTION
### Title
Fix Typo in JavaScript Review Challenge

### Description
This PR fixes a typographical error in the JavaScript review challenge documentation.

### Changes Made
- Corrected the spelling of "crypic" to "cryptic" in the markdown file.
- Updated relevant documentation to reflect this change.

### Related Issues/References
- Related to issue #58221.

### Commit Information
- This change is part of commit `6860e42208`.

### Testing
- Tested locally by running the application and verifying that the documentation displays correctly.

### Additional Notes
- No additional dependencies were added.
