### PR TITLE
fix(curriculum): Update intro text for Sentence Maker lab

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -2606,7 +2606,7 @@
       "lab-sentence-maker": {
         "title": "Build a Sentence Maker",
         "intro": [
-          "In this lab, you'll create different stories by assigning different words to different variables."
+          "In this lab, you will continue practicing with strings and concatenation by creating and customizing various stories."
         ]
       },
       "lecture-working-with-data-types": {


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

Closes #58837

This PR updates the intro text for the Sentence Maker lab to:

"In this lab, you will continue practicing with strings and concatenation by creating and customizing various stories."

This change improves the clarity and conciseness of the lab's introduction, making it easier for learners to understand the purpose of the exercise. It also maintains a consistent tone with other lab introductions.  The change is a simple text update and does not introduce any regressions.  No functional testing is required beyond confirming the updated text is displayed correctly.