### PR TITLE
fix(curriculum): update test to allow flexible spacing in error message assertion

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641daae5e18eae4b562633e4.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641daae5e18eae4b562633e4.md
@@ -35,7 +35,7 @@ assert.match(code, /(`|"|')\s*<p\s+class\s*=\s*("|')error-msg\2>/)
 Your `p` element should have the text `"There was an error loading the authors"`.
 
 ```js
-assert.match(code, /(`|"|')<p\s+class\s*=\s*("|')error-msg\2>There\s+was\s+an\s+error\s+loading\s+the\s+authors<\/p>\s*\1\s*;?/)
+assert.match(code, /(`|"|')<p\s+class\s*=\s*("|')error-msg\2>\s*There\s+was\s+an\s+error\s+loading\s+the\s+authors\s*<\/p>\s*\1\s*;?/)
 ```
 
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-fcc-authors-page/641daae5e18eae4b562633e4.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-fcc-authors-page/641daae5e18eae4b562633e4.md
@@ -35,7 +35,7 @@ assert.match(code, /(`|"|')\s*<p\s+class\s*=\s*("|')error-msg\2>/)
 Your `p` element should have the text `"There was an error loading the authors"`.
 
 ```js
-assert.match(code, /(`|"|')<p\s+class\s*=\s*("|')error-msg\2>There\s+was\s+an\s+error\s+loading\s+the\s+authors<\/p>\s*\1\s*;?/)
+assert.match(code, /(`|"|')<p\s+class\s*=\s*("|')error-msg\2>\s*There\s+was\s+an\s+error\s+loading\s+the\s+authors\s*<\/p>\s*\1\s*;?/)
 ```
 
 


### PR DESCRIPTION

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #59224 

<!-- Feel free to add any additional description of changes below this line -->

Changes Made:
Updated the test for the error message inside the <p> element to allow flexible spacing.
Modified the regex to accept extra spaces before and after the text while ensuring the correct message is still present.

Reason for Change:
The original test failed when there were spaces inside the <p> tags, even though the output was correct.
