### PR TITLE
chore (curriculum): fixed spelling mistake for multipart

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lecture-understanding-form-validation/6733d3ab69e94b7df7ee91b0.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-understanding-form-validation/6733d3ab69e94b7df7ee91b0.md
@@ -75,7 +75,7 @@ But maybe you don't want to send the data as a URL-encoded form payload?
 
 The `form` element accepts an `enctype` attribute, which represents the encoding type to use for the data.
 
-This attribute only accepts three values: `application/x-www-form-urlencoded` (which is the default, sending the data as a URL-encoded form body), `text/plain` (which sends the data in plaintext form, in `name=value` pairs separated by new lines), or `mulitpart/form-data`, which is specifically for handling forms with a file upload.
+This attribute only accepts three values: `application/x-www-form-urlencoded` (which is the default, sending the data as a URL-encoded form body), `text/plain` (which sends the data in plaintext form, in `name=value` pairs separated by new lines), or `multipart/form-data`, which is specifically for handling forms with a file upload.
 
 In this video, you've learned the basics of form submissions. In future videos, we'll dive deeper into working with forms and how they interact with the server.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #58856

<!-- Feel free to add any additional description of changes below this line -->

Updated the spelling error on line 78
