### PR TITLE
fix(curriculum): updated the description to suggest that only the division operator must be used.

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64c9fa51209ab5395d524cce.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64c9fa51209ab5395d524cce.md
@@ -7,14 +7,27 @@ dashedName: step-84
 
 # --description--
 
-Below that boolean expression, add another boolean expression that checks if the player's `x` position is greater than or equal to the platform's `x` position minus half of the player's width.
+Below that boolean expression, add another boolean expression that checks if the player's `x` position is greater than or equal to the platform's `x` position minus half of the player's width. Note: Use only the division ('/') operator.
 
 # --hints--
 
-You should have a boolean expression that checks if the player's `x` position is greater than or equal to the platform's `x` position minus half of the player's width.
+You should have a boolean expression that checks if the player's `x` position is greater than or equal to the platform's `x` position minus half of the player's width. 
 
 ```js
-assert.match(code, /const\s+collisionDetectionRules\s*=\s*\[\s*player\.position\.y\s*\+\s*player\.height\s*<=\s*platform\.position\.y\s*,\s*player\.position\.y\s*\+\s*player\.height\s*\+\s*player\.velocity\.y\s*>=\s*platform\.position\.y\s*,\s*player\.position\.x\s*>=\s*platform\.position\.x\s*-\s*\(?player\.width\s*\/\s*2\)?\s*,?\s*]\s*;?/);
+const yHeightCheck = /player\.position\.y\s*\+\s*player\.height\s*<=\s*platform\.position\.y/;
+const yVelocityCheck = /player\.position\.y\s*\+\s*player\.height\s*\+\s*player\.velocity\.y\s*>=\s*platform\.position\.y/;
+const halfWidthWithParentheses = /\(\s*player\.width\s*\/\s*2\s*\)/;
+const halfWidthWithoutParentheses = /player\.width\s*\/\s*2/;
+
+const collisionDetectionRulesRegex = new RegExp(
+  `const\\s+collisionDetectionRules\\s*=\\s*\\[\\s*` +
+  `${yHeightCheck.source}\\s*,\\s*` +
+  `${yVelocityCheck.source}\\s*,\\s*` +
+  `player\\.position\\.x\\s*>=\\s*platform\\.position\\.x\\s*-\\s*(?:${halfWidthWithParentheses.source}|${halfWidthWithoutParentheses.source})\\s*,?\\s*` +
+  `]\\s*;?`
+);
+
+assert.match(code, collisionDetectionRulesRegex);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64c9fe7b2ffa3539fbf82d32.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64c9fe7b2ffa3539fbf82d32.md
@@ -7,14 +7,24 @@ dashedName: step-85
 
 # --description--
 
-Add one last boolean expression that checks if the player's `x` position is less than or equal to the sum of the platform's `x` position plus the platform's width minus one-third of the player's width.
+Add one last boolean expression that checks if the player's `x` position is less than or equal to the sum of the platform's `x` position plus the platform's width minus one-third of the player's width. Note: Use only the division ('/') operator.
 
 # --hints--
 
 You should have a boolean expression that checks if the player's `x` position is lesser than or equal to the platform's `x` position plus the platform's width minus the player's width divided by `3`.
 
 ```js
-assert.match(code, /player\.position\.x\s*<=\s*platform\.position\.x\s*\+\s*platform\.width\s*-\s*player\.width\s*\/\s*3\s*,?/)
+const playerXPosition = `player\\.position\\.x`;
+const platformXPosition = `platform\\.position\\.x`;
+const platformWidth = `platform\\.width`;
+const thirdWidthWithParentheses = `\\(\\s*player\\.width\\s*\\/\\s*3\\s*\\)`;
+const thirdWidthWithoutParentheses = `player\\.width\\s*\\/\\s*3`;
+
+const xPositionCheckRegex = new RegExp(
+  `${playerXPosition}\\s*<=\\s*${platformXPosition}\\s*\\+\\s*${platformWidth}\\s*-\\s*(?:${thirdWidthWithParentheses}|${thirdWidthWithoutParentheses})\\s*,?`
+);
+
+assert.match(code, xPositionCheckRegex);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64caeb134c3cdc5498cd75b9.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64caeb134c3cdc5498cd75b9.md
@@ -7,14 +7,24 @@ dashedName: step-88
 
 # --description--
 
