### PR TITLE
fix(client): Ensure Tab key moves between questions in quiz navigation

### DIFF
--- a/client/src/templates/Challenges/components/multiple-choice-questions.tsx
+++ b/client/src/templates/Challenges/components/multiple-choice-questions.tsx
@@ -57,7 +57,7 @@ function MultipleChoiceQuestions({
                     htmlFor={`mc-question-${questionIndex}-answer-${answerIndex}`}
                   >
                     <input
-                      name='quiz'
+                      name={`quiz-${questionIndex}`}
                       checked={selectedOptions[questionIndex] === answerIndex}
                       className='sr-only'
                       onChange={() =>


### PR DESCRIPTION

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the 59277 below with the issue number.-->

Closes #59277

<!-- Feel free to add any additional description of changes below this line -->

Updated radio input 'name' attribute to differentiate between questions, allowing proper tab navigation.


https://www.loom.com/share/7726b9c5801b4d9db00d8967038f4199?sid=57ca315f-6c1c-4287-81f9-edef3ae2f403
