### PR TITLE
fix(curriculum): Fixed test to allow both inline styles and CSS classes for text color.

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-real-time-counter/66bb3e20d3dc5b6d0a21f5dd.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-real-time-counter/66bb3e20d3dc5b6d0a21f5dd.md
@@ -65,7 +65,8 @@ const charCount = document.getElementById('char-count');
 textInput.value = "I am learning a new language and it is called c++.";
 textInput.dispatchEvent(new Event('input'));
 textInput.dispatchEvent(new Event('change'));
-assert.strictEqual(charCount.style.color, 'red');
+const computedStyle = window.getComputedStyle(charCount);
+assert.strictEqual(computedStyle.color, 'red');
 ```
 
 If character count is greater than or equal to `50`, the user shouldn't be able to enter more characters.

--- a/curriculum/challenges/english/25-front-end-development/lab-real-time-counter/66bb3e20d3dc5b6d0a21f5dd.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-real-time-counter/66bb3e20d3dc5b6d0a21f5dd.md
@@ -66,7 +66,15 @@ textInput.value = "I am learning a new language and it is called c++.";
 textInput.dispatchEvent(new Event('input'));
 textInput.dispatchEvent(new Event('change'));
 const computedStyle = window.getComputedStyle(charCount);
-assert.strictEqual(computedStyle.color, 'red');
+assert.oneOf(computedStyle.color, [
+  "red",
+  "rgb(255, 0, 0)",
+  "rgb(100%, 0%, 0%)",
+  "rgba(255, 0, 0, 1)",
+  "rgba(100%, 0%, 0%, 1)",
+  "hsl(0, 100%, 50%)",
+  "hsla(0, 100%, 50%, 1)"
+]);
 ```
 
 If character count is greater than or equal to `50`, the user shouldn't be able to enter more characters.


### PR DESCRIPTION


Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #58546 

<!-- Feel free to add any additional description of changes below this line -->

Changes Made:
Updated the test conditions to check the computed style of #char-count instead of directly asserting style.color.
Modified the test to accept both inline styles (charCount.style.color = 'red') and CSS classes that apply the red color via external stylesheets.

Reason for Change:
The original test only validated inline styles, making it too restrictive.

Affected File:
freeCodeCamp/curriculum/challenges/english/25-front-end-development/lab-real-time-counter/66bb3e20d3dc5b6d0a21f5dd.md
