### PR TITLE
fix(curriculum): update anchor tag test to test only those li elements

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-travel-agency-page/669e2f60e83c011754f711f9.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-travel-agency-page/669e2f60e83c011754f711f9.md
@@ -157,7 +157,7 @@ assert.lengthOf(document.querySelectorAll('p + ul li'), 2);
 Both your list items should contain an anchor element.
 
 ```js
-const listItems = document.querySelectorAll('li');
+const listItems = document.querySelectorAll('p + ul li');
 assert.isNotEmpty(listItems);
 for (let e of listItems) {
   assert.strictEqual(e.children[0].tagName, 'A');


### PR DESCRIPTION
…ments

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #58822

<!-- Feel free to add any additional description of changes below this line -->

Changes made: updated test number 18 to only test the first two list elements for the challenge. The test, as originally written, was testing against all list elements. 

Reason for change: The test states it's verifying that "Both your list items should contain an anchor element." This indicates to campers that their list elements for "Group Travels" and "Private Tours" should contain an anchor tag. If a camper choses to use list elements elsewhere in the challenged for aesthetic/organizational purposes, their code could fail even if the "Group Travels" and "Private Tours" elements are formatted properly. 

Affected page: https://www.freecodecamp.org/learn/full-stack-developer/lab-travel-agency-page/build-a-travel-agency-page

EDIT, 02.18.2025: opened the build and ran curriculum tests
