### PR TITLE
fix(curriculum): Improve instruction clarity

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-recursion-by-building-a-decimal-to-binary-converter/674dd79dcfa5690e16e59775.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-recursion-by-building-a-decimal-to-binary-converter/674dd79dcfa5690e16e59775.md
@@ -9,7 +9,7 @@ dashedName: step-103
 
 You have set the `id` attribute for your paragraph elements to the `obj.inputVal` property.
 
-Now, use the `.getElementById()` method to select the element with that attribute value, again using the `obj.inputVal` property.
+Now, use the `.getElementById()` method to select the element with that attribute value, again using the `obj.inputVal` property. You should pass the `obj.inputVal` value directly to your `getElementById` call.
 
 After that, set the `textContent` property of the selected element equal to the `msg` property of the current object, to update its text after the delay you specified earlier.
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-decimal-to-binary-converter/6464ad3c9b2e6cf58224cfa9.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-decimal-to-binary-converter/6464ad3c9b2e6cf58224cfa9.md
@@ -9,7 +9,7 @@ dashedName: step-103
 
 You have set the `id` attribute for your paragraph elements to the `obj.inputVal` property.
 
-Now, use `getElementById` to select the element with that attribute value, again using the `obj.inputVal` property.
+Now, use `getElementById` to select the element with that attribute value, again using the `obj.inputVal` property. You should pass the `obj.inputVal` value directly to your `getElementById` call.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #55816 

<!-- Feel free to add any additional description of changes below this line -->

Note that despite the issue description of step 104, the offending step is step 103. There are also two distinct affected courses, namely the Javascript algorithms and Data structures standalone course and the Full stack developer certification.

Added the clarification to inform users against using string interpolation as suggested in the issue discussion.

**Before change**
JavaScript algorithms and Data Structures:
![Before_Change](https://github.com/user-attachments/assets/045c7a54-3099-4812-a5ab-13a4e37bb9af)
Full stack developer certification:
![image](https://github.com/user-attachments/assets/84db9fac-b43c-44b5-aa27-5b5f715d8787)

**After change**
JavaScript algorithms and Data Structures:
![After_change](https://github.com/user-attachments/assets/649d73f2-1fb4-49b8-b1a6-334614464dff)
Full stack developer certification:
![image](https://github.com/user-attachments/assets/9d2bada4-bef5-4111-a95b-51b588d76d47)
