### PR TITLE
fix(curriculum): correct typo in enctype attribute description

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/review-form-validation-with-javascript/6723ce555ff2dfc0cc04b69a.md
+++ b/curriculum/challenges/english/25-front-end-development/review-form-validation-with-javascript/6723ce555ff2dfc0cc04b69a.md
@@ -91,7 +91,7 @@ button.addEventListener('click',(event) => {
 </form>
 ```
 
-- **`enctype` Attribute**: The `form` element accepts an `enctype` attribute, which represents the encoding type to use for the data. This attribute only accepts three values: `application/x-www-form-urlencoded` (which is the default, sending the data as a URL-encoded form body), `text/plain` (which sends the data in plaintext form, in `name=value` pairs separated by new lines), or `mulitpart/form-data`, which is specifically for handling forms with a file upload.
+- **`enctype` Attribute**: The `form` element accepts an `enctype` attribute, which represents the encoding type to use for the data. This attribute only accepts three values: `application/x-www-form-urlencoded` (which is the default, sending the data as a URL-encoded form body), `text/plain` (which sends the data in plaintext form, in `name=value` pairs separated by new lines), or `multipart/form-data`, which is specifically for handling forms with a file upload.
 
 
 # --assignment--

--- a/curriculum/challenges/english/25-front-end-development/review-javascript/6723d3cfdd0717d3f1bf27e3.md
+++ b/curriculum/challenges/english/25-front-end-development/review-javascript/6723d3cfdd0717d3f1bf27e3.md
@@ -2126,7 +2126,7 @@ button.addEventListener('click',(event) => {
 </form>
 ```
 
-- **`enctype` Attribute**: The `form` element accepts an `enctype` attribute, which represents the encoding type to use for the data. This attribute only accepts three values: `application/x-www-form-urlencoded` (which is the default, sending the data as a URL-encoded form body), `text/plain` (which sends the data in plaintext form, in `name=value` pairs separated by new lines), or `mulitpart/form-data`, which is specifically for handling forms with a file upload.
+- **`enctype` Attribute**: The `form` element accepts an `enctype` attribute, which represents the encoding type to use for the data. This attribute only accepts three values: `application/x-www-form-urlencoded` (which is the default, sending the data as a URL-encoded form body), `text/plain` (which sends the data in plaintext form, in `name=value` pairs separated by new lines), or `multipart/form-data`, which is specifically for handling forms with a file upload.
 
 ## The `date()` Object and Common Methods
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Closes #58334

This pull request fixes a typo in two curriculum files where "mulitpart" was incorrectly spelled. It replaces it with the correct spelling, "multipart," in the following files:
- `review-form-validation-with-javascript/6723ce555ff2dfc0cc04b69a.md` (line 94)
- `review-javascript/6723d3cfdd0717d3f1bf27e3.md` (line 2129)