### PR TITLE
feat(curriculum): prioritize showing index.jsx

### DIFF
--- a/client/utils/sort-challengefiles.js
+++ b/client/utils/sort-challengefiles.js
@@ -1,12 +1,12 @@
 exports.sortChallengeFiles = function sortChallengeFiles(challengeFiles) {
   const xs = challengeFiles.slice();
   xs.sort((a, b) => {
+    if (a.history[0] === 'index.jsx') return -1;
+    if (b.history[0] === 'index.jsx') return 1;
     if (a.history[0] === 'index.html') return -1;
     if (b.history[0] === 'index.html') return 1;
     if (a.history[0] === 'styles.css') return -1;
     if (b.history[0] === 'styles.css') return 1;
-    if (a.history[0] === 'index.jsx') return -1;
-    if (b.history[0] === 'index.jsx') return 1;
     if (a.history[0] === 'script.js') return -1;
     if (b.history[0] === 'script.js') return 1;
     if (a.history[0] === 'index.ts') return -1;

--- a/client/utils/sort-challengefiles.test.js
+++ b/client/utils/sort-challengefiles.test.js
@@ -14,13 +14,13 @@ describe('sort-files', () => {
       expect(sorted.length).toEqual(expected.length);
     });
 
-    it('should sort the objects into html, css, jsx, js, ts order', () => {
+    it('should sort the objects into jsx, html, css, js, ts order', () => {
       const sorted = sortChallengeFiles(challengeFiles);
       const sortedKeys = sorted.map(({ fileKey }) => fileKey);
       const expected = [
+        'indexjsx',
         'indexhtml',
         'stylescss',
-        'indexjsx',
         'scriptjs',
         'indexts'
       ];


### PR DESCRIPTION
If we have an index.jsx file, it's likely the most relevant one for the learner, so now it's open by default.

Before:
![original html, css, jsx order](https://github.com/user-attachments/assets/3f28bd45-2417-44df-a52d-b3cf1990056b)


After: 
![re-ordered editor tabs](https://github.com/user-attachments/assets/e0370d60-5620-45f6-884e-bc8a5e018c46)


Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes https://github.com/freeCodeCamp/freeCodeCamp/issues/59049

<!-- Feel free to add any additional description of changes below this line -->
