### PR TITLE
fix(client): navigate campers to the correct page when exiting quiz

### DIFF
--- a/client/src/templates/Challenges/hooks/use-page-leave.ts
+++ b/client/src/templates/Challenges/hooks/use-page-leave.ts
@@ -3,7 +3,7 @@ import { useLocation, globalHistory } from '@gatsbyjs/reach-router';
 
 interface Props {
   onWindowClose: (event: BeforeUnloadEvent) => void;
-  onHistoryChange: () => void;
+  onHistoryChange: (targetPathname: string) => void;
 }
 
 export const usePageLeave = ({ onWindowClose, onHistoryChange }: Props) => {
@@ -20,7 +20,7 @@ export const usePageLeave = ({ onWindowClose, onHistoryChange }: Props) => {
         action === 'PUSH' && location.pathname !== curLocation.pathname;
 
       if (isBack || isRouteChanged) {
-        onHistoryChange();
+        onHistoryChange(location.pathname);
       }
     });
 

--- a/client/src/templates/Challenges/quiz/show.tsx
+++ b/client/src/templates/Challenges/quiz/show.tsx
@@ -128,6 +128,8 @@ const ShowQuiz = ({
 
   const [exitConfirmed, setExitConfirmed] = useState(false);
 
+  const [exitPathname, setExitPathname] = useState(blockHashSlug);
+
   const blockNameTitle = `${t(
     `intro:${superBlock}.blocks.${block}.title`
   )} - ${title}`;
@@ -231,7 +233,7 @@ const ShowQuiz = ({
 
   const handleExitQuizModalBtnClick = () => {
     setExitConfirmed(true);
-    void navigate(blockHashSlug);
+    void navigate(exitPathname);
     closeExitQuizModal();
   };
 
@@ -243,21 +245,37 @@ const ShowQuiz = ({
     [t]
   );
 
-  const onHistoryChange = useCallback(() => {
-    // We don't block navigation in the following cases.
-    // - When campers have submitted the quiz:
-    //   - If they don't pass, the Finish Quiz button is disabled, there isn't anything for them to do other than leaving the page
-    //   - If they pass, the Submit-and-go button shows up, and campers should be allowed to leave the page
-    // - When they have clicked the exit button on the exit modal
-    if (hasSubmitted || exitConfirmed) {
-      return;
-    }
+  const onHistoryChange = useCallback(
+    (targetPathname: string) => {
+      // We don't block navigation in the following cases.
+      // - When campers have submitted the quiz:
+      //   - If they don't pass, the Finish Quiz button is disabled, there isn't anything for them to do other than leaving the page
+      //   - If they pass, the Submit-and-go button shows up, and campers should be allowed to leave the page
+      // - When they have clicked the exit button on the exit modal
+      if (hasSubmitted || exitConfirmed) {
+        return;
+      }
 
-    // We need to use Reach Router, because the pathname is already prefixed
-    // with the language and Gatsby's navigate will prefix it again.
-    void reachNavigate(`${curLocation.pathname}`);
-    openExitQuizModal();
-  }, [curLocation.pathname, hasSubmitted, exitConfirmed, openExitQuizModal]);
+      const newPathname = targetPathname.startsWith('/learn')
+        ? blockHashSlug
+        : targetPathname;
+
+      // Save the pathname of the page the user wants to navigate to before we block the navigation.
+      setExitPathname(newPathname);
+
+      // We need to use Reach Router, because the pathname is already prefixed
+      // with the language and Gatsby's navigate will prefix it again.
+      void reachNavigate(`${curLocation.pathname}`);
+      openExitQuizModal();
+    },
+    [
+      curLocation.pathname,
+      hasSubmitted,
+      exitConfirmed,
+      openExitQuizModal,
+      blockHashSlug
+    ]
+  );
 
   usePageLeave({
     onWindowClose,


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

I just found that when exiting the quiz challenge, campers are always directed to /learn, regardless of the page they actually want to go to.

To reproduce:
- Go to a quiz challenge
- Click on any page in the dropdown menu in the navbar (donate, settings, profile)
- The exit confirmation modal shows up, but clicking the "Yes" button would take you to /learn

This issue is because we always navigate to `blockHashSlug` when the button is clicked.

<!-- Feel free to add any additional description of changes below this line -->
