### PR TITLE
fix(curriculum): correct 'crytpic' typo to 'cryptic' in JavaScript challenges

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/review-javascript-variables-and-data-types/6723be264695fb7e619fe1fa.md
+++ b/curriculum/challenges/english/25-front-end-development/review-javascript-variables-and-data-types/6723be264695fb7e619fe1fa.md
@@ -39,9 +39,9 @@ let pet = {
 In this example below, two symbols are created with the same description, but they are not equal.
 
 ```js
-const crytpicKey1= Symbol('saltNpepper');
-const crytpicKey2= Symbol('saltNpepper');
-console.log(crytpicKey1 === crytpicKey2); // false
+const crypticKey1= Symbol('saltNpepper');
+const crypticKey2= Symbol('saltNpepper');
+console.log(crypticKey1 === crypticKey2); // false
 ```
 
 - **BigInt**: When the number is too large for the `Number` data type, you can use the BigInt data type to represent integers of arbitrary length.

--- a/curriculum/challenges/english/25-front-end-development/review-javascript/6723d3cfdd0717d3f1bf27e3.md
+++ b/curriculum/challenges/english/25-front-end-development/review-javascript/6723d3cfdd0717d3f1bf27e3.md
@@ -40,9 +40,9 @@ let pet = {
 In the example below, two symbols are created with the same description, but they are not equal.
 
 ```js
-const crytpicKey1= Symbol('saltNpepper');
-const crytpicKey2= Symbol('saltNpepper');
-console.log(crytpicKey1 === crytpicKey2); // false
+const crypticKey1= Symbol('saltNpepper');
+const crypticKey2= Symbol('saltNpepper');
+console.log(crypticKey1 === crypticKey2); // false
 ```
 
 - **BigInt**: When the number is too large for the `Number` data type, you can use the BigInt data type to represent integers of arbitrary length.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #58221


<!-- Feel free to add any additional description of changes below this line -->

This pull request fixes the typo 'crytpic' to 'cryptic' in the following curriculum files:

review-javascript/6723d3cfdd0717d3f1bf27e3.md
review-javascript-variables-and-data-types/6723be264695fb7e619fe1fa.md

