### PR TITLE
refactor: remove growthbook fragment

### DIFF
--- a/client/src/components/growth-book/growth-book-redux-connector.tsx
+++ b/client/src/components/growth-book/growth-book-redux-connector.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useEffect } from 'react';
+import { useEffect } from 'react';
 
 import { useFeature } from '@growthbook/growthbook-react';
 import { connect } from 'react-redux';
@@ -35,7 +35,7 @@ type StateProps = ReturnType<typeof mapStateToProps>;
 type DispatchProps = { setIsRandomCompletionThreshold: (arg: boolean) => void };
 
 interface GrowthBookReduxConnector extends StateProps, DispatchProps {
-  children: ReactNode;
+  children: JSX.Element;
 }
 
 const mapDispatchToProps = {
@@ -72,8 +72,7 @@ const GrowthBookReduxConnector = ({
     showModalsRandomly,
     setIsRandomCompletionThreshold
   ]);
-  // eslint-disable-next-line react/jsx-no-useless-fragment
-  return <>{children}</>;
+  return children;
 };
 
 export default connect(

--- a/client/src/components/growth-book/growth-book-wrapper.tsx
+++ b/client/src/components/growth-book/growth-book-wrapper.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import {
   FeatureDefinition,
   GrowthBook,
@@ -42,7 +42,7 @@ const mapStateToProps = createSelector(
 
 type StateProps = ReturnType<typeof mapStateToProps>;
 interface GrowthBookWrapper extends StateProps {
-  children: ReactNode;
+  children: JSX.Element;
 }
 
 interface UserAttributes {


### PR DESCRIPTION
It looks like the type of element in wrapRootElement is just JSX.Element not ReactNode. Once that's changed, connect is happen to take GrowthBookReduxConnector as an argument

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Ref: https://github.com/freeCodeCamp/freeCodeCamp/pull/58675

<!-- Feel free to add any additional description of changes below this line -->
