### PR TITLE
fix(curriculum): wrap output strings in double quotes

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/review-javascript-variables-and-data-types/6723be264695fb7e619fe1fa.md
+++ b/curriculum/challenges/english/25-front-end-development/review-javascript-variables-and-data-types/6723be264695fb7e619fe1fa.md
@@ -195,17 +195,17 @@ error = "Not Found"; // This would cause an error in Java
 
 ```js
 let age = 25;
-console.log(typeof age); // number
+console.log(typeof age); // "number"
 
 let isLoggedin = true;
-console.log(typeof isLoggedin); // boolean
+console.log(typeof isLoggedin); // "boolean"
 ```
 
-- However, there's a well-known quirk in JavaScript when it comes to `null`. The `typeof` operator returns `object` for `null` values.
+- However, there's a well-known quirk in JavaScript when it comes to `null`. The `typeof` operator returns `”object”` for `null` values.
 
 ```js
 let user = null;
-console.log(typeof user); // object
+console.log(typeof user); // "object"
 ```
 
 # --assignment--

--- a/curriculum/challenges/english/25-front-end-development/review-javascript-variables-and-data-types/6723be264695fb7e619fe1fa.md
+++ b/curriculum/challenges/english/25-front-end-development/review-javascript-variables-and-data-types/6723be264695fb7e619fe1fa.md
@@ -201,7 +201,7 @@ let isLoggedin = true;
 console.log(typeof isLoggedin); // "boolean"
 ```
 
-- However, there's a well-known quirk in JavaScript when it comes to `null`. The `typeof` operator returns `”object”` for `null` values.
+- However, there's a well-known quirk in JavaScript when it comes to `null`. The `typeof` operator returns `"object"` for `null` values.
 
 ```js
 let user = null;


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.


Closes #58876

What changed:
I Wrapped `typeof` return values (`number`, `boolean`, `object`) in quotes within comments to accurately reflect their string representation. 

