### PR TITLE
fix(curriculum): incorrect helpCategory for react labs

### DIFF
--- a/curriculum/challenges/_meta/lab-mood-board/meta.json
+++ b/curriculum/challenges/_meta/lab-mood-board/meta.json
@@ -5,7 +5,7 @@
   "dashedName": "lab-mood-board",
   "superBlock": "full-stack-developer",
   "challengeOrder": [{ "id": "673b3d6b7ef7318eef926d5a", "title": "Build a Mood Board" }],
-  "helpCategory": "HTML-CSS",
+  "helpCategory": "JavaScript",
   "blockLayout": "link",
   "blockType": "lab"
 }

--- a/curriculum/challenges/_meta/lab-reusable-footer/meta.json
+++ b/curriculum/challenges/_meta/lab-reusable-footer/meta.json
@@ -5,7 +5,7 @@
   "dashedName": "lab-reusable-footer",
   "superBlock": "full-stack-developer",
   "challengeOrder": [{ "id": "673b02b03134b04637bf7055", "title": "Build a Reusable Footer" }],
-  "helpCategory": "HTML-CSS",
+  "helpCategory": "JavaScript",
   "blockLayout": "link",
   "blockType": "lab"
 }


### PR DESCRIPTION
- mood-board and reusable-footer labs were incorrectly categorized as "HTML-CSS" instead of "Javascript"
- resolves #59115

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #59115

<!-- Feel free to add any additional description of changes below this line -->
