### PR TITLE
fix(config, client): correct environment name in paypal config

### DIFF
--- a/client/src/components/Donation/paypal-button.tsx
+++ b/client/src/components/Donation/paypal-button.tsx
@@ -50,10 +50,10 @@ type PaypalButtonState = {
 const {
   paypalClientId,
   deploymentEnv
-}: { paypalClientId: string | null; deploymentEnv: 'staging' | 'live' } =
+}: { paypalClientId: string | null; deploymentEnv: 'staging' | 'production' } =
   envData as {
     paypalClientId: string | null;
-    deploymentEnv: 'staging' | 'live';
+    deploymentEnv: 'staging' | 'production';
   };
 
 class PaypalButton extends Component<PaypalButtonProps, PaypalButtonState> {

--- a/shared/config/donation-settings.ts
+++ b/shared/config/donation-settings.ts
@@ -17,7 +17,7 @@ export const defaultDonation: DonationConfig = {
 export const defaultTierAmount: DonationAmount = 2000;
 
 export const onetimeSKUConfig = {
-  live: [
+  production: [
     { amount: '15000', id: 'sku_IElisJHup0nojP' },
     { amount: '10000', id: 'sku_IEliodY88lglPk' },
     { amount: '7500', id: 'sku_IEli9AXW8DwNtT' },
@@ -48,7 +48,7 @@ export const donationSubscriptionConfig = {
 // Shared paypal configuration
 // keep the 5 dollars for the modal
 export const paypalConfigTypes = {
-  live: {
+  production: {
     month: {
       500: { planId: 'P-6B636789V3105190KMTJFH7A' },
       1000: { planId: 'P-53P76823N8780520DMVTWF3I' },
@@ -125,7 +125,7 @@ export enum PaymentProvider {
 }
 
 const stripeProductIds = {
-  live: {
+  production: {
     month: {
       500: 'prod_Cc9bIxB2NvjpLy',
       1000: 'prod_BuiSxWk7jGSFlJ',
@@ -144,6 +144,6 @@ const stripeProductIds = {
 };
 
 export const allStripeProductIdsArray = [
-  ...Object.values(stripeProductIds['live']['month']),
+  ...Object.values(stripeProductIds['production']['month']),
   ...Object.values(stripeProductIds['staging']['month'])
 ];


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #59413

The error is probably because of a change in the possible values of `DEPLOYMENT_ENV`. I think previously it was `live` / `staging`, and we changed it to `production` / `staging`:
- https://github.com/freeCodeCamp/freeCodeCamp/blob/8cf491291b922ed9d2f6993a077f4daa9f459db3/.github/workflows/deploy-legacy.yml#L13
- https://github.com/freeCodeCamp/freeCodeCamp/blob/8cf491291b922ed9d2f6993a077f4daa9f459db3/.github/workflows/deploy-legacy.yml#L208

## Testing

I was able to reproduce the issue if I set `DEPLOYMENT_ENV` to `production`. So to test this change, I think you can just:
- Set `DEPLOYMENT_ENV=production` 
- Start the app 
- Go to /donate and certification pages

<!-- Feel free to add any additional description of changes below this line -->
