### PR TITLE
fix(curriculum): correct 'againt' typo to 'against' in css-flex-box challenges

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/quiz-css-flexbox/66ed8fe7f45ce3ece4053eb2.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-css-flexbox/66ed8fe7f45ce3ece4053eb2.md
@@ -342,7 +342,7 @@ Auto-size items to be equally large to fill the container.
 
 #### --text--
 
-Which value for `justify-content` will evenly distribute items along the main axis, have the same spacing between each pair of adjacent items, and have items whose sides are flush againt the main axis edge?
+Which value for `justify-content` will evenly distribute items along the main axis, have the same spacing between each pair of adjacent items, and have items whose sides are flush against the main axis edge?
 
 #### --distractors--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #58147

<!-- Feel free to add any additional description of changes below this line -->

This pull request fixes the typo 'againt' to 'against' in the following curriculum files:

freeCodeCamp/curriculum/challenges/english/25-front-end-development/quiz-css-flexbox/66ed8fe7f45ce3ece4053eb2.md
