### PR TITLE
fix(curriculum): fix casing for Gitpod in Code editor lecture 

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-code-editors-and-ides/672d26269456511aa3db614d.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-code-editors-and-ides/672d26269456511aa3db614d.md
@@ -70,7 +70,7 @@ The lecture lists several cloud-based options, but one popular editor is primari
 
 ---
 
-GitPod
+Gitpod
 
 ### --feedback--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #58626

<!-- Feel free to add any additional description of changes below this line -->

I'm having trouble finding where this change appears on the website in Gitpod. I tried searching manually but couldn't locate it. Could you point me to the correct URL or section where I can preview this update?