### PR TITLE
fix(a11y): associate MCQ options with the correct question

### DIFF
--- a/client/src/templates/Challenges/components/multiple-choice-questions.tsx
+++ b/client/src/templates/Challenges/components/multiple-choice-questions.tsx
@@ -35,8 +35,10 @@ function MultipleChoiceQuestions({
         }
       />
       {questions.map((question, questionIndex) => (
-        <div key={questionIndex}>
-          <PrismFormatted className={'line-numbers'} text={question.text} />
+        <fieldset key={questionIndex}>
+          <legend className='mcq-question-text'>
+            <PrismFormatted className={'line-numbers'} text={question.text} />
+          </legend>
           <div className='video-quiz-options'>
             {question.answers.map(({ answer }, answerIndex) => {
               const isSubmittedAnswer =
@@ -57,7 +59,7 @@ function MultipleChoiceQuestions({
                     htmlFor={`mc-question-${questionIndex}-answer-${answerIndex}`}
                   >
                     <input
-                      name='quiz'
+                      name={`mc-question-${questionIndex}`}
                       checked={selectedOptions[questionIndex] === answerIndex}
                       className='sr-only'
                       onChange={() =>
@@ -109,7 +111,7 @@ function MultipleChoiceQuestions({
             })}
           </div>
           <Spacer size='m' />
-        </div>
+        </fieldset>
       ))}
       <Spacer size='m' />
     </>

--- a/client/src/templates/Challenges/video.css
+++ b/client/src/templates/Challenges/video.css
@@ -150,3 +150,10 @@ input:focus-visible + .video-quiz-input-visible {
 .mcq-prism-incorrect code {
   color: var(--danger-color);
 }
+
+/* Override the default styles of `legend` element */
+.mcq-question-text {
+  border: none;
+  color: var(--primary-color);
+  margin: 0;
+}


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR:
- Fixes an a11y issue where all radio buttons in MCQ challenges are incorrectly grouped together (because they have the same `name`)
- Adds `fieldset` and `legend` to the radio groups so that the question text and options are linked
- Closes #59277

---

Note: The proper fix for this issue would be replacing the implementation with the fcc/ui Quiz and QuizQuestion components. However, the replacement requires a lot more work, and since this a11y issue is quite severe, I decided to make a patch first.

<!-- Feel free to add any additional description of changes below this line -->
