### PR TITLE
fix(curriculum): update hints and test for magazine layout lab

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-magazine-layout/6735a7370e0ae93a4577c689.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-magazine-layout/6735a7370e0ae93a4577c689.md
@@ -107,10 +107,13 @@ const magazineCoverStyle = getComputedStyle(document.querySelector('.magazine-co
 assert.match(magazineCoverStyle.gridTemplateAreas, /("|')small-article1 small-article2 cover-image\1$/);
 ```
 
-Your `.magazine-cover` class should have a `grid-template-columns` property set to `1fr 1fr 1fr`.
+Your `.magazine-cover` class should have a `grid-template-columns` property set to `1fr 1fr 1fr` or `repeat(3,1fr)`.
 
 ```js
-assert.equal(new __helpers.CSSHelp(document).getStyle('.magazine-cover')?.gridTemplateColumns, '1fr 1fr 1fr');
+assert(
+    new __helpers.CSSHelp(document).getStyle('.magazine-cover').gridTemplateColumns === '1fr 1fr 1fr' ||
+    new __helpers.CSSHelp(document).getStyle('.magazine-cover').gridTemplateColumns === 'repeat(3, 1fr)'
+);
 ```
 
 Your `.magazine-cover` class should have a `grid-template-rows` property set to `auto 1fr 1fr`.

--- a/curriculum/challenges/english/25-front-end-development/lab-magazine-layout/6735a7370e0ae93a4577c689.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-magazine-layout/6735a7370e0ae93a4577c689.md
@@ -112,7 +112,7 @@ Your `.magazine-cover` `class` should use the `grid-template-columns` property t
 ```js
 assert.oneOf(
     new __helpers.CSSHelp(document).getStyle('.magazine-cover').gridTemplateColumns,
-    ['1fr 1fr 1fr', 'repeat(3, 1fr)']
+    ['1fr 1fr 1fr', 'repeat(3, 1fr)'] 
 );
 ```
 

--- a/curriculum/challenges/english/25-front-end-development/lab-magazine-layout/6735a7370e0ae93a4577c689.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-magazine-layout/6735a7370e0ae93a4577c689.md
@@ -110,9 +110,9 @@ assert.match(magazineCoverStyle.gridTemplateAreas, /("|')small-article1 small-ar
 Your `.magazine-cover` `class` should use the `grid-template-columns` property to divide the space into three equal parts. Remember you can use either the `repeat` function or manually define each fractional unit.
 
 ```js
-assert(
-    new __helpers.CSSHelp(document).getStyle('.magazine-cover').gridTemplateColumns === '1fr 1fr 1fr' ||
-    new __helpers.CSSHelp(document).getStyle('.magazine-cover').gridTemplateColumns === 'repeat(3, 1fr)'
+assert.oneOf(
+    new __helpers.CSSHelp(document).getStyle('.magazine-cover').gridTemplateColumns,
+    ['1fr 1fr 1fr', 'repeat(3, 1fr)']
 );
 ```
 

--- a/curriculum/challenges/english/25-front-end-development/lab-magazine-layout/6735a7370e0ae93a4577c689.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-magazine-layout/6735a7370e0ae93a4577c689.md
@@ -111,7 +111,7 @@ Your `.magazine-cover` selector should use the `grid-template-columns` property 
 
 ```js
 assert.oneOf(
-    new __helpers.CSSHelp(document).getStyle('.magazine-cover').gridTemplateColumns,
+    new __helpers.CSSHelp(document)?.getStyle('.magazine-cover')?.gridTemplateColumns,
     ['1fr 1fr 1fr', 'repeat(3, 1fr)'] 
 );
 ```

--- a/curriculum/challenges/english/25-front-end-development/lab-magazine-layout/6735a7370e0ae93a4577c689.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-magazine-layout/6735a7370e0ae93a4577c689.md
@@ -111,7 +111,7 @@ Your `.magazine-cover` selector should use the `grid-template-columns` property 
 
 ```js
 assert.oneOf(
-    new __helpers.CSSHelp(document)?.getStyle('.magazine-cover')?.gridTemplateColumns,
+    new __helpers.CSSHelp(document).getStyle('.magazine-cover')?.gridTemplateColumns,
     ['1fr 1fr 1fr', 'repeat(3, 1fr)'] 
 );
 ```

--- a/curriculum/challenges/english/25-front-end-development/lab-magazine-layout/6735a7370e0ae93a4577c689.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-magazine-layout/6735a7370e0ae93a4577c689.md
@@ -107,7 +107,7 @@ const magazineCoverStyle = getComputedStyle(document.querySelector('.magazine-co
 assert.match(magazineCoverStyle.gridTemplateAreas, /("|')small-article1 small-article2 cover-image\1$/);
 ```
 
-Your `.magazine-cover` `class` should use the `grid-template-columns` property to divide the space into three equal parts. Remember you can use either the `repeat` function or manually define each fractional unit.
+Your `.magazine-cover` selector should use the `grid-template-columns` property to divide the space into three equal parts. Remember you can use either the `repeat` function or manually define each fractional unit.
 
 ```js
 assert(

--- a/curriculum/challenges/english/25-front-end-development/lab-magazine-layout/6735a7370e0ae93a4577c689.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-magazine-layout/6735a7370e0ae93a4577c689.md
@@ -107,7 +107,7 @@ const magazineCoverStyle = getComputedStyle(document.querySelector('.magazine-co
 assert.match(magazineCoverStyle.gridTemplateAreas, /("|')small-article1 small-article2 cover-image\1$/);
 ```
 
-Your `.magazine-cover` class should have a `grid-template-columns` property set to `1fr 1fr 1fr` or `repeat(3,1fr)`.
+Your `.magazine-cover` `class` should use the `grid-template-columns` property to divide the space into three equal parts. Remember you can use either the `repeat` function or manually define each fractional unit.
 
 ```js
 assert(


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #58237 

<!-- Feel free to add any additional description of changes below this line -->

Changes Made:
Updated the test conditions to accept both grid-template-columns: repeat(3, 1fr); and grid-template-columns: 1fr 1fr 1fr; as valid inputs. This allows for flexibility in how users choose to define grid layouts.

Enhanced test descriptions to explicitly mention that both methods of defining grid-template-columns are acceptable, ensuring that users are aware of the flexibility.

Reason for Change:
These changes address the issue of the test suite's inflexibility concerning the CSS grid-template-columns property. By allowing both expressions, the test now accommodates a broader range of correct CSS practices, enhancing the learning experience.

Affected File:
curriculum/challenges/english/25-front-end-development/lab-magazine-layout/6735a7370e0ae93a4577c689.md