### PR TITLE
refactor: use srcdoc instead of frame.write

### DIFF
--- a/client/src/templates/Challenges/utils/frame.ts
+++ b/client/src/templates/Challenges/utils/frame.ts
@@ -22,8 +22,11 @@ interface Hooks {
 
 export interface Context {
   window?: Window &
-    typeof globalThis & { i18nContent?: i18n; __pyodide: unknown };
-  document?: FrameDocument | PythonDocument;
+    typeof globalThis & {
+      i18nContent?: i18n;
+      __pyodide: unknown;
+      document: FrameDocument | PythonDocument;
+    };
   element: HTMLIFrameElement;
   build: string;
   sources: Source;
@@ -197,6 +200,7 @@ const createFrame =
   (document: Document, id: string, title?: string) =>
   (frameContext: Context) => {
     const frame = document.createElement('iframe');
+    frame.srcdoc = createContent(id, frameContext);
     frame.id = id;
     if (typeof title === 'string') {
       frame.title = i18next.t('misc.iframe-preview', { title });
@@ -225,7 +229,6 @@ const mountFrame =
     return {
       ...frameContext,
       element,
-      document: element.contentDocument,
       window: element.contentWindow
     };
   };
@@ -310,7 +313,7 @@ const initTestFrame = (frameReady?: () => void) => (frameContext: Context) => {
       // provide the file name and get the original source
       const getUserInput = (fileName: string) =>
         toString(sources[fileName as keyof typeof sources]);
-      await frameContext.document?.__initTestFrame({
+      await frameContext.window?.document?.__initTestFrame({
         code: sources,
         getUserInput,
         loadEnzyme
@@ -348,11 +351,9 @@ const initMainFrame =
           };
         }
 
-        if (
-          frameContext.document &&
-          '__initPythonFrame' in frameContext.document
-        ) {
-          await frameContext.document?.__initPythonFrame();
+        const document = frameContext.window?.document;
+        if (document && '__initPythonFrame' in document) {
+          await document.__initPythonFrame();
         }
         if (frameReady) frameReady();
       })
@@ -369,15 +370,16 @@ function handleDocumentNotFound(err: string) {
 const initPreviewFrame = () => (frameContext: Context) => frameContext;
 
 const waitForFrame = (frameContext: Context) => {
-  return new Promise((resolve, reject) => {
-    if (!frameContext.document) {
+  return new Promise<void>((resolve, reject) => {
+    const rejectId = setTimeout(() => {
       // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
       reject(DOCUMENT_NOT_FOUND_ERROR);
-    } else if (frameContext.document.readyState === 'loading') {
-      frameContext.document.addEventListener('DOMContentLoaded', resolve);
-    } else {
-      resolve(null);
-    }
+    }, 10000);
+
+    frameContext.window?.addEventListener('load', () => {
+      clearTimeout(rejectId);
+      resolve();
+    });
   });
 };
 
@@ -391,19 +393,6 @@ export const createContent = (
   return (
     doctype + createBeforeAllScript(hooks?.beforeAll) + createHeader(id) + build
   );
-};
-
-const writeContentToFrame = (id: string) => (frameContext: Context) => {
-  const frame = frameContext.document;
-
-  // it's possible, if the preview is rapidly opened and closed, for the frame
-  // to be null at this point.
-  if (frame) {
-    frame.open();
-    frame.write(createContent(id, frameContext));
-    frame.close();
-  }
-  return frameContext;
 };
 
 const restoreScrollPosition = (frameContext: Context) => {
@@ -478,7 +467,6 @@ const createFramer = ({
     updateWindowFunctions ?? noop,
     updateProxyConsole(proxyLogger),
     updateWindowI18next,
-    writeContentToFrame(id),
     restoreScrollPosition,
     init(frameReady, proxyLogger)
   ) as (args: Context) => void;

--- a/client/src/templates/Challenges/utils/frame.ts
+++ b/client/src/templates/Challenges/utils/frame.ts
@@ -376,7 +376,10 @@ const waitForFrame = (frameContext: Context) => {
       reject(DOCUMENT_NOT_FOUND_ERROR);
     }, 10000);
 
-    frameContext.window?.addEventListener('load', () => {
+    // We have to add the listener to the frame, not its contentWindow, because
+    // the the latter does not receive the load event in Safari. It does not
+    // matter which we use for Chrome and Firefox.
+    frameContext.element?.addEventListener('load', () => {
       clearTimeout(rejectId);
       resolve();
     });


### PR DESCRIPTION
`frame.write` has been deprecated for nearly 10 years and all our DOM challenges relied on it. `srcdoc` achieves the same result, namely all script elements are executed, and is not deprecated.

QA note: the tests do not use iframes at all, so the fact they're all passing doesn't mean much.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->
