### PR TITLE
fix(curriculum): add optional chaining to prevent "TypeError" in null checks

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5efae0543cbd2bbdab94e333.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5efae0543cbd2bbdab94e333.md
@@ -45,7 +45,7 @@ The Cats `img` element should have an `alt` attribute with the value `Five cats 
 
 ```js
 const catsImg = document.querySelectorAll('figure > img')[1];
-assert(catsImg?.getAttribute('alt')?.replace(/\s+/g, ' ').match(/^Five cats looking around a field\.?$/i));
+assert.match(catsImg?.getAttribute('alt')?.replace(/\s+/g, ' '), /^Five cats looking around a field\.?$/i);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5efae0543cbd2bbdab94e333.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5efae0543cbd2bbdab94e333.md
@@ -45,12 +45,7 @@ The Cats `img` element should have an `alt` attribute with the value `Five cats 
 
 ```js
 const catsImg = document.querySelectorAll('figure > img')[1];
-assert(
-  catsImg
-    .getAttribute('alt')
-    .replace(/\s+/g, ' ')
-    .match(/^Five cats looking around a field\.?$/i)
-);
+assert(catsImg?.getAttribute('alt')?.replace(/\s+/g, ' ').match(/^Five cats looking around a field\.?$/i));
 ```
 
 # --seed--


### PR DESCRIPTION

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

In https://www.freecodecamp.org/learn/2022/responsive-web-design/learn-html-by-building-a-cat-photo-app/step-32, if the user has an invalid alt attribute or the `img` element is missing, the console shows an error like:
[TypeError: Cannot read properties of null (reading 'replace')].

This happens because calling replace on null causes an error. To fix this, we can use optional chaining.

This way, users won’t see confusing error messages in the console.

![img](https://github.com/user-attachments/assets/762d8c1b-73fb-495e-879c-f2ae38f47b0b)
