### PR TITLE
fix: run tests in iife to avoid name conflicts

### DIFF
--- a/tools/client-plugins/browser-scripts/test-evaluator.ts
+++ b/tools/client-plugins/browser-scripts/test-evaluator.ts
@@ -132,7 +132,7 @@ ctx.onmessage = async (e: TestEvaluatorEvent) => {
 __utils.flushLogs();
 __userCodeWasExecuted = true;
 __utils.toggleProxyLogger(true);
-${e.data.testString}`)) as unknown;
+(async () => {${e.data.testString}})()`)) as unknown;
     } catch (err) {
       if (__userCodeWasExecuted) {
         // rethrow error, since test failed.


### PR DESCRIPTION
This lets us overwrite user defined variables in tests without throwing SyntaxErrors.

This fixes the errors in https://github.com/freeCodeCamp/freeCodeCamp/pull/58804 e.g. https://github.com/freeCodeCamp/freeCodeCamp/actions/runs/13328020520/job/37226163426 which happens because the variable "password" is declared in the solution and redeclared in the third test.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->



<!-- Feel free to add any additional description of changes below this line -->
