### PR TITLE
feat(Curriculum): Add review tasks to blocks 5 and 6 A2 curriculum

### DIFF
--- a/curriculum/challenges/_meta/learn-how-to-describe-your-current-project/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-describe-your-current-project/meta.json
@@ -58,44 +58,52 @@
       "title": "Task 12"
     },
     {
+      "id": "67ca0b9a589d4e405f17a0de",
+      "title": "Task 13"
+    },
+    {
       "id": "655bd1b0faed39415ed2760f",
       "title": "Dialogue 2: Data Analysis Team Discuss Their Projects"
     },
     {
       "id": "655bd2158780e2421b674e61",
-      "title": "Task 13"
-    },
-    {
-      "id": "655bd2f3caad89436a3dcc04",
       "title": "Task 14"
     },
     {
-      "id": "655bd57d0e13e146b2404569",
+      "id": "655bd2f3caad89436a3dcc04",
       "title": "Task 15"
     },
     {
-      "id": "655bd798ce91bd4861b69281",
+      "id": "655bd57d0e13e146b2404569",
       "title": "Task 16"
     },
     {
-      "id": "655bd91a858b2b4a30da3cad",
+      "id": "655bd798ce91bd4861b69281",
       "title": "Task 17"
     },
     {
-      "id": "655bda6270ef334ad8a7f005",
+      "id": "655bd91a858b2b4a30da3cad",
       "title": "Task 18"
     },
     {
-      "id": "655bdc7e9c4116509df13f34",
+      "id": "655bda6270ef334ad8a7f005",
       "title": "Task 19"
     },
     {
-      "id": "655bdf9f7f844952b7e7f036",
+      "id": "655bdc7e9c4116509df13f34",
       "title": "Task 20"
     },
     {
-      "id": "655be33b7a463a5593c91cb4",
+      "id": "655bdf9f7f844952b7e7f036",
       "title": "Task 21"
+    },
+    {
+      "id": "655be33b7a463a5593c91cb4",
+      "title": "Task 22"
+    },
+    {
+      "id": "67ca0ba8f61b0a4094fd5e08",
+      "title": "Task 23"
     },
     {
       "id": "655c9a549835a8601764bd0b",
@@ -103,31 +111,35 @@
     },
     {
       "id": "655c9a89818e18606c18ca4b",
-      "title": "Task 22"
-    },
-    {
-      "id": "655c9b2e0bcbe16161996ab7",
-      "title": "Task 23"
-    },
-    {
-      "id": "655c9bcb5bedb4620acb6f18",
       "title": "Task 24"
     },
     {
-      "id": "655c9d9470acf0643482b95b",
+      "id": "655c9b2e0bcbe16161996ab7",
       "title": "Task 25"
     },
     {
-      "id": "655c9e73e89d886538976452",
+      "id": "655c9bcb5bedb4620acb6f18",
       "title": "Task 26"
     },
     {
-      "id": "655c9ee249f7ef65f6d2dd36",
+      "id": "655c9d9470acf0643482b95b",
       "title": "Task 27"
     },
     {
-      "id": "655ca014b022ff6692049b91",
+      "id": "655c9e73e89d886538976452",
       "title": "Task 28"
+    },
+    {
+      "id": "655c9ee249f7ef65f6d2dd36",
+      "title": "Task 29"
+    },
+    {
+      "id": "655ca014b022ff6692049b91",
+      "title": "Task 30"
+    },
+    {
+      "id": "67ca0bb4d64ab640cb7f4c2b",
+      "title": "Task 31"
     },
     {
       "id": "655ca0a6639d6b67683ebbcd",
@@ -135,59 +147,63 @@
     },
     {
       "id": "655cadb5df07e269cccaa056",
-      "title": "Task 29"
-    },
-    {
-      "id": "656918c77e73780c34392e17",
-      "title": "Task 30"
-    },
-    {
-      "id": "656a2fa76e9c4636f6ac7a49",
-      "title": "Task 31"
-    },
-    {
-      "id": "656a43974f689442c0a0eeb2",
       "title": "Task 32"
     },
     {
-      "id": "656a444cef055b4342f1f323",
+      "id": "656918c77e73780c34392e17",
       "title": "Task 33"
     },
     {
-      "id": "656a44b06bea9443b8ff45bd",
+      "id": "656a2fa76e9c4636f6ac7a49",
       "title": "Task 34"
     },
     {
-      "id": "656a456b46b4b04437f2d3e9",
+      "id": "656a43974f689442c0a0eeb2",
       "title": "Task 35"
     },
     {
-      "id": "656a45d4f36ea1448aa359d2",
+      "id": "656a444cef055b4342f1f323",
       "title": "Task 36"
     },
     {
-      "id": "656a46814617c04516f698eb",
+      "id": "656a44b06bea9443b8ff45bd",
       "title": "Task 37"
     },
     {
-      "id": "656a46e84a0ad845901ea907",
+      "id": "656a456b46b4b04437f2d3e9",
       "title": "Task 38"
     },
     {
-      "id": "656a4758b0f85e45d03f9e17",
+      "id": "656a45d4f36ea1448aa359d2",
       "title": "Task 39"
     },
     {
-      "id": "656a47c9473b0f46463f7d55",
+      "id": "656a46814617c04516f698eb",
       "title": "Task 40"
     },
     {
-      "id": "656a4815c0d43346a2e27b51",
+      "id": "656a46e84a0ad845901ea907",
       "title": "Task 41"
     },
     {
-      "id": "656a48d41b97ff476586ee9c",
+      "id": "656a4758b0f85e45d03f9e17",
       "title": "Task 42"
+    },
+    {
+      "id": "656a47c9473b0f46463f7d55",
+      "title": "Task 43"
+    },
+    {
+      "id": "656a4815c0d43346a2e27b51",
+      "title": "Task 44"
+    },
+    {
+      "id": "656a48d41b97ff476586ee9c",
+      "title": "Task 45"
+    },
+    {
+      "id": "67ca0bc1529fd24101862db1",
+      "title": "Task 46"
     },
     {
       "id": "656a494313c73747b15a02c0",
@@ -195,67 +211,71 @@
     },
     {
       "id": "656a49a16377b8485270dd2d",
-      "title": "Task 43"
-    },
-    {
-      "id": "656a4a4225a07e491ca4f31e",
-      "title": "Task 44"
-    },
-    {
-      "id": "656a4a7596c46e495c64a7ec",
-      "title": "Task 45"
-    },
-    {
-      "id": "656a4ac4529e0f49ab900c3b",
-      "title": "Task 46"
-    },
-    {
-      "id": "656a4afc5f944649f391898f",
       "title": "Task 47"
     },
     {
-      "id": "656a4b4891e9e54a34dc4dcf",
+      "id": "656a4a4225a07e491ca4f31e",
       "title": "Task 48"
     },
     {
-      "id": "656a4b9e4822ba4a9893459e",
+      "id": "656a4a7596c46e495c64a7ec",
       "title": "Task 49"
     },
     {
-      "id": "656a4bea53d6fd4ae86bdb70",
+      "id": "656a4ac4529e0f49ab900c3b",
       "title": "Task 50"
     },
     {
-      "id": "656a4c42ee183c4b3b92bfeb",
+      "id": "656a4afc5f944649f391898f",
       "title": "Task 51"
     },
     {
-      "id": "656a4c92a476854b89f98ffd",
+      "id": "656a4b4891e9e54a34dc4dcf",
       "title": "Task 52"
     },
     {
-      "id": "656a4d1943d8f24c030ded74",
+      "id": "656a4b9e4822ba4a9893459e",
       "title": "Task 53"
     },
     {
-      "id": "656a4d74286f4d4c4ae58de0",
+      "id": "656a4bea53d6fd4ae86bdb70",
       "title": "Task 54"
     },
     {
-      "id": "656a4dd03541de4ca98a61e8",
+      "id": "656a4c42ee183c4b3b92bfeb",
       "title": "Task 55"
     },
     {
-      "id": "656a4e001d2b804cdea7000a",
+      "id": "656a4c92a476854b89f98ffd",
       "title": "Task 56"
     },
     {
-      "id": "656a4e35a774444d1946a899",
+      "id": "656a4d1943d8f24c030ded74",
       "title": "Task 57"
     },
     {
-      "id": "656a4e8a59ef3c4d8dfc2ad9",
+      "id": "656a4d74286f4d4c4ae58de0",
       "title": "Task 58"
+    },
+    {
+      "id": "656a4dd03541de4ca98a61e8",
+      "title": "Task 59"
+    },
+    {
+      "id": "656a4e001d2b804cdea7000a",
+      "title": "Task 60"
+    },
+    {
+      "id": "656a4e35a774444d1946a899",
+      "title": "Task 61"
+    },
+    {
+      "id": "656a4e8a59ef3c4d8dfc2ad9",
+      "title": "Task 62"
+    },
+    {
+      "id": "67ca0bcb4d28674182caa4e7",
+      "title": "Task 63"
     }
   ],
   "helpCategory": "English",

--- a/curriculum/challenges/_meta/learn-how-to-discuss-your-morning-or-evening-routine/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-discuss-your-morning-or-evening-routine/meta.json
@@ -258,72 +258,76 @@
       "title": "Task 61"
     },
     {
+      "id": "67c8bb14718cddacc3748282",
+      "title": "Task 62"
+    },
+    {
       "id": "655a591ad34faa18c8338f9b",
       "title": "Dialogue 3: Evening Routine with Kids"
     },
     {
       "id": "655a5bfadf47e1199f9b65eb",
-      "title": "Task 62"
-    },
-    {
-      "id": "655a5e76ca6f8d1b1a88e0f1",
       "title": "Task 63"
     },
     {
-      "id": "655a78fdfac0e22b0c400e72",
+      "id": "655a5e76ca6f8d1b1a88e0f1",
       "title": "Task 64"
     },
     {
-      "id": "655a79e595bd202b4cd5e2d2",
+      "id": "655a78fdfac0e22b0c400e72",
       "title": "Task 65"
     },
     {
-      "id": "655a7d752ffc542e5874af0b",
+      "id": "655a79e595bd202b4cd5e2d2",
       "title": "Task 66"
     },
     {
-      "id": "655a7c5211e5252cf8a4ed01",
+      "id": "655a7d752ffc542e5874af0b",
       "title": "Task 67"
     },
     {
-      "id": "655a88194beb4332037ff7ce",
+      "id": "655a7c5211e5252cf8a4ed01",
       "title": "Task 68"
     },
     {
-      "id": "655a896f31ca6a32913d1106",
+      "id": "655a88194beb4332037ff7ce",
       "title": "Task 69"
     },
     {
-      "id": "655a8ae1f10749350bc8820f",
+      "id": "655a896f31ca6a32913d1106",
       "title": "Task 70"
     },
     {
-      "id": "655a8b62e5681235c3fb5492",
+      "id": "655a8ae1f10749350bc8820f",
       "title": "Task 71"
     },
     {
-      "id": "655a8c9d2a0ea136a0fd3631",
+      "id": "655a8b62e5681235c3fb5492",
       "title": "Task 72"
     },
     {
-      "id": "655a8d7c939fcf37604516e4",
+      "id": "655a8c9d2a0ea136a0fd3631",
       "title": "Task 73"
     },
     {
-      "id": "655a8ecc0cad80393b5f3b5b",
+      "id": "655a8d7c939fcf37604516e4",
       "title": "Task 74"
     },
     {
-      "id": "655a8fcbb859993a93204e44",
+      "id": "655a8ecc0cad80393b5f3b5b",
       "title": "Task 75"
     },
     {
-      "id": "655a9a4cef8a173b8c27fc84",
+      "id": "655a8fcbb859993a93204e44",
       "title": "Task 76"
     },
     {
-      "id": "655a9d161bf4cf51369ff1e0",
+      "id": "655a9a4cef8a173b8c27fc84",
       "title": "Task 77"
+    },
+    {
+      "id": "655a9d161bf4cf51369ff1e0",
+      "title": "Task 78"
     },
     {
       "id": "655a9f8d6d3af8538a178166",
@@ -331,55 +335,55 @@
     },
     {
       "id": "655aa098bb38a05474a3f5b4",
-      "title": "Task 78"
-    },
-    {
-      "id": "655b258e8cd2985ed8412275",
       "title": "Task 79"
     },
     {
-      "id": "655b266c2ea5495f43b97ea5",
+      "id": "655b258e8cd2985ed8412275",
       "title": "Task 80"
     },
     {
-      "id": "655b275cadbebf5fc0f0db05",
+      "id": "655b266c2ea5495f43b97ea5",
       "title": "Task 81"
     },
     {
-      "id": "655b283d10fee46040e0a893",
+      "id": "655b275cadbebf5fc0f0db05",
       "title": "Task 82"
     },
     {
-      "id": "655b2919ff561b60fcde19ae",
+      "id": "655b283d10fee46040e0a893",
       "title": "Task 83"
     },
     {
-      "id": "655b29fb2c8b1861bf4fbab1",
+      "id": "655b2919ff561b60fcde19ae",
       "title": "Task 84"
     },
     {
-      "id": "655b2aa6807cae6273ca23fb",
+      "id": "655b29fb2c8b1861bf4fbab1",
       "title": "Task 85"
     },
     {
-      "id": "655b2b5cc4ea3062f9811dec",
+      "id": "655b2aa6807cae6273ca23fb",
       "title": "Task 86"
     },
     {
-      "id": "655b2d250741166530dd6e43",
+      "id": "655b2b5cc4ea3062f9811dec",
       "title": "Task 87"
     },
     {
-      "id": "655b3197bb31ca670081f6d7",
+      "id": "655b2d250741166530dd6e43",
       "title": "Task 88"
     },
     {
-      "id": "655b3274b6c61c67d95b5e67",
+      "id": "655b3197bb31ca670081f6d7",
       "title": "Task 89"
     },
     {
-      "id": "655b32b2812874680f3198d3",
+      "id": "655b3274b6c61c67d95b5e67",
       "title": "Task 90"
+    },
+    {
+      "id": "655b32b2812874680f3198d3",
+      "title": "Task 91"
     },
     {
       "id": "655b34a4b45a76689cb429c6",
@@ -387,35 +391,35 @@
     },
     {
       "id": "655b34e53bf2cb6908042c98",
-      "title": "Task 91"
-    },
-    {
-      "id": "655b3581926acd6a172fa94b",
       "title": "Task 92"
     },
     {
-      "id": "655b363149b5ba6b15434574",
+      "id": "655b3581926acd6a172fa94b",
       "title": "Task 93"
     },
     {
-      "id": "655b37ecf9da446bd1dcff4f",
+      "id": "655b363149b5ba6b15434574",
       "title": "Task 94"
     },
     {
-      "id": "655b38c1f5351d6c827c8e8f",
+      "id": "655b37ecf9da446bd1dcff4f",
       "title": "Task 95"
     },
     {
-      "id": "655b39e59c29d16d64a2ce8e",
+      "id": "655b38c1f5351d6c827c8e8f",
       "title": "Task 96"
     },
     {
-      "id": "655b3b06ec00a46e572868a2",
+      "id": "655b39e59c29d16d64a2ce8e",
       "title": "Task 97"
     },
     {
-      "id": "657a45a85a8f6cfeef7803db",
+      "id": "655b3b06ec00a46e572868a2",
       "title": "Task 98"
+    },
+    {
+      "id": "657a45a85a8f6cfeef7803db",
+      "title": "Task 99"
     }
   ],
   "helpCategory": "English",

--- a/curriculum/challenges/_meta/learn-how-to-discuss-your-morning-or-evening-routine/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-discuss-your-morning-or-evening-routine/meta.json
@@ -386,40 +386,44 @@
       "title": "Task 91"
     },
     {
+      "id": "67ca0719cf479630dbb12495",
+      "title": "Task 92"
+    },
+    {
       "id": "655b34a4b45a76689cb429c6",
       "title": "Dialogue 5: Sophie and Brian Talk about the Weekend"
     },
     {
       "id": "655b34e53bf2cb6908042c98",
-      "title": "Task 92"
-    },
-    {
-      "id": "655b3581926acd6a172fa94b",
       "title": "Task 93"
     },
     {
-      "id": "655b363149b5ba6b15434574",
+      "id": "655b3581926acd6a172fa94b",
       "title": "Task 94"
     },
     {
-      "id": "655b37ecf9da446bd1dcff4f",
+      "id": "655b363149b5ba6b15434574",
       "title": "Task 95"
     },
     {
-      "id": "655b38c1f5351d6c827c8e8f",
+      "id": "655b37ecf9da446bd1dcff4f",
       "title": "Task 96"
     },
     {
-      "id": "655b39e59c29d16d64a2ce8e",
+      "id": "655b38c1f5351d6c827c8e8f",
       "title": "Task 97"
     },
     {
-      "id": "655b3b06ec00a46e572868a2",
+      "id": "655b39e59c29d16d64a2ce8e",
       "title": "Task 98"
     },
     {
-      "id": "657a45a85a8f6cfeef7803db",
+      "id": "655b3b06ec00a46e572868a2",
       "title": "Task 99"
+    },
+    {
+      "id": "657a45a85a8f6cfeef7803db",
+      "title": "Task 100"
     }
   ],
   "helpCategory": "English",

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/655bd2158780e2421b674e61.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/655bd2158780e2421b674e61.md
@@ -1,8 +1,8 @@
 ---
 id: 655bd2158780e2421b674e61
-title: Task 13
+title: Task 14
 challengeType: 19
-dashedName: task-13
+dashedName: task-14
 ---
 
 <!-- (Audio) Sarah: Hi Bob! I'm looking at customer data to find patterns -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/655bd2f3caad89436a3dcc04.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/655bd2f3caad89436a3dcc04.md
@@ -1,8 +1,8 @@
 ---
 id: 655bd2f3caad89436a3dcc04
-title: Task 14
+title: Task 15
 challengeType: 22
-dashedName: task-14
+dashedName: task-15
 ---
 
 <!-- (Audio) Sarah: Hi Bob! I'm looking at customer data to find patterns -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/655bd57d0e13e146b2404569.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/655bd57d0e13e146b2404569.md
@@ -1,8 +1,8 @@
 ---
 id: 655bd57d0e13e146b2404569
-title: Task 15
+title: Task 16
 challengeType: 19
-dashedName: task-15
+dashedName: task-16
 ---
 
 <!-- (Audio) Sarah: Hi Bob! I'm looking at customer data to find patterns. We're trying to understand what our customers like and what they buy. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/655bd798ce91bd4861b69281.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/655bd798ce91bd4861b69281.md
@@ -1,8 +1,8 @@
 ---
 id: 655bd798ce91bd4861b69281
-title: Task 16
+title: Task 17
 challengeType: 19
-dashedName: task-16
+dashedName: task-17
 ---
 
 <!-- (Audio) Sarah: I'm looking at customer data to find patterns. We're trying to understand what our customers like and what they buy, but we are not having any luck at the moment. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/655bd91a858b2b4a30da3cad.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/655bd91a858b2b4a30da3cad.md
@@ -1,8 +1,8 @@
 ---
 id: 655bd91a858b2b4a30da3cad
-title: Task 17
+title: Task 18
 challengeType: 22
-dashedName: task-17
+dashedName: task-18
 ---
 
 <!-- (Audio) Bob: Interesting! I'm making pictures with our data for our reports. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/655bda6270ef334ad8a7f005.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/655bda6270ef334ad8a7f005.md
@@ -1,8 +1,8 @@
 ---
 id: 655bda6270ef334ad8a7f005
-title: Task 18
+title: Task 19
 challengeType: 19
-dashedName: task-18
+dashedName: task-19
 ---
 
 <!-- (Audio) Bob: Interesting! I'm making pictures with our data for our reports. We think it may help people understand better. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/655bdc7e9c4116509df13f34.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/655bdc7e9c4116509df13f34.md
@@ -1,8 +1,8 @@
 ---
 id: 655bdc7e9c4116509df13f34
-title: Task 19
+title: Task 20
 challengeType: 22
-dashedName: task-19
+dashedName: task-20
 ---
 
 <!-- (Audio) Bob: We think it may help people understand better. I'm using some tools to help me. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/655bdf9f7f844952b7e7f036.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/655bdf9f7f844952b7e7f036.md
@@ -1,8 +1,8 @@
 ---
 id: 655bdf9f7f844952b7e7f036
-title: Task 20
+title: Task 21
 challengeType: 19
-dashedName: task-20
+dashedName: task-21
 ---
 
 <!-- (Audio) Bob: Interesting! I'm making pictures with our data for our reports. We think it may help people understand better. I'm using some tools to help me. Sarah: Pictures can be great to explain things. We are not using pictures, but it's surely fun to work with data like this. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/655be33b7a463a5593c91cb4.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/655be33b7a463a5593c91cb4.md
@@ -1,8 +1,8 @@
 ---
 id: 655be33b7a463a5593c91cb4
-title: Task 21
+title: Task 22
 challengeType: 22
-dashedName: task-21
+dashedName: task-22
 ---
 
 <!-- (Audio) Sarah: Pictures can be great to explain things. We are not using pictures, but it's definitely fun to work with data like this. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/655c9a89818e18606c18ca4b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/655c9a89818e18606c18ca4b.md
@@ -1,8 +1,8 @@
 ---
 id: 655c9a89818e18606c18ca4b
-title: Task 22
+title: Task 24
 challengeType: 22
-dashedName: task-22
+dashedName: task-24
 ---
 
 <!-- (Audio) Mark: Hi Maria! I'm testing a new software to find problems. It's a nice experience so far, but we're doing more tests to make sure everything works. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/655c9b2e0bcbe16161996ab7.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/655c9b2e0bcbe16161996ab7.md
@@ -1,8 +1,8 @@
 ---
 id: 655c9b2e0bcbe16161996ab7
-title: Task 23
+title: Task 25
 challengeType: 19
-dashedName: task-23
+dashedName: task-25
 ---
 
 <!-- (Audio) Mark: Hi Maria! I'm testing a new software to find problems. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/655c9bcb5bedb4620acb6f18.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/655c9bcb5bedb4620acb6f18.md
@@ -1,8 +1,8 @@
 ---
 id: 655c9bcb5bedb4620acb6f18
-title: Task 24
+title: Task 26
 challengeType: 19
-dashedName: task-24
+dashedName: task-26
 ---
 
 <!-- (Audio) Mark: It's a nice experience so far, but we're doing more tests to make sure everything works. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/655c9d9470acf0643482b95b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/655c9d9470acf0643482b95b.md
@@ -1,8 +1,8 @@
 ---
 id: 655c9d9470acf0643482b95b
-title: Task 25
+title: Task 27
 challengeType: 19
-dashedName: task-25
+dashedName: task-27
 ---
 
 <!-- (Audio) Mark: We're also asking some people to tell us what they think. It's a bit busy, but I'm learning a lot. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/655c9e73e89d886538976452.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/655c9e73e89d886538976452.md
@@ -1,8 +1,8 @@
 ---
 id: 655c9e73e89d886538976452
-title: Task 26
+title: Task 28
 challengeType: 22
-dashedName: task-26
+dashedName: task-28
 ---
 
 <!-- (Audio) Maria: That's good to hear. I'm managing the team that's making a new part for the client's platform. We're trying to work on it and talk to the client to make sure they like it. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/655c9ee249f7ef65f6d2dd36.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/655c9ee249f7ef65f6d2dd36.md
@@ -1,8 +1,8 @@
 ---
 id: 655c9ee249f7ef65f6d2dd36
-title: Task 27
+title: Task 29
 challengeType: 19
-dashedName: task-27
+dashedName: task-29
 ---
 
 <!-- (Audio) Maria: That's good to hear. I'm managing the team that's making a new part for the client's platform. We're trying to work on it and talk to the client to make sure they like it. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/655ca014b022ff6692049b91.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/655ca014b022ff6692049b91.md
@@ -1,8 +1,8 @@
 ---
 id: 655ca014b022ff6692049b91
-title: Task 28
+title: Task 30
 challengeType: 22
-dashedName: task-28
+dashedName: task-30
 ---
 
 <!-- (Audio) Mark: Nice. Good luck there. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/655cadb5df07e269cccaa056.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/655cadb5df07e269cccaa056.md
@@ -1,8 +1,8 @@
 ---
 id: 655cadb5df07e269cccaa056
-title: Task 29
+title: Task 32
 challengeType: 22
-dashedName: task-29
+dashedName: task-32
 ---
 
 <!-- (Audio) Amy: Hi, Brian. What's happening with your project? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656918c77e73780c34392e17.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656918c77e73780c34392e17.md
@@ -1,8 +1,8 @@
 ---
 id: 656918c77e73780c34392e17
-title: Task 30
+title: Task 33
 challengeType: 22
-dashedName: task-30
+dashedName: task-33
 ---
 
 <!-- (Audio) Brian: Hey Amy! I'm not working on anything big at the moment. I'm taking a short break to learn more about the front end. It's good to stop a bit and refresh my skills. How about you?

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a2fa76e9c4636f6ac7a49.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a2fa76e9c4636f6ac7a49.md
@@ -1,8 +1,8 @@
 ---
 id: 656a2fa76e9c4636f6ac7a49
-title: Task 31
+title: Task 34
 challengeType: 19
-dashedName: task-31
+dashedName: task-34
 ---
 
 <!-- (Audio) Brian: I'm taking a short break to learn more about the frontend. It's good to stop a bit and refresh my skills.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a43974f689442c0a0eeb2.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a43974f689442c0a0eeb2.md
@@ -1,8 +1,8 @@
 ---
 id: 656a43974f689442c0a0eeb2
-title: Task 32
+title: Task 35
 challengeType: 22
-dashedName: task-32
+dashedName: task-35
 ---
 
 <!-- (Audio) Amy: That sounds like a good idea, Brian. I'm currently working on a series of blog posts about tech trends. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a444cef055b4342f1f323.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a444cef055b4342f1f323.md
@@ -1,8 +1,8 @@
 ---
 id: 656a444cef055b4342f1f323
-title: Task 33
+title: Task 36
 challengeType: 19
-dashedName: task-33
+dashedName: task-36
 ---
 
 <!-- (Audio) Amy: That sounds like a good idea, Brian. I'm currently working on a series of blog posts about tech trends. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a44b06bea9443b8ff45bd.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a44b06bea9443b8ff45bd.md
@@ -1,8 +1,8 @@
 ---
 id: 656a44b06bea9443b8ff45bd
-title: Task 34
+title: Task 37
 challengeType: 22
-dashedName: task-34
+dashedName: task-37
 ---
 
 <!-- (Audio) Amy: It's exciting. I'm interviewing some experts and I'm getting information for the articles. It's keeping me busy, but I enjoy it. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a456b46b4b04437f2d3e9.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a456b46b4b04437f2d3e9.md
@@ -1,8 +1,8 @@
 ---
 id: 656a456b46b4b04437f2d3e9
-title: Task 35
+title: Task 38
 challengeType: 19
-dashedName: task-35
+dashedName: task-38
 ---
 
 <!-- (Audio) Amy: It's exciting. I'm interviewing some experts and I'm getting information for the articles. It's keeping me busy, but I enjoy it. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a45d4f36ea1448aa359d2.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a45d4f36ea1448aa359d2.md
@@ -1,8 +1,8 @@
 ---
 id: 656a45d4f36ea1448aa359d2
-title: Task 36
+title: Task 39
 challengeType: 22
-dashedName: task-36
+dashedName: task-39
 ---
 
 <!-- (Audio) Brian: That sounds interesting! Are you using any new tools or strategies to create engaging content? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a46814617c04516f698eb.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a46814617c04516f698eb.md
@@ -1,8 +1,8 @@
 ---
 id: 656a46814617c04516f698eb
-title: Task 37
+title: Task 40
 challengeType: 19
-dashedName: task-37
+dashedName: task-40
 ---
 
 <!-- (Audio) Brian: That sounds interesting! Are you using any new tools or strategies to create engaging content? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a46e84a0ad845901ea907.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a46e84a0ad845901ea907.md
@@ -1,8 +1,8 @@
 ---
 id: 656a46e84a0ad845901ea907
-title: Task 38
+title: Task 41
 challengeType: 22
-dashedName: task-38
+dashedName: task-41
 ---
 
 <!-- (Audio) Amy: Yes, I am. I'm experimenting with video interviews and interactive infographics to make the content more engaging for our readers. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a4758b0f85e45d03f9e17.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a4758b0f85e45d03f9e17.md
@@ -1,8 +1,8 @@
 ---
 id: 656a4758b0f85e45d03f9e17
-title: Task 39
+title: Task 42
 challengeType: 19
-dashedName: task-39
+dashedName: task-42
 ---
 
 <!-- (Audio) Amy: Yes, I am. I'm experimenting with video interviews and interactive infographics to make the content more engaging for our readers. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a47c9473b0f46463f7d55.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a47c9473b0f46463f7d55.md
@@ -1,8 +1,8 @@
 ---
 id: 656a47c9473b0f46463f7d55
-title: Task 40
+title: Task 43
 challengeType: 19
-dashedName: task-40
+dashedName: task-43
 ---
 
 <!-- (Audio) Amy: Yes, I am. I'm experimenting with video interviews and interactive infographics to make the content more engaging for our readers. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a4815c0d43346a2e27b51.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a4815c0d43346a2e27b51.md
@@ -1,8 +1,8 @@
 ---
 id: 656a4815c0d43346a2e27b51
-title: Task 41
+title: Task 44
 challengeType: 22
-dashedName: task-41
+dashedName: task-44
 ---
 
 <!-- (Audio) Amy: Yes, I am. I'm experimenting with video interviews and interactive infographics to make the content more engaging for our readers. It's a bit challenging, but I'm learning a lot in the process. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a48d41b97ff476586ee9c.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a48d41b97ff476586ee9c.md
@@ -1,8 +1,8 @@
 ---
 id: 656a48d41b97ff476586ee9c
-title: Task 42
+title: Task 45
 challengeType: 22
-dashedName: task-42
+dashedName: task-45
 ---
 
 <!-- (Audio) Brian: That's great, Amy! Tell us when the blog posts are out. I'm looking forward to reading them. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a49a16377b8485270dd2d.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a49a16377b8485270dd2d.md
@@ -1,8 +1,8 @@
 ---
 id: 656a49a16377b8485270dd2d
-title: Task 43
+title: Task 47
 challengeType: 22
-dashedName: task-43
+dashedName: task-47
 ---
 
 <!-- (Audio) Bob: Hi Sarah, what are you up to these days? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a4a4225a07e491ca4f31e.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a4a4225a07e491ca4f31e.md
