### PR TITLE
refactor: better test errors

### DIFF
--- a/curriculum/test/test-challenges.js
+++ b/curriculum/test/test-challenges.js
@@ -73,6 +73,7 @@ process.on('uncaughtException', err => {
 // some errors *may* not be reported, since cleanup is triggered by the first
 // error and that starts shutting down the browser and the server.
 const handleRejection = err => {
+  console.error('Unhandled rejection:');
   // setting the error code because node does not (yet) exit with a non-zero
   // code on unhandled exceptions.
   process.exitCode = 1;
@@ -631,7 +632,7 @@ async function getContextEvaluator(build, sources, code, loadEnzyme) {
     evaluate: async (testString, timeout) =>
       Promise.race([
         new Promise((_, reject) =>
-          setTimeout(() => reject('timeout'), timeout)
+          setTimeout(() => reject(Error('timeout')), timeout)
         ),
         await page.evaluate(async testString => {
           return await document.__runTest(testString);


### PR DESCRIPTION
I don't know why, but if the timeout rejects, this creates an unhandled
rejection (despite being inside a try-catch block). This happens even
if the rejection loses the race.

While we could delete the race, it gives us some information: if it
fails, we know that particular test is far too slow.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->
<!-- Feel free to add any additional description of changes below this line -->
