### PR TITLE
fix(curriculum): registration form anchor fix

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fab8367d35de04e5cb7929.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fab8367d35de04e5cb7929.md
@@ -49,7 +49,7 @@ The text inside your anchor element has extra leading or trailing whitespace. Th
 
 ```js
 const nestedAnchor = document.querySelector('fieldset:nth-child(3) + label > input + a')?.textContent;
-const innerContent = nestedAnchor.innerHTML;
+const innerContent = nestedAnchor?.innerHTML;
 assert.isNotTrue(/^\s+|\s+$/.test(innerContent));
 ```
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-registration-form/60fab8367d35de04e5cb7929.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-registration-form/60fab8367d35de04e5cb7929.md
@@ -49,7 +49,7 @@ The text inside your anchor element has extra leading or trailing whitespace. Th
 
 ```js
 const nestedAnchor = document.querySelector('fieldset:nth-child(3) + label > input + a')?.textContent;
-const innerContent = nestedAnchor.innerHTML;
+const innerContent = nestedAnchor?.innerHTML;
 assert.isNotTrue(/^\s+|\s+$/.test(innerContent));
 ```
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #58514

<!-- Feel free to add any additional description of changes below this line -->
Very simple fix of adding a `?` after the variable name.

I think we should adjust the word "following" but it's beyond the scope of this PR. 