### PR TITLE
fix: optionally keep source if setting file contents

### DIFF
--- a/shared/utils/polyvinyl.ts
+++ b/shared/utils/polyvinyl.ts
@@ -113,7 +113,7 @@ export function setContent(
   return {
     ...poly,
     contents,
-    source: source ?? null
+    source
   };
 }
 

--- a/shared/utils/polyvinyl.ts
+++ b/shared/utils/polyvinyl.ts
@@ -103,16 +103,17 @@ function checkPoly(poly: ChallengeFile) {
   );
 }
 
-// setContent will lose source if set
+// setContent will lose source if not supplied
 export function setContent(
   contents: string,
-  poly: ChallengeFile
+  poly: ChallengeFile,
+  source?: string | null
 ): ChallengeFile {
   checkPoly(poly);
   return {
     ...poly,
     contents,
-    source: null
+    source: source ?? null
   };
 }
 
@@ -157,9 +158,7 @@ export async function transformContents(
   polyP: ChallengeFile | Promise<ChallengeFile>
 ) {
   const poly = await polyP;
-  const newPoly = setContent(await wrap(poly.contents), poly);
-  // if no source exist, set the original contents as source
-  newPoly.source = poly.source || poly.contents;
+  const newPoly = setContent(await wrap(poly.contents), poly, poly.source);
   return newPoly;
 }
 
@@ -179,9 +178,11 @@ export async function transformHeadTailAndContents(
 }
 
 // createSource(poly: PolyVinyl) => PolyVinyl
-export function createSource(poly: Pick<ChallengeFile, 'contents' | 'source'>) {
+export function createSource<Rest>(
+  poly: Pick<ChallengeFile, 'contents' | 'source'> & Rest
+): Rest & { contents: string; source: string } {
   return {
     ...poly,
-    source: poly.source || poly.contents
+    source: poly.source ?? poly.contents
   };
 }

--- a/shared/utils/polyvinyl.ts
+++ b/shared/utils/polyvinyl.ts
@@ -19,7 +19,7 @@ export type ChallengeFile = IncompleteChallengeFile & {
   head: string;
   tail: string;
   seed?: string;
-  source?: string | null;
+  source?: string;
   path: string;
   history: string[];
 };
@@ -107,7 +107,7 @@ function checkPoly(poly: ChallengeFile) {
 export function setContent(
   contents: string,
   poly: ChallengeFile,
-  source?: string | null
+  source?: string
 ): ChallengeFile {
   checkPoly(poly);
   return {


### PR DESCRIPTION
It's optional because setContent is used is code-storage-epic and I did not what to change its behaviour.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes https://github.com/freeCodeCamp/freeCodeCamp/issues/58741 

<!-- Feel free to add any additional description of changes below this line -->
