### PR TITLE
fix: add blank line between type alias and SelectionTabs function

### DIFF
--- a/client/src/components/Donation/multi-tier-donation-form.tsx
+++ b/client/src/components/Donation/multi-tier-donation-form.tsx
@@ -30,6 +30,7 @@ type MultiTierDonationFormProps = {
   defaultTheme?: LocalStorageThemes;
   isAnimationEnabled?: boolean;
 };
+
 function SelectionTabs({
   donationAmount,
   setDonationAmount,


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!-- Feel free to add any additional description of changes below this line -->
Added a blank line between the MultiTierDonationFormProps type alias and the SelectionTabs function to maintain consistency and improve readability across the codebase.
