### PR TITLE
fix(curriculum): improve syntax validation in steps 28 and 45 of BST lesson

### DIFF
--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-tree-traversal-by-building-a-binary-search-tree/65c644829cfb63acf3479d09.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-tree-traversal-by-building-a-binary-search-tree/65c644829cfb63acf3479d09.md
@@ -18,10 +18,7 @@ You should use a properly structured `for` loop with `node` as the iteration var
   test: () =>
     assert(
       runPython(`
-        _Node(_code)
-        .find_for("node", "nodes")  
-        .find_body()  
-        .has_call("bst.insert(node)")
+        _Node(_code).find_for("node", "nodes").find_body().has_call("bst.insert(node)")
       `)
     )
 });

--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-tree-traversal-by-building-a-binary-search-tree/65c644829cfb63acf3479d09.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-tree-traversal-by-building-a-binary-search-tree/65c644829cfb63acf3479d09.md
@@ -11,10 +11,20 @@ Insert the nodes in the list `nodes` into the `bst` instance by iterating over t
 
 # --hints--
 
-You should use a properly structured for loop with `node` as the iteration variable and call `bst.insert(node)` inside the loop.
+You should use a properly structured `for` loop with `node` as the iteration variable and call `bst.insert(node)` inside the loop.
 
 ```js
-assert.match(code, /for\s+node\s+in\s+nodes\s*:\s*[\r\n]+\s*bst\.insert\(node\)/);
+({
+  test: () =>
+    assert(
+      runPython(`
+        _Node(_code)
+        .find_for("node", "nodes")  # Ensures for-loop exists
+        .find_body()  # Checks inside the loop
+        .has_call("bst.insert(node)")  # Ensures bst.insert(node) is called
+      `)
+    )
+});
 ```
 
 # --seed--

--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-tree-traversal-by-building-a-binary-search-tree/65c644829cfb63acf3479d09.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-tree-traversal-by-building-a-binary-search-tree/65c644829cfb63acf3479d09.md
@@ -11,16 +11,10 @@ Insert the nodes in the list `nodes` into the `bst` instance by iterating over t
 
 # --hints--
 
-You should have a `for node in nodes` loop.
+You should use a properly structured for loop with `node` as the iteration variable and call `bst.insert(node)` inside the loop.
 
 ```js
-assert.match(code, /for\s+node\s+in\s+nodes/);
-```
-
-You should have `bst.insert(node)` inside the `for` loop.
-
-```js
-assert.match(code, /bst\.insert/);
+assert.match(code, /for\s+node\s+in\s+nodes\s*:\s*[\r\n]+\s*bst\.insert\(node\)/);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-tree-traversal-by-building-a-binary-search-tree/65c644829cfb63acf3479d09.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-tree-traversal-by-building-a-binary-search-tree/65c644829cfb63acf3479d09.md
@@ -19,9 +19,9 @@ You should use a properly structured `for` loop with `node` as the iteration var
     assert(
       runPython(`
         _Node(_code)
-        .find_for("node", "nodes")  # Ensures for-loop exists
-        .find_body()  # Checks inside the loop
-        .has_call("bst.insert(node)")  # Ensures bst.insert(node) is called
+        .find_for("node", "nodes")  
+        .find_body()  
+        .has_call("bst.insert(node)")
       `)
     )
 });

--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-tree-traversal-by-building-a-binary-search-tree/65ca089e848eca0672b9cd77.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-tree-traversal-by-building-a-binary-search-tree/65ca089e848eca0672b9cd77.md
@@ -20,10 +20,7 @@ You should assign `self._min_value(node.right)` to `node.key` after your `elif` 
   test: () =>
     assert(
       runPython(`
-        _Node(_code)
-        .find_function("_delete")
-        .find_ifs()[0]
-        .is_ordered(
+        _Node(_code).find_function("_delete").find_ifs()[0].is_ordered(
           "if node.left is None:",
           "return node.right",
           "elif node.right is None:",

--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-tree-traversal-by-building-a-binary-search-tree/65ca089e848eca0672b9cd77.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-tree-traversal-by-building-a-binary-search-tree/65ca089e848eca0672b9cd77.md
@@ -16,7 +16,23 @@ Add a `_min_value` call after your `elif` block, passing `node.right` as the arg
 You should assign `self._min_value(node.right)` to `node.key` after your `elif` block.
 
 ```js
-assert.match(code, /else\s*:\s*[\r\n]+\s*if\s+node\.left\s+is\s+None\s*:\s*[\r\n]+\s*return\s+node\.right\s*[\r\n]+\s*elif\s+node\.right\s+is\s+None\s*:\s*[\r\n]+\s*return\s+node\.left\s*[\r\n]+\s*node\.key\s*=\s*self\._min_value\(\s*node\.right\s*\)/);
+({
+  test: () =>
+    assert(
+      runPython(`
+        _Node(_code)
+        .find_function("_delete")
+        .find_ifs()[0]
+        .is_ordered(
+          "if node.left is None:",
+          "return node.right",
+          "elif node.right is None:",
+          "return node.left",
+          "node.key = self._min_value(node.right)"
+        )
+      `)
+    )
+});
 ```
 
 # --seed--

--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-tree-traversal-by-building-a-binary-search-tree/65ca089e848eca0672b9cd77.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-tree-traversal-by-building-a-binary-search-tree/65ca089e848eca0672b9cd77.md
@@ -16,7 +16,7 @@ Add a `_min_value` call after your `elif` block, passing `node.right` as the arg
 You should assign `self._min_value(node.right)` to `node.key` after your `elif` block.
 
 ```js
-assert.match(code, /node\.key\s*=\s*self\._min_value\(\s*node\.right\s*\)/);
+assert.match(code, /else\s*:\s*[\r\n]+\s*if\s+node\.left\s+is\s+None\s*:\s*[\r\n]+\s*return\s+node\.right\s*[\r\n]+\s*elif\s+node\.right\s+is\s+None\s*:\s*[\r\n]+\s*return\s+node\.left\s*[\r\n]+\s*node\.key\s*=\s*self\._min_value\(\s*node\.right\s*\)/);
 ```
 
 # --seed--


### PR DESCRIPTION


Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #59270 

<!-- Feel free to add any additional description of changes below this line -->

Changes Made:
Step 28: Updated the test to enforce correct for-loop syntax.
Step 45: Updated the test to ensure `node.key = self._min_value(node.right)` appears only after the `elif` block.

Reason for Change:
The previous tests allowed incorrect syntax and incorrect placements, leading to false positives. These updates enforce stricter validation for better learning outcomes.
