### PR TITLE
fix(curriculum): Updated test to allow both slategray and slategrey for border color

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-business-card/6690e10ebe2181212abc9652.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-business-card/6690e10ebe2181212abc9652.md
@@ -149,7 +149,7 @@ Inside the `.business-card` element, there should be an `img` element with the `
 assert.exists(document.querySelector('img.profile-image'));
 ```
 
-The image source should be set to a valid image.f
+The image source should be set to a valid image.
 
 ```js
 assert.isAbove(document.querySelector('.profile-image').getAttribute('src').length, 0);

--- a/curriculum/challenges/english/25-front-end-development/lab-business-card/6690e10ebe2181212abc9652.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-business-card/6690e10ebe2181212abc9652.md
@@ -149,7 +149,7 @@ Inside the `.business-card` element, there should be an `img` element with the `
 assert.exists(document.querySelector('img.profile-image'));
 ```
 
-The image source should be set to a valid image.
+The image source should be set to a valid image.f
 
 ```js
 assert.isAbove(document.querySelector('.profile-image').getAttribute('src').length, 0);
@@ -206,7 +206,10 @@ assert.exists(document.querySelector('p.company + hr'));
 The `hr` elements should have a `1px` dashed top border in `slategray` color.
 
 ```js
-assert.equal(new __helpers.CSSHelp(document).getStyle('hr').getPropVal('border-top'), '1px dashed slategray');
+assert.oneOf(
+  new __helpers.CSSHelp(document).getStyle('hr').getPropVal('border-top'), 
+  ['1px dashed slategray', '1px dashed slategrey']
+);
 ```
 
 After the first `hr` element, there should be a `p` element with an email address as your text.


### PR DESCRIPTION


Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #58738 

<!-- Feel free to add any additional description of changes below this line -->

Changes Made:

Updated the test conditions to allow both "slategray" and "slategrey" for the border-top property of <hr>.
Modified the assertion to use assert.oneOf() instead of assert.equal() to accommodate both variations.

Reason for Change:

The original test only accepted "slategray", which caused failures if "slategrey" was used instead. This update ensures flexibility in color naming.

Affected File:
freeCodeCamp/curriculum/challenges/english/25-front-end-development/lab-business-card/6690e10ebe2181212abc9652.md
