### PR TITLE
fix(curriculum): update verbiage in registration form

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fac4095512d3066053d73c.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fac4095512d3066053d73c.md
@@ -9,7 +9,7 @@ dashedName: step-34
 
 Adding a dropdown to the form is easy with the `select` element. The `select` element is a container for a group of `option` elements, and the `option` element acts as a label for each dropdown option. Both elements require closing tags.
 
-Start by adding a `select` element below the two `label` elements. Then nest 5 `option` elements within the `select` element.
+Start by adding a `select` element below the last `label` element. Then nest 5 `option` elements within the `select` element.
 
 # --hints--
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-registration-form/60fac4095512d3066053d73c.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-registration-form/60fac4095512d3066053d73c.md
@@ -9,7 +9,7 @@ dashedName: step-29
 
 Adding a dropdown to the form is easy with the `select` element. The `select` element is a container for a group of `option` elements, and the `option` element acts as a label for each dropdown option. Both elements require closing tags.
 
-Start by adding a `select` element below the two `label` elements. Then nest 5 `option` elements within the `select` element.
+Start by adding a `select` element below the last `label` element. Then nest 5 `option` elements within the `select` element.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #59088

**Summary:** 

 I updated the verbiage in the following files as they both had the same issue: 
 
`curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fac4095512d3066053d73c.md`

`curriculum/challenges/english/25-front-end-development/workshop-registration-form/60fac4095512d3066053d73c.md
`


<!-- Feel free to add any additional description of changes below this line -->
