### PR TITLE
fix: prevent text selection in summary element

### DIFF
--- a/client/src/templates/Challenges/classic/editor.css
+++ b/client/src/templates/Challenges/classic/editor.css
@@ -291,6 +291,10 @@ textarea.inputarea {
 .code-details-summary {
   display: list-item;
   cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 
 .editor-upper-jaw pre code {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

When opening/closing the dropdown, the "Example code" text sometimes  
automatically selected which can be annoying for the user. I Added `user-select: none;` to prevent this issue.

See the video for the issue demonstration.

https://github.com/user-attachments/assets/c7323f50-d4a3-4afb-b400-a8d9d0c9dbf6


