### PR TITLE
fix(curriculum): minor improvements to JS Fundamentals review

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/review-form-validation-with-javascript/6723ce555ff2dfc0cc04b69a.md
+++ b/curriculum/challenges/english/25-front-end-development/review-form-validation-with-javascript/6723ce555ff2dfc0cc04b69a.md
@@ -53,7 +53,7 @@ input.addEventListener("input", (e) => {
 - **Definition**: Every event that triggers in the DOM has some sort of default behavior. The click event on a checkbox toggles the state of that checkbox, by default. Pressing the space bar on a focused button activates the button. The `preventDefault()` method on these `Event` objects stops that behavior from happening.
 
 ```js
-button.addEventListener('click',(event) => {
+button.addEventListener('click', (event) => {
   // Prevent the default button click behavior  
   event.preventDefault(); 
   alert('Button click prevented!');

--- a/curriculum/challenges/english/25-front-end-development/review-javascript-fundamentals/6723ca166fe90eb0a3146848.md
+++ b/curriculum/challenges/english/25-front-end-development/review-javascript-fundamentals/6723ca166fe90eb0a3146848.md
@@ -138,7 +138,7 @@ console.log(myNum) // 10
 
 ```js
 if (true) {
-    var num = 5;
+  var num = 5;
 }
 console.log(num); // 5
 ```
@@ -170,22 +170,40 @@ let num = 10;
 
 ## Working with Imports, Exports and Modules
 
-- **Module**: This is a self-contained unit of code that encapsulates related functions, classes, or variables.
-- **Imports and Exports**: It is common practice to have separate files for reusable pieces of code like helper functions or arrays that you wish to use across many files. To do this, you would need to export that code and import it in the file you wish to use it in.
+- **Module**: This is a self-contained unit of code that encapsulates related functions, classes, or variables. To create a module, you write your JavaScript code in a separate file.
+- **Exports**: Any variables, functions, or classes you want to make available to other parts of your application need to be explicitly exported using the `export` keyword. There are two types of export: named export and default export.
+- **Imports**: To use the exported items in another part of your application, you need to import them using the `import` keyword. The types can be named import, default import, and namespace import.
 
 ```js
-// This function is located in a file called math.js
+// Within a file called math.js, we export the following functions:
+
+// Named export
 export function add(num1, num2) {
-    return num1 + num2;
+  return num1 + num2;
 }
 
-// We can import the add function from the math.js file
+// Default export
+export default function subtract(num1, num2) {
+  return num1 - num2;
+}
+
+// Within another file, we can import the functions from math.js.
+
+// Named import - This line imports the add function.
+// The name of the function must exactly match the one exported from math.js.
 import { add } from './math.js';
 
-// This line imports everything from the file
-// import * as Math from './math.js';
+// Default import - This line imports the subtract function.
+// The name of the function can be anything.
+import subtractFunc from './math.js';
+
+// Namespace import - This line imports everything from the file.
+import * as Math from './math.js';
 
 console.log(add(5, 3)); // 8
+console.log(subtractFunc(5, 3)); // 2
+console.log(Math.add(5, 3)); // 8
+console.log(Math.subtract(5, 3)); // 2
 ```
 
 # --assignment--

--- a/curriculum/challenges/english/25-front-end-development/review-javascript-variables-and-data-types/6723be264695fb7e619fe1fa.md
+++ b/curriculum/challenges/english/25-front-end-development/review-javascript-variables-and-data-types/6723be264695fb7e619fe1fa.md
@@ -20,7 +20,7 @@ Data types help the program understand the kind of data it's working with, wheth
 - **Number**: A number represents both integers and floating-point values. Examples of integers include 7, 19, and 90. 
 - **Floating point**: A floating point number is a number with a decimal point. Examples include 3.14, 0.5, and 0.0001.
 - **String**: A string is a sequence of characters, or text, enclosed in quotes. `"I like coding"` and `'JavaScript is fun'` are examples of strings.
-- **Boolean**: A boolean represents one of two possible values: `true` or `false`. You can use a boolean to represent a condition, such as `isLoggedin = true`.
+- **Boolean**: A boolean represents one of two possible values: `true` or `false`. You can use a boolean to represent a condition, such as `isLoggedIn = true`.
 - **Undefined and Null**: An `undefined` value is a variable that has been declared but not assigned a value. A `null` value is an empty value, or a variable that has intentionally been assigned a value of `null`.
 - **Object**: An object is a collection of key-value pairs. The key is the property name, and the value is the property value.
 
@@ -85,7 +85,7 @@ cityName = "Los Angeles"; // TypeError: Assignment to constant variable.
 ## Variable Naming Conventions
 
 - Variable names should be descriptive and meaningful.
-- Variable names should be camelCase like `cityName`, `isLoggedin`, and `veryBigNumber`.
+- Variable names should be camelCase like `cityName`, `isLoggedIn`, and `veryBigNumber`.
 - Variable names should not start with a number. They must begin with a letter, `_`, or `$`.
 - Variable names should not contain spaces or special characters, except for `_` and `$`.
 - Variable names should not be reserved keywords.
@@ -197,8 +197,8 @@ error = "Not Found"; // This would cause an error in Java
 let age = 25;
 console.log(typeof age); // "number"
 
-let isLoggedin = true;
-console.log(typeof isLoggedin); // "boolean"
+let isLoggedIn = true;
+console.log(typeof isLoggedIn); // "boolean"
 ```
 
 - However, there's a well-known quirk in JavaScript when it comes to `null`. The `typeof` operator returns `"object"` for `null` values.

--- a/curriculum/challenges/english/25-front-end-development/review-javascript/6723d3cfdd0717d3f1bf27e3.md
+++ b/curriculum/challenges/english/25-front-end-development/review-javascript/6723d3cfdd0717d3f1bf27e3.md
@@ -21,7 +21,7 @@ Data types help the program understand the kind of data it's working with, wheth
 - **Number**: A number represents both integers and floating-point values. Examples of integers include 7, 19, and 90. 
 - **Floating point**: A floating point number is a number with a decimal point. Examples include 3.14, 0.5, and 0.0001.
 - **String**: A string is a sequence of characters, or text, enclosed in quotes. `"I like coding"` and `'JavaScript is fun'` are examples of strings.
-- **Boolean**: A boolean represents one of two possible values: `true` or `false`. You can use a boolean to represent a condition, such as `isLoggedin = true`.
+- **Boolean**: A boolean represents one of two possible values: `true` or `false`. You can use a boolean to represent a condition, such as `isLoggedIn = true`.
 - **Undefined and Null**: An undefined value is a variable that has been declared but not assigned a value. A null value is an empty value or a variable that has intentionally been assigned a value of `null`.
 - **Object**: An object is a collection of key-value pairs. The key is the property name, and the value is the property value.
 
@@ -86,7 +86,7 @@ cityName = 'Los Angeles'; // TypeError: Assignment to constant variable.
 ## Variable Naming Conventions
 
 - Variable names should be descriptive and meaningful.
-- Variable names should be camelCase like `cityName`, `isLoggedin`, and `veryBigNumber`.
+- Variable names should be camelCase like `cityName`, `isLoggedIn`, and `veryBigNumber`.
 - Variable names should not start with a number. They must begin with a letter, `_`, or `$`.
 - Variable names should not contain spaces or special characters, except for `_` and `$`.
 - Variable names should not be reserved keywords.
@@ -198,8 +198,8 @@ error = "Not Found"; // This would cause an error in Java
 let age = 25;
 console.log(typeof age); // number
 
-let isLoggedin = true;
-console.log(typeof isLoggedin); // boolean
+let isLoggedIn = true;
+console.log(typeof isLoggedIn); // boolean
 ```
 
 - However, there's a well-known quirk in JavaScript when it comes to null. The `typeof` operator returns `object` for null values.
@@ -1201,7 +1201,7 @@ console.log(myNum) // 10
 
 ```js
 if (true) {
-    var num = 5;
+  var num = 5;
 }
 console.log(num); // 5
 ```
@@ -1233,24 +1233,41 @@ let num = 10;
 
 ## Working with Imports, Exports and Modules
 
-- **Module**: This is a self-contained unit of code that encapsulates related functions, classes, or variables.
-- **Imports and Exports**: It is common practice to have separate files for reusable pieces of code like helper functions or arrays that you wish to use across many files. To do this, you would need ot export that code and import it in the file you wish to use it in. 
+- **Module**: This is a self-contained unit of code that encapsulates related functions, classes, or variables. To create a module, you write your JavaScript code in a separate file.
+- **Exports**: Any variables, functions, or classes you want to make available to other parts of your application need to be explicitly exported using the `export` keyword. There are two types of export: named export and default export.
+- **Imports**: To use the exported items in another part of your application, you need to import them using the `import` keyword. The types can be named import, default import, and namespace import.
 
 ```js
-// This function is located in a file called math.js
+// Within a file called math.js, we export the following functions:
+
+// Named export
 export function add(num1, num2) {
-    return num1 + num2;
+  return num1 + num2;
 }
 
-// We can import the add function from the math.js file
+// Default export
+export default function subtract(num1, num2) {
+  return num1 - num2;
+}
+
+// Within another file, we can import the functions from math.js.
+
+// Named import - This line imports the add function.
+// The name of the function must exactly match the one exported from math.js.
 import { add } from './math.js';
 
-// This line imports everything from the file
-// import * as Math from './math.js';
+// Default import - This line imports the subtract function.
+// The name of the function can be anything.
+import subtractFunc from './math.js';
+
+// Namespace import - This line imports everything from the file.
+import * as Math from './math.js';
 
 console.log(add(5, 3)); // 8
+console.log(subtractFunc(5, 3)); // 2
+console.log(Math.add(5, 3)); // 8
+console.log(Math.subtract(5, 3)); // 2
 ```
-
 
 ## Callback Functions and the `forEach` Method
 
@@ -2088,7 +2105,7 @@ input.addEventListener("input", (e) => {
 - **Definition**: Every event that triggers in the DOM has some sort of default behavior. The click event on a checkbox toggles the state of that checkbox, by default. Pressing the space bar on a focused button activates the button. The `preventDefault()` method on these `Event` objects stops that behavior from happening.
 
 ```js
-button.addEventListener('click',(event) => {
+button.addEventListener('click', (event) => {
   // Prevent the default button click behavior  
   event.preventDefault(); 
   alert('Button click prevented!');


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

When I was reviewing #59189, I noticed that the JS Fundamentals review page:
- Isn't mentioning the term "named export" explicitly (there is an example, but we aren't using the term) while we use this term in a later challenge (https://www.freecodecamp.org/learn/full-stack-developer/workshop-reusable-mega-navbar/step-1)
- Is missing an example of default export and import
- Is missing an example how namespace import is used

This PR address those issues, along with some minor typo/formatting fixes.

<!-- Feel free to add any additional description of changes below this line -->
