### PR TITLE
fix(api): delete exam auth tokens with user

### DIFF
--- a/api/__mocks__/env-exam.ts
+++ b/api/__mocks__/env-exam.ts
@@ -379,3 +379,9 @@ export async function seedEnvExamAttempt() {
     data: examAttempt
   });
 }
+
+export async function seedExamEnvExamAuthToken() {
+  return fastifyTestInstance.prisma.examEnvironmentAuthorizationToken.create({
+    data: { userId: defaultUserId, expireAt: new Date(Date.now() + 60000) }
+  });
+}

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -390,7 +390,7 @@ model ExamEnvironmentAuthorizationToken {
   userId   String   @unique @db.ObjectId
 
   // Relations
-  user user @relation(fields: [userId], references: [id])
+  user user @relation(fields: [userId], references: [id], onDelete: Cascade)
 }
 
 model sessions {

--- a/api/src/routes/protected/user.test.ts
+++ b/api/src/routes/protected/user.test.ts
@@ -421,11 +421,12 @@ describe('userRoutes', () => {
           await fastifyTestInstance.prisma.envExamAttempt.count();
         expect(countBefore).toBe(1);
 
-        await superPost('/account/delete');
+        const res = await superPost('/account/delete');
 
         const countAfter =
           await fastifyTestInstance.prisma.envExamAttempt.count();
         expect(countAfter).toBe(0);
+        expect(res.status).toBe(200);
       });
 
       test("POST deletes all the user's exam tokens", async () => {
@@ -434,11 +435,12 @@ describe('userRoutes', () => {
           await fastifyTestInstance.prisma.examEnvironmentAuthorizationToken.count();
         expect(countBefore).toBe(1);
 
-        await superPost('/account/delete');
+        const res = await superPost('/account/delete');
 
         const countAfter =
           await fastifyTestInstance.prisma.examEnvironmentAuthorizationToken.count();
         expect(countAfter).toBe(0);
+        expect(res.status).toBe(200);
       });
     });
 

--- a/api/src/routes/protected/user.test.ts
+++ b/api/src/routes/protected/user.test.ts
@@ -19,7 +19,8 @@ import { JWT_SECRET } from '../../utils/env';
 import {
   clearEnvExam,
   seedEnvExam,
-  seedEnvExamAttempt
+  seedEnvExamAttempt,
+  seedExamEnvExamAuthToken
 } from '../../../__mocks__/env-exam';
 import { getMsTranscriptApiUrl } from './user';
 
@@ -425,9 +426,19 @@ describe('userRoutes', () => {
         const countAfter =
           await fastifyTestInstance.prisma.envExamAttempt.count();
         expect(countAfter).toBe(0);
-        const examAttemptsAfter =
-          await fastifyTestInstance.prisma.envExamAttempt.findMany();
-        expect(examAttemptsAfter).toHaveLength(0);
+      });
+
+      test("POST deletes all the user's exam tokens", async () => {
+        await seedExamEnvExamAuthToken();
+        const countBefore =
+          await fastifyTestInstance.prisma.examEnvironmentAuthorizationToken.count();
+        expect(countBefore).toBe(1);
+
+        await superPost('/account/delete');
+
+        const countAfter =
+          await fastifyTestInstance.prisma.examEnvironmentAuthorizationToken.count();
+        expect(countAfter).toBe(0);
       });
     });
 

--- a/api/src/routes/protected/user.test.ts
+++ b/api/src/routes/protected/user.test.ts
@@ -349,10 +349,6 @@ describe('userRoutes', () => {
     });
 
     describe('/account/delete', () => {
-      beforeEach(async () => {
-        await seedEnvExam();
-        await seedEnvExamAttempt();
-      });
       afterEach(async () => {
         await fastifyTestInstance.prisma.userToken.deleteMany({
           where: { OR: [{ userId: defaultUserId }, { userId: otherUserId }] }
@@ -418,12 +414,17 @@ describe('userRoutes', () => {
       });
 
       test("POST deletes all the user's exam attempts", async () => {
-        const examAttempts =
-          await fastifyTestInstance.prisma.envExamAttempt.findMany();
-        expect(examAttempts).toHaveLength(1);
+        await seedEnvExam();
+        await seedEnvExamAttempt();
+        const countBefore =
+          await fastifyTestInstance.prisma.envExamAttempt.count();
+        expect(countBefore).toBe(1);
 
         await superPost('/account/delete');
 
+        const countAfter =
+          await fastifyTestInstance.prisma.envExamAttempt.count();
+        expect(countAfter).toBe(0);
         const examAttemptsAfter =
           await fastifyTestInstance.prisma.envExamAttempt.findMany();
         expect(examAttemptsAfter).toHaveLength(0);

--- a/api/src/routes/protected/user.ts
+++ b/api/src/routes/protected/user.ts
@@ -76,9 +76,6 @@ export const userRoutes: FastifyPluginCallbackTypebox = (
       await fastify.prisma.user.delete({
         where: { id: req.user!.id }
       });
-      await fastify.prisma.examEnvironmentAuthorizationToken.deleteMany({
-        where: { userId: req.user!.id }
-      });
       reply.clearOurCookies();
 
       return {};


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

It looked like this was happening before, since we had an explicit query to delete them. However, that query was unreachable if there were tokens and unnecessary if there weren't any.

<!-- Feel free to add any additional description of changes below this line -->
