### PR TITLE
fix(curriculum): hint on step 5 of story teller workshop

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-storytelling-app/671fa47e415d88263d349a10.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-storytelling-app/671fa47e415d88263d349a10.md
@@ -17,7 +17,7 @@ You should create a `script` element.
 assert(document.querySelectorAll('script').length === 3);
 ```
 
-Your `script` element should be have an `src` attribute set to `script.js`.
+Your `script` element should have an `src` attribute set to `script.js`.
 
 ```js
 const script = document.querySelector("script[data-src$='script.js']");


### PR DESCRIPTION
#### Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Closes #58142

<!-- Feel free to add any additional description of changes below this line -->

#### Description: 

This PR fixes a grammatical error in the hint text for Step 5 of the Storyteller Workshop. The current hint contains a redundant "be" that affects readability.

#### Current Text:

```Your `script` element should be have an `src` attribute set to `script.js`.```

#### Corrected Text:

```Your `script` element should have an `src` attribute set to `script.js`.```

##### Screenshot:

![Screenshot 2025-01-19 at 2 32 24 AM](https://github.com/user-attachments/assets/60f676f0-b655-4369-bdac-d651d0bc133b)
