### PR TITLE
fix(curriculum): refine Cat Photo App test case to improve accuracy and learner experience

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5dfb6250eacea3f48c6300b2.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5dfb6250eacea3f48c6300b2.md
@@ -33,8 +33,7 @@ The new image should have an `alt` value of `A slice of lasagna on a plate.` Mak
 
 ```js
 assert(
-  document.querySelectorAll('section')?.[1]
-    ?.lastElementChild?.getAttribute('alt')
+  document.querySelectorAll('section')[1].querySelector('ul').nextElementSibling?.getAttribute('alt')
     .replace(/\s+/g, ' ')
     .match(/^A slice of lasagna on a plate\.?$/i)
 );

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5dfb6250eacea3f48c6300b2.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5dfb6250eacea3f48c6300b2.md
@@ -32,10 +32,9 @@ assert.isTrue(document.querySelectorAll('section')[1].querySelector('ul').nextEl
 The new image should have an `alt` value of `A slice of lasagna on a plate.` Make sure the `alt` attribute's value is surrounded with quotation marks.
 
 ```js
-assert(
+assert.match(
   document.querySelectorAll('section')[1].querySelector('ul').nextElementSibling?.getAttribute('alt')
-    .replace(/\s+/g, ' ')
-    .match(/^A slice of lasagna on a plate\.?$/i)
+    .replace(/\s+/g, ' '), /^A slice of lasagna on a plate\.?$/i
 );
 ```
 

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5dfb6250eacea3f48c6300b2.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5dfb6250eacea3f48c6300b2.md
@@ -33,8 +33,7 @@ The new image should have an `alt` value of `A slice of lasagna on a plate.` Mak
 
 ```js
 assert.match(
-  document.querySelectorAll('section')[1].querySelector('ul').nextElementSibling?.getAttribute('alt')?
-    .replace(/\s+/g, ' '), /^A slice of lasagna on a plate\.?$/i
+  document.querySelectorAll('section')[1].querySelector('ul').nextElementSibling?.getAttribute('alt')?.replace(/\s+/g, ' '), /^A slice of lasagna on a plate\.?$/i 
 );
 ```
 

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5dfb6250eacea3f48c6300b2.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5dfb6250eacea3f48c6300b2.md
@@ -33,7 +33,7 @@ The new image should have an `alt` value of `A slice of lasagna on a plate.` Mak
 
 ```js
 assert.match(
-  document.querySelectorAll('section')[1].querySelector('ul').nextElementSibling?.getAttribute('alt')
+  document.querySelectorAll('section')[1].querySelector('ul').nextElementSibling?.getAttribute('alt')?
     .replace(/\s+/g, ' '), /^A slice of lasagna on a plate\.?$/i
 );
 ```

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5dfb6250eacea3f48c6300b2.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5dfb6250eacea3f48c6300b2.md
@@ -20,13 +20,13 @@ And its `alt` attribute value to:
 There should be an `img` element right after the closing `</ul>` tag.
 
 ```js
-assert.equal(document.querySelectorAll('section')?.[1]?.lastElementChild?.nodeName, 'IMG');
+assert.equal(document.querySelectorAll('section')[1].querySelector('ul').nextElementSibling?.nodeName, 'IMG');
 ```
 
 The new image does not have an `alt` attribute. Check that there is a space after the opening tag's name and/or there are spaces before all attribute names.
 
 ```js
-assert.isTrue(document.querySelectorAll('section')?.[1]?.lastElementChild?.hasAttribute('alt'));
+assert.isTrue(document.querySelectorAll('section')[1].querySelector('ul').nextElementSibling?.hasAttribute('alt'));
 ```
 
 The new image should have an `alt` value of `A slice of lasagna on a plate.` Make sure the `alt` attribute's value is surrounded with quotation marks.
@@ -43,14 +43,14 @@ assert(
 The new image does not have a `src` attribute. Check that there is a space after the opening tag's name and/or there are spaces before all attribute names.
 
 ```js
-assert.isTrue(document.querySelectorAll('section')?.[1]?.lastElementChild?.hasAttribute('src'));
+assert.isTrue(document.querySelectorAll('section')[1].querySelector('ul').nextElementSibling?.hasAttribute('src'));
 ```
 
 The new image should have a `src` value of `https://cdn.freecodecamp.org/curriculum/cat-photo-app/lasagna.jpg`. Make sure the `src` attribute's value is surrounded with quotation marks.
 
 ```js
 assert.strictEqual(
-  document.querySelectorAll('section')?.[1]?.lastElementChild?.getAttribute('src'),
+  document.querySelectorAll('section')[1].querySelector('ul').nextElementSibling?.getAttribute('src'),
     'https://cdn.freecodecamp.org/curriculum/cat-photo-app/lasagna.jpg'
 );
 ```

--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-photo-app/5dfb6250eacea3f48c6300b2.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-photo-app/5dfb6250eacea3f48c6300b2.md
@@ -20,13 +20,13 @@ And its `alt` attribute value to:
 There should be an `img` element right after the closing `</ul>` tag.
 
 ```js
-assert.equal(document.querySelectorAll('section')[1].lastElementChild.nodeName, 'IMG');
+assert.equal(document.querySelectorAll('section')[1].querySelector('ul').nextElementSibling.nodeName, 'IMG');
 ```
 
 The new image does not have an `alt` attribute. Check that there is a space after the opening tag's name and/or there are spaces before all attribute names.
 
 ```js
-assert.isTrue(document.querySelectorAll('section')[1].lastElementChild.hasAttribute('alt'));
+assert.isTrue(document.querySelectorAll('section')[1].querySelector('ul').nextElementSibling.hasAttribute('alt'));
 ```
 
 The new image should have an `alt` value of `A slice of lasagna on a plate.` Make sure the `alt` attribute's value is surrounded with quotation marks.
@@ -42,14 +42,14 @@ assert.match(
 The new image does not have a `src` attribute. Check that there is a space after the opening tag's name and/or there are spaces before all attribute names.
 
 ```js
-assert.isTrue(document.querySelectorAll('section')[1].lastElementChild.hasAttribute('src'));
+assert.isTrue(document.querySelectorAll('section')[1].querySelector('ul').nextElementSibling.hasAttribute('src'));
 ```
 
 The new image should have a `src` value of `https://cdn.freecodecamp.org/curriculum/cat-photo-app/lasagna.jpg`. Make sure the `src` attribute's value is surrounded with quotation marks.
 
 ```js
 assert.equal(
-  document.querySelectorAll('section')[1].lastElementChild.getAttribute('src'),
+  document.querySelectorAll('section')[1].querySelector('ul').nextElementSibling.getAttribute('src'),
     'https://cdn.freecodecamp.org/curriculum/cat-photo-app/lasagna.jpg'
 );
 ```

--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-photo-app/5dfb6250eacea3f48c6300b2.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-photo-app/5dfb6250eacea3f48c6300b2.md
@@ -33,7 +33,7 @@ The new image should have an `alt` value of `A slice of lasagna on a plate.` Mak
 
 ```js
 assert.match(
-  document.querySelectorAll('section')[1].querySelector('ul').nextElementSibling.getAttribute('alt')
+  document.querySelectorAll('section')[1].querySelector('ul').nextElementSibling?.getAttribute('alt')
     .replace(/\s+/g, ' '), /^A slice of lasagna on a plate\.?$/i
 );
 ```
@@ -83,7 +83,7 @@ assert.notMatch(code, /\<img\s+.+\s+src\s*=\s*https:\/\/cdn\.freecodecamp\.org\/
           <li>laser pointers</li>
           <li>lasagna</li>
         </ul>
-
+        
 --fcc-editable-region--
       </section>
     </main>

--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-photo-app/5dfb6250eacea3f48c6300b2.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-photo-app/5dfb6250eacea3f48c6300b2.md
@@ -33,8 +33,7 @@ The new image should have an `alt` value of `A slice of lasagna on a plate.` Mak
 
 ```js
 assert.match(
-  document.querySelectorAll('section')[1].querySelector('ul').nextElementSibling?.getAttribute('alt')
-    .replace(/\s+/g, ' '), /^A slice of lasagna on a plate\.?$/i
+  document.querySelectorAll('section')[1].querySelector('ul').nextElementSibling?.getAttribute('alt')?.replace(/\s+/g, ' '), /^A slice of lasagna on a plate\.?$/i 
 );
 ```
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-photo-app/5dfb6250eacea3f48c6300b2.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-photo-app/5dfb6250eacea3f48c6300b2.md
@@ -48,7 +48,7 @@ The new image should have a `src` value of `https://cdn.freecodecamp.org/curricu
 
 ```js
 assert.equal(
-  document.querySelectorAll('section')[1].querySelector('ul').nextElementSibling.getAttribute('src'),
+  document.querySelectorAll('section')[1].querySelector('ul').nextElementSibling?.getAttribute('src'),
     'https://cdn.freecodecamp.org/curriculum/cat-photo-app/lasagna.jpg'
 );
 ```

--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-photo-app/5dfb6250eacea3f48c6300b2.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-photo-app/5dfb6250eacea3f48c6300b2.md
@@ -32,10 +32,10 @@ assert.isTrue(document.querySelectorAll('section')[1].querySelector('ul').nextEl
 The new image should have an `alt` value of `A slice of lasagna on a plate.` Make sure the `alt` attribute's value is surrounded with quotation marks.
 
 ```js
-assert.match(
-  document.querySelectorAll('section')[1]
-    .lastElementChild.getAttribute('alt')
-    .replace(/\s+/g, ' '), /^A slice of lasagna on a plate\.?$/i
+assert(
+  document.querySelectorAll('section')[1].querySelector('ul').nextElementSibling?.getAttribute('alt')
+    .replace(/\s+/g, ' ')
+    .match(/^A slice of lasagna on a plate\.?$/i)
 );
 ```
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-photo-app/5dfb6250eacea3f48c6300b2.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-photo-app/5dfb6250eacea3f48c6300b2.md
@@ -32,10 +32,9 @@ assert.isTrue(document.querySelectorAll('section')[1].querySelector('ul').nextEl
 The new image should have an `alt` value of `A slice of lasagna on a plate.` Make sure the `alt` attribute's value is surrounded with quotation marks.
 
 ```js
-assert(
-  document.querySelectorAll('section')[1].querySelector('ul').nextElementSibling?.getAttribute('alt')
-    .replace(/\s+/g, ' ')
-    .match(/^A slice of lasagna on a plate\.?$/i)
+assert.match(
+  document.querySelectorAll('section')[1].querySelector('ul').nextElementSibling.getAttribute('alt')
+    .replace(/\s+/g, ' '), /^A slice of lasagna on a plate\.?$/i
 );
 ```
 
@@ -84,7 +83,7 @@ assert.notMatch(code, /\<img\s+.+\s+src\s*=\s*https:\/\/cdn\.freecodecamp\.org\/
           <li>laser pointers</li>
           <li>lasagna</li>
         </ul>
-        
+
 --fcc-editable-region--
       </section>
     </main>


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.


Closes #58387

This update adjusts the Cat Photo App test case to better reflect the intended solution path, reducing false negatives and improving the learning experience for users working through the curriculum.

