### PR TITLE
refactor(client): fixed/hid type errors + extended isPoly

### DIFF
--- a/client/src/templates/Challenges/classic/saved-challenges.test.ts
+++ b/client/src/templates/Challenges/classic/saved-challenges.test.ts
@@ -5,7 +5,6 @@ import type {
 import { mergeChallengeFiles } from './saved-challenges';
 
 const jsChallenge = {
-  id: '1',
   contents: 'js contents',
   fileKey: 'jsFileKey',
   name: 'name',
@@ -13,11 +12,11 @@ const jsChallenge = {
   head: 'head',
   tail: 'tail',
   history: [],
-  seed: 'original js contents'
+  seed: 'original js contents',
+  path: 'index.js'
 };
 
 const cssChallenge = {
-  id: '2',
   contents: 'css contents',
   fileKey: 'cssFileKey',
   name: 'name',
@@ -25,11 +24,11 @@ const cssChallenge = {
   head: 'head',
   tail: 'tail',
   history: [],
-  seed: 'original css contents'
+  seed: 'original css contents',
+  path: 'styles.css'
 };
 
 const htmlChallenge = {
-  id: '3',
   contents: 'html contents',
   fileKey: 'htmlFileKey',
   name: 'name',
@@ -37,7 +36,8 @@ const htmlChallenge = {
   head: 'head',
   tail: 'tail',
   history: [],
-  seed: 'original html contents'
+  seed: 'original html contents',
+  path: 'index.html'
 };
 
 const savedJsChallenge: SavedChallengeFile = {

--- a/client/utils/__fixtures__/challenges.ts
+++ b/client/utils/__fixtures__/challenges.ts
@@ -2,7 +2,6 @@ import { ChallengeFile } from "../../src/redux/prop-types";
 
 export const challengeFiles: ChallengeFile[] = [
   {
-    id: '0',
     contents: 'some ts',
     error: null,
     ext: 'ts',
@@ -14,9 +13,9 @@ export const challengeFiles: ChallengeFile[] = [
     tail: '',
     editableRegionBoundaries: [],
     usesMultifileEditor: true,
+    path: 'index.ts',
   },
   {
-    id: '1',
     contents: 'some css',
     error: null,
     ext: 'css',
@@ -28,9 +27,9 @@ export const challengeFiles: ChallengeFile[] = [
     tail: '',
     editableRegionBoundaries: [],
     usesMultifileEditor: true,
+    path: 'styles.css',
   },
   {
-    id: '2',
     contents: 'some html',
     error: null,
     ext: 'html',
@@ -42,9 +41,9 @@ export const challengeFiles: ChallengeFile[] = [
     tail: '',
     editableRegionBoundaries: [],
     usesMultifileEditor: true,
+    path: 'index.html',
   },
   {
-    id: '3',
     contents: 'some js',
     error: null,
     ext: 'js',
@@ -56,9 +55,9 @@ export const challengeFiles: ChallengeFile[] = [
     tail: '',
     editableRegionBoundaries: [],
     usesMultifileEditor: true,
+    path: 'script.js',
   },
   {
-    id: '4',
     contents: 'some jsx',
     error: null,
     ext: 'jsx',
@@ -70,5 +69,6 @@ export const challengeFiles: ChallengeFile[] = [
     tail: '',
     editableRegionBoundaries: [],
     usesMultifileEditor: true,
+    path: 'index.jsx',
   }
 ]

--- a/shared/utils/polyvinyl.ts
+++ b/shared/utils/polyvinyl.ts
@@ -69,26 +69,32 @@ export function createPoly<Rest>({
 }
 
 export function isPoly(poly: unknown): poly is ChallengeFile {
-  return (
-    !!poly &&
-    typeof poly === 'object' &&
-    'contents' in poly &&
+  function hasProperties(poly: unknown): poly is Record<string, unknown> {
+    return (
+      !!poly &&
+      typeof poly === 'object' &&
+      'contents' in poly &&
+      'name' in poly &&
+      'ext' in poly &&
+      'fileKey' in poly &&
+      'head' in poly &&
+      'tail' in poly &&
+      'seed' in poly &&
+      'history' in poly
+    );
+  }
+
+  const hasCorrectTypes = (poly: Record<string, unknown>): boolean =>
     typeof poly.contents === 'string' &&
-    'name' in poly &&
     typeof poly.name === 'string' &&
-    'ext' in poly &&
     exts.includes(poly.ext as Ext) &&
-    'fileKey' in poly &&
     typeof poly.fileKey === 'string' &&
-    'head' in poly &&
     typeof poly.head === 'string' &&
-    'tail' in poly &&
     typeof poly.tail === 'string' &&
-    'seed' in poly &&
     typeof poly.seed === 'string' &&
-    'history' in poly &&
-    Array.isArray(poly.history)
-  );
+    Array.isArray(poly.history);
+
+  return hasProperties(poly) && hasCorrectTypes(poly);
 }
 
 function checkPoly(poly: ChallengeFile) {


### PR DESCRIPTION
It doesn't make sense to assert an object has a set of properties without at least checking the required ones.

This one contains some code changes, so I figured it was worth a separate PR.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
