### PR TITLE
chore(curriculum): ignore junk in curriculum folder

### DIFF
--- a/curriculum/utils.test.ts
+++ b/curriculum/utils.test.ts
@@ -170,11 +170,10 @@ describe('getSuperOrder', () => {
 });
 
 describe('getSuperBlockFromPath', () => {
-  const junkRegex = /^\./; // Ignore Thumbs.db and .DS_Store
-
+  const englishFolder = path.join(__dirname, './challenges/english');
   const directories = fs
-    .readdirSync(path.join(__dirname, './challenges/english'))
-    .filter(item => !junkRegex.test(item));
+    .readdirSync(englishFolder)
+    .filter(item => fs.lstatSync(path.join(englishFolder, item)).isDirectory());
 
   it('handles all the directories in ./challenges/english', () => {
     expect.assertions(24);

--- a/curriculum/utils.test.ts
+++ b/curriculum/utils.test.ts
@@ -170,9 +170,11 @@ describe('getSuperOrder', () => {
 });
 
 describe('getSuperBlockFromPath', () => {
-  const directories = fs.readdirSync(
-    path.join(__dirname, './challenges/english')
-  );
+  const junkRegex = /^\./; // Ignore Thumbs.db and .DS_Store
+
+  const directories = fs
+    .readdirSync(path.join(__dirname, './challenges/english'))
+    .filter(item => !junkRegex.test(item));
 
   it('handles all the directories in ./challenges/english', () => {
     expect.assertions(24);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
I swore there was an issue related to this at one point. When I find it, I'll update the issue description.  Basically when `test-curriculum-js` is ran, the test fails if there is a junk file.

Because everything in the folder is read in the superblock test, irrelevant things get picked up.  An possible alternative is to specifically test for files. 


