### PR TITLE
fix(tools): use dashed name for live version of challenge in editor

### DIFF
--- a/tools/challenge-editor/api/utils/get-step-contents.ts
+++ b/tools/challenge-editor/api/utils/get-step-contents.ts
@@ -7,11 +7,11 @@ export const getStepContent = async (
   sup: string,
   block: string,
   step: string
-): Promise<{ name: string; fileData: string }> => {
+): Promise<{ name: string; dashedName: string; fileData: string }> => {
   const filePath = join(CHALLENGE_DIR, sup, block, step);
 
   const fileData = await readFile(filePath, 'utf8');
   const name = matter(fileData).data.title as string;
-
-  return { name, fileData };
+  const dashedName = matter(fileData).data.dashedName as string;
+  return { name, dashedName, fileData };
 };

--- a/tools/challenge-editor/client/interfaces/challenge-content.ts
+++ b/tools/challenge-editor/client/interfaces/challenge-content.ts
@@ -1,4 +1,5 @@
 export interface ChallengeContent {
   name: string;
   fileData: string;
+  dashedName: string;
 }

--- a/tools/challenge-editor/client/src/components/editor/editor.tsx
+++ b/tools/challenge-editor/client/src/components/editor/editor.tsx
@@ -20,6 +20,7 @@ const Editor = () => {
   const [loading, setLoading] = useState(false);
   const [items, setItems] = useState({
     name: '',
+    dashedName: '',
     fileData: ''
   });
   const [stepContent, setStepContent] = useState('');
@@ -90,7 +91,9 @@ const Editor = () => {
       </p>
       <p>
         <Link
-          to={`${import.meta.env.CHALLENGE_EDITOR_LEARN_CLIENT_LOCATION}/learn/${superBlockNameMap[superblock || '']}/${block || ''}/${items.name.replace(/[\s]+/g, '-').toLowerCase() || ''}`}
+          to={`${import.meta.env.CHALLENGE_EDITOR_LEARN_CLIENT_LOCATION}/learn/${superBlockNameMap[superblock || '']}/${block || ''}/${
+            items.dashedName
+          }`}
           target='_blank'
         >
           View Live Version of the Challenge in your running development


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #59399

<!-- Feel free to add any additional description of changes below this line -->
I updated the API so we actually knew the real dashed name from the challenge. From there I used the value in the client to populate our links. 