### PR TITLE
fix(curriculum): update border test to accept CSS border property

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-stylized-to-do-list/66c051d13a6a20255a963695.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-stylized-to-do-list/66c051d13a6a20255a963695.md
@@ -179,13 +179,14 @@ assert.exists(
 The links should have an outline when focused.
 
 ```js
+const css = new __helpers.CSSHelp(document);
 assert.exists(
-  new __helpers.CSSHelp(document).getStyle('.sub-item-link:focus')?.outline ||
-    new __helpers.CSSHelp(document).getStyle('a:focus')?.outline ||
-    new __helpers.CSSHelp(document).getStyle('a.sub-item-link:focus')?.outline ||
-    new __helpers.CSSHelp(document).getStyle('.sub-item-link:focus')?.border ||
-    new __helpers.CSSHelp(document).getStyle('a:focus')?.border ||
-    new __helpers.CSSHelp(document).getStyle('a.sub-item-link:focus')?.border
+  css.getStyle('.sub-item-link:focus')?.outline ||
+    css.getStyle('a:focus')?.outline ||
+    css.getStyle('a.sub-item-link:focus')?.outline ||
+    css.getStyle('.sub-item-link:focus')?.border ||
+    css.getStyle('a:focus')?.border ||
+    css.getStyle('a.sub-item-link:focus')?.border
 );
 ```
 

--- a/curriculum/challenges/english/25-front-end-development/lab-stylized-to-do-list/66c051d13a6a20255a963695.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-stylized-to-do-list/66c051d13a6a20255a963695.md
@@ -182,7 +182,10 @@ The links should have an outline when focused.
 assert.exists(
   new __helpers.CSSHelp(document).getStyle('.sub-item-link:focus')?.outline ||
     new __helpers.CSSHelp(document).getStyle('a:focus')?.outline ||
-    new __helpers.CSSHelp(document).getStyle('a.sub-item-link:focus')?.outline
+    new __helpers.CSSHelp(document).getStyle('a.sub-item-link:focus')?.outline ||
+    new __helpers.CSSHelp(document).getStyle('.sub-item-link:focus')?.border ||
+    new __helpers.CSSHelp(document).getStyle('a:focus')?.border ||
+    new __helpers.CSSHelp(document).getStyle('a.sub-item-link:focus')?.border
 );
 ```
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #58248

<!-- Feel free to add any additional description of changes below this line -->

Changes Made:
 Updated the test conditions to accept both outline and border CSS properties for the link outline.

Reason for Change: 
This change allows coders to an additional, valid CSS property in the lab. 

Affected File:
 curriculum/challenges/english/25-front-end-development/lab-stylized-to-do-list/66c051d13a6a20255a963695.md
