### PR TITLE
#58666 . fix: remove redundant sentence in intro text for trivia bot lab

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -2597,8 +2597,7 @@
       "lab-javascript-trivia-bot": {
         "title": "Build a JavaScript Trivia Bot",
         "intro": [
-          "In this lab, you'll practice working with JavaScript variables and strings by building a trivia bot.",
-          "You'll practice how to use variables and basic strings."
+          "In this lab, you'll practice working with JavaScript variables and strings by building a trivia bot."
         ]
       },
       "lab-sentence-maker": {


### PR DESCRIPTION
This pull request removes the redundant second sentence in the "intro" field for the Trivia Bot Lab. The introduction has been updated to a concise version, ensuring the text is clear and focused on the lab's purpose.

Changes Made
Replaced the "intro" field text with the following:
"intro": [
  "In this lab, you'll practice working with JavaScript variables and strings by building a trivia bot."
]