### PR TITLE
fix: resolve issue #59437 - correct typo in CSS lesson

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lecture-importance-of-accessibility-and-good-html-structure/672a539b887ec68c593cdc4b.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-importance-of-accessibility-and-good-html-structure/672a539b887ec68c593cdc4b.md
@@ -129,7 +129,7 @@ In this table, the cell with `Nora`'s age (`5`) will have one column header (`Ag
 
 However, some screen readers may not be able to interpret tables with complex structures, so you should also try to flatten the table as much as possible to avoid row and column headers that span across multiple cells.
 
-Your goal should always be to make sure users can access this information, even if their screen readers can't handle complex table structures.
+Your goal should always be to make sure users can access this information, even if their screen readers can handle complex table structures.
 
 Now, for cell width, it's recommended to avoid using fixed values. You should use relative values instead, like percentages. Also, try to avoid defining cell height. This will allow users to adjust the text size to fit their needs.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #59437 

<!-- Feel free to add any additional description of changes below this line -->
Fix word correction in Transcript  of file `672a539b887ec68c593cdc4b.md` 
I change: `can't` -> `can` as mention in issue .
file directory is `freeCodeCamp/curriculum/challenges/english/25-front-end-development/lecture-importance-of-accessibility-and-good-html-structure`
