### PR TITLE
fix(curriculum): correct src property in music player step 6 test feedback

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-string-and-array-methods-by-building-a-music-player/65606ed6ea2baca053327e9b.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-string-and-array-methods-by-building-a-music-player/65606ed6ea2baca053327e9b.md
@@ -49,7 +49,7 @@ The third object in your `allSongs` array should have a `duration` property set 
 assert.equal(allSongs[2].duration, "3:51");
 ```
 
-The third object in your `allSongs` array should have a `src` property set to the string `"https://cdn.freecodecamp.org/curriculum/js-music-player/can't-stay-down.mp3"`.
+The third object in your `allSongs` array should have a `src` property set to the string `"https://cdn.freecodecamp.org/curriculum/js-music-player/still-learning.mp3"`.
 
 ```js
 assert.equal(allSongs[2].src, "https://cdn.freecodecamp.org/curriculum/js-music-player/still-learning.mp3");

--- a/curriculum/challenges/english/25-front-end-development/workshop-music-player/674728eda5829d7b4c360643.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-music-player/674728eda5829d7b4c360643.md
@@ -49,7 +49,7 @@ The third object in your `allSongs` array should have a `duration` property set 
 assert.equal(allSongs[2].duration, "3:51");
 ```
 
-The third object in your `allSongs` array should have a `src` property set to the string `"https://cdn.freecodecamp.org/curriculum/js-music-player/can't-stay-down.mp3"`.
+The third object in your `allSongs` array should have a `src` property set to the string `"https://cdn.freecodecamp.org/curriculum/js-music-player/still-learning.mp3"`.
 
 ```js
 assert.equal(allSongs[2].src, "https://cdn.freecodecamp.org/curriculum/js-music-player/still-learning.mp3");


### PR DESCRIPTION
 Fixed a minor bug in the test feedback for Step 6 of the Building a Music Player project. The test feedback incorrectly references the src property of the third object in the allSongs array as "can't-stay-down.mp3" instead of the correct file, "still-learning.mp3". 

Checklist:
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Closes #58413