### PR TITLE
fix(client): order editors like their tabs

### DIFF
--- a/client/src/templates/Challenges/classic/multifile-editor.tsx
+++ b/client/src/templates/Challenges/classic/multifile-editor.tsx
@@ -99,10 +99,11 @@ const MultifileEditor = (props: MultifileEditorProps) => {
 
   const editorKeys = [];
 
+  // The order of the keys should match the order set by sortChallengeFiles
+  if (indexjsx) editorKeys.push('indexjsx');
   if (indexhtml) editorKeys.push('indexhtml');
   if (stylescss) editorKeys.push('stylescss');
   if (scriptjs) editorKeys.push('scriptjs');
-  if (indexjsx) editorKeys.push('indexjsx');
   if (mainpy) editorKeys.push('mainpy');
   if (indexts) editorKeys.push('indexts');
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

I forgot about this when creating https://github.com/freeCodeCamp/freeCodeCamp/pull/59100

Before:
![image](https://github.com/user-attachments/assets/597ba61b-15fc-420d-b1e9-b9da0059c32c)

After:
![image](https://github.com/user-attachments/assets/ca175bf6-4827-4712-81f9-ce8f2076e236)


<!-- Feel free to add any additional description of changes below this line -->
