### PR TITLE
fix: wrap in quotes number, boolean and object

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/review-javascript-variables-and-data-types/6723be264695fb7e619fe1fa.md
+++ b/curriculum/challenges/english/25-front-end-development/review-javascript-variables-and-data-types/6723be264695fb7e619fe1fa.md
@@ -195,17 +195,17 @@ error = "Not Found"; // This would cause an error in Java
 
 ```js
 let age = 25;
-console.log(typeof age); // number
+console.log(typeof age); // "number"
 
 let isLoggedin = true;
-console.log(typeof isLoggedin); // boolean
+console.log(typeof isLoggedin); // "boolean"
 ```
 
 - However, there's a well-known quirk in JavaScript when it comes to `null`. The `typeof` operator returns `object` for `null` values.
 
 ```js
 let user = null;
-console.log(typeof user); // object
+console.log(typeof user); // "object"
 ```
 
 # --assignment--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #58876

<!-- Feel free to add any additional description of changes below this line -->

I have wrapped  in quotes the three commented types (number, boolean, object) and successfully tested locally.
