### PR TITLE
Fixing h1 Css

### DIFF
--- a/client/src/pages/blocked.tsx
+++ b/client/src/pages/blocked.tsx
@@ -10,7 +10,7 @@ function BlockedPage(): JSX.Element {
         <Spacer size='l' />
         <Row>
           <Col lg={8} lgOffset={2} sm={10} smOffset={1} xs={12}>
-            <h1 id='content-start' data-playwright-test-label='main-heading'>
+            <h1 id='content-start' data-playwright-test-label='main-heading' className='text-center text-3xl md:text-4xl lg:text-5xl'>
               We can&apos;t log you in.
             </h1>
             <Spacer size='l' />

--- a/client/src/pages/blocked.tsx
+++ b/client/src/pages/blocked.tsx
@@ -10,7 +10,7 @@ function BlockedPage(): JSX.Element {
         <Spacer size='l' />
         <Row>
           <Col lg={8} lgOffset={2} sm={10} smOffset={1} xs={12}>
-            <h1 id='content-start' data-playwright-test-label='main-heading' className='text-center text-3xl md:text-4xl lg:text-5xl'>
+            <h1 id='content-start' data-playwright-test-label='main-heading'  className='text-center text-3xl md:text-4xl lg:text-5xl'>
               We can&apos;t log you in.
             </h1>
             <Spacer size='l' />

--- a/client/src/pages/supporters.tsx
+++ b/client/src/pages/supporters.tsx
@@ -62,7 +62,7 @@ function ConditionalContent({
     return (
       <Col md={12}>
         <Spacer size='l' />
-        <h1 id='content-start' className='text-center'>
+        <h1 id='content-start' className='text-center text-3xl md:text-4xl lg:text-5xl'>
           {t('learn.donation-record-not-found')}
         </h1>
         <Spacer size='m' />
@@ -90,7 +90,7 @@ function ConditionalContent({
     return (
       <Col md={12}>
         <Spacer size='l' />
-        <h1 id='content-start' className='text-center'>
+        <h1 id='content-start' className='text-center text-3xl md:text-4xl lg:text-5xl'>
           {t('learn.sign-in-see-benefits')}
         </h1>
         <Spacer size='l' />


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes locally on my machine.

Closes #57897

<!-- Feel free to add any additional description of changes below this line -->

This pull request addresses the issue where the h1 element on review pages was smaller than the h2 element. The following updates have been made:

- Updated the CSS for the h1 element to ensure a responsive design across all devices.
- Increased the font size of the h1 element to properly distinguish it from the h2 element.
- Verified that the changes render correctly on mobile, tablet, and desktop views.

Please review these changes and let me know if any further adjustments are needed.
