### PR TITLE
fix(a11y): separate disclosure content from toggle button

### DIFF
--- a/client/src/templates/Introduction/components/block-header.tsx
+++ b/client/src/templates/Introduction/components/block-header.tsx
@@ -34,35 +34,37 @@ function BlockHeader({
   blockIntroArr
 }: BlockHeaderProps): JSX.Element {
   return (
-    <h3 className='block-grid-title'>
-      <button
-        aria-expanded={isExpanded ? 'true' : 'false'}
-        aria-controls={`${blockDashed}-panel`}
-        className='block-header'
-        onClick={handleClick}
-      >
-        <span className='block-header-button-text map-title'>
-          <CheckMark isCompleted={isCompleted} />
-          {blockType && <BlockLabel blockType={blockType} />}
-          <span>
-            {blockTitle}
-            <span className='sr-only'>, {courseCompletionStatus}</span>
+    <>
+      <h3 className='block-grid-title'>
+        <button
+          aria-expanded={isExpanded ? 'true' : 'false'}
+          aria-controls={`${blockDashed}-panel`}
+          className='block-header'
+          onClick={handleClick}
+        >
+          <span className='block-header-button-text map-title'>
+            <CheckMark isCompleted={isCompleted} />
+            {blockType && <BlockLabel blockType={blockType} />}
+            <span>
+              {blockTitle}
+              <span className='sr-only'>, {courseCompletionStatus}</span>
+            </span>
+            <DropDown />
           </span>
-          <DropDown />
-        </span>
-        {isExpanded && !isEmpty(blockIntroArr) && (
-          <BlockIntros intros={blockIntroArr as string[]} />
-        )}
-        {!isExpanded && !isCompleted && completedCount > 0 && (
-          <div aria-hidden='true' className='progress-wrapper'>
-            <div>
-              <ProgressBar now={percentageCompleted} />
+          {!isExpanded && !isCompleted && completedCount > 0 && (
+            <div aria-hidden='true' className='progress-wrapper'>
+              <div>
+                <ProgressBar now={percentageCompleted} />
+              </div>
+              <span>{`${percentageCompleted}%`}</span>
             </div>
-            <span>{`${percentageCompleted}%`}</span>
-          </div>
-        )}
-      </button>
-    </h3>
+          )}
+        </button>
+      </h3>
+      {isExpanded && !isEmpty(blockIntroArr) && (
+        <BlockIntros intros={blockIntroArr as string[]} />
+      )}
+    </>
   );
 }
 

--- a/client/src/templates/Introduction/intro.css
+++ b/client/src/templates/Introduction/intro.css
@@ -337,6 +337,10 @@ button.map-title {
   margin-bottom: 0;
 }
 
+.block-grid .block-description {
+  padding: 18px 15px;
+}
+
 a.map-grid-item.challenge-completed {
   background: var(--highlight-background);
   position: relative;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

The block intro text for these h3 toggle buttons is being included inside the button. This is causing screen readers to announce the entire button again (including the intro text) when the button is expanded, which is not the expected behavior. Instead, the button content should remain the same and only the aria-expanded attribute should change, which will cause the screen reader to just announce "expanded". Screen reader users can then navigate to the intro content below the button as usual.

This PR moves the block intro text out of the button to immediately after the h3. From what I can tell, this change does not affect the styling at all. Everything looks exactly the same. Only the underlying structure has changed.