### PR TITLE
feat(tools): set playwright ui port to zero

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "test-utils": "jest utils",
     "prepare": "husky",
     "playwright:run": "playwright test",
-    "playwright:watch": "playwright test --ui"
+    "playwright:watch": "playwright test --ui-port=0"
   },
   "dependencies": {
     "dotenv": "16.4.5"


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

Mentioned in #59306

<!-- Feel free to add any additional description of changes below this line -->
This sets Playwright's UI port to zero. When using WSL 2, this will cause the Playwright UI to open up in your system's default browser.  Prior to Playwright not properly opening for me, it displayed in a new standalone window. Opening it up in my system's browser feels more natural. 

I have not tested this in Gitpod or ran Playwright in there, and will like some additional testing before it is approved. My running hypothesis is that it will open up in another tab. 