### PR TITLE
fix(i18n): remove redundant sentence

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -2597,8 +2597,7 @@
       "lab-javascript-trivia-bot": {
         "title": "Build a JavaScript Trivia Bot",
         "intro": [
-          "In this lab, you'll practice working with JavaScript variables and strings by building a trivia bot.",
-          "You'll practice how to use variables and basic strings."
+          "In this lab, you'll practice working with JavaScript variables and strings by building a trivia bot."
         ]
       },
       "lab-sentence-maker": {


### PR DESCRIPTION
This PR removes the redundant sentence from the intro text for the trivia bot lab (#58666).

Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.


Closes #58666 

