### PR TITLE
fix(client): display correct full-stack requirement

### DIFF
--- a/client/src/client-only-routes/show-project-links.tsx
+++ b/client/src/client-only-routes/show-project-links.tsx
@@ -106,7 +106,7 @@ const ShowProjectLinks = (props: ShowProjectLinksProps): JSX.Element => {
         { name: Certification.JsAlgoDataStruct },
         { name: Certification.LegacyFrontEnd },
         { name: Certification.LegacyDataVis },
-        { name: Certification.LegacyBackEnd },
+        { name: Certification.BackEndDevApis },
         { name: Certification.LegacyInfoSecQa }
       ] as const;
 

--- a/client/src/components/settings/certification.tsx
+++ b/client/src/components/settings/certification.tsx
@@ -160,7 +160,7 @@ const LegacyFullStack = (props: CertificationSettingsProps) => {
           <li>{t(`certification.title.${Certification.JsAlgoDataStruct}`)}</li>
           <li>{t(`certification.title.${Certification.LegacyFrontEnd}`)}</li>
           <li>{t(`certification.title.${Certification.LegacyDataVis}`)}</li>
-          <li>{t(`certification.title.${Certification.LegacyBackEnd}`)}</li>
+          <li>{t(`certification.title.${Certification.BackEndDevApis}`)}</li>
           <li>{t(`certification.title.${Certification.LegacyInfoSecQa}`)}</li>
         </ul>
       </div>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

A Camper mentioned not being able to claim their Full Stack Certification, despite claiming all certifications listed.

This happened because of an _extreme_ oversight here: https://github.com/freeCodeCamp/freeCodeCamp/pull/57505

NOTE: This PR fixes a bug - it does not change any prior existing requirements to claim the certifications. All that happened is we introduced a mistaken paragraph in the client.