### PR TITLE
fix: typo in the submit event in forms video

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lecture-understanding-form-validation/6733d3ab69e94b7df7ee91b0.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-understanding-form-validation/6733d3ab69e94b7df7ee91b0.md
@@ -2,7 +2,7 @@
 id: 6733d3ab69e94b7df7ee91b0
 title: How Does the Submit Event Work with Forms?
 challengeType: 11
-videoId: EWGb5yFyQs4
+videoId: ht7Eg6GX6tE
 dashedName: how-does-the-submit-event-work-with-forms
 ---
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #58857

Related to #58856

<!-- Feel free to add any additional description of changes below this line -->
This PR swaps out the video id for this lecture for a new one with the fixed typo.