### PR TITLE
fix(curriculum): typo in DOM Manipulation and Click Events with JavaScript Quiz

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/quiz-dom-manipulation-and-click-event-with-javascript/66edd07682767adff3a6231e.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-dom-manipulation-and-click-event-with-javascript/66edd07682767adff3a6231e.md
@@ -276,7 +276,7 @@ Which of these does not set the element text color to `red`.
 
 #### --text--
 
-In the case of a click event, which `Event` property returns the clicked sub-element that triggerred the parent's callback?
+In the case of a click event, which `Event` property returns the clicked sub-element that triggered the parent's callback?
 
 #### --distractors--
 
@@ -427,7 +427,7 @@ The first parameter is the function callback and the second is the delay duratio
 
 ---
 
-`setTimeout` calls a function once after a delay and `setInterval` call a function continously after an interval delay.
+`setTimeout` calls a function once after a delay and `setInterval` call a function continuously after an interval delay.
 
 ---
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Closes #58178

Fixed the typos in DOM Manipulation and Click Events with JavaScript Quiz ([759ce92](https://github.com/freeCodeCamp/freeCodeCamp/commit/759ce928324e324632a62697eedd1c2f2a2989e8)).
“…triggerred…” was corrected to “triggered” and “…continously…” was corrected to “continuously”.

The specific file was tested with the following test command:
FCC_CHALLENGE_ID=66edd07682767adff3a6231e pnpm run test:curriculum

I followed the contribution guidelines and how to open a pull request to the best of my knowledge.
Hope this pull request is useful.