### PR TITLE
fix(curriculum): Added reminder that <meta> elements are void and require no closing tag in Cafe Menu Step 3

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-basic-css-by-building-a-cafe-menu/5f331e55dfab7a896e53c3a1.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-basic-css-by-building-a-cafe-menu/5f331e55dfab7a896e53c3a1.md
@@ -11,6 +11,8 @@ The `title` is one of several elements that provide extra information not visibl
 
 Inside the `head` element, nest a `meta` element with an attribute named `charset` set to the value `utf-8` to tell the browser how to encode characters for the page.
 
+Remember that `meta` elements are void elements that require no ending tag.
+
 # --hints--
 
 You should have a `meta` tag.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #58989 

<!-- Feel free to add any additional description of changes below this line -->

Changes Made:
Added a reminder in Step 3 of the Cafe Menu project that `meta` elements are void elements and do not require a closing tag. This reinforces learning from the Cat Photo App project, where `meta` elements were first introduced.

Reason for Change:
The current step does not mention that `meta` elements are void.
