### PR TITLE
fix(client): show preview

### DIFF
--- a/shared/utils/polyvinyl.ts
+++ b/shared/utils/polyvinyl.ts
@@ -18,7 +18,7 @@ export type ChallengeFile = IncompleteChallengeFile & {
   error?: unknown;
   head: string;
   tail: string;
-  seed: string;
+  seed?: string;
   source?: string | null;
   path: string;
   history: string[];
@@ -79,7 +79,6 @@ export function isPoly(poly: unknown): poly is ChallengeFile {
       'fileKey' in poly &&
       'head' in poly &&
       'tail' in poly &&
-      'seed' in poly &&
       'history' in poly
     );
   }
@@ -91,7 +90,6 @@ export function isPoly(poly: unknown): poly is ChallengeFile {
     typeof poly.fileKey === 'string' &&
     typeof poly.head === 'string' &&
     typeof poly.tail === 'string' &&
-    typeof poly.seed === 'string' &&
     Array.isArray(poly.history);
 
   return hasProperties(poly) && hasCorrectTypes(poly);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

seed is only used when resetting a lesson, not when previewing it

I'm not sure how to test this, but I'll try to come up with something.

<!-- Feel free to add any additional description of changes below this line -->
