### PR TITLE
fix(curriculum): clarify requirements for padRow argument

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f34626216270c682e2f7b.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f34626216270c682e2f7b.md
@@ -34,7 +34,7 @@ assert.notMatch(__helpers.removeJSComments(code), /push\(\s*character/);
 You should call `padRow` in your `.push()` call.
 
 ```js
-assert.match(__helpers.removeJSComments(code), /push\(\s*padRow\(\s*\)\)/);
+assert.match(__helpers.removeJSComments(code), /push\(\s*padRow\((.+)?\)\)/);
 ```
 
 You should not have arguments in your `padRow` call.

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f34626216270c682e2f7b.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f34626216270c682e2f7b.md
@@ -40,7 +40,7 @@ assert.match(__helpers.removeJSComments(code), /push\(\s*padRow\((.+)?\)\)/);
 You should not have arguments in your `padRow` call.
 
 ```js
-assert.notMatch(__helpers.removeJSComments(code), /push\(\s*padRow\([a-z\d,\{\}\[\]]+\)\)/);
+assert.match(__helpers.removeJSComments(code), /push\(\s*padRow\(\s*\)/);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f34626216270c682e2f7b.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f34626216270c682e2f7b.md
@@ -31,16 +31,16 @@ You should not use `character.repeat` in your `.push()` call.
 assert.notMatch(__helpers.removeJSComments(code), /push\(\s*character/);
 ```
 
-You should not have arguments in your `padRow` call.
-
-```js
-assert.notMatch(__helpers.removeJSComments(code), /push\(\s*padRow\([a-z\d,\{\}\[\]]+\)\)/);
-```
-
 You should call `padRow` in your `.push()` call.
 
 ```js
 assert.match(__helpers.removeJSComments(code), /push\(\s*padRow\(\s*\)\)/);
+```
+
+You should not have arguments in your `padRow` call.
+
+```js
+assert.notMatch(__helpers.removeJSComments(code), /push\(\s*padRow\([a-z\d,\{\}\[\]]+\)\)/);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f34626216270c682e2f7b.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f34626216270c682e2f7b.md
@@ -15,7 +15,7 @@ A function is called by referencing the function's name, and adding `()`. Here's
 test();
 ```
 
-Replace the `character.repeat(i + 1)` in your `.push()` call with a function call for your `padRow` function.
+Replace the `character.repeat(i + 1)` in your `.push()` call with a function call for your `padRow` function. Do not add any arguments to it yet.
 
 # --hints--
 
@@ -35,6 +35,12 @@ You should call `padRow` in your `.push()` call.
 
 ```js
 assert.match(__helpers.removeJSComments(code), /push\(\s*padRow\(\s*\)\)/);
+```
+
+You should not have arguments in your `padRow` call.
+
+```js
+assert.notMatch(__helpers.removeJSComments(code), /push\(\s*padRow\([a-z\d,\{\}\[\]]+\)\)/);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f34626216270c682e2f7b.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f34626216270c682e2f7b.md
@@ -34,13 +34,13 @@ assert.notMatch(__helpers.removeJSComments(code), /push\(\s*character/);
 You should call `padRow` in your `.push()` call.
 
 ```js
-assert.match(__helpers.removeJSComments(code), /push\(\s*padRow\((.+)?\)\)/);
+assert.match(__helpers.removeJSComments(code), /push\(\s*?padRow\((.+?)?\)\)/);
 ```
 
 You should not have arguments in your `padRow` call.
 
 ```js
-assert.match(__helpers.removeJSComments(code), /push\(\s*padRow\(\s*\)/);
+assert.match(__helpers.removeJSComments(code), /push\(\s*?padRow\(\s*?\)/);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f34626216270c682e2f7b.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-introductory-javascript-by-building-a-pyramid-generator/660f34626216270c682e2f7b.md
@@ -31,16 +31,16 @@ You should not use `character.repeat` in your `.push()` call.
 assert.notMatch(__helpers.removeJSComments(code), /push\(\s*character/);
 ```
 
-You should call `padRow` in your `.push()` call.
-
-```js
-assert.match(__helpers.removeJSComments(code), /push\(\s*padRow\(\s*\)\)/);
-```
-
 You should not have arguments in your `padRow` call.
 
 ```js
 assert.notMatch(__helpers.removeJSComments(code), /push\(\s*padRow\([a-z\d,\{\}\[\]]+\)\)/);
+```
+
+You should call `padRow` in your `.push()` call.
+
+```js
+assert.match(__helpers.removeJSComments(code), /push\(\s*padRow\(\s*\)\)/);
 ```
 
 # --seed--


### PR DESCRIPTION
Make the instructions clarify the function call should not have arguments yet (and added a new test to check for it).

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #58291

<!-- Feel free to add any additional description of changes below this line -->
