### PR TITLE
fix(curriculum): explicitly show case for general

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-fcc-forum-leaderboard/673c91f0b934834bc4a3ecc2.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-fcc-forum-leaderboard/673c91f0b934834bc4a3ecc2.md
@@ -26,7 +26,7 @@ Fulfill the user stories below and get all the tests to pass to complete the lab
    - the text of the `category` key of the selected category.
    - a class of `category` followed by the `className` property of the selected category.
    - an `href` with the value of `<forumCategoryUrl>/<className>/<id>`, where `<className>` is the `className` property of the selected category and `id` is the argument passed to `forumCategory`.
-1. If the `allCategories` object does not have the selected category id as its property, `className` and `category` should be indicated as `general`.
+1. If the `allCategories` object does not have the selected category id as its property, `category` should be indicated as `General` and `className` should be indicated as `general`.
 1. You should have a function named `avatars` that takes two arrays representing posters and users, respectively.
 1. The `avatars` function should return a string made by joining `img` elements, one for each poster found inside the user array. _Hint:_ You can find users by comparing the `user_id` property of the poster with the `id` property` of the user.
 1. The `avatars` function should set each avatar's size by accessing the `avatar_template` property and replacing `{size}` with `30`.
@@ -240,7 +240,7 @@ assert.match(
 );
 ```
 
-`forumCategory(200)` should return a string containing an anchor element with `class="category career"`.
+`forumCategory(200)` should return a string containing an anchor element with `class="category general"`.
 
 ```js
 const actual = forumCategory(200);


### PR DESCRIPTION
…ass name

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #58668

<!-- Feel free to add any additional description of changes below this line -->
Change wording 1

Before
If the `allCategories` object does not have the selected category id as its property, `className` and `category` should be indicated as `general`.

After
If the `allCategories` object does not have the selected category id as its property, `category` should be indicated as `General` and `className` should be indicated as `general`.

![Capture-1](https://github.com/user-attachments/assets/ce4221a0-6337-4d20-a0cf-604f8893b639)

Change wording 2

Before
 `forumCategory(200)` should return a string containing an anchor element with `class="category career"`.

 After
`forumCategory(200)` should return a string containing an anchor element with `class="category general"`.

![Capture-2](https://github.com/user-attachments/assets/53da4952-c44a-4616-a7a7-2a4624e6ec50)
