### PR TITLE
fix(curriculum): typo in recipe ingredient converter step 11

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-recipe-ingredient-converter/67353950c86fe2dfd84bc2f3.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-recipe-ingredient-converter/67353950c86fe2dfd84bc2f3.md
@@ -33,7 +33,7 @@ Your `adjustForServings` function should return a function.
 assert.isFunction(adjustForServings?.());
 ```
 
-Your inner function should accept a `newServings` argmuent.
+Your inner function should have a `newServings` parameter.
 
 ```js
 assert.match(adjustForServings?.()?.toString(), /\(newServings\)/);


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Closes #58228

Replaced “Your inner function should accept a `newServings` argmuent.” with “Your inner function should have a `newServings` parameter.” on line 36 6d808de.