### PR TITLE
chore: upload to crowdin earlier

### DIFF
--- a/.github/workflows/crowdin-upload.client-ui.yml
+++ b/.github/workflows/crowdin-upload.client-ui.yml
@@ -2,8 +2,8 @@ name: i18n - Upload Client UI
 on:
   workflow_dispatch:
   schedule:
-    # runs every weekday at 7:00 AM UTC
-    - cron: '0 7 * * 1-5'
+    # runs every weekday at 7:15 AM UTC
+    - cron: '15 7 * * 1-5'
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/crowdin-upload.client-ui.yml
+++ b/.github/workflows/crowdin-upload.client-ui.yml
@@ -2,8 +2,8 @@ name: i18n - Upload Client UI
 on:
   workflow_dispatch:
   schedule:
-    # runs every weekday at 11:15 AM UTC
-    - cron: '15 11 * * 1-5'
+    # runs every weekday at 7:00 AM UTC
+    - cron: '0 7 * * 1-5'
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/crowdin-upload.curriculum.yml
+++ b/.github/workflows/crowdin-upload.curriculum.yml
@@ -2,8 +2,8 @@ name: i18n - Upload Curriculum
 on:
   workflow_dispatch:
   schedule:
-    # runs every weekday at 11:30 AM UTC
-    - cron: '30 11 * * 1-5'
+    # runs every weekday at 7:30 AM UTC
+    - cron: '30 7 * * 1-5'
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The curriculum upload can take nearly 3 hours, so this gives a healthier
buffer (over 5 hours, currently) before the download begins

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->
