### PR TITLE
docs(readme): remove devops section

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,10 +257,6 @@ Recent Contributions:
 
 ![Alt](https://repobeats.axiom.co/api/embed/89be0a1a1c8f641c54f9234a7423e7755352c746.svg 'Repobeats analytics image')
 
-### Platform, Build, and Deployment Status
-
-The general platform status for all our applications is available at [`status.freecodecamp.org`](https://status.freecodecamp.org). The build and deployment status for the code is available in [our DevOps Guide](https://contribute.freecodecamp.org/#/devops).
-
 ### License
 
 Copyright © 2025 freeCodeCamp.org


### PR DESCRIPTION
This PR removes the outdated section about devops and platform status.