### PR TITLE
fix(curriculum): preposition missing from captions

### DIFF
--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d88b76573df039d43f29bc.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d88b76573df039d43f29bc.md
@@ -87,7 +87,7 @@ Watch the video
       "startTime": 11.8,
       "finishTime": 16.1,
       "dialogue": {
-        "text": "I also can't disclose sensitive information to anyone outside the company.",
+        "text": "I also can't disclose sensitive information to anyone outside of the company.",
         "align": "right"
       }
     },


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

The word \"of\" is missing from the captions.