### PR TITLE
chore(client): remove profile settings callout

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -232,7 +232,6 @@
     ]
   },
   "settings": {
-    "profile-note": "Note: the profile settings have been moved to the profile page.",
     "share-projects": "Share your non-freeCodeCamp projects, articles or accepted pull requests.",
     "privacy": "The settings in this section enable you to control what is shown on your freeCodeCamp public portfolio. Press save to save your changes.",
     "data": "To see what data we hold on your account, click the \"Download your data\" button below",

--- a/client/src/client-only-routes/show-settings.tsx
+++ b/client/src/client-only-routes/show-settings.tsx
@@ -4,13 +4,13 @@ import { useTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 
-import { Callout, Container, Spacer } from '@freecodecamp/ui';
+import { Container, Spacer } from '@freecodecamp/ui';
 import { useFeatureIsOn } from '@growthbook/growthbook-react';
 
 import store from 'store';
 import envData from '../../config/env.json';
 import { createFlashMessage } from '../components/Flash/redux';
-import { FullWidthRow, Loader } from '../components/helpers';
+import { Loader } from '../components/helpers';
 import Certification from '../components/settings/certification';
 import MiscSettings from '../components/settings/misc-settings';
 import DangerZone from '../components/settings/danger-zone';
@@ -146,9 +146,6 @@ export function ShowSettings(props: ShowSettingsProps): JSX.Element {
       <Container>
         <main>
           <Spacer size='l' />
-          <FullWidthRow>
-            <Callout variant='info'>{t('settings.profile-note')}</Callout>
-          </FullWidthRow>
           <h1
             id='content-start'
             className='text-center'


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR removes the following banner from /settings:

<details>
  <summary>Banner</summary>

<img width="783" alt="Screenshot 2025-03-13 at 14 02 08" src="https://github.com/user-attachments/assets/ec72f55a-ffe2-4112-bc52-ab48d621a22f" />

</details>

It's been a while since we moved profile settings to the profile page (#56135), so I think this banner is no longer needed.

<!-- Feel free to add any additional description of changes below this line -->
