### PR TITLE
feat(curriculum): added tests and edited getResults function in lab-quiz-game

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-quiz-game/66f17db06803d11a1bd19a20.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-quiz-game/66f17db06803d11a1bd19a20.md
@@ -19,7 +19,7 @@ Fulfill the user stories below and get all the tests to pass to complete the lab
 1. The `answer` key should have the value of a string, representing the correct answer to the question. Also, the value of `answer` should be included in the `choices` array.
 1. You should have a function named `getRandomQuestion` that takes an array of questions as a parameter and returns a random question object from the array.
 1. You should have a function named `getRandomComputerChoice` that takes the array of the available choices as a parameter, and returns a random answer to the selected question.
-1. You should have a function named `getResults` that takes the selected question object and the computer choice as its parameters and returns `The computer's choice is correct!` if the answer is correct. Otherwise, it returns `The computer's choice is wrong. The correct answer is: <correct-answer>`, where `<correct-answer>` is the value of the correct answer to the chosen question.
+1. You should have a function named `getResults`.It takes 2 parameters: `selectedQuestion` of type object and the `computerChoice` of type string and returns `The computer's choice is correct!` if the answer is correct. Otherwise, it returns `The computer's choice is wrong. The correct answer is: <correct-answer>`, where `<correct-answer>` is the value of the correct answer to the chosen question.
 
 # --hints--
 
@@ -108,6 +108,18 @@ You should have a function named `getResults`.
 assert.isFunction(getResults);
 ```
 
+check the data type of the first parameter of `getResults` using `typeof` operator.If it is not an object exit from the function using `return`
+
+```js
+assert.equal(getResults("some text", "computer has chosen option A"));
+```
+
+check the data type of the second parameter of `getResults` using `typeof` operator.If it is not a string exit from the function using `return`
+
+```js
+assert.equal(getResults(questions[0], {message:"I am object"}));
+```
+
 If the computer choice matches the answer, `getResults` should return `The computer's choice is correct!`
 
 ```js
@@ -117,8 +129,10 @@ assert.equal(getResults(questions[0], questions[0].answer), `The computer's choi
 If the computer choice doesn't match the answer, `getResults` should return `The computer's choice is wrong. The correct answer is: <correct-answer>`, where `<correct-answer>` is the value of the correct answer to the chosen question.
 
 ```js
-assert.equal(getResults({category: 'misc', choices: ['a', 'b', 'c'], question: "question?", answer: "b"}, "a"), `The computer's choice is wrong. The correct answer is: b`)
+assert.equal(getResults({category: "science",question: "What is the chemical symbol for potassium?",choices: ["P", "K", "Pt"],answer: "K"},"P"), `The computer's choice is wrong. The correct answer is: K`);
 ```
+
+
 
 # --seed--
 
@@ -174,11 +188,21 @@ function getRandomComputerChoice(choices) {
     return choices[randomIndex];
 }
 
-function getResults(obj, computerChoice) {
-    return computerChoice === obj.answer
-        ? "The computer's choice is correct!"
-        : `The computer's choice is wrong. The correct answer is: ${obj.answer}`;
+function getResults(questionObject, choice) {
+  if (typeof questionObject !== 'object') {
+    return;
+  }
+  if (typeof choice !== 'string') {
+    return;
+  }
+  if (questionObject.answer === choice) {
+    return "The computer's choice is correct!";
+  } else {
+    return `The computer's choice is wrong. The correct answer is: ${questionObject.answer}`;
+  }
 }
+
+
 
 const questionObj = getRandomQuestion(questions);
 const { question, choices } = questionObj;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #59339

<!-- Feel free to add any additional description of changes below this line -->
I edited function getResults to ensure that 1st parameter must be an object and 2nd parameter must be a string
![getResults](https://github.com/user-attachments/assets/0a79d2f9-704a-4959-9ee3-80bea355db29)

I checked that all tests work as intended:
![allTests](https://github.com/user-attachments/assets/5b3beb10-c0f2-4406-83f7-3195cf42ff80)

I added 2 additional tests to check if the desired functionality works properly.here are several images of testing different scenarios in my local environment:
1) if the user does not check the data types of the 2 parameters:
![missingBoth](https://github.com/user-attachments/assets/c971f11c-3379-46b2-8b2e-50ace613eacf)
2) if the user does not check the data type of the 1st parameter:
![missing1st](https://github.com/user-attachments/assets/81473f32-0ddb-4963-9fa3-afc3134cb2a6)
3)if the user does not check the data type of the 2nd parameter:
![missing2nd](https://github.com/user-attachments/assets/62f4c506-e961-45e4-9379-b1d099cc2676)
4)if the user checks both parameters and all tests work correctly:
![correctBehavior](https://github.com/user-attachments/assets/3b7d8d4b-3234-43cd-bb66-0b79a75f6181)
