### PR TITLE
feat: simplify superblock layouts

### DIFF
--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -16,7 +16,7 @@ import { Link } from '../../../components/helpers';
 import { completedChallengesSelector } from '../../../redux/selectors';
 import { playTone } from '../../../utils/tone';
 import { makeExpandedBlockSelector, toggleBlock } from '../redux';
-import { isGridBased, isProjectBased } from '../../../utils/curriculum-layout';
+import { isProjectBased } from '../../../utils/curriculum-layout';
 import { BlockLayouts, BlockTypes } from '../../../../../shared/config/blocks';
 import CheckMark from './check-mark';
 import Challenges from './challenges';
@@ -113,10 +113,6 @@ class Block extends Component<BlockProps> {
 
     const isProjectBlock = challenges.some(challenge => {
       return isProjectBased(challenge.challengeType, block);
-    });
-
-    const isGridSuperBlock = challenges.some(challenge => {
-      return isGridBased(superBlock, challenge.challengeType);
     });
 
     const isAudited = isAuditedSuperBlock(curriculumLocale, superBlock);
@@ -410,10 +406,9 @@ class Block extends Component<BlockProps> {
       !isEmptyBlock && (
         <>
           {layoutToComponent[blockLayout]}
-          {(!isGridSuperBlock || isProjectBlock) &&
-            superBlock !== SuperBlocks.FullStackDeveloper && (
-              <Spacer size='m' />
-            )}
+          {superBlock !== SuperBlocks.FullStackDeveloper && (
+            <Spacer size='xs' />
+          )}
         </>
       )
     );

--- a/client/src/utils/curriculum-layout.ts
+++ b/client/src/utils/curriculum-layout.ts
@@ -1,26 +1,4 @@
 import { challengeTypes } from '../../../shared/config/challenge-types';
-import { SuperBlocks } from '../../../shared/config/curriculum';
-
-// Show a grid layout on the superblock level
-
-const gridBasedSuperBlocks = [
-  SuperBlocks.RespWebDesignNew,
-  SuperBlocks.JsAlgoDataStructNew,
-  SuperBlocks.SciCompPy,
-  SuperBlocks.A2English
-];
-
-export const isGridBased = (
-  superBlock: SuperBlocks,
-  challengeType: unknown = null
-) => {
-  // Python projects should not be displayed as a grid, but should be displayed
-  // as a list of projects. Otherwise, if we do not do this the project will be
-  // shown as a single certification project.
-
-  if (challengeType === challengeTypes.pythonProject) return false;
-  return gridBasedSuperBlocks.includes(superBlock);
-};
 
 // Show a single project in a certification layout
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Nielda noticed that the B2 and A1 English superblocks were laid out differently. While debugging that, we realised that we could simplify things a bit and still have the layouts look decent.

Before:
![image](https://github.com/user-attachments/assets/4b546530-f07e-4519-a6cf-9130df7d20af)

After: 

![image](https://github.com/user-attachments/assets/d3937248-b311-47b2-9293-0b8b1b96aa1a)

A2/B1 English after:

![image](https://github.com/user-attachments/assets/9e60ab3f-e445-4b52-bc0d-fb098a3eb3ca)


<!-- Feel free to add any additional description of changes below this line -->
