### PR TITLE
fix(curriculum): Fixed question to replace misleading 'standard' and `alternative' terms with accurate content-box and border-box distinctions.

### DIFF
--- a/curriculum/challenges/english/16-the-odin-project/top-the-box-model/the-box-model-lesson-i.md
+++ b/curriculum/challenges/english/16-the-odin-project/top-the-box-model/the-box-model-lesson-i.md
@@ -13,23 +13,23 @@ Because the box model concept is so incredibly fundamental, let’s dig a bit de
 
 ## --text--
 
-What is the difference between the standard and alternative box model?
+Which of the following correctly describes the difference between the `content-box` and `border-box` box models in CSS?
 
 ## --answers--
 
-The standard box model calculates the width and height of an element based on the content alone, while the alternative box model calculates based on the content plus padding and border.
+The `content-box` model includes content, padding, and border within the specified width and height, while the `border-box` model includes only the content.
 
 ---
 
-The standard box model includes content, padding, and border, while the alternative box model includes only the content.
+In the `content-box` model, the specified width and height apply only to the content, excluding padding and border, whereas in the `border-box` model, they include padding and border.
 
 ---
 
-The standard box model and the alternative box model are the same and have no differences.
+The `content-box` model and the `border-box` model are the same and have no differences.
 
 ---
 
-The standard box model includes only the content, while the alternative box model includes content, padding, and border.
+In the `border-box` model, the width and height apply only to the content, while in the `content-box` model, they include padding and border
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/16-the-odin-project/top-the-box-model/the-box-model-lesson-i.md
+++ b/curriculum/challenges/english/16-the-odin-project/top-the-box-model/the-box-model-lesson-i.md
@@ -29,7 +29,7 @@ The `content-box` model and the `border-box` model are the same and have no diff
 
 ---
 
-In the `border-box` model, the width and height apply only to the content, while in the `content-box` model, they include padding and border
+In the `border-box` model, the width and height apply only to the content, while in the `content-box` model, they include padding and border.
 
 ## --video-solution--
 


### PR DESCRIPTION

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #58651 

<!-- Feel free to add any additional description of changes below this line -->

Changes Made:

Reworded the question to remove misleading terms like "standard" and "alternative" and replaced them with content-box and border-box. Updated answer choices to correctly reflect how content-box applies width/height only to content, while border-box includes padding and border. Marked the correct answer to align with CSS behavior.

Reason for Change:
The original question used unclear terminology, potentially causing confusion about which model is "standard." 

Affected File:
freeCodeCamp/curriculum/challenges/english/16-the-odin-project/top-the-box-model/the-box-model-lesson-i.md