### PR TITLE
Fix(curriculum): improve dice game tests for straights

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/review-algorithmic-thinking-by-building-a-dice-game/657e230500602983e01fff6e.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/review-algorithmic-thinking-by-building-a-dice-game/657e230500602983e01fff6e.md
@@ -9,7 +9,7 @@ dashedName: step-14
 
 For the last portion of the game, you will need to create an algorithm that checks for the presence of a straight. A small straight is when four of the dice have consecutive values in any order (Ex. in a roll of `41423`, we have `1234`) resulting in a score of `30` points. A large straight is when all five dice have consecutive values in any order (Ex. in a roll of `35124`, we have `12345`) resulting in a score of `40` points.
 
-Declare a `checkForStraights` function which accepts an array of numbers. If the user gets a large straight, update the fifth radio button with a score of `40`. If the user gets a small straight, update the fourth radio button with a score of `30`. If the user gets no straight, update the last radio button to display `0`.
+Declare a `checkForStraights` function which accepts an array of numbers. If the user gets a large straight, update the fifth radio button with a score of `40`. If the user gets a small straight, update the fourth radio button with a score of `30`. Regardless, it should always update the last radio button to display a score of 0, with the correct attributes.
 
 Call your `checkForStraights` function when the `rollDiceBtn` is clicked to complete your dice game!
 
@@ -21,29 +21,59 @@ Your `checkForStraights` variable should be a function.
 assert.isFunction(checkForStraights);
 ```
 
-If a small straight is rolled, your `checkForStraights` function should enable the fourth radio button, set the value to `30`, and update the displayed text to `, score = 30`.
+If a small straight is rolled, your `checkForStraights` function should enable the fourth radio button, set the value to `30`, update the displayed text to `, score = 30` and leave the fifth radio button disabled.
 
 ```js
-resetRadioOptions();
-checkForStraights([4,2,5,3,5]);
-assert.isTrue(scoreInputs[4].disabled);
-assert.isFalse(scoreInputs[3].disabled);
-assert.strictEqual(scoreInputs[3].value, "30");
-assert.strictEqual(scoreSpans[3].innerText, ", score = 30");
+const assertSmallStraight = (_diceValuesArr) => {
+  resetRadioOptions();
+  checkForStraights(_diceValuesArr);
+  assert.isTrue(scoreInputs[4].disabled);
+  assert.isFalse(scoreInputs[3].disabled);
+  assert.strictEqual(scoreInputs[3].value, "30");
+  assert.strictEqual(scoreSpans[3].innerText, ", score = 30");
+}
+// Basic straights
+assertSmallStraight([1,1,2,3,4])
+assertSmallStraight([2,3,4,5,5])
+assertSmallStraight([3,4,5,6,6])
+// 5 unique numbers, but only small straight
+assertSmallStraight([1,2,3,4,6])
+assertSmallStraight([1,3,4,5,6])
+// Straights with duplicates in middle
+assertSmallStraight([1,2,2,3,4])
+assertSmallStraight([2,3,3,4,5])
+assertSmallStraight([3,4,5,5,6])
+// Out of order straights
+assertSmallStraight([1,3,2,1,4])
+assertSmallStraight([5,4,3,3,2])
+assertSmallStraight([3,4,5,6,1])
 ```
 
 If a large straight is rolled, your `checkForStraights` function should enable the fourth button, set the value to `30`, update the displayed text to `, score = 30`. Additionally, the function should enable the fifth radio button, set the value to `40`, and update the displayed text to `, score = 40`. 
 
 ```js
