### PR TITLE
fix(curriculum): Mega Navbar step 1 - update regex

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6740495ba48aa94e5667b436.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6740495ba48aa94e5667b436.md
@@ -29,7 +29,7 @@ assert.match(code, /export\s+(const|function)\s+Navbar\s*(=\s*)?\(\)\s*(=>\s*)?\
 You should return an empty pair of round parentheses inside the `Navbar` function.
 
 ```js
-assert.match(code, /export\s+(const|function)\s+Navbar\s*(=\s*)?\(\)\s*(=>\s*)?\{\s*return\s*\(\s*\);?\s*\}/)
+assert.match(code, /export\s+(const|function)\s+Navbar\s*(=\s*)?\(\)\s*(=>\s*)?\{\s*return\s*\(\s*\)\s*;?\s*\}/)
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6740495ba48aa94e5667b436.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6740495ba48aa94e5667b436.md
@@ -29,7 +29,7 @@ assert.match(code, /export\s+(const|function)\s+Navbar\s*(=\s*)?\(\)\s*(=>\s*)?\
 You should return an empty pair of round parentheses inside the `Navbar` function.
 
 ```js
-assert.match(code, /export\s+(const|function)\s+Navbar\s*(=\s*)?\(\)\s*(=>\s*)?\{\s*return\s*\(\s*\)\s*\}/)
+assert.match(code, /export\s+(const|function)\s+Navbar\s*(=\s*)?\(\)\s*(=>\s*)?\{\s*return\s*\(\s*\);?\s*\}/)
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #58698

<!-- Feel free to add any additional description of changes below this line -->
Updated the regex for Step 1 of the Reusable Mega Navbar workshop, to allow for semicolons to be placed at the end of the return statement. This will now accept solutions with semicolons at the end.