### PR TITLE
fix(curriculum): registration form step 19 - update verbiage

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60f80e0081e0f2052ae5b505.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60f80e0081e0f2052ae5b505.md
@@ -7,7 +7,7 @@ dashedName: step-19
 
 # --description--
 
-Specifying the `type` attribute of a form element is important for the browser to know what kind of data it should expect. If the `type` is not specified, the browser will default to `text`.
+Specifying the `type` attribute of an `input` element is important for the browser to know what kind of data it should expect. If the `type` is not specified, the browser will default to `text`.
 
 Give the first two `input` elements a `type` attribute of `text`, the third a `type` attribute of `email`, and the fourth a `type` attribute of `password`.
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-registration-form/60f80e0081e0f2052ae5b505.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-registration-form/60f80e0081e0f2052ae5b505.md
@@ -7,7 +7,7 @@ dashedName: step-14
 
 # --description--
 
-Specifying the `type` attribute of a form element is important for the browser to know what kind of data it should expect. If the `type` is not specified, the browser will default to `text`.
+Specifying the `type` attribute of an `input` element is important for the browser to know what kind of data it should expect. If the `type` is not specified, the browser will default to `text`.
 
 Give the first two `input` elements a `type` attribute of `text`, the third a `type` attribute of `email`, and the fourth a `type` attribute of `password`.
 


### PR DESCRIPTION
Pretty straightforward change. I've updated the text in Step-19 of the registration form to specify that the `type` needs to be added to the `input` element instead of `form`. 

Screenshot of change:
![image](https://github.com/user-attachments/assets/2926f1e9-77e9-440c-b85c-f5e396830b66)


Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #59073

<!-- Feel free to add any additional description of changes below this line -->
