### PR TITLE
fix(curriculum): Fix typo in challenge title

### DIFF
--- a/curriculum/challenges/_meta/lecture-working-with-dates/meta.json
+++ b/curriculum/challenges/_meta/lecture-working-with-dates/meta.json
@@ -8,7 +8,7 @@
   "challengeOrder": [
     {
       "id": "6733aafb9c0802f66cc1e056",
-      "title": "How Does the JavaScript Data Object Work, and What Are Some Common Methods?"
+      "title": "How Does the JavaScript Date Object Work, and What Are Some Common Methods?"
     },
     {
       "id": "6733d608654c17868e01c0a2",

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-dates/6733aafb9c0802f66cc1e056.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-dates/6733aafb9c0802f66cc1e056.md
@@ -1,9 +1,9 @@
 ---
 id: 6733aafb9c0802f66cc1e056
-title: How Does the JavaScript Data Object Work, and What Are Some Common Methods?
+title: How Does the JavaScript Date Object Work, and What Are Some Common Methods?
 challengeType: 11
 videoId: aFGXBwkmNqg
-dashedName: how-does-the-javascript-data-object-work-and-what-are-some-common-methods
+dashedName: how-does-the-javascript-date-object-work-and-what-are-some-common-methods
 ---
 
 # --description--


### PR DESCRIPTION
Closes #58314

This PR fixes a typo in the challenge title from "Data" to "Date". The typo was found in the following files:
- `curriculum/challenges/english/25-front-end-development/lecture-working-with-dates/6733aafb9c0802f66cc1e056.md`
- `curriculum/challenges/_meta/lecture-working-with-dates/meta.json`

### Checklist
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Thank you for reviewing this PR!
