### PR TITLE
fix: make title grammar correct by changing 'Object' to 'Objects'

### DIFF
--- a/client/src/pages/learn/scientific-computing-with-python/learn-classes-and-objects-by-building-a-sudoku-solver/index.md
+++ b/client/src/pages/learn/scientific-computing-with-python/learn-classes-and-objects-by-building-a-sudoku-solver/index.md
@@ -1,5 +1,5 @@
 ---
-title: Learn Classes and Object by Building a Sudoku Solver
+title: Learn Classes and Objects by Building a Sudoku Solver
 block: learn-classes-and-objects-by-building-a-sudoku-solver
 superBlock: scientific-computing-with-python
 ---


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

I think 'Objects' should be used in the title instead of 'Object', since the description consistently uses 'objects' and not 'object'. I tried different grammar tools, and they confirm that 'objects' is correct.