### PR TITLE
fix(curriculum): remove extra space before backtick in 'nest-anchor-element' challenge

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/nest-an-anchor-element-within-a-paragraph.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/nest-an-anchor-element-within-a-paragraph.md
@@ -81,7 +81,7 @@ const anchorParent = document.querySelector('a[href="https://www.freecatphotoapp
 assert.strictEqual(anchorParent.tagName,"P")
 ```
 
-Your `p` element should have the text `View more ` (with a space after it).
+Your `p` element should have the text `View more` (with a space after it).
 
 ```js
 const textContent = document.querySelector('a[href="https://www.freecatphotoapp.com"]').parentNode.textContent;


### PR DESCRIPTION
Checklist:
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

## Problem
There was an unnecessary space before the backtick in the markdown file for the **Nest an Anchor Element within a Paragraph** challenge, which caused formatting inconsistencies.

## Solution
- Removed the extra space before the backtick to maintain consistent formatting in the challenge description.
- Ensured the file aligns with the other markdown files in the curriculum.

## Test
- Visually reviewed the markdown content.
- Verified that no other formatting issues were present in the file.
- No errors reported when viewing the file in the curriculum.
