### PR TITLE
fix: remove duplicate if statement

### DIFF
--- a/api/src/exam-environment/utils/exam.ts
+++ b/api/src/exam-environment/utils/exam.ts
@@ -428,26 +428,24 @@ export function generateExam(exam: EnvExam): Omit<EnvGeneratedExam, 'id'> {
         const questionSet = shuffledQuestionSets.find(qs => {
           if (qs.type === questionSetConfig.type) {
             if (qs.questions.length >= questionSetConfig.numberOfQuestions) {
-              if (qs.questions.length >= questionSetConfig.numberOfQuestions) {
-                // Find questionSetConfig.numberOfQuestions who have `questionSetConfig.numberOfCorrectAnswers` and `questionSetConfig.numberOfIncorrectAnswers`
-                const questions = qs.questions.filter(q => {
-                  const numberOfCorrectAnswers = q.answers.filter(
-                    a => a.isCorrect
-                  ).length;
-                  const numberOfIncorrectAnswers = q.answers.filter(
-                    a => !a.isCorrect
-                  ).length;
-                  return (
-                    numberOfCorrectAnswers >=
-                      questionSetConfig.numberOfCorrectAnswers &&
-                    numberOfIncorrectAnswers >=
-                      questionSetConfig.numberOfIncorrectAnswers
-                  );
-                });
+              // Find questionSetConfig.numberOfQuestions who have `questionSetConfig.numberOfCorrectAnswers` and `questionSetConfig.numberOfIncorrectAnswers`
+              const questions = qs.questions.filter(q => {
+                const numberOfCorrectAnswers = q.answers.filter(
+                  a => a.isCorrect
+                ).length;
+                const numberOfIncorrectAnswers = q.answers.filter(
+                  a => !a.isCorrect
+                ).length;
+                return (
+                  numberOfCorrectAnswers >=
+                    questionSetConfig.numberOfCorrectAnswers &&
+                  numberOfIncorrectAnswers >=
+                    questionSetConfig.numberOfIncorrectAnswers
+                );
+              });
 
-                if (questions.length >= questionSetConfig.numberOfQuestions) {
-                  return true;
-                }
+              if (questions.length >= questionSetConfig.numberOfQuestions) {
+                return true;
               }
             }
           }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #59028 

<!-- Feel free to add any additional description of changes below this line -->

I removed the duplicate if statement check on line 431 - "if (qs.questions.length >= questionSetConfig.numberOfQuestions) {"
since it's identical to the check on line 430. 
