### PR TITLE
fix(curriculum): add more tests to showLunchMenu with different number of elements

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-lunch-picker-program/66db529d37ad966480ebb633.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-lunch-picker-program/66db529d37ad966480ebb633.md
@@ -357,6 +357,24 @@ try {
 }
 ```
 
+`showLunchMenu(["Greens"])` should log `"Menu items: Greens"` to the console.
+
+```js
+let testLunches = ["Greens"];
+const tempArr = [];
+const temp = console.log;
+try {
+  console.log = obj => tempArr.push(obj);
+  showLunchMenu(testLunches);
+  assert.strictEqual(tempArr[0], "Menu items: Greens");
+  testLunches = ["Pizza"]
+  showLunchMenu(testLunches);
+  assert.strictEqual(tempArr[1], "Menu items: Pizza");
+} finally {
+  console.log = temp;
+}
+```
+
 `showLunchMenu(["Greens", "Corns", "Beans"])` should log `"Menu items: Greens, Corns, Beans"` to the console.
 
 ```js
@@ -370,6 +388,24 @@ try {
   testLunches = ["Pizza", "Burger", "Fries"]
   showLunchMenu(testLunches);
   assert.strictEqual(tempArr[1], "Menu items: Pizza, Burger, Fries");
+} finally {
+  console.log = temp;
+}
+```
+
+`showLunchMenu(["Greens", "Corns", "Beans", "Peas", "Lentils", "Roots"])` should log `"Menu items: Greens, Corns, Beans, Peas, Lentils, Roots"` to the console.
+
+```js
+let testLunches = ["Greens", "Corns", "Beans", "Peas", "Lentils", "Roots"];
+const tempArr = [];
+const temp = console.log;
+try {
+  console.log = obj => tempArr.push(obj);
+  showLunchMenu(testLunches);
+  assert.strictEqual(tempArr[0], "Menu items: Greens, Corns, Beans, Peas, Lentils, Roots");
+  testLunches = ["Pizza", "Burger", "Fries", "Tacos", "Soda", "Nuggets"]
+  showLunchMenu(testLunches);
+  assert.strictEqual(tempArr[1], "Menu items: Pizza, Burger, Fries, Tacos, Soda, Nuggets");
 } finally {
   console.log = temp;
 }


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

Closes #58917