@@ -1,8 +1,8 @@
 ---
 id: 656a4a4225a07e491ca4f31e
-title: Task 44
+title: Task 48
 challengeType: 19
-dashedName: task-44
+dashedName: task-48
 ---
 
 <!-- (Audio) Sarah: Hi Bob! I'm not working on any data projects at the moment. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a4a7596c46e495c64a7ec.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a4a7596c46e495c64a7ec.md
@@ -1,8 +1,8 @@
 ---
 id: 656a4a7596c46e495c64a7ec
-title: Task 45
+title: Task 49
 challengeType: 22
-dashedName: task-45
+dashedName: task-49
 ---
 
 <!-- (Audio) Sarah: Hi Bob! I'm not working on any data projects at the moment. I'm taking some time off to learn new things. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a4ac4529e0f49ab900c3b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a4ac4529e0f49ab900c3b.md
@@ -1,8 +1,8 @@
 ---
 id: 656a4ac4529e0f49ab900c3b
-title: Task 46
+title: Task 50
 challengeType: 19
-dashedName: task-46
+dashedName: task-50
 ---
 
 <!-- (Audio) Sarah: I'm attending online courses in data visualization, and I'm also exploring creative writing. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a4afc5f944649f391898f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a4afc5f944649f391898f.md
@@ -1,8 +1,8 @@
 ---
 id: 656a4afc5f944649f391898f
-title: Task 47
+title: Task 51
 challengeType: 19
-dashedName: task-47
+dashedName: task-51
 ---
 
 <!-- (Audio) Sarah:  I'm attending online courses in data visualization, and I'm also exploring creative writing. It's a bit different from my usual work, but I'm enjoying the change. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a4b4891e9e54a34dc4dcf.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a4b4891e9e54a34dc4dcf.md
@@ -1,8 +1,8 @@
 ---
 id: 656a4b4891e9e54a34dc4dcf
-title: Task 48
+title: Task 52
 challengeType: 22
-dashedName: task-48
+dashedName: task-52
 ---
 
 <!-- (Audio) Bob: That's a productive break, Sarah. Are you finding the courses helpful? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a4b9e4822ba4a9893459e.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a4b9e4822ba4a9893459e.md
@@ -1,8 +1,8 @@
 ---
 id: 656a4b9e4822ba4a9893459e
-title: Task 49
+title: Task 53
 challengeType: 19
-dashedName: task-49
+dashedName: task-53
 ---
 
 <!-- (Audio) Bob: That's a productive break, Sarah. Are you finding the courses helpful? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a4bea53d6fd4ae86bdb70.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a4bea53d6fd4ae86bdb70.md
@@ -1,8 +1,8 @@
 ---
 id: 656a4bea53d6fd4ae86bdb70
-title: Task 50
+title: Task 54
 challengeType: 22
-dashedName: task-50
+dashedName: task-54
 ---
 
 <!-- (Audio) Sarah: Absolutely! I'm learning new skills that I believe will be valuable in my future projects.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a4c42ee183c4b3b92bfeb.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a4c42ee183c4b3b92bfeb.md
@@ -1,8 +1,8 @@
 ---
 id: 656a4c42ee183c4b3b92bfeb
-title: Task 51
+title: Task 55
 challengeType: 22
-dashedName: task-51
+dashedName: task-55
 ---
 
 <!-- (Audio) By the way, what's keeping you busy these days? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a4c92a476854b89f98ffd.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a4c92a476854b89f98ffd.md
@@ -1,8 +1,8 @@
 ---
 id: 656a4c92a476854b89f98ffd
-title: Task 52
+title: Task 56
 challengeType: 19
-dashedName: task-52
+dashedName: task-56
 ---
 
 <!-- (Audio) Sarah: Absolutely! I'm learning new skills that I believe will be valuable in my future projects. By the way, what's keeping you busy these days? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a4d1943d8f24c030ded74.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a4d1943d8f24c030ded74.md
@@ -1,8 +1,8 @@
 ---
 id: 656a4d1943d8f24c030ded74
-title: Task 53
+title: Task 57
 challengeType: 19
-dashedName: task-53
+dashedName: task-57
 ---
 
 <!-- (Audio) Bob: Well, I'm not currently working on any major data analysis projects, either. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a4d74286f4d4c4ae58de0.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a4d74286f4d4c4ae58de0.md
@@ -1,8 +1,8 @@
 ---
 id: 656a4d74286f4d4c4ae58de0
-title: Task 54
+title: Task 58
 challengeType: 19
-dashedName: task-54
+dashedName: task-58
 ---
 
 <!-- (Audio) Bob: Well, I'm currently not working on any major data analysis projects, either. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a4dd03541de4ca98a61e8.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a4dd03541de4ca98a61e8.md
@@ -1,8 +1,8 @@
 ---
 id: 656a4dd03541de4ca98a61e8
-title: Task 55
+title: Task 59
 challengeType: 19
-dashedName: task-55
+dashedName: task-59
 ---
 
 <!-- (Audio) Bob: I'm taking some time to review our data security protocols. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a4e001d2b804cdea7000a.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a4e001d2b804cdea7000a.md
@@ -1,8 +1,8 @@
 ---
 id: 656a4e001d2b804cdea7000a
-title: Task 56
+title: Task 60
 challengeType: 19
-dashedName: task-56
+dashedName: task-60
 ---
 
 <!-- (Audio) Bob: I'm supposed to figure out if our current practices are robust enough to protect sensitive information. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a4e35a774444d1946a899.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a4e35a774444d1946a899.md
@@ -1,8 +1,8 @@
 ---
 id: 656a4e35a774444d1946a899
-title: Task 57
+title: Task 61
 challengeType: 22
-dashedName: task-57
+dashedName: task-61
 ---
 
 <!-- (Audio) Bob: It's essential to ensure our data is secure. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a4e8a59ef3c4d8dfc2ad9.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/656a4e8a59ef3c4d8dfc2ad9.md
@@ -1,8 +1,8 @@
 ---
 id: 656a4e8a59ef3c4d8dfc2ad9
-title: Task 58
+title: Task 62
 challengeType: 22
-dashedName: task-58
+dashedName: task-62
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/67ca0b9a589d4e405f17a0de.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/67ca0b9a589d4e405f17a0de.md
@@ -1,0 +1,77 @@
+---
+id: 67ca0b9a589d4e405f17a0de
+title: Task 13
+challengeType: 22
+dashedName: task-13
+---
+<!-- REVIEW -->
+
+# --description--
+
+This is a review of the entire dialogue you just studied.
+
+# --instructions--
+
+Place the following phrases in the correct spot:
+
+`fix`, `network`, `to steal`, `stay`, `two of us`, and `cybersecurity`.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`Sophie: Hey James, what's your BLANK project about?`
+
+`James: Hi Sophie! I'm checking our BLANK for problems. We want to be safe from hackers. I'm using special tools to see where we might have problems, and then I have to BLANK them.`
+
+`Sophie: That's important work. I'm helping our team learn how to BLANK safe online. We're taking some lessons and practicing what to do if someone tries BLANK our identity.`
+
+`James: That's great, Sophie! The BLANK are doing some important work.`
+
+## --blanks--  
+
+`cybersecurity`
+
+### --feedback--  
+
+This noun refers to protecting computer systems and networks from attacks.
+
+---
+
+`network`
+
+### --feedback--
+
+This noun refers to a system of connected computers or devices. 
+
+---
+
+`fix`
+
+### --feedback--
+
+This verb means to repair or correct something that is broken or has problems.
+
+---
+
+`stay`
+
+### --feedback--  
+
+This verb means to continue being in a certain condition or state. 
+
+---
+
+`to steal`
+
+### --feedback--  
+
+These two words describe taking something that does not belong to you. The first word is a particle, and the second is a verb in its base form.
+
+---
+
+`two of us`  
+
+### --feedback-- 
+
+These three words refer to both people in the conversation. The first word is a number, the second is a preposition, and the third is a pronoun.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/67ca0b9a589d4e405f17a0de.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/67ca0b9a589d4e405f17a0de.md
@@ -34,7 +34,7 @@ Place the following phrases in the correct spot:
 
 ### --feedback--  
 
-This noun refers to protecting computer systems and networks from attacks.
+This refers to protecting computer systems and networks from attacks.
 
 ---
 
@@ -42,7 +42,7 @@ This noun refers to protecting computer systems and networks from attacks.
 
 ### --feedback--
 
-This noun refers to a system of connected computers or devices. 
+This refers to a system of connected computers or devices. 
 
 ---
 
@@ -50,7 +50,7 @@ This noun refers to a system of connected computers or devices.
 
 ### --feedback--
 
-This verb means to repair or correct something that is broken or has problems.
+This means to repair or correct something that is broken or has problems.
 
 ---
 
@@ -58,7 +58,7 @@ This verb means to repair or correct something that is broken or has problems.
 
 ### --feedback--  
 
-This verb means to continue being in a certain condition or state. 
+This verb means "to continue being in a certain condition or state". 
 
 ---
 
@@ -66,7 +66,7 @@ This verb means to continue being in a certain condition or state.
 
 ### --feedback--  
 
-These two words describe taking something that does not belong to you. The first word is a particle, and the second is a verb in its base form.
+This describes taking something that does not belong to you. It begins with a particle followed by a verb in its base form.
 
 ---
 
@@ -74,4 +74,4 @@ These two words describe taking something that does not belong to you. The first
 
 ### --feedback-- 
 
-These three words refer to both people in the conversation. The first word is a number, the second is a preposition, and the third is a pronoun.
+This refers to both people in the conversation. It begins with a number followed by a preposition and then the objective pronoun relative to `we`.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/67ca0ba8f61b0a4094fd5e08.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/67ca0ba8f61b0a4094fd5e08.md
@@ -1,0 +1,69 @@
+---
+id: 67ca0ba8f61b0a4094fd5e08
+title: Task 23
+challengeType: 22
+dashedName: task-23
+---
+<!-- REVIEW -->
+
+# --description--  
+
+This is a review of the entire dialogue you just studied.  
+
+# --instructions--  
+
+Place the following phrases in the correct spot:  
+
+`patterns`, `at the moment`, `our data`, `tools`, and `work with`.  
+
+# --fillInTheBlank--  
+
+## --sentence--  
+
+`Bob: Hi Sarah, what are you doing now?`  
+
+`Sarah: Hi Bob! I'm looking at customer data to find BLANK. We're trying to understand what our customers like and what they buy, but we're not having any luck BLANK.`  
+
+`Bob: Interesting! I'm making pictures with BLANK for our reports. We think it may help people understand them better. I'm using some BLANK to help me.`  
+
+`Sarah: Pictures can be great to explain things. We're not using pictures, but it's definitely fun to BLANK data like this.`  
+
+## --blanks--  
+
+`patterns`
+
+### --feedback--
+
+This noun refers to repeated trends or behaviors in data. 
+
+---
+
+`at the moment`
+
+### --feedback--
+
+These three words indicate something happening right now. The first is a preposition, the second is an article, and the third is a noun. 
+
+---
+
+`our data`
+
+### --feedback--
+
+These two words refer to information belonging to the group. The first is a possessive adjective, and the second is a noun.
+
+---
+
+`tools`  
+
+### --feedback--
+
+This plural noun refers to software or resources used to complete a task.
+
+---
+
+`work with`
+
+### --feedback--
+
+These two words describe handling or managing something. The first is a verb, and the second is a preposition.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/67ca0ba8f61b0a4094fd5e08.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/67ca0ba8f61b0a4094fd5e08.md
@@ -34,7 +34,7 @@ Place the following phrases in the correct spot:
 
 ### --feedback--
 
-This noun refers to repeated trends or behaviors in data. 
+This refers to repeated trends or behaviors in data. 
 
 ---
 
@@ -42,7 +42,7 @@ This noun refers to repeated trends or behaviors in data.
 
 ### --feedback--
 
-These three words indicate something happening right now. The first is a preposition, the second is an article, and the third is a noun. 
+This indicates something happening right now. It begins with a preposition followed by a definite article and then a noun. 
 
 ---
 
@@ -50,7 +50,7 @@ These three words indicate something happening right now. The first is a preposi
 
 ### --feedback--
 
-These two words refer to information belonging to the group. The first is a possessive adjective, and the second is a noun.
+This refers to information belonging to the group. It begins with a possessive adjective followed by a noun.
 
 ---
 
@@ -66,4 +66,4 @@ This plural noun refers to software or resources used to complete a task.
 
 ### --feedback--
 
-These two words describe handling or managing something. The first is a verb, and the second is a preposition.
+This describes handling or managing something. It begins with a verb followed by a preposition.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/67ca0bb4d64ab640cb7f4c2b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/67ca0bb4d64ab640cb7f4c2b.md
@@ -1,0 +1,77 @@
+---
+id: 67ca0bb4d64ab640cb7f4c2b
+title: Task 31
+challengeType: 22
+dashedName: task-31
+---
+<!-- REVIEW -->
+
+# --description--  
+
+This is a review of the entire dialogue you just studied.  
+
+# --instructions--  
+
+Place the following phrases in the correct spot:  
+
+`also`, `bit`, `so far`, `that's`, `on it`, and `there`.  
+
+# --fillInTheBlank--  
+
+## --sentence--  
+
+`Maria: Hi Mark, how's the project going?`  
+
+`Mark: Hi Maria! I'm testing a new software tool to find problems. It’s a nice experience BLANK, but we're doing more tests to make sure everything works. We're BLANK asking some people to tell us what they think. It's a BLANK busy, but I'm learning a lot.`  
+
+`Maria: That's good to hear. I'm managing the team BLANK making a new part for the client's platform. We're trying to work BLANK and talk to the client to make sure they like it.`  
+
+`Mark: Nice. Good luck BLANK.`  
+
+## --blanks--  
+
+`so far`
+
+### --feedback--
+
+These two words indicate progress up to the present time. The first is an adverb, and the second is an adverb.
+
+---
+
+`also`
+
+### --feedback--
+
+This adverb means "in addition" or "too."
+
+---
+
+`bit`
+
+### --feedback--
+
+This noun refers to a small amount of something.
+
+---
+
+`that's`
+
+### --feedback--  
+
+This contraction combines a demonstrative pronoun and a verb. The first letter is capitalized. 
+
+---
+
+`on it`
+
+### --feedback--
+
+These two words mean actively working on something. The first is a preposition, and the second is a pronoun.
+
+---
+
+`there`
+
+### --feedback--  
+
+This adverb refers to a place or position.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/67ca0bb4d64ab640cb7f4c2b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/67ca0bb4d64ab640cb7f4c2b.md
@@ -34,7 +34,7 @@ Place the following phrases in the correct spot:
 
 ### --feedback--
 
-These two words indicate progress up to the present time. The first is an adverb, and the second is an adverb.
+This indicates progress up to the present time. It begins with an intensifier meaning the same as `very` followed by an adverb.
 
 ---
 
@@ -42,7 +42,7 @@ These two words indicate progress up to the present time. The first is an adverb
 
 ### --feedback--
 
-This adverb means "in addition" or "too."
+This means "in addition" or "too."
 
 ---
 
@@ -50,7 +50,7 @@ This adverb means "in addition" or "too."
 
 ### --feedback--
 
-This noun refers to a small amount of something.
+This refers to a small amount of something.
 
 ---
 
@@ -66,7 +66,7 @@ This contraction combines a demonstrative pronoun and a verb. The first letter i
 
 ### --feedback--
 
-These two words mean actively working on something. The first is a preposition, and the second is a pronoun.
+This means actively working on something. It begins with a preposition followed by a pronoun.
 
 ---
 
@@ -74,4 +74,4 @@ These two words mean actively working on something. The first is a preposition, 
 
 ### --feedback--  
 
-This adverb refers to a place or position.
+This refers to a place or position.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/67ca0bc1529fd24101862db1.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/67ca0bc1529fd24101862db1.md
@@ -1,0 +1,82 @@
+---
+id: 67ca0bc1529fd24101862db1
+title: Task 46
+challengeType: 22
+dashedName: task-46
+---
+
+<!-- REVIEW -->
+
+# --description--
+
+This is a review of the entire dialogue you just studied.
+
+# --instructions--  
+
+Place the following phrases in the correct spot:
+
+`short break`, `series of`, `information`, `strategies`, `engaging`, and `out`.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`Amy: Hi Brian, what's happening with your project?`
+
+`Brian: Hey Amy! I'm not working on anything big at the moment. I'm taking a BLANK to learn more about the front end. It's good to stop a bit and refresh my skills. How about you?`
+
+`Amy: That sounds like a good idea, Brian. I'm currently working on a BLANK blog posts about tech trends. It's exciting. I'm interviewing some experts and I’m getting BLANK for the articles. It's keeping me busy, but I enjoy it.`
+
+`Brian: That sounds interesting! Are you using any new tools or BLANK to create engaging content?`
+
+`Amy: Yes, I am. I'm experimenting with video interviews and interactive infographics to make the content more BLANK for our readers. It's a bit challenging, but I'm learning a lot in the process.`
+
+`Brian: That's great, Amy! Tell us when the blog posts are BLANK. I'm looking forward to reading them.`
+
+## --blanks--  
+
+`short break`
+
+### --feedback--
+
+These two words refer to a brief period of rest. The first word is an adjective, and the second is a noun.
+
+---
+
+`series of`
+
+### --feedback--  
+
+These two words indicate multiple related things, such as articles or events. The first word is a noun, and the second is a preposition.
+
+---
+
+`information`
+
+### --feedback--
+
+This noun refers to facts or data collected for a purpose.
+
+---
+
+`strategies`
+
+### --feedback--
+
+This plural noun refers to plans or methods used to achieve a goal.
+
+---
+
+`engaging`
+
+### --feedback--
+
+This adjective describes something interesting or attention-grabbing.
+
+---
+
+`out`
+
+### --feedback--  
+
+This adverb means something has been released or made available. 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/67ca0bc1529fd24101862db1.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/67ca0bc1529fd24101862db1.md
@@ -39,7 +39,7 @@ Place the following phrases in the correct spot:
 
 ### --feedback--
 
-These two words refer to a brief period of rest. The first word is an adjective, and the second is a noun.
+This refers to a brief period of rest. It begins with an adjective followed by a noun.
 
 ---
 
@@ -47,7 +47,7 @@ These two words refer to a brief period of rest. The first word is an adjective,
 
 ### --feedback--  
 
-These two words indicate multiple related things, such as articles or events. The first word is a noun, and the second is a preposition.
+This indicates multiple related things, such as articles or events. It begins with a noun followed by a preposition.
 
 ---
 
@@ -55,7 +55,7 @@ These two words indicate multiple related things, such as articles or events. Th
 
 ### --feedback--
 
-This noun refers to facts or data collected for a purpose.
+This refers to facts or data collected for a purpose.
 
 ---
 
@@ -71,7 +71,7 @@ This plural noun refers to plans or methods used to achieve a goal.
 
 ### --feedback--
 
-This adjective describes something interesting or attention-grabbing.
+This describes something interesting or attention-grabbing.
 
 ---
 
@@ -79,4 +79,4 @@ This adjective describes something interesting or attention-grabbing.
 
 ### --feedback--  
 
-This adverb means something has been released or made available. 
+This means something has been released or made available.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/67ca0bcb4d28674182caa4e7.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/67ca0bcb4d28674182caa4e7.md
@@ -1,0 +1,100 @@
+---
+id: 67ca0bcb4d28674182caa4e7
+title: Task 63
+challengeType: 22
+dashedName: task-63
+---
+
+<!-- REVIEW -->
+
+# --description--
+
+This is a review of the entire dialogue you just studied.
+
+# --instructions--
+
+Place the following phrases in the correct spot:
+
+`keeping`, `figure out`, `time off`, `continuous`, `major`, `change`, `valuable`, and `up to`.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`Bob: Hi Sarah, what are you BLANK these days?`
+
+`Sarah: Hi Bob! I'm not working on any data projects at the moment. I'm taking some BLANK to learn new things. I'm attending online courses in data visualization, and I'm also exploring creative writing. It's a bit different from my usual work, but I'm enjoying the BLANK.`
+
+`Bob: That's a productive break, Sarah. Are you finding the courses helpful?`
+
+`Sarah: Absolutely! I'm learning new skills that I believe will be BLANK in my future projects. By the way, what's BLANK you busy these days?`
+
+`Bob: Well, I'm currently not working on any BLANK data analysis projects either. I'm taking some time to review our data security protocols. I'm supposed to BLANK if our current practices are robust enough to protect sensitive information. It's essential to ensure our data is secure.`
+
+`Sarah: I agree. Keeping our data safe is a top priority.`
+
+`Bob: Indeed. It's a BLANK effort to adapt to new security challenges.`
+
+## --blanks--
+
+`up to`  
+
+### --feedback-- 
+
+These two words mean "what someone is doing" at the moment. The first is a preposition, and the second is a particle.
+
+---
+
+`time off`
+
+### --feedback--
+
+These two words refer to a break from work or regular activities. The first word is a noun, and the second is a preposition.
+
+---
+
+`change`
+
+### --feedback--
+
+This noun refers to something becoming different.
+
+---
+
+`valuable`
+
+### --feedback--
+
+This adjective describes something useful or beneficial.
+
+---
+
+`keeping`
+
+### --feedback--
+
+This verb in gerund form means maintaining or ensuring something stays in a certain state.
+
+---
+
+`major`
+
+### --feedback--  
+
+This adjective describes something large or important. 
+
+---
+
+`figure out`
+
+### --feedback--
+
+These two words mean to find a solution or understand something. The first is a verb, and the second is a particle.  
+
+---
+
+`continuous`
+
+### --feedback--  
+
+This adjective describes something ongoing or without interruption.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/67ca0bcb4d28674182caa4e7.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-describe-your-current-project/67ca0bcb4d28674182caa4e7.md
@@ -41,7 +41,7 @@ Place the following phrases in the correct spot:
 
 ### --feedback-- 
 
-These two words mean "what someone is doing" at the moment. The first is a preposition, and the second is a particle.
+This means "what someone is doing" at the moment. It begins with a preposition followed by a particle.
 
 ---
 
@@ -49,7 +49,7 @@ These two words mean "what someone is doing" at the moment. The first is a prepo
 
 ### --feedback--
 
-These two words refer to a break from work or regular activities. The first word is a noun, and the second is a preposition.
+This refers to a break from work or regular activities. It begins with a noun followed by a preposition.
 
 ---
 
@@ -57,7 +57,7 @@ These two words refer to a break from work or regular activities. The first word
 
 ### --feedback--
 
-This noun refers to something becoming different.
+This refers to something becoming different.
 
 ---
 
@@ -65,7 +65,7 @@ This noun refers to something becoming different.
 
 ### --feedback--
 
-This adjective describes something useful or beneficial.
+This describes something useful or beneficial.
 
 ---
 
@@ -73,7 +73,7 @@ This adjective describes something useful or beneficial.
 
 ### --feedback--
 
-This verb in gerund form means maintaining or ensuring something stays in a certain state.
+This means "maintaining or ensuring something stays in a certain state". Use the `-ing` form.
 
 ---
 
@@ -81,7 +81,7 @@ This verb in gerund form means maintaining or ensuring something stays in a cert
 
 ### --feedback--  
 
-This adjective describes something large or important. 
+This describes something large or important. 
 
 ---
 
@@ -89,7 +89,7 @@ This adjective describes something large or important.
 
 ### --feedback--
 
-These two words mean to find a solution or understand something. The first is a verb, and the second is a particle.  
+This means "to find a solution or understand something". It begins with a verb followed by a particle.  
 
 ---
 
@@ -97,4 +97,4 @@ These two words mean to find a solution or understand something. The first is a 
 
 ### --feedback--  
 
-This adjective describes something ongoing or without interruption.
+This describes something ongoing or without interruption.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/6557985a95ab6db1c4a31b6c.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/6557985a95ab6db1c4a31b6c.md
@@ -3,7 +3,6 @@ id: 6557985a95ab6db1c4a31b6c
 title: Task 14
 challengeType: 19
 dashedName: task-14
-
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/6557e5c6a854bfcad48808c4.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/6557e5c6a854bfcad48808c4.md
@@ -5,418 +5,92 @@ challengeType: 22
 dashedName: task-35
 ---
 
-<!-- (Audio) Complete dialogue between James and Sarah. -->
+<!-- REVIEW -->
 
 # --description--
 
-This challenge is designed to summarize and reinforce the understanding of James and Sarah's conversation. It includes key vocabulary and concepts you studied before. After listening, fill in the blanks with the correct words to complete the summary of their conversation.
+This is a review of the entire dialogue you just studied.
+
+# --instructions--
+
+Place the following phrases in the correct spot:
+
+`urgent updates`, `go straight`, `as well`, `keep it`, `quick shower`, `balanced`, and `don't do`.
 
 # --fillInTheBlank--
 
 ## --sentence--
 
-`Sarah has a consistent morning routine. She BLANK up around 7 AM and starts her day by BLANK a bit. After making a cup of BLANK, she takes a BLANK shower and goes to the kitchen to BLANK a balanced breakfast. This helps her stay BLANK during the morning. She checks her BLANK and messages before BLANK to work. She likes to stay BLANK about the day's tasks. James thinks her productivity BLANK coming to work is impressive and says he BLANK try some of her habits to become more BLANK in the morning as well.`
+`Sarah: Hey, James! Thanks. Look, I BLANK anything out of the ordinary, I think. I usually wake up around 7 AM. The first thing I do is stretch a bit to wake up. Then, I BLANK to the kitchen to make a cup of coffee. It's my morning fuel!`
+
+`James: Coffee is always a good start! What do you do after that?`
+
+`Sarah: After coffee, I like to take a BLANK to freshen up. It helps me feel more alert and ready for the day. Then, I get dressed, jeans and a T-shirt, you know. Our company has a relaxed dress code and I like to BLANK casual.`
+
+`James: Yeah, me too. What's next in your routine?`
+
+`Sarah: Well, after all that, I have a BLANK breakfast. I often have cereal with some fruit and a glass of orange juice. Breakfast is important to keep my energy up during the morning.`
+
+`James: An early coffee and then breakfast! I never thought of that!`
+
+`Sarah: It helps me stay awake early in the morning! Anyway, before leaving for work, I like to check my emails and messages to see if there are any BLANK from the team. I like to stay informed about any important tasks for the day.`
+
+`James: I can't imagine being so productive even before coming to work! Thanks for sharing, Sarah. I'll try some of these tips. Maybe I can get more productive in the morning BLANK.`
+
+`Sarah: It's my pleasure. It's the consistency that helps me start the day on the right foot.`
 
 ## --blanks--
 
-`wakes`
+`don't do`
 
 ### --feedback--
 
-Indicates that Sarah stops sleeping and starts her day.
+These two words form a negative statement. The first word is an auxiliary verb, and the second is a base verb.
 
 ---
 
-`stretching`
+`go straight`
 
 ### --feedback--
 
-Refers to extending the body or limbs as part of waking up. This word has `ing`
+These two words describe movement in a direct manner. The first word is a verb, and the second is an adverb.
 
 ---
 
-`coffee`
+`quick shower`
 
 ### --feedback--
 
-A beverage that Sarah makes in the morning.
+These two words describe a short washing routine. The first word is an adjective, and the second is a noun.
 
 ---
 
-`quick`
+`keep it`
 
 ### --feedback--
 
-Done in a short amount of time, referring to her shower.
+These two words mean to maintain something a certain way. The first word is a verb, and the second is a pronoun.
 
 ---
 
-`have`
+`balanced`
 
 ### --feedback--
 
-Refers to the act of eating her breakfast.
+This word describes something stable and healthy. It is an adjective.
 
 ---
 
-`alert`
+`urgent updates`
 
 ### --feedback--
 
-Describes being fully aware and attentive.
+These two words refer to important new information. The first word is an adjective, and the second is a noun in plural form.
 
 ---
 
-`emails`
+`as well`
 
 ### --feedback--
 
-Electronic messages that Sarah checks. It is in plural and without `-`
-
----
-
-`leaving`
-
-### --feedback--
-
-Going away from a place, in this case, her home. Try finishing the word with `ing`
-
----
-
-`informed`
-
-### --feedback--
-
-Having knowledge or being aware of the day's tasks after accessing her email.
-
----
-
-`before`
-
-### --feedback--
-
-The opposite of `after`.
-
----
-
-`will`
-
-### --feedback--
-
-Modal verb that expresses future intentions.
-
----
-
-`productive`
-
-### --feedback--
-
-Efficient or achieving a significant amount, in this case, in the morning.
-
-# --scene--
-
-```json
-{
-  "setup": {
-    "background": "company2-breakroom.png",
-    "characters": [
-      {
-        "character": "James",
-        "position": { "x": -25, "y": 0, "z": 1 }
-      },
-      {
-        "character": "Sarah",
-        "position": { "x": 125, "y": 0, "z": 1 }
-      }
-    ],
-    "audio": {
-      "filename": "2.2-1.mp3",
-      "startTime": 1
-    },
-    "alwaysShowDialogue": true
-  },
-  "commands": [
-    {
-      "character": "James",
-      "position": { "x": 25, "y": 0, "z": 1 },
-      "startTime": 0
-    },
-    {
-      "character": "Sarah",
-      "position": { "x": 70, "y": 0, "z": 1 },
-      "startTime": 0.5
-    },
-    {
-      "character": "James",
-      "startTime": 1,
-      "finishTime": 2,
-      "dialogue": {
-        "text": "Good morning, Sarah!",
-        "align": "left"
-      }
-    },
-    {
-      "character": "James",
-      "startTime": 2.2,
-      "finishTime": 5.4,
-      "dialogue": {
-        "text": "Wow, it seems like you have a ton of energy this morning!",
-        "align": "left"
-      }
-    },
-    {
-      "character": "James",
-      "startTime": 5.6,
-      "finishTime": 7.7,
-      "dialogue": {
-        "text": "What do you do to start the day off right?",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Sarah",
-      "startTime": 7.9,
-      "finishTime": 9.4,
-      "dialogue": {
-        "text": "Hey, James! Thanks.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Sarah",
-      "startTime": 9.6,
-      "finishTime": 12.3,
-      "dialogue": {
-        "text": "Look, I don't do anything out of the ordinary, I think.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Sarah",
-      "startTime": 12.5,
-      "finishTime": 14.5,
-      "dialogue": {
-        "text": "I usually wake up around 7.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Sarah",
-      "startTime": 14.7,
-      "finishTime": 17,
-      "dialogue": {
-        "text": "The first thing I do is stretch a bit to wake up.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Sarah",
-      "startTime": 17.2,
-      "finishTime": 19.7,
-      "dialogue": {
-        "text": "Then, I go straight to the kitchen to make a cup of coffee.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Sarah",
-      "startTime": 19.9,
-      "finishTime": 21.1,
-      "dialogue": {
-        "text": "It's my morning fuel!",
-        "align": "right"
-      }
-    },
-    {
-      "character": "James",
-      "startTime": 21.3,
-      "finishTime": 23.3,
-      "dialogue": {
-        "text": "Coffee is always a good start!",
-        "align": "left"
-      }
-    },
-    {
-      "character": "James",
-      "startTime": 23.5,
-      "finishTime": 24.7,
-      "dialogue": {
-        "text": "What do you do after that?",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Sarah",
-      "startTime": 25.2,
-      "finishTime": 28,
-      "dialogue": {
-        "text": "After coffee, I like to take a quick shower to freshen up.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Sarah",
-      "startTime": 28.2,
-      "finishTime": 30.4,
-      "dialogue": {
-        "text": "It helps me feel more alert and ready for the day.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Sarah",
-      "startTime": 30.6,
-      "finishTime": 33.6,
-      "dialogue": {
-        "text": "Then, I get dressed, jeans and a T-shirt, you know.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Sarah",
-      "startTime": 33.8,
-      "finishTime": 36.8,
-      "dialogue": {
-        "text": "Our company has a relaxed dress code and I like to keep it casual.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "James",
-      "startTime": 37,
-      "finishTime": 39.8,
-      "dialogue": {
-        "text": "Yeah, me too. What's next in your routine?",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Sarah",
-      "startTime": 40,
-      "finishTime": 42.5,
-      "dialogue": {
-        "text": "Well, after that, I have a balanced breakfast.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Sarah",
-      "startTime": 42.7,
-      "finishTime": 46.2,
-      "dialogue": {
-        "text": "I often have cereal with some fruit and a glass of orange juice.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Sarah",
-      "startTime": 46.4,
-      "finishTime": 48.9,
-      "dialogue": {
-        "text": "Breakfast is important to keep my energy up during the morning.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "James",
-      "startTime": 49.1,
-      "finishTime": 52.9,
-      "dialogue": {
-        "text": "An early coffee and then breakfast! I never thought of that!",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Sarah",
-      "startTime": 53.1,
-      "finishTime": 55.6,
-      "dialogue": {
-        "text": "It helps me stay awake early in the morning!",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Sarah",
-      "startTime": 55.8,
-      "finishTime": 60.2,
-      "dialogue": {
-        "text": "Anyway, before leaving for work, I like to check my emails and messages",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Sarah",
-      "startTime": 60.2,
-      "finishTime": 61.8,
-      "dialogue": {
-        "text": "to see if there are any urgent updates from the team.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Sarah",
-      "startTime": 62,
-      "finishTime": 64.5,
-      "dialogue": {
-        "text": "I like to stay informed about any important tasks for the day.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "James",
-      "startTime": 64.7,
-      "finishTime": 68.7,
-      "dialogue": {
-        "text": "I can't imagine being so productive even before coming to work!",
-        "align": "left"
-      }
-    },
-    {
-      "character": "James",
-      "startTime": 68.9,
-      "finishTime": 71.9,
-      "dialogue": {
-        "text": "Thanks for sharing, Sarah. I'll try some of these tips.",
-        "align": "left"
-      }
-    },
-    {
-      "character": "James",
-      "startTime": 72.1,
-      "finishTime": 74.9,
-      "dialogue": {
-        "text": "Maybe I can get more productive in the morning as well.",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Sarah",
-      "startTime": 75.1,
-      "finishTime": 76.4,
-      "dialogue": {
-        "text": "It's my pleasure.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Sarah",
-      "startTime": 76.6,
-      "finishTime": 79.3,
-      "dialogue": {
-        "text": "It's the consistency that helps me start the day off on the right foot.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Sarah",
-      "position": { "x": 125, "y": 0, "z": 1 },
-      "startTime": 79.8
-    },
-    {
-      "character": "James",
-      "position": { "x": -25, "y": 0, "z": 1 },
-      "startTime": 80.3
-    }
-  ]
-}
-```
+These two words mean "also" or "in addition." The first word is an adverb, and the second is an adverb.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/6557e5c6a854bfcad48808c4.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/6557e5c6a854bfcad48808c4.md
@@ -45,7 +45,7 @@ Place the following phrases in the correct spot:
 
 ### --feedback--
 
-These two words form a negative statement. The first word is an auxiliary verb, and the second is a base verb.
+This forms a negative statement. It begins with an auxiliary verb in the negative form followed by a base verb.
 
 ---
 
@@ -53,7 +53,7 @@ These two words form a negative statement. The first word is an auxiliary verb, 
 
 ### --feedback--
 
-These two words describe movement in a direct manner. The first word is a verb, and the second is an adverb.
+This describes movement in a direct manner. It begins with a verb followed by an adverb.
 
 ---
 
@@ -61,7 +61,7 @@ These two words describe movement in a direct manner. The first word is a verb, 
 
 ### --feedback--
 
-These two words describe a short washing routine. The first word is an adjective, and the second is a noun.
+This describes a short washing routine. It begins with an adjective followed by a noun.
 
 ---
 
@@ -69,7 +69,7 @@ These two words describe a short washing routine. The first word is an adjective
 
 ### --feedback--
 
-These two words mean to maintain something a certain way. The first word is a verb, and the second is a pronoun.
+This means "to maintain something a certain way". It begins with a verb followed by a pronoun.
 
 ---
 
@@ -77,7 +77,7 @@ These two words mean to maintain something a certain way. The first word is a ve
 
 ### --feedback--
 
-This word describes something stable and healthy. It is an adjective.
+This describes something stable and healthy.
 
 ---
 
@@ -85,7 +85,7 @@ This word describes something stable and healthy. It is an adjective.
 
 ### --feedback--
 
-These two words refer to important new information. The first word is an adjective, and the second is a noun in plural form.
+This refers to important new information. It begins with an adjective followed by a noun in its plural form.
 
 ---
 
@@ -93,4 +93,4 @@ These two words refer to important new information. The first word is an adjecti
 
 ### --feedback--
 
-These two words mean "also" or "in addition." The first word is an adverb, and the second is an adverb.
+This means "also" or "in addition". It begins with an adverb followed by another.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655a5bfadf47e1199f9b65eb.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655a5bfadf47e1199f9b65eb.md
@@ -1,8 +1,8 @@
 ---
 id: 655a5bfadf47e1199f9b65eb
-title: Task 62
+title: Task 63
 challengeType: 19
-dashedName: task-62
+dashedName: task-63
 ---
 
 <!-- (Audio) Jake: Hey Sarah. Sophie said you have very good tips for a great morning. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655a5e76ca6f8d1b1a88e0f1.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655a5e76ca6f8d1b1a88e0f1.md
@@ -1,8 +1,8 @@
 ---
 id: 655a5e76ca6f8d1b1a88e0f1
-title: Task 63
+title: Task 64
 challengeType: 19
-dashedName: task-63
+dashedName: task-64
 ---
 
 <!-- (Audio) Jake: I want to have a good evening routine, too, but it's complicated with my two kids running around. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655a78fdfac0e22b0c400e72.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655a78fdfac0e22b0c400e72.md
@@ -1,8 +1,8 @@
 ---
 id: 655a78fdfac0e22b0c400e72
-title: Task 64
+title: Task 65
 challengeType: 22
-dashedName: task-64
+dashedName: task-65
 ---
 
 <!-- (Audio) Jake: Hey Sarah. Sophie said you have very good tips for a great morning. I want to have a good evening routine, too, but it's complicated with my two kids running around. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655a79e595bd202b4cd5e2d2.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655a79e595bd202b4cd5e2d2.md
@@ -1,8 +1,8 @@
 ---
 id: 655a79e595bd202b4cd5e2d2
-title: Task 65
+title: Task 66
 challengeType: 22
-dashedName: task-65
+dashedName: task-66
 ---
 
 <!-- (Audio) Jake: Do you have any ideas that could help? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655a7c5211e5252cf8a4ed01.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655a7c5211e5252cf8a4ed01.md
@@ -1,8 +1,8 @@
 ---
 id: 655a7c5211e5252cf8a4ed01
-title: Task 67
+title: Task 68
 challengeType: 22
-dashedName: task-67
+dashedName: task-68
 ---
 
 <!-- (Audio) Sarah: I totally understand, Jake. It can be tough. Let's see if we can comeup with some ideas that include the kids. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655a7d752ffc542e5874af0b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655a7d752ffc542e5874af0b.md
@@ -1,8 +1,8 @@
 ---
 id: 655a7d752ffc542e5874af0b
-title: Task 66
+title: Task 67
 challengeType: 19
-dashedName: task-66
+dashedName: task-67
 ---
 
 <!-- (Audio) Jake: Do you have any ideas that could help? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655a88194beb4332037ff7ce.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655a88194beb4332037ff7ce.md
@@ -1,8 +1,8 @@
 ---
 id: 655a88194beb4332037ff7ce
-title: "Task 68"
+title: Task 69
 challengeType: 22
-dashedName: task-68
+dashedName: task-69
 ---
 
 <!-- (Audio) Jake: Great! I usually get home around 6. After that, it's a bit chaotic. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655a896f31ca6a32913d1106.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655a896f31ca6a32913d1106.md
@@ -1,8 +1,8 @@
 ---
 id: 655a896f31ca6a32913d1106
-title: Task 69
+title: Task 70
 challengeType: 22
-dashedName: task-69
+dashedName: task-70
 ---
 
 <!-- (Audio) Sarah: You can start by involving your kids in light activities. Go for a family walk or play a short outdoor game together when you get home. It's a great way to have fun and stay active. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655a8ae1f10749350bc8820f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655a8ae1f10749350bc8820f.md
@@ -1,8 +1,8 @@
 ---
 id: 655a8ae1f10749350bc8820f
-title: Task 70
+title: Task 71
 challengeType: 22
-dashedName: task-70
+dashedName: task-71
 ---
 
 <!-- (Audio) Sarah: Plan simple and quick meals for weekdays. Involve the kids in setting the table as well. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655a8b62e5681235c3fb5492.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655a8b62e5681235c3fb5492.md
@@ -1,8 +1,8 @@
 ---
 id: 655a8b62e5681235c3fb5492
-title: Task 71
+title: Task 72
 challengeType: 22
-dashedName: task-71
+dashedName: task-72
 ---
 
 <!-- (Audio) Jake: Good idea! After dinner, I usually help them with their homework. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655a8c9d2a0ea136a0fd3631.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655a8c9d2a0ea136a0fd3631.md
@@ -1,8 +1,8 @@
 ---
 id: 655a8c9d2a0ea136a0fd3631
-title: Task 72
+title: Task 73
 challengeType: 19
-dashedName: task-72
+dashedName: task-73
 ---
 
 <!-- (Audio) Sarah: While they do homework, use the time to stretch or relax a bit.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655a8d7c939fcf37604516e4.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655a8d7c939fcf37604516e4.md
@@ -1,8 +1,8 @@
 ---
 id: 655a8d7c939fcf37604516e4
-title: Task 73
+title: Task 74
 challengeType: 22
-dashedName: task-73
+dashedName: task-74
 ---
 
 <!-- (Audio) Jake: How about bedtime? Sarah: Keep a consistent bedtime routine for your kids. Read them a bedtime story or talk to them about nice, calm things at bedtime. This helps them relax and give you some quiet time after they sleep. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655a8ecc0cad80393b5f3b5b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655a8ecc0cad80393b5f3b5b.md
@@ -1,8 +1,8 @@
 ---
 id: 655a8ecc0cad80393b5f3b5b
-title: Task 74
+title: Task 75
 challengeType: 22
-dashedName: task-74
+dashedName: task-75
 ---
 
 <!-- (Audio) Jake: That makes sense! What do you do before going to sleep, Sarah? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655a8fcbb859993a93204e44.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655a8fcbb859993a93204e44.md
@@ -1,8 +1,8 @@
 ---
 id: 655a8fcbb859993a93204e44
-title: Task 75
+title: Task 76
 challengeType: 22
-dashedName: task-75
+dashedName: task-76
 ---
 
 <!-- (Audio) Sarah: I like to relax by reading a book or listening to music. Sometimes, I meditate. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655a9a4cef8a173b8c27fc84.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655a9a4cef8a173b8c27fc84.md
@@ -1,8 +1,8 @@
 ---
 id: 655a9a4cef8a173b8c27fc84
-title: Task 76
+title: Task 77
 challengeType: 19
-dashedName: task-76
+dashedName: task-77
 ---
 
 <!-- (Audio) Sarah: If your kids are asleep, you can do these things too. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655a9d161bf4cf51369ff1e0.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655a9d161bf4cf51369ff1e0.md
@@ -54,7 +54,7 @@ Place the following phrases in the correct spot:
 
 ### --feedback--
 
-This adjective describes something difficult or challenging.
+This describes something difficult or challenging.
 
 ---
 
@@ -62,7 +62,7 @@ This adjective describes something difficult or challenging.
 
 ### --feedback--
 
-These two words mean to think of or create an idea. The first word is a verb, and the second is a preposition.
+This means "to think of or create an idea". It begins with a verb followed by a preposition.
 
 ---
 
@@ -70,7 +70,7 @@ These two words mean to think of or create an idea. The first word is a verb, an
 
 ### --feedback--
 
-These two words introduce the first step of a process. The first word is a verb, and the second is a preposition.
+This introduces the first step of a process. It begins with a verb followed by a preposition.
 
 ---
 
@@ -78,7 +78,7 @@ These two words introduce the first step of a process. The first word is a verb,
 
 ### --feedback--
 
-These three words refer to arranging plates, utensils, and other items before a meal. The first word is a verb in the present participle form, the second is an article, and the third is a noun.
+This refers to arranging plates, utensils, and other items before a meal. It begins with a verb in the present participle form, followed by a definite article and then a noun.
 
 ---
 
@@ -86,7 +86,7 @@ These three words refer to arranging plates, utensils, and other items before a 
 
 ### --feedback--
 
-This adjective describes something that happens in the same way regularly.
+This describes something that happens in the same way regularly.
 
 ---
 
@@ -94,4 +94,4 @@ This adjective describes something that happens in the same way regularly.
 
 ### --feedback--
 
-These two words introduce a way to unwind. The first word is a verb, and the second is a preposition.
+This introduces a way to unwind. It begins with a verb followed by a preposition.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655a9d161bf4cf51369ff1e0.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655a9d161bf4cf51369ff1e0.md
@@ -1,8 +1,8 @@
 ---
 id: 655a9d161bf4cf51369ff1e0
-title: Task 77
+title: Task 78
 challengeType: 22
-dashedName: task-77
+dashedName: task-78
 ---
 
 <!-- (Audio) The entire dialogue -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655a9d161bf4cf51369ff1e0.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655a9d161bf4cf51369ff1e0.md
@@ -4,18 +4,49 @@ title: Task 78
 challengeType: 22
 dashedName: task-78
 ---
-
-<!-- (Audio) The entire dialogue -->
+<!-- REVIEW -->
 
 # --description--
 
