### PR TITLE
fix(client): handle quiz exit on i18n clients

### DIFF
--- a/client/src/templates/Challenges/quiz/show.tsx
+++ b/client/src/templates/Challenges/quiz/show.tsx
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import type { Dispatch } from 'redux';
 import { createSelector } from 'reselect';
-import { useLocation } from '@reach/router';
+import { useLocation, navigate as reachNavigate } from '@reach/router';
 import {
   Container,
   Col,
@@ -252,7 +252,9 @@ const ShowQuiz = ({
       return;
     }
 
-    void navigate(`${curLocation.pathname}`);
+    // We need to use Reach Router, because the pathname is already prefixed
+    // with the language and Gatsby's navigate will prefix it again.
+    void reachNavigate(`${curLocation.pathname}`);
     openExitQuizModal();
   }, [curLocation.pathname, hasSubmitted, exitConfirmed, openExitQuizModal]);
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

`navigate` automatically includes the `pathPrefix`, e.g. `japanese`, so if you call it with an already prefixed path, it ends up being prefixed twice.

To test, you need to build the client (`gatsby develop` doesn't include the pathPrefix). The `serve` command needs to be `gatsby serve --prefix-paths -p 8000`, too.

Closes https://github.com/freeCodeCamp/freeCodeCamp/issues/58299

<!-- Feel free to add any additional description of changes below this line -->
