### PR TITLE
fix(curriculum): Improve Pokemon Search App hint

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/build-a-pokemon-search-app-project/build-a-pokemon-search-app.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/build-a-pokemon-search-app-project/build-a-pokemon-search-app.md
@@ -43,7 +43,7 @@ Fulfill the user stories and pass all the tests below to complete this project. 
 
 # --hints--
 
-You should have an `input` element with an `id` of `"search-input"`. The `input` should be marked as **required**.
+You should have an `input` element with an `id` of `"search-input"`. The `input` should be marked as required.
 
 ```js
 const el = document.getElementById('search-input');

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/build-a-pokemon-search-app-project/build-a-pokemon-search-app.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/build-a-pokemon-search-app-project/build-a-pokemon-search-app.md
@@ -43,7 +43,7 @@ Fulfill the user stories and pass all the tests below to complete this project. 
 
 # --hints--
 
-You should have an `input` element with an `id` of `"search-input"` and is **required**.
+You should have an `input` element with an `id` of `"search-input"`. The `input` should be marked as **required**.
 
 ```js
 const el = document.getElementById('search-input');


### PR DESCRIPTION

### **Checklist**

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine or in Gitpod.

---

### **Closes Issue**  
Closes #58654  

---

### **Description of Changes**  
This PR updates the hint text in the **Build a Pokémon Search App** project to remove ambiguity.  

**Before:**  
> "You are required to have the id..."  

**Issue:**  
Some campers misinterpreted this as **"you must use the `id`"**, rather than **"you should make the input required."**  

**After (Updated Text):**  
> "You should have an `input` element with an `id` of `"search-input"`. The `input` should be marked as required."  

This makes the requirement clearer and avoids confusion for learners.

---

### **Additional Context**  
![411148491-bf8f9ee9-236b-4cc0-a8b7-479ccb04d4b8](https://github.com/user-attachments/assets/46ef2683-8714-4919-bc82-c8a242b1b122)

- The change is made in the following file:  
  📂 `/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/build-a-pokemon-search-app-project/build-a-pokemon-search-app.md`  
- Ensures that users understand that they must both **use the correct `id`** and **set the input as required**.  

Let me know if any adjustments are needed! 😊🚀
