### PR TITLE
fix(api): strip query params on redirect

### DIFF
--- a/api/src/utils/redirection.test.ts
+++ b/api/src/utils/redirection.test.ts
@@ -165,6 +165,23 @@ describe('redirection', () => {
       expect(result).toEqual(expectedReturn);
     });
 
+    it('should strip off any query parameters from the referer', () => {
+      const req = {
+        headers: {
+          referer: `https://www.freecodecamp.org/espanol/learn/rosetta-code/?query=param`
+        }
+      };
+
+      const expectedReturn = {
+        origin: 'https://www.freecodecamp.org',
+        pathPrefix: 'espanol',
+        returnTo: 'https://www.freecodecamp.org/espanol/learn/rosetta-code/'
+      };
+
+      const result = getRedirectParams(req);
+      expect(result).toEqual(expectedReturn);
+    });
+
     it('should use HOME_LOCATION with missing referer', () => {
       const req = {
         headers: {}

--- a/api/src/utils/redirection.ts
+++ b/api/src/utils/redirection.ts
@@ -113,7 +113,12 @@ function getParamsFromUrl(
   // if this is not one of the client languages, validation will convert
   // this to '' before it is used.
   const pathPrefix = returnUrl.pathname.split('/')[1] ?? '';
-  return normalize({ returnTo: returnUrl.href, origin, pathPrefix });
+  return normalize({
+    // strip off any query parameters
+    returnTo: returnUrl.origin + returnUrl.pathname,
+    origin,
+    pathPrefix
+  });
 }
 
 /**


### PR DESCRIPTION
We use query params to show flash messages, so we should strip them
when redirecting. Otherwise if we try to send a flash message and
redirect to a url with query params, then we end up stacking query
params

/?messages=success%5B0%5D%3Dflash.signin-success

 becomes

/?messages=success%5B0%5D%3Dflash.signin-success?messages=
success%5B0%5D%3Dflash.signin-success

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This is tricky to test locally because the referer header isn't sent.

<!-- Feel free to add any additional description of changes below this line -->
