### PR TITLE
fix(curriculum): delete irrelevant information in description of step 8

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/613e275749ebd008e74bb62e.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/613e275749ebd008e74bb62e.md
@@ -7,8 +7,6 @@ dashedName: step-8
 
 # --description--
 
-A useful property of an _SVG_ (scalable vector graphics) is that it contains a `path` attribute which allows the image to be scaled without affecting the resolution of the resultant image.
-
 Currently, the `img` is assuming its default size, which is too large. CSS has a `max` function which returns the largest of a set of comma-separated values. For example:
 
 ```css

--- a/curriculum/challenges/english/25-front-end-development/workshop-accessibility-quiz/613e275749ebd008e74bb62e.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-accessibility-quiz/613e275749ebd008e74bb62e.md
@@ -7,8 +7,6 @@ dashedName: step-8
 
 # --description--
 
-A useful property of an _SVG_ (scalable vector graphics) is that it contains a `path` attribute which allows the image to be scaled without affecting the resolution of the resultant image.
-
 Currently, the `img` is assuming its default size, which is too large. CSS has a `max` function which returns the largest of a set of comma-separated values. For example:
 
 ```css


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #58646

<!-- Feel free to add any additional description of changes below this line -->
Removed irrelevant information in description of step 8.

> A useful property of an SVG (scalable vector graphics) is that it contains a path attribute which allows the image to be scaled without affecting the resolution of the resultant image.

- For some reasons, there are some errors in my local and gitpod so I can't test from my side.
