### PR TITLE
feat: remove getUserInput

### DIFF
--- a/client/src/templates/Challenges/utils/build.ts
+++ b/client/src/templates/Challenges/utils/build.ts
@@ -309,7 +309,7 @@ function buildBackendChallenge({ url }: BuildChallengeData) {
   return {
     challengeType: challengeTypes.backend,
     build: concatHtml({ testRunner: frameRunnerSrc }),
-    sources: { url }
+    sources: { contents: url }
   };
 }
 

--- a/client/src/templates/Challenges/utils/frame.ts
+++ b/client/src/templates/Challenges/utils/frame.ts
@@ -1,4 +1,4 @@
-import { toString, flow } from 'lodash-es';
+import { flow } from 'lodash-es';
 import i18next, { type i18n } from 'i18next';
 
 import { format } from '../../../utils/format';
@@ -310,12 +310,8 @@ const initTestFrame = (frameReady?: () => void) => (frameContext: Context) => {
   waitForFrame(frameContext)
     .then(async () => {
       const { sources, loadEnzyme } = frameContext;
-      // provide the file name and get the original source
-      const getUserInput = (fileName: string) =>
-        toString(sources[fileName as keyof typeof sources]);
       await frameContext.window?.document?.__initTestFrame({
         code: sources,
-        getUserInput,
         loadEnzyme
       });
 

--- a/curriculum/challenges/english/03-front-end-development-libraries/react-and-redux/getting-started-with-react-redux.md
+++ b/curriculum/challenges/english/03-front-end-development-libraries/react-and-redux/getting-started-with-react-redux.md
@@ -34,10 +34,9 @@ assert(
 The `DisplayMessages` constructor should be called properly with `super`, passing in `props`.
 
 ```js
-(getUserInput) =>
-  assert(
+assert(
     (function () {
-      const noWhiteSpace = __helpers.removeWhiteSpace(getUserInput('index'));
+      const noWhiteSpace = __helpers.removeWhiteSpace(code);
       return (
         noWhiteSpace.includes('constructor(props)') &&
         noWhiteSpace.includes('super(props')

--- a/curriculum/challenges/english/03-front-end-development-libraries/react-and-redux/moving-forward-from-here.md
+++ b/curriculum/challenges/english/03-front-end-development-libraries/react-and-redux/moving-forward-from-here.md
@@ -23,11 +23,10 @@ Log the message `'Now I know React and Redux!'` to the console.
 The message `Now I know React and Redux!` should be logged to the console.
 
 ```js
-(getUserInput) =>
+() =>
   assert(
     /console\s*\.\s*log\s*\(\s*('|"|`)Now I know React and Redux!\1\s*\)/.test(
-      getUserInput('index')
-    )
+      code)
   );
 ```
 

--- a/curriculum/challenges/english/03-front-end-development-libraries/react-and-redux/use-provider-to-connect-redux-to-react.md
+++ b/curriculum/challenges/english/03-front-end-development-libraries/react-and-redux/use-provider-to-connect-redux-to-react.md
@@ -40,12 +40,12 @@ assert(
 The `Provider` wrapper component should have a prop of `store` passed to it, equal to the Redux store.
 
 ```js
-(getUserInput) =>
+() =>
   assert(
     (function () {
       const mockedComponent = Enzyme.mount(React.createElement(AppWrapper));
       return __helpers
-        .removeWhiteSpace(getUserInput('index'))
+        .removeWhiteSpace(code)
         .includes('<Providerstore={store}>');
     })()
   );

--- a/curriculum/challenges/english/03-front-end-development-libraries/react/override-default-props.md
+++ b/curriculum/challenges/english/03-front-end-development-libraries/react/override-default-props.md
@@ -43,14 +43,13 @@ assert(
 The `Items` component should have a prop of `{ quantity: 10 }` passed from the `ShoppingCart` component.
 
 ```js
-(getUserInput) =>
+() =>
   assert(
     (function () {
       const mockedComponent = Enzyme.mount(React.createElement(ShoppingCart));
       return (
         mockedComponent.find('Items').props().quantity == 10 &&
-        getUserInput('index')
-          .replace(/ /g, '')
+        code.replace(/ /g, '')
           .includes('<Itemsquantity={10}/>')
       );
     })()

--- a/curriculum/challenges/english/03-front-end-development-libraries/react/render-react-on-the-server-with-rendertostring.md
+++ b/curriculum/challenges/english/03-front-end-development-libraries/react/render-react-on-the-server-with-rendertostring.md
@@ -21,10 +21,9 @@ The `renderToString()` method is provided on `ReactDOMServer`, which is availabl
 The `App` component should render to a string using `ReactDOMServer.renderToString`.
 
 ```js
-(getUserInput) =>
+() =>
   assert(
-    getUserInput('index')
-      .replace(/ /g, '')
+    code.replace(/ /g, '')
       .includes('ReactDOMServer.renderToString(<App/>)') &&
       Enzyme.mount(React.createElement(App)).children().name() === 'div'
   );

--- a/curriculum/challenges/english/03-front-end-development-libraries/react/render-state-in-the-user-interface-another-way.md
+++ b/curriculum/challenges/english/03-front-end-development-libraries/react/render-state-in-the-user-interface-another-way.md
@@ -40,8 +40,7 @@ assert(
 The rendered `h1` tag should include a reference to `{name}`.
 
 ```js
-(getUserInput) =>
-  assert(/<h1>\n*\s*\{\s*name\s*\}\s*\n*<\/h1>/.test(getUserInput('index')));
+assert(/<h1>\n*\s*\{\s*name\s*\}\s*\n*<\/h1>/.test(code));
 ```
 
 The rendered `h1` heading element should contain text rendered from the component's state.

--- a/curriculum/challenges/english/03-front-end-development-libraries/react/render-with-an-if-else-condition.md
+++ b/curriculum/challenges/english/03-front-end-development-libraries/react/render-with-an-if-else-condition.md
@@ -74,11 +74,7 @@ async () => {
 The render method should use an `if/else` statement to check the condition of `this.state.display`.
 
 ```js
-(getUserInput) =>
-  assert(
-    getUserInput('index').includes('if') &&
-      getUserInput('index').includes('else')
-  );
+assert(code.includes('if') && code.includes('else'));
 ```
 
 # --seed--

--- a/curriculum/challenges/english/03-front-end-development-libraries/react/use--for-a-more-concise-conditional.md
+++ b/curriculum/challenges/english/03-front-end-development-libraries/react/use--for-a-more-concise-conditional.md
@@ -78,7 +78,7 @@ async () => {
 The render method should use the `&&` logical operator to check the condition of `this.state.display`.
 
 ```js
-(getUserInput) => assert(getUserInput('index').includes('&&'));
+assert(code.includes('&&'));
 ```
 
 # --seed--

--- a/curriculum/challenges/english/03-front-end-development-libraries/react/use-proptypes-to-define-the-props-you-expect.md
+++ b/curriculum/challenges/english/03-front-end-development-libraries/react/use-proptypes-to-define-the-props-you-expect.md
@@ -51,16 +51,8 @@ assert(
 The `Items` component should include a `propTypes` check to require a value for `quantity` and ensure that its value is a number.
 
 ```js
-(getUserInput) =>
-  assert(
-    (function () {
-      const noWhiteSpace = __helpers.removeWhiteSpace(getUserInput('index'));
-      return (
-        noWhiteSpace.includes('quantity:PropTypes.number.isRequired') &&
-        noWhiteSpace.includes('Items.propTypes=')
-      );
-    })()
-  );
+const noWhiteSpace = __helpers.removeWhiteSpace(code);
+assert(noWhiteSpace.includes('quantity:PropTypes.number.isRequired') && noWhiteSpace.includes('Items.propTypes='));
 ```
 
 # --seed--

--- a/curriculum/challenges/english/03-front-end-development-libraries/react/write-a-react-component-from-scratch.md
+++ b/curriculum/challenges/english/03-front-end-development-libraries/react/write-a-react-component-from-scratch.md
@@ -21,12 +21,7 @@ Render this component to the DOM using `ReactDOM.render()`. There is a `div` wit
 There should be a React component called `MyComponent`.
 
 ```js
-(getUserInput) =>
-  assert(
-    __helpers
-      .removeWhiteSpace(getUserInput('index'))
-      .includes('classMyComponentextendsReact.Component{')
-  );
+assert(__helpers.removeWhiteSpace(code).includes('classMyComponentextendsReact.Component{'));
 ```
 
 `MyComponent` should contain an `h1` tag with text `My First React Component!` Case and punctuation matter.

--- a/curriculum/challenges/english/03-front-end-development-libraries/redux/combine-multiple-reducers.md
+++ b/curriculum/challenges/english/03-front-end-development-libraries/redux/combine-multiple-reducers.md
@@ -77,10 +77,9 @@ assert(
 The `rootReducer` should be a function that combines the `counterReducer` and the `authReducer`.
 
 ```js
-(getUserInput) =>
-  assert(
+assert(
     (function () {
-      const noWhiteSpace = __helpers.removeWhiteSpace(getUserInput('index'));
+      const noWhiteSpace = __helpers.removeWhiteSpace(code);
       return (
         typeof rootReducer === 'function' &&
         noWhiteSpace.includes('Redux.combineReducers')

--- a/curriculum/challenges/english/03-front-end-development-libraries/redux/copy-an-object-with-object.assign.md
+++ b/curriculum/challenges/english/03-front-end-development-libraries/redux/copy-an-object-with-object.assign.md
@@ -68,7 +68,7 @@ assert(
 `Object.assign` should be used to return new state.
 
 ```js
-(getUserInput) => assert(getUserInput('index').includes('Object.assign'));
+assert(code.includes('Object.assign'));
 ```
 
 # --seed--

--- a/curriculum/challenges/english/03-front-end-development-libraries/redux/dispatch-an-action-event.md
+++ b/curriculum/challenges/english/03-front-end-development-libraries/redux/dispatch-an-action-event.md
@@ -38,16 +38,15 @@ assert(store.getState().login === false);
 The `store.dispatch()` method should be used to dispatch an action of type `LOGIN`.
 
 ```js
-(getUserInput) =>
-  assert(
+assert(
     (function () {
-      let noWhiteSpace = getUserInput('index').replace(/\s/g, '');
+      let noWhiteSpace = code.replace(/\s/g, '');
       return (
         noWhiteSpace.includes('store.dispatch(loginAction())') ||
         noWhiteSpace.includes("store.dispatch({type: 'LOGIN'})") === true
       );
     })()
-  );
+);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/03-front-end-development-libraries/redux/get-state-from-the-redux-store.md
+++ b/curriculum/challenges/english/03-front-end-development-libraries/redux/get-state-from-the-redux-store.md
@@ -25,10 +25,7 @@ assert(store.getState() === 5);
 A variable `currentState` should exist and should be assigned the current state of the Redux store.
 
 ```js
-(getUserInput) =>
-  assert(
-    currentState === 5 && getUserInput('index').includes('store.getState()')
-  );
+assert(currentState === 5 && code.includes('store.getState()'));
 ```
 
 # --seed--

--- a/curriculum/challenges/english/03-front-end-development-libraries/redux/use-a-switch-statement-to-handle-multiple-actions.md
+++ b/curriculum/challenges/english/03-front-end-development-libraries/redux/use-a-switch-statement-to-handle-multiple-actions.md
@@ -70,11 +70,10 @@ assert(
 The `authReducer` function should handle multiple action types with a `switch` statement.
 
 ```js
-(getUserInput) =>
-  assert(
-    getUserInput('index').toString().includes('switch') &&
-      getUserInput('index').toString().includes('case') &&
-      getUserInput('index').toString().includes('default')
+assert(
+    code.toString().includes('switch') &&
+      code.toString().includes('case') &&
+      code.toString().includes('default')
   );
 ```
 

--- a/curriculum/challenges/english/03-front-end-development-libraries/redux/use-const-for-action-types.md
+++ b/curriculum/challenges/english/03-front-end-development-libraries/redux/use-const-for-action-types.md
@@ -93,7 +93,6 @@ assert(noWhiteSpace.includes('const'))
 The action creators and the reducer should reference the `LOGIN` and `LOGOUT` constants.
 
 ```js
-(getUserInput) =>
   assert(
     (function () {
       const noWhiteSpace = __helpers.removeWhiteSpace(

--- a/curriculum/challenges/english/03-front-end-development-libraries/redux/use-const-for-action-types.md
+++ b/curriculum/challenges/english/03-front-end-development-libraries/redux/use-const-for-action-types.md
@@ -70,14 +70,13 @@ assert(
 The `authReducer` function should handle multiple action types with a switch statement.
 
 ```js
-(getUserInput) =>
-  assert(
+assert(
     (function () {
       return (
         typeof authReducer === 'function' &&
-        getUserInput('index').toString().includes('switch') &&
-        getUserInput('index').toString().includes('case') &&
-        getUserInput('index').toString().includes('default')
+        code.toString().includes('switch') &&
+        code.toString().includes('case') &&
+        code.toString().includes('default')
       );
     })()
   );
@@ -98,7 +97,7 @@ The action creators and the reducer should reference the `LOGIN` and `LOGOUT` co
   assert(
     (function () {
       const noWhiteSpace = __helpers.removeWhiteSpace(
-        getUserInput('index').toString()
+        code.toString()
       );
       return (
         noWhiteSpace.includes('caseLOGIN:') &&

--- a/curriculum/challenges/english/03-front-end-development-libraries/redux/use-the-spread-operator-on-arrays.md
+++ b/curriculum/challenges/english/03-front-end-development-libraries/redux/use-the-spread-operator-on-arrays.md
@@ -60,7 +60,7 @@ assert(
 The spread operator should be used to return new state.
 
 ```js
-(getUserInput) => assert(getUserInput('index').includes('...state'));
+assert(code.includes('...state'));
 ```
 
 # --seed--

--- a/curriculum/challenges/english/05-back-end-development-and-apis/back-end-development-and-apis-projects/exercise-tracker.md
+++ b/curriculum/challenges/english/05-back-end-development-and-apis/back-end-development-and-apis-projects/exercise-tracker.md
@@ -61,19 +61,16 @@ Log:
 You should provide your own project, not the example URL.
 
 ```js
-(getUserInput) => {
-  const url = getUserInput('url');
   assert(
-    !/.*\/exercise-tracker\.freecodecamp\.rocks/.test(getUserInput('url'))
+    !/.*\/exercise-tracker\.freecodecamp\.rocks/.test(code)
   );
-};
 ```
 
 You can `POST` to `/api/users` with form data `username` to create a new user.
 
 ```js
-async (getUserInput) => {
-  const url = getUserInput('url');
+async () => {
+  const url = code;
   const res = await fetch(url + '/api/users', {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
@@ -89,8 +86,8 @@ async (getUserInput) => {
 The returned response from `POST /api/users` with form data `username` will be an object with `username` and `_id` properties.
 
 ```js
-async (getUserInput) => {
-  const url = getUserInput('url');
+async () => {
+  const url = code;
   const res = await fetch(url + '/api/users', {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
@@ -109,8 +106,8 @@ async (getUserInput) => {
 You can make a `GET` request to `/api/users` to get a list of all users.
 
 ```js
-async(getUserInput) => {
-  const url = getUserInput('url');
+async () => {
+  const url = code;
   const res = await fetch(url + '/api/users');
   assert.isTrue(res.ok);
   if(!res.ok) {
@@ -122,8 +119,8 @@ async(getUserInput) => {
 The `GET` request to `/api/users` returns an array.
 
 ```js
-async(getUserInput) => {
-  const url = getUserInput('url');
+async () => {
+  const url = code;
   const res = await fetch(url + '/api/users');
   if(res.ok){
     const users = await res.json();
@@ -137,8 +134,8 @@ async(getUserInput) => {
 Each element in the array returned from `GET /api/users` is an object literal containing a user's `username` and `_id`.
 
 ```js
-async(getUserInput) => {
-  const url = getUserInput('url');
+async () => {
+  const url = code;
   const res = await fetch(url + '/api/users');
   if(res.ok){
     const users = await res.json();
@@ -157,8 +154,8 @@ async(getUserInput) => {
 You can `POST` to `/api/users/:_id/exercises` with form data `description`, `duration`, and optionally `date`. If no date is supplied, the current date will be used. 
 
 ```js
-async (getUserInput) => {
-  const url = getUserInput('url');
+async () => {
+  const url = code;
   const res = await fetch(url + '/api/users', {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
@@ -191,8 +188,8 @@ async (getUserInput) => {
 The response returned from `POST /api/users/:_id/exercises` will be the user object with the exercise fields added.
 
 ```js
-async (getUserInput) => {
-  const url = getUserInput('url');
+async () => {
+  const url = code;
   const res = await fetch(url + '/api/users', {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
@@ -244,8 +241,8 @@ async (getUserInput) => {
 You can make a `GET` request to `/api/users/:_id/logs` to retrieve a full exercise log of any user.
 
 ```js
-async (getUserInput) => {
-  const url = getUserInput('url');
+async () => {
+  const url = code;
   const res = await fetch(url + '/api/users', {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
@@ -283,8 +280,8 @@ async (getUserInput) => {
 A request to a user's log `GET /api/users/:_id/logs` returns a user object with a `count` property representing the number of exercises that belong to that user.
 
 ```js
-async (getUserInput) => {
-  const url = getUserInput('url');
+async () => {
+  const url = code;
   const res = await fetch(url + '/api/users', {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
@@ -324,8 +321,8 @@ async (getUserInput) => {
 A `GET` request to `/api/users/:_id/logs` will return the user object with a `log` array of all the exercises added.
 
 ```js
-async(getUserInput) => {
-  const url = getUserInput('url');
+async () => {
+  const url = code;
   const res = await fetch(url + '/api/users', {
     method: 'POST',
     headers: {
@@ -368,8 +365,8 @@ async(getUserInput) => {
 Each item in the `log` array that is returned from `GET /api/users/:_id/logs` is an object that should have a `description`, `duration`, and `date` properties.
 
 ```js
-async(getUserInput) => {
-  const url = getUserInput('url');
+async () => {
+  const url = code;
   const res = await fetch(url + `/api/users`, {
     method: 'POST',
     headers: {
@@ -415,8 +412,8 @@ async(getUserInput) => {
 The `description` property of any object in the `log` array that is returned from `GET /api/users/:_id/logs` should be a string.
 
 ```js
-async(getUserInput) => {
-  const url = getUserInput('url');
+async () => {
+  const url = code;
   const res = await fetch(url + '/api/users', {
     method: 'POST',
     headers: {
@@ -462,8 +459,8 @@ async(getUserInput) => {
 The `duration` property of any object in the `log` array that is returned from `GET /api/users/:_id/logs` should be a number.
 
 ```js
-async(getUserInput) => {
-  const url = getUserInput('url');
+async () => {
+  const url = code;
   const res = await fetch(url + '/api/users', {
     method: 'POST',
     headers: {
@@ -509,8 +506,8 @@ async(getUserInput) => {
 The `date` property of any object in the `log` array that is returned from `GET /api/users/:_id/logs` should be a string. Use the `dateString` format of the `Date` API.
 
 ```js
-async (getUserInput) => {
-  const url = getUserInput('url');
+async () => {
+  const url = code;
   const res = await fetch(url + '/api/users', {
     method: 'POST',
     headers: {
@@ -571,8 +568,8 @@ async (getUserInput) => {
 You can add `from`, `to` and `limit` parameters to a `GET /api/users/:_id/logs` request to retrieve part of the log of any user. `from` and `to` are dates in `yyyy-mm-dd` format. `limit` is an integer of how many logs to send back.
 
 ```js
-async (getUserInput) => {
-  const url = getUserInput('url');
+async () => {
+  const url = code;
   const res = await fetch(url + '/api/users', {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },

--- a/curriculum/challenges/english/05-back-end-development-and-apis/back-end-development-and-apis-projects/file-metadata-microservice.md
+++ b/curriculum/challenges/english/05-back-end-development-and-apis/back-end-development-and-apis-projects/file-metadata-microservice.md
@@ -23,20 +23,18 @@ Build a full stack JavaScript app that is functionally similar to this: <a href=
 You should provide your own project, not the example URL.
 
 ```js
-(getUserInput) => {
   assert(
     !/.*\/file-metadata-microservice\.freecodecamp\.rocks/.test(
-      getUserInput('url')
+      code
     )
   );
-};
 ```
 
 You can submit a form that includes a file upload.
 
 ```js
-async (getUserInput) => {
-  const site = await fetch(getUserInput('url'));
+async () => {
+  const site = await fetch(code);
   const data = await site.text();
   const doc = new DOMParser().parseFromString(data, 'text/html');
   assert(doc.querySelector('input[type="file"]'));
@@ -46,8 +44,8 @@ async (getUserInput) => {
 The form file input field has the `name` attribute set to `upfile`.
 
 ```js
-async (getUserInput) => {
-  const site = await fetch(getUserInput('url'));
+async () => {
+  const site = await fetch(code);
   const data = await site.text();
   const doc = new DOMParser().parseFromString(data, 'text/html');
   assert(doc.querySelector('input[name="upfile"]'));
@@ -57,14 +55,14 @@ async (getUserInput) => {
 When you submit a file, you receive the file `name`, `type`, and `size` in bytes within the JSON response.
 
 ```js
-async (getUserInput) => {
+async () => {
   const formData = new FormData();
   const fileData = await fetch(
     'https://cdn.freecodecamp.org/weather-icons/01d.png'
   );
   const file = await fileData.blob();
   formData.append('upfile', file, 'icon');
-  const data = await fetch(getUserInput('url') + '/api/fileanalyse', {
+  const data = await fetch(code + '/api/fileanalyse', {
     method: 'POST',
     body: formData
   });

--- a/curriculum/challenges/english/05-back-end-development-and-apis/back-end-development-and-apis-projects/request-header-parser-microservice.md
+++ b/curriculum/challenges/english/05-back-end-development-and-apis/back-end-development-and-apis-projects/request-header-parser-microservice.md
@@ -19,20 +19,17 @@ Build a full stack JavaScript app that is functionally similar to this: <a href=
 You should provide your own project, not the example URL.
 
 ```js
-(getUserInput) => {
   assert(
     !/.*\/request-header-parser-microservice\.freecodecamp\.rocks/.test(
-      getUserInput('url')
+      code
     )
   );
-};
 ```
 
 A request to `/api/whoami` should return a JSON object with your IP address in the `ipaddress` key.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/api/whoami').then(
+  $.get(code + '/api/whoami').then(
     (data) => assert(data.ipaddress && data.ipaddress.length > 0),
     (xhr) => {
       throw new Error(xhr.responseText);
@@ -43,8 +40,7 @@ A request to `/api/whoami` should return a JSON object with your IP address in t
 A request to `/api/whoami` should return a JSON object with your preferred language in the `language` key.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/api/whoami').then(
+  $.get(code + '/api/whoami').then(
     (data) => assert(data.language && data.language.length > 0),
     (xhr) => {
       throw new Error(xhr.responseText);
@@ -55,8 +51,7 @@ A request to `/api/whoami` should return a JSON object with your preferred langu
 A request to `/api/whoami` should return a JSON object with your software in the `software` key.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/api/whoami').then(
+  $.get(code + '/api/whoami').then(
     (data) => assert(data.software && data.software.length > 0),
     (xhr) => {
       throw new Error(xhr.responseText);

--- a/curriculum/challenges/english/05-back-end-development-and-apis/back-end-development-and-apis-projects/timestamp-microservice.md
+++ b/curriculum/challenges/english/05-back-end-development-and-apis/back-end-development-and-apis-projects/timestamp-microservice.md
@@ -21,18 +21,15 @@ Build a full stack JavaScript app that is functionally similar to this: <a href=
 You should provide your own project, not the example URL.
 
 ```js
-(getUserInput) => {
   assert(
-    !/.*\/timestamp-microservice\.freecodecamp\.rocks/.test(getUserInput('url'))
+    !/.*\/timestamp-microservice\.freecodecamp\.rocks/.test(code)
   );
-};
 ```
 
 A request to `/api/:date?` with a valid date should return a JSON object with a `unix` key that is a Unix timestamp of the input date in milliseconds (as type Number)
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/api/2016-12-25').then(
+  $.get(code + '/api/2016-12-25').then(
     (data) => {
       assert.equal(
         data.unix,
@@ -49,8 +46,7 @@ A request to `/api/:date?` with a valid date should return a JSON object with a 
 A request to `/api/:date?` with a valid date should return a JSON object with a `utc` key that is a string of the input date in the format: `Thu, 01 Jan 1970 00:00:00 GMT`
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/api/2016-12-25').then(
+  $.get(code + '/api/2016-12-25').then(
     (data) => {
       assert.equal(
         data.utc,
@@ -67,8 +63,7 @@ A request to `/api/:date?` with a valid date should return a JSON object with a 
 A request to `/api/1451001600000` should return `{ unix: 1451001600000, utc: "Fri, 25 Dec 2015 00:00:00 GMT" }`
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/api/1451001600000').then(
+  $.get(code + '/api/1451001600000').then(
     (data) => {
       assert(
         data.unix === 1451001600000 &&
@@ -84,8 +79,7 @@ A request to `/api/1451001600000` should return `{ unix: 1451001600000, utc: "Fr
 Your project can handle dates that can be successfully parsed by `new Date(date_string)`
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/api/05 October 2011, GMT').then(
+  $.get(code + '/api/05 October 2011, GMT').then(
     (data) => {
       assert(
         data.unix === 1317772800000 &&
@@ -101,8 +95,7 @@ Your project can handle dates that can be successfully parsed by `new Date(date_
 If the input date string is invalid, the API returns an object having the structure `{ error : "Invalid Date" }`
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/api/this-is-not-a-date').then(
+  $.get(code + '/api/this-is-not-a-date').then(
     (data) => {
       assert.equal(data.error.toLowerCase(), 'invalid date');
     },
@@ -115,8 +108,7 @@ If the input date string is invalid, the API returns an object having the struct
 An empty date parameter should return the current time in a JSON object with a `unix` key
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/api').then(
+  $.get(code + '/api').then(
     (data) => {
       var now = Date.now();
       assert.approximately(data.unix, now, 20000);
@@ -130,8 +122,7 @@ An empty date parameter should return the current time in a JSON object with a `
 An empty date parameter should return the current time in a JSON object with a `utc` key
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/api').then(
+  $.get(code + '/api').then(
     (data) => {
       var now = Date.now();
       var serverTime = new Date(data.utc).getTime();

--- a/curriculum/challenges/english/05-back-end-development-and-apis/back-end-development-and-apis-projects/url-shortener-microservice.md
+++ b/curriculum/challenges/english/05-back-end-development-and-apis/back-end-development-and-apis-projects/url-shortener-microservice.md
@@ -23,20 +23,18 @@ Build a full stack JavaScript app that is functionally similar to this: <a href=
 You should provide your own project, not the example URL.
 
 ```js
-(getUserInput) => {
   assert(
     !/.*\/url-shortener-microservice\.freecodecamp\.rocks/.test(
-      getUserInput('url')
+      code
     )
   );
-};
 ```
 
 You can POST a URL to `/api/shorturl` and get a JSON response with `original_url` and `short_url` properties. Here's an example: `{ original_url : 'https://freeCodeCamp.org', short_url : 1}`
 
 ```js
-async (getUserInput) => {
-  const url = getUserInput('url');
+async () => {
+  const url = code;
   const urlVariable = Date.now();
   const fullUrl = `${url}/?v=${urlVariable}`
   const res = await fetch(url + '/api/shorturl', {
@@ -57,8 +55,8 @@ async (getUserInput) => {
 When you visit `/api/shorturl/<short_url>`, you will be redirected to the original URL.
 
 ```js
-async (getUserInput) => {
-  const url = getUserInput('url');
+async () => {
+  const url = code;
   const urlVariable = Date.now();
   const fullUrl = `${url}/?v=${urlVariable}`
   let shortenedUrlVariable;
@@ -89,8 +87,8 @@ async (getUserInput) => {
 If you pass an invalid URL that doesn't follow the valid `http://www.example.com` format, the JSON response will contain `{ error: 'invalid url' }`
 
 ```js
-async (getUserInput) => {
-  const url = getUserInput('url');
+async () => {
+  const url = code;
   const res = await fetch(url + '/api/shorturl', {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },

--- a/curriculum/challenges/english/05-back-end-development-and-apis/basic-node-and-express/chain-middleware-to-create-a-time-server.md
+++ b/curriculum/challenges/english/05-back-end-development-and-apis/basic-node-and-express/chain-middleware-to-create-a-time-server.md
@@ -34,8 +34,7 @@ In the route `app.get('/now', ...)` chain a middleware function and the final ha
 The /now endpoint should have mounted middleware
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/chain-middleware-time').then(
+  $.get(code + '/_api/chain-middleware-time').then(
     (data) => {
       assert.equal(
         data.stackLength,
@@ -52,8 +51,7 @@ The /now endpoint should have mounted middleware
 The `/now` endpoint should return the current time.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/chain-middleware-time').then(
+  $.get(code + '/_api/chain-middleware-time').then(
     (data) => {
       var now = new Date();
       assert.isAtMost(

--- a/curriculum/challenges/english/05-back-end-development-and-apis/basic-node-and-express/get-data-from-post-requests.md
+++ b/curriculum/challenges/english/05-back-end-development-and-apis/basic-node-and-express/get-data-from-post-requests.md
@@ -31,8 +31,7 @@ There are also a couple of other methods which are used to negotiate a connectio
 Test 1 : Your API endpoint should respond with the correct name
 
 ```js
-(getUserInput) =>
-  $.post(getUserInput('url') + '/name', { first: 'Mick', last: 'Jagger' }).then(
+  $.post(code + '/name', { first: 'Mick', last: 'Jagger' }).then(
     (data) => {
       assert.equal(
         data.name,
@@ -49,8 +48,7 @@ Test 1 : Your API endpoint should respond with the correct name
 Test 2 : Your API endpoint should respond with the correct name
 
 ```js
-(getUserInput) =>
-  $.post(getUserInput('url') + '/name', {
+  $.post(code + '/name', {
     first: 'Keith',
     last: 'Richards'
   }).then(

--- a/curriculum/challenges/english/05-back-end-development-and-apis/basic-node-and-express/get-query-parameter-input-from-the-client.md
+++ b/curriculum/challenges/english/05-back-end-development-and-apis/basic-node-and-express/get-query-parameter-input-from-the-client.md
@@ -23,8 +23,7 @@ Build an API endpoint, mounted at `GET /name`. Respond with a JSON document, tak
 Test 1 : Your API endpoint should respond with `{ "name": "Mick Jagger" }` when the `/name` endpoint is called with `?first=Mick&last=Jagger`
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/name?first=Mick&last=Jagger').then(
+  $.get(code + '/name?first=Mick&last=Jagger').then(
     (data) => {
       assert.equal(
         data.name,
@@ -41,8 +40,7 @@ Test 1 : Your API endpoint should respond with `{ "name": "Mick Jagger" }` when 
 Test 2 : Your API endpoint should respond with `{ "name": "Keith Richards" }` when the `/name` endpoint is called with `?first=Keith&last=Richards`
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/name?last=Richards&first=Keith').then(
+  $.get(code + '/name?last=Richards&first=Keith').then(
     (data) => {
       assert.equal(
         data.name,

--- a/curriculum/challenges/english/05-back-end-development-and-apis/basic-node-and-express/get-route-parameter-input-from-the-client.md
+++ b/curriculum/challenges/english/05-back-end-development-and-apis/basic-node-and-express/get-route-parameter-input-from-the-client.md
@@ -21,8 +21,7 @@ Build an echo server, mounted at the route `GET /:word/echo`. Respond with a JSO
 Test 1 : Your echo server should repeat words correctly
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/eChOtEsT/echo').then(
+  $.get(code + '/eChOtEsT/echo').then(
     (data) => {
       assert.equal(
         data.echo,
@@ -39,8 +38,7 @@ Test 1 : Your echo server should repeat words correctly
 Test 2 : Your echo server should repeat words correctly
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/ech0-t3st/echo').then(
+  $.get(code + '/ech0-t3st/echo').then(
     (data) => {
       assert.equal(
         data.echo,

--- a/curriculum/challenges/english/05-back-end-development-and-apis/basic-node-and-express/implement-a-root-level-request-logger-middleware.md
+++ b/curriculum/challenges/english/05-back-end-development-and-apis/basic-node-and-express/implement-a-root-level-request-logger-middleware.md
@@ -32,8 +32,7 @@ Build a simple logger. For every request, it should log to the console a string 
 Root level logger middleware should be active
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/root-middleware-logger').then(
+  $.get(code + '/_api/root-middleware-logger').then(
     (data) => {
       assert.isTrue(
         data.passed,

--- a/curriculum/challenges/english/05-back-end-development-and-apis/basic-node-and-express/meet-the-node-console.md
+++ b/curriculum/challenges/english/05-back-end-development-and-apis/basic-node-and-express/meet-the-node-console.md
@@ -37,8 +37,7 @@ Modify the `myApp.js` file to log "Hello World" to the console.
 `"Hello World"` should be in the console
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/hello-console').then(
+  $.get(code + '/_api/hello-console').then(
     (data) => {
       assert.isTrue(data.passed, '"Hello World" is not in the server console');
     },

--- a/curriculum/challenges/english/05-back-end-development-and-apis/basic-node-and-express/serve-an-html-file.md
+++ b/curriculum/challenges/english/05-back-end-development-and-apis/basic-node-and-express/serve-an-html-file.md
@@ -25,8 +25,7 @@ Send the `/views/index.html` file as a response to GET requests to the `/` path.
 Your app should serve the file views/index.html
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url')).then(
+  $.get(code).then(
     (data) => {
       assert.match(
         data,

--- a/curriculum/challenges/english/05-back-end-development-and-apis/basic-node-and-express/serve-json-on-a-specific-route.md
+++ b/curriculum/challenges/english/05-back-end-development-and-apis/basic-node-and-express/serve-json-on-a-specific-route.md
@@ -21,8 +21,7 @@ Serve the object `{"message": "Hello json"}` as a response, in JSON format, to G
 The endpoint `/json` should serve the JSON object `{"message": "Hello json"}`
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/json').then(
+  $.get(code + '/json').then(
     (data) => {
       assert.equal(
         data.message,

--- a/curriculum/challenges/english/05-back-end-development-and-apis/basic-node-and-express/serve-static-assets.md
+++ b/curriculum/challenges/english/05-back-end-development-and-apis/basic-node-and-express/serve-static-assets.md
@@ -25,8 +25,7 @@ Now your app should be able to serve a CSS stylesheet. Note that the `/public/st
 Your app should serve asset files from the `/public` directory to the `/public` path
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/public/style.css').then(
+  $.get(code + '/public/style.css').then(
     (data) => {
       assert.match(
         data,
@@ -43,8 +42,7 @@ Your app should serve asset files from the `/public` directory to the `/public` 
 Your app should not serve files from any other folders except from `/public` directory 
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/server.js').then(
+  $.get(code + '/server.js').then(
     (data) => {
        assert.equal(
         data?.status + '',

--- a/curriculum/challenges/english/05-back-end-development-and-apis/basic-node-and-express/start-a-working-express-server.md
+++ b/curriculum/challenges/english/05-back-end-development-and-apis/basic-node-and-express/start-a-working-express-server.md
@@ -31,8 +31,7 @@ Use the `app.get()` method to serve the string "Hello Express" to GET requests m
 Your app should serve the string 'Hello Express'
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url')).then(
+  $.get(code).then(
     (data) => {
       assert.equal(
         data,

--- a/curriculum/challenges/english/05-back-end-development-and-apis/basic-node-and-express/use-body-parser-to-parse-post-requests.md
+++ b/curriculum/challenges/english/05-back-end-development-and-apis/basic-node-and-express/use-body-parser-to-parse-post-requests.md
@@ -37,8 +37,7 @@ When using `extended=false`, values can be only strings or arrays. The object re
 The 'body-parser' middleware should be mounted
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/add-body-parser').then(
+  $.get(code + '/_api/add-body-parser').then(
     (data) => {
       assert.isAbove(
         data.mountedAt,

--- a/curriculum/challenges/english/05-back-end-development-and-apis/basic-node-and-express/use-the-.env-file.md
+++ b/curriculum/challenges/english/05-back-end-development-and-apis/basic-node-and-express/use-the-.env-file.md
@@ -27,8 +27,7 @@ You will need to use the `dotenv` package. It loads environment variables from y
 The response of the endpoint `/json` should change according to the environment variable `MESSAGE_STYLE`
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/use-env-vars').then(
+  $.get(code + '/_api/use-env-vars').then(
     (data) => {
       assert.isTrue(
         data.passed,

--- a/curriculum/challenges/english/05-back-end-development-and-apis/managing-packages-with-npm/add-a-description-to-your-package.json.md
+++ b/curriculum/challenges/english/05-back-end-development-and-apis/managing-packages-with-npm/add-a-description-to-your-package.json.md
@@ -29,8 +29,7 @@ Add a `description` to the package.json file of your project.
 package.json should have a valid "description" key
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/package.json').then(
+  $.get(code + '/_api/package.json').then(
     (data) => {
       var packJson = JSON.parse(data);
       assert(packJson.description, '"description" is missing');

--- a/curriculum/challenges/english/05-back-end-development-and-apis/managing-packages-with-npm/add-a-license-to-your-package.json.md
+++ b/curriculum/challenges/english/05-back-end-development-and-apis/managing-packages-with-npm/add-a-license-to-your-package.json.md
@@ -25,8 +25,7 @@ Fill the `license` field in the package.json file of your project as you find su
 package.json should have a valid "license" key
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/package.json').then(
+  $.get(code + '/_api/package.json').then(
     (data) => {
       var packJson = JSON.parse(data);
       assert(packJson.license, '"license" is missing');

--- a/curriculum/challenges/english/05-back-end-development-and-apis/managing-packages-with-npm/add-a-version-to-your-package.json.md
+++ b/curriculum/challenges/english/05-back-end-development-and-apis/managing-packages-with-npm/add-a-version-to-your-package.json.md
@@ -23,8 +23,7 @@ Add a `version` to the package.json file of your project.
 package.json should have a valid "version" key
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/package.json').then(
+  $.get(code + '/_api/package.json').then(
     (data) => {
       var packJson = JSON.parse(data);
       assert(packJson.version, '"version" is missing');

--- a/curriculum/challenges/english/05-back-end-development-and-apis/managing-packages-with-npm/add-keywords-to-your-package.json.md
+++ b/curriculum/challenges/english/05-back-end-development-and-apis/managing-packages-with-npm/add-keywords-to-your-package.json.md
@@ -27,8 +27,7 @@ One of the keywords should be "freecodecamp".
 package.json should have a valid "keywords" key
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/package.json').then(
+  $.get(code + '/_api/package.json').then(
     (data) => {
       var packJson = JSON.parse(data);
       assert(packJson.keywords, '"keywords" is missing');
@@ -42,8 +41,7 @@ package.json should have a valid "keywords" key
 "keywords" field should be an Array
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/package.json').then(
+  $.get(code + '/_api/package.json').then(
     (data) => {
       var packJson = JSON.parse(data);
       assert.isArray(packJson.keywords, '"keywords" is not an array');
@@ -57,8 +55,7 @@ package.json should have a valid "keywords" key
 "keywords" should include "freecodecamp"
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/package.json').then(
+  $.get(code + '/_api/package.json').then(
     (data) => {
       var packJson = JSON.parse(data);
       assert.include(

--- a/curriculum/challenges/english/05-back-end-development-and-apis/managing-packages-with-npm/expand-your-project-with-external-packages-from-npm.md
+++ b/curriculum/challenges/english/05-back-end-development-and-apis/managing-packages-with-npm/expand-your-project-with-external-packages-from-npm.md
@@ -31,8 +31,7 @@ Add version `1.1.0` of the `@freecodecamp/example` package to the `dependencies`
 `"dependencies"` should include `"@freecodecamp/example"`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/package.json').then(
+  $.get(code + '/_api/package.json').then(
     (data) => {
       var packJson = JSON.parse(data);
       assert.property(
@@ -50,8 +49,7 @@ Add version `1.1.0` of the `@freecodecamp/example` package to the `dependencies`
 `"@freecodecamp/example"` version should be `"1.1.0"`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/package.json').then(
+  $.get(code + '/_api/package.json').then(
     (data) => {
       var packJson = JSON.parse(data);
       assert.match(

--- a/curriculum/challenges/english/05-back-end-development-and-apis/managing-packages-with-npm/how-to-use-package.json-the-core-of-any-node.js-project-or-npm-package.md
+++ b/curriculum/challenges/english/05-back-end-development-and-apis/managing-packages-with-npm/how-to-use-package.json-the-core-of-any-node.js-project-or-npm-package.md
@@ -39,8 +39,7 @@ If you are using Gitpod, make sure the app is running and the preview window is 
 `package.json` should have a valid "author" key
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/package.json').then(
+  $.get(code + '/_api/package.json').then(
     (data) => {
       var packJson = JSON.parse(data);
       assert(packJson.author, '"author" is missing');

--- a/curriculum/challenges/english/05-back-end-development-and-apis/managing-packages-with-npm/manage-npm-dependencies-by-understanding-semantic-versioning.md
+++ b/curriculum/challenges/english/05-back-end-development-and-apis/managing-packages-with-npm/manage-npm-dependencies-by-understanding-semantic-versioning.md
@@ -27,8 +27,7 @@ In the dependencies section of your `package.json` file, change the version of `
 `"dependencies"` should include `"@freecodecamp/example"`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/package.json').then(
+  $.get(code + '/_api/package.json').then(
     (data) => {
       var packJson = JSON.parse(data);
       assert.property(
@@ -46,8 +45,7 @@ In the dependencies section of your `package.json` file, change the version of `
 `"@freecodecamp/example"` version should be `"1.2.13"`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/package.json').then(
+  $.get(code + '/_api/package.json').then(
     (data) => {
       var packJson = JSON.parse(data);
       assert.equal(

--- a/curriculum/challenges/english/05-back-end-development-and-apis/managing-packages-with-npm/remove-a-package-from-your-dependencies.md
+++ b/curriculum/challenges/english/05-back-end-development-and-apis/managing-packages-with-npm/remove-a-package-from-your-dependencies.md
@@ -25,8 +25,7 @@ Remove the `@freecodecamp/example` package from your dependencies.
 `"dependencies"` should not include `"@freecodecamp/example"`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/package.json').then(
+  $.get(code + '/_api/package.json').then(
     (data) => {
       var packJson = JSON.parse(data);
       assert.notProperty(

--- a/curriculum/challenges/english/05-back-end-development-and-apis/managing-packages-with-npm/use-the-caret-character-to-use-the-latest-minor-version-of-a-dependency.md
+++ b/curriculum/challenges/english/05-back-end-development-and-apis/managing-packages-with-npm/use-the-caret-character-to-use-the-latest-minor-version-of-a-dependency.md
@@ -29,8 +29,7 @@ Use the caret (`^`) to prefix the version of `@freecodecamp/example` in your dep
 `"dependencies"` should include `"@freecodecamp/example"`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/package.json').then(
+  $.get(code + '/_api/package.json').then(
     (data) => {
       var packJson = JSON.parse(data);
       assert.property(
@@ -48,8 +47,7 @@ Use the caret (`^`) to prefix the version of `@freecodecamp/example` in your dep
 `"@freecodecamp/example"` version should match `"^1.x.x"`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/package.json').then(
+  $.get(code + '/_api/package.json').then(
     (data) => {
       var packJson = JSON.parse(data);
       assert.match(

--- a/curriculum/challenges/english/05-back-end-development-and-apis/managing-packages-with-npm/use-the-tilde-character-to-always-use-the-latest-patch-version-of-a-dependency.md
+++ b/curriculum/challenges/english/05-back-end-development-and-apis/managing-packages-with-npm/use-the-tilde-character-to-always-use-the-latest-patch-version-of-a-dependency.md
@@ -29,8 +29,7 @@ Use the tilde (`~`) character to prefix the version of `@freecodecamp/example` i
 `"dependencies"` should include `"@freecodecamp/example"`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/package.json').then(
+  $.get(code + '/_api/package.json').then(
     (data) => {
       var packJson = JSON.parse(data);
       assert.property(
@@ -48,8 +47,7 @@ Use the tilde (`~`) character to prefix the version of `@freecodecamp/example` i
 `"@freecodecamp/example"` version should match `"~1.2.13"`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/package.json').then(
+  $.get(code + '/_api/package.json').then(
     (data) => {
       var packJson = JSON.parse(data);
       assert.match(

--- a/curriculum/challenges/english/05-back-end-development-and-apis/mongodb-and-mongoose/chain-search-query-helpers-to-narrow-search-results.md
+++ b/curriculum/challenges/english/05-back-end-development-and-apis/mongodb-and-mongoose/chain-search-query-helpers-to-narrow-search-results.md
@@ -19,9 +19,8 @@ Modify the `queryChain` function to find people who like the food specified by t
 Chaining query helpers should succeed
 
 ```js
-(getUserInput) =>
   $.ajax({
-    url: getUserInput('url') + '/_api/query-tools',
+    url: code + '/_api/query-tools',
     type: 'POST',
     contentType: 'application/json',
     data: JSON.stringify([

--- a/curriculum/challenges/english/05-back-end-development-and-apis/mongodb-and-mongoose/create-a-model.md
+++ b/curriculum/challenges/english/05-back-end-development-and-apis/mongodb-and-mongoose/create-a-model.md
@@ -43,8 +43,7 @@ Now, create a model from the `personSchema` and assign it to the existing variab
 Creating an instance from a mongoose schema should succeed
 
 ```js
-(getUserInput) =>
-  $.post(getUserInput('url') + '/_api/mongoose-model', {
+  $.post(code + '/_api/mongoose-model', {
     name: 'Mike',
     age: 28,
     favoriteFoods: ['pizza', 'cheese']

--- a/curriculum/challenges/english/05-back-end-development-and-apis/mongodb-and-mongoose/create-and-save-a-record-of-a-model.md
+++ b/curriculum/challenges/english/05-back-end-development-and-apis/mongodb-and-mongoose/create-and-save-a-record-of-a-model.md
@@ -28,8 +28,7 @@ person.save(function(err, data) {
 Creating and saving a db item should succeed
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/create-and-save-person').then(
+  $.get(code + '/_api/create-and-save-person').then(
     (data) => {
       assert.isString(data.name, '"item.name" should be a String');
       assert.isNumber(data.age, '28', '"item.age" should be a Number');

--- a/curriculum/challenges/english/05-back-end-development-and-apis/mongodb-and-mongoose/create-many-records-with-model.create.md
+++ b/curriculum/challenges/english/05-back-end-development-and-apis/mongodb-and-mongoose/create-many-records-with-model.create.md
@@ -21,9 +21,8 @@ Modify the `createManyPeople` function to create many people using `Model.create
 Creating many db items at once should succeed
 
 ```js
-(getUserInput) =>
   $.ajax({
-    url: getUserInput('url') + '/_api/create-many-people',
+    url: code + '/_api/create-many-people',
     type: 'POST',
     contentType: 'application/json',
     data: JSON.stringify([

--- a/curriculum/challenges/english/05-back-end-development-and-apis/mongodb-and-mongoose/delete-many-documents-with-model.remove.md
+++ b/curriculum/challenges/english/05-back-end-development-and-apis/mongodb-and-mongoose/delete-many-documents-with-model.remove.md
@@ -21,9 +21,8 @@ Modify the `removeManyPeople` function to delete all the people whose name is wi
 Deleting many items at once should succeed
 
 ```js
-(getUserInput) =>
   $.ajax({
-    url: getUserInput('url') + '/_api/remove-many-people',
+    url: code + '/_api/remove-many-people',
     type: 'POST',
     contentType: 'application/json',
     data: JSON.stringify([

--- a/curriculum/challenges/english/05-back-end-development-and-apis/mongodb-and-mongoose/delete-one-document-using-model.findbyidandremove.md
+++ b/curriculum/challenges/english/05-back-end-development-and-apis/mongodb-and-mongoose/delete-one-document-using-model.findbyidandremove.md
@@ -19,8 +19,7 @@ Modify the `removeById` function to delete one person by the person's `_id`. You
 Deleting an item should succeed
 
 ```js
-(getUserInput) =>
-  $.post(getUserInput('url') + '/_api/remove-one-person', {
+  $.post(code + '/_api/remove-one-person', {
     name: 'Jason Bourne',
     age: 36,
     favoriteFoods: ['apples']

--- a/curriculum/challenges/english/05-back-end-development-and-apis/mongodb-and-mongoose/install-and-set-up-mongoose.md
+++ b/curriculum/challenges/english/05-back-end-development-and-apis/mongodb-and-mongoose/install-and-set-up-mongoose.md
@@ -33,8 +33,7 @@ mongoose.connect(<Your URI>, { useNewUrlParser: true, useUnifiedTopology: true }
 "mongoose version ^5.11.15" dependency should be in package.json
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/file/package.json').then(
+  $.get(code + '/_api/file/package.json').then(
     (data) => {
       var packJson = JSON.parse(data);
       assert.property(packJson.dependencies, 'mongoose');
@@ -53,8 +52,7 @@ mongoose.connect(<Your URI>, { useNewUrlParser: true, useUnifiedTopology: true }
 "mongoose" should be connected to a database
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/is-mongoose-ok').then(
+  $.get(code + '/_api/is-mongoose-ok').then(
     (data) => {
       assert.isTrue(data.isMongooseOk, 'mongoose is not connected');
     },

--- a/curriculum/challenges/english/05-back-end-development-and-apis/mongodb-and-mongoose/perform-classic-updates-by-running-find-edit-then-save.md
+++ b/curriculum/challenges/english/05-back-end-development-and-apis/mongodb-and-mongoose/perform-classic-updates-by-running-find-edit-then-save.md
@@ -21,8 +21,7 @@ Modify the `findEditThenSave` function to find a person by `_id` (use any of the
 Find-edit-update an item should succeed
 
 ```js
-(getUserInput) =>
-  $.post(getUserInput('url') + '/_api/find-edit-save', {
+  $.post(code + '/_api/find-edit-save', {
     name: 'Poldo',
     age: 40,
     favoriteFoods: ['spaghetti']

--- a/curriculum/challenges/english/05-back-end-development-and-apis/mongodb-and-mongoose/perform-new-updates-on-a-document-using-model.findoneandupdate.md
+++ b/curriculum/challenges/english/05-back-end-development-and-apis/mongodb-and-mongoose/perform-new-updates-on-a-document-using-model.findoneandupdate.md
@@ -21,8 +21,7 @@ Modify the `findAndUpdate` function to find a person by `Name` and set the perso
 findOneAndUpdate an item should succeed
 
 ```js
-(getUserInput) =>
-  $.post(getUserInput('url') + '/_api/find-one-update', {
+  $.post(code + '/_api/find-one-update', {
     name: 'Dorian Gray',
     age: 35,
     favoriteFoods: ['unknown']

--- a/curriculum/challenges/english/05-back-end-development-and-apis/mongodb-and-mongoose/use-model.find-to-search-your-database.md
+++ b/curriculum/challenges/english/05-back-end-development-and-apis/mongodb-and-mongoose/use-model.find-to-search-your-database.md
@@ -21,8 +21,7 @@ Use the function argument `personName` as the search key.
 Find all items corresponding to a criteria should succeed
 
 ```js
-(getUserInput) =>
-  $.post(getUserInput('url') + '/_api/find-all-by-name', {
+  $.post(code + '/_api/find-all-by-name', {
     name: 'r@nd0mN4m3',
     age: 24,
     favoriteFoods: ['pizza']

--- a/curriculum/challenges/english/05-back-end-development-and-apis/mongodb-and-mongoose/use-model.findbyid-to-search-your-database-by-id.md
+++ b/curriculum/challenges/english/05-back-end-development-and-apis/mongodb-and-mongoose/use-model.findbyid-to-search-your-database-by-id.md
@@ -19,8 +19,7 @@ Modify the `findPersonById` to find the only person having a given `_id`, using 
 Find an item by Id should succeed
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/find-by-id').then(
+  $.get(code + '/_api/find-by-id').then(
     (data) => {
       assert.equal(data.name, 'test', 'item.name is not what expected');
       assert.equal(data.age, 0, 'item.age is not what expected');

--- a/curriculum/challenges/english/05-back-end-development-and-apis/mongodb-and-mongoose/use-model.findone-to-return-a-single-matching-document-from-your-database.md
+++ b/curriculum/challenges/english/05-back-end-development-and-apis/mongodb-and-mongoose/use-model.findone-to-return-a-single-matching-document-from-your-database.md
@@ -19,8 +19,7 @@ Modify the `findOneByFood` function to find just one person which has a certain 
 Find one item should succeed
 
 ```js
-(getUserInput) =>
-  $.post(getUserInput('url') + '/_api/find-one-by-food', {
+  $.post(code + '/_api/find-one-by-food', {
     name: 'Gary',
     age: 46,
     favoriteFoods: ['chicken salad']

--- a/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/announce-new-users.md
+++ b/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/announce-new-users.md
@@ -41,8 +41,8 @@ Submit your page when you think you've got it right. If you're running into erro
 Event `'user'` should be emitted with `username`, `currentUsers`, and `connected`.
 
 ```js
-async (getUserInput) => {
-  const url = new URL("/_api/server.js", getUserInput("url"));
+async () => {
+  const url = new URL("/_api/server.js", code);
   const res = await fetch(url);
   const data = await res.text();
   // Regex is lenient to match both `username` and `name` as the key on purpose.
@@ -57,8 +57,8 @@ async (getUserInput) => {
 Client should properly handle and display the new data from event `'user'`.
 
 ```js
-async (getUserInput) => {
-  const url = new URL("/public/client.js", getUserInput("url"));
+async () => {
+  const url = new URL("/public/client.js", code);
   const res = await fetch(url);
   const data = await res.text();
   assert.match(

--- a/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/authentication-strategies.md
+++ b/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/authentication-strategies.md
@@ -43,8 +43,8 @@ Submit your page when you think you've got it right. If you're running into erro
 Passport-local should be a dependency.
 
 ```js
-async (getUserInput) => {
-  const url = new URL("/_api/package.json", getUserInput("url"));
+async () => {
+  const url = new URL("/_api/package.json", code);
   const res = await fetch(url);
   const packJson = await res.json();
   assert.property(
@@ -58,8 +58,8 @@ async (getUserInput) => {
 Passport-local should be correctly required and set up.
 
 ```js
-async (getUserInput) => {
-  const url = new URL("/_api/server.js", getUserInput("url"));
+async () => {
+  const url = new URL("/_api/server.js", code);
   const res = await fetch(url);
   const data = await res.text();
   assert.match(

--- a/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/authentication-with-socket.io.md
+++ b/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/authentication-with-socket.io.md
@@ -72,8 +72,8 @@ Submit your page when you think you've got it right. If you're running into erro
 `passport.socketio` should be a dependency.
 
 ```js
-async (getUserInput) => {
-  const url = new URL("/_api/package.json", getUserInput("url"));
+async () => {
+  const url = new URL("/_api/package.json", code);
   const res = await fetch(url);
   const packJson = await res.json();
   assert.property(
@@ -87,8 +87,8 @@ async (getUserInput) => {
 `cookie-parser` should be a dependency.
 
 ```js
-async (getUserInput) => {
-  const url = new URL("/_api/package.json", getUserInput("url"));
+async () => {
+  const url = new URL("/_api/package.json", code);
   const res = await fetch(url);
   const packJson = await res.json();
   assert.property(
@@ -102,8 +102,8 @@ async (getUserInput) => {
 passportSocketIo should be properly required.
 
 ```js
-async (getUserInput) => {
-  const url = new URL("/_api/server.js", getUserInput("url"));
+async () => {
+  const url = new URL("/_api/server.js", code);
   const res = await fetch(url);
   const data = await res.text();
   assert.match(
@@ -117,8 +117,8 @@ async (getUserInput) => {
 passportSocketIo should be properly setup.
 
 ```js
-async (getUserInput) => {
-  const url = new URL("/_api/server.js", getUserInput("url"));
+async () => {
+  const url = new URL("/_api/server.js", code);
   const res = await fetch(url);
   const data = await res.text();
   assert.match(

--- a/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/clean-up-your-project-with-modules.md
+++ b/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/clean-up-your-project-with-modules.md
@@ -33,8 +33,8 @@ Submit your page when you think you've got it right. If you're running into erro
 Modules should be present.
 
 ```js
-async (getUserInput) => {
-  const url = new URL("/_api/server.js", getUserInput("url"));
+async () => {
+  const url = new URL("/_api/server.js", code);
   const res = await fetch(url);
   const data = await res.text();
   assert.match(

--- a/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/communicate-by-emitting.md
+++ b/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/communicate-by-emitting.md
@@ -45,8 +45,8 @@ Submit your page when you think you've got it right. If you're running into erro
 `currentUsers` should be defined.
 
 ```js
-async (getUserInput) => {
-  const url = new URL("/_api/server.js", getUserInput("url"));
+async () => {
+  const url = new URL("/_api/server.js", code);
   const res = await fetch(url);
   const data = await res.text();
   assert.match(
@@ -60,8 +60,8 @@ async (getUserInput) => {
 Server should emit the current user count at each new connection.
 
 ```js
-async (getUserInput) => {
-  const url = new URL("/_api/server.js", getUserInput("url"));
+async () => {
+  const url = new URL("/_api/server.js", code);
   const res = await fetch(url);
   const data = await res.text();
   assert.match(
@@ -75,8 +75,8 @@ async (getUserInput) => {
 Your client should be listening for `'user count'` event.
 
 ```js
-async (getUserInput) => {
-  const url = new URL("/public/client.js", getUserInput("url"));
+async () => {
+  const url = new URL("/public/client.js", code);
   const res = await fetch(url);
   const data = await res.text();
   assert.match(

--- a/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/create-new-middleware.md
+++ b/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/create-new-middleware.md
@@ -40,8 +40,8 @@ Submit your page when you think you've got it right. If you're running into erro
 The middleware `ensureAuthenticated` should be implemented and attached to the `/profile` route.
 
 ```js
-async (getUserInput) => {
-  const url = new URL("/_api/server.js", getUserInput("url"));
+async () => {
+  const url = new URL("/_api/server.js", code);
   const res = await fetch(url);
   const data = await res.text();
   assert.match(
@@ -60,8 +60,8 @@ async (getUserInput) => {
 An unauthenticated GET request to `/profile` should correctly redirect to `/`.
 
 ```js
-async (getUserInput) => {
-  const url = new URL("/profile", getUserInput("url"));
+async () => {
+  const url = new URL("/profile", code);
   const res = await fetch(url);
   const data = await res.text();
   assert.match(

--- a/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/handle-a-disconnect.md
+++ b/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/handle-a-disconnect.md
@@ -29,8 +29,8 @@ Submit your page when you think you've got it right. If you're running into erro
 Server should handle the event disconnect from a socket.
 
 ```js
-async (getUserInput) => {
-  const url = new URL("/_api/server.js", getUserInput("url"));
+async () => {
+  const url = new URL("/_api/server.js", code);
   const res = await fetch(url);
   const data = await res.text();
   assert.match(data, /socket.on.*('|")disconnect('|")/s, '');
@@ -40,8 +40,8 @@ async (getUserInput) => {
 Your client should be listening for `'user count'` event.
 
 ```js
-async (getUserInput) => {
-  const url = new URL("/public/client.js", getUserInput("url"));
+async () => {
+  const url = new URL("/public/client.js", code);
   const res = await fetch(url);
   const data = await res.text();
   assert.match(

--- a/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/hashing-your-passwords.md
+++ b/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/hashing-your-passwords.md
@@ -31,8 +31,8 @@ Submit your page when you think you've got it right. If you're running into erro
 BCrypt should be a dependency.
 
 ```js
-async (getUserInput) => {
-  const url = new URL("/_api/package.json", getUserInput("url"));
+async () => {
+  const url = new URL("/_api/package.json", code);
   const res = await fetch(url);
   const packJson = await res.json()
   assert.property(
@@ -46,8 +46,8 @@ async (getUserInput) => {
 BCrypt should be correctly required and implemented.
 
 ```js
-async (getUserInput) => {
-  const url = new URL("/_api/server.js", getUserInput("url"));
+async () => {
+  const url = new URL("/_api/server.js", code);
   const res = await fetch(url);
   const data = await res.text();
   assert.match(

--- a/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/how-to-put-a-profile-together.md
+++ b/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/how-to-put-a-profile-together.md
@@ -33,8 +33,8 @@ Submit your page when you think you've got it right. If you're running into erro
 You should correctly add a Pug render variable to `/profile`.
 
 ```js
-async (getUserInput) => {
-  const url = new URL("/_api/server.js", getUserInput("url"));
+async () => {
+  const url = new URL("/_api/server.js", code);
   const res = await fetch(url);
   const data = await res.text();
   assert.match(

--- a/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/how-to-use-passport-strategies.md
+++ b/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/how-to-use-passport-strategies.md
@@ -27,8 +27,8 @@ Submit your page when you think you've got it right. If you're running into erro
 All steps should be correctly implemented in `server.js`.
 
 ```js
-async (getUserInput) => {
-  const url = new URL("/_api/server.js", getUserInput("url"));
+async () => {
+  const url = new URL("/_api/server.js", code);
   const res = await fetch(url);
   const data = await res.text();
   assert.match(
@@ -52,8 +52,8 @@ async (getUserInput) => {
 A POST request to `/login` should correctly redirect to `/`.
 
 ```js
-async (getUserInput) => {
-  const url = new URL("/login", getUserInput("url"));
+async () => {
+  const url = new URL("/login", code);
   const res = await fetch(url, { method: 'POST' });
   const data = await res.text();
   assert.match(

--- a/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/implement-the-serialization-of-a-passport-user.md
+++ b/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/implement-the-serialization-of-a-passport-user.md
@@ -47,8 +47,8 @@ Submit your page when you think you've got it right. If you're running into erro
 Database connection should be present.
 
 ```js
-async (getUserInput) => {
-  const url = new URL("/", getUserInput("url"));
+async () => {
+  const url = new URL("/", code);
   const res = await fetch(url);
   const data = await res.text();
   assert.match(
@@ -62,8 +62,8 @@ async (getUserInput) => {
 Deserialization should now be correctly using the DB and `done(null, null)` should be called with the `doc`.
 
 ```js
-async (getUserInput) => {
-  const url = new URL("/_api/server.js", getUserInput("url"));
+async () => {
+  const url = new URL("/_api/server.js", code);
   const res = await fetch(url);
   const data = await res.text();
   assert.match(

--- a/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/implementation-of-social-authentication-ii.md
+++ b/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/implementation-of-social-authentication-ii.md
@@ -38,8 +38,8 @@ Submit your page when you think you've got it right. If you're running into erro
 `passport-github` dependency should be added.
 
 ```js
-async (getUserInput) => {
-  const url = new URL("/_api/package.json", getUserInput("url"));
+async () => {
+  const url = new URL("/_api/package.json", code);
   const res = await fetch(url);
   const packJson = await res.json();
   assert.property(
@@ -53,8 +53,8 @@ async (getUserInput) => {
 `passport-github` should be required.
 
 ```js
-async (getUserInput) => {
-  const url = new URL("/_api/auth.js", getUserInput("url"));
+async () => {
+  const url = new URL("/_api/auth.js", code);
   const res = await fetch(url);
   const data = await res.text();
   assert.match(
@@ -68,8 +68,8 @@ async (getUserInput) => {
 GitHub strategy should be setup correctly thus far.
 
 ```js
-async (getUserInput) => {
-  const url = new URL("/_api/auth.js", getUserInput("url"));
+async () => {
+  const url = new URL("/_api/auth.js", code);
   const res = await fetch(url);
   const data = await res.text();
   assert.match(

--- a/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/implementation-of-social-authentication-iii.md
+++ b/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/implementation-of-social-authentication-iii.md
@@ -50,8 +50,8 @@ Submit your page when you think you've got it right. If you're running into erro
 GitHub strategy setup should be complete.
 
 ```js
-async (getUserInput) => {
-  const url = new URL("/_api/auth.js", getUserInput("url"));
+async () => {
+  const url = new URL("/_api/auth.js", code);
   const res = await fetch(url);
   const data = await res.text();
   assert.match(

--- a/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/implementation-of-social-authentication.md
+++ b/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/implementation-of-social-authentication.md
@@ -38,9 +38,9 @@ Submit your page when you think you've got it right. If you're running into erro
 Route `/auth/github` should be correct.
 
 ```js
-async (getUserInput) => {
+async () => {
   try {
-    const res = await fetch(getUserInput('url') + '/_api/routes.js');
+    const res = await fetch(code + '/_api/routes.js');
     if (res.ok) {
       const data = await res.text();
       assert.match(
@@ -51,7 +51,7 @@ async (getUserInput) => {
     } else {
       throw new Error(res.statusText);
     }
-    const res2 = await fetch(getUserInput('url') + '/_api/app-stack');
+    const res2 = await fetch(code + '/_api/app-stack');
     if (res2.ok) {
       const data2 = JSON.parse(await res2.json());
       const dataLayer = data2.find(layer => layer?.route?.path === '/auth/github');
@@ -69,9 +69,9 @@ async (getUserInput) => {
 Route `/auth/github/callback` should be correct.
 
 ```js
-async (getUserInput) => {
+async () => {
   try {
-    const res = await fetch(getUserInput('url') + '/_api/routes.js');
+    const res = await fetch(code + '/_api/routes.js');
     if (res.ok) {
       const data = await res.text();
       assert.match(
@@ -82,7 +82,7 @@ async (getUserInput) => {
     } else {
       throw new Error(res.statusText);
     }
-    const res2 = await fetch(getUserInput('url') + '/_api/app-stack');
+    const res2 = await fetch(code + '/_api/app-stack');
     if (res2.ok) {
       const data2 = JSON.parse(await res2.json());
       const dataLayer = data2.find(layer => layer?.route?.path === '/auth/github/callback');

--- a/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/logging-a-user-out.md
+++ b/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/logging-a-user-out.md
@@ -37,8 +37,8 @@ Submit your page when you think you've got it right. If you're running into erro
 `req.logout()` should be called in your `/logout` route.
 
 ```js
-async (getUserInput) => {
-  const url = new URL("/_api/server.js", getUserInput("url"));
+async () => {
+  const url = new URL("/_api/server.js", code);
   const res = await fetch(url);
   const data = await res.text();
   assert.match(
@@ -52,8 +52,8 @@ async (getUserInput) => {
 `/logout` should redirect to the home page.
 
 ```js
-async (getUserInput) => {
-  const url = new URL("/logout", getUserInput("url"));
+async () => {
+  const url = new URL("/logout", code);
   const res = await fetch(url);
   const data = await res.text();
   assert.match(

--- a/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/registration-of-new-users.md
+++ b/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/registration-of-new-users.md
@@ -65,8 +65,8 @@ Submit your page when you think you've got it right. If you're running into erro
 You should have a `/register` route and display a registration form on the home page.
 
 ```js
-async (getUserInput) => {
-  const url = new URL("/_api/server.js", getUserInput("url"));
+async () => {
+  const url = new URL("/_api/server.js", code);
   const res = await fetch(url);
   const data = await res.text();
   assert.match(
@@ -85,8 +85,8 @@ async (getUserInput) => {
 Registering should work.
 
 ```js
-async (getUserInput) => {
-  const url = getUserInput('url');
+async () => {
+  const url = code;
   const user = `freeCodeCampTester${Date.now()}`;
   const xhttp = new XMLHttpRequest();
   xhttp.onreadystatechange = function () {
@@ -113,8 +113,8 @@ async (getUserInput) => {
 Login should work.
 
 ```js
-async (getUserInput) => {
-  const url = getUserInput('url');
+async () => {
+  const url = code;
   const user = `freeCodeCampTester${Date.now()}`;
   const xhttpReg = new XMLHttpRequest();
   xhttpReg.onreadystatechange = function () {
@@ -162,9 +162,8 @@ async (getUserInput) => {
 Logout should work.
 
 ```js
-(getUserInput) =>
   $.ajax({
-    url: getUserInput('url') + '/logout',
+    url: code + '/logout',
     type: 'GET',
     xhrFields: { withCredentials: true }
   }).then(
@@ -180,9 +179,8 @@ Logout should work.
 Profile should no longer work after logout.
 
 ```js
-(getUserInput) =>
   $.ajax({
-    url: getUserInput('url') + '/profile',
+    url: code + '/profile',
     type: 'GET',
     crossDomain: true,
     xhrFields: { withCredentials: true }

--- a/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/send-and-display-chat-messages.md
+++ b/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/send-and-display-chat-messages.md
@@ -35,8 +35,8 @@ Submit your page when you think you've got it right. If you're running into erro
 Server should listen for `'chat message'` and then emit it properly.
 
 ```js
-async (getUserInput) => {
-  const url = new URL("/_api/server.js", getUserInput("url"));
+async () => {
+  const url = new URL("/_api/server.js", code);
   const res = await fetch(url);
   const data = await res.text();
   assert.match(
@@ -50,8 +50,8 @@ async (getUserInput) => {
 Client should properly handle and display the new data from event `'chat message'`.
 
 ```js
-async (getUserInput) => {
-  const url = new URL("/public/client.js", getUserInput("url"));
+async () => {
+  const url = new URL("/public/client.js", code);
   const res = await fetch(url);
   const data = await res.text();
   assert.match(

--- a/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/serialization-of-a-user-object.md
+++ b/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/serialization-of-a-user-object.md
@@ -53,8 +53,8 @@ Submit your page when you think you've got it right. If you're running into erro
 You should serialize the user object correctly.
 
 ```js
-async (getUserInput) => {
-  const url = new URL("/_api/server.js", getUserInput("url"));
+async () => {
+  const url = new URL("/_api/server.js", code);
   const res = await fetch(url);
   const data = await res.text();
   assert.match(
@@ -73,8 +73,8 @@ async (getUserInput) => {
 You should deserialize the user object correctly.
 
 ```js
-async (getUserInput) => {
-  const url = new URL("/_api/server.js", getUserInput("url"));
+async () => {
+  const url = new URL("/_api/server.js", code);
   const res = await fetch(url);
   const data = await res.text();
   assert.match(
@@ -93,8 +93,8 @@ async (getUserInput) => {
 MongoDB should be a dependency.
 
 ```js
-async (getUserInput) => {
-  const url = new URL("/_api/package.json", getUserInput("url"));
+async () => {
+  const url = new URL("/_api/package.json", code);
   const res = await fetch(url);
   const packJson = await res.json();
   assert.property(
@@ -108,8 +108,8 @@ async (getUserInput) => {
 Mongodb should be properly required including the ObjectId.
 
 ```js
-async (getUserInput) => {
-  const url = new URL("/_api/server.js", getUserInput("url"));
+async () => {
+  const url = new URL("/_api/server.js", code);
   const res = await fetch(url);
   const data = await res.text();
   assert.match(

--- a/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/set-up-a-template-engine.md
+++ b/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/set-up-a-template-engine.md
@@ -37,8 +37,8 @@ Submit your page when you think you've got it right. If you're running into erro
 Pug should be a dependency.
 
 ```js
-async (getUserInput) => {
-  const url = new URL("/_api/package.json", getUserInput("url"));
+async () => {
+  const url = new URL("/_api/package.json", code);
   const res = await fetch(url);
   const packJson = await res.json();
   assert.property(
@@ -52,8 +52,8 @@ async (getUserInput) => {
 View engine should be Pug.
 
 ```js
-async (getUserInput) => {
-  const url = new URL("/_api/app", getUserInput("url"));
+async () => {
+  const url = new URL("/_api/app", code);
   const res = await fetch(url);
   const app = await res.json();
   assert.equal(app?.settings?.['view engine'], "pug");
@@ -63,8 +63,8 @@ async (getUserInput) => {
 You should set the `views` property of the application to `./views/pug`.
 
 ```js
-async (getUserInput) => {
-  const url = new URL("/_api/app", getUserInput("url"));
+async () => {
+  const url = new URL("/_api/app", code);
   const res = await fetch(url);
   const app = await res.json();
   assert.equal(app?.settings?.views, "./views/pug");
@@ -74,8 +74,8 @@ async (getUserInput) => {
 Use the correct ExpressJS method to render the index page from the response.
 
 ```js
-async (getUserInput) => {
-  const url = new URL("/", getUserInput("url"));
+async () => {
+  const url = new URL("/", code);
   const res = await fetch(url);
   const data = await res.text();
       assert.match(
@@ -89,8 +89,8 @@ async (getUserInput) => {
 Pug should be working.
 
 ```js
-async (getUserInput) => {
-  const url = new URL("/", getUserInput("url"));
+async () => {
+  const url = new URL("/", code);
   const res = await fetch(url);
   const data = await res.text();
       assert.match(

--- a/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/set-up-passport.md
+++ b/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/set-up-passport.md
@@ -36,8 +36,8 @@ Submit your page when you think you've got it right. If you're running into erro
 Passport and Express-session should be dependencies.
 
 ```js
-async (getUserInput) => {
-  const url = new URL("/_api/package.json", getUserInput("url"));
+async () => {
+  const url = new URL("/_api/package.json", code);
   const res = await fetch(url);
   const packJson = await res.json();
   assert.property(
@@ -56,8 +56,8 @@ async (getUserInput) => {
 Dependencies should be correctly required.
 
 ```js
-async (getUserInput) => {
-  const url = new URL("/_api/server.js", getUserInput("url"));
+async () => {
+  const url = new URL("/_api/server.js", code);
   const res = await fetch(url);
   const data = await res.text();
   assert.match(
@@ -76,8 +76,8 @@ async (getUserInput) => {
 Express app should use new dependencies.
 
 ```js
-async (getUserInput) => {
-  const url = new URL("/_api/server.js", getUserInput("url"));
+async () => {
+  const url = new URL("/_api/server.js", code);
   const res = await fetch(url);
   const data = await res.text();
   assert.match(data, /passport\.initialize/, 'Your express app should use "passport.initialize()"');
@@ -88,8 +88,8 @@ async (getUserInput) => {
 Session and session secret should be correctly set up.
 
 ```js
-async (getUserInput) => {
-  const url = new URL("/_api/server.js", getUserInput("url"));
+async () => {
+  const url = new URL("/_api/server.js", code);
   const res = await fetch(url);
   const data = await res.text();
   assert.match(

--- a/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/set-up-the-environment.md
+++ b/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/set-up-the-environment.md
@@ -49,8 +49,8 @@ Submit your page when you think you've got it right. If you're running into erro
 `socket.io` should be a dependency.
 
 ```js
-async (getUserInput) => {
-  const url = new URL("/_api/package.json", getUserInput("url"));
+async () => {
+  const url = new URL("/_api/package.json", code);
   const res = await fetch(url);
   const packJson = await res.json();
   assert.property(
@@ -64,8 +64,8 @@ async (getUserInput) => {
 You should correctly require and instantiate `http` as `http`.
 
 ```js
-async (getUserInput) => {
-  const url = new URL("/_api/server.js", getUserInput("url"));
+async () => {
+  const url = new URL("/_api/server.js", code);
   const res = await fetch(url);
   const data = await res.text();
   assert.match(
@@ -79,8 +79,8 @@ async (getUserInput) => {
 You should correctly require and instantiate `socket.io` as `io`.
 
 ```js
-async (getUserInput) => {
-  const url = new URL("/_api/server.js", getUserInput("url"));
+async () => {
+  const url = new URL("/_api/server.js", code);
   const res = await fetch(url);
   const data = await res.text();
   assert.match(
@@ -94,8 +94,8 @@ async (getUserInput) => {
 Socket.IO should be listening for connections.
 
 ```js
-async (getUserInput) => {
-  const url = new URL("/_api/server.js", getUserInput("url"));
+async () => {
+  const url = new URL("/_api/server.js", code);
   const res = await fetch(url);
   const data = await res.text();
   assert.match(
@@ -109,8 +109,8 @@ async (getUserInput) => {
 Your client should connect to your server.
 
 ```js
-async (getUserInput) => {
-  const url = new URL("/public/client.js", getUserInput("url"));
+async () => {
+  const url = new URL("/public/client.js", code);
   const res = await fetch(url);
   const data = await res.text();
   assert.match(

--- a/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/use-a-template-engines-powers.md
+++ b/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/use-a-template-engines-powers.md
@@ -59,8 +59,8 @@ Submit your page when you think you've got it right. If you're running into erro
 Pug should correctly render variables.
 
 ```js
-async (getUserInput) => {
-  const url = new URL("/", getUserInput("url"));
+async () => {
+  const url = new URL("/", code);
   const res = await fetch(url);
   const data = await res.text();
   assert.match(

--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/assert-deep-equality-with-.deepequal-and-.notdeepequal.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/assert-deep-equality-with-.deepequal-and-.notdeepequal.md
@@ -21,8 +21,7 @@ Within `tests/1_unit-tests.js` under the test labeled `#7` in the `Equality` sui
 All tests should pass.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=6').then(
+  $.get(code + '/_api/get-tests?type=unit&n=6').then(
     (data) => {
       assert.equal(data.state, 'passed');
     },
@@ -35,8 +34,7 @@ All tests should pass.
 You should choose the correct method for the first assertion - `deepEqual` vs. `notDeepEqual`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=6').then(
+  $.get(code + '/_api/get-tests?type=unit&n=6').then(
     (data) => {
       assert.equal(
         data.assertions[0].method,
@@ -53,8 +51,7 @@ You should choose the correct method for the first assertion - `deepEqual` vs. `
 You should choose the correct method for the second assertion - `deepEqual` vs. `notDeepEqual`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=6').then(
+  $.get(code + '/_api/get-tests?type=unit&n=6').then(
     (data) => {
       assert.equal(
         data.assertions[1].method,

--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/compare-the-properties-of-two-elements.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/compare-the-properties-of-two-elements.md
@@ -19,8 +19,7 @@ Within `tests/1_unit-tests.js` under the test labeled `#8` in the `Comparisons` 
 All tests should pass.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=7').then(
+  $.get(code + '/_api/get-tests?type=unit&n=7').then(
     (data) => {
       assert.equal(data.state, 'passed');
     },
@@ -33,8 +32,7 @@ All tests should pass.
 You should choose the correct method for the first assertion - `isAbove` vs. `isAtMost`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=7').then(
+  $.get(code + '/_api/get-tests?type=unit&n=7').then(
     (data) => {
       assert.equal(
         data.assertions[0].method,
@@ -51,8 +49,7 @@ You should choose the correct method for the first assertion - `isAbove` vs. `is
 You should choose the correct method for the second assertion - `isAbove` vs. `isAtMost`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=7').then(
+  $.get(code + '/_api/get-tests?type=unit&n=7').then(
     (data) => {
       assert.equal(data.assertions[1].method, 'isAbove', '1 is greater than 0');
     },
@@ -65,8 +62,7 @@ You should choose the correct method for the second assertion - `isAbove` vs. `i
 You should choose the correct method for the third assertion - `isAbove` vs. `isAtMost`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=7').then(
+  $.get(code + '/_api/get-tests?type=unit&n=7').then(
     (data) => {
       assert.equal(
         data.assertions[2].method,
@@ -83,8 +79,7 @@ You should choose the correct method for the third assertion - `isAbove` vs. `is
 You should choose the correct method for the fourth assertion - `isAbove` vs. `isAtMost`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=7').then(
+  $.get(code + '/_api/get-tests?type=unit&n=7').then(
     (data) => {
       assert.equal(
         data.assertions[3].method,

--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/learn-how-javascript-assertions-work.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/learn-how-javascript-assertions-work.md
@@ -23,8 +23,7 @@ Within `tests/1_unit-tests.js` under the test labeled `#1` in the `Basic Asserti
 All tests should pass.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=0').then(
+  $.get(code + '/_api/get-tests?type=unit&n=0').then(
     (data) => {
       assert.equal(data.state, 'passed');
     },
@@ -37,8 +36,7 @@ All tests should pass.
 You should choose the correct method for the first assertion - `isNull` vs. `isNotNull`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=0').then(
+  $.get(code + '/_api/get-tests?type=unit&n=0').then(
     (data) => {
       assert.equal(data.assertions[0].method, 'isNull', 'Null is null');
     },
@@ -51,8 +49,7 @@ You should choose the correct method for the first assertion - `isNull` vs. `isN
 You should choose the correct method for the second assertion - `isNull` vs. `isNotNull`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=0').then(
+  $.get(code + '/_api/get-tests?type=unit&n=0').then(
     (data) => {
       assert.equal(data.assertions[1].method, 'isNotNull', '1 is not null');
     },

--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/run-functional-tests-on-an-api-response-using-chai-http-iii---put-method.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/run-functional-tests-on-an-api-response-using-chai-http-iii---put-method.md
@@ -63,8 +63,7 @@ Follow the assertion order above - we rely on it. Also, be sure to remove `asser
 All tests should pass.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=functional&n=2').then(
+  $.get(code + '/_api/get-tests?type=functional&n=2').then(
     (data) => {
       assert.equal(data.state, 'passed');
     },
@@ -77,8 +76,7 @@ All tests should pass.
 You should test for `res.status` to be 200.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=functional&n=2').then(
+  $.get(code + '/_api/get-tests?type=functional&n=2').then(
     (data) => {
       assert.equal(data.assertions[0].method, 'equal');
       assert.equal(data.assertions[0].args[0], 'res.status');
@@ -93,8 +91,7 @@ You should test for `res.status` to be 200.
 You should test for `res.type` to be `'application/json'`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=functional&n=2').then(
+  $.get(code + '/_api/get-tests?type=functional&n=2').then(
     (data) => {
       assert.equal(data.assertions[1].method, 'equal');
       assert.equal(data.assertions[1].args[0], 'res.type');
@@ -109,8 +106,7 @@ You should test for `res.type` to be `'application/json'`.
 You should test for `res.body.name` to be `'Cristoforo'`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=functional&n=2').then(
+  $.get(code + '/_api/get-tests?type=functional&n=2').then(
     (data) => {
       assert.equal(data.assertions[2].method, 'equal');
       assert.equal(data.assertions[2].args[0], 'res.body.name');
@@ -125,8 +121,7 @@ You should test for `res.body.name` to be `'Cristoforo'`.
 You should test for `res.body.surname` to be `'Colombo'`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=functional&n=2').then(
+  $.get(code + '/_api/get-tests?type=functional&n=2').then(
     (data) => {
       assert.equal(data.assertions[3].method, 'equal');
       assert.equal(data.assertions[3].args[0], 'res.body.surname');

--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/run-functional-tests-on-an-api-response-using-chai-http-iv---put-method.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/run-functional-tests-on-an-api-response-using-chai-http-iv---put-method.md
@@ -40,8 +40,7 @@ Follow the assertion order above - we rely on it. Also, be sure to remove `asser
 All tests should pass
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=functional&n=3').then(
+  $.get(code + '/_api/get-tests?type=functional&n=3').then(
     (data) => {
       assert.equal(data.state, 'passed');
     },
@@ -54,8 +53,7 @@ All tests should pass
 You should test for `res.status` to be 200
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=functional&n=3').then(
+  $.get(code + '/_api/get-tests?type=functional&n=3').then(
     (data) => {
       assert.equal(data.assertions[0].method, 'equal');
       assert.equal(data.assertions[0].args[0], 'res.status');
@@ -70,8 +68,7 @@ You should test for `res.status` to be 200
 You should test for `res.type` to be `'application/json'`
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=functional&n=3').then(
+  $.get(code + '/_api/get-tests?type=functional&n=3').then(
     (data) => {
       assert.equal(data.assertions[1].method, 'equal');
       assert.equal(data.assertions[1].args[0], 'res.type');
@@ -86,8 +83,7 @@ You should test for `res.type` to be `'application/json'`
 You should test for `res.body.name` to be `'Giovanni'`
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=functional&n=3').then(
+  $.get(code + '/_api/get-tests?type=functional&n=3').then(
     (data) => {
       assert.equal(data.assertions[2].method, 'equal');
       assert.equal(data.assertions[2].args[0], 'res.body.name');
@@ -102,8 +98,7 @@ You should test for `res.body.name` to be `'Giovanni'`
 You should test for `res.body.surname` to be `'da Verrazzano'`
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=functional&n=3').then(
+  $.get(code + '/_api/get-tests?type=functional&n=3').then(
     (data) => {
       assert.equal(data.assertions[3].method, 'equal');
       assert.equal(data.assertions[3].args[0], 'res.body.surname');

--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/run-functional-tests-on-api-endpoints-using-chai-http-ii.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/run-functional-tests-on-api-endpoints-using-chai-http-ii.md
@@ -21,8 +21,7 @@ Send your name as a URL query by appending `?name=<your_name>` to the route. The
 All tests should pass
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=functional&n=1').then(
+  $.get(code + '/_api/get-tests?type=functional&n=1').then(
     (data) => {
       assert.equal(data.state, 'passed');
     },
@@ -35,8 +34,7 @@ All tests should pass
 You should test for `res.status` == 200
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=functional&n=1').then(
+  $.get(code + '/_api/get-tests?type=functional&n=1').then(
     (data) => {
       assert.equal(data.assertions[0].method, 'equal');
       assert.equal(data.assertions[0].args[0], 'res.status');
@@ -51,8 +49,7 @@ You should test for `res.status` == 200
 You should test for `res.text` == `'hello <your_name>'`
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=functional&n=1').then(
+  $.get(code + '/_api/get-tests?type=functional&n=1').then(
     (data) => {
       assert.equal(data.assertions[1].method, 'equal');
       assert.equal(data.assertions[1].args[0], 'res.text');

--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/run-functional-tests-on-api-endpoints-using-chai-http.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/run-functional-tests-on-api-endpoints-using-chai-http.md
@@ -51,8 +51,7 @@ There should be no URL query. Without a name URL query, the endpoint responds wi
 All tests should pass
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=functional&n=0').then(
+  $.get(code + '/_api/get-tests?type=functional&n=0').then(
     (data) => {
       assert.equal(data.state, 'passed');
     },
@@ -65,8 +64,7 @@ All tests should pass
 You should test for `res.status` == 200
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=functional&n=0').then(
+  $.get(code + '/_api/get-tests?type=functional&n=0').then(
     (data) => {
       assert.equal(data.assertions[0].method, 'equal');
       assert.equal(data.assertions[0].args[0], 'res.status');
@@ -81,8 +79,7 @@ You should test for `res.status` == 200
 You should test for `res.text` == `'hello Guest'`
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=functional&n=0').then(
+  $.get(code + '/_api/get-tests?type=functional&n=0').then(
     (data) => {
       assert.equal(data.assertions[1].method, 'equal');
       assert.equal(data.assertions[1].args[0], 'res.text');

--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/run-functional-tests-using-a-headless-browser-ii.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/run-functional-tests-using-a-headless-browser-ii.md
@@ -31,8 +31,7 @@ Do not forget to remove the `assert.fail()` call.
 All tests should pass.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=functional&n=6').then(
+  $.get(code + '/_api/get-tests?type=functional&n=6').then(
     (data) => {
       assert.equal(data.state, 'passed');
     },
@@ -45,8 +44,7 @@ All tests should pass.
 You should assert that the headless browser request succeeded.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=functional&n=6').then(
+  $.get(code + '/_api/get-tests?type=functional&n=6').then(
     (data) => {
       assert.equal(data.assertions[0].method, 'browser.success');
     },
@@ -59,8 +57,7 @@ You should assert that the headless browser request succeeded.
 You should assert that the text inside the element `span#name` is `'Amerigo'`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=functional&n=6').then(
+  $.get(code + '/_api/get-tests?type=functional&n=6').then(
     (data) => {
       assert.equal(data.assertions[1].method, 'browser.text');
       assert.match(data.assertions[1].args[0], /('|")span#name\1/);
@@ -75,8 +72,7 @@ You should assert that the text inside the element `span#name` is `'Amerigo'`.
 You should assert that the text inside the element `span#surname` is `'Vespucci'`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=functional&n=6').then(
+  $.get(code + '/_api/get-tests?type=functional&n=6').then(
     (data) => {
       assert.equal(data.assertions[2].method, 'browser.text');
       assert.match(data.assertions[2].args[0], /('|")span#surname\1/);
@@ -91,8 +87,7 @@ You should assert that the text inside the element `span#surname` is `'Vespucci'
 You should assert that the element `span#dates` exist and its count is 1.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=functional&n=6').then(
+  $.get(code + '/_api/get-tests?type=functional&n=6').then(
     (data) => {
       assert.equal(data.assertions[3].method, 'browser.elements');
       assert.match(data.assertions[3].args[0], /('|")span#dates\1/);

--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/run-functional-tests-using-a-headless-browser.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/run-functional-tests-using-a-headless-browser.md
@@ -64,8 +64,7 @@ Do not forget to remove the `assert.fail()` call.
 All tests should pass.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=functional&n=5').then(
+  $.get(code + '/_api/get-tests?type=functional&n=5').then(
     (data) => {
       assert.equal(data.state, 'passed');
     },
@@ -78,8 +77,7 @@ All tests should pass.
 You should assert that the headless browser request succeeded.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=functional&n=5').then(
+  $.get(code + '/_api/get-tests?type=functional&n=5').then(
     (data) => {
       assert.equal(data.assertions[0].method, 'browser.success');
     },
@@ -92,8 +90,7 @@ You should assert that the headless browser request succeeded.
 You should assert that the text inside the element `span#name` is `'Cristoforo'`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=functional&n=5').then(
+  $.get(code + '/_api/get-tests?type=functional&n=5').then(
     (data) => {
       assert.equal(data.assertions[1].method, 'browser.text');
       assert.match(data.assertions[1].args[0], /('|")span#name\1/);
@@ -108,8 +105,7 @@ You should assert that the text inside the element `span#name` is `'Cristoforo'`
 You should assert that the text inside the element `span#surname` is `'Colombo'`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=functional&n=5').then(
+  $.get(code + '/_api/get-tests?type=functional&n=5').then(
     (data) => {
       assert.equal(data.assertions[2].method, 'browser.text');
       assert.match(data.assertions[2].args[0], /('|")span#surname\1/);
@@ -124,8 +120,7 @@ You should assert that the text inside the element `span#surname` is `'Colombo'`
 You should assert that the element `span#dates` exist and its count is 1.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=functional&n=5').then(
+  $.get(code + '/_api/get-tests?type=functional&n=5').then(
     (data) => {
       assert.equal(data.assertions[3].method, 'browser.elements');
       assert.match(data.assertions[3].args[0], /('|")span#dates\1/);

--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/simulate-actions-using-a-headless-browser.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/simulate-actions-using-a-headless-browser.md
@@ -50,8 +50,7 @@ suiteSetup(function(done) {
 All tests should pass.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=functional&n=4').then(
+  $.get(code + '/_api/get-tests?type=functional&n=4').then(
     (data) => {
       assert.equal(data.state, 'passed');
     },

--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/test-for-truthiness.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/test-for-truthiness.md
@@ -29,8 +29,7 @@ Within `tests/1_unit-tests.js` under the test labeled `#4` in the `Basic Asserti
 All tests should pass.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=3').then(
+  $.get(code + '/_api/get-tests?type=unit&n=3').then(
     (data) => {
       assert.equal(data.state, 'passed');
     },
@@ -43,8 +42,7 @@ All tests should pass.
 You should choose the correct method for the first assertion - `isTrue` vs. `isNotTrue`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=3').then(
+  $.get(code + '/_api/get-tests?type=unit&n=3').then(
     (data) => {
       assert.equal(data.assertions[0].method, 'isTrue', 'True is true');
     },
@@ -57,8 +55,7 @@ You should choose the correct method for the first assertion - `isTrue` vs. `isN
 You should choose the correct method for the second assertion - `isTrue` vs. `isNotTrue`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=3').then(
+  $.get(code + '/_api/get-tests?type=unit&n=3').then(
     (data) => {
       assert.equal(
         data.assertions[1].method,
@@ -75,8 +72,7 @@ You should choose the correct method for the second assertion - `isTrue` vs. `is
 You should choose the correct method for the third assertion - `isTrue` vs. `isNotTrue`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=3').then(
+  $.get(code + '/_api/get-tests?type=unit&n=3').then(
     (data) => {
       assert.equal(
         data.assertions[2].method,

--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/test-if-a-string-contains-a-substring.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/test-if-a-string-contains-a-substring.md
@@ -21,8 +21,7 @@ Within `tests/1_unit-tests.js` under the test labeled `#14` in the `Strings` sui
 All tests should pass.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=13').then(
+  $.get(code + '/_api/get-tests?type=unit&n=13').then(
     (data) => {
       assert.equal(data.state, 'passed');
     },
@@ -35,8 +34,7 @@ All tests should pass.
 You should choose the correct method for the first assertion - `include` vs. `notInclude`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=13').then(
+  $.get(code + '/_api/get-tests?type=unit&n=13').then(
     (data) => {
       assert.equal(
         data.assertions[0].method,
@@ -53,8 +51,7 @@ You should choose the correct method for the first assertion - `include` vs. `no
 You should choose the correct method for the second assertion - `include` vs. `notInclude`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=13').then(
+  $.get(code + '/_api/get-tests?type=unit&n=13').then(
     (data) => {
       assert.equal(
         data.assertions[1].method,

--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/test-if-a-value-falls-within-a-specific-range.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/test-if-a-value-falls-within-a-specific-range.md
@@ -27,8 +27,7 @@ Choose the minimum range (3rd parameter) to make the test always pass. It should
 All tests should pass.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=9').then(
+  $.get(code + '/_api/get-tests?type=unit&n=9').then(
     (data) => {
       assert.equal(data.state, 'passed');
     },
@@ -41,8 +40,7 @@ All tests should pass.
 You should choose the correct range for the first assertion - `approximately(actual, expected, range)`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=9').then(
+  $.get(code + '/_api/get-tests?type=unit&n=9').then(
     (data) => {
       assert.equal(data.assertions[0].method, 'approximately');
       assert.equal(
@@ -60,8 +58,7 @@ You should choose the correct range for the first assertion - `approximately(act
 You should choose the correct range for the second assertion - `approximately(actual, expected, range)`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=9').then(
+  $.get(code + '/_api/get-tests?type=unit&n=9').then(
     (data) => {
       assert.equal(data.assertions[1].method, 'approximately');
       assert.equal(

--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/test-if-a-value-is-a-string.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/test-if-a-value-is-a-string.md
@@ -21,8 +21,7 @@ Within `tests/1_unit-tests.js` under the test labeled `#13` in the `Strings` sui
 All tests should pass.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=12').then(
+  $.get(code + '/_api/get-tests?type=unit&n=12').then(
     (data) => {
       assert.equal(data.state, 'passed');
     },
@@ -35,8 +34,7 @@ All tests should pass.
 You should choose the correct method for the first assertion - `isString` vs. `isNotString`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=12').then(
+  $.get(code + '/_api/get-tests?type=unit&n=12').then(
     (data) => {
       assert.equal(
         data.assertions[0].method,
@@ -53,8 +51,7 @@ You should choose the correct method for the first assertion - `isString` vs. `i
 You should choose the correct method for the second assertion - `isString` vs. `isNotString`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=12').then(
+  $.get(code + '/_api/get-tests?type=unit&n=12').then(
     (data) => {
       assert.equal(
         data.assertions[1].method,
@@ -71,8 +68,7 @@ You should choose the correct method for the second assertion - `isString` vs. `
 You should choose the correct method for the third assertion - `isString` vs. `isNotString`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=12').then(
+  $.get(code + '/_api/get-tests?type=unit&n=12').then(
     (data) => {
       assert.equal(data.assertions[2].method, 'isString', 'A JSON is a string');
     },

--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/test-if-a-value-is-an-array.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/test-if-a-value-is-an-array.md
@@ -19,8 +19,7 @@ Within `tests/1_unit-tests.js` under the test labeled `#11` in the `Arrays` suit
 All tests should pass.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=10').then(
+  $.get(code + '/_api/get-tests?type=unit&n=10').then(
     (data) => {
       assert.equal(data.state, 'passed');
     },
@@ -33,8 +32,7 @@ All tests should pass.
 You should choose the correct method for the first assertion - `isArray` vs. `isNotArray`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=10').then(
+  $.get(code + '/_api/get-tests?type=unit&n=10').then(
     (data) => {
       assert.equal(
         data.assertions[0].method,
@@ -51,8 +49,7 @@ You should choose the correct method for the first assertion - `isArray` vs. `is
 You should choose the correct method for the second assertion - `isArray` vs. `isNotArray`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=10').then(
+  $.get(code + '/_api/get-tests?type=unit&n=10').then(
     (data) => {
       assert.equal(
         data.assertions[1].method,

--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/test-if-a-value-is-of-a-specific-data-structure-type.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/test-if-a-value-is-of-a-specific-data-structure-type.md
@@ -21,8 +21,7 @@ Within `tests/1_unit-tests.js` under the test labeled `#17` in the `Objects` sui
 All tests should pass.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=16').then(
+  $.get(code + '/_api/get-tests?type=unit&n=16').then(
     (data) => {
       assert.equal(data.state, 'passed');
     },
@@ -35,8 +34,7 @@ All tests should pass.
 You should choose the correct method for the first assertion - `typeOf` vs. `notTypeOf`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=16').then(
+  $.get(code + '/_api/get-tests?type=unit&n=16').then(
     (data) => {
       assert.equal(
         data.assertions[0].method,
@@ -53,8 +51,7 @@ You should choose the correct method for the first assertion - `typeOf` vs. `not
 You should choose the correct method for the second assertion - `typeOf` vs. `notTypeOf`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=16').then(
+  $.get(code + '/_api/get-tests?type=unit&n=16').then(
     (data) => {
       assert.equal(
         data.assertions[1].method,
@@ -71,8 +68,7 @@ You should choose the correct method for the second assertion - `typeOf` vs. `no
 You should choose the correct method for the third assertion - `typeOf` vs. `notTypeOf`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=16').then(
+  $.get(code + '/_api/get-tests?type=unit&n=16').then(
     (data) => {
       assert.equal(
         data.assertions[2].method,
@@ -89,8 +85,7 @@ You should choose the correct method for the third assertion - `typeOf` vs. `not
 You should choose the correct method for the fourth assertion - `typeOf` vs. `notTypeOf`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=16').then(
+  $.get(code + '/_api/get-tests?type=unit&n=16').then(
     (data) => {
       assert.equal(
         data.assertions[3].method,
@@ -107,8 +102,7 @@ You should choose the correct method for the fourth assertion - `typeOf` vs. `no
 You should choose the correct method for the fifth assertion - `typeOf` vs. `notTypeOf`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=16').then(
+  $.get(code + '/_api/get-tests?type=unit&n=16').then(
     (data) => {
       assert.equal(
         data.assertions[4].method,

--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/test-if-a-variable-or-function-is-defined.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/test-if-a-variable-or-function-is-defined.md
@@ -19,8 +19,7 @@ Within `tests/1_unit-tests.js` under the test labeled `#2` in the `Basic Asserti
 All tests should pass.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=1').then(
+  $.get(code + '/_api/get-tests?type=unit&n=1').then(
     (data) => {
       assert.equal(data.state, 'passed');
     },
@@ -33,8 +32,7 @@ All tests should pass.
 You should choose the correct method for the first assertion - `isDefined` vs. `isUndefined`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=1').then(
+  $.get(code + '/_api/get-tests?type=unit&n=1').then(
     (data) => {
       assert.equal(
         data.assertions[0].method,
@@ -51,8 +49,7 @@ You should choose the correct method for the first assertion - `isDefined` vs. `
 You should choose the correct method for the second assertion - `isDefined` vs. `isUndefined`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=1').then(
+  $.get(code + '/_api/get-tests?type=unit&n=1').then(
     (data) => {
       assert.equal(
         data.assertions[1].method,
@@ -69,8 +66,7 @@ You should choose the correct method for the second assertion - `isDefined` vs. 
 You should choose the correct method for the third assertion - `isDefined` vs. `isUndefined`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=1').then(
+  $.get(code + '/_api/get-tests?type=unit&n=1').then(
     (data) => {
       assert.equal(
         data.assertions[2].method,

--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/test-if-an-array-contains-an-item.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/test-if-an-array-contains-an-item.md
@@ -19,8 +19,7 @@ Within `tests/1_unit-tests.js` under the test labeled `#12` in the `Arrays` suit
 All tests should pass.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=11').then(
+  $.get(code + '/_api/get-tests?type=unit&n=11').then(
     (data) => {
       assert.equal(data.state, 'passed');
     },
@@ -33,8 +32,7 @@ All tests should pass.
 You should choose the correct method for the first assertion - `include` vs. `notInclude`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=11').then(
+  $.get(code + '/_api/get-tests?type=unit&n=11').then(
     (data) => {
       assert.equal(
         data.assertions[0].method,
@@ -51,8 +49,7 @@ You should choose the correct method for the first assertion - `include` vs. `no
 You should choose the correct method for the second assertion - `include` vs. `notInclude`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=11').then(
+  $.get(code + '/_api/get-tests?type=unit&n=11').then(
     (data) => {
       assert.equal(
         data.assertions[1].method,

--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/test-if-an-object-has-a-property.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/test-if-an-object-has-a-property.md
@@ -21,8 +21,7 @@ Within `tests/1_unit-tests.js` under the test labeled `#16` in the `Objects` sui
 All tests should pass.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=15').then(
+  $.get(code + '/_api/get-tests?type=unit&n=15').then(
     (data) => {
       assert.equal(data.state, 'passed');
     },
@@ -35,8 +34,7 @@ All tests should pass.
 You should choose the correct method for the first assertion - `property` vs. `notProperty`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=15').then(
+  $.get(code + '/_api/get-tests?type=unit&n=15').then(
     (data) => {
       assert.equal(
         data.assertions[0].method,
@@ -53,8 +51,7 @@ You should choose the correct method for the first assertion - `property` vs. `n
 You should choose the correct method for the second assertion - `property` vs. `notProperty`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=15').then(
+  $.get(code + '/_api/get-tests?type=unit&n=15').then(
     (data) => {
       assert.equal(
         data.assertions[1].method,
@@ -71,8 +68,7 @@ You should choose the correct method for the second assertion - `property` vs. `
 You should choose the correct method for the third assertion - `property` vs. `notProperty`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=15').then(
+  $.get(code + '/_api/get-tests?type=unit&n=15').then(
     (data) => {
       assert.equal(data.assertions[2].method, 'property', 'Cars have wheels');
     },

--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/test-if-an-object-is-an-instance-of-a-constructor.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/test-if-an-object-is-an-instance-of-a-constructor.md
@@ -21,8 +21,7 @@ Within `tests/1_unit-tests.js` under the test labeled `#18` in the `Objects` sui
 All tests should pass.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=17').then(
+  $.get(code + '/_api/get-tests?type=unit&n=17').then(
     (data) => {
       assert.equal(data.state, 'passed');
     },
@@ -35,8 +34,7 @@ All tests should pass.
 You should choose the correct method for the first assertion - `instanceOf` vs. `notInstanceOf`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=17').then(
+  $.get(code + '/_api/get-tests?type=unit&n=17').then(
     (data) => {
       assert.equal(
         data.assertions[0].method,
@@ -53,8 +51,7 @@ You should choose the correct method for the first assertion - `instanceOf` vs. 
 You should choose the correct method for the second assertion - `instanceOf` vs. `notInstanceOf`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=17').then(
+  $.get(code + '/_api/get-tests?type=unit&n=17').then(
     (data) => {
       assert.equal(
         data.assertions[1].method,
@@ -71,8 +68,7 @@ You should choose the correct method for the second assertion - `instanceOf` vs.
 You should choose the correct method for the third assertion - `instanceOf` vs. `notInstanceOf`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=17').then(
+  $.get(code + '/_api/get-tests?type=unit&n=17').then(
     (data) => {
       assert.equal(
         data.assertions[2].method,
@@ -89,8 +85,7 @@ You should choose the correct method for the third assertion - `instanceOf` vs. 
 You should choose the correct method for the fourth assertion - `instanceOf` vs. `notInstanceOf`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=17').then(
+  $.get(code + '/_api/get-tests?type=unit&n=17').then(
     (data) => {
       assert.equal(
         data.assertions[3].method,

--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/test-if-one-value-is-below-or-at-least-as-large-as-another.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/test-if-one-value-is-below-or-at-least-as-large-as-another.md
@@ -19,8 +19,7 @@ Within `tests/1_unit-tests.js` under the test labelled `#9` in the `Comparisons`
 All tests should pass.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=8').then(
+  $.get(code + '/_api/get-tests?type=unit&n=8').then(
     (data) => {
       assert.equal(data.state, 'passed');
     },
@@ -33,8 +32,7 @@ All tests should pass.
 You should choose the correct method for the first assertion - `isBelow` vs. `isAtLeast`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=8').then(
+  $.get(code + '/_api/get-tests?type=unit&n=8').then(
     (data) => {
       assert.equal(
         data.assertions[0].method,
@@ -51,8 +49,7 @@ You should choose the correct method for the first assertion - `isBelow` vs. `is
 You should choose the correct method for the second assertion - `isBelow` vs. `isAtLeast`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=8').then(
+  $.get(code + '/_api/get-tests?type=unit&n=8').then(
     (data) => {
       assert.equal(
         data.assertions[1].method,
@@ -69,8 +66,7 @@ You should choose the correct method for the second assertion - `isBelow` vs. `i
 You should choose the correct method for the third assertion - `isBelow` vs. `isAtLeast`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=8').then(
+  $.get(code + '/_api/get-tests?type=unit&n=8').then(
     (data) => {
       assert.equal(data.assertions[2].method, 'isBelow', '1 is smaller than 2');
     },
@@ -83,8 +79,7 @@ You should choose the correct method for the third assertion - `isBelow` vs. `is
 You should choose the correct method for the fourth assertion - `isBelow` vs. `isAtLeast`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=8').then(
+  $.get(code + '/_api/get-tests?type=unit&n=8').then(
     (data) => {
       assert.equal(
         data.assertions[3].method,

--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/use-assert.isok-and-assert.isnotok.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/use-assert.isok-and-assert.isnotok.md
@@ -23,8 +23,7 @@ Within `tests/1_unit-tests.js` under the test labeled `#3` in the `Basic Asserti
 All tests should pass.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=2').then(
+  $.get(code + '/_api/get-tests?type=unit&n=2').then(
     (data) => {
       assert.equal(data.state, 'passed');
     },
@@ -37,8 +36,7 @@ All tests should pass.
 You should choose the correct method for the first assertion - `isOk` vs. `isNotOk`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=2').then(
+  $.get(code + '/_api/get-tests?type=unit&n=2').then(
     (data) => {
       assert.equal(data.assertions[0].method, 'isNotOk', 'Null is falsy');
     },
@@ -51,8 +49,7 @@ You should choose the correct method for the first assertion - `isOk` vs. `isNot
 You should choose the correct method for the second assertion - `isOk` vs. `isNotOk`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=2').then(
+  $.get(code + '/_api/get-tests?type=unit&n=2').then(
     (data) => {
       assert.equal(data.assertions[1].method, 'isOk', 'A string is truthy');
     },
@@ -65,8 +62,7 @@ You should choose the correct method for the second assertion - `isOk` vs. `isNo
 You should choose the correct method for the third assertion - `isOk` vs. `isNotOk`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=2').then(
+  $.get(code + '/_api/get-tests?type=unit&n=2').then(
     (data) => {
       assert.equal(data.assertions[2].method, 'isOk', 'true is truthy');
     },

--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/use-regular-expressions-to-test-a-string.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/use-regular-expressions-to-test-a-string.md
@@ -21,8 +21,7 @@ Within `tests/1_unit-tests.js` under the test labeled `#15` in the `Strings` sui
 All tests should pass.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=14').then(
+  $.get(code + '/_api/get-tests?type=unit&n=14').then(
     (data) => {
       assert.equal(data.state, 'passed');
     },
@@ -35,8 +34,7 @@ All tests should pass.
 You should choose the correct method for the first assertion - `match` vs. `notMatch`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=14').then(
+  $.get(code + '/_api/get-tests?type=unit&n=14').then(
     (data) => {
       assert.equal(
         data.assertions[0].method,
@@ -53,8 +51,7 @@ You should choose the correct method for the first assertion - `match` vs. `notM
 You should choose the correct method for the second assertion - `match` vs. `notMatch`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=14').then(
+  $.get(code + '/_api/get-tests?type=unit&n=14').then(
     (data) => {
       assert.equal(
         data.assertions[1].method,

--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/use-the-double-equals-to-assert-equality.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/use-the-double-equals-to-assert-equality.md
@@ -21,8 +21,7 @@ Within `tests/1_unit-tests.js` under the test labeled `#5` in the `Equality` sui
 All tests should pass.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=4').then(
+  $.get(code + '/_api/get-tests?type=unit&n=4').then(
     (data) => {
       assert.equal(data.state, 'passed');
     },
@@ -35,8 +34,7 @@ All tests should pass.
 You should choose the correct method for the first assertion - `equal` vs. `notEqual`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=4').then(
+  $.get(code + '/_api/get-tests?type=unit&n=4').then(
     (data) => {
       assert.equal(
         data.assertions[0].method,
@@ -53,8 +51,7 @@ You should choose the correct method for the first assertion - `equal` vs. `notE
 You should choose the correct method for the second assertion - `equal` vs. `notEqual`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=4').then(
+  $.get(code + '/_api/get-tests?type=unit&n=4').then(
     (data) => {
       assert.equal(
         data.assertions[1].method,
@@ -71,8 +68,7 @@ You should choose the correct method for the second assertion - `equal` vs. `not
 You should choose the correct method for the third assertion - `equal` vs. `notEqual`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=4').then(
+  $.get(code + '/_api/get-tests?type=unit&n=4').then(
     (data) => {
       assert.equal(
         data.assertions[2].method,
@@ -89,8 +85,7 @@ You should choose the correct method for the third assertion - `equal` vs. `notE
 You should choose the correct method for the fourth assertion - `equal` vs. `notEqual`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=4').then(
+  $.get(code + '/_api/get-tests?type=unit&n=4').then(
     (data) => {
       assert.equal(data.assertions[3].method, 'notEqual', "6 + '2' is '62'...");
     },

--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/use-the-triple-equals-to-assert-strict-equality.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/use-the-triple-equals-to-assert-strict-equality.md
@@ -21,8 +21,7 @@ Within `tests/1_unit-tests.js` under the test labeled `#6` in the `Equality` sui
 All tests should pass.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=5').then(
+  $.get(code + '/_api/get-tests?type=unit&n=5').then(
     (data) => {
       assert.equal(data.state, 'passed');
     },
@@ -35,8 +34,7 @@ All tests should pass.
 You should choose the correct method for the first assertion - `strictEqual` vs. `notStrictEqual`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=5').then(
+  $.get(code + '/_api/get-tests?type=unit&n=5').then(
     (data) => {
       assert.equal(
         data.assertions[0].method,
@@ -53,8 +51,7 @@ You should choose the correct method for the first assertion - `strictEqual` vs.
 You should choose the correct method for the second assertion - `strictEqual` vs. `notStrictEqual`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=5').then(
+  $.get(code + '/_api/get-tests?type=unit&n=5').then(
     (data) => {
       assert.equal(data.assertions[1].method, 'strictEqual', '3*2 = 6...');
     },
@@ -67,8 +64,7 @@ You should choose the correct method for the second assertion - `strictEqual` vs
 You should choose the correct method for the third assertion - `strictEqual` vs. `notStrictEqual`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=5').then(
+  $.get(code + '/_api/get-tests?type=unit&n=5').then(
     (data) => {
       assert.equal(
         data.assertions[2].method,
@@ -85,8 +81,7 @@ You should choose the correct method for the third assertion - `strictEqual` vs.
 You should choose the correct method for the fourth assertion - `strictEqual` vs. `notStrictEqual`.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=5').then(
+  $.get(code + '/_api/get-tests?type=unit&n=5').then(
     (data) => {
       assert.equal(
         data.assertions[3].method,

--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/american-british-translator.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/american-british-translator.md
@@ -64,19 +64,17 @@ Write the following tests in `tests/2_functional-tests.js`:
 You should provide your own project, not the example URL.
 
 ```js
-(getUserInput) => {
   assert(
     !/.*\/american-british-translator\.freecodecamp\.rocks/.test(
-      getUserInput('url')
+      code
     )
   );
-};
 ```
 
 You can `POST` to `/api/translate` with a body containing `text` with the text to translate and `locale` with either `american-to-british` or `british-to-american`. The returned object should contain the submitted `text` and `translation` with the translated text.
 
 ```js
-async (getUserInput) => {
+async () => {
   try {
     const text = 'Mangoes are my favorite fruit.';
     const locale = 'american-to-british';
@@ -85,7 +83,7 @@ async (getUserInput) => {
       translation:
         'Mangoes are my <span class="highlight">favourite</span> fruit.'
     };
-    let data = await fetch(getUserInput('url') + '/api/translate', {
+    let data = await fetch(code + '/api/translate', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ text, locale })
@@ -104,7 +102,7 @@ async (getUserInput) => {
 The `/api/translate` route should handle the way time is written in American and British English. For example, ten thirty is written as "10.30" in British English and "10:30" in American English. The `span` element should wrap the entire time string, i.e. `<span class="highlight">10:30</span>`.
 
 ```js
-async (getUserInput) => {
+async () => {
   try {
     const text = 'Lunch is at 12:15 today.';
     const locale = 'american-to-british';
@@ -112,7 +110,7 @@ async (getUserInput) => {
       text: text,
       translation: 'Lunch is at <span class="highlight">12.15</span> today.'
     };
-    let data = await fetch(getUserInput('url') + '/api/translate', {
+    let data = await fetch(code + '/api/translate', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ text, locale })
@@ -131,7 +129,7 @@ async (getUserInput) => {
 The `/api/translate` route should also handle the way titles/honorifics are abbreviated in American and British English. For example, Doctor Wright is abbreviated as "Dr Wright" in British English and "Dr. Wright" in American English. See `/components/american-to-british-titles.js` for the different titles your application should handle.
 
 ```js
-async (getUserInput) => {
+async () => {
   try {
     const text = 'Dr. Grosh will see you now.';
     const locale = 'american-to-british';
@@ -139,7 +137,7 @@ async (getUserInput) => {
       text: text,
       translation: '<span class="highlight">Dr</span> Grosh will see you now.'
     };
-    let data = await fetch(getUserInput('url') + '/api/translate', {
+    let data = await fetch(code + '/api/translate', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ text, locale })
@@ -158,7 +156,7 @@ async (getUserInput) => {
 Wrap any translated spelling or terms with `<span class="highlight">...</span>` tags so they appear in green.
 
 ```js
-async (getUserInput) => {
+async () => {
   try {
     const text = 'Mangoes are my favorite fruit.';
     const locale = 'american-to-british';
@@ -167,7 +165,7 @@ async (getUserInput) => {
       translation:
         'Mangoes are my <span class="highlight">favourite</span> fruit.'
     };
-    let data = await fetch(getUserInput('url') + '/api/translate', {
+    let data = await fetch(code + '/api/translate', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ text, locale })
@@ -186,10 +184,10 @@ async (getUserInput) => {
 If one or more of the required fields is missing, return `{ error: 'Required field(s) missing' }`.
 
 ```js
-async (getUserInput) => {
+async () => {
   try {
     const locale = 'american-to-british';
-    let data = await fetch(getUserInput('url') + '/api/translate', {
+    let data = await fetch(code + '/api/translate', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ locale })
@@ -207,10 +205,10 @@ async (getUserInput) => {
 If `text` is empty, return `{ error: 'No text to translate' }`
 
 ```js
-async (getUserInput) => {
+async () => {
   try {
     const locale = 'american-to-british';
-    let data = await fetch(getUserInput('url') + '/api/translate', {
+    let data = await fetch(code + '/api/translate', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ text: '', locale })
@@ -228,11 +226,11 @@ async (getUserInput) => {
 If `locale` does not match one of the two specified locales, return `{ error: 'Invalid value for locale field' }`.
 
 ```js
-async (getUserInput) => {
+async () => {
   try {
     const text = "Ceci n'est pas une pipe";
     const locale = 'french-to-american';
-    let data = await fetch(getUserInput('url') + '/api/translate', {
+    let data = await fetch(code + '/api/translate', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ text, locale })
@@ -250,14 +248,14 @@ async (getUserInput) => {
 If `text` requires no translation, return `"Everything looks good to me!"` for the `translation` value.
 
 ```js
-async (getUserInput) => {
+async () => {
   try {
     const locale = 'british-to-american';
     const output = {
       text: 'SaintPeter and nhcarrigan give their regards!',
       translation: 'Everything looks good to me!'
     };
-    let data = await fetch(getUserInput('url') + '/api/translate', {
+    let data = await fetch(code + '/api/translate', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ text: output.text, locale })
@@ -277,9 +275,9 @@ async (getUserInput) => {
 All 24 unit tests are complete and passing.
 
 ```js
-async (getUserInput) => {
+async () => {
   try {
-    const getTests = await $.get(getUserInput('url') + '/_api/get-tests');
+    const getTests = await $.get(code + '/_api/get-tests');
     assert.isArray(getTests);
     const unitTests = getTests.filter((test) => {
       return !!test.context.match(/Unit Tests/gi);
@@ -302,9 +300,9 @@ async (getUserInput) => {
 All 6 functional tests are complete and passing.
 
 ```js
-async (getUserInput) => {
+async () => {
   try {
-    const getTests = await $.get(getUserInput('url') + '/_api/get-tests');
+    const getTests = await $.get(code + '/_api/get-tests');
     assert.isArray(getTests);
     const functTests = getTests.filter((test) => {
       return !!test.context.match(/Functional Tests/gi);

--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/issue-tracker.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/issue-tracker.md
@@ -44,15 +44,13 @@ Write the following tests in `tests/2_functional-tests.js`:
 You can provide your own project, not the example URL.
 
 ```js
-(getUserInput) => {
-  assert(!/.*\/issue-tracker\.freecodecamp\.rocks/.test(getUserInput('url')));
-};
+  assert(!/.*\/issue-tracker\.freecodecamp\.rocks/.test(code));
 ```
 
 You can send a `POST` request to `/api/issues/{projectname}` with form data containing the required fields `issue_title`, `issue_text`, `created_by`, and optionally `assigned_to` and `status_text`.
 
 ```js
-async (getUserInput) => {
+async () => {
   try {
     let test_data = {
       issue_title: 'Faux Issue Title',
@@ -60,7 +58,7 @@ async (getUserInput) => {
       created_by: 'fCC'
     };
     const data = await $.post(
-      getUserInput('url') + '/api/issues/fcc-project',
+      code + '/api/issues/fcc-project',
       test_data
     );
     assert.isObject(data);
@@ -74,7 +72,7 @@ async (getUserInput) => {
 The `POST` request to `/api/issues/{projectname}` will return the created object, and must include all of the submitted fields. Excluded optional fields will be returned as empty strings. Additionally, include `created_on` (date/time), `updated_on` (date/time), `open` (boolean, `true` for open - default value, `false` for closed), and `_id`.
 
 ```js
-async (getUserInput) => {
+async () => {
   try {
     let test_data = {
       issue_title: 'Faux Issue Title 2',
@@ -83,7 +81,7 @@ async (getUserInput) => {
       assigned_to: 'Chai and Mocha'
     };
     const data = await $.post(
-      getUserInput('url') + '/api/issues/fcc-project',
+      code + '/api/issues/fcc-project',
       test_data
     );
     assert.isObject(data);
@@ -108,10 +106,10 @@ async (getUserInput) => {
 If you send a `POST` request to `/api/issues/{projectname}` without the required fields, returned will be the error `{ error: 'required field(s) missing' }`
 
 ```js
-async (getUserInput) => {
+async () => {
   try {
     let test_data = { created_by: 'fCC' };
-    const data = await $.post(getUserInput('url') + '/api/issues/fcc-project', {
+    const data = await $.post(code + '/api/issues/fcc-project', {
       created_by: 'fCC'
     });
     assert.isObject(data);
@@ -126,11 +124,11 @@ async (getUserInput) => {
 You can send a `GET` request to `/api/issues/{projectname}` for an array of all issues for that specific `projectname`, with all the fields present for each issue.
 
 ```js
-async (getUserInput) => {
+async () => {
   try {
     let test_data = { issue_text: 'Get Issues Test', created_by: 'fCC' };
     const url =
-      getUserInput('url') +
+      code +
       '/api/issues/get_issues_test_' +
       Date.now().toString().substring(7);
     const data1 = await $.post(
@@ -173,14 +171,14 @@ async (getUserInput) => {
 You can send a `GET` request to `/api/issues/{projectname}` and filter the request by also passing along any field and value as a URL query (ie. `/api/issues/{project}?open=false`). You can pass one or more field/value pairs at once.
 
 ```js
-async (getUserInput) => {
+async () => {
   try {
     let test_data = {
       issue_title: 'To be Filtered',
       issue_text: 'Filter Issues Test'
     };
     const url =
-      getUserInput('url') +
+      code +
       '/api/issues/get_issues_test_' +
       Date.now().toString().substring(7);
     const data1 = await $.post(
@@ -219,14 +217,14 @@ async (getUserInput) => {
 You can send a `PUT` request to `/api/issues/{projectname}` with an `_id` and one or more fields to update. On success, the `updated_on` field should be updated, and returned should be `{  result: 'successfully updated', '_id': _id }`.
 
 ```js
-async (getUserInput) => {
+async () => {
   try {
     let initialData = {
       issue_title: 'Issue to be Updated',
       issue_text: 'Functional Test - Put target',
       created_by: 'fCC'
     };
-    const url = getUserInput('url') + '/api/issues/fcc-project';
+    const url = code + '/api/issues/fcc-project';
     const itemToUpdate = await $.post(url, initialData);
     const updateSuccess = await $.ajax({
       url: url,
@@ -254,9 +252,9 @@ async (getUserInput) => {
 When the `PUT` request sent to `/api/issues/{projectname}` does not include an `_id`, the return value is `{ error: 'missing _id' }`.
 
 ```js
-async (getUserInput) => {
+async () => {
   try {
-    const url = getUserInput('url') + '/api/issues/fcc-project';
+    const url = code + '/api/issues/fcc-project';
     const badUpdate = await $.ajax({ url: url, type: 'PUT' });
     assert.isObject(badUpdate);
     assert.property(badUpdate, 'error');
@@ -270,9 +268,9 @@ async (getUserInput) => {
 When the `PUT` request sent to `/api/issues/{projectname}` does not include update fields, the return value is `{ error: 'no update field(s) sent', '_id': _id }`. On any other error, the return value is `{ error: 'could not update', '_id': _id }`.
 
 ```js
-async (getUserInput) => {
+async () => {
   try {
-    const url = getUserInput('url') + '/api/issues/fcc-project';
+    const url = code + '/api/issues/fcc-project';
     const badUpdate = await $.ajax({
       url: url,
       type: 'PUT',
@@ -300,14 +298,14 @@ async (getUserInput) => {
 You can send a `DELETE` request to `/api/issues/{projectname}` with an `_id` to delete an issue. If no `_id` is sent, the return value is `{ error: 'missing _id' }`. On success, the return value is `{ result: 'successfully deleted', '_id': _id }`. On failure, the return value is `{ error: 'could not delete', '_id': _id }`.
 
 ```js
-async (getUserInput) => {
+async () => {
   try {
     let initialData = {
       issue_title: 'Issue to be Deleted',
       issue_text: 'Functional Test - Delete target',
       created_by: 'fCC'
     };
-    const url = getUserInput('url') + '/api/issues/fcc-project';
+    const url = code + '/api/issues/fcc-project';
     const itemToDelete = await $.post(url, initialData);
     assert.isObject(itemToDelete);
     const deleteSuccess = await $.ajax({
@@ -342,9 +340,9 @@ async (getUserInput) => {
 All 14 functional tests are complete and passing.
 
 ```js
-async (getUserInput) => {
+async () => {
   try {
-    const getTests = await $.get(getUserInput('url') + '/_api/get-tests');
+    const getTests = await $.get(code + '/_api/get-tests');
     assert.isArray(getTests);
     assert.isAtLeast(getTests.length, 14, 'At least 14 tests passed');
     getTests.forEach((test) => {

--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/metric-imperial-converter.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/metric-imperial-converter.md
@@ -56,13 +56,11 @@ Write the following tests in `tests/2_functional-tests.js`:
 You can provide your own project, not the example URL.
 
 ```js
-getUserInput => {
   assert(
     !/.*\/metric-imperial-converter\.freecodecamp\.rocks/.test(
-      getUserInput('url')
+      code
     )
   );
-};
 ```
 
 You can `GET` `/api/convert` with a single parameter containing an accepted number and unit and have it converted. (Hint: Split the input by looking for the index of the first character which will mark the start of the unit)
@@ -74,18 +72,18 @@ You can `GET` `/api/convert` with a single parameter containing an accepted numb
 You can convert `'gal'` to `'L'` and vice versa. (1 gal to 3.78541 L)
 
 ```js
-async getUserInput => {
+async () => {
   try {
-    const data1 = await $.get(getUserInput('url') + '/api/convert?input=1gal');
+    const data1 = await $.get(code + '/api/convert?input=1gal');
     assert.equal(data1.returnNum, 3.78541);
     assert.equal(data1.returnUnit, 'L');
-    const data2 = await $.get(getUserInput('url') + '/api/convert?input=10gal');
+    const data2 = await $.get(code + '/api/convert?input=10gal');
     assert.equal(data2.returnNum, 37.8541);
     assert.equal(data2.returnUnit, 'L');
-    const data3 = await $.get(getUserInput('url') + '/api/convert?input=1l');
+    const data3 = await $.get(code + '/api/convert?input=1l');
     assert.equal(data3.returnNum, 0.26417);
     assert.equal(data3.returnUnit, 'gal');
-    const data4 = await $.get(getUserInput('url') + '/api/convert?input=10l');
+    const data4 = await $.get(code + '/api/convert?input=10l');
     assert.equal(data4.returnNum, 2.64172);
     assert.equal(data4.returnUnit, 'gal');
   } catch (xhr) {
@@ -97,18 +95,18 @@ async getUserInput => {
 You can convert `'lbs'` to `'kg'` and vice versa. (1 lbs to 0.453592 kg)
 
 ```js
-async getUserInput => {
+async () => {
   try {
-    const data1 = await $.get(getUserInput('url') + '/api/convert?input=1lbs');
+    const data1 = await $.get(code + '/api/convert?input=1lbs');
     assert.equal(data1.returnNum, 0.45359);
     assert.equal(data1.returnUnit, 'kg');
-    const data2 = await $.get(getUserInput('url') + '/api/convert?input=10lbs');
+    const data2 = await $.get(code + '/api/convert?input=10lbs');
     assert.equal(data2.returnNum, 4.53592);
     assert.equal(data2.returnUnit, 'kg');
-    const data3 = await $.get(getUserInput('url') + '/api/convert?input=1kg');
+    const data3 = await $.get(code + '/api/convert?input=1kg');
     assert.equal(data3.returnNum, 2.20462);
     assert.equal(data3.returnUnit, 'lbs');
-    const data4 = await $.get(getUserInput('url') + '/api/convert?input=10kg');
+    const data4 = await $.get(code + '/api/convert?input=10kg');
     assert.equal(data4.returnNum, 22.04624);
     assert.equal(data4.returnUnit, 'lbs');
   } catch (xhr) {
@@ -120,18 +118,18 @@ async getUserInput => {
 You can convert `'mi'` to `'km'` and vice versa. (1 mi to 1.60934 km)
 
 ```js
-async getUserInput => {
+async () => {
   try {
-    const data1 = await $.get(getUserInput('url') + '/api/convert?input=1mi');
+    const data1 = await $.get(code + '/api/convert?input=1mi');
     assert.equal(data1.returnNum, 1.60934);
     assert.equal(data1.returnUnit, 'km');
-    const data2 = await $.get(getUserInput('url') + '/api/convert?input=10mi');
+    const data2 = await $.get(code + '/api/convert?input=10mi');
     assert.equal(data2.returnNum, 16.0934);
     assert.equal(data2.returnUnit, 'km');
-    const data3 = await $.get(getUserInput('url') + '/api/convert?input=1km');
+    const data3 = await $.get(code + '/api/convert?input=1km');
     assert.equal(data3.returnNum, 0.62137);
     assert.equal(data3.returnUnit, 'mi');
-    const data4 = await $.get(getUserInput('url') + '/api/convert?input=10km');
+    const data4 = await $.get(code + '/api/convert?input=10km');
     assert.equal(data4.returnNum, 6.21373);
     assert.equal(data4.returnUnit, 'mi');
   } catch (xhr) {
@@ -143,18 +141,18 @@ async getUserInput => {
 All incoming units should be accepted in both upper and lower case, but should be returned in both the `initUnit` and `returnUnit` in lower case, except for liter, which should be represented as an uppercase `'L'`.
 
 ```js
-async getUserInput => {
+async () => {
   try {
-    const data1 = await $.get(getUserInput('url') + '/api/convert?input=1gal');
+    const data1 = await $.get(code + '/api/convert?input=1gal');
     assert.equal(data1.initUnit, 'gal');
     assert.equal(data1.returnUnit, 'L');
-    const data2 = await $.get(getUserInput('url') + '/api/convert?input=10L');
+    const data2 = await $.get(code + '/api/convert?input=10L');
     assert.equal(data2.initUnit, 'L');
     assert.equal(data2.returnUnit, 'gal');
-    const data3 = await $.get(getUserInput('url') + '/api/convert?input=1l');
+    const data3 = await $.get(code + '/api/convert?input=1l');
     assert.equal(data3.initUnit, 'L');
     assert.equal(data3.returnUnit, 'gal');
-    const data4 = await $.get(getUserInput('url') + '/api/convert?input=10KM');
+    const data4 = await $.get(code + '/api/convert?input=10KM');
     assert.equal(data4.initUnit, 'km');
     assert.equal(data4.returnUnit, 'mi');
   } catch (xhr) {
@@ -166,9 +164,9 @@ async getUserInput => {
 If the unit of measurement is invalid, returned will be `'invalid unit'`.
 
 ```js
-async getUserInput => {
+async () => {
   try {
-    const data = await $.get(getUserInput('url') + '/api/convert?input=1min');
+    const data = await $.get(code + '/api/convert?input=1min');
     assert(data.error === 'invalid unit' || data === 'invalid unit');
   } catch (xhr) {
     throw new Error(xhr.responseText || xhr.message);
@@ -179,10 +177,10 @@ async getUserInput => {
 If the number is invalid, returned will be `'invalid number'`.
 
 ```js
-async getUserInput => {
+async () => {
   try {
     const data = await $.get(
-      getUserInput('url') + '/api/convert?input=1//2gal'
+      code + '/api/convert?input=1//2gal'
     );
     assert(data.error === 'invalid number' || data === 'invalid number');
   } catch (xhr) {
@@ -194,10 +192,10 @@ async getUserInput => {
 If both the unit and number are invalid, returned will be `'invalid number and unit'`.
 
 ```js
-async getUserInput => {
+async () => {
   try {
     const data = await $.get(
-      getUserInput('url') + '/api/convert?input=1//2min'
+      code + '/api/convert?input=1//2min'
     );
     assert(
       data.error === 'invalid number and unit' ||
@@ -212,24 +210,24 @@ async getUserInput => {
 You can use fractions, decimals or both in the parameter (ie. 5, 1/2, 2.5/6), but if nothing is provided it will default to 1.
 
 ```js
-async getUserInput => {
+async () => {
   try {
-    const data1 = await $.get(getUserInput('url') + '/api/convert?input=mi');
+    const data1 = await $.get(code + '/api/convert?input=mi');
     assert.approximately(data1.initNum, 1, 0.001);
     assert.approximately(data1.returnNum, 1.60934, 0.001);
     assert.equal(data1.returnUnit, 'km');
-    const data2 = await $.get(getUserInput('url') + '/api/convert?input=1/5mi');
+    const data2 = await $.get(code + '/api/convert?input=1/5mi');
     assert.approximately(data2.initNum, 1 / 5, 0.1);
     assert.approximately(data2.returnNum, 0.32187, 0.001);
     assert.equal(data2.returnUnit, 'km');
     const data3 = await $.get(
-      getUserInput('url') + '/api/convert?input=1.5/7km'
+      code + '/api/convert?input=1.5/7km'
     );
     assert.approximately(data3.initNum, 1.5 / 7, 0.001);
     assert.approximately(data3.returnNum, 0.13315, 0.001);
     assert.equal(data3.returnUnit, 'mi');
     const data4 = await $.get(
-      getUserInput('url') + '/api/convert?input=3/2.7km'
+      code + '/api/convert?input=3/2.7km'
     );
     assert.approximately(data4.initNum, 3 / 2.7, 0.001);
     assert.approximately(data4.returnNum, 0.69041, 0.001);
@@ -243,9 +241,9 @@ async getUserInput => {
 Your return will consist of the `initNum`, `initUnit`, `returnNum`, `returnUnit`, and `string` spelling out units in the format `'{initNum} {initUnitString} converts to {returnNum} {returnUnitString}'` with the result rounded to 5 decimals.
 
 ```js
-async getUserInput => {
+async () => {
   try {
-    const data = await $.get(getUserInput('url') + '/api/convert?input=2mi');
+    const data = await $.get(code + '/api/convert?input=2mi');
     assert.equal(data.initNum, 2);
     assert.equal(data.initUnit, 'mi');
     assert.approximately(data.returnNum, 3.21868, 0.001);
@@ -260,9 +258,9 @@ async getUserInput => {
 All 16 unit tests are complete and passing.
 
 ```js
-async getUserInput => {
+async () => {
   try {
-    const getTests = await $.get(getUserInput('url') + '/_api/get-tests');
+    const getTests = await $.get(code + '/_api/get-tests');
     assert.isArray(getTests);
     const unitTests = getTests.filter(test => {
       return !!test.context.match(/Unit Tests/gi);
@@ -285,9 +283,9 @@ async getUserInput => {
 All 5 functional tests are complete and passing.
 
 ```js
-async getUserInput => {
+async () => {
   try {
-    const getTests = await $.get(getUserInput('url') + '/_api/get-tests');
+    const getTests = await $.get(code + '/_api/get-tests');
     assert.isArray(getTests);
     const functTests = getTests.filter(test => {
       return !!test.context.match(/Functional Tests/gi);

--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/personal-library.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/personal-library.md
@@ -27,26 +27,24 @@ Build a full stack JavaScript app that is functionally similar to this: <a href=
 You can provide your own project, not the example URL.
 
 ```js
-(getUserInput) => {
   assert(
-    !/.*\/personal-library\.freecodecamp\.rocks/.test(getUserInput('url'))
+    !/.*\/personal-library\.freecodecamp\.rocks/.test(code)
   );
-};
 ```
 
 You can send a <b>POST</b> request to `/api/books` with `title` as part of the form data to add a book.  The returned response will be an object with the `title` and a unique `_id` as keys.  If `title` is not included in the request, the returned response should be the string `missing required field title`.
 
 ```js
-async (getUserInput) => {
+async () => {
   try {
-    let data1 = await $.post(getUserInput('url') + '/api/books', {
+    let data1 = await $.post(code + '/api/books', {
       title: 'Faux Book 1'
     });
     assert.isObject(data1);
     assert.property(data1, 'title');
     assert.equal(data1.title, 'Faux Book 1');
     assert.property(data1, '_id');
-    let data2 = await $.post(getUserInput('url') + '/api/books');
+    let data2 = await $.post(code + '/api/books');
     assert.isString(data2);
     assert.equal(data2, 'missing required field title');
   } catch (err) {
@@ -58,9 +56,9 @@ async (getUserInput) => {
 You can send a <b>GET</b> request to `/api/books` and receive a JSON response representing all the books. The JSON response will be an array of objects with each object (book) containing `title`, `_id`, and `commentcount` properties.
 
 ```js
-async (getUserInput) => {
+async () => {
   try {
-    let url = getUserInput('url') + '/api/books';
+    let url = code + '/api/books';
     let a = $.post(url, { title: 'Faux Book A' });
     let b = $.post(url, { title: 'Faux Book B' });
     let c = $.post(url, { title: 'Faux Book C' });
@@ -86,9 +84,9 @@ async (getUserInput) => {
 You can send a <b>GET</b> request to `/api/books/{_id}` to retrieve a single object of a book containing the properties `title`, `_id`, and a `comments` array (empty array if no comments present). If no book is found, return the string `no book exists`.
 
 ```js
-async (getUserInput) => {
+async () => {
   try {
-    let url = getUserInput('url') + '/api/books';
+    let url = code + '/api/books';
     let noBook = await $.get(url + '/5f665eb46e296f6b9b6a504d');
     assert.isString(noBook);
     assert.equal(noBook, 'no book exists');
@@ -110,9 +108,9 @@ async (getUserInput) => {
 You can send a <b>POST</b> request containing `comment` as the form body data to `/api/books/{_id}` to add a comment to a book. The returned response will be the books object similar to <b>GET</b> `/api/books/{_id}` request in an earlier test. If `comment` is not included in the request, return the string `missing required field comment`. If no book is found, return the string `no book exists`.
 
 ```js
-async (getUserInput) => {
+async () => {
   try {
-    let url = getUserInput('url') + '/api/books';
+    let url = code + '/api/books';
     let commentTarget = await $.post(url, { title: 'Notable Book' });
     assert.isObject(commentTarget);
     let bookId = commentTarget._id;
@@ -148,9 +146,9 @@ async (getUserInput) => {
 You can send a <b>DELETE</b> request to `/api/books/{_id}` to delete a book from the collection. The returned response will be the string `delete successful` if successful. If no book is found, return the string `no book exists`.
 
 ```js
-async (getUserInput) => {
+async () => {
   try {
-    let url = getUserInput('url') + '/api/books';
+    let url = code + '/api/books';
     let deleteTarget = await $.post(url, { title: 'Deletable Book' });
     assert.isObject(deleteTarget);
     let bookId = deleteTarget._id;
@@ -172,10 +170,10 @@ async (getUserInput) => {
 You can send a <b>DELETE</b> request to `/api/books` to delete all books in the database. The returned response will be the string `complete delete successful` if successful.
 
 ```js
-async (getUserInput) => {
+async () => {
   try {
     const deleteAll = await $.ajax({
-      url: getUserInput('url') + '/api/books',
+      url: code + '/api/books',
       type: 'DELETE'
     });
     assert.isString(deleteAll);
@@ -189,9 +187,9 @@ async (getUserInput) => {
 All 10 functional tests required are complete and passing.
 
 ```js
-async (getUserInput) => {
+async () => {
   try {
-    const getTests = await $.get(getUserInput('url') + '/_api/get-tests');
+    const getTests = await $.get(code + '/_api/get-tests');
     assert.isArray(getTests);
     assert.isAtLeast(getTests.length, 10, 'At least 10 tests passed');
     getTests.forEach((test) => {

--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/sudoku-solver.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/sudoku-solver.md
@@ -62,21 +62,19 @@ Write the following tests in `tests/2_functional-tests.js`
 You should provide your own project, not the example URL.
 
 ```js
-(getUserInput) => {
-  const url = getUserInput('url');
-  assert(!/.*\/sudoku-solver\.freecodecamp\.rocks/.test(getUserInput('url')));
-};
+  const url = code;
+  assert(!/.*\/sudoku-solver\.freecodecamp\.rocks/.test(code));
 ```
 
 You can `POST` `/api/solve` with form data containing `puzzle` which will be a string containing a combination of numbers (1-9) and periods `.` to represent empty spaces. The returned object will contain a `solution` property with the solved puzzle.
 
 ```js
-async (getUserInput) => {
+async () => {
   const input =
     '..9..5.1.85.4....2432......1...69.83.9.....6.62.71...9......1945....4.37.4.3..6..';
   const output =
     '769235418851496372432178956174569283395842761628713549283657194516924837947381625';
-  const data = await fetch(getUserInput('url') + '/api/solve', {
+  const data = await fetch(code + '/api/solve', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ puzzle: input })
@@ -90,11 +88,11 @@ async (getUserInput) => {
 If the object submitted to `/api/solve` is missing `puzzle`, the returned value will be `{ error: 'Required field missing' }`
 
 ```js
-async (getUserInput) => {
+async () => {
   const input =
     '..9..5.1.85.4....2432......1...69.83.9.....6.62.71...9......1945....4.37.4.3..6..';
   const output = 'Required field missing';
-  const data = await fetch(getUserInput('url') + '/api/solve', {
+  const data = await fetch(code + '/api/solve', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ notpuzzle: input })
@@ -108,11 +106,11 @@ async (getUserInput) => {
 If the puzzle submitted to `/api/solve` contains values which are not numbers or periods, the returned value will be `{ error: 'Invalid characters in puzzle' }`
 
 ```js
-async (getUserInput) => {
+async () => {
   const input =
     'AA9..5.1.85.4....2432......1...69.83.9.....6.62.71...9......1945....4.37.4.3..6..';
   const output = 'Invalid characters in puzzle';
-  const data = await fetch(getUserInput('url') + '/api/solve', {
+  const data = await fetch(code + '/api/solve', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ puzzle: input })
@@ -126,14 +124,14 @@ async (getUserInput) => {
 If the puzzle submitted to `/api/solve` is greater or less than 81 characters, the returned value will be `{ error: 'Expected puzzle to be 81 characters long' }`
 
 ```js
-async (getUserInput) => {
+async () => {
   const inputs = [
     '..9..5.1.85.4....2432......1...69.83.9.....6.62.71...9......1945....4.37.4.3..6.',
     '..9..5.1.85.4....2432......1...69.83.9.....6.62.71...9......1945....4.37.4.3..6...'
   ];
   const output = 'Expected puzzle to be 81 characters long';
   for (const input of inputs) {
-    const data = await fetch(getUserInput('url') + '/api/solve', {
+    const data = await fetch(code + '/api/solve', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ puzzle: input })
@@ -148,11 +146,11 @@ async (getUserInput) => {
 If the puzzle submitted to `/api/solve` is invalid or cannot be solved, the returned value will be `{ error: 'Puzzle cannot be solved' }`
 
 ```js
-async (getUserInput) => {
+async () => {
   const input =
     '9.9..5.1.85.4....2432......1...69.83.9.....6.62.71...9......1945....4.37.4.3..6..';
   const output = 'Puzzle cannot be solved';
-  const data = await fetch(getUserInput('url') + '/api/solve', {
+  const data = await fetch(code + '/api/solve', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ puzzle: input })
@@ -166,12 +164,12 @@ async (getUserInput) => {
 You can `POST` to `/api/check` an object containing `puzzle`, `coordinate`, and `value` where the `coordinate` is the letter A-I indicating the row, followed by a number 1-9 indicating the column, and `value` is a number from 1-9.
 
 ```js
-async (getUserInput) => {
+async () => {
   const input =
     '..9..5.1.85.4....2432......1...69.83.9.....6.62.71...9......1945....4.37.4.3..6..';
   const coordinate = 'A1';
   const value = '7';
-  const data = await fetch(getUserInput('url') + '/api/check', {
+  const data = await fetch(code + '/api/check', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ puzzle: input, coordinate, value })
@@ -185,13 +183,13 @@ async (getUserInput) => {
 The return value from the `POST` to `/api/check` will be an object containing a `valid` property, which is `true` if the number may be placed at the provided coordinate and `false` if the number may not. If false, the returned object will also contain a `conflict` property which is an array containing the strings `"row"`, `"column"`, and/or `"region"` depending on which makes the placement invalid.
 
 ```js
-async (getUserInput) => {
+async () => {
   const input =
     '..9..5.1.85.4....2432......1...69.83.9.....6.62.71...9......1945....4.37.4.3..6..';
   const coordinate = 'A1';
   const value = '1';
   const conflict = ['row', 'column'];
-  const data = await fetch(getUserInput('url') + '/api/check', {
+  const data = await fetch(code + '/api/check', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ puzzle: input, coordinate, value })
@@ -208,12 +206,12 @@ async (getUserInput) => {
 If `value` submitted to `/api/check` is already placed in `puzzle` on that `coordinate`, the returned value will be an object containing a `valid` property with `true` if `value` is not conflicting.
 
 ```js
-async (getUserInput) => {
+async () => {
   const input =
   '..9..5.1.85.4....2432......1...69.83.9.....6.62.71...9......1945....4.37.4.3..6..';
   const coordinate = 'C3';
   const value = '2';
-  const data = await fetch(getUserInput('url') + '/api/check', {
+  const data = await fetch(code + '/api/check', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ puzzle: input, coordinate, value })
@@ -227,13 +225,13 @@ async (getUserInput) => {
 If the puzzle submitted to `/api/check` contains values which are not numbers or periods, the returned value will be `{ error: 'Invalid characters in puzzle' }`
 
 ```js
-async (getUserInput) => {
+async () => {
   const input =
     'AA9..5.1.85.4....2432......1...69.83.9.....6.62.71...9......1945....4.37.4.3..6..';
   const coordinate = 'A1';
   const value = '1';
   const output = 'Invalid characters in puzzle';
-  const data = await fetch(getUserInput('url') + '/api/check', {
+  const data = await fetch(code + '/api/check', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ puzzle: input, coordinate, value })
@@ -247,7 +245,7 @@ async (getUserInput) => {
 If the puzzle submitted to `/api/check` is greater or less than 81 characters, the returned value will be `{ error: 'Expected puzzle to be 81 characters long' }`
 
 ```js
-async (getUserInput) => {
+async () => {
   const inputs = [
     '..9..5.1.85.4....2432......1...69.83.9.....6.62.71...9......1945....4.37.4.3..6.',
     '..9..5.1.85.4....2432......1...69.83.9.....6.62.71...9......1945....4.37.4.3..6...'
@@ -256,7 +254,7 @@ async (getUserInput) => {
   const value = '1';
   const output = 'Expected puzzle to be 81 characters long';
   for (const input of inputs) {
-    const data = await fetch(getUserInput('url') + '/api/check', {
+    const data = await fetch(code + '/api/check', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ puzzle: input, coordinate, value })
@@ -271,7 +269,7 @@ async (getUserInput) => {
 If the object submitted to `/api/check` is missing `puzzle`, `coordinate` or `value`, the returned value will be `{ error: 'Required field(s) missing' }`
 
 ```js
-async (getUserInput) => {
+async () => {
   const inputs = [
     {
       puzzle: '..9..5.1.85.4....2432......1...69.83.9.....6.62.71...9......1945....4.37.4.3..6..',
@@ -288,7 +286,7 @@ async (getUserInput) => {
   ];
   for (const input of inputs) {
     const output = 'Required field(s) missing';
-    const data = await fetch(getUserInput('url') + '/api/check', {
+    const data = await fetch(code + '/api/check', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(input)
@@ -303,14 +301,14 @@ async (getUserInput) => {
 If the coordinate submitted to `api/check` does not point to an existing grid cell, the returned value will be `{ error: 'Invalid coordinate'}`
 
 ```js
-async (getUserInput) => {
+async () => {
   const input =
     '..9..5.1.85.4....2432......1...69.83.9.....6.62.71...9......1945....4.37.4.3..6..';
   const output = 'Invalid coordinate';
   const coordinates = ['A0', 'A10', 'J1', 'A', '1', 'XZ18'];
   const value = '7';
   for (const coordinate of coordinates) {
-    const data = await fetch(getUserInput('url') + '/api/check', {
+    const data = await fetch(code + '/api/check', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ puzzle: input, coordinate, value })
@@ -325,14 +323,14 @@ async (getUserInput) => {
 If the `value` submitted to `/api/check` is not a number between 1 and 9, the returned value will be `{ error: 'Invalid value' }`
 
 ```js
-async (getUserInput) => {
+async () => {
   const input =
     '..9..5.1.85.4....2432......1...69.83.9.....6.62.71...9......1945....4.37.4.3..6..';
   const output = 'Invalid value';
   const coordinate = 'A1';
   const values = ['0', '10', 'A'];
   for (const value of values) {
-    const data = await fetch(getUserInput('url') + '/api/check', {
+    const data = await fetch(code + '/api/check', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ puzzle: input, coordinate, value })
@@ -347,9 +345,9 @@ async (getUserInput) => {
 All 12 unit tests are complete and passing.
 
 ```js
-async (getUserInput) => {
+async () => {
   try {
-    const getTests = await $.get(getUserInput('url') + '/_api/get-tests');
+    const getTests = await $.get(code + '/_api/get-tests');
     assert.isArray(getTests);
     const unitTests = getTests.filter((test) => {
       return !!test.context.match(/Unit\s*Tests/gi);
@@ -372,9 +370,9 @@ async (getUserInput) => {
 All 14 functional tests are complete and passing.
 
 ```js
-async (getUserInput) => {
+async () => {
   try {
-    const getTests = await $.get(getUserInput('url') + '/_api/get-tests');
+    const getTests = await $.get(code + '/_api/get-tests');
     assert.isArray(getTests);
     const functTests = getTests.filter((test) => {
       return !!test.context.match(/Functional\s*Tests/gi);

--- a/curriculum/challenges/english/09-information-security/information-security-projects/anonymous-message-board.md
+++ b/curriculum/challenges/english/09-information-security/information-security-projects/anonymous-message-board.md
@@ -40,20 +40,18 @@ Write the following tests in `tests/2_functional-tests.js`:
 You can provide your own project, not the example URL.
 
 ```js
-(getUserInput) => {
   assert(
     !/.*\/anonymous-message-board\.freecodecamp\.rocks/.test(
-      getUserInput('url')
+      code
     )
   );
-};
 ```
 
 Only allow your site to be loaded in an iFrame on your own pages.
 
 ```js
-async (getUserInput) => {
-  const data = await fetch(getUserInput('url') + '/_api/app-info');
+async () => {
+  const data = await fetch(code + '/_api/app-info');
   const parsed = await data.json();
   assert.isTrue(parsed.headers['x-frame-options']?.includes('SAMEORIGIN'));
 };
@@ -62,8 +60,8 @@ async (getUserInput) => {
 Do not allow DNS prefetching.
 
 ```js
-async (getUserInput) => {
-  const data = await fetch(getUserInput('url') + '/_api/app-info');
+async () => {
+  const data = await fetch(code + '/_api/app-info');
   const parsed = await data.json();
   assert.isTrue(parsed.headers['x-dns-prefetch-control']?.includes('off'));
 };
@@ -72,8 +70,8 @@ async (getUserInput) => {
 Only allow your site to send the referrer for your own pages.
 
 ```js
-async (getUserInput) => {
-  const data = await fetch(getUserInput('url') + '/_api/app-info');
+async () => {
+  const data = await fetch(code + '/_api/app-info');
   const parsed = await data.json();
   assert.isTrue(parsed.headers['referrer-policy']?.includes('same-origin'));
 };
@@ -82,12 +80,12 @@ async (getUserInput) => {
 You can send a POST request to `/api/threads/{board}` with form data including `text` and `delete_password`. The saved database record will have at least the fields `_id`, `text`, `created_on`(date & time), `bumped_on`(date & time, starts same as `created_on`), `reported` (boolean), `delete_password`, & `replies` (array).
 
 ```js
-async (getUserInput) => {
+async () => {
   const date = new Date();
   const text = `fcc_test_${date}`;
   const deletePassword = 'delete_me';
   const data = { text, delete_password: deletePassword };
-  const url = getUserInput('url');
+  const url = code;
   const res = await fetch(url + '/api/threads/fcc_test', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -114,8 +112,8 @@ async (getUserInput) => {
 You can send a POST request to `/api/replies/{board}` with form data including `text`, `delete_password`, & `thread_id`. This will update the `bumped_on` date to the comment's date. In the thread's `replies` array, an object will be saved with at least the properties `_id`, `text`, `created_on`, `delete_password`, & `reported`.
 
 ```js
-async (getUserInput) => {
-  const url = getUserInput('url');
+async () => {
+  const url = code;
   const body = await fetch(url + '/api/threads/fcc_test');
   const thread = await body.json();
 
@@ -151,8 +149,8 @@ async (getUserInput) => {
 You can send a GET request to `/api/threads/{board}`. Returned will be an array of the most recent 10 bumped threads on the board with only the most recent 3 replies for each. The `reported` and `delete_password` fields will not be sent to the client.
 
 ```js
-async (getUserInput) => {
-  const url = getUserInput('url');
+async () => {
+  const url = code;
   const res = await fetch(url + '/api/threads/fcc_test');
 
   if (res.ok) {
@@ -182,8 +180,8 @@ async (getUserInput) => {
 You can send a GET request to `/api/replies/{board}?thread_id={thread_id}`. Returned will be the entire thread with all its replies, also excluding the same fields from the client as the previous test.
 
 ```js
-async (getUserInput) => {
-  const url = getUserInput('url');
+async () => {
+  const url = code;
   let res = await fetch(url + '/api/threads/fcc_test');
   const threads = await res.json();
   const thread_id = threads[0]._id;
@@ -214,8 +212,8 @@ async (getUserInput) => {
 You can send a DELETE request to `/api/threads/{board}` and pass along the `thread_id` & `delete_password` to delete the thread. Returned will be the string `incorrect password` or `success`.
 
 ```js
-async (getUserInput) => {
-  const url = getUserInput('url');
+async () => {
+  const url = code;
   let res = await fetch(url + '/api/threads/fcc_test');
   const threads = await res.json();
   const thread_id = threads[0]._id;
@@ -251,8 +249,8 @@ async (getUserInput) => {
 You can send a DELETE request to `/api/replies/{board}` and pass along the `thread_id`, `reply_id`, & `delete_password`. Returned will be the string `incorrect password` or `success`. On success, the text of the `reply_id` will be changed to `[deleted]`.
 
 ```js
-async (getUserInput) => {
-  const url = getUserInput('url');
+async () => {
+  const url = code;
 
   const thread_data = {
     text: "fcc_test_thread",
@@ -306,8 +304,8 @@ async (getUserInput) => {
 You can send a PUT request to `/api/threads/{board}` and pass along the `thread_id`. Returned will be the string `reported`. The `reported` value of the `thread_id` will be changed to `true`.
 
 ```js
-async (getUserInput) => {
-  const url = getUserInput('url');
+async () => {
+  const url = code;
 
   let res = await fetch(`${url}/api/threads/fcc_test`);
   const threads = await res.json();
@@ -337,8 +335,8 @@ async (getUserInput) => {
 You can send a PUT request to `/api/replies/{board}` and pass along the `thread_id` & `reply_id`. Returned will be the string `reported`. The `reported` value of the `reply_id` will be changed to `true`.
 
 ```js
-async (getUserInput) => {
-  const url = getUserInput('url');
+async () => {
+  const url = code;
 
   let res = await fetch(`${url}/api/threads/fcc_test`);
   const threads = await res.json();
@@ -369,8 +367,8 @@ async (getUserInput) => {
 All 10 functional tests are complete and passing.
 
 ```js
-async (getUserInput) => {
-  const tests = await fetch(getUserInput('url') + '/_api/get-tests');
+async () => {
+  const tests = await fetch(code + '/_api/get-tests');
   const parsed = await tests.json();
   assert.isTrue(parsed.length >= 10);
   parsed.forEach((test) => {

--- a/curriculum/challenges/english/09-information-security/information-security-projects/secure-real-time-multiplayer-game.md
+++ b/curriculum/challenges/english/09-information-security/information-security-projects/secure-real-time-multiplayer-game.md
@@ -34,13 +34,11 @@ Make sure that your game is secure! Include these security measures:
 You can provide your own project, not the example URL.
 
 ```js
-(getUserInput) => {
   assert(
     !/.*\/secure-real-time-multiplayer-game\.freecodecamp\.rocks/.test(
-      getUserInput('url')
+      code
     )
   );
-};
 ```
 
 Multiple players can connect to a server and play.
@@ -130,8 +128,8 @@ Players can disconnect from the game at any time.
 Prevent the client from trying to guess / sniff the MIME type.
 
 ```js
-async (getUserInput) => {
-  const data = await fetch(getUserInput('url') + '/_api/app-info');
+async () => {
+  const data = await fetch(code + '/_api/app-info');
   const parsed = await data.json();
   assert.equal(parsed.headers['x-content-type-options'], 'nosniff');
 };
@@ -140,8 +138,8 @@ async (getUserInput) => {
 Prevent cross-site scripting (XSS) attacks.
 
 ```js
-async (getUserInput) => {
-  const data = await fetch(getUserInput('url') + '/_api/app-info');
+async () => {
+  const data = await fetch(code + '/_api/app-info');
   const parsed = await data.json();
   assert.equal(parsed.headers['x-xss-protection'], '1; mode=block');
 };
@@ -150,8 +148,8 @@ async (getUserInput) => {
 Nothing from the website is cached in the client.
 
 ```js
-async (getUserInput) => {
-  const data = await fetch(getUserInput('url') + '/_api/app-info');
+async () => {
+  const data = await fetch(code + '/_api/app-info');
   const parsed = await data.json();
   assert.equal(parsed.headers['surrogate-control'], 'no-store');
   assert.equal(
@@ -166,8 +164,8 @@ async (getUserInput) => {
 The headers say that the site is powered by "PHP 7.4.3" even though it isn't (as a security measure).
 
 ```js
-async (getUserInput) => {
-  const data = await fetch(getUserInput('url') + '/_api/app-info');
+async () => {
+  const data = await fetch(code + '/_api/app-info');
   const parsed = await data.json();
   assert.equal(parsed.headers['x-powered-by'], 'PHP 7.4.3');
 };

--- a/curriculum/challenges/english/09-information-security/information-security-projects/stock-price-checker.md
+++ b/curriculum/challenges/english/09-information-security/information-security-projects/stock-price-checker.md
@@ -40,18 +40,16 @@ Write the following tests in `tests/2_functional-tests.js`:
 You can provide your own project, not the example URL.
 
 ```js
-(getUserInput) => {
   assert(
-    !/.*\/stock-price-checker\.freecodecamp\.rocks/.test(getUserInput('url'))
+    !/.*\/stock-price-checker\.freecodecamp\.rocks/.test(code)
   );
-};
 ```
 
 You should set the content security policies to only allow loading of scripts and CSS from your server.
 
 ```js
-async (getUserInput) => {
-  const data = await fetch(getUserInput('url') + '/_api/app-info');
+async () => {
+  const data = await fetch(code + '/_api/app-info');
   const parsed = await data.json();
   assert.isTrue(
     parsed.headers['content-security-policy'].includes("script-src 'self'")
@@ -65,9 +63,9 @@ async (getUserInput) => {
 You can send a `GET` request to `/api/stock-prices`, passing a NASDAQ stock symbol to a `stock` query parameter. The returned object will contain a property named `stockData`.
 
 ```js
-async (getUserInput) => {
+async () => {
   const data = await fetch(
-    getUserInput('url') + '/api/stock-prices?stock=GOOG'
+    code + '/api/stock-prices?stock=GOOG'
   );
   const parsed = await data.json();
   assert.property(parsed, 'stockData');
@@ -77,9 +75,9 @@ async (getUserInput) => {
 The `stockData` property includes the `stock` symbol as a string, the `price` as a number, and `likes` as a number.
 
 ```js
-async (getUserInput) => {
+async () => {
   const data = await fetch(
-    getUserInput('url') + '/api/stock-prices?stock=GOOG'
+    code + '/api/stock-prices?stock=GOOG'
   );
   const parsed = await data.json();
   const ticker = parsed.stockData;
@@ -98,9 +96,9 @@ You can also pass along a `like` field as `true` (boolean) to have your like add
 If you pass along 2 stocks, the returned value will be an array with information about both stocks. Instead of `likes`, it will display `rel_likes` (the difference between the likes on both stocks) for both `stockData` objects.
 
 ```js
-async (getUserInput) => {
+async () => {
   const data = await fetch(
-    getUserInput('url') + '/api/stock-prices?stock=GOOG&stock=MSFT'
+    code + '/api/stock-prices?stock=GOOG&stock=MSFT'
   );
   const parsed = await data.json();
   const ticker = parsed.stockData;
@@ -113,8 +111,8 @@ async (getUserInput) => {
 All 5 functional tests are complete and passing.
 
 ```js
-async (getUserInput) => {
-  const tests = await fetch(getUserInput('url') + '/_api/get-tests');
+async () => {
+  const tests = await fetch(code + '/_api/get-tests');
   const parsed = await tests.json();
   assert.isTrue(parsed.length >= 5);
   parsed.forEach((test) => {

--- a/curriculum/challenges/english/09-information-security/information-security-with-helmetjs/ask-browsers-to-access-your-site-via-https-only-with-helmet.hsts.md
+++ b/curriculum/challenges/english/09-information-security/information-security-with-helmetjs/ask-browsers-to-access-your-site-via-https-only-with-helmet.hsts.md
@@ -23,8 +23,7 @@ Note: Configuring HTTPS on a custom website requires the acquisition of a domain
 helmet.hsts() middleware should be mounted correctly
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/app-info').then(
+  $.get(code + '/_api/app-info').then(
     (data) => {
       assert.include(data.appStack, 'hsts');
       assert.property(data.headers, 'strict-transport-security');
@@ -38,8 +37,7 @@ helmet.hsts() middleware should be mounted correctly
 maxAge should be equal to 7776000 s (90 days)
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/app-info').then(
+  $.get(code + '/_api/app-info').then(
     (data) => {
       assert.match(
         data.headers['strict-transport-security'],

--- a/curriculum/challenges/english/09-information-security/information-security-with-helmetjs/avoid-inferring-the-response-mime-type-with-helmet.nosniff.md
+++ b/curriculum/challenges/english/09-information-security/information-security-with-helmetjs/avoid-inferring-the-response-mime-type-with-helmet.nosniff.md
@@ -19,8 +19,7 @@ Use the `helmet.noSniff()` method on your server.
 helmet.noSniff() middleware should be mounted correctly
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/app-info').then(
+  $.get(code + '/_api/app-info').then(
     (data) => {
       assert.include(data.appStack, 'nosniff');
       assert.equal(data.headers['x-content-type-options'], 'nosniff');

--- a/curriculum/challenges/english/09-information-security/information-security-with-helmetjs/disable-client-side-caching-with-helmet.nocache.md
+++ b/curriculum/challenges/english/09-information-security/information-security-with-helmetjs/disable-client-side-caching-with-helmet.nocache.md
@@ -21,8 +21,7 @@ Use the `helmet.noCache()` method on your server.
 helmet.noCache() middleware should be mounted correctly
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/app-info').then(
+  $.get(code + '/_api/app-info').then(
     (data) => {
       assert.include(data.appStack, 'nocache');
       assert.equal(

--- a/curriculum/challenges/english/09-information-security/information-security-with-helmetjs/disable-dns-prefetching-with-helmet.dnsprefetchcontrol.md
+++ b/curriculum/challenges/english/09-information-security/information-security-with-helmetjs/disable-dns-prefetching-with-helmet.dnsprefetchcontrol.md
@@ -21,8 +21,7 @@ Use the `helmet.dnsPrefetchControl()` method on your server.
 helmet.dnsPrefetchControl() middleware should be mounted correctly
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/app-info').then(
+  $.get(code + '/_api/app-info').then(
     (data) => {
       assert.include(data.appStack, 'dnsPrefetchControl');
       assert.equal(data.headers['x-dns-prefetch-control'], 'off');

--- a/curriculum/challenges/english/09-information-security/information-security-with-helmetjs/hash-and-compare-passwords-asynchronously.md
+++ b/curriculum/challenges/english/09-information-security/information-security-with-helmetjs/hash-and-compare-passwords-asynchronously.md
@@ -50,8 +50,7 @@ Submit your page when you think you've got it right.
 Async hash should be generated and correctly compared.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/server.js').then(
+  $.get(code + '/_api/server.js').then(
     (data) => {
       assert.match(
         data,

--- a/curriculum/challenges/english/09-information-security/information-security-with-helmetjs/hash-and-compare-passwords-synchronously.md
+++ b/curriculum/challenges/english/09-information-security/information-security-with-helmetjs/hash-and-compare-passwords-synchronously.md
@@ -35,8 +35,7 @@ Submit your page when you think you've got it right.
 Sync hash should be generated and correctly compared.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/server.js').then(
+  $.get(code + '/_api/server.js').then(
     (data) => {
       assert.match(
         data,

--- a/curriculum/challenges/english/09-information-security/information-security-with-helmetjs/hide-potentially-dangerous-information-using-helmet.hidepoweredby.md
+++ b/curriculum/challenges/english/09-information-security/information-security-with-helmetjs/hide-potentially-dangerous-information-using-helmet.hidepoweredby.md
@@ -17,8 +17,7 @@ Hackers can exploit known vulnerabilities in Express/Node if they see that your 
 helmet.hidePoweredBy() middleware should be mounted correctly
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/app-info').then(
+  $.get(code + '/_api/app-info').then(
     (data) => {
       assert.include(data.appStack, 'hidePoweredBy');
       assert.notEqual(data.headers['x-powered-by'], 'Express');

--- a/curriculum/challenges/english/09-information-security/information-security-with-helmetjs/install-and-require-helmet.md
+++ b/curriculum/challenges/english/09-information-security/information-security-with-helmetjs/install-and-require-helmet.md
@@ -27,8 +27,7 @@ Helmet version `3.21.3` has already been installed, so require it as `helmet` in
 `helmet` version `3.21.3` should be in `package.json`
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/package.json').then(
+  $.get(code + '/_api/package.json').then(
     (data) => {
       const packJson = JSON.parse(data);
       const helmet = packJson.dependencies.helmet;

--- a/curriculum/challenges/english/09-information-security/information-security-with-helmetjs/mitigate-the-risk-of-clickjacking-with-helmet.frameguard.md
+++ b/curriculum/challenges/english/09-information-security/information-security-with-helmetjs/mitigate-the-risk-of-clickjacking-with-helmet.frameguard.md
@@ -23,8 +23,7 @@ Use `helmet.frameguard()` passing with the configuration object `{action: 'deny'
 helmet.frameguard() middleware should be mounted correctly
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/app-info').then(
+  $.get(code + '/_api/app-info').then(
     (data) => {
       assert.include(
         data.appStack,
@@ -41,8 +40,7 @@ helmet.frameguard() middleware should be mounted correctly
 helmet.frameguard() 'action' should be set to 'DENY'
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/app-info').then(
+  $.get(code + '/_api/app-info').then(
     (data) => {
       assert.property(data.headers, 'x-frame-options');
       assert.equal(data.headers['x-frame-options'], 'DENY');

--- a/curriculum/challenges/english/09-information-security/information-security-with-helmetjs/mitigate-the-risk-of-cross-site-scripting-xss-attacks-with-helmet.xssfilter.md
+++ b/curriculum/challenges/english/09-information-security/information-security-with-helmetjs/mitigate-the-risk-of-cross-site-scripting-xss-attacks-with-helmet.xssfilter.md
@@ -29,8 +29,7 @@ Use `helmet.xssFilter()` to sanitize input sent to your server.
 helmet.xssFilter() middleware should be mounted correctly
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/app-info').then(
+  $.get(code + '/_api/app-info').then(
     (data) => {
       assert.include(data.appStack, 'xXssProtection');
       assert.property(data.headers, 'x-xss-protection');

--- a/curriculum/challenges/english/09-information-security/information-security-with-helmetjs/prevent-ie-from-opening-untrusted-html-with-helmet.ienoopen.md
+++ b/curriculum/challenges/english/09-information-security/information-security-with-helmetjs/prevent-ie-from-opening-untrusted-html-with-helmet.ienoopen.md
@@ -21,8 +21,7 @@ Use the `helmet.ieNoOpen()` method on your server.
 helmet.ieNoOpen() middleware should be mounted correctly
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/app-info').then(
+  $.get(code + '/_api/app-info').then(
     (data) => {
       assert.include(data.appStack, 'ienoopen');
       assert.equal(data.headers['x-download-options'], 'noopen');

--- a/curriculum/challenges/english/09-information-security/information-security-with-helmetjs/set-a-content-security-policy-with-helmet.contentsecuritypolicy.md
+++ b/curriculum/challenges/english/09-information-security/information-security-with-helmetjs/set-a-content-security-policy-with-helmet.contentsecuritypolicy.md
@@ -25,8 +25,7 @@ Hint: in the `'self'` keyword, the single quotes are part of the keyword itself,
 helmet.contentSecurityPolicy() middleware should be mounted correctly
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/app-info').then(
+  $.get(code + '/_api/app-info').then(
     (data) => {
       assert.include(data.appStack, 'csp');
     },
@@ -39,8 +38,7 @@ helmet.contentSecurityPolicy() middleware should be mounted correctly
 Your csp config is not correct. defaultSrc should be ["'self'"] and scriptSrc should be ["'self'", 'trusted-cdn.com']
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/app-info').then(
+  $.get(code + '/_api/app-info').then(
     (data) => {
       var cspHeader = Object.keys(data.headers).filter(function (k) {
         return (

--- a/curriculum/challenges/english/09-information-security/information-security-with-helmetjs/understand-bcrypt-hashes.md
+++ b/curriculum/challenges/english/09-information-security/information-security-with-helmetjs/understand-bcrypt-hashes.md
@@ -27,8 +27,7 @@ Submit your page when you think you've got it right.
 BCrypt should be a dependency.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/package.json').then(
+  $.get(code + '/_api/package.json').then(
     (data) => {
       var packJson = JSON.parse(data);
       assert.property(
@@ -46,8 +45,7 @@ BCrypt should be a dependency.
 BCrypt should be properly required.
 
 ```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/server.js').then(
+  $.get(code + '/_api/server.js').then(
     (data) => {
       assert.match(
         data,

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-basic-css-by-building-a-cafe-menu/5f3477ae8466a9a3d2cc953c.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-basic-css-by-building-a-cafe-menu/5f3477ae8466a9a3d2cc953c.md
@@ -20,11 +20,8 @@ assert(!code.match(/style/i));
 You should not have any CSS selectors in your HTML file.
 
 ```js
-(getUserInput) => {
-  const html = getUserInput('editableContents');
-  assert(!html.includes('style'));
-  assert(!html.includes('text-align'));
-}
+assert(!editableContents.includes('style'));
+assert(!editableContents.includes('text-align'));
 ```
 
 # --seed--

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-basic-css-by-building-a-cafe-menu/5f3477aefa51bfc29327200b.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-basic-css-by-building-a-cafe-menu/5f3477aefa51bfc29327200b.md
@@ -18,23 +18,19 @@ Start by rewriting the styles you have created into the `styles.css` file. Make 
 Your `styles.css` file should have the `h1, h2, p` type selector.
 
 ```js
-(getUserInput) => {
-  assert(getUserInput('editableContents').replace(/[\s\n]*/g, "").match(/(h1|h2|p),(h1|h2|p),(h1|h2|p){/));
-}
+assert(editableContents.replace(/[\s\n]*/g, "").match(/(h1|h2|p),(h1|h2|p),(h1|h2|p){/));
 ```
  
 Your selector should set the `text-align` property to `center`.
 
 ```js
-(getUserInput) => {
-  assert(getUserInput('editableContents').match(/text-align:\s*center;?/));
-}
+assert(editableContents.match(/text-align:\s*center;?/));
 ```
 
 Your code should not contain the `<style>` tags.
 
 ```js
-  assert.isFalse(/<\/html>(\n|.)*<\/?\s*style\s*>/.test(code));
+assert.isFalse(/<\/html>(\n|.)*<\/?\s*style\s*>/.test(code));
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-cafe-menu/5f3477ae8466a9a3d2cc953c.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cafe-menu/5f3477ae8466a9a3d2cc953c.md
@@ -20,11 +20,8 @@ assert(!code.match(/style/i));
 You should not have any CSS selectors in your HTML file.
 
 ```js
-(getUserInput) => {
-  const html = getUserInput('editableContents');
-  assert(!html.includes('style'));
-  assert(!html.includes('text-align'));
-}
+assert(!editableContents.includes('style'));
+assert(!editableContents.includes('text-align'));
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-cafe-menu/5f3477aefa51bfc29327200b.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cafe-menu/5f3477aefa51bfc29327200b.md
@@ -18,23 +18,19 @@ Start by rewriting the styles you have created into the `styles.css` file. Make 
 Your `styles.css` file should have the `h1, h2, p` type selector.
 
 ```js
-(getUserInput) => {
-  assert(getUserInput('editableContents').replace(/[\s\n]*/g, "").match(/(h1|h2|p),(h1|h2|p),(h1|h2|p){/));
-}
+assert(editableContents.replace(/[\s\n]*/g, "").match(/(h1|h2|p),(h1|h2|p),(h1|h2|p){/));
 ```
  
 Your selector should set the `text-align` property to `center`.
 
 ```js
-(getUserInput) => {
-  assert(getUserInput('editableContents').match(/text-align:\s*center;?/));
-}
+assert(editableContents.match(/text-align:\s*center;?/));
 ```
 
 Your code should not contain the `<style>` tags.
 
 ```js
-  assert.isFalse(/<\/html>(\n|.)*<\/?\s*style\s*>/.test(code));
+assert.isFalse(/<\/html>(\n|.)*<\/?\s*style\s*>/.test(code));
 ```
 
 # --seed--

--- a/curriculum/test/test-challenges.js
+++ b/curriculum/test/test-challenges.js
@@ -678,17 +678,12 @@ async function initializeTestRunner({
   await page.reload();
   await page.setContent(createContent(testId, { build, sources, hooks }));
   await page.evaluate(
-    async (code, sources, loadEnzyme) => {
-      const getUserInput = fileName => sources[fileName];
-      // TODO: use frame's functions directly, so it behaves more like the
-      // client.
+    async (sources, loadEnzyme) => {
       await document.__initTestFrame({
         code: sources,
-        getUserInput,
         loadEnzyme
       });
     },
-    code,
     sources,
     loadEnzyme
   );

--- a/tools/client-plugins/browser-scripts/frame-runner.ts
+++ b/tools/client-plugins/browser-scripts/frame-runner.ts
@@ -31,10 +31,6 @@ async function initTestFrame(e: InitTestFrameArg = { code: {} }) {
     return out;
   };
 
-  if (!e.getUserInput) {
-    e.getUserInput = () => code;
-  }
-
   /* eslint-disable @typescript-eslint/no-unused-vars */
   // Fake Deep Equal dependency
   const DeepEqual = (a: Record<string, unknown>, b: Record<string, unknown>) =>
@@ -100,7 +96,7 @@ async function initTestFrame(e: InitTestFrameArg = { code: {} }) {
       const test = await testPromise;
       if (typeof test === 'function') {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-        await test(e.getUserInput);
+        await test();
       }
       return { pass: true };
     } catch (err) {

--- a/tools/client-plugins/browser-scripts/index.d.ts
+++ b/tools/client-plugins/browser-scripts/index.d.ts
@@ -20,7 +20,6 @@ export interface InitTestFrameArg {
     editableContents?: string;
     original?: { [id: string]: string | null };
   };
-  getUserInput?: (fileName: string) => string;
   loadEnzyme?: () => void;
 }
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

All uses of `getUserInput` except `getUserInput('editableContents')` were effectively the same as using `code`, but more convoluted. Getting rid of it simplifies the interaction between the between the client code and the test runner as well as letting us clean up the curriculum tests.

<!-- Feel free to add any additional description of changes below this line -->