-resetRadioOptions();
-checkForStraights([4,2,5,3,6]);
-assert.isFalse(scoreInputs[4].disabled);
-assert.isFalse(scoreInputs[3].disabled);
-assert.strictEqual(scoreInputs[3].value, "30");
-assert.strictEqual(scoreSpans[3].innerText, ", score = 30");
+const assertLargeStraight = (_diceValuesArr) => {
+  resetRadioOptions();
+  checkForStraights(_diceValuesArr);
+  assert.isFalse(scoreInputs[3].disabled);
+  assert.strictEqual(scoreInputs[3].value, "30");
+  assert.strictEqual(scoreSpans[3].innerText, ", score = 30");
+  assert.isFalse(scoreInputs[4].disabled);
+  assert.strictEqual(scoreInputs[4].value, "40");
+  assert.strictEqual(scoreSpans[4].innerText, ", score = 40");
+}
+// Basic straights
+assertLargeStraight([1,2,3,4,5])
+assertLargeStraight([2,3,4,5,6])
+// Backward straights
+assertLargeStraight([5,4,3,2,1])
+assertLargeStraight([6,5,4,3,2])
+// Out of order straights
+assertLargeStraight([1,5,3,4,2])
+assertLargeStraight([2,4,6,5,3])
 ```
 
-If no straight is rolled, your `checkForStraights` function should enable the final radio button, set the value to `0`, and update the displayed text to `, score = 0`.
+If no straight is rolled, your `checkForStraights` function should not enable the fourth or fifth radio button.
 
 ```js
 const assertNoStraight = (_diceValuesArr) => {
@@ -51,13 +81,33 @@ const assertNoStraight = (_diceValuesArr) => {
   checkForStraights(_diceValuesArr);
   assert.isTrue(scoreInputs[3].disabled);
   assert.isTrue(scoreInputs[4].disabled);
-  assert.isFalse(scoreInputs[5].disabled);
-  assert.strictEqual(scoreInputs[5].value, "0");
-  assert.strictEqual(scoreSpans[5].innerText, ", score = 0");
 }
+// Simple cases
+assertNoStraight([1,4,4,4,4]);
+assertNoStraight([2,2,3,3,3]);
+assertNoStraight([5,5,5,5,5]);
+assertNoStraight([6,5,1,5,6]);
+// Almost a straight, but broken in middle
+assertNoStraight([1,2,3,5,6]);
+assertNoStraight([1,2,4,5,6]);
+// Almost a straight with duplicates in middle
+assertNoStraight([1,2,2,3,5]);
+assertNoStraight([2,4,4,5,6]);
+// Repeat of last 4 cases, but not in order
+assertNoStraight([1,5,6,2,3]);
+assertNoStraight([5,2,4,1,6]);
+assertNoStraight([2,1,5,3,2]);
+assertNoStraight([2,4,5,4,6]);
+```
 
-assertNoStraight([1,1,1,1,1]);
-assertNoStraight([1,1,4,4,4]);
+If no straight is rolled, your `checkForStraights` function should enable the final radio button set the value to `0`, and update the displayed text to `, score = 0`.
+
+```js
+resetRadioOptions();
+checkForStraights([1,1,1,1,1]);
+assert.isFalse(scoreInputs[5].disabled);
+assert.strictEqual(scoreInputs[5].value, "0");
+assert.strictEqual(scoreSpans[5].innerText, ", score = 0");
 ```
 
 You should call the `checkForStraights` function when the `rollDiceBtn` is clicked.

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/review-algorithmic-thinking-by-building-a-dice-game/657e230500602983e01fff6e.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/review-algorithmic-thinking-by-building-a-dice-game/657e230500602983e01fff6e.md
@@ -32,17 +32,7 @@ assert.strictEqual(scoreInputs[3].value, "30");
 assert.strictEqual(scoreSpans[3].innerText, ", score = 30");
 ```
 
-If a large straight is rolled, your `checkForStraights` function should enable the fifth radio button, set the value to `40`, and update the displayed text to `, score = 40`.
-
-```js
-resetRadioOptions();
-checkForStraights([4,2,5,3,1]);
-assert.isFalse(scoreInputs[4].disabled);
-assert.strictEqual(scoreInputs[4].value, "40");
-assert.strictEqual(scoreSpans[4].innerText, ", score = 40");
-```
-
-If a large straight is rolled, your `checkForStraights` function should also enable the fourth radio button, set the value to `30`, and update the displayed text to `, score = 30`.
+If a large straight is rolled, your `checkForStraights` function should enable the fourth button, set the value to `30`, update the displayed text to `, score = 30`. Additionally, the function should enable the fifth radio button, set the value to `40`, and update the displayed text to `, score = 40`. 
 
 ```js
 resetRadioOptions();


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #58348

<!-- Feel free to add any additional description of changes below this line -->

- Updated the instructions to match our solution (the `None of the above` button should always be enabled, not only when there is no straight)
- Consolidated the two test cases on finding large straights. I think the focus of the problem should be on detecting large straights, and not on which buttons get enabled, so there's no point repeating the same suite of tests across two different sections. I'm open to splitting it back into two cases if you have a good reason for it.
- Separated the test case on checking for no straights into two tests: one that checks for false positives of straights and one that checks that the `None of the above` button is enabled
- More comprehensive straight testing:
  - Small straight testing: Basic small straights, straights with duplicates, straights out of order
  - Large straight testing: Basic large straights, large straights out of order
  - Checking when no straight is found: Added many more cases that are very close to a straight but not quite
