### PR TITLE
fix: removed extra line break between sections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,7 +63,6 @@ $RECYCLE.BIN/
 # Icon must end with two \r
 Icon
 
-
 # Thumbnails
 ._*
 


### PR DESCRIPTION
This PR includes a change suggested for the line break between sections for gitignore file

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ ] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or Gitpod.
