### PR TITLE
fix(curriculum): improved the readability of an instruction

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fad6dfcc0d930a59becf12.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fad6dfcc0d930a59becf12.md
@@ -9,7 +9,7 @@ dashedName: step-43
 
 The HTML for the registration form is finished. Now, you can spruce it up a bit.
 
-Start by changing the font to `Tahoma`, and the font size to `16px` in the `body`.
+Start by adding `Tahoma` as the font with a font size of `16px` in the `body` selector.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

- [ ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

Ref: #59075 

The instructions in Step 43 of the Registration Form in the Responsive Web Design curriculum say to change the font in the body selector, but no font had been clearly specified in the body selector. I've changed the sentence to clearly understand the font specifications for the body selector.
