### PR TITLE
fix(curriculum): update quiz question about typeof null

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/quiz-javascript-variables-and-data-types/66edc25ae5ea80bf6f785552.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-javascript-variables-and-data-types/66edc25ae5ea80bf6f785552.md
@@ -291,19 +291,19 @@ What will be the output of `console.log(typeof null);`?
 
 #### --distractors--
 
-`undefined`
+`"undefined"`
 
 ---
 
-`null`
+`"null"`
 
 ---
 
-`NaN`
+`"NaN"`
 
 #### --answer--
 
-`object`
+`"object"`
 
 ### --question--
 


### PR DESCRIPTION

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

Closes #58878

This PR updates the 13th question in the JavaScript Data Types quiz. The distractor options are now correctly wrapped in quotes to reflect that the `typeof` operator returns a string. This update ensures the accuracy of the options and adheres to the correct formatting.

Changes:
- Updated distractor options for the `typeof null` question to include quotes around the string values.
