### PR TITLE
fix(curriculum): change input type from text to number for numeric values

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/review-form-validation-with-javascript/6723ce555ff2dfc0cc04b69a.md
+++ b/curriculum/challenges/english/25-front-end-development/review-form-validation-with-javascript/6723ce555ff2dfc0cc04b69a.md
@@ -68,7 +68,7 @@ button.addEventListener('click',(event) => {
 ```js
 <form action="https://freecodecamp.org">
   <input
-    type="text"
+    type="number"
     id="input"
     placeholder="Enter a number"
     name="number"
@@ -82,7 +82,7 @@ button.addEventListener('click',(event) => {
 ```js
 <form action="/data" method="POST">
   <input
-    type="text"
+    type="number"
     id="input"
     placeholder="Enter a number"
     name="number"

--- a/curriculum/challenges/english/25-front-end-development/review-javascript/6723d3cfdd0717d3f1bf27e3.md
+++ b/curriculum/challenges/english/25-front-end-development/review-javascript/6723d3cfdd0717d3f1bf27e3.md
@@ -2103,7 +2103,7 @@ button.addEventListener('click',(event) => {
 ```js
 <form action="https://freecodecamp.org">
   <input
-    type="text"
+    type="number"
     id="input"
     placeholder="Enter a number"
     name="number"
@@ -2117,7 +2117,7 @@ button.addEventListener('click',(event) => {
 ```js
 <form action="/data" method="POST">
   <input
-    type="text"
+    type="number"
     id="input"
     placeholder="Enter a number"
     name="number"


### PR DESCRIPTION


Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #59247 

<!-- Feel free to add any additional description of changes below this line -->

Changes Made:
Updated input fields that accept numeric values from type="text" to type="number".

Changes applied in the following files and lines:
review-form-validation-with-javascript/6723ce555ff2dfc0cc04b69a.md (Lines 71, 85)
review-javascript/6723d3cfdd0717d3f1bf27e3.md (Lines 2106, 2120)

Reason for Change:
The original inputs were incorrectly set to type="text", even though they expect numeric values. 