### PR TITLE
Fix missing word in Step 18 of cat photo app tutorial

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-photo-app/5f07be6ef7412fbad0c5626b.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-photo-app/5f07be6ef7412fbad0c5626b.md
@@ -18,7 +18,7 @@ The `section` element is used to define sections in a document, such as chapters
 </section>
 ```
 
-Take your `h2`, two `p` elements, and anchor (`a`) elements and nest them in a `section` element.
+Take your `h2` element, two `p` elements, and an anchor (`a`) element and nest them in a `section` element.
 
 # --hints--
 


### PR DESCRIPTION
This PR fixes issue #59038 by correcting the wording in Step 18 of the cat photo app tutorial.

- Changed "h2" to "h2 element"
- Changed "anchor (a) elements" to "anchor (a) element"

This follows the FreeCodeCamp contribution guidelines.
