### PR TITLE
fix: replace unpkg w/ jsdelivr & cdnjs

### DIFF
--- a/client/src/templates/Challenges/utils/build.ts
+++ b/client/src/templates/Challenges/utils/build.ts
@@ -231,7 +231,7 @@ export async function buildDOMChallenge(
   const isMultifile = challengeFiles.length > 1;
 
   const requiresReact16 = required.some(({ src }) =>
-    src?.includes('https://unpkg.com/react@16')
+    src?.includes('https://cdn.jsdelivr.net/npm/react@16')
   );
 
   // I'm reasonably sure this is fine, but we need to migrate transformers to

--- a/client/src/templates/Challenges/utils/build.ts
+++ b/client/src/templates/Challenges/utils/build.ts
@@ -231,7 +231,7 @@ export async function buildDOMChallenge(
   const isMultifile = challengeFiles.length > 1;
 
   const requiresReact16 = required.some(({ src }) =>
-    src?.includes('https://cdn.jsdelivr.net/npm/react@16')
+    src?.includes('https://cdnjs.cloudflare.com/ajax/libs/react/16.')
   );
 
   // I'm reasonably sure this is fine, but we need to migrate transformers to

--- a/curriculum/challenges/_meta/react-and-redux/meta.json
+++ b/curriculum/challenges/_meta/react-and-redux/meta.json
@@ -7,16 +7,16 @@
   "template": "<body><div id='root'></div>${ source || '' }</body>",
   "required": [
     {
-      "src": "https://unpkg.com/react@16.4.0/umd/react.production.min.js"
+      "src": "https://cdn.jsdelivr.net/npm/react@16.4.0/umd/react.production.min.js"
     },
     {
-      "src": "https://unpkg.com/react-dom@16.4.0/umd/react-dom.production.min.js"
+      "src": "https://cdn.jsdelivr.net/npm/react-dom@16.4.0/umd/react-dom.production.min.js"
     },
     {
-      "src": "https://unpkg.com/react-dom@16.4.0/umd/react-dom-test-utils.production.min.js"
+      "src": "https://cdn.jsdelivr.net/npm/react-dom@16.4.0/umd/react-dom-test-utils.production.min.js"
     },
     {
-      "src": "https://unpkg.com/react-dom@16.4.0/umd/react-dom-server.browser.production.min.js"
+      "src": "https://cdn.jsdelivr.net/npm/react-dom@16.4.0/umd/react-dom-server.browser.production.min.js"
     },
     {
       "src": "https://cdnjs.cloudflare.com/ajax/libs/redux/3.7.2/redux.min.js"

--- a/curriculum/challenges/_meta/react-and-redux/meta.json
+++ b/curriculum/challenges/_meta/react-and-redux/meta.json
@@ -7,16 +7,16 @@
   "template": "<body><div id='root'></div>${ source || '' }</body>",
   "required": [
     {
-      "src": "https://cdn.jsdelivr.net/npm/react@16.4.0/umd/react.production.min.js"
+      "src": "https://cdnjs.cloudflare.com/ajax/libs/react/16.4.0/umd/react.production.min.js"
     },
     {
-      "src": "https://cdn.jsdelivr.net/npm/react-dom@16.4.0/umd/react-dom.production.min.js"
+      "src": "https://cdnjs.cloudflare.com/ajax/libs/react-dom/16.4.0/umd/react-dom.production.min.js"
     },
     {
-      "src": "https://cdn.jsdelivr.net/npm/react-dom@16.4.0/umd/react-dom-test-utils.production.min.js"
+      "src": "https://cdnjs.cloudflare.com/ajax/libs/react-dom/16.4.0/umd/react-dom-test-utils.production.min.js"
     },
     {
-      "src": "https://cdn.jsdelivr.net/npm/react-dom@16.4.0/umd/react-dom-server.browser.production.min.js"
+      "src": "https://cdnjs.cloudflare.com/ajax/libs/react-dom/16.4.0/umd/react-dom-server.browser.production.min.js"
     },
     {
       "src": "https://cdnjs.cloudflare.com/ajax/libs/redux/3.7.2/redux.min.js"

--- a/curriculum/challenges/_meta/react/meta.json
+++ b/curriculum/challenges/_meta/react/meta.json
@@ -7,16 +7,16 @@
   "template": "<body><div id='root'></div><div id='challenge-node'></div>${ source || '' }</body>",
   "required": [
     {
-      "src": "https://unpkg.com/react@16.4.0/umd/react.production.min.js"
+      "src": "https://cdn.jsdelivr.net/npm/react@16.4.0/umd/react.production.min.js"
     },
     {
-      "src": "https://unpkg.com/react-dom@16.4.0/umd/react-dom.production.min.js"
+      "src": "https://cdn.jsdelivr.net/npm/react-dom@16.4.0/umd/react-dom.production.min.js"
     },
     {
-      "src": "https://unpkg.com/react-dom@16.4.0/umd/react-dom-test-utils.production.min.js"
+      "src": "https://cdn.jsdelivr.net/npm/react-dom@16.4.0/umd/react-dom-test-utils.production.min.js"
     },
     {
-      "src": "https://unpkg.com/react-dom@16.4.0/umd/react-dom-server.browser.production.min.js"
+      "src": "https://cdn.jsdelivr.net/npm/react-dom@16.4.0/umd/react-dom-server.browser.production.min.js"
     }
   ],
   "superBlock": "front-end-development-libraries",

--- a/curriculum/challenges/_meta/react/meta.json
+++ b/curriculum/challenges/_meta/react/meta.json
@@ -7,16 +7,16 @@
   "template": "<body><div id='root'></div><div id='challenge-node'></div>${ source || '' }</body>",
   "required": [
     {
-      "src": "https://cdn.jsdelivr.net/npm/react@16.4.0/umd/react.production.min.js"
+      "src": "https://cdnjs.cloudflare.com/ajax/libs/react/16.4.0/umd/react.production.min.js"
     },
     {
-      "src": "https://cdn.jsdelivr.net/npm/react-dom@16.4.0/umd/react-dom.production.min.js"
+      "src": "https://cdnjs.cloudflare.com/ajax/libs/react-dom/16.4.0/umd/react-dom.production.min.js"
     },
     {
-      "src": "https://cdn.jsdelivr.net/npm/react-dom@16.4.0/umd/react-dom-test-utils.production.min.js"
+      "src": "https://cdnjs.cloudflare.com/ajax/libs/react-dom/16.4.0/umd/react-dom-test-utils.production.min.js"
     },
     {
-      "src": "https://cdn.jsdelivr.net/npm/react-dom@16.4.0/umd/react-dom-server.browser.production.min.js"
+      "src": "https://cdnjs.cloudflare.com/ajax/libs/react-dom/16.4.0/umd/react-dom-server.browser.production.min.js"
     }
   ],
   "superBlock": "front-end-development-libraries",

--- a/curriculum/challenges/english/25-front-end-development/lab-mood-board/673b3d6b7ef7318eef926d5a.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-mood-board/673b3d6b7ef7318eef926d5a.md
@@ -144,9 +144,9 @@ assert.exists(moodBoard);
   <head>
     <meta charset="UTF-8" />
     <title>Mood Board</title>
-    <script src="https://cdn.jsdelivr.net/npm/react@18/umd/react.development.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.development.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@babel/standalone/babel.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.0/umd/react.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.0/umd/react-dom.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.26.3/babel.min.js"></script>
     <script
       data-plugins="transform-modules-umd"
       type="text/babel"
@@ -231,9 +231,9 @@ body {
   <head>
     <meta charset="UTF-8" />
     <title>Mood Board</title>
-    <script src="https://cdn.jsdelivr.net/npm/react@18/umd/react.development.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.development.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@babel/standalone/babel.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.0/umd/react.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.0/umd/react-dom.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.26.3/babel.min.js"></script>
     <script
       data-plugins="transform-modules-umd"
       type="text/babel"

--- a/curriculum/challenges/english/25-front-end-development/lab-mood-board/673b3d6b7ef7318eef926d5a.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-mood-board/673b3d6b7ef7318eef926d5a.md
@@ -144,9 +144,9 @@ assert.exists(moodBoard);
   <head>
     <meta charset="UTF-8" />
     <title>Mood Board</title>
-    <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
-    <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
-    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/react@18/umd/react.development.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@babel/standalone/babel.min.js"></script>
     <script
       data-plugins="transform-modules-umd"
       type="text/babel"
@@ -231,9 +231,9 @@ body {
   <head>
     <meta charset="UTF-8" />
     <title>Mood Board</title>
-    <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
-    <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
-    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/react@18/umd/react.development.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@babel/standalone/babel.min.js"></script>
     <script
       data-plugins="transform-modules-umd"
       type="text/babel"

--- a/curriculum/challenges/english/25-front-end-development/lab-mood-board/673b3d6b7ef7318eef926d5a.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-mood-board/673b3d6b7ef7318eef926d5a.md
@@ -144,8 +144,8 @@ assert.exists(moodBoard);
   <head>
     <meta charset="UTF-8" />
     <title>Mood Board</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.0/umd/react.development.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.0/umd/react-dom.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.1/umd/react.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.1/umd/react-dom.development.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.26.3/babel.min.js"></script>
     <script
       data-plugins="transform-modules-umd"
@@ -231,8 +231,8 @@ body {
   <head>
     <meta charset="UTF-8" />
     <title>Mood Board</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.0/umd/react.development.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.0/umd/react-dom.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.1/umd/react.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.1/umd/react-dom.development.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.26.3/babel.min.js"></script>
     <script
       data-plugins="transform-modules-umd"

--- a/curriculum/challenges/english/25-front-end-development/lab-reusable-footer/673b02b03134b04637bf7055.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-reusable-footer/673b02b03134b04637bf7055.md
@@ -104,9 +104,9 @@ links.forEach(link => {
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Footer Component</title>
-    <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
-    <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
-    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/react@18/umd/react.development.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@babel/standalone/babel.min.js"></script>
     <script
       data-plugins="transform-modules-umd"
       type="text/babel"
@@ -146,9 +146,9 @@ export const Footer = () => {};
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Footer Component</title>
-    <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
-    <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
-    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/react@18/umd/react.development.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@babel/standalone/babel.min.js"></script>
     <script
       data-plugins="transform-modules-umd"
       type="text/babel"

--- a/curriculum/challenges/english/25-front-end-development/lab-reusable-footer/673b02b03134b04637bf7055.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-reusable-footer/673b02b03134b04637bf7055.md
@@ -104,9 +104,9 @@ links.forEach(link => {
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Footer Component</title>
-    <script src="https://cdn.jsdelivr.net/npm/react@18/umd/react.development.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.development.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@babel/standalone/babel.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.0/umd/react.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.0/umd/react-dom.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.26.3/babel.min.js"></script>
     <script
       data-plugins="transform-modules-umd"
       type="text/babel"
@@ -146,9 +146,9 @@ export const Footer = () => {};
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Footer Component</title>
-    <script src="https://cdn.jsdelivr.net/npm/react@18/umd/react.development.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.development.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@babel/standalone/babel.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.0/umd/react.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.0/umd/react-dom.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.26.3/babel.min.js"></script>
     <script
       data-plugins="transform-modules-umd"
       type="text/babel"

--- a/curriculum/challenges/english/25-front-end-development/lab-reusable-footer/673b02b03134b04637bf7055.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-reusable-footer/673b02b03134b04637bf7055.md
@@ -104,8 +104,8 @@ links.forEach(link => {
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Footer Component</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.0/umd/react.development.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.0/umd/react-dom.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.1/umd/react.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.1/umd/react-dom.development.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.26.3/babel.min.js"></script>
     <script
       data-plugins="transform-modules-umd"
@@ -146,8 +146,8 @@ export const Footer = () => {};
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Footer Component</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.0/umd/react.development.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.0/umd/react-dom.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.1/umd/react.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.1/umd/react-dom.development.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.26.3/babel.min.js"></script>
     <script
       data-plugins="transform-modules-umd"

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6740495ba48aa94e5667b436.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6740495ba48aa94e5667b436.md
@@ -50,10 +50,10 @@ assert.match(code, /export\s+(const|function)\s+Navbar\s*(=\s*)?\(\)\s*(=>\s*)?\
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Navbar</title>
-    <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
-    <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/react@18/umd/react.development.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.development.js"></script>
 
-    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@babel/standalone/babel.min.js"></script>
     <script
       data-plugins="transform-modules-umd"
       type="text/babel"

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6740495ba48aa94e5667b436.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6740495ba48aa94e5667b436.md
@@ -50,10 +50,10 @@ assert.match(code, /export\s+(const|function)\s+Navbar\s*(=\s*)?\(\)\s*(=>\s*)?\
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Navbar</title>
-    <script src="https://cdn.jsdelivr.net/npm/react@18/umd/react.development.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.0/umd/react.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.0/umd/react-dom.development.js"></script>
 
-    <script src="https://cdn.jsdelivr.net/npm/@babel/standalone/babel.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.26.3/babel.min.js"></script>
     <script
       data-plugins="transform-modules-umd"
       type="text/babel"

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6740495ba48aa94e5667b436.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6740495ba48aa94e5667b436.md
@@ -50,8 +50,8 @@ assert.match(code, /export\s+(const|function)\s+Navbar\s*(=\s*)?\(\)\s*(=>\s*)?\
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Navbar</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.0/umd/react.development.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.0/umd/react-dom.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.1/umd/react.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.1/umd/react-dom.development.js"></script>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.26.3/babel.min.js"></script>
     <script

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/67457ff2dc531fbed928a0f0.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/67457ff2dc531fbed928a0f0.md
@@ -52,8 +52,8 @@ assert.equal(document.querySelector('nav')?.getAttribute('class'), 'navbar');
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Navbar</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.0/umd/react.development.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.0/umd/react-dom.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.1/umd/react.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.1/umd/react-dom.development.js"></script>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.26.3/babel.min.js"></script>
     <script

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/67457ff2dc531fbed928a0f0.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/67457ff2dc531fbed928a0f0.md
@@ -52,10 +52,10 @@ assert.equal(document.querySelector('nav')?.getAttribute('class'), 'navbar');
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Navbar</title>
-    <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
-    <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/react@18/umd/react.development.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.development.js"></script>
 
-    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@babel/standalone/babel.min.js"></script>
     <script
       data-plugins="transform-modules-umd"
       type="text/babel"

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/67457ff2dc531fbed928a0f0.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/67457ff2dc531fbed928a0f0.md
@@ -52,10 +52,10 @@ assert.equal(document.querySelector('nav')?.getAttribute('class'), 'navbar');
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Navbar</title>
-    <script src="https://cdn.jsdelivr.net/npm/react@18/umd/react.development.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.0/umd/react.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.0/umd/react-dom.development.js"></script>
 
-    <script src="https://cdn.jsdelivr.net/npm/@babel/standalone/babel.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.26.3/babel.min.js"></script>
     <script
       data-plugins="transform-modules-umd"
       type="text/babel"

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6745c732dbeb7c04f346e6f7.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6745c732dbeb7c04f346e6f7.md
@@ -33,10 +33,10 @@ assert.lengthOf(document.querySelectorAll('ul li'), 3);
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Navbar</title>
-    <script src="https://cdn.jsdelivr.net/npm/react@18/umd/react.development.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.0/umd/react.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.0/umd/react-dom.development.js"></script>
 
-    <script src="https://cdn.jsdelivr.net/npm/@babel/standalone/babel.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.26.3/babel.min.js"></script>
     <script
       data-plugins="transform-modules-umd"
       type="text/babel"

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6745c732dbeb7c04f346e6f7.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6745c732dbeb7c04f346e6f7.md
@@ -33,10 +33,10 @@ assert.lengthOf(document.querySelectorAll('ul li'), 3);
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Navbar</title>
-    <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
-    <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/react@18/umd/react.development.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.development.js"></script>
 
-    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@babel/standalone/babel.min.js"></script>
     <script
       data-plugins="transform-modules-umd"
       type="text/babel"

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6745c732dbeb7c04f346e6f7.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6745c732dbeb7c04f346e6f7.md
@@ -33,8 +33,8 @@ assert.lengthOf(document.querySelectorAll('ul li'), 3);
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Navbar</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.0/umd/react.development.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.0/umd/react-dom.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.1/umd/react.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.1/umd/react-dom.development.js"></script>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.26.3/babel.min.js"></script>
     <script

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6745c7b06a0b530602cb63fa.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6745c7b06a0b530602cb63fa.md
@@ -29,10 +29,10 @@ assert(document.querySelectorAll('ul li')[2]?.classList.contains('nav-item'));
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Navbar</title>
-    <script src="https://cdn.jsdelivr.net/npm/react@18/umd/react.development.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.0/umd/react.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.0/umd/react-dom.development.js"></script>
 
-    <script src="https://cdn.jsdelivr.net/npm/@babel/standalone/babel.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.26.3/babel.min.js"></script>
     <script
       data-plugins="transform-modules-umd"
       type="text/babel"

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6745c7b06a0b530602cb63fa.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6745c7b06a0b530602cb63fa.md
@@ -29,10 +29,10 @@ assert(document.querySelectorAll('ul li')[2]?.classList.contains('nav-item'));
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Navbar</title>
-    <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
-    <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/react@18/umd/react.development.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.development.js"></script>
 
-    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@babel/standalone/babel.min.js"></script>
     <script
       data-plugins="transform-modules-umd"
       type="text/babel"

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6745c7b06a0b530602cb63fa.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6745c7b06a0b530602cb63fa.md
@@ -29,8 +29,8 @@ assert(document.querySelectorAll('ul li')[2]?.classList.contains('nav-item'));
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Navbar</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.0/umd/react.development.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.0/umd/react-dom.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.1/umd/react.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.1/umd/react-dom.development.js"></script>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.26.3/babel.min.js"></script>
     <script

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6745c89fba004707ded84453.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6745c89fba004707ded84453.md
@@ -39,8 +39,8 @@ assert.equal(document.querySelector('a')?.textContent, 'Dashboard');
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Navbar</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.0/umd/react.development.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.0/umd/react-dom.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.1/umd/react.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.1/umd/react-dom.development.js"></script>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.26.3/babel.min.js"></script>
     <script

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6745c89fba004707ded84453.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6745c89fba004707ded84453.md
@@ -39,10 +39,10 @@ assert.equal(document.querySelector('a')?.textContent, 'Dashboard');
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Navbar</title>
-    <script src="https://cdn.jsdelivr.net/npm/react@18/umd/react.development.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.0/umd/react.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.0/umd/react-dom.development.js"></script>
 
-    <script src="https://cdn.jsdelivr.net/npm/@babel/standalone/babel.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.26.3/babel.min.js"></script>
     <script
       data-plugins="transform-modules-umd"
       type="text/babel"

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6745c89fba004707ded84453.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6745c89fba004707ded84453.md
@@ -39,10 +39,10 @@ assert.equal(document.querySelector('a')?.textContent, 'Dashboard');
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Navbar</title>
-    <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
-    <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/react@18/umd/react.development.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.development.js"></script>
 
-    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@babel/standalone/babel.min.js"></script>
     <script
       data-plugins="transform-modules-umd"
       type="text/babel"

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6745cebbf97ef2129f3b9bab.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6745cebbf97ef2129f3b9bab.md
@@ -39,8 +39,8 @@ assert.equal(document.querySelectorAll('a')[1]?.textContent, 'Widgets');
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Navbar</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.0/umd/react.development.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.0/umd/react-dom.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.1/umd/react.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.1/umd/react-dom.development.js"></script>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.26.3/babel.min.js"></script>
     <script

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6745cebbf97ef2129f3b9bab.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6745cebbf97ef2129f3b9bab.md
@@ -39,10 +39,10 @@ assert.equal(document.querySelectorAll('a')[1]?.textContent, 'Widgets');
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Navbar</title>
-    <script src="https://cdn.jsdelivr.net/npm/react@18/umd/react.development.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.0/umd/react.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.0/umd/react-dom.development.js"></script>
 
-    <script src="https://cdn.jsdelivr.net/npm/@babel/standalone/babel.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.26.3/babel.min.js"></script>
     <script
       data-plugins="transform-modules-umd"
       type="text/babel"

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6745cebbf97ef2129f3b9bab.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6745cebbf97ef2129f3b9bab.md
@@ -39,10 +39,10 @@ assert.equal(document.querySelectorAll('a')[1]?.textContent, 'Widgets');
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Navbar</title>
-    <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
-    <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/react@18/umd/react.development.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.development.js"></script>
 
-    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@babel/standalone/babel.min.js"></script>
     <script
       data-plugins="transform-modules-umd"
       type="text/babel"

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6745d799beeb822076a4da9d.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6745d799beeb822076a4da9d.md
@@ -41,10 +41,10 @@ assert.equal(document.querySelector('li button')?.textContent, 'Apps');
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Navbar</title>
-    <script src="https://cdn.jsdelivr.net/npm/react@18/umd/react.development.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.0/umd/react.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.0/umd/react-dom.development.js"></script>
 
-    <script src="https://cdn.jsdelivr.net/npm/@babel/standalone/babel.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.26.3/babel.min.js"></script>
     <script
       data-plugins="transform-modules-umd"
       type="text/babel"

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6745d799beeb822076a4da9d.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6745d799beeb822076a4da9d.md
@@ -41,10 +41,10 @@ assert.equal(document.querySelector('li button')?.textContent, 'Apps');
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Navbar</title>
-    <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
-    <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/react@18/umd/react.development.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.development.js"></script>
 
-    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@babel/standalone/babel.min.js"></script>
     <script
       data-plugins="transform-modules-umd"
       type="text/babel"

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6745d799beeb822076a4da9d.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6745d799beeb822076a4da9d.md
@@ -41,8 +41,8 @@ assert.equal(document.querySelector('li button')?.textContent, 'Apps');
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Navbar</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.0/umd/react.development.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.0/umd/react-dom.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.1/umd/react.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.1/umd/react-dom.development.js"></script>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.26.3/babel.min.js"></script>
     <script

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6745d9df333efe2543a1f457.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6745d9df333efe2543a1f457.md
@@ -39,10 +39,10 @@ assert.equal(document.querySelector('li ul')?.getAttribute('aria-label'), 'Apps'
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Navbar</title>
-    <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
-    <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/react@18/umd/react.development.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.development.js"></script>
 
-    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@babel/standalone/babel.min.js"></script>
     <script
       data-plugins="transform-modules-umd"
       type="text/babel"

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6745d9df333efe2543a1f457.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6745d9df333efe2543a1f457.md
@@ -39,10 +39,10 @@ assert.equal(document.querySelector('li ul')?.getAttribute('aria-label'), 'Apps'
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Navbar</title>
-    <script src="https://cdn.jsdelivr.net/npm/react@18/umd/react.development.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.0/umd/react.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.0/umd/react-dom.development.js"></script>
 
-    <script src="https://cdn.jsdelivr.net/npm/@babel/standalone/babel.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.26.3/babel.min.js"></script>
     <script
       data-plugins="transform-modules-umd"
       type="text/babel"

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6745d9df333efe2543a1f457.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6745d9df333efe2543a1f457.md
@@ -39,8 +39,8 @@ assert.equal(document.querySelector('li ul')?.getAttribute('aria-label'), 'Apps'
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Navbar</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.0/umd/react.development.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.0/umd/react-dom.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.1/umd/react.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.1/umd/react-dom.development.js"></script>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.26.3/babel.min.js"></script>
     <script

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6745dce846995b2a466594be.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6745dce846995b2a466594be.md
@@ -27,8 +27,8 @@ assert.lengthOf(document.querySelectorAll('.sub-menu li'), 3);
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Navbar</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.0/umd/react.development.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.0/umd/react-dom.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.1/umd/react.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.1/umd/react-dom.development.js"></script>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.26.3/babel.min.js"></script>
     <script

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6745dce846995b2a466594be.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6745dce846995b2a466594be.md
@@ -27,10 +27,10 @@ assert.lengthOf(document.querySelectorAll('.sub-menu li'), 3);
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Navbar</title>
-    <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
-    <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/react@18/umd/react.development.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.development.js"></script>
 
-    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@babel/standalone/babel.min.js"></script>
     <script
       data-plugins="transform-modules-umd"
       type="text/babel"

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6745dce846995b2a466594be.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6745dce846995b2a466594be.md
@@ -27,10 +27,10 @@ assert.lengthOf(document.querySelectorAll('.sub-menu li'), 3);
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Navbar</title>
-    <script src="https://cdn.jsdelivr.net/npm/react@18/umd/react.development.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.0/umd/react.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.0/umd/react-dom.development.js"></script>
 
-    <script src="https://cdn.jsdelivr.net/npm/@babel/standalone/babel.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.26.3/babel.min.js"></script>
     <script
       data-plugins="transform-modules-umd"
       type="text/babel"

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6745de9ce925b92d72df713a.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6745de9ce925b92d72df713a.md
@@ -29,10 +29,10 @@ assert.equal(document.querySelectorAll('li a')[4]?.getAttribute('href'), '#');
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Navbar</title>
-    <script src="https://cdn.jsdelivr.net/npm/react@18/umd/react.development.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.0/umd/react.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.0/umd/react-dom.development.js"></script>
 
-    <script src="https://cdn.jsdelivr.net/npm/@babel/standalone/babel.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.26.3/babel.min.js"></script>
     <script
       data-plugins="transform-modules-umd"
       type="text/babel"

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6745de9ce925b92d72df713a.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6745de9ce925b92d72df713a.md
@@ -29,10 +29,10 @@ assert.equal(document.querySelectorAll('li a')[4]?.getAttribute('href'), '#');
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Navbar</title>
-    <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
-    <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/react@18/umd/react.development.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.development.js"></script>
 
-    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@babel/standalone/babel.min.js"></script>
     <script
       data-plugins="transform-modules-umd"
       type="text/babel"

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6745de9ce925b92d72df713a.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6745de9ce925b92d72df713a.md
@@ -29,8 +29,8 @@ assert.equal(document.querySelectorAll('li a')[4]?.getAttribute('href'), '#');
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Navbar</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.0/umd/react.development.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.0/umd/react-dom.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.1/umd/react.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.1/umd/react-dom.development.js"></script>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.26.3/babel.min.js"></script>
     <script

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6745e2aca895c935168e7d91.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6745e2aca895c935168e7d91.md
@@ -41,10 +41,10 @@ assert.equal(document.querySelectorAll('li a')[4]?.textContent, 'Email');
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Navbar</title>
-    <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
-    <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/react@18/umd/react.development.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.development.js"></script>
 
-    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@babel/standalone/babel.min.js"></script>
     <script
       data-plugins="transform-modules-umd"
       type="text/babel"
@@ -193,10 +193,10 @@ export const Navbar = () => {
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Navbar</title>
-    <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
-    <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/react@18/umd/react.development.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.development.js"></script>
 
-    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@babel/standalone/babel.min.js"></script>
     <script
       data-plugins="transform-modules-umd"
       type="text/babel"

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6745e2aca895c935168e7d91.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6745e2aca895c935168e7d91.md
@@ -41,8 +41,8 @@ assert.equal(document.querySelectorAll('li a')[4]?.textContent, 'Email');
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Navbar</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.0/umd/react.development.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.0/umd/react-dom.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.1/umd/react.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.1/umd/react-dom.development.js"></script>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.26.3/babel.min.js"></script>
     <script
@@ -193,8 +193,8 @@ export const Navbar = () => {
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Navbar</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.0/umd/react.development.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.0/umd/react-dom.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.1/umd/react.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.1/umd/react-dom.development.js"></script>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.26.3/babel.min.js"></script>
     <script

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6745e2aca895c935168e7d91.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6745e2aca895c935168e7d91.md
@@ -41,10 +41,10 @@ assert.equal(document.querySelectorAll('li a')[4]?.textContent, 'Email');
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Navbar</title>
-    <script src="https://cdn.jsdelivr.net/npm/react@18/umd/react.development.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.0/umd/react.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.0/umd/react-dom.development.js"></script>
 
-    <script src="https://cdn.jsdelivr.net/npm/@babel/standalone/babel.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.26.3/babel.min.js"></script>
     <script
       data-plugins="transform-modules-umd"
       type="text/babel"
@@ -193,10 +193,10 @@ export const Navbar = () => {
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Navbar</title>
-    <script src="https://cdn.jsdelivr.net/npm/react@18/umd/react.development.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.0/umd/react.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.0/umd/react-dom.development.js"></script>
 
-    <script src="https://cdn.jsdelivr.net/npm/@babel/standalone/babel.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.26.3/babel.min.js"></script>
     <script
       data-plugins="transform-modules-umd"
       type="text/babel"

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef11f75254548672d998c.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef11f75254548672d998c.md
@@ -43,8 +43,8 @@ assert.match(functionDefinition, /\{[^{]*bio[^{]*\}/);
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Card component</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.0/umd/react.development.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.0/umd/react-dom.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.1/umd/react.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.1/umd/react-dom.development.js"></script>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.26.3/babel.min.js"></script>
     <script

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef11f75254548672d998c.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef11f75254548672d998c.md
@@ -43,10 +43,10 @@ assert.match(functionDefinition, /\{[^{]*bio[^{]*\}/);
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Card component</title>
-    <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
-    <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/react@18/umd/react.development.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.development.js"></script>
 
-    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@babel/standalone/babel.min.js"></script>
     <script
       data-plugins="transform-modules-umd"
       type="text/babel"

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef11f75254548672d998c.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef11f75254548672d998c.md
@@ -43,10 +43,10 @@ assert.match(functionDefinition, /\{[^{]*bio[^{]*\}/);
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Card component</title>
-    <script src="https://cdn.jsdelivr.net/npm/react@18/umd/react.development.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.0/umd/react.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.0/umd/react-dom.development.js"></script>
 
-    <script src="https://cdn.jsdelivr.net/npm/@babel/standalone/babel.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.26.3/babel.min.js"></script>
     <script
       data-plugins="transform-modules-umd"
       type="text/babel"

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef2d357676e50e4691658.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef2d357676e50e4691658.md
@@ -40,10 +40,10 @@ async () => {
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Card component</title>
-    <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
-    <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/react@18/umd/react.development.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.development.js"></script>
 
-    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@babel/standalone/babel.min.js"></script>
     <script
       data-plugins="transform-modules-umd"
       type="text/babel"

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef2d357676e50e4691658.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef2d357676e50e4691658.md
@@ -40,10 +40,10 @@ async () => {
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Card component</title>
-    <script src="https://cdn.jsdelivr.net/npm/react@18/umd/react.development.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.0/umd/react.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.0/umd/react-dom.development.js"></script>
 
-    <script src="https://cdn.jsdelivr.net/npm/@babel/standalone/babel.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.26.3/babel.min.js"></script>
     <script
       data-plugins="transform-modules-umd"
       type="text/babel"

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef2d357676e50e4691658.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef2d357676e50e4691658.md
@@ -40,8 +40,8 @@ async () => {
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Card component</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.0/umd/react.development.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.0/umd/react-dom.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.1/umd/react.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.1/umd/react-dom.development.js"></script>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.26.3/babel.min.js"></script>
     <script

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef2d357676e50e4691659.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef2d357676e50e4691659.md
@@ -78,8 +78,8 @@ async () => {
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Card component</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.0/umd/react.development.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.0/umd/react-dom.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.1/umd/react.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.1/umd/react-dom.development.js"></script>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.26.3/babel.min.js"></script>
     <script

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef2d357676e50e4691659.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef2d357676e50e4691659.md
@@ -78,10 +78,10 @@ async () => {
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Card component</title>
-    <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
-    <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/react@18/umd/react.development.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.development.js"></script>
 
-    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@babel/standalone/babel.min.js"></script>
     <script
       data-plugins="transform-modules-umd"
       type="text/babel"

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef2d357676e50e4691659.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef2d357676e50e4691659.md
@@ -78,10 +78,10 @@ async () => {
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Card component</title>
-    <script src="https://cdn.jsdelivr.net/npm/react@18/umd/react.development.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.0/umd/react.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.0/umd/react-dom.development.js"></script>
 
-    <script src="https://cdn.jsdelivr.net/npm/@babel/standalone/babel.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.26.3/babel.min.js"></script>
     <script
       data-plugins="transform-modules-umd"
       type="text/babel"

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef2d357676e50e469165a.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef2d357676e50e469165a.md
@@ -40,10 +40,10 @@ async() => {
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Card component</title>
-    <script src="https://cdn.jsdelivr.net/npm/react@18/umd/react.development.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.0/umd/react.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.0/umd/react-dom.development.js"></script>
 
-    <script src="https://cdn.jsdelivr.net/npm/@babel/standalone/babel.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.26.3/babel.min.js"></script>
     <script
       data-plugins="transform-modules-umd"
       type="text/babel"

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef2d357676e50e469165a.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef2d357676e50e469165a.md
@@ -40,8 +40,8 @@ async() => {
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Card component</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.0/umd/react.development.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.0/umd/react-dom.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.1/umd/react.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.1/umd/react-dom.development.js"></script>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.26.3/babel.min.js"></script>
     <script

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef2d357676e50e469165a.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef2d357676e50e469165a.md
@@ -40,10 +40,10 @@ async() => {
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Card component</title>
-    <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
-    <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/react@18/umd/react.development.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.development.js"></script>
 
-    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@babel/standalone/babel.min.js"></script>
     <script
       data-plugins="transform-modules-umd"
       type="text/babel"

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef2d357676e50e469165b.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef2d357676e50e469165b.md
@@ -50,8 +50,8 @@ async () => {
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Card component</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.0/umd/react.development.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.0/umd/react-dom.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.1/umd/react.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.1/umd/react-dom.development.js"></script>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.26.3/babel.min.js"></script>
     <script

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef2d357676e50e469165b.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef2d357676e50e469165b.md
@@ -50,10 +50,10 @@ async () => {
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Card component</title>
-    <script src="https://cdn.jsdelivr.net/npm/react@18/umd/react.development.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.0/umd/react.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.0/umd/react-dom.development.js"></script>
 
-    <script src="https://cdn.jsdelivr.net/npm/@babel/standalone/babel.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.26.3/babel.min.js"></script>
     <script
       data-plugins="transform-modules-umd"
       type="text/babel"

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef2d357676e50e469165b.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef2d357676e50e469165b.md
@@ -50,10 +50,10 @@ async () => {
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Card component</title>
-    <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
-    <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/react@18/umd/react.development.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.development.js"></script>
 
-    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@babel/standalone/babel.min.js"></script>
     <script
       data-plugins="transform-modules-umd"
       type="text/babel"

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef2d357676e50e469165c.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef2d357676e50e469165c.md
@@ -61,8 +61,8 @@ async () => {
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Card component</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.0/umd/react.development.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.0/umd/react-dom.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.1/umd/react.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.1/umd/react-dom.development.js"></script>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.26.3/babel.min.js"></script>
     <script

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef2d357676e50e469165c.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef2d357676e50e469165c.md
@@ -61,10 +61,10 @@ async () => {
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Card component</title>
-    <script src="https://cdn.jsdelivr.net/npm/react@18/umd/react.development.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.0/umd/react.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.0/umd/react-dom.development.js"></script>
 
-    <script src="https://cdn.jsdelivr.net/npm/@babel/standalone/babel.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.26.3/babel.min.js"></script>
     <script
       data-plugins="transform-modules-umd"
       type="text/babel"

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef2d357676e50e469165c.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef2d357676e50e469165c.md
@@ -61,10 +61,10 @@ async () => {
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Card component</title>
-    <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
-    <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/react@18/umd/react.development.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.development.js"></script>
 
-    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@babel/standalone/babel.min.js"></script>
     <script
       data-plugins="transform-modules-umd"
       type="text/babel"

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef2d357676e50e469165d.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef2d357676e50e469165d.md
@@ -59,10 +59,10 @@ assert.equal(secondCard.querySelector('p:last-child').textContent, 'I have been 
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Card component</title>
-    <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
-    <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/react@18/umd/react.development.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.development.js"></script>
 
-    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@babel/standalone/babel.min.js"></script>
     <script
       data-plugins="transform-modules-umd"
       type="text/babel"
@@ -161,10 +161,10 @@ export function App() {
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Card component</title>
-    <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
-    <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/react@18/umd/react.development.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.development.js"></script>
 
-    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@babel/standalone/babel.min.js"></script>
     <script
       data-plugins="transform-modules-umd"
       type="text/babel"

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef2d357676e50e469165d.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef2d357676e50e469165d.md
@@ -59,8 +59,8 @@ assert.equal(secondCard.querySelector('p:last-child').textContent, 'I have been 
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Card component</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.0/umd/react.development.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.0/umd/react-dom.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.1/umd/react.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.1/umd/react-dom.development.js"></script>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.26.3/babel.min.js"></script>
     <script
@@ -161,8 +161,8 @@ export function App() {
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Card component</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.0/umd/react.development.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.0/umd/react-dom.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.1/umd/react.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.1/umd/react-dom.development.js"></script>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.26.3/babel.min.js"></script>
     <script

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef2d357676e50e469165d.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef2d357676e50e469165d.md
@@ -59,10 +59,10 @@ assert.equal(secondCard.querySelector('p:last-child').textContent, 'I have been 
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Card component</title>
-    <script src="https://cdn.jsdelivr.net/npm/react@18/umd/react.development.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.0/umd/react.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.0/umd/react-dom.development.js"></script>
 
-    <script src="https://cdn.jsdelivr.net/npm/@babel/standalone/babel.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.26.3/babel.min.js"></script>
     <script
       data-plugins="transform-modules-umd"
       type="text/babel"
@@ -161,10 +161,10 @@ export function App() {
   <head>
     <meta charset="UTF-8" />
     <title>Reusable Card component</title>
-    <script src="https://cdn.jsdelivr.net/npm/react@18/umd/react.development.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.0/umd/react.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.0/umd/react-dom.development.js"></script>
 
-    <script src="https://cdn.jsdelivr.net/npm/@babel/standalone/babel.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.26.3/babel.min.js"></script>
     <script
       data-plugins="transform-modules-umd"
       type="text/babel"

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://unpkg.com/knip@5/schema.json",
+  "$schema": "https://cdn.jsdelivr.net/npm/knip@5/schema.json",
   "ignoreBinaries": ["create:shared", "install-puppeteer", "pm2"],
   "ignoreWorkspaces": ["api-server"], // Ignored based on https://github.com/freeCodeCamp/freeCodeCamp/pull/52330#issuecomment-1807917235
   "workspaces": {

--- a/tools/client-plugins/browser-scripts/typescript-worker.ts
+++ b/tools/client-plugins/browser-scripts/typescript-worker.ts
@@ -46,11 +46,11 @@ let compilerHost: CompilerHost | null = null;
 let cachedVersion: string | null = null;
 
 // NOTE: vfs.globals must only be imported once, otherwise it will throw.
-importScripts('https://unpkg.com/@typescript/vfs@1.6.0/dist/vfs.globals.js');
+importScripts('https://cdn.jsdelivr.net/npm/@typescript/vfs@1.6.0/dist/vfs.globals.js');
 
 function importTS(version: string) {
   if (cachedVersion == version) return;
-  importScripts('https://unpkg.com/typescript@' + version);
+  importScripts('https://cdn.jsdelivr.net/npm/typescript@' + version);
   cachedVersion = version;
 }
 

--- a/tools/client-plugins/browser-scripts/typescript-worker.ts
+++ b/tools/client-plugins/browser-scripts/typescript-worker.ts
@@ -39,7 +39,7 @@ interface CancelEvent extends MessageEvent {
   };
 }
 
-const TS_VERSION = '5'; // hardcoding for now, in the future this may be dynamic
+const TS_VERSION = '5.7.3'; // hardcoding for now, in the future this may be dynamic. Must be fully specified version
 
 let tsEnv: VirtualTypeScriptEnvironment | null = null;
 let compilerHost: CompilerHost | null = null;
@@ -50,7 +50,7 @@ importScripts('https://cdn.jsdelivr.net/npm/@typescript/vfs@1.6.0/dist/vfs.globa
 
 function importTS(version: string) {
   if (cachedVersion == version) return;
-  importScripts('https://cdn.jsdelivr.net/npm/typescript@' + version);
+  importScripts(`https://cdnjs.cloudflare.com/ajax/libs/typescript/${version}/typescript.min.js`);
   cachedVersion = version;
 }
 

--- a/tools/client-plugins/browser-scripts/typescript-worker.ts
+++ b/tools/client-plugins/browser-scripts/typescript-worker.ts
@@ -46,11 +46,15 @@ let compilerHost: CompilerHost | null = null;
 let cachedVersion: string | null = null;
 
 // NOTE: vfs.globals must only be imported once, otherwise it will throw.
-importScripts('https://cdn.jsdelivr.net/npm/@typescript/vfs@1.6.0/dist/vfs.globals.js');
+importScripts(
+  'https://cdn.jsdelivr.net/npm/@typescript/vfs@1.6.0/dist/vfs.globals.js'
+);
 
 function importTS(version: string) {
   if (cachedVersion == version) return;
-  importScripts(`https://cdnjs.cloudflare.com/ajax/libs/typescript/${version}/typescript.min.js`);
+  importScripts(
+    `https://cdnjs.cloudflare.com/ajax/libs/typescript/${version}/typescript.min.js`
+  );
   cachedVersion = version;
 }
 

--- a/tools/client-plugins/browser-scripts/typescript-worker.ts
+++ b/tools/client-plugins/browser-scripts/typescript-worker.ts
@@ -39,7 +39,8 @@ interface CancelEvent extends MessageEvent {
   };
 }
 
-const TS_VERSION = '5.7.3'; // hardcoding for now, in the future this may be dynamic. Must be fully specified version
+// Pin at the latest TS version available as cdnjs doesn't support version range.
+const TS_VERSION = '5.7.3';
 
 let tsEnv: VirtualTypeScriptEnvironment | null = null;
 let compilerHost: CompilerHost | null = null;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

UNPKG has not been actively maintained and ~~has been down since `Mar 15, 2025`~~ was down from Mar 15, 2025, 2:00 AM and down for 18 hours (https://github.com/unpkg/unpkg/issues/412). Migrating to jsDelivr means a more stable and reliant service.

The PR replaces UNPKG usage with jsDelivr.