### PR TITLE
fix: align search query with forum post title (#59274)

### DIFF
--- a/client/src/templates/Challenges/components/help-modal.tsx
+++ b/client/src/templates/Challenges/components/help-modal.tsx
@@ -33,15 +33,15 @@ const mapDispatchToProps = (dispatch: Dispatch) =>
     dispatch
   );
 
-export const generateSearchLink = (title: string, block: string) => {
-  const blockWithoutHyphens = block.replace(/-/g, ' ');
-
-  const query = /^(step|task)\s*\d*$/i.test(title)
-    ? encodeURIComponent(`${blockWithoutHyphens} - ${title}`)
-    : encodeURIComponent(title);
-  const search = `${forumLocation}/search?q=${query}`;
-  return search;
-};
+  export const generateSearchLink = (title: string, block: string) => {
+   
+    const blockTitle = block.replace(/-/g, ' ');
+  
+    const query = /^(step|task)\s*\d*$/i.test(title)
+      ? encodeURIComponent(`${blockTitle} - ${title}`)
+      : encodeURIComponent(title);
+    return `${forumLocation}/search?q=${query}`;
+  };
 
 interface CheckboxProps {
   name: string;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or Gitpod.
  I couldn’t test the changes locally due to environment constraints. Please let me know if testing is required, and I’ll work on it.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #59274

<!-- Feel free to add any additional description of changes below this line -->

This PR fixes issue #59274 by aligning the search query text with the forum post title. The `generateSearchLink` function now uses the same text as the forum post title.