### PR TITLE
fix(curriculum): group definitions and display examples as a list

### DIFF
--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a46e84a0ad845901ea907.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a46e84a0ad845901ea907.md
@@ -19,7 +19,7 @@ An `infographic` is a visual image like a chart or diagram used to represent inf
 
 For example:
 
-* `We experiment with new teaching methods` (trying new ideas)
+* `We experiment with new teaching methods.` (trying new ideas)
 
 * `The journalist conducts interviews with her readers` (conversation for information)
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a46e84a0ad845901ea907.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a46e84a0ad845901ea907.md
@@ -23,7 +23,7 @@ For example:
 
 * `The journalist conducts interviews with her readers.` (conversation for information)
 
-* `They use infographics to explain data` (visual images for information)
+* `They use infographics to explain data.` (visual images for information)
 
 # --fillInTheBlank--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a46e84a0ad845901ea907.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a46e84a0ad845901ea907.md
@@ -21,7 +21,7 @@ For example:
 
 * `We experiment with new teaching methods.` (trying new ideas)
 
-* `The journalist conducts interviews with her readers` (conversation for information)
+* `The journalist conducts interviews with her readers.` (conversation for information)
 
 * `They use infographics to explain data` (visual images for information)
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a46e84a0ad845901ea907.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a46e84a0ad845901ea907.md
@@ -13,15 +13,17 @@ To `experiment` means to try new ideas or methods.
 
 An `interview` is a conversation where someone asks questions to get information. 
 
-An `infographic` is a visual image like a chart or diagram used to represent information. For example:
+An `infographic` is a visual image like a chart or diagram used to represent information.
 
 `Readers` are people who read, especially those who read a particular publication.
 
-`We experiment with new teaching methods` (trying new ideas)
+For example:
 
-`The journalist conducts interviews with her readers` (conversation for information)
+* `We experiment with new teaching methods` (trying new ideas)
 
-`They use infographics to explain data` (visual images for information)
+* `The journalist conducts interviews with her readers` (conversation for information)
+
+* `They use infographics to explain data` (visual images for information)
 
 # --fillInTheBlank--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Placed `Reader` definition below the other definitions and turned the examples into a list.
![image](https://github.com/user-attachments/assets/a8ba86e6-e4f2-4d34-b12d-5937abe8e26d)