-This challenge tests your understanding of some key concepts from the dialogue between Jake and Sarah about evening routines. 
+This is a review of the entire dialogue you just studied.
+
+# --instructions--
+
+Place the following phrases in the correct spot:
+
+`relax by`, `come up`, `consistent`, `complicated`, `setting the table`, and `start by`.
 
 # --fillInTheBlank--
 
 ## --sentence--
 
-`Jake finds his evenings BLANK with his two kids, but he wants to improve his routine. Sarah suggests involving the kids in BLANK activities and maintaining a BLANK bedtime routine. She mentions the benefits of stretching or relaxing for self-care BLANK the kids do their homework. Reading a BLANK story helps the kids relax. She emphasizes that good evening routines BLANK contribute to overall well-being.`
+`Jake: Hey Sarah. Sophie said you have some good tips for a great morning. I want to have a good evening routine, too, but it's BLANK with my two kids running around. Do you have any ideas that could help?`
+
+`Sarah: I totally understand, Jake. It can be tough. Let's see if we can BLANK with some ideas that include the kids.`
+
+`Jake: Great! I usually get home around 6. After that, it's a bit chaotic.`
+
+`Sarah: You can BLANK involving your kids in light activities. Go for a family walk or play a short outdoor game together when you get home. It's a great way to have fun and stay active.`
+
+`Jake: Nice! What about dinner? It's always a rush.`
+
+`Sarah: Plan simple and quick meals for weekdays. Involve the kids in BLANK as well.`
+
+`Jake: Good idea! After dinner, I usually help them with their homework.`
+
+`Sarah: That's important. While they do homework, use the time to stretch or relax a bit. This also helps with your self-care.`
+
+`Jake: Amazing. Hmm… How about bedtime?`
+
+`Sarah: Keep a BLANK bedtime routine for your kids. Read them a bedtime story or talk to them about nice, calm things at bedtime. This helps them relax and gives you some quiet time after they go to sleep.`
+
+`Jake: That makes sense! What do you do before going to sleep, Sarah?`
+
+`Sarah: I like to BLANK reading a book or listening to music. Sometimes, I meditate. If your kids are asleep, you can do these things too.`
+
+`Jake: Great suggestions, Sarah! Thanks for helping me with my evening routine.`
+
+`Sarah: Anytime, Jake.`
 
 ## --blanks--
 
@@ -23,15 +54,31 @@ This challenge tests your understanding of some key concepts from the dialogue b
 
 ### --feedback--
 
-Refers to the difficulty of managing evening routines with active kids.
+This adjective describes something difficult or challenging.
 
 ---
 
-`light`
+`come up`
 
 ### --feedback--
 
-Describes activities that are not too intense or demanding.
+These two words mean to think of or create an idea. The first word is a verb, and the second is a preposition.
+
+---
+
+`start by`
+
+### --feedback--
+
+These two words introduce the first step of a process. The first word is a verb, and the second is a preposition.
+
+---
+
+`setting the table`
+
+### --feedback--
+
+These three words refer to arranging plates, utensils, and other items before a meal. The first word is a verb in the present participle form, the second is an article, and the third is a noun.
 
 ---
 
@@ -39,372 +86,12 @@ Describes activities that are not too intense or demanding.
 
 ### --feedback--
 
-Indicates regularity and uniformity in bedtime routines.
+This adjective describes something that happens in the same way regularly.
 
 ---
 
-`while`
+`relax by`
 
 ### --feedback--
 
-Used in sentences to indicate that two actions or events are happening at the same time. 
-
----
-
-`bedtime`
-
-### --feedback--
-
-Indicates the type of story suitable for reading at night.
-
----
-
-`can`
-
-### --feedback--
-
-Shows the possibility or ability of routines contributing to well-being.
-
-# --scene--
-
-```json
-{
-  "setup": {
-    "background": "company1-reception.png",
-    "characters": [
-      {
-        "character": "Jake",
-        "position": { "x": -25, "y": 0, "z": 1 }
-      },
-      {
-        "character": "Sarah",
-        "position": { "x": 125, "y": 0, "z": 1 }
-      }
-    ],
-    "audio": {
-      "filename": "2.2-3.mp3",
-      "startTime": 1
-    },
-    "alwaysShowDialogue": true
-  },
-  "commands": [
-    {
-      "character": "Jake",
-      "position": { "x": 25, "y": 0, "z": 1 },
-      "startTime": 0
-    },
-    {
-      "character": "Sarah",
-      "position": { "x": 70, "y": 0, "z": 1 },
-      "startTime": 0.5
-    },
-    {
-      "character": "Jake",
-      "startTime": 1,
-      "finishTime": 5.2,
-      "dialogue": {
-        "text": "Hey Sarah. Sophie said you have some good tips for a great morning.",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Jake",
-      "startTime": 5.7,
-      "finishTime": 7.2,
-      "dialogue": {
-        "text": "I want to have a good evening routine, too,",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Jake",
-      "startTime": 8.2,
-      "finishTime": 10.7,
-      "dialogue": {
-        "text": "but it's complicated with my two kids running around.",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Jake",
-      "startTime": 10.9,
-      "finishTime": 12.9,
-      "dialogue": {
-        "text": "Do you have any ideas that could help?",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Sarah",
-      "startTime": 13.2,
-      "finishTime": 14.7,
-      "dialogue": {
-        "text": "I totally understand, Jake.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Sarah",
-      "startTime": 14.9,
-      "finishTime": 15.7,
-      "dialogue": {
-        "text": "It can be tough.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Sarah",
-      "startTime": 16,
-      "finishTime": 19.2,
-      "dialogue": {
-        "text": "Let's see if we can come up with some ideas that include the kids.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Jake",
-      "startTime": 19.4,
-      "finishTime": 22.1,
-      "dialogue": {
-        "text": "Great! I usually get home at around 6.",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Jake",
-      "startTime": 22.3,
-      "finishTime": 24.3,
-      "dialogue": {
-        "text": "After that, it's a bit chaotic.",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Sarah",
-      "startTime": 24.5,
-      "finishTime": 27.5,
-      "dialogue": {
-        "text": "You can start by involving your kids in light activities.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Sarah",
-      "startTime": 27.9,
-      "finishTime": 29.3,
-      "dialogue": {
-        "text": "Go for a family walk",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Sarah",
-      "startTime": 29.3,
-      "finishTime": 31.4,
-      "dialogue": {
-        "text": "or play a short outdoor game together when you get home.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Sarah",
-      "startTime": 31.6,
-      "finishTime": 34.1,
-      "dialogue": {
-        "text": "It's a great way to have fun and stay active.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Jake",
-      "startTime": 34.3,
-      "finishTime": 36.4,
-      "dialogue": {
-        "text": "Nice! What about dinner?",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Jake",
-      "startTime": 36.4,
-      "finishTime": 37.1,
-      "dialogue": {
-        "text": "It's always a rush.",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Sarah",
-      "startTime": 37.3,
-      "finishTime": 40.5,
-      "dialogue": {
-        "text": "Plan simple and quick meals for weekdays.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Sarah",
-      "startTime": 40.7,
-      "finishTime": 42.7,
-      "dialogue": {
-        "text": "Involve the kids in setting the table as well.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Jake",
-      "startTime": 42.9,
-      "finishTime": 46.6,
-      "dialogue": {
-        "text": "Good idea! After dinner, I usually help them with their homework.",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Sarah",
-      "startTime": 46.8,
-      "finishTime": 48,
-      "dialogue": {
-        "text": "That's important.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Sarah",
-      "startTime": 48,
-      "finishTime": 51,
-      "dialogue": {
-        "text": "While they do homework, use the time to stretch or relax a bit.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Sarah",
-      "startTime": 51.2,
-      "finishTime": 52.7,
-      "dialogue": {
-        "text": "This also helps with your self-care.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Jake",
-      "startTime": 52.9,
-      "finishTime": 56.4,
-      "dialogue": {
-        "text": "Amazing. Hmm… How about bedtime?",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Sarah",
-      "startTime": 56.6,
-      "finishTime": 59.2,
-      "dialogue": {
-        "text": "Keep a consistent bedtime routine for your kids.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Sarah",
-      "startTime": 59.5,
-      "finishTime": 63.3,
-      "dialogue": {
-        "text": "Read them a bedtime story or talk to them about nice, calm things at bedtime.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Sarah",
-      "startTime": 63.6,
-      "finishTime": 67,
-      "dialogue": {
-        "text": "This helps them relax and gives you some quiet time after they go to sleep.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Jake",
-      "startTime": 67.5,
-      "finishTime": 68.5,
-      "dialogue": {
-        "text": "That makes sense!",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Jake",
-      "startTime": 68.8,
-      "finishTime": 71.1,
-      "dialogue": {
-        "text": "What do you do before going to sleep, Sarah?",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Sarah",
-      "startTime": 71.7,
-      "finishTime": 74.7,
-      "dialogue": {
-        "text": "I like to relax by reading a book or listening to music.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Sarah",
-      "startTime": 75,
-      "finishTime": 76.6,
-      "dialogue": {
-        "text": "Sometimes, I meditate.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Sarah",
-      "startTime": 76.9,
-      "finishTime": 79.1,
-      "dialogue": {
-        "text": "If your kids are asleep, you can do these things too.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Jake",
-      "startTime": 79.2,
-      "finishTime": 80.7,
-      "dialogue": {
-        "text": "Great suggestions, Sarah!",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Jake",
-      "startTime": 80.9,
-      "finishTime": 83,
-      "dialogue": {
-        "text": "Thanks for helping me with my evening routine.",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Sarah",
-      "startTime": 83.5,
-      "finishTime": 84.3,
-      "dialogue": {
-        "text": "Anytime, Jake.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Sarah",
-      "position": { "x": 125, "y": 0, "z": 1 },
-      "startTime": 84.8
-    },
-    {
-      "character": "Jake",
-      "position": { "x": -25, "y": 0, "z": 1 },
-      "startTime": 85.3
-    }
-  ]
-}
-```
+These two words introduce a way to unwind. The first word is a verb, and the second is a preposition.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655aa098bb38a05474a3f5b4.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655aa098bb38a05474a3f5b4.md
@@ -1,8 +1,8 @@
 ---
 id: 655aa098bb38a05474a3f5b4
-title: Task 78
+title: Task 79
 challengeType: 19
-dashedName: task-78
+dashedName: task-79
 ---
 
 <!-- (Audio) Brian: Hey Maria, is it true that you are never home in the evenings? How do you do that? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655b258e8cd2985ed8412275.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655b258e8cd2985ed8412275.md
@@ -1,8 +1,8 @@
 ---
 id: 655b258e8cd2985ed8412275
-title: "Task 79"
+title: Task 80
 challengeType: 19
-dashedName: task-79
+dashedName: task-80
 ---
 
 <!-- (Audio) Maria: Hi Brian. Well, yeah! I like doing entertaining things in the evening, so I go out a lot. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655b266c2ea5495f43b97ea5.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655b266c2ea5495f43b97ea5.md
@@ -1,8 +1,8 @@
 ---
 id: 655b266c2ea5495f43b97ea5
-title: "Task 80"
+title: Task 81
 challengeType: 19
-dashedName: task-80
+dashedName: task-81
 ---
 
 <!-- (Audio) Maria: On Mondays, I have dance classes from 6 to 7:30. I love dancing. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655b275cadbebf5fc0f0db05.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655b275cadbebf5fc0f0db05.md
@@ -1,8 +1,8 @@
 ---
 id: 655b275cadbebf5fc0f0db05
-title: "Task 81"
+title: Task 82
 challengeType: 22
-dashedName: task-81
+dashedName: task-82
 ---
 
 <!-- (Audio) Maria: On Tuesdays, I learn Japanese. I take online lessons at 7. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655b283d10fee46040e0a893.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655b283d10fee46040e0a893.md
@@ -1,8 +1,8 @@
 ---
 id: 655b283d10fee46040e0a893
-title: Task 82
+title: Task 83
 challengeType: 19
-dashedName: task-82
+dashedName: task-83
 ---
 
 <!-- (Audio) Maria: On Tuesdays, I learn Japanese. I take online lessons at 7. I think it is the only day I am home so early. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655b2919ff561b60fcde19ae.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655b2919ff561b60fcde19ae.md
@@ -1,8 +1,8 @@
 ---
 id: 655b2919ff561b60fcde19ae
-title: "Task 83"
+title: Task 84
 challengeType: 19
-dashedName: task-83
+dashedName: task-84
 ---
 
 <!-- (Audio) Maria: Then, on Wednesdays, I go to a local theater group. Practice goes until 9. We perform small plays. It's really fun. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655b29fb2c8b1861bf4fbab1.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655b29fb2c8b1861bf4fbab1.md
@@ -1,8 +1,8 @@
 ---
 id: 655b29fb2c8b1861bf4fbab1
-title: Task 84
+title: Task 85
 challengeType: 19
-dashedName: task-84
+dashedName: task-85
 ---
 
 <!-- (Audio) Maria: Thursdays are for watching shows. I look for live concerts or theater plays. It's my favorite time to relax. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655b2aa6807cae6273ca23fb.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655b2aa6807cae6273ca23fb.md
@@ -1,8 +1,8 @@
 ---
 id: 655b2aa6807cae6273ca23fb
-title: "Task 85"
+title: Task 86
 challengeType: 19
-dashedName: task-85
+dashedName: task-86
 ---
 
 <!-- (Audio) Brian: Wow! Do you rest at home on Fridays at least?

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655b2b5cc4ea3062f9811dec.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655b2b5cc4ea3062f9811dec.md
@@ -1,8 +1,8 @@
 ---
 id: 655b2b5cc4ea3062f9811dec
-title: Task 86
+title: Task 87
 challengeType: 22
-dashedName: task-86
+dashedName: task-87
 ---
 
 <!-- (Audio) Maria: On Fridays, I like to hang out with friends. We normally meet at a bar, chat and have something to eat and drink. But I'm not really a night owl, so I like to be back home by 9:30 tops. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655b2d250741166530dd6e43.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655b2d250741166530dd6e43.md
@@ -1,8 +1,8 @@
 ---
 id: 655b2d250741166530dd6e43
-title: Task 87
+title: Task 88
 challengeType: 19
-dashedName: task-87
+dashedName: task-88
 ---
 
 <!-- (Audio) Brian: So many activities! I don't think I could keep up that pace... -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655b3197bb31ca670081f6d7.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655b3197bb31ca670081f6d7.md
@@ -1,8 +1,8 @@
 ---
 id: 655b3197bb31ca670081f6d7
-title: Task 88
+title: Task 89
 challengeType: 22
-dashedName: task-88
+dashedName: task-89
 ---
 
 <!-- (Audio) Brian: So many activities! I don't think I could keep up that pace. But it is nice to know you enjoy it to the fullest, Maria. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655b3274b6c61c67d95b5e67.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655b3274b6c61c67d95b5e67.md
@@ -1,8 +1,8 @@
 ---
 id: 655b3274b6c61c67d95b5e67
-title: Task 89
+title: Task 90
 challengeType: 19
-dashedName: task-89
+dashedName: task-90
 ---
 
 <!-- (Audio) Brian: I think I will try to go out more often in the evening as well. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655b32b2812874680f3198d3.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655b32b2812874680f3198d3.md
@@ -1,8 +1,8 @@
 ---
 id: 655b32b2812874680f3198d3
-title: "Task 90"
+title: Task 91
 challengeType: 22
-dashedName: task-90
+dashedName: task-91
 ---
 
 <!-- (Audio) Maria: Sure, Brian! Just don't forget to give yourself time to rest. Find what your interests are and have some fun! -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655b34e53bf2cb6908042c98.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655b34e53bf2cb6908042c98.md
@@ -1,8 +1,8 @@
 ---
 id: 655b34e53bf2cb6908042c98
-title: Task 91
+title: Task 92
 challengeType: 19
-dashedName: task-91
+dashedName: task-92
 ---
 
 <!-- (Audio) Sophie: Hey Brian. TGIF, right? Do you have any plans for the weekend? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655b34e53bf2cb6908042c98.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655b34e53bf2cb6908042c98.md
@@ -1,8 +1,8 @@
 ---
 id: 655b34e53bf2cb6908042c98
-title: Task 92
+title: Task 93
 challengeType: 19
-dashedName: task-92
+dashedName: task-93
 ---
 
 <!-- (Audio) Sophie: Hey Brian. TGIF, right? Do you have any plans for the weekend? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655b3581926acd6a172fa94b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655b3581926acd6a172fa94b.md
@@ -1,8 +1,8 @@
 ---
 id: 655b3581926acd6a172fa94b
-title: Task 93
+title: Task 94
 challengeType: 19
-dashedName: task-93
+dashedName: task-94
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655b3581926acd6a172fa94b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655b3581926acd6a172fa94b.md
@@ -1,8 +1,8 @@
 ---
 id: 655b3581926acd6a172fa94b
-title: Task 92
+title: Task 93
 challengeType: 19
-dashedName: task-92
+dashedName: task-93
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655b363149b5ba6b15434574.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655b363149b5ba6b15434574.md
@@ -1,8 +1,8 @@
 ---
 id: 655b363149b5ba6b15434574
-title: Task 94
+title: Task 95
 challengeType: 19
-dashedName: task-94
+dashedName: task-95
 ---
 
 <!-- (Audio) Sophie: Nice! On Saturday, I usually sleep until 9:30. In the morning, I do some house cleaning. In the afternoon, I watch a movie at home, or I go out with friends to do some window-shopping at the mall. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655b363149b5ba6b15434574.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655b363149b5ba6b15434574.md
@@ -1,8 +1,8 @@
 ---
 id: 655b363149b5ba6b15434574
-title: Task 93
+title: Task 94
 challengeType: 19
-dashedName: task-93
+dashedName: task-94
 ---
 
 <!-- (Audio) Sophie: Nice! On Saturday, I usually sleep until 9:30. In the morning, I do some house cleaning. In the afternoon, I watch a movie at home, or I go out with friends to do some window-shopping at the mall. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655b37ecf9da446bd1dcff4f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655b37ecf9da446bd1dcff4f.md
@@ -1,8 +1,8 @@
 ---
 id: 655b37ecf9da446bd1dcff4f
-title: "Task 94"
+title: Task 95
 challengeType: 22
-dashedName: task-94
+dashedName: task-95
 ---
 
 <!-- (Audio)

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655b37ecf9da446bd1dcff4f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655b37ecf9da446bd1dcff4f.md
@@ -1,8 +1,8 @@
 ---
 id: 655b37ecf9da446bd1dcff4f
-title: Task 95
+title: Task 96
 challengeType: 22
-dashedName: task-95
+dashedName: task-96
 ---
 
 <!-- (Audio)

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655b38c1f5351d6c827c8e8f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655b38c1f5351d6c827c8e8f.md
@@ -1,8 +1,8 @@
 ---
 id: 655b38c1f5351d6c827c8e8f
-title: Task 95
+title: Task 96
 challengeType: 19
-dashedName: task-95
+dashedName: task-96
 ---
 
 <!-- (Audio) Brian: I have a relaxing Sunday too. In the morning and in the evening, I work on a personal coding project. In the afternoon, I take a break and go for a quick walk in the park. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655b38c1f5351d6c827c8e8f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655b38c1f5351d6c827c8e8f.md
@@ -1,8 +1,8 @@
 ---
 id: 655b38c1f5351d6c827c8e8f
-title: Task 96
+title: Task 97
 challengeType: 19
-dashedName: task-96
+dashedName: task-97
 ---
 
 <!-- (Audio) Brian: I have a relaxing Sunday too. In the morning and in the evening, I work on a personal coding project. In the afternoon, I take a break and go for a quick walk in the park. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655b39e59c29d16d64a2ce8e.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655b39e59c29d16d64a2ce8e.md
@@ -1,8 +1,8 @@
 ---
 id: 655b39e59c29d16d64a2ce8e
-title: Task 96
+title: Task 97
 challengeType: 22
-dashedName: task-96
+dashedName: task-97
 ---
 
 <!-- (Audio) Sophie: That's a good mix of indoor and outdoor activities. I don't work at the computer on weekends like you, though. I save that for the weekdays, I suppose. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655b39e59c29d16d64a2ce8e.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655b39e59c29d16d64a2ce8e.md
@@ -1,8 +1,8 @@
 ---
 id: 655b39e59c29d16d64a2ce8e
-title: Task 97
+title: Task 98
 challengeType: 22
-dashedName: task-97
+dashedName: task-98
 ---
 
 <!-- (Audio) Sophie: That's a good mix of indoor and outdoor activities. I don't work at the computer on weekends like you, though. I save that for the weekdays, I suppose. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655b3b06ec00a46e572868a2.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655b3b06ec00a46e572868a2.md
@@ -1,8 +1,8 @@
 ---
 id: 655b3b06ec00a46e572868a2
-title: Task 97
+title: Task 98
 challengeType: 19
-dashedName: task-97
+dashedName: task-98
 ---
 
 <!-- (Audio) Brian: I know, right? But it is a personal project and I like it a lot, so I don't mind spending some of my time on it. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655b3b06ec00a46e572868a2.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/655b3b06ec00a46e572868a2.md
@@ -1,8 +1,8 @@
 ---
 id: 655b3b06ec00a46e572868a2
-title: Task 98
+title: Task 99
 challengeType: 19
-dashedName: task-98
+dashedName: task-99
 ---
 
 <!-- (Audio) Brian: I know, right? But it is a personal project and I like it a lot, so I don't mind spending some of my time on it. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/657a45a85a8f6cfeef7803db.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/657a45a85a8f6cfeef7803db.md
@@ -44,7 +44,7 @@ Place the following phrases in the correct spot:
 
 These three words indicate something unusual. The first word is a preposition, the second is an article, and the third is an adjective.  
 
----  
+---
 
 `some`  
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/657a45a85a8f6cfeef7803db.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/657a45a85a8f6cfeef7803db.md
@@ -1,320 +1,85 @@
 ---
 id: 657a45a85a8f6cfeef7803db
-title: Task 99
+title: Task 100
 challengeType: 22
-dashedName: task-99
+dashedName: task-100
 ---
-
-<!-- (Audio) The entire dialogue -->
+<!-- REVIEW -->
 
 # --description--
 
-This challenge tests your understanding of key concepts from the dialogue about weekend routines between Sophie and Brian. 
+This is a review of the entire dialogue you just studied.  
+
+# --instructions--
+
+Place the following phrases in the correct spot:  
+
+`stay at`, `work at`, `take a break`, `some`, `out of the`, and `don't mind`.  
 
 # --fillInTheBlank--
 
-## --sentence--
+## --sentence--  
 
-`Sophie enjoys BLANK in on Saturday and has a BLANK morning on Sunday, focusing on leisure activities like movies and video games. Brian starts his day BLANK with a run, visits his parents, and dedicates time to a BLANK coding project. Both have a mix of indoor and BLANK activities, but Brian also dedicates part of his weekend to BLANK.`
+`Sophie: Hey Brian. TGIF, right? Do you have any plans for the weekend?`  
 
-## --blanks--
+`Brian: Nothing BLANK ordinary, Sophie. On Saturday, I wake up early, at 7:00. I run in the park near my place in the morning. In the afternoon, I visit my parents and I have lunch with them.`  
 
-`sleeping`
+`Sophie: Nice! On Saturday, I usually sleep until 9:30. In the morning, I do BLANK house cleaning. In the afternoon, I watch a movie at home, or I go out with friends to do some window-shopping at the mall.`  
 
-### --feedback--
+`Brian: And on Sunday?`  
 
-Reflects Sophie's preference to sleep late on Saturday.
+`Sophie: On Sunday, I have a lazy morning. I just BLANK home and play some video games on my console. In the evening, I make dinner and go to sleep early, because, on Monday, it’s back to work again.`  
 
----
+`Brian: I have a relaxing Sunday, too. In the morning and in the evening, I work on a personal coding project. In the afternoon, I BLANK and go for a quick walk in the park.`  
 
-`lazy`
+`Sophie: That’s a good mix of indoor and outdoor activities! I don't BLANK the computer on weekends like you, though. I save that for the weekdays, I suppose.`  
 
-### --feedback--
+`Brian: I know, right? But it is a personal project and I like it a lot, so I BLANK spending some of my time on it.`  
 
-Describes Sophie's relaxed approach to Sunday mornings.
+## --blanks--  
 
----
+`out of the`  
 
-`early`
+### --feedback--  
 
-### --feedback--
+These three words indicate something unusual. The first word is a preposition, the second is an article, and the third is an adjective.  
 
-Indicates Brian's habit of waking up early for a run.
+---  
 
----
+`some`  
 
-`personal`
+### --feedback--  
 
-### --feedback--
-
-Refers to the nature of Brian's project, the one he works on during the weekend.
+This word is a determiner used to refer to an unspecified amount.  
 
 ---
 
-`outdoor`
+`stay at`  
 
-### --feedback--
+### --feedback--  
 
-Highlights the balance of activities both indoors and outdoors in their routines.
+These two words describe remaining in a place. The first word is a verb, and the second is a preposition.  
 
 ---
 
-`coding`
+`take a break`  
 
-### --feedback--
+### --feedback--  
 
-It's the work that Brian does on his computer as part of his weekend routine, unlike Sophie's.
+These three words mean to pause an activity for rest. The first word is a verb, the second is an article, and the third is a noun.  
 
-# --scene--
+---
 
-```json
-{
-  "setup": {
-    "background": "company1-reception.png",
-    "characters": [
-      {
-        "character": "Sophie",
-        "position": { "x": -25, "y": 0, "z": 1 }
-      },
-      {
-        "character": "Brian",
-        "position": { "x": 125, "y": 0, "z": 1 }
-      }
-    ],
-    "audio": {
-      "filename": "2.2-5.mp3",
-      "startTime": 1
-    },
-    "alwaysShowDialogue": true
-  },
-  "commands": [
-    {
-      "character": "Sophie",
-      "position": { "x": 25, "y": 0, "z": 1 },
-      "startTime": 0
-    },
-    {
-      "character": "Brian",
-      "position": { "x": 70, "y": 0, "z": 1 },
-      "startTime": 0.5
-    },
-    {
-      "character": "Sophie",
-      "startTime": 1.2,
-      "finishTime": 4.8,
-      "dialogue": {
-        "text": "Hey Brian. TGIF, right? Do you have any plans for the weekend?",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Brian",
-      "startTime": 5,
-      "finishTime": 6.7,
-      "dialogue": {
-        "text": "Nothing out of the ordinary, Sophie.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Brian",
-      "startTime": 6.9,
-      "finishTime": 9.3,
-      "dialogue": {
-        "text": "On Saturday, I wake up early, at 7:00.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Brian",
-      "startTime": 9.4,
-      "finishTime": 11.6,
-      "dialogue": {
-        "text": "I run in the park near my place in the morning.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Brian",
-      "startTime": 11.9,
-      "finishTime": 15.2,
-      "dialogue": {
-        "text": "In the afternoon, I visit my parents and I have lunch with them.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Sophie",
-      "startTime": 16,
-      "finishTime": 19.3,
-      "dialogue": {
-        "text": "Nice! On Saturday, I usually sleep until 9:30.",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Sophie",
-      "startTime": 19.8,
-      "finishTime": 21.6,
-      "dialogue": {
-        "text": "In the morning, I do some house cleaning.",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Sophie",
-      "startTime": 21.8,
-      "finishTime": 23.8,
-      "dialogue": {
-        "text": "In the afternoon, I watch a movie at home,",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Sophie",
-      "startTime": 23.9,
-      "finishTime": 26.5,
-      "dialogue": {
-        "text": "or I go out with friends to do some window-shopping at the mall.",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Brian",
-      "startTime": 26.7,
-      "finishTime": 27.8,
-      "dialogue": {
-        "text": "And on Sunday?",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Sophie",
-      "startTime": 28.3,
-      "finishTime": 30.1,
-      "dialogue": {
-        "text": "On Sunday, I have a lazy morning.",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Sophie",
-      "startTime": 30.2,
-      "finishTime": 33,
-      "dialogue": {
-        "text": "I just stay at home and play some video games on my console.",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Sophie",
-      "startTime": 33.3,
-      "finishTime": 35.8,
-      "dialogue": {
-        "text": "In the evening, I make dinner and go to sleep early,",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Sophie",
-      "startTime": 35.8,
-      "finishTime": 37.8,
-      "dialogue": {
-        "text": "because, on Monday, it's back to work again.",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Brian",
-      "startTime": 38.2,
-      "finishTime": 40,
-      "dialogue": {
-        "text": "I have a relaxing Sunday, too.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Brian",
-      "startTime": 40.3,
-      "finishTime": 44.4,
-      "dialogue": {
-        "text": "In the morning and in the evening, I work on a personal coding project.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Brian",
-      "startTime": 44.5,
-      "finishTime": 48.1,
-      "dialogue": {
-        "text": "In the afternoon, I take a break and go for a quick walk in the park.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Sophie",
-      "startTime": 48.8,
-      "finishTime": 51.1,
-      "dialogue": {
-        "text": "That's a good mix of indoor and outdoor activities!",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Sophie",
-      "startTime": 51.4,
-      "finishTime": 53.6,
-      "dialogue": {
-        "text": "I don't work at the computer on weekends like you, though.",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Sophie",
-      "startTime": 53.7,
-      "finishTime": 55.5,
-      "dialogue": {
-        "text": "I save that for the weekdays, I suppose.",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Brian",
-      "startTime": 55.7,
-      "finishTime": 56.9,
-      "dialogue": {
-        "text": "I know, right?",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Brian",
-      "startTime": 57,
-      "finishTime": 59.9,
-      "dialogue": {
-        "text": "But it is a personal project and I like it a lot,",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Brian",
-      "startTime": 59.9,
-      "finishTime": 62,
-      "dialogue": {
-        "text": "so I don't mind spending some of my time on it.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Brian",
-      "position": { "x": 125, "y": 0, "z": 1 },
-      "startTime": 62.5
-    },
-    {
-      "character": "Sophie",
-      "position": { "x": -25, "y": 0, "z": 1 },
-      "startTime": 63
-    }
-  ]
-}
-```
+`work at`  
+
+### --feedback--  
+
+These two words describe putting effort into an activity. The first word is a verb, and the second is a preposition.  
+
+---
+
+`don't mind`  
+
+### --feedback--  
+
+These two words indicate that something is not a problem. The first word is an auxiliary verb, and the second is a main verb.  

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/657a45a85a8f6cfeef7803db.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/657a45a85a8f6cfeef7803db.md
@@ -42,7 +42,7 @@ Place the following phrases in the correct spot:
 
 ### --feedback--  
 
