### PR TITLE
fix: resize xterm with container

### DIFF
--- a/client/src/templates/Challenges/classic/desktop-layout.tsx
+++ b/client/src/templates/Challenges/classic/desktop-layout.tsx
@@ -357,7 +357,9 @@ const DesktopLayout = (props: DesktopLayoutProps): JSX.Element => {
             data-playwright-test-label='preview-pane'
           >
             <ReflexContainer orientation='horizontal'>
-              {displayPreviewPane && <ReflexElement>{preview}</ReflexElement>}
+              {displayPreviewPane && (
+                <ReflexElement {...reflexProps}>{preview}</ReflexElement>
+              )}
               {displayPreviewPane && displayPreviewConsole && (
                 <ReflexSplitter propagate={true} {...resizeProps} />
               )}

--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -269,10 +269,7 @@ function ShowClassic({
     return isValidLayout ? reflexLayout : BASE_LAYOUT;
   };
 
-  const onPreviewResize = () => {
-    console.log('onPreviewResize');
-    xtermFitRef.current?.fit();
-  };
+  const onPreviewResize = () => xtermFitRef.current?.fit();
 
   // layout: Holds the information of the panes sizes for desktop view
   const [layout, setLayout] = useState(getLayoutState());

--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -157,6 +157,7 @@ const handleContentWidgetEvents = (e: MouseEvent | TouchEvent): void => {
 };
 
 const StepPreview = ({
+  dimensions,
   disableIframe,
   previewMounted,
   challengeType,
@@ -164,10 +165,11 @@ const StepPreview = ({
 }: Pick<PreviewProps, 'disableIframe' | 'previewMounted'> & {
   challengeType: number;
   xtermFitRef: React.MutableRefObject<FitAddon | null>;
+  dimensions?: { width: number; height: number };
 }) => {
   return challengeType === challengeTypes.python ||
     challengeType === challengeTypes.multifilePythonCertProject ? (
-    <XtermTerminal xtermFitRef={xtermFitRef} />
+    <XtermTerminal dimensions={dimensions} xtermFitRef={xtermFitRef} />
   ) : (
     <Preview disableIframe={disableIframe} previewMounted={previewMounted} />
   );
@@ -267,7 +269,10 @@ function ShowClassic({
     return isValidLayout ? reflexLayout : BASE_LAYOUT;
   };
 
-  const onPreviewResize = () => xtermFitRef.current?.fit();
+  const onPreviewResize = () => {
+    console.log('onPreviewResize');
+    xtermFitRef.current?.fit();
+  };
 
   // layout: Holds the information of the panes sizes for desktop view
   const [layout, setLayout] = useState(getLayoutState());

--- a/client/src/templates/Challenges/classic/xterm.tsx
+++ b/client/src/templates/Challenges/classic/xterm.tsx
@@ -16,9 +16,11 @@ const registerServiceWorker = async () => {
 };
 
 export const XtermTerminal = ({
-  xtermFitRef
+  xtermFitRef,
+  dimensions
 }: {
   xtermFitRef: MutableRefObject<FitAddon | null>;
+  dimensions?: { height: number; width: number };
 }) => {
   const termContainerRef = useRef<HTMLDivElement | null>(null);
 
@@ -103,8 +105,16 @@ export const XtermTerminal = ({
     };
   }, [xtermFitRef]);
 
+  useEffect(() => {
+    if (xtermFitRef.current) xtermFitRef.current.fit();
+
+    // dimensions is an implicit dependency, since it's not directly used by the
+    // effect, but fitAddon.fit() needs to be called whenever the container size
+    // changes.
+  }, [xtermFitRef, dimensions]);
+
   return (
-    <div ref={termContainerRef}>
+    <div style={{ height: dimensions?.height }} ref={termContainerRef}>
       <link rel='stylesheet' href='/js/xterm.css' />
     </div>
   );


### PR DESCRIPTION
This only works 100% on desktop since it relies on the dimensions prop for the height, without which it defaults to 408px. The obvious fix, setting the height of the container to 100%, doesn't work because xterm throws an error while trying to render the PreviewPortal.

It's not obvious to me why that's happening.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Ref: https://github.com/freeCodeCamp/freeCodeCamp/issues/58725 

It doesn't close all of the issue, but it addresses it partially.

<!-- Feel free to add any additional description of changes below this line -->
