### PR TITLE
fix(i18n): typo for intro text to DOM review

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -2961,7 +2961,7 @@
         "title": "DOM Manipulation and Click Events with JavaScript Review",
         "intro": [
           "Before you're quizzed on the DOM, you should review what you've learned about it.",
-          "Open up this page to review concepts including how to work with the <code>DOM</code>, <code>Web API's/code>, the <code>addEventListener()</code> method and more."
+          "Open up this page to review concepts including how to work with the <code>DOM</code>, <code>Web API's</code>, the <code>addEventListener()</code> method and more."
         ]
       },
       "quiz-dom-manipulation-and-click-event-with-javascript": {


### PR DESCRIPTION
Added missing '<' in introductory text in the DOM review section. 
![Screenshot 2025-01-29 115803](https://github.com/user-attachments/assets/9099176a-bd39-41a0-8c43-e37dd45082b0)
After merge, the text should view like intended.


Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes [#58464](https://github.com/freeCodeCamp/freeCodeCamp/issues/58464)

<!-- Feel free to add any additional description of changes below this line -->
