### PR TITLE
fix(curriculum): ensure 'security threats' appears as a blank in Task 93

### DIFF
--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66b574b395758f34f3867693.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66b574b395758f34f3867693.md
@@ -31,7 +31,7 @@ Place the following phrases in the correct spot:
 
 `Anna: Sounds good. How often do we hold these training sessions?`
 
-`Brian: We have them BLANK. But I'm planning an extra session next month because of recent security threats. Attendance is mandatory, right?`
+`Brian: We have them BLANK. But I'm planning an extra session next month because of recent BLANK. Attendance is mandatory, right?`
 
 `Anna: Yes, it's mandatory. And how long are these sessions?`
 
@@ -66,6 +66,14 @@ These two words together means adding something at the present moment.
 ### --feedback--
 
 This word means happening every three months or four times a year.
+
+---
+
+`security threats`
+
+### --feedback--
+
+These two words together mean potential dangers or risks to the safety of a system or data.
 
 ---
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66b574b395758f34f3867693.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66b574b395758f34f3867693.md
@@ -73,7 +73,7 @@ This word means happening every three months or four times a year.
 
 ### --feedback--
 
-These two words together mean potential dangers or risks to the safety of a system or data.
+These two words together refer to a possible danger to a system. The first word relates to protecting data, and the second word means a potential risk.
 
 ---
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #58460 

### **Pull Request Description**  
This PR ensures that **"security threats"** appears as a blank in **Task 93**. Additionally, it adds the following feedback:  

> **"These two words together mean potential dangers or risks to the safety of a system or data."**  

Playwright tests have been added to verify two scenarios:  
1. **All 7 blanks, including "security threats", are correctly filled** → `completion-success-icon` appears.  
2. **The blank for "security threats" is incorrectly filled** → The feedback message is displayed.  

All tests have passed (screenshot attached). 
<img width="1050" alt="tests_step93" src="https://github.com/user-attachments/assets/c5d63627-42de-4aa4-ae7e-f94d51df86f1" />
