### PR TITLE
fix(curriculum): fix regex issues and improve trivia-bot test flexibility

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-javascript-trivia-bot/66ed41f912d0bb1dc62da5dd.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-javascript-trivia-bot/66ed41f912d0bb1dc62da5dd.md
@@ -80,7 +80,7 @@ You should give `codingFact` a value  that includes `favoriteLanguage` using con
 ```js
 const codeWithoutComments = __helpers.removeJSComments(code);
 const [first, second, third] = codeWithoutComments.match(/(let )?\s*codingFact\s*=\s*(("|')?.+?\2?\s*\+\s*|favoriteLanguage\s*\+\s*(("|')?.+?\2?))/g);
-assert.match(code, /let\scodingFact\s*=\s*("|')?.+?\1?\s*\+\s*favoriteLanguage/)
+assert.match(code, /let\scodingFact\s*=\s*(("|')?.+?\1?\s*\+\s*|favoriteLanguage\s*\+\s*(("|')?.+?\3?))/);
 assert.include(first, 'let');
 assert.exists(first);
 assert.isNotEmpty(codingFact); 

--- a/curriculum/challenges/english/25-front-end-development/lab-javascript-trivia-bot/66ed41f912d0bb1dc62da5dd.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-javascript-trivia-bot/66ed41f912d0bb1dc62da5dd.md
@@ -79,7 +79,7 @@ You should give `codingFact` a value  that includes `favoriteLanguage` using con
 
 ```js
 const codeWithoutComments = __helpers.removeJSComments(code);
-const [first, second, third] = codeWithoutComments.match(/(let )?\s*codingFact\s*=\s*("|')?.+?\2?\s*\+\s*favoriteLanguage/g)
+const [first, second, third] = codeWithoutComments.match(/(let )?\s*codingFact\s*=\s*(("|')?.+?\2?\s*\+\s*|favoriteLanguage\s*\+\s*(("|')?.+?\2?))/g);
 assert.match(code, /let\scodingFact\s*=\s*("|')?.+?\1?\s*\+\s*favoriteLanguage/)
 assert.include(first, 'let');
 assert.exists(first);
@@ -100,7 +100,7 @@ You should assign a new value to `codingFact` that also contains `favoriteLangua
 ```js
 const codeWithoutComments = __helpers.removeJSComments(code);
 const loggingCodingFacts = codeWithoutComments.match(/console\.log\(\s*codingFact\s*\)/g)
-const [first, second, third] = codeWithoutComments.match(/(let )?\s*codingFact\s*=\s*("|')?.+?\2?\s*\+\s*favoriteLanguage/g)
+const [first, second, third] = codeWithoutComments.match(/(let )?\s*codingFact\s*=\s*(("|')?.+?\2?\s*\+\s*|favoriteLanguage\s*\+\s*(("|')?.+?\2?))/g);
 assert.include(output[4], favoriteLanguage);
 assert.notEqual(output[4], output[3]);
 assert.isAtLeast(loggingCodingFacts.length, 2);
@@ -113,7 +113,7 @@ You should assign a value to `codingFact` for the third time that also contains 
 ```js
 const codeWithoutComments = __helpers.removeJSComments(code);
 const loggingCodingFacts = codeWithoutComments.match(/console\.log\(\s*codingFact\s*\)/g)
-const [first, second, third] = codeWithoutComments.match(/(let )?\s*codingFact\s*=\s*("|')?.+?\2?\s*\+\s*favoriteLanguage/g)
+const [first, second, third] = codeWithoutComments.match(/(let )?\s*codingFact\s*=\s*(("|')?.+?\2?\s*\+\s*|favoriteLanguage\s*\+\s*(("|')?.+?\2?))/g);
 assert.include(output[5], favoriteLanguage);
 assert.notEqual(output[5], output[4]);
 assert.equal(output[5], codingFact);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #58502

<!-- Feel free to add any additional description of changes below this line -->

Modified regex expression so `favoriteLanguage` can be placed anywhere in the string, including at the start and in the middle. Previously the regex only worked when favoriteLanguage was at the end. This caused the `third` variable to be `undefined`, failing the `assert.exists(third);` test.

Tested with the following cases:
```js
// PASS
// codingFact = "This will pass " + favoriteLanguage;
// codingFact = favoriteLanguage + " should pass";
// codingFact = "This test " + favoriteLanguage + " passes";

//FAIL
// codingFact = favoriteLanguage;
// codingFact = "This will fail";
// codingFact = 'This will fail';
```

