### PR TITLE
fix(curriculum): remove extra space backtick in challenges

### DIFF
--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-data-structures-by-building-the-merge-sort-algorithm/6569b20f829b7e69d43c232a.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-data-structures-by-building-the-merge-sort-algorithm/6569b20f829b7e69d43c232a.md
@@ -13,7 +13,7 @@ Using the augmented assignment addition operator, add `1` to the value of `sorte
 
 # --hints--
 
-You should use the `+= ` operator to increment the current value of `sorted_index` by one within the `while` loop.
+You should use the `+=` operator to increment the current value of `sorted_index` by one within the `while` loop.
 
 ```js
 ({

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-intermediate-css-by-building-a-cat-painting/646dec359bef3b7811fba5a6.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-intermediate-css-by-building-a-cat-painting/646dec359bef3b7811fba5a6.md
@@ -17,7 +17,7 @@ Your `.cat-right-inner-eye` selector should have a `position` property set to `a
 assert(new __helpers.CSSHelp(document).getStyle('.cat-right-inner-eye')?.position === 'absolute')
 ```
 
-Your `.cat-right-inner-eye` selector should have a `top` property set to ` 8px`.
+Your `.cat-right-inner-eye` selector should have a `top` property set to `8px`.
 
 ```js
 assert(new __helpers.CSSHelp(document).getStyle('.cat-right-inner-eye')?.top === '8px')


### PR DESCRIPTION
Checklist:
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

## Problem
There was an unnecessary space after the backtick in the markdown file for the **Learn Data Structures By Building The Merge Sort Algorithm** and **Learn Intermediate Css By Building A Cat Painting** challenges, which caused formatting inconsistencies.

## Solution
- Removed the extra space before the backtick to maintain consistent formatting in the challenge description.
- Ensured the file aligns with the other markdown files in the curriculum.

## Test
- Visually reviewed the markdown content.
- Verified that no other formatting issues were present in the file.
- No errors reported when viewing the file in the curriculum.
