### PR TITLE
fix(curriculum): password cannot be used globally in lab

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-password-generator/66f53dc2c5bd6a11d6c3282f.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-password-generator/66f53dc2c5bd6a11d6c3282f.md
@@ -85,8 +85,9 @@ assert.match(password, /^[A-Za-z0-9!@#$%^&*()]+$/);
 You should not directly modify the globally scoped variable `password` inside of the `generatePassword` function. 
 
 ```js
-const generatedPassword = generatePassword(10); 
-assert.notEqual(password,generatedPassword); 
+copiedPassword = password;
+generatePassword(10);
+assert.strictEqual(password, copiedPassword);
 ```
 
 You should log the generated password to the console.

--- a/curriculum/challenges/english/25-front-end-development/lab-password-generator/66f53dc2c5bd6a11d6c3282f.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-password-generator/66f53dc2c5bd6a11d6c3282f.md
@@ -85,7 +85,7 @@ assert.match(password, /^[A-Za-z0-9!@#$%^&*()]+$/);
 You should not directly modify the globally scoped variable `password` inside of the `generatePassword` function. 
 
 ```js
-copiedPassword = password;
+const copiedPassword = password;
 generatePassword(10);
 assert.strictEqual(password, copiedPassword);
 ```

--- a/curriculum/challenges/english/25-front-end-development/lab-password-generator/66f53dc2c5bd6a11d6c3282f.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-password-generator/66f53dc2c5bd6a11d6c3282f.md
@@ -82,7 +82,7 @@ assert.strictEqual(password.length, testLength);
 assert.match(password, /^[A-Za-z0-9!@#$%^&*()]+$/);
 ```
 
-You should not directly modify `password` inside of the `generatePassword` function. 
+You should not directly modify the globally scoped variable `password` inside of the `generatePassword` function. 
 
 ```js
 const generatedPassword = generatePassword(10); 

--- a/curriculum/challenges/english/25-front-end-development/lab-password-generator/66f53dc2c5bd6a11d6c3282f.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-password-generator/66f53dc2c5bd6a11d6c3282f.md
@@ -82,6 +82,13 @@ assert.strictEqual(password.length, testLength);
 assert.match(password, /^[A-Za-z0-9!@#$%^&*()]+$/);
 ```
 
+You should not directly modify `password` inside of the `generatePassword` function. 
+
+```js
+const generatedPassword = generatePassword(10); 
+assert.notEqual(password,generatedPassword); 
+```
+
 You should log the generated password to the console.
 
 ```js


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #58867

<!-- Feel free to add any additional description of changes below this line -->
Something a little weird is going on with my local installation. I believe it's possible there was another API issue. I could not visit the local web page but at minimum I know the test isn't broken. And my test logic seems reasonable on paper. 

Edit: I think it might be I forgot to turn a process off. 