### PR TITLE
fix(api): use req, not _req when logging

### DIFF
--- a/api/src/plugins/csrf.ts
+++ b/api/src/plugins/csrf.ts
@@ -26,9 +26,9 @@ const csrf: FastifyPluginCallback = (fastify, _options, done) => {
   });
 
   // All routes except signout should add a CSRF token to the response
-  fastify.addHook('onRequest', (_req, reply, done) => {
-    const logger = fastify.log.child({ _req });
-    const isSignout = _req.url === '/signout' || _req.url === '/signout/';
+  fastify.addHook('onRequest', (req, reply, done) => {
+    const logger = fastify.log.child({ req });
+    const isSignout = req.url === '/signout' || req.url === '/signout/';
 
     if (!isSignout) {
       logger.debug('Adding CSRF token to response');


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

I missed this when reviewing https://github.com/freeCodeCamp/freeCodeCamp/pull/59062, the issue is that we have defined a serializer for `{ req }`, but not for `{ _req }`

<!-- Feel free to add any additional description of changes below this line -->
