### PR TITLE
fix(curriculum): add extra hint for anchor elements test in travel agency lab

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-travel-agency-page/669e2f60e83c011754f711f9.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-travel-agency-page/669e2f60e83c011754f711f9.md
@@ -247,7 +247,7 @@ for (let image of images) {
 }
 ```
 
-Each `a` element should have an `href` attribute with the value of `https://www.freecodecamp.org/learn`.
+Each `a` element should have an `href` attribute with the value of `https://www.freecodecamp.org/learn`. Don't forget the links in the list items.
 
 ```js
 const anchors = document.querySelectorAll('a');
@@ -257,7 +257,7 @@ for (let anchor of anchors) {
 }
 ```
 
-Each `a` element should have a `target` attribute with the value of `_blank`.
+Each `a` element should have a `target` attribute with the value of `_blank`. Don't forget the links in the list items.
 
 ```js
 const anchors = document.querySelectorAll('a');


### PR DESCRIPTION
fix(curriculum): clarify anchor elements requirement in travel agency lab page

Checklist:
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Closes #58392

Added reminder text to the `href` and `target` attribute test hints to help prevent a common mistake where users forget to include anchor elements in list items of the travel agency lab project. This makes the requirements clearer for learners working on this lab project.

Changes made:
1. Updated the `href` attribute test hint to include: "Don't forget the links in the list items."
2. Updated the `target` attribute test hint to include: "Don't forget the links in the list items."