### PR TITLE
fix(curriculum): clear element before test

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-markdown-to-html-converter/66f55eac933ff64ce654ca74.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-markdown-to-html-converter/66f55eac933ff64ce654ca74.md
@@ -12,7 +12,7 @@ Markdown is a markup language used to add formatting elements to plain-text docu
 
 **Note:** The final result won't be a comprehensive Markdown to HTML converter, but you can add extra functionalities to it if you would like.
 
-**Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab. 
+**Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab.
 
 **User Stories:**
 
@@ -100,6 +100,7 @@ When the value of `#markdown-input` is `# title 1`, `<h1>title 1</h1>` should be
 ```js
 const input = document.querySelector("#markdown-input");
 const output = document.querySelector("#html-output");
+output.innerText = "";
 input.value = "# title 1";
 input.dispatchEvent(new Event("input"));
 const testDiv = document.createElement("div");
@@ -115,6 +116,7 @@ When the value of `#markdown-input` is `# title 1`, an `h1` element with the tex
 ```js
 const input = document.querySelector("#markdown-input");
 const preview = document.querySelector("#preview");
+preview.innerHTML = "";
 input.value = "# title 1";
 input.dispatchEvent(new Event("input"));
 const headings = preview.querySelectorAll("h1");
@@ -166,6 +168,7 @@ When the value of `#markdown-input` is `## title 2`, `<h2>title 2</h2>` should b
 ```js
 const input = document.querySelector("#markdown-input");
 const output = document.querySelector("#html-output");
+output.innerText = "";
 input.value = "## title 2";
 input.dispatchEvent(new Event("input"));
 const testDiv = document.createElement("div");
@@ -181,6 +184,7 @@ When the value of `#markdown-input` is `## title 2`, an `h2` element with the te
 ```js
 const input = document.querySelector("#markdown-input");
 const preview = document.querySelector("#preview");
+preview.innerHTML = "";
 input.value = "## title 2";
 input.dispatchEvent(new Event("input"));
 const headings = preview.querySelectorAll("h2");
@@ -232,6 +236,7 @@ When the value of `#markdown-input` is `### title 3`, `<h3>title 3</h3>` should 
 ```js
 const input = document.querySelector("#markdown-input");
 const output = document.querySelector("#html-output");
+output.innerText = "";
 input.value = "### title 3";
 input.dispatchEvent(new Event("input"));
 const testDiv = document.createElement("div");
@@ -247,6 +252,7 @@ When the value of `#markdown-input` is `### title 3`, an `h3` element with the t
 ```js
 const input = document.querySelector("#markdown-input");
 const preview = document.querySelector("#preview");
+preview.innerHTML = "";
 input.value = "### title 3";
 input.dispatchEvent(new Event("input"));
 const headings = preview.querySelectorAll("h3");
@@ -298,6 +304,7 @@ When the value of `#markdown-input` is `**this is bold**`, `<strong>this is bold
 ```js
 const input = document.querySelector("#markdown-input");
 const output = document.querySelector("#html-output");
+output.innerText = "";
 input.value = "**this is bold**";
 input.dispatchEvent(new Event("input"));
 const testDiv = document.createElement("div");
@@ -313,6 +320,7 @@ When the value of `#markdown-input` is `**this is bold**`, a `strong` element wi
 ```js
 const input = document.querySelector("#markdown-input");
 const preview = document.querySelector("#preview");
+preview.innerHTML = "";
 input.value = "**this is bold**";
 input.dispatchEvent(new Event("input"));
 const strongs = preview.querySelectorAll("strong");
@@ -340,6 +348,7 @@ When the value of `#markdown-input` is `__this is bold__`, `<strong>this is bold
 ```js
 const input = document.querySelector("#markdown-input");
 const output = document.querySelector("#html-output");
+output.innerText = "";
 input.value = "__this is bold__";
 input.dispatchEvent(new Event("input"));
 const testDiv = document.createElement("div");
@@ -355,6 +364,7 @@ When the value of `#markdown-input` is `__this is bold__`, a `strong` element wi
 ```js
 const input = document.querySelector("#markdown-input");
 const preview = document.querySelector("#preview");
+preview.innerHTML = "";
 input.value = "__this is bold__";
 input.dispatchEvent(new Event("input"));
 const strongs = preview.querySelectorAll("strong");
@@ -395,6 +405,7 @@ When the value of `#markdown-input` is `*this is italic*`, `<em>this is italic</
 ```js
 const input = document.querySelector("#markdown-input");
 const output = document.querySelector("#html-output");
+output.innerText = "";
 input.value = "*this is italic*";
 input.dispatchEvent(new Event("input"));
 const testDiv = document.createElement("div");
@@ -410,6 +421,7 @@ When the value of `#markdown-input` is `*this is italic*`, an `em` element with 
 ```js
 const input = document.querySelector("#markdown-input");
 const preview = document.querySelector("#preview");
+preview.innerHTML = "";
 input.value = "*this is italic*";
 input.dispatchEvent(new Event("input"));
 const italics = preview.querySelectorAll("em");
@@ -450,6 +462,7 @@ When the value of `#markdown-input` is `_this is italic_`, `<em>this is italic</
 ```js
 const input = document.querySelector("#markdown-input");
 const output = document.querySelector("#html-output");
+output.innerText = "";
 input.value = "_this is italic_";
 input.dispatchEvent(new Event("input"));
 const testDiv = document.createElement("div");
@@ -465,6 +478,7 @@ When the value of `#markdown-input` is `_this is italic_`, an `em` element with 
 ```js
 const input = document.querySelector("#markdown-input");
 const preview = document.querySelector("#preview");
+preview.innerHTML = "";
 input.value = "_this is italic_";
 input.dispatchEvent(new Event("input"));
 const italics = preview.querySelectorAll("em");
@@ -519,6 +533,7 @@ When the value of `#markdown-input` is either `# **title 1**` or `# __title 1__`
 ```js
 const input = document.querySelector("#markdown-input");
 const output = document.querySelector("#html-output");
+output.innerText = "";
 input.value = "# **title 1**";
 input.dispatchEvent(new Event("input"));
 const testDiv1 = document.createElement("div");
@@ -531,6 +546,7 @@ assert.lengthOf(headings[0].children, 1);
 assert.exists(testStrong);
 assert.equal(testStrong.innerText, "title 1");
 
+output.innerText = "";
 input.value = "# __title 1__";
 input.dispatchEvent(new Event("input"));
 const testDiv2 = document.createElement("div");
@@ -549,6 +565,7 @@ When the value of `#markdown-input` is either `# **title 1**` or `# __title 1__`
 ```js
 const input = document.querySelector("#markdown-input");
 const preview = document.querySelector("#preview");
+preview.innerHTML = "";
 input.value = "# **title 1**";
 input.dispatchEvent(new Event("input"));
 let headings = preview.querySelectorAll("h1")
@@ -559,6 +576,7 @@ assert.lengthOf(headings[0].children, 1);
 assert.exists(testStrong);
 assert.equal(testStrong.innerText, "title 1");
 
+preview.innerHTML = "";
 input.value = "# __title 1__";
 input.dispatchEvent(new Event("input"));
 headings = preview.querySelectorAll("h1")
@@ -589,6 +607,7 @@ When the value of `#markdown-input` is `![alt-text](image-source)`, `<img alt="a
 ```js
 const input = document.querySelector("#markdown-input");
 const output = document.querySelector("#html-output");
+output.innerText = "";
 input.value = "![alt-text](image-source)";
 input.dispatchEvent(new Event("input"));
 const testDiv = document.createElement("div");
@@ -605,6 +624,7 @@ When the value of `#markdown-input` is `![alt-text](image-source)`, `<img alt="a
 ```js
 const input = document.querySelector("#markdown-input");
 const preview = document.querySelector("#preview");
+preview.innerHTML = "";
 input.value = "![alt-text](image-source)";
 input.dispatchEvent(new Event("input"));
 const imgs = preview.querySelectorAll("img");
@@ -649,6 +669,7 @@ When the value of `#markdown-input` is `[link text](URL)`, `<a href="URL">link t
 ```js
 const input = document.querySelector("#markdown-input");
 const output = document.querySelector("#html-output");
+output.innerText = "";
 input.value = "[link text](URL)";
 input.dispatchEvent(new Event("input"));
 const testDiv = document.createElement("div");
@@ -665,6 +686,7 @@ When the value of `#markdown-input` is `[link text](URL)`, `<a href="URL">link t
 ```js
 const input = document.querySelector("#markdown-input");
 const preview = document.querySelector("#preview");
+preview.innerHTML = "";
 input.value = "[link text](URL)";
 input.dispatchEvent(new Event("input"));
 const anchors = preview.querySelectorAll("a");
@@ -708,6 +730,7 @@ When the value of `#markdown-input` is `> this is a quote`, `<blockquote>this is
 ```js
 const input = document.querySelector("#markdown-input");
 const output = document.querySelector("#html-output");
+output.innerText = "";
 input.value = "> this is a quote";
 input.dispatchEvent(new Event("input"));
 const testDiv = document.createElement("div");
@@ -723,6 +746,7 @@ When the value of `#markdown-input` is `> this is a quote`, `<blockquote>this is
 ```js
 const input = document.querySelector("#markdown-input");
 const preview = document.querySelector("#preview");
+preview.innerHTML = "";
 input.value = "> this is a quote";
 input.dispatchEvent(new Event("input"));
 const quotes = preview.querySelectorAll("blockquote");
@@ -782,6 +806,7 @@ When the value of `#markdown-input` is `> **this is a *quote***`, `<blockquote><
 ```js
 const input = document.querySelector("#markdown-input");
 const output = document.querySelector("#html-output");
+output.innerText = "";
 input.value = "> **this is a *quote***";
 input.dispatchEvent(new Event("input"));
 const testDiv = document.createElement("div");
@@ -804,6 +829,7 @@ When the value of `#markdown-input` is `> **this is a *quote***`, you should set
 ```js
 const input = document.querySelector("#markdown-input");
 const preview = document.querySelector("#preview");
+preview.innerHTML = "";
 input.value = "> **this is a *quote***";
 input.dispatchEvent(new Event("input"));
 const quotes = preview.querySelectorAll("blockquote");


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

Ref #59129

- - -
- I'm not crazy!
1. If `convertMarkdown` function updates directly `#html-output` and `#preview`, test using `convertMarkdown` will fill the elements (obviously).
2. Coincidentally with ~~one~~ two exceptions tests checking the contents of `#html-output` and `#preview` are after the corresponding `convertMarkdown` tests.
3. This means, tests implicitly checking if event listener on the `#markdown-input` is working and `#html-output` and `#preview` change accordingly, might give false positive result. Because they were already set by the tests with `convertMarkdown` function.