### PR TITLE
fix(api): auth error logging

### DIFF
--- a/api/src/plugins/auth0.ts
+++ b/api/src/plugins/auth0.ts
@@ -112,7 +112,8 @@ export const auth0Client: FastifyPluginCallbackTypebox = fp(
         if (error instanceof Error && error.message === 'Invalid state') {
           fastify.log.error('Auth failed: invalid state');
         } else {
-          fastify.log.error('Auth failed', error);
+          fastify.log.error('Auth failed:');
+          fastify.log.error(error);
           fastify.Sentry.captureException(error);
         }
         // It's important _not_ to redirect to /signin here, as that could


### PR DESCRIPTION
fastify's logging isn't variadic. I'm not sure what the second argument
does, but it doesn't appear in the logs.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
