### PR TITLE
chore(client): remove unused CSS

### DIFF
--- a/client/src/components/Footer/footer.css
+++ b/client/src/components/Footer/footer.css
@@ -78,19 +78,6 @@
   }
 }
 
-.footer-row {
-  margin: 0;
-}
-
-.footer-col {
-  padding-inline: 15px;
-  font-size: 16px;
-}
-
-.footer-col a {
-  padding: 5px 0;
-}
-
 .footer-desc-col {
   padding-inline: 15px;
   margin-bottom: 30px;
@@ -150,18 +137,12 @@ p.footer-donation a:hover {
 }
 
 @media (min-width: 500px) {
-  .footer-col {
-    font-size: 15;
-  }
   .mobile-app-container {
     flex-direction: row;
   }
 }
 
 @media (min-width: 800px) {
-  .footer-col {
-    font-size: 16.5;
-  }
   .footer-bottom .our-nonprofit a {
     padding: 5px;
   }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

After looking through the project, I couldn't find where these CSS classes are used. They might have been used in an older version, but they don't seem to be needed now. Also, the font-size value of 15 or 16.5 in .footer-col is not a valid CSS value. Please let me know if I missed anything.

