### PR TITLE
Fix #58994: Improve distractors for repeat(0) question

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-common-string-methods/67326c3392068ec6184a0c95.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-common-string-methods/67326c3392068ec6184a0c95.md
@@ -145,37 +145,22 @@ Think about how `repeat()` handles invalid count values.
 3
 
 ## --text--
-
 If you call `"*".repeat(0);`, what is the output?
 
 ## --answers--
-
-"*"
-
+" "
 ### --feedback--
-
-Consider what happens when you ask to repeat something zero times.
-
+This is a single space, not an empty string. Check what `repeat(0)` actually returns.
 ---
-
 An empty string.
-
 ---
-
-`null`
-
+"0"
 ### --feedback--
-
-Consider what happens when you ask to repeat something zero times.
-
+The `repeat()` method doesn’t return the count as a string. Think about what zero repetitions means.
 ---
-
-`"*****"`
-
+"*0"
 ### --feedback--
-
-Consider what happens when you ask to repeat something zero times.
+The `repeat()` method doesn’t combine the string and count. Consider the result of no repetitions.
 
 ## --video-solution--
-
 2


### PR DESCRIPTION
Checklist:
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open-a-pull-request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

Closes #58994

Updated the third comprehension check question in `67326c3392068ec6184a0c95.md` per issue #58994. Replaced obvious distractors (`"*", "null", "*****"`) with subtler ones (`" "`, `"0"`, `"*0"`) to make the question more challenging and educational. Tested locally by editing the Markdown file. Amended commit to add sign-off after camper-chan’s feedback. This is my first contribution—happy to adjust further!