### PR TITLE
fix(client): allow 10 question quizzes

### DIFF
--- a/client/src/templates/Challenges/quiz/show.tsx
+++ b/client/src/templates/Challenges/quiz/show.tsx
@@ -176,7 +176,8 @@ const ShowQuiz = ({
       correct: t('learn.quiz.correct-answer'),
       incorrect: t('learn.quiz.incorrect-answer')
     },
-    passingGrade: 85,
+    // 10 question quizzes need 80% (8/10) to pass, 20 need 85% (17/20)
+    passingGrade: quiz.length === 10 ? 80 : 85,
     onSuccess: () => {
       openCompletionModal(), setIsPassed(true);
     },

--- a/client/src/templates/Challenges/quiz/show.tsx
+++ b/client/src/templates/Challenges/quiz/show.tsx
@@ -176,8 +176,8 @@ const ShowQuiz = ({
       correct: t('learn.quiz.correct-answer'),
       incorrect: t('learn.quiz.incorrect-answer')
     },
-    // 10 question quizzes need 80% (8/10) to pass, 20 need 85% (17/20)
-    passingGrade: quiz.length === 10 ? 80 : 85,
+    // 10 question quizzes need 90% (9/10) to pass, 20 need 85% (17/20)
+    passingGrade: quiz.length === 10 ? 90 : 85,
     onSuccess: () => {
       openCompletionModal(), setIsPassed(true);
     },

--- a/client/src/templates/Challenges/quiz/show.tsx
+++ b/client/src/templates/Challenges/quiz/show.tsx
@@ -176,8 +176,7 @@ const ShowQuiz = ({
       correct: t('learn.quiz.correct-answer'),
       incorrect: t('learn.quiz.incorrect-answer')
     },
-    // 10 question quizzes need 90% (9/10) to pass, 20 need 85% (17/20)
-    passingGrade: quiz.length === 10 ? 90 : 85,
+    passingGrade: 90,
     onSuccess: () => {
       openCompletionModal(), setIsPassed(true);
     },

--- a/curriculum/challenges/english/25-front-end-development/quiz-advanced-react/66f1ad049d7a6ac0886cc2ba.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-advanced-react/66f1ad049d7a6ac0886cc2ba.md
@@ -7,7 +7,7 @@ dashedName: quiz-advanced-react
 
 # --description--
 
-To pass the quiz, you must correctly answer at least 17 of the 20 questions below.
+To pass the quiz, you must correctly answer at least 18 of the 20 questions below.
 
 # --quizzes--
 

--- a/curriculum/challenges/english/25-front-end-development/quiz-asynchronous-javascript/66edd630f7666cfa54b404d0.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-asynchronous-javascript/66edd630f7666cfa54b404d0.md
@@ -7,7 +7,7 @@ dashedName: quiz-asynchronous-javascript
 
 # --description--
 
-To pass the quiz, you must correctly answer at least 17 of the 20 questions below.
+To pass the quiz, you must correctly answer at least 18 of the 20 questions below.
 
 # --quizzes--
 

--- a/curriculum/challenges/english/25-front-end-development/quiz-bash-and-sql/66f1affc0ef4fcca423d4688.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-bash-and-sql/66f1affc0ef4fcca423d4688.md
@@ -7,7 +7,7 @@ dashedName: quiz-bash-and-sql
 
 # --description--
 
-To pass the quiz, you must correctly answer at least 17 of the 20 questions below.
+To pass the quiz, you must correctly answer at least 18 of the 20 questions below.
 
 # --quizzes--
 

--- a/curriculum/challenges/english/25-front-end-development/quiz-bash-commands/66f1af4fedf643c78d024c5e.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-bash-commands/66f1af4fedf643c78d024c5e.md
@@ -7,7 +7,7 @@ dashedName: quiz-bash-commands
 
 # --description--
 
-To pass the quiz, you must correctly answer at least 17 of the 20 questions below.
+To pass the quiz, you must correctly answer at least 18 of the 20 questions below.
 
 # --quizzes--
 

--- a/curriculum/challenges/english/25-front-end-development/quiz-bash-scripting/66f1afbd9998e9c985d8e73b.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-bash-scripting/66f1afbd9998e9c985d8e73b.md
@@ -7,7 +7,7 @@ dashedName: quiz-bash-scripting
 
 # --description--
 
-To pass the quiz, you must correctly answer at least 17 of the 20 questions below.
+To pass the quiz, you must correctly answer at least 18 of the 20 questions below.
 
 # --quizzes--
 

--- a/curriculum/challenges/english/25-front-end-development/quiz-basic-css/66ed8fa2f45ce3ece4053eab.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-basic-css/66ed8fa2f45ce3ece4053eab.md
@@ -7,7 +7,7 @@ dashedName: quiz-basic-css
 
 # --description--
 
-To pass the quiz, you must correctly answer at least 17 of the 20 questions below.
+To pass the quiz, you must correctly answer at least 18 of the 20 questions below.
 
 # --quizzes--
 

--- a/curriculum/challenges/english/25-front-end-development/quiz-basic-html/66df3b712c41c499e9d31e5b.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-basic-html/66df3b712c41c499e9d31e5b.md
@@ -7,7 +7,7 @@ dashedName: quiz-basic-html
 
 # --description--
 
-To pass the quiz, you must correctly answer at least 17 of the 20 questions below.
+To pass the quiz, you must correctly answer at least 18 of the 20 questions below.
 
 # --quizzes--
 

--- a/curriculum/challenges/english/25-front-end-development/quiz-computer-basics/66ed8fb9f45ce3ece4053eac.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-computer-basics/66ed8fb9f45ce3ece4053eac.md
@@ -7,7 +7,7 @@ dashedName: quiz-computer-basics
 
 # --description--
 
-To pass the quiz, you must correctly answer at least 17 of the 20 questions below.
+To pass the quiz, you must correctly answer at least 18 of the 20 questions below.
 
 # --quizzes--
 

--- a/curriculum/challenges/english/25-front-end-development/quiz-css-accessibility/66ed8fc1f45ce3ece4053ead.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-css-accessibility/66ed8fc1f45ce3ece4053ead.md
@@ -7,7 +7,7 @@ dashedName: quiz-css-accessibility
 
 # --description--
 
-To pass the quiz, you must correctly answer at least 17 of the 20 questions below.
+To pass the quiz, you must correctly answer at least 18 of the 20 questions below.
 
 # --quizzes--
 

--- a/curriculum/challenges/english/25-front-end-development/quiz-css-animations/66ed8fc9f45ce3ece4053eae.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-css-animations/66ed8fc9f45ce3ece4053eae.md
@@ -7,7 +7,7 @@ dashedName: quiz-css-animations
 
 # --description--
 
-To pass the quiz, you must correctly answer at least 17 of the 20 questions below.
+To pass the quiz, you must correctly answer at least 18 of the 20 questions below.
 
 # --quizzes--
 

--- a/curriculum/challenges/english/25-front-end-development/quiz-css-attribute-selectors/66ed8fd0f45ce3ece4053eaf.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-css-attribute-selectors/66ed8fd0f45ce3ece4053eaf.md
@@ -7,7 +7,7 @@ dashedName: quiz-css-attribute-selectors
 
 # --description--
 
-To pass the quiz, you must correctly answer at least 17 of the 20 questions below.
+To pass the quiz, you must correctly answer at least 18 of the 20 questions below.
 
 # --quizzes--
 

--- a/curriculum/challenges/english/25-front-end-development/quiz-css-backgrounds-and-borders/66ed8fd7f45ce3ece4053eb0.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-css-backgrounds-and-borders/66ed8fd7f45ce3ece4053eb0.md
@@ -7,7 +7,7 @@ dashedName: quiz-css-backgrounds-and-borders
 
 # --description--
 
-To pass the quiz, you must correctly answer at least 17 of the 20 questions below.
+To pass the quiz, you must correctly answer at least 18 of the 20 questions below.
 
 # --quizzes--
 

--- a/curriculum/challenges/english/25-front-end-development/quiz-css-colors/66ed8fe1f45ce3ece4053eb1.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-css-colors/66ed8fe1f45ce3ece4053eb1.md
@@ -7,7 +7,7 @@ dashedName: quiz-css-colors
 
 # --description--
 
-To pass the quiz, you must correctly answer at least 17 of the 20 questions below.
+To pass the quiz, you must correctly answer at least 18 of the 20 questions below.
 
 # --quizzes--
 

--- a/curriculum/challenges/english/25-front-end-development/quiz-css-flexbox/66ed8fe7f45ce3ece4053eb2.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-css-flexbox/66ed8fe7f45ce3ece4053eb2.md
@@ -7,7 +7,7 @@ dashedName: quiz-css-flexbox
 
 # --description--
 
-To pass the quiz, you must correctly answer at least 17 of the 20 questions below.
+To pass the quiz, you must correctly answer at least 18 of the 20 questions below.
 
 # --quizzes--
 

--- a/curriculum/challenges/english/25-front-end-development/quiz-css-grid/66ed8fedf45ce3ece4053eb3.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-css-grid/66ed8fedf45ce3ece4053eb3.md
@@ -7,7 +7,7 @@ dashedName: quiz-css-grid
 
 # --description--
 
-To pass the quiz, you must correctly answer at least 17 of the 20 questions below.
+To pass the quiz, you must correctly answer at least 18 of the 20 questions below.
 
 # --quizzes--
 

--- a/curriculum/challenges/english/25-front-end-development/quiz-css-layout-and-effects/66ed8ff4f45ce3ece4053eb4.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-css-layout-and-effects/66ed8ff4f45ce3ece4053eb4.md
@@ -7,7 +7,7 @@ dashedName: quiz-css-layout-and-effects
 
 # --description--
 
-To pass the quiz, you must correctly answer at least 17 of the 20 questions below.
+To pass the quiz, you must correctly answer at least 18 of the 20 questions below.
 
 # --quizzes--
 

--- a/curriculum/challenges/english/25-front-end-development/quiz-css-libraries-and-frameworks/66f1aeb60b11aec5abe83c2e.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-css-libraries-and-frameworks/66f1aeb60b11aec5abe83c2e.md
@@ -7,7 +7,7 @@ dashedName: quiz-css-libraries-and-frameworks
 
 # --description--
 
-To pass the quiz, you must correctly answer at least 17 of the 20 questions below.
+To pass the quiz, you must correctly answer at least 18 of the 20 questions below.
 
 # --quizzes--
 

--- a/curriculum/challenges/english/25-front-end-development/quiz-css-positioning/66ed8ffcf45ce3ece4053eb5.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-css-positioning/66ed8ffcf45ce3ece4053eb5.md
@@ -7,7 +7,7 @@ dashedName: quiz-css-positioning
 
 # --description--
 
-To pass the quiz, you must correctly answer at least 17 of the 20 questions below.
+To pass the quiz, you must correctly answer at least 18 of the 20 questions below.
 
 # --quizzes--
 

--- a/curriculum/challenges/english/25-front-end-development/quiz-css-pseudo-classes/66ed9002f45ce3ece4053eb6.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-css-pseudo-classes/66ed9002f45ce3ece4053eb6.md
@@ -7,7 +7,7 @@ dashedName: quiz-css-pseudo-classes
 
 # --description--
 
-To pass the quiz, you must correctly answer at least 17 of the 20 questions below.
+To pass the quiz, you must correctly answer at least 18 of the 20 questions below.
 
 # --quizzes--
 

--- a/curriculum/challenges/english/25-front-end-development/quiz-css-relative-and-absolute-units/66ed9009f45ce3ece4053eb7.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-css-relative-and-absolute-units/66ed9009f45ce3ece4053eb7.md
@@ -7,7 +7,7 @@ dashedName: quiz-css-relative-and-absolute-units
 
 # --description--
 
-To pass the quiz, you must correctly answer at least 17 of the 20 questions below.
+To pass the quiz, you must correctly answer at least 18 of the 20 questions below.
 
 # --quizzes--
 

--- a/curriculum/challenges/english/25-front-end-development/quiz-css-typography/66ed9010f45ce3ece4053eb8.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-css-typography/66ed9010f45ce3ece4053eb8.md
@@ -7,7 +7,7 @@ dashedName: quiz-css-typography
 
 # --description--
 
-To pass the quiz, you must correctly answer at least 17 of the 20 questions below.
+To pass the quiz, you must correctly answer at least 18 of the 20 questions below.
 
 # --quizzes--
 

--- a/curriculum/challenges/english/25-front-end-development/quiz-css-variables/66ed9018f45ce3ece4053eb9.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-css-variables/66ed9018f45ce3ece4053eb9.md
@@ -7,7 +7,7 @@ dashedName: quiz-css-variables
 
 # --description--
 
-To pass the quiz, you must correctly answer at least 17 of the 20 questions below.
+To pass the quiz, you must correctly answer at least 18 of the 20 questions below.
 
 # --quizzes--
 

--- a/curriculum/challenges/english/25-front-end-development/quiz-debugging-javascript/66edd10913f078e7669eca81.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-debugging-javascript/66edd10913f078e7669eca81.md
@@ -7,7 +7,7 @@ dashedName: quiz-debugging-javascript
 
 # --description--
 
-To pass the quiz, you must correctly answer at least 17 of the 20 questions below.
+To pass the quiz, you must correctly answer at least 18 of the 20 questions below.
 
 # --quizzes--
 

--- a/curriculum/challenges/english/25-front-end-development/quiz-design-fundamentals/66ed901ff45ce3ece4053eba.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-design-fundamentals/66ed901ff45ce3ece4053eba.md
@@ -7,7 +7,7 @@ dashedName: quiz-design-fundamentals
 
 # --description--
 
-To pass the quiz, you must correctly answer at least 17 of the 20 questions below.
+To pass the quiz, you must correctly answer at least 18 of the 20 questions below.
 
 # --quizzes--
 

--- a/curriculum/challenges/english/25-front-end-development/quiz-dom-manipulation-and-click-event-with-javascript/66edd07682767adff3a6231e.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-dom-manipulation-and-click-event-with-javascript/66edd07682767adff3a6231e.md
@@ -7,7 +7,7 @@ dashedName: quiz-dom-manipulation-and-click-event-with-javascript
 
 # --description--
 
-To pass the quiz, you must correctly answer at least 17 of the 20 questions below.
+To pass the quiz, you must correctly answer at least 18 of the 20 questions below.
 
 # --quizzes--
 

--- a/curriculum/challenges/english/25-front-end-development/quiz-form-validation-with-javascript/66edd3403d7077eece6dc4b6.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-form-validation-with-javascript/66edd3403d7077eece6dc4b6.md
@@ -7,7 +7,7 @@ dashedName: quiz-form-validation-with-javascript
 
 # --description--
 
-To pass the quiz, you must correctly answer at least 17 of the 20 questions below.
+To pass the quiz, you must correctly answer at least 18 of the 20 questions below.
 
 # --quizzes--
 

--- a/curriculum/challenges/english/25-front-end-development/quiz-git/66f1b06a5a5d10cc100af620.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-git/66f1b06a5a5d10cc100af620.md
@@ -7,7 +7,7 @@ dashedName: quiz-git
 
 # --description--
 
-To pass the quiz, you must correctly answer at least 17 of the 20 questions below.
+To pass the quiz, you must correctly answer at least 18 of the 20 questions below.
 
 # --quizzes--
 

--- a/curriculum/challenges/english/25-front-end-development/quiz-html-accessibility/66ed9026f45ce3ece4053ebb.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-html-accessibility/66ed9026f45ce3ece4053ebb.md
@@ -7,7 +7,7 @@ dashedName: quiz-html-accessibility
 
 # --description--
 
-To pass the quiz, you must correctly answer at least 17 of the 20 questions below.
+To pass the quiz, you must correctly answer at least 18 of the 20 questions below.
 
 # --quizzes--
 

--- a/curriculum/challenges/english/25-front-end-development/quiz-html-tables-and-forms/66ed902df45ce3ece4053ebc.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-html-tables-and-forms/66ed902df45ce3ece4053ebc.md
@@ -7,7 +7,7 @@ dashedName: quiz-html-tables-and-forms
 
 # --description--
 
-To pass the quiz, you must correctly answer at least 17 of the 20 questions below.
+To pass the quiz, you must correctly answer at least 18 of the 20 questions below.
 
 # --quizzes--
 

--- a/curriculum/challenges/english/25-front-end-development/quiz-javascript-arrays/66edcccbba6dacdb65a59067.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-javascript-arrays/66edcccbba6dacdb65a59067.md
@@ -7,7 +7,7 @@ dashedName: quiz-javascript-arrays
 
 # --description--
 
-To pass the quiz, you must correctly answer at least 17 of the 20 questions below.
+To pass the quiz, you must correctly answer at least 18 of the 20 questions below.
 
 # --quizzes--
 

--- a/curriculum/challenges/english/25-front-end-development/quiz-javascript-audio-and-video/66edd3b3096349f06cf688bb.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-javascript-audio-and-video/66edd3b3096349f06cf688bb.md
@@ -7,7 +7,7 @@ dashedName: quiz-javascript-audio-and-video
 
 # --description--
 
-To pass the quiz, you must correctly answer at least 17 of the 20 questions below.
+To pass the quiz, you must correctly answer at least 18 of the 20 questions below.
 
 # --quizzes--
 

--- a/curriculum/challenges/english/25-front-end-development/quiz-javascript-classes/67358ac128957c865dcf3ddf.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-javascript-classes/67358ac128957c865dcf3ddf.md
@@ -7,7 +7,7 @@ dashedName: quiz-javascript-classes
 
 # --description--
 
-To pass the quiz, you must correctly answer at least 17 of the 20 questions below.
+To pass the quiz, you must correctly answer at least 18 of the 20 questions below.
 
 # --quizzes--
 

--- a/curriculum/challenges/english/25-front-end-development/quiz-javascript-comparisons-and-conditionals/66edc47c11492ac5cf258ad9.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-javascript-comparisons-and-conditionals/66edc47c11492ac5cf258ad9.md
@@ -7,7 +7,7 @@ dashedName: quiz-javascript-comparisons-and-conditionals
 
 # --description--
 
-To pass the quiz, you must correctly answer at least 17 of the 20 questions below.
+To pass the quiz, you must correctly answer at least 18 of the 20 questions below.
 
 # --quizzes--
 

--- a/curriculum/challenges/english/25-front-end-development/quiz-javascript-dates/66edd3711bb9f7efa73aef91.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-javascript-dates/66edd3711bb9f7efa73aef91.md
@@ -7,7 +7,7 @@ dashedName: quiz-javascript-dates
 
 # --description--
 
-To pass the quiz, you must correctly answer at least 17 of the 20 questions below.
+To pass the quiz, you must correctly answer at least 18 of the 20 questions below.
 
 # --quizzes--
 

--- a/curriculum/challenges/english/25-front-end-development/quiz-javascript-events/66edd0ac31fea6e678eb925a.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-javascript-events/66edd0ac31fea6e678eb925a.md
@@ -7,7 +7,7 @@ dashedName: quiz-javascript-events
 
 # --description--
 
-To pass the quiz, you must correctly answer at least 17 of the 20 questions below.
+To pass the quiz, you must correctly answer at least 18 of the 20 questions below.
 
 # --quizzes--
 

--- a/curriculum/challenges/english/25-front-end-development/quiz-javascript-functional-programming/66edd4f31ff19bf5573bf64b.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-javascript-functional-programming/66edd4f31ff19bf5573bf64b.md
@@ -7,7 +7,7 @@ dashedName: quiz-javascript-functional-programming
 
 # --description--
 
-To pass the quiz, you must correctly answer at least 17 of the 20 questions below.
+To pass the quiz, you must correctly answer at least 18 of the 20 questions below.
 
 # --quizzes--
 

--- a/curriculum/challenges/english/25-front-end-development/quiz-javascript-functions/66edcc779993c0da6906dbb9.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-javascript-functions/66edcc779993c0da6906dbb9.md
@@ -7,7 +7,7 @@ dashedName: quiz-javascript-functions
 
 # --description--
 
-To pass the quiz, you must correctly answer at least 17 of the 20 questions below.
+To pass the quiz, you must correctly answer at least 18 of the 20 questions below.
 
 # --quizzes--
 

--- a/curriculum/challenges/english/25-front-end-development/quiz-javascript-fundamentals/66edcd875b0d91de1fbbb492.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-javascript-fundamentals/66edcd875b0d91de1fbbb492.md
@@ -7,7 +7,7 @@ dashedName: quiz-javascript-fundamentals
 
 # --description--
 
-To pass the quiz, you must correctly answer at least 17 of the 20 questions below.
+To pass the quiz, you must correctly answer at least 18 of the 20 questions below.
 
 # --quizzes--
 

--- a/curriculum/challenges/english/25-front-end-development/quiz-javascript-higher-order-functions/66edcdd18a4ef8df16e6bb7e.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-javascript-higher-order-functions/66edcdd18a4ef8df16e6bb7e.md
@@ -7,7 +7,7 @@ dashedName: quiz-javascript-higher-order-functions
 
 # --description--
 
-To pass the quiz, you must correctly answer at least 17 of the 20 questions below.
+To pass the quiz, you must correctly answer at least 18 of the 20 questions below.
 
 # --quizzes--
 

--- a/curriculum/challenges/english/25-front-end-development/quiz-javascript-loops/66edcd49e73385dd4df54ac7.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-javascript-loops/66edcd49e73385dd4df54ac7.md
@@ -7,7 +7,7 @@ dashedName: quiz-javascript-loops
 
 # --description--
 
-To pass the quiz, you must correctly answer at least 17 of the 20 questions below.
+To pass the quiz, you must correctly answer at least 18 of the 20 questions below.
 
 # --quizzes--
 

--- a/curriculum/challenges/english/25-front-end-development/quiz-javascript-maps-and-sets/67358be1c7903489c0a7db78.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-javascript-maps-and-sets/67358be1c7903489c0a7db78.md
@@ -7,7 +7,7 @@ dashedName: quiz-javascript-maps-and-sets
 
 # --description--
 
-To pass the quiz, you must correctly answer at least 17 of the 20 questions below.
+To pass the quiz, you must correctly answer at least 18 of the 20 questions below.
 
 # --quizzes--
 

--- a/curriculum/challenges/english/25-front-end-development/quiz-javascript-math/66edc3ab8c6413c344f401bf.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-javascript-math/66edc3ab8c6413c344f401bf.md
@@ -7,7 +7,7 @@ dashedName: quiz-javascript-math
 
 # --description--
 
-To pass the quiz, you must correctly answer at least 17 of the 20 questions below.
+To pass the quiz, you must correctly answer at least 18 of the 20 questions below.
 
 # --quizzes--
 

--- a/curriculum/challenges/english/25-front-end-development/quiz-javascript-objects/66edcd0ecb4b25dc64a34804.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-javascript-objects/66edcd0ecb4b25dc64a34804.md
@@ -7,7 +7,7 @@ dashedName: quiz-javascript-objects
 
 # --description--
 
-To pass the quiz, you must correctly answer at least 17 of the 20 questions below.
+To pass the quiz, you must correctly answer at least 18 of the 20 questions below.
 
 # --quizzes--
 

--- a/curriculum/challenges/english/25-front-end-development/quiz-javascript-regular-expressions/66edd3011f18f4ee1bd9d28b.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-javascript-regular-expressions/66edd3011f18f4ee1bd9d28b.md
@@ -7,7 +7,7 @@ dashedName: quiz-javascript-regular-expressions
 
 # --description--
 
-To pass the quiz, you must correctly answer at least 17 of the 20 questions below.
+To pass the quiz, you must correctly answer at least 18 of the 20 questions below.
 
 # --quizzes--
 

--- a/curriculum/challenges/english/25-front-end-development/quiz-javascript-strings/66edc31c44f1b9c1d5c5ebca.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-javascript-strings/66edc31c44f1b9c1d5c5ebca.md
@@ -7,7 +7,7 @@ dashedName: quiz-javascript-strings
 
 # --description--
 
-To pass the quiz, you must correctly answer at least 17 of the 20 questions below.
+To pass the quiz, you must correctly answer at least 18 of the 20 questions below.
 
 # --quizzes--
 

--- a/curriculum/challenges/english/25-front-end-development/quiz-javascript-variables-and-data-types/66edc25ae5ea80bf6f785552.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-javascript-variables-and-data-types/66edc25ae5ea80bf6f785552.md
@@ -7,7 +7,7 @@ dashedName: quiz-javascript-variables-and-data-types
 
 # --description--
 
-To pass the quiz, you must correctly answer at least 17 of the 20 questions below.
+To pass the quiz, you must correctly answer at least 18 of the 20 questions below.
 
 # --quizzes--
 

--- a/curriculum/challenges/english/25-front-end-development/quiz-local-storage-and-crud/66edd3f9bef926f129990425.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-local-storage-and-crud/66edd3f9bef926f129990425.md
@@ -7,7 +7,7 @@ dashedName: quiz-local-storage-and-crud
 
 # --description--
 
-To pass the quiz, you must correctly answer at least 17 of the 20 questions below.
+To pass the quiz, you must correctly answer at least 18 of the 20 questions below.
 
 # --quizzes--
 

--- a/curriculum/challenges/english/25-front-end-development/quiz-nano/66f1b03b922a53cb231e1c0d.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-nano/66f1b03b922a53cb231e1c0d.md
@@ -7,7 +7,7 @@ dashedName: quiz-nano
 
 # --description--
 
-To pass the quiz, you must correctly answer at least 17 of the 20 questions below.
+To pass the quiz, you must correctly answer at least 18 of the 20 questions below.
 
 # --quizzes--
 

--- a/curriculum/challenges/english/25-front-end-development/quiz-react-basics/66f1a2009e65c9a40a26d51e.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-react-basics/66f1a2009e65c9a40a26d51e.md
@@ -7,7 +7,7 @@ dashedName: quiz-react-basics
 
 # --description--
 
-To pass the quiz, you must correctly answer at least 17 of the 20 questions below.
+To pass the quiz, you must correctly answer at least 18 of the 20 questions below.
 
 # --quizzes--
 

--- a/curriculum/challenges/english/25-front-end-development/quiz-react-state-and-hooks/66f1a417757b6ca4eecd89d6.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-react-state-and-hooks/66f1a417757b6ca4eecd89d6.md
@@ -7,7 +7,7 @@ dashedName: quiz-react-state-and-hooks
 
 # --description--
 
-To pass the quiz, you must correctly answer at least 17 of the 20 questions below.
+To pass the quiz, you must correctly answer at least 18 of the 20 questions below.
 
 # --quizzes--
 

--- a/curriculum/challenges/english/25-front-end-development/quiz-recursion/66edd43cded6bff30944b676.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-recursion/66edd43cded6bff30944b676.md
@@ -7,7 +7,7 @@ dashedName: quiz-recursion
 
 # --description--
 
-To pass the quiz, you must correctly answer at least 17 of the 20 questions below.
+To pass the quiz, you must correctly answer at least 18 of the 20 questions below.
 
 # --quizzes--
 

--- a/curriculum/challenges/english/25-front-end-development/quiz-relational-database/66f1af82732957c895f0b21a.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-relational-database/66f1af82732957c895f0b21a.md
@@ -7,7 +7,7 @@ dashedName: quiz-relational-database
 
 # --description--
 
-To pass the quiz, you must correctly answer at least 17 of the 20 questions below.
+To pass the quiz, you must correctly answer at least 18 of the 20 questions below.
 
 # --quizzes--
 

--- a/curriculum/challenges/english/25-front-end-development/quiz-responsive-web-design/66ed9034f45ce3ece4053ebd.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-responsive-web-design/66ed9034f45ce3ece4053ebd.md
@@ -7,7 +7,7 @@ dashedName: quiz-responsive-web-design
 
 # --description--
 
-To pass the quiz, you must correctly answer at least 17 of the 20 questions below.
+To pass the quiz, you must correctly answer at least 18 of the 20 questions below.
 
 # --quizzes--
 

--- a/curriculum/challenges/english/25-front-end-development/quiz-semantic-html/66ed903cf45ce3ece4053ebe.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-semantic-html/66ed903cf45ce3ece4053ebe.md
@@ -7,7 +7,7 @@ dashedName: quiz-semantic-html
 
 # --description--
 
-To pass the quiz, you must correctly answer at least 17 of the 20 questions below.
+To pass the quiz, you must correctly answer at least 18 of the 20 questions below.
 
 # --quizzes--
 

--- a/curriculum/challenges/english/25-front-end-development/quiz-styling-forms/66ed9043f45ce3ece4053ebf.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-styling-forms/66ed9043f45ce3ece4053ebf.md
@@ -7,7 +7,7 @@ dashedName: quiz-styling-forms
 
 # --description--
 
-To pass the quiz, you must correctly answer at least 17 of the 20 questions below.
+To pass the quiz, you must correctly answer at least 18 of the 20 questions below.
 
 # --quizzes--
 

--- a/curriculum/challenges/english/25-front-end-development/quiz-testing/66f1aeffc5774ac692112a7e.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-testing/66f1aeffc5774ac692112a7e.md
@@ -7,7 +7,7 @@ dashedName: quiz-testing
 
 # --description--
 
-To pass the quiz, you must correctly answer at least 17 of the 20 questions below.
+To pass the quiz, you must correctly answer at least 18 of the 20 questions below.
 
 # --quizzes--
 

--- a/curriculum/challenges/english/25-front-end-development/quiz-typescript/66f1ae758b77cfc3e4da6151.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-typescript/66f1ae758b77cfc3e4da6151.md
@@ -7,7 +7,7 @@ dashedName: quiz-typescript
 
 # --description--
 
-To pass the quiz, you must correctly answer at least 17 of the 20 questions below.
+To pass the quiz, you must correctly answer at least 18 of the 20 questions below.
 
 # --quizzes--
 

--- a/curriculum/challenges/english/25-front-end-development/quiz-web-performance/66f1adcf97e3e4c1bd89ebf5.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-web-performance/66f1adcf97e3e4c1bd89ebf5.md
@@ -7,7 +7,7 @@ dashedName: quiz-web-performance
 
 # --description--
 
-To pass the quiz, you must correctly answer at least 17 of the 20 questions below.
+To pass the quiz, you must correctly answer at least 18 of the 20 questions below.
 
 # --quizzes--
 

--- a/curriculum/schema/challenge-schema.js
+++ b/curriculum/schema/challenge-schema.js
@@ -112,7 +112,14 @@ const quizJoi = Joi.object().keys({
         answer: Joi.string().required()
       })
     )
-    .length(20)
+    .custom((value, helpers) => {
+      return value.length === 10 || value.length === 20
+        ? value
+        : helpers.error('array.invalidLength');
+    })
+    .messages({
+      'array.invalidLength': 'Quiz must have exactly 10 or 20 questions.'
+    })
     .required()
 });
 


### PR DESCRIPTION
Some modules don't have a lot of content - making it tough to come up with 20 questions for a quiz. This allows quizzes that have 10 questions. ~~For 20 question quizzes, you need 17/20 (85%) correct to pass. For 10 question quizzes, this makes it 8/10 (80%) to pass. I could argue that we move that to 90%.~~ What do you think @jdwilkin4?

Edit: Since we won't be having the cooldown period, and the quizzes will be more accurate after the audit, we are making all quizzes 90% to pass.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
