### PR TITLE
fix: sync the db during before hook

### DIFF
--- a/e2e/donation-modal.spec.ts
+++ b/e2e/donation-modal.spec.ts
@@ -274,7 +274,9 @@ test.describe('Donation modal appearance logic - New user', () => {
 
 test.describe('Donation modal appearance logic - Certified user claiming a new block', () => {
   test.use({ storageState: 'playwright/.auth/certified-user.json' });
-  execSync('node ./tools/scripts/seed/seed-demo-user --almost-certified-user');
+  test.beforeEach(() =>
+    execSync('node ./tools/scripts/seed/seed-demo-user --almost-certified-user')
+  );
 
   test('should appear if the user has just completed a new block, and should not appear if the user re-submits the projects of the block', async ({
     page,


### PR DESCRIPTION
Fixes a very weird bug where running _any_ e2e test would remove one lesson from the certified user's completed challenge array. This happened because the seeding was happening when the test was loaded (i.e. all the time), rather than just before the test.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->
