### PR TITLE
Unnecessary CSS Rule in Registration Form Project #58533

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/6537e0be715fcb57d31ba8c3.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/6537e0be715fcb57d31ba8c3.md
@@ -148,10 +148,6 @@ input[type="file"] {
   padding: 1px 2px;
 }
 
-.inline{
-  display: inline; 
-}
-
 --fcc-editable-region--
 
 --fcc-editable-region--

--- a/curriculum/challenges/english/25-front-end-development/workshop-registration-form/6537e0be715fcb57d31ba8c3.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-registration-form/6537e0be715fcb57d31ba8c3.md
@@ -147,9 +147,6 @@ input[type="file"] {
   padding: 1px 2px;
 }
 
-.inline{
-  display: inline; 
-}
 
 --fcc-editable-region--
 


### PR DESCRIPTION
This PR removes the redundant .inline { display: inline; } CSS rule from the registration form challenge files. The display: inline property is already the default for inline elements, making this rule unnecessary.

Affected files:

  1.   freeCodeCamp/curriculum/challenges/english/25-front-end-development/workshop-registration-form/6537e0be715fcb57d31ba8c3.md
  2.   freeCodeCamp/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/6537e0be715fcb57d31ba8c3.md

This change improves code clarity by removing unnecessary styling.

#58533