### PR TITLE
feat(api): set log level for csrf errors

### DIFF
--- a/api/src/plugins/csrf.ts
+++ b/api/src/plugins/csrf.ts
@@ -22,7 +22,8 @@ const csrf: FastifyPluginCallback = (fastify, _options, done) => {
     ///Ignore all other possible sources of CSRF
     // tokens since we know we can provide this one
     getToken: req => req.headers[CSRF_HEADER] as string,
-    cookieOpts: { signed: false, sameSite: 'strict' }
+    cookieOpts: { signed: false, sameSite: 'strict' },
+    logLevel: 'debug'
   });
 
   // All routes except signout should add a CSRF token to the response

--- a/package.json
+++ b/package.json
@@ -140,7 +140,8 @@
   "packageManager": "pnpm@9.10.0+sha512.73a29afa36a0d092ece5271de5177ecbf8318d454ecd701343131b8ebc0c1a91c487da46ab77c8e596d6acf1461e3594ced4becedf8921b074fbd8653ed7051c",
   "pnpm": {
     "patchedDependencies": {
-      "@fastify/oauth2@7.8.1": "patches/@fastify__oauth2@7.8.1.patch"
+      "@fastify/oauth2@7.8.1": "patches/@fastify__oauth2@7.8.1.patch",
+      "@fastify/csrf-protection@6.4.1": "patches/@fastify__csrf-protection@6.4.1.patch"
     },
     "peerDependencyRules": {
       "allowedVersions": {

--- a/patches/@fastify__csrf-protection@6.4.1.patch
+++ b/patches/@fastify__csrf-protection@6.4.1.patch
@@ -1,0 +1,46 @@
+diff --git a/index.js b/index.js
+index a183decaf9ec2403a483c7b80cee3c41122c3c25..e5f6b046e43879b31d2b149d7e0cebf941e1c09e 100644
+--- a/index.js
++++ b/index.js
+@@ -14,7 +14,8 @@ const defaultOptions = {
+   sessionKey: '_csrf',
+   getToken: getTokenDefault,
+   getUserInfo: getUserInfoDefault,
+-  sessionPlugin: '@fastify/cookie'
++  sessionPlugin: '@fastify/cookie',
++  logLevel: 'warn'
+ }
+ 
+ async function fastifyCsrfProtection (fastify, opts) {
+@@ -24,7 +25,8 @@ async function fastifyCsrfProtection (fastify, opts) {
+     sessionKey,
+     getToken,
+     getUserInfo,
+-    sessionPlugin
++    sessionPlugin,
++    logLevel
+   } = Object.assign({}, defaultOptions, opts)
+ 
+   const csrfOpts = opts && opts.csrfOpts ? opts.csrfOpts : {}
+@@ -34,6 +36,7 @@ async function fastifyCsrfProtection (fastify, opts) {
+   assert(typeof getToken === 'function', 'getToken should be a function')
+   assert(typeof getUserInfo === 'function', 'getUserInfo should be a function')
+   assert(typeof cookieOpts === 'object', 'cookieOpts should be a object')
++  assert(typeof logLevel === 'string', 'logLevel should be a string')
+   assert(
+     ['@fastify/cookie', '@fastify/session', '@fastify/secure-session'].includes(sessionPlugin),
+     "sessionPlugin should be one of the following: '@fastify/cookie', '@fastify/session', '@fastify/secure-session'"
+@@ -113,11 +116,11 @@ async function fastifyCsrfProtection (fastify, opts) {
+   function csrfProtection (req, reply, next) {
+     const secret = getSecret(req, reply)
+     if (!secret) {
+-      req.log.warn('Missing csrf secret')
++      req.log[logLevel]('Missing csrf secret')
+       return reply.send(new MissingCSRFSecretError())
+     }
+     if (!tokens.verify(secret, getToken(req), getUserInfo(req))) {
+-      req.log.warn('Invalid csrf token')
++      req.log[logLevel]('Invalid csrf token')
+       return reply.send(new InvalidCSRFTokenError())
+     }
+     next()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
+  '@fastify/csrf-protection@6.4.1':
+    hash: elxrdbqdtcfdnqaccvz7u6zxb4
+    path: patches/@fastify__csrf-protection@6.4.1.patch
   '@fastify/oauth2@7.8.1':
     hash: fjqma2r6xxjavghcsvyjlkhmyy
     path: patches/@fastify__oauth2@7.8.1.patch
@@ -166,7 +169,7 @@ importers:
         version: 9.4.0
       '@fastify/csrf-protection':
         specifier: 6.4.1
-        version: 6.4.1
+        version: 6.4.1(patch_hash=elxrdbqdtcfdnqaccvz7u6zxb4)
       '@fastify/multipart':
         specifier: ^8.3.0
         version: 8.3.1
@@ -17230,7 +17233,7 @@ snapshots:
       cookie-signature: 1.2.1
       fastify-plugin: 4.5.1
 
-  '@fastify/csrf-protection@6.4.1':
+  '@fastify/csrf-protection@6.4.1(patch_hash=elxrdbqdtcfdnqaccvz7u6zxb4)':
     dependencies:
       '@fastify/csrf': 6.2.0
       '@fastify/error': 3.4.1


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

I created tests for the plugin PR https://github.com/fastify/csrf-protection/pull/186, so I didn't duplicate them here. I did check that the log level is now debug, though.

<!-- Feel free to add any additional description of changes below this line -->