-Inside that array, add a boolean expression that checks if the player's `x` position is greater than or equal to the platform's `x` position minus half of the player's width.
+Inside that array, add a boolean expression that checks if the player's `x` position is greater than or equal to the platform's `x` position minus half of the player's width. Note: Use only the division ('/') operator.
 
 # --hints--
 
 You should have a boolean expression that checks if the player's `x` position is greater than or equal to the platform's `x` position minus half of the player's width.
 
 ```js
-assert.match(code, /const\s+platformDetectionRules\s*=\s*\[\s*player\.position\.x\s*>=\s*platform\.position\.x\s*-\s*player\.width\s*\/\s*2\s*,?\s*\]\s*;?/)
+const halfWidthWithParentheses = /\(\s*player\.width\s*\/\s*2\s*\)/;
+const halfWidthWithoutParentheses = /player\.width\s*\/\s*2/;
+
+const platformXPosition = `platform\\.position\\.x`;
+const playerXPosition = `player\\.position\\.x`;
+
+const platformDetectionRulesRegex = new RegExp(
+  `const\\s+platformDetectionRules\\s*=\\s*\\[\\s*${playerXPosition}\\s*>=\\s*${platformXPosition}\\s*-\\s*(?:${halfWidthWithParentheses.source}|${halfWidthWithoutParentheses.source})\\s*,?\\s*\\]\\s*;?`
+);
+
+assert.match(code, platformDetectionRulesRegex);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64caeb134c3cdc5498cd75b9.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64caeb134c3cdc5498cd75b9.md
@@ -21,7 +21,10 @@ const platformXPosition = `platform\\.position\\.x`;
 const playerXPosition = `player\\.position\\.x`;
 
 const platformDetectionRulesRegex = new RegExp(
-  `const\\s+platformDetectionRules\\s*=\\s*\\[\\s*${playerXPosition}\\s*>=\\s*${platformXPosition}\\s*-\\s*(?:${halfWidthWithParentheses.source}|${halfWidthWithoutParentheses.source})\\s*,?\\s*\\]\\s*;?`
+  `const\\s+platformDetectionRules\\s*=\\s*\\[\\s*` +
+  `${playerXPosition}\\s*>=\\s*${platformXPosition}\\s*-\\s*(?:${halfWidthWithParentheses.source}|${halfWidthWithoutParentheses.source})\\s*,\\s*` +
+  `${playerXPosition}\\s*<=\\s*${platformXPosition}\\s*\\+\\s*${platformWidth}\\s*-\\s*(?:${thirdWidthWithParentheses.source}|${thirdWidthWithoutParentheses.source})\\s*,?\\s*` +
+  `\\]\\s*;?`
 );
 
 assert.match(code, platformDetectionRulesRegex);

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64caeeae2fa57756035d6012.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64caeeae2fa57756035d6012.md
@@ -15,19 +15,18 @@ You should have a boolean expression that checks if the player's `x` position is
 
 ```js
 const halfWidth = /player\.width\s*\/\s*2/;
-const thirdWidthWithParentheses = /\(\s*player\.width\s*\/\s*3\s*\)/;
-const thirdWidthWithoutParentheses = /player\.width\s*\/\s*3/;
+const thirdWidth = /player\.width\s*\/\s*3/;
 
 const xGreaterCheck = new RegExp(
-  `player\\.position\\.x\\s*>=\\s*platform\\.position\\.x\\s*-\s*${halfWidth.source}\\s*,?`
+  `player\\.position\\.x\\s*>=\\s*platform\\.position\\.x\\s*-\s*${halfWidth.source}\\s*,`
 );
 
 const xLesserCheck = new RegExp(
-  `player\\.position\\.x\\s*<=\\s*platform\\.position\\.x\\s*\\+\\s*platform\\.width\\s*-\s*(?:${thirdWidthWithParentheses.source}|${thirdWidthWithoutParentheses.source})\\s*,?`
+  `player\\.position\\.x\\s*<=\\s*platform\\.position\\.x\\s*\\+\\s*platform\\.width\\s*-\s*${thirdWidth.source}\\s*,?`
 );
 
 const platformDetectionRulesRegex = new RegExp(
-  `const\\s+platformDetectionRules\\s*=\\s*\\[\\s*${xGreaterCheck.source}\\s*,\\s*${xLesserCheck.source}\\s*\\]\\s*;?`
+  `const\\s+platformDetectionRules\\s*=\\s*\\[\\s*${xGreaterCheck.source}\\s*${xLesserCheck.source}\\s*\\]\\s*;?`
 );
 
 assert.match(code, platformDetectionRulesRegex);

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64caeeae2fa57756035d6012.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64caeeae2fa57756035d6012.md
@@ -15,7 +15,6 @@ You should have a boolean expression that checks if the player's `x` position is
 
 ```js
 const halfWidth = /player\.width\s*\/\s*2/;
-
 const thirdWidthWithParentheses = /\(\s*player\.width\s*\/\s*3\s*\)/;
 const thirdWidthWithoutParentheses = /player\.width\s*\/\s*3/;
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64caeeae2fa57756035d6012.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64caeeae2fa57756035d6012.md
@@ -7,14 +7,31 @@ dashedName: step-89
 
 # --description--
 
-Below that boolean expression, add another boolean expression that checks if the player's `x` position is less than or equal to the sum of the platform's `x` position plus the platform's width minus one-third of the player's width.
+Below that boolean expression, add another boolean expression that checks if the player's `x` position is less than or equal to the sum of the platform's `x` position plus the platform's width minus one-third of the player's width. Note: Use only the division ('/') operator.
 
 # --hints--
 
 You should have a boolean expression that checks if the player's `x` position is less than or equal to the sum of the platform's `x` position and the platform's width minus one third of the player's width.
 
 ```js
-assert.match(code, /const\s+platformDetectionRules\s*=\s*\[\s*player\.position\.x\s*>=\s*platform\.position\.x\s*-\s*player\.width\s*\/\s*2\s*,\s*player\.position\.x\s*<=\s*platform\.position\.x\s*\+\s*platform\.width\s*-\s*player\.width\s*\/\s*3\s*,?\s*\]\s*;?/)
+const halfWidth = /player\.width\s*\/\s*2/;
+
+const thirdWidthWithParentheses = /\(\s*player\.width\s*\/\s*3\s*\)/;
+const thirdWidthWithoutParentheses = /player\.width\s*\/\s*3/;
+
+const xGreaterCheck = new RegExp(
+  `player\\.position\\.x\\s*>=\\s*platform\\.position\\.x\\s*-\s*${halfWidth.source}\\s*,?`
+);
+
+const xLesserCheck = new RegExp(
+  `player\\.position\\.x\\s*<=\\s*platform\\.position\\.x\\s*\\+\\s*platform\\.width\\s*-\s*(?:${thirdWidthWithParentheses.source}|${thirdWidthWithoutParentheses.source})\\s*,?`
+);
+
+const platformDetectionRulesRegex = new RegExp(
+  `const\\s+platformDetectionRules\\s*=\\s*\\[\\s*${xGreaterCheck.source}\\s*,\\s*${xLesserCheck.source}\\s*\\]\\s*;?`
+);
+
+assert.match(code, platformDetectionRulesRegex);
 ```
 
 # --seed--


### PR DESCRIPTION

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #55821 

<!-- Feel free to add any additional description of changes below this line -->

Changes Made:

Added a note in the description for the Steps 84,85,88 and 89: "Note: Use only the division ('/') operator." This clarifies the expected method for numerical operations within these steps.

Updated the test conditions in the platform detection rules for Steps 84, 88 to accept both player.width / 2 and (player.width / 2) expressions. 

Modified the test conditions for Steps 85 and 89 to also accept both player.width / 3 and (player.width / 3) for determining one-third of the player's width. This change aims to accommodate variations in how developers might write expressions that compute a third of a value.

I have also put different type of assertions in separate variables, as  it makes them easier to read

Reason for Change: Made improvements to fix issues with how the test checks for code in several steps. Now, the test is more flexible and can recognize different ways of writing math operations. I have also added a note which makes it clear which math operation to use.