-These three words indicate something unusual. The first word is a preposition, the second is an article, and the third is an adjective.  
+This indicates something unusual. It begins with a preposition followed by another and then a definite article.  
 
 ---
 
@@ -50,7 +50,7 @@ These three words indicate something unusual. The first word is a preposition, t
 
 ### --feedback--  
 
-This word is a determiner used to refer to an unspecified amount.  
+This is a determiner used to refer to an unspecified amount.
 
 ---
 
@@ -58,7 +58,7 @@ This word is a determiner used to refer to an unspecified amount.
 
 ### --feedback--  
 
-These two words describe remaining in a place. The first word is a verb, and the second is a preposition.  
+This describes remaining in a place. It begins with a verb followed by a preposition.  
 
 ---
 
@@ -66,7 +66,7 @@ These two words describe remaining in a place. The first word is a verb, and the
 
 ### --feedback--  
 
-These three words mean to pause an activity for rest. The first word is a verb, the second is an article, and the third is a noun.  
+This means "to pause an activity for rest". It begins with a verb followed by an indefinite article and then a noun.  
 
 ---
 
@@ -74,7 +74,7 @@ These three words mean to pause an activity for rest. The first word is a verb, 
 
 ### --feedback--  
 
-These two words describe putting effort into an activity. The first word is a verb, and the second is a preposition.  
+This describes putting effort into an activity. It begins with a verb followed by a preposition.  
 
 ---
 
@@ -82,4 +82,4 @@ These two words describe putting effort into an activity. The first word is a ve
 
 ### --feedback--  
 
-These two words indicate that something is not a problem. The first word is an auxiliary verb, and the second is a main verb.  
+This indicates that something is not a problem. It begins with an auxiliary verb in the negative followed by the main verb.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/657a45a85a8f6cfeef7803db.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/657a45a85a8f6cfeef7803db.md
@@ -1,8 +1,8 @@
 ---
 id: 657a45a85a8f6cfeef7803db
-title: Task 98
+title: Task 99
 challengeType: 22
-dashedName: task-98
+dashedName: task-99
 ---
 
 <!-- (Audio) The entire dialogue -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/67c8bb14718cddacc3748282.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/67c8bb14718cddacc3748282.md
@@ -1,0 +1,106 @@
+---
+id: 67c8bb14718cddacc3748282
+title: Task 62
+challengeType: 22
+dashedName: task-62
+---
+
+<!-- REVIEW -->
+
+# --description--
+
+This is a review of the entire dialogue you just studied.
+
+# --instructions--
+
+Place the following phrases in the correct spot:
+
+`don't start`, `too much`, `because`, `try to include`, `Don't forget to`, `not to`, and `running around`.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`Sophie: So, I'm here BLANK I feel sleepy during the mornings. I BLANK productive until it's almost midday. Do you have any tips on how to have a healthy morning routine?`
+
+`Expert: Absolutely! My first suggestion is BLANK hit the snooze button multiple times. It may be tempting, but it disrupts your sleep cycle and you may feel groggy during the day. Set one alarm and get up when it rings.`
+
+`Sophie: That's a good point. What else?`
+
+`Expert: Another thing: don't skip breakfast. Breakfast gives you the energy to start the day. If you skip it, you probably compensate later by eating BLANK or you feel sluggish in the morning. Have a balanced breakfast instead.`
+
+`Sophie: I have a friend who does that in her routine. Any other suggestions?`
+
+`Expert: Yes, BLANK your day by checking your phone or emails immediately. It creates stress and makes you feel like you have to rush. Take a few minutes for yourself. For example, you can stretch or do some breathing exercises to clear your mind.`
+
+`Sophie: That's a good idea.`
+
+`Expert: One more thing: don't rush during your morning routine. Give yourself time to get ready without BLANK. If you start the day feeling relaxed, you may have a more productive day.`
+
+`Sophie: Wow, thanks! I'll BLANK these changes into my morning routine.`
+
+`Expert: You're welcome! And remember: the small changes make a big difference. Your morning starts well when you have a good night's sleep. BLANK get enough sleep to feel well-rested in the morning. Have a great morning!`
+
+## --blanks--
+
+`because`
+
+### --feedback--
+
+This word introduces a reason. It is a conjunction.
+
+---
+
+`don't get`
+
+### --feedback--
+
+These two words form a negative statement. The first word is an auxiliary verb, and the second is a base verb.
+
+---
+
+`not to`
+
+### --feedback--
+
+These two words form a negative infinitive phrase. The first word is an adverb, and the second is a particle.
+
+---
+
+`too much`
+
+### --feedback--
+
+These two words indicate an excessive amount. The first word is an adverb, and the second is a determiner.
+
+---
+
+`don't start`
+
+### --feedback--
+
+These two words form a negative command. The first word is an auxiliary verb, and the second is a base verb.
+
+---
+
+`running around`
+
+### --feedback--
+
+These two words describe moving quickly in an unorganized way. The first word is a verb in the present participle form, and the second is a preposition.
+
+---
+
+`try to include`
+
+### --feedback--
+
+These three words form a suggestion. The first word is a verb, the second is a particle, and the third is a verb in the base form.
+
+---
+
+`Don't forget to`
+
+### --feedback--
+
+These three words form a reminder or instruction. The first word is an auxiliary verb, the second is a base verb, and the third is a particle. The first letter is capitalized.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/67c8bb14718cddacc3748282.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/67c8bb14718cddacc3748282.md
@@ -47,7 +47,7 @@ Place the following phrases in the correct spot:
 
 ### --feedback--
 
-This word introduces a reason. It is a conjunction.
+This introduces a reason. It is a conjunction.
 
 ---
 
@@ -55,7 +55,7 @@ This word introduces a reason. It is a conjunction.
 
 ### --feedback--
 
-These two words form a negative statement. The first word is an auxiliary verb, and the second is a base verb.
+This forms a negative statement. It begins with an auxiliary verb in the negative followed by a base verb.
 
 ---
 
@@ -63,7 +63,7 @@ These two words form a negative statement. The first word is an auxiliary verb, 
 
 ### --feedback--
 
-These two words form a negative infinitive phrase. The first word is an adverb, and the second is a particle.
+This forms a negative infinitive phrase. It begins with the adverb for negatives followed by a particle.
 
 ---
 
@@ -71,7 +71,7 @@ These two words form a negative infinitive phrase. The first word is an adverb, 
 
 ### --feedback--
 
-These two words indicate an excessive amount. The first word is an adverb, and the second is a determiner.
+This indicates an excessive amount. It begins with an adverb followed by determiner.
 
 ---
 
@@ -79,7 +79,7 @@ These two words indicate an excessive amount. The first word is an adverb, and t
 
 ### --feedback--
 
-These two words form a negative command. The first word is an auxiliary verb, and the second is a base verb.
+This forms a negative command. It begins with an auxiliary verb in the negative followed by a base verb.
 
 ---
 
@@ -87,7 +87,7 @@ These two words form a negative command. The first word is an auxiliary verb, an
 
 ### --feedback--
 
-These two words describe moving quickly in an unorganized way. The first word is a verb in the present participle form, and the second is a preposition.
+This describes moving quickly in an unorganized way. It begins with a verb in the present participle form followed by a preposition.
 
 ---
 
@@ -95,7 +95,7 @@ These two words describe moving quickly in an unorganized way. The first word is
 
 ### --feedback--
 
-These three words form a suggestion. The first word is a verb, the second is a particle, and the third is a verb in the base form.
+This forms a suggestion. It begins with a verb followed by a particle and then a verb in its base form.
 
 ---
 
@@ -103,4 +103,4 @@ These three words form a suggestion. The first word is a verb, the second is a p
 
 ### --feedback--
 
-These three words form a reminder or instruction. The first word is an auxiliary verb, the second is a base verb, and the third is a particle. The first letter is capitalized.
+This forms a reminder or instruction. It begins with an auxiliary verb in the negative followed by a base verb and then a particle. The first letter is capitalized.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/67c8bb14718cddacc3748282.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/67c8bb14718cddacc3748282.md
@@ -15,7 +15,7 @@ This is a review of the entire dialogue you just studied.
 
 Place the following phrases in the correct spot:
 
-`don't start`, `too much`, `because`, `try to include`, `Don't forget to`, `not to`, and `running around`.
+`don't start`, `too much`, `because`, `try to include`, `Don't forget to`, `not to`, `running around`, and `don't get`.
 
 # --fillInTheBlank--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/67ca0719cf479630dbb12495.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/67ca0719cf479630dbb12495.md
@@ -46,7 +46,7 @@ Place the following phrases in the correct spot:
 
 ### --feedback--  
 
-These three words form a yes/no question asking for confirmation. The first word is a verb, the second is a pronoun, and the third is an adjective.  
+This forms a `yes`/`no` question asking for confirmation. It begins with a verb followed by a pronoun and then an adjective.  
 
 ---
 
@@ -54,7 +54,7 @@ These three words form a yes/no question asking for confirmation. The first word
 
 ### --feedback--  
 
-These three words indicate a time of day. The first is a preposition, the second is an article, and the third is a noun.  
+This indicates a time of day. It begins with a preposition followed by a definite article and then a noun.  
 
 ---
 
@@ -62,7 +62,7 @@ These three words indicate a time of day. The first is a preposition, the second
 
 ### --feedback--  
 
-This verb means to sign up for or participate in a class or lesson.  
+This means "to sign up for or participate in a class or lesson".  
 
 ---
 
@@ -70,7 +70,7 @@ This verb means to sign up for or participate in a class or lesson.
 
 ### --feedback--  
 
-These two words together mean to search or seek something. The first word is a verb, and the second is a preposition.  
+This means "to search or seek something". It begins with a verb followed by a preposition.  
 
 ---
 
@@ -78,7 +78,7 @@ These two words together mean to search or seek something. The first word is a v
 
 ### --feedback--  
 
-These two words describe spending time casually with friends. The first word is a verb, and the second is a preposition.  
+This describes spending time casually with friends. It begins with a verb followed by a preposition.  
 
 ---
 
@@ -86,7 +86,7 @@ These two words describe spending time casually with friends. The first word is 
 
 ### --feedback--  
 
-These two words mean to maintain the same pace or level as someone or something else. The first word is a verb, and the second is a preposition.  
+This means "to maintain the same pace or level as someone or something else". It begins with a verb followed by a preposition.  
 
 ---
 
@@ -94,4 +94,4 @@ These two words mean to maintain the same pace or level as someone or something 
 
 ### --feedback--  
 
-This word is a reflexive pronoun referring back to the speaker.  
+This is a reflexive pronoun referring back to the speaker. 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/67ca0719cf479630dbb12495.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/67ca0719cf479630dbb12495.md
@@ -1,0 +1,97 @@
+---
+id: 67ca0719cf479630dbb12495
+title: Task 92
+challengeType: 22
+dashedName: task-92
+---
+<!-- REVIEW -->
+
+# --description--
+
+This is a review of the entire dialogue you just studied.
+
+# --instructions--
+
+Place the following phrases in the correct spot:  
+
+`yourself`, `keep up`, `is it true`, `look for`, `in the evening`, `take`, and `hang out`.  
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`Brian: Hey Maria, BLANK that you're never home in the evenings? How do you do that?`  
+
+`Maria: Hi Brian. Well, yeah! I like doing fun things BLANK, so I go out a lot. On Mondays, I have dance classes from 6 to 7:30 PM. I love dancing.`  
+
+`Brian: Oh, great! What about Tuesdays?`  
+
+`Maria: On Tuesdays, I learn Japanese. I BLANK online lessons at 7 PM. I think it's the only day I am home so early. Then, on Wednesdays, I go to a local theater group. Practice goes until 9 PM. We perform small plays. It's really fun.`  
+
+`Brian: That's exciting! How about Thursdays?`  
+
+`Maria: Thursdays are for watching shows. I BLANK live concerts or theater plays. It's my favorite time to relax.`  
+
+`Brian: Wow! Do you rest at home on Fridays at least?`  
+
+`Maria: Not at all. I leave the weekends for that. On Fridays, I like to BLANK with friends. We normally meet at a bar, chat and have something to eat and drink. But I'm not really a night owl, so I like to be back home by 9:30 PM tops.`  
+
+`Brian: So many activities! I don't think I could BLANK that pace. But it's nice to know you enjoy it to the fullest, Maria. I think I'll try to go out more often in the evening as well.`  
+
+`Maria: Sure, Brian! Just don't forget to give BLANK time to rest. Find what your interests are and have some fun!`  
+
+## --blanks--
+
+`is it true`  
+
+### --feedback--  
+
+These three words form a yes/no question asking for confirmation. The first word is a verb, the second is a pronoun, and the third is an adjective.  
+
+---  
+
+`in the evening`  
+
+### --feedback--  
+
+These three words indicate a time of day. The first is a preposition, the second is an article, and the third is a noun.  
+
+---  
+
+`take`  
+
+### --feedback--  
+
+This verb means to sign up for or participate in a class or lesson.  
+
+---  
+
+`look for`  
+
+### --feedback--  
+
+These two words together mean to search or seek something. The first word is a verb, and the second is a preposition.  
+
+---  
+
+`hang out`  
+
+### --feedback--  
+
+These two words describe spending time casually with friends. The first word is a verb, and the second is a preposition.  
+
+---  
+
+`keep up`  
+
+### --feedback--  
+
+These two words mean to maintain the same pace or level as someone or something else. The first word is a verb, and the second is a preposition.  
+
+---  
+
+`yourself`  
+
+### --feedback--  
+
+This word is a reflexive pronoun referring back to the speaker.  

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/67ca0719cf479630dbb12495.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/67ca0719cf479630dbb12495.md
@@ -48,7 +48,7 @@ Place the following phrases in the correct spot:
 
 These three words form a yes/no question asking for confirmation. The first word is a verb, the second is a pronoun, and the third is an adjective.  
 
----  
+---
 
 `in the evening`  
 
@@ -56,7 +56,7 @@ These three words form a yes/no question asking for confirmation. The first word
 
 These three words indicate a time of day. The first is a preposition, the second is an article, and the third is a noun.  
 
----  
+---
 
 `take`  
 
@@ -64,7 +64,7 @@ These three words indicate a time of day. The first is a preposition, the second
 
 This verb means to sign up for or participate in a class or lesson.  
 
----  
+---
 
 `look for`  
 
@@ -72,7 +72,7 @@ This verb means to sign up for or participate in a class or lesson.
 
 These two words together mean to search or seek something. The first word is a verb, and the second is a preposition.  
 
----  
+---
 
 `hang out`  
 
@@ -80,7 +80,7 @@ These two words together mean to search or seek something. The first word is a v
 
 These two words describe spending time casually with friends. The first word is a verb, and the second is a preposition.  
 
----  
+---
 
 `keep up`  
 
@@ -88,7 +88,7 @@ These two words describe spending time casually with friends. The first word is 
 
 These two words mean to maintain the same pace or level as someone or something else. The first word is a verb, and the second is a preposition.  
 
----  
+---
 
 `yourself`  
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related to #https://github.com/freeCodeCamp/freeCodeCamp/issues/55293

The EC team found that "summary tasks" were ineffective and confusing for learners, as noted in the related issue. In the B1 curriculum, we replaced them with "review tasks."

This PR is part of a series to apply the same changes to the A2 curriculum. To keep reviews easier, I'm splitting the updates into multiple PRs. This one covers Blocks 5 and 6.
