### PR TITLE
fix: edit distractors on q18 of semantic-html quiz for even length

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/quiz-semantic-html/66ed903cf45ce3ece4053ebe.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-semantic-html/66ed903cf45ce3ece4053ebe.md
@@ -395,15 +395,15 @@ What is the role of the `i` element?
 
 #### --distractors--
 
-It creates interactive buttons.
+It is used to represent text that has been marked for reference purposes.
 
 ---
 
-It handles user authentication and login.
+It is used to provide a caption or legend for disclosure boxes.
 
 ---
 
-It formats numerical data.
+It is used to format numerical data and sort it from smallest to largest.
 
 #### --answer--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #58756

<!-- Feel free to add any additional description of changes below this line -->

Edited distraction choices on question 18 of the semantic HTML quiz to ensure all choices are of roughly equal length. Previously, the distractions were much shorter than the answer, which made it obvious what the correct answer was. The distractions have been replaced with the longer choices suggested within the issue. 

Before changes:
<img width="657" alt="Screenshot 2025-02-13 at 1 02 42 PM" src="https://github.com/user-attachments/assets/ee36c87b-63fa-40dd-b59b-6affa7de601e" />


After changes:
<img width="667" alt="Screenshot 2025-02-13 at 1 01 21 PM" src="https://github.com/user-attachments/assets/9eb5ce73-fd78-446c-b16d-7fa64de05377" />

