### PR TITLE
fix(curriculum): remove extra space after backtick in 'use-the-map' challenge

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/functional-programming/use-the-map-method-to-extract-data-from-an-array.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/functional-programming/use-the-map-method-to-extract-data-from-an-array.md
@@ -33,7 +33,7 @@ const names = users.map(user => user.name);
 console.log(names);
 ```
 
-The console would display the value ` [ 'John', 'Amy', 'camperCat' ]`.
+The console would display the value `[ 'John', 'Amy', 'camperCat' ]`.
 
 # --instructions--
 


### PR DESCRIPTION
Checklist:
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

## Problem
There was an unnecessary space after the backtick in the markdown file for the **Use the map Method to Extract Data from an Array** challenge, which caused formatting inconsistencies.

## Solution
- Removed the extra space before the backtick to maintain consistent formatting in the challenge description.
- Ensured the file aligns with the other markdown files in the curriculum.

## Test
- Visually reviewed the markdown content.
- Verified that no other formatting issues were present in the file.
- No errors reported when viewing the file in the curriculum.
