### PR TITLE
fix(learn): console panel overlapping with the preview panel

### DIFF
--- a/client/src/templates/Challenges/components/preview.css
+++ b/client/src/templates/Challenges/components/preview.css
@@ -1,7 +1,6 @@
 .challenge-preview,
 .challenge-preview-frame {
   height: 100%;
-  min-height: 70vh;
   width: 100%;
   padding: 0;
   margin: 0;

--- a/client/src/templates/Challenges/components/project-preview-modal.css
+++ b/client/src/templates/Challenges/components/project-preview-modal.css
@@ -1,4 +1,6 @@
 .project-preview-modal-body {
   line-height: 0;
   padding: 0;
+  min-height: 70vh;
+  height: 70vh;
 }

--- a/client/src/templates/Challenges/components/project-preview-modal.tsx
+++ b/client/src/templates/Challenges/components/project-preview-modal.tsx
@@ -60,7 +60,7 @@ function ProjectPreviewModal({
       open={isOpen}
     >
       <Modal.Header closeButtonClassNames='close'>{previewTitle}</Modal.Header>
-      <Modal.Body>
+      <Modal.Body className='project-preview-modal-body'>
         <Preview
           previewId={projectPreviewId}
           previewMounted={() => projectPreviewMounted({ challengeData })}


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Closes #57028

Followed previous pull requests comments to "remove the min-height from preview.css and add it back in for the modal".

Removed “min-height: 70vh;” from preview.css, so the console panel no longer [overlaps with the music player](https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures-v8/learn-basic-string-and-array-methods-by-building-a-music-player/step-76). 

Below are screenshots for reference:
console overlapping preview
<img width="1440" alt="music-player-console-overlapping-previw" src="https://github.com/user-attachments/assets/b1b0151f-5d62-40ac-b878-4ddb4726dad6" />

console not overlapping preview
<img width="1440" alt="music-player-console-not-overlapping-previw" src="https://github.com/user-attachments/assets/135b27cf-0aa2-4835-b800-c476f8fca4a3" />

Added “min-height: 70vh;” and “height: 70vh;” to the existing "project-preview-modal-body" class in project-preview-modal.css. "height: 70vh;' makes the Preview component fill the empty space in the parent element.
Added “.project.preview-modal-body” to the Modal.body React component in project-preview-modal-tsx to apply the css. 
The above stops the Preview component from compressing inside project preview modals without "min-height: 70vh;".
[Click on "this example project" of this link to see the preview modal.](https://www.freecodecamp.org/learn/full-stack-developer/lab-recipe-page/build-a-recipe-page)

Below are screenshots for reference: 
compressed preview modal
<img width="1440" alt="recipe-page-compressed-preview-modal" src="https://github.com/user-attachments/assets/44f78b42-40b4-4db2-b4a5-c22382e90f0a" />

expanded preview modal
<img width="1440" alt="recipe-page-expanded-preview-modal" src="https://github.com/user-attachments/assets/76240a38-de08-4d89-bc71-258e5f763db9" />

Any feedback is welcome.