### PR TITLE
fix: use 0 based index for FSD

### DIFF
--- a/curriculum/utils.js
+++ b/curriculum/utils.js
@@ -139,7 +139,7 @@ function getBlockOrder(blockName, superBlockStructure) {
       `The block "${blockName}" does not appear in the superblock structure.`
     );
 
-  return index + 1;
+  return index;
 }
 exports.createSuperOrder = createSuperOrder;
 exports.getSuperOrder = getSuperOrder;

--- a/curriculum/utils.test.ts
+++ b/curriculum/utils.test.ts
@@ -250,11 +250,11 @@ describe('getBlockOrder', () => {
   it('returns the correct order when the chapter only contains one module', () => {
     expect(
       getBlockOrder('welcome-to-freecodecamp', mockSuperBlockStructure)
-    ).toBe(1);
+    ).toBe(0);
   });
 
   it('returns the correct order when the chapter contains multiple modules', () => {
-    expect(getBlockOrder('block-one-m2', mockSuperBlockStructure)).toBe(4);
+    expect(getBlockOrder('block-one-m2', mockSuperBlockStructure)).toBe(3);
   });
 
   it('throws if a block does not exist', () => {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This will allow the site to function again. There's one place that it matters if the block order is zero or one based, but it matters quite a lot.

<!-- Feel free to add any additional description of changes below this line -->
