### PR TITLE
feat(api): add endpoint for submitting daily coding challenges

### DIFF
--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -29,6 +29,17 @@ type CompletedChallenge {
   examResults        ExamResults? // Undefined
 }
 
+enum CompletedLanguage {
+  javascript
+  python
+}
+
+type CompletedDailyCodingChallenge {
+  id                 String
+  completedDate      Float // TODO(Post-MVP): Change to DateTime
+  completedLanguages CompletedLanguage[]
+}
+
 type PartiallyCompletedChallenge {
   id            String
   completedDate Float
@@ -77,77 +88,78 @@ type QuizAttempt {
 
 /// Corresponds to the `user` collection.
 model user {
-  id                           String                        @id @default(auto()) @map("_id") @db.ObjectId
-  about                        String
-  acceptedPrivacyTerms         Boolean
-  completedChallenges          CompletedChallenge[]
-  completedExams               CompletedExam[] // Undefined
-  quizAttempts                 QuizAttempt[] // Undefined
-  currentChallengeId           String?
-  donationEmails               String[] // Undefined | String[] (only possible for built in Types like String)
-  email                        String
-  emailAuthLinkTTL             DateTime? // Null | Undefined
-  emailVerified                Boolean
-  emailVerifyTTL               DateTime? // Null | Undefined
-  externalId                   String
-  githubProfile                String? // Undefined
-  isApisMicroservicesCert      Boolean? // Undefined
-  isBackEndCert                Boolean? // Undefined
-  isBanned                     Boolean? // Undefined
-  isCheater                    Boolean? // Undefined
-  isDataAnalysisPyCertV7       Boolean? // Undefined
-  isDataVisCert                Boolean? // Undefined
-  isDonating                   Boolean
-  isFoundationalCSharpCertV8   Boolean? // Undefined
-  isFrontEndCert               Boolean? // Undefined
-  isFrontEndLibsCert           Boolean? // Undefined
-  isFullStackCert              Boolean? // Undefined
-  isHonest                     Boolean?
-  isInfosecCertV7              Boolean? // Undefined
-  isInfosecQaCert              Boolean? // Undefined
-  isJsAlgoDataStructCert       Boolean? // Undefined
-  isJsAlgoDataStructCertV8     Boolean? // Undefined
-  isMachineLearningPyCertV7    Boolean? // Undefined
-  isQaCertV7                   Boolean? // Undefined
-  isRelationalDatabaseCertV8   Boolean? // Undefined
-  isRespWebDesignCert          Boolean? // Undefined
-  isSciCompPyCertV7            Boolean? // Undefined
-  is2018DataVisCert            Boolean? // Undefined
-  is2018FullStackCert          Boolean? // Undefined
-  isCollegeAlgebraPyCertV8     Boolean? // Undefined
-  // isUpcomingPythonCertV8    Boolean? // Undefined. It is in the db but has never been used.
-  keyboardShortcuts            Boolean? // Undefined
-  linkedin                     String? // Null | Undefined
-  location                     String? // Null
-  name                         String? // Null
-  needsModeration              Boolean? // Undefined
-  newEmail                     String? // Null | Undefined
-  partiallyCompletedChallenges PartiallyCompletedChallenge[] // Undefined | PartiallyCompletedChallenge[]
-  password                     String? // Undefined
-  picture                      String
-  portfolio                    Portfolio[]
-  profileUI                    ProfileUI? // Undefined
-  progressTimestamps           Json? // ProgressTimestamp[] | Null[] | Int64[] | Double[] - TODO: NORMALIZE
+  id                             String                          @id @default(auto()) @map("_id") @db.ObjectId
+  about                          String
+  acceptedPrivacyTerms           Boolean
+  completedChallenges            CompletedChallenge[]
+  completedDailyCodingChallenges CompletedDailyCodingChallenge[]
+  completedExams                 CompletedExam[] // Undefined
+  quizAttempts                   QuizAttempt[] // Undefined
+  currentChallengeId             String?
+  donationEmails                 String[] // Undefined | String[] (only possible for built in Types like String)
+  email                          String
+  emailAuthLinkTTL               DateTime? // Null | Undefined
+  emailVerified                  Boolean
+  emailVerifyTTL                 DateTime? // Null | Undefined
+  externalId                     String
+  githubProfile                  String? // Undefined
+  isApisMicroservicesCert        Boolean? // Undefined
+  isBackEndCert                  Boolean? // Undefined
+  isBanned                       Boolean? // Undefined
+  isCheater                      Boolean? // Undefined
+  isDataAnalysisPyCertV7         Boolean? // Undefined
+  isDataVisCert                  Boolean? // Undefined
+  isDonating                     Boolean
+  isFoundationalCSharpCertV8     Boolean? // Undefined
+  isFrontEndCert                 Boolean? // Undefined
+  isFrontEndLibsCert             Boolean? // Undefined
+  isFullStackCert                Boolean? // Undefined
+  isHonest                       Boolean?
+  isInfosecCertV7                Boolean? // Undefined
+  isInfosecQaCert                Boolean? // Undefined
+  isJsAlgoDataStructCert         Boolean? // Undefined
+  isJsAlgoDataStructCertV8       Boolean? // Undefined
+  isMachineLearningPyCertV7      Boolean? // Undefined
+  isQaCertV7                     Boolean? // Undefined
+  isRelationalDatabaseCertV8     Boolean? // Undefined
+  isRespWebDesignCert            Boolean? // Undefined
+  isSciCompPyCertV7              Boolean? // Undefined
+  is2018DataVisCert              Boolean? // Undefined
+  is2018FullStackCert            Boolean? // Undefined
+  isCollegeAlgebraPyCertV8       Boolean? // Undefined
+  // isUpcomingPythonCertV8         Boolean? // Undefined. It is in the db but has never been used.
+  keyboardShortcuts              Boolean? // Undefined
+  linkedin                       String? // Null | Undefined
+  location                       String? // Null
+  name                           String? // Null
+  needsModeration                Boolean? // Undefined
+  newEmail                       String? // Null | Undefined
+  partiallyCompletedChallenges   PartiallyCompletedChallenge[] // Undefined | PartiallyCompletedChallenge[]
+  password                       String? // Undefined
+  picture                        String
+  portfolio                      Portfolio[]
+  profileUI                      ProfileUI? // Undefined
+  progressTimestamps             Json? // ProgressTimestamp[] | Null[] | Int64[] | Double[] - TODO: NORMALIZE
   /// A random number between 0 and 1.
   ///
   /// Valuable for selectively performing random logic.
-  rand                         Float?
-  savedChallenges              SavedChallenge[] // Undefined | SavedChallenge[]
-  sendQuincyEmail              Boolean
-  theme                        String? // Undefined
-  timezone                     String? // Undefined
-  twitter                      String? // Null | Undefined
-  unsubscribeId                String
+  rand                           Float?
+  savedChallenges                SavedChallenge[] // Undefined | SavedChallenge[]
+  sendQuincyEmail                Boolean
+  theme                          String? // Undefined
+  timezone                       String? // Undefined
+  twitter                        String? // Null | Undefined
+  unsubscribeId                  String
   /// Used to track the number of times the user's record was written to.
   ///
   /// This has the main benefit of allowing concurrent ops to check for race conditions.
-  updateCount                  Int?                          @default(0)
-  username                     String // TODO(Post-MVP): make this unique
-  usernameDisplay              String? // Undefined
-  verificationToken            String? // Undefined
-  website                      String? // Undefined
-  yearsTopContributor          String[] // Undefined | String[]
-  isClassroomAccount           Boolean? // Undefined
+  updateCount                    Int?                            @default(0)
+  username                       String // TODO(Post-MVP): make this unique
+  usernameDisplay                String? // Undefined
+  verificationToken              String? // Undefined
+  website                        String? // Undefined
+  yearsTopContributor            String[] // Undefined | String[]
+  isClassroomAccount             Boolean? // Undefined
 
   // Relations
   examAttempts                      EnvExamAttempt[]

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -29,15 +29,17 @@ type CompletedChallenge {
   examResults        ExamResults? // Undefined
 }
 
-enum CompletedLanguage {
+enum DailyCodingChallengeLanguage {
   javascript
   python
 }
 
 type CompletedDailyCodingChallenge {
-  id                 String
-  completedDate      Float // TODO(Post-MVP): Change to DateTime
-  completedLanguages CompletedLanguage[]
+  id            String                         @db.ObjectId
+  /// Date in milliseconds since epoch
+  /// This is not a DateTime, because DateTime does not serialize directly to JSON
+  completedDate Int
+  languages     DailyCodingChallengeLanguage[]
 }
 
 type PartiallyCompletedChallenge {

--- a/api/src/plugins/__fixtures__/user.ts
+++ b/api/src/plugins/__fixtures__/user.ts
@@ -11,6 +11,7 @@ export const newUser = (email: string) => ({
   about: '',
   acceptedPrivacyTerms: false,
   completedChallenges: [],
+  completedDailyCodingChallenges: [],
   completedExams: [],
   quizAttempts: [],
   currentChallengeId: '',

--- a/api/src/routes/protected/challenge.test.ts
+++ b/api/src/routes/protected/challenge.test.ts
@@ -5,6 +5,7 @@ const mockVerifyTrophyWithMicrosoft = jest.fn();
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { omit } from 'lodash';
 import { Static } from '@fastify/type-provider-typebox';
+import { DailyCodingChallengeLanguage } from '@prisma/client';
 
 import { challengeTypes } from '../../../../shared/config/challenge-types';
 import {
@@ -149,8 +150,7 @@ const updatedMultiFileCertProjectBody = {
 const dailyCodingChallengeId = '5900f36e1000cf542c50fe80';
 const dailyCodingChallengeBody = {
   id: dailyCodingChallengeId,
-  challengeType: 27,
-  language: 'javascript'
+  language: DailyCodingChallengeLanguage.javascript
 };
 
 describe('challengeRoutes', () => {
@@ -934,20 +934,6 @@ describe('challengeRoutes', () => {
           expect(response.statusCode).toBe(400);
         });
 
-        test('POST rejects requests without a challengeType', async () => {
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          const { challengeType, ...noChallengeTypeReqBody } =
-            dailyCodingChallengeBody;
-          const response = await superPost(
-            '/daily-coding-challenge-completed'
-          ).send(noChallengeTypeReqBody);
-
-          expect(response.body).toStrictEqual(
-            isValidChallengeCompletionErrorMsg
-          );
-          expect(response.statusCode).toBe(400);
-        });
-
         test('POST rejects requests without a language', async () => {
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
           const { language, ...noLanguageReqBody } = dailyCodingChallengeBody;
@@ -967,20 +953,6 @@ describe('challengeRoutes', () => {
           ).send({
             ...dailyCodingChallengeBody,
             id: 'not-a-valid-id'
-          });
-
-          expect(response.body).toStrictEqual(
-            isValidChallengeCompletionErrorMsg
-          );
-          expect(response.statusCode).toBe(400);
-        });
-
-        test('POST rejects requests without valid challengeType', async () => {
-          const response = await superPost(
-            '/daily-coding-challenge-completed'
-          ).send({
-            ...dailyCodingChallengeBody,
-            challengeType: 'not-a-valid-challenge-type'
           });
 
           expect(response.body).toStrictEqual(
@@ -1039,7 +1011,7 @@ describe('challengeRoutes', () => {
               {
                 id: dailyCodingChallengeId,
                 completedDate,
-                completedLanguages: ['javascript']
+                languages: [DailyCodingChallengeLanguage.javascript]
               }
             ],
             // should add to progressTimestamps
@@ -1056,7 +1028,7 @@ describe('challengeRoutes', () => {
               {
                 id: dailyCodingChallengeId,
                 completedDate,
-                completedLanguages: ['javascript']
+                languages: [DailyCodingChallengeLanguage.javascript]
               }
             ]
           });
@@ -1075,7 +1047,7 @@ describe('challengeRoutes', () => {
               {
                 id: dailyCodingChallengeId,
                 completedDate,
-                completedLanguages: ['javascript']
+                languages: [DailyCodingChallengeLanguage.javascript]
               }
             ],
             // should not add to progressTimestamps
@@ -1092,7 +1064,7 @@ describe('challengeRoutes', () => {
               {
                 id: dailyCodingChallengeId,
                 completedDate,
-                completedLanguages: ['javascript']
+                languages: [DailyCodingChallengeLanguage.javascript]
               }
             ]
           });
@@ -1108,13 +1080,16 @@ describe('challengeRoutes', () => {
             where: { email: 'foo@bar.com' }
           });
 
-          // should add 'python' to completedLanguages + should not update completedDate
+          // should add 'python' to languages + should not update completedDate
           expect(user3).toMatchObject({
             completedDailyCodingChallenges: [
               {
                 id: dailyCodingChallengeId,
                 completedDate,
-                completedLanguages: ['javascript', 'python']
+                languages: [
+                  DailyCodingChallengeLanguage.javascript,
+                  DailyCodingChallengeLanguage.python
+                ]
               }
             ],
             // should not add to progressTimestamps
@@ -1131,7 +1106,10 @@ describe('challengeRoutes', () => {
               {
                 id: dailyCodingChallengeId,
                 completedDate,
-                completedLanguages: ['javascript', 'python']
+                languages: [
+                  DailyCodingChallengeLanguage.javascript,
+                  DailyCodingChallengeLanguage.python
+                ]
               }
             ]
           });

--- a/api/src/routes/protected/challenge.ts
+++ b/api/src/routes/protected/challenge.ts
@@ -3,6 +3,7 @@ import jwt from 'jsonwebtoken';
 import { uniqBy, matches } from 'lodash';
 import { CompletedExam, ExamResults } from '@prisma/client';
 import isURL from 'validator/lib/isURL';
+import type { FastifyInstance, FastifyReply } from 'fastify';
 
 import { challengeTypes } from '../../../../shared/config/challenge-types';
 import * as schemas from '../../schemas';
@@ -33,6 +34,7 @@ import {
   canSubmitCodeRoadCertProject,
   verifyTrophyWithMicrosoft
 } from '../helpers/challenge-helpers';
+import { UpdateReqType } from '../../utils';
 
 interface JwtPayload {
   userToken: string;
@@ -381,107 +383,7 @@ export const challengeRoutes: FastifyPluginCallbackTypebox = (
         }
       }
     },
-    async (req, reply) => {
-      const logger = fastify.log.child({ req });
-      logger.info(`User ${req.user?.id} submitted a daily coding challenge`);
-
-      const { id, language } = req.body;
-
-      const user = await fastify.prisma.user.findUniqueOrThrow({
-        where: { id: req.user?.id },
-        select: {
-          completedDailyCodingChallenges: true,
-          progressTimestamps: true
-        }
-      });
-
-      const { completedDailyCodingChallenges, progressTimestamps = [] } = user;
-
-      const points = getPoints(progressTimestamps as ProgressTimestamp[]);
-      const oldCompletedChallenge = completedDailyCodingChallenges.find(
-        c => c.id === id
-      );
-
-      const alreadyCompleted = !!oldCompletedChallenge;
-      const languageAlreadyCompleted =
-        oldCompletedChallenge?.completedLanguages.includes(language);
-
-      if (alreadyCompleted) {
-        const { completedDate, completedLanguages } = oldCompletedChallenge;
-
-        if (languageAlreadyCompleted) {
-          // alreadyCompleted && languageAlreadyCompleted, no need to change anything in the database
-          void reply.send({
-            alreadyCompleted,
-            points,
-            completedDate,
-            completedDailyCodingChallenges
-          });
-          return;
-        } else {
-          // alreadyCompleted && !languageAlreadyCompleted, add the language to the record
-          const { completedDailyCodingChallenges } =
-            await fastify.prisma.user.update({
-              where: { id: req.user?.id },
-              select: {
-                completedDailyCodingChallenges: true
-              },
-              data: {
-                completedDailyCodingChallenges: {
-                  updateMany: {
-                    where: { id },
-                    data: {
-                      completedLanguages: [
-                        ...new Set([...completedLanguages, language])
-                      ]
-                    }
-                  }
-                }
-              }
-            });
-          void reply.send({
-            alreadyCompleted,
-            points,
-            completedDate,
-            completedDailyCodingChallenges
-          });
-          return;
-        }
-      } else {
-        // !alreadyCompleted, add new record for completed challenge
-        const newCompletedDate = Date.now();
-
-        const newCompletedChallenge = {
-          id,
-          completedDate: newCompletedDate,
-          completedLanguages: [language]
-        };
-
-        const newCompletedChallenges = [
-          ...completedDailyCodingChallenges,
-          newCompletedChallenge
-        ];
-
-        const newProgressTimestamps = Array.isArray(progressTimestamps)
-          ? [...progressTimestamps, newCompletedDate]
-          : [newCompletedDate];
-
-        await fastify.prisma.user.update({
-          where: { id: req.user?.id },
-          data: {
-            completedDailyCodingChallenges: newCompletedChallenges,
-            progressTimestamps: newProgressTimestamps
-          }
-        });
-        void reply.send({
-          alreadyCompleted,
-          points: points + 1,
-          completedDate: newCompletedDate,
-          completedDailyCodingChallenges: newCompletedChallenges
-        });
-        return;
-      }
-    }
+    postDailyCodingChallengeCompleted
   );
 
   fastify.post(
@@ -948,3 +850,103 @@ export const challengeRoutes: FastifyPluginCallbackTypebox = (
 
   done();
 };
+
+async function postDailyCodingChallengeCompleted(
+  this: FastifyInstance,
+  req: UpdateReqType<typeof schemas.dailyCodingChallengeCompleted>,
+  reply: FastifyReply
+) {
+  const logger = this.log.child({ req });
+  logger.info(`User ${req.user?.id} submitted a daily coding challenge`);
+
+  const { id, language } = req.body;
+
+  const user = await this.prisma.user.findUniqueOrThrow({
+    where: { id: req.user?.id },
+    select: {
+      completedDailyCodingChallenges: true,
+      progressTimestamps: true
+    }
+  });
+
+  const { completedDailyCodingChallenges, progressTimestamps = [] } = user;
+
+  const points = getPoints(progressTimestamps as ProgressTimestamp[]);
+  const oldCompletedChallenge = completedDailyCodingChallenges.find(
+    c => c.id === id
+  );
+
+  const alreadyCompleted = !!oldCompletedChallenge;
+  const languageAlreadyCompleted =
+    oldCompletedChallenge?.languages.includes(language);
+
+  if (alreadyCompleted) {
+    const { completedDate, languages } = oldCompletedChallenge;
+
+    if (languageAlreadyCompleted) {
+      // alreadyCompleted && languageAlreadyCompleted, no need to change anything in the database
+      return reply.send({
+        alreadyCompleted,
+        points,
+        completedDate,
+        completedDailyCodingChallenges
+      });
+    } else {
+      // alreadyCompleted && !languageAlreadyCompleted, add the language to the record
+      const { completedDailyCodingChallenges } = await this.prisma.user.update({
+        where: { id: req.user?.id },
+        select: {
+          completedDailyCodingChallenges: true
+        },
+        data: {
+          completedDailyCodingChallenges: {
+            updateMany: {
+              where: { id },
+              data: {
+                languages: [...new Set([...languages, language])]
+              }
+            }
+          }
+        }
+      });
+      return reply.send({
+        alreadyCompleted,
+        points,
+        completedDate,
+        completedDailyCodingChallenges
+      });
+    }
+  } else {
+    // !alreadyCompleted, add new record for completed challenge
+    const newCompletedDate = Date.now();
+
+    const newCompletedChallenge = {
+      id,
+      completedDate: newCompletedDate,
+      languages: [language]
+    };
+
+    const newCompletedChallenges = [
+      ...completedDailyCodingChallenges,
+      newCompletedChallenge
+    ];
+
+    const newProgressTimestamps = Array.isArray(progressTimestamps)
+      ? [...progressTimestamps, newCompletedDate]
+      : [newCompletedDate];
+
+    await this.prisma.user.update({
+      where: { id: req.user?.id },
+      data: {
+        completedDailyCodingChallenges: newCompletedChallenges,
+        progressTimestamps: newProgressTimestamps
+      }
+    });
+    return reply.send({
+      alreadyCompleted,
+      points: points + 1,
+      completedDate: newCompletedDate,
+      completedDailyCodingChallenges: newCompletedChallenges
+    });
+  }
+}

--- a/api/src/routes/protected/challenge.ts
+++ b/api/src/routes/protected/challenge.ts
@@ -368,18 +368,23 @@ export const challengeRoutes: FastifyPluginCallbackTypebox = (
     '/daily-coding-challenge-completed',
     {
       schema: schemas.dailyCodingChallengeCompleted,
-      errorHandler(error, request, reply) {
+      errorHandler(error, req, reply) {
+        const logger = fastify.log.child({ req });
         if (error.validation) {
+          logger.warn({ validationError: error.validation });
           void reply.code(400);
           void reply.send({
             type: 'error',
             message: 'That does not appear to be a valid challenge submission.'
           });
-          fastify.errorHandler(error, request, reply);
+          fastify.errorHandler(error, req, reply);
         }
       }
     },
     async req => {
+      const logger = fastify.log.child({ req });
+      logger.info(`User ${req.user?.id} submitted a daily coding challenge`);
+
       const { id, language } = req.body;
 
       const user = await fastify.prisma.user.findUniqueOrThrow({

--- a/api/src/routes/protected/challenge.ts
+++ b/api/src/routes/protected/challenge.ts
@@ -381,7 +381,7 @@ export const challengeRoutes: FastifyPluginCallbackTypebox = (
         }
       }
     },
-    async req => {
+    async (req, reply) => {
       const logger = fastify.log.child({ req });
       logger.info(`User ${req.user?.id} submitted a daily coding challenge`);
 
@@ -411,12 +411,13 @@ export const challengeRoutes: FastifyPluginCallbackTypebox = (
 
         if (languageAlreadyCompleted) {
           // alreadyCompleted && languageAlreadyCompleted, no need to change anything in the database
-          return {
+          void reply.send({
             alreadyCompleted,
             points,
             completedDate,
             completedDailyCodingChallenges
-          };
+          });
+          return;
         } else {
           // alreadyCompleted && !languageAlreadyCompleted, add the language to the record
           const { completedDailyCodingChallenges } =
@@ -438,13 +439,13 @@ export const challengeRoutes: FastifyPluginCallbackTypebox = (
                 }
               }
             });
-
-          return {
+          void reply.send({
             alreadyCompleted,
             points,
             completedDate,
             completedDailyCodingChallenges
-          };
+          });
+          return;
         }
       } else {
         // !alreadyCompleted, add new record for completed challenge
@@ -472,13 +473,13 @@ export const challengeRoutes: FastifyPluginCallbackTypebox = (
             progressTimestamps: newProgressTimestamps
           }
         });
-
-        return {
+        void reply.send({
           alreadyCompleted,
           points: points + 1,
           completedDate: newCompletedDate,
           completedDailyCodingChallenges: newCompletedChallenges
-        };
+        });
+        return;
       }
     }
   );

--- a/api/src/routes/protected/user.test.ts
+++ b/api/src/routes/protected/user.test.ts
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import jwt, { JwtPayload } from 'jsonwebtoken';
-import type { Prisma } from '@prisma/client';
+import { DailyCodingChallengeLanguage, type Prisma } from '@prisma/client';
 import { ObjectId } from 'mongodb';
 import _ from 'lodash';
 
@@ -81,7 +81,10 @@ const testUserData: Prisma.userCreateInput = {
     {
       id: '5900f36e1000cf542c50fe80',
       completedDate: 1742941672524,
-      completedLanguages: ['python', 'javascript']
+      languages: [
+        DailyCodingChallengeLanguage.python,
+        DailyCodingChallengeLanguage.javascript
+      ]
     }
   ],
   partiallyCompletedChallenges: [{ id: '123', completedDate: 123 }],
@@ -228,7 +231,10 @@ const publicUserData = {
     {
       id: '5900f36e1000cf542c50fe80',
       completedDate: 1742941672524,
-      completedLanguages: ['python', 'javascript']
+      languages: [
+        DailyCodingChallengeLanguage.python,
+        DailyCodingChallengeLanguage.javascript
+      ]
     }
   ],
   completedExams: testUserData.completedExams,

--- a/api/src/routes/protected/user.test.ts
+++ b/api/src/routes/protected/user.test.ts
@@ -77,6 +77,13 @@ const testUserData: Prisma.userCreateInput = {
       }
     }
   ],
+  completedDailyCodingChallenges: [
+    {
+      id: '5900f36e1000cf542c50fe80',
+      completedDate: 1742941672524,
+      completedLanguages: ['python', 'javascript']
+    }
+  ],
   partiallyCompletedChallenges: [{ id: '123', completedDate: 123 }],
   completedExams: [],
   quizAttempts: [
@@ -217,6 +224,13 @@ const publicUserData = {
       }
     }
   ],
+  completedDailyCodingChallenges: [
+    {
+      id: '5900f36e1000cf542c50fe80',
+      completedDate: 1742941672524,
+      completedLanguages: ['python', 'javascript']
+    }
+  ],
   completedExams: testUserData.completedExams,
   completedSurveys: [], // TODO: add surveys
   quizAttempts: testUserData.quizAttempts,
@@ -289,6 +303,7 @@ const baseProgressData = {
   isRelationalDatabaseCertV8: false,
   isCollegeAlgebraPyCertV8: false,
   completedChallenges: [],
+  completedDailyCodingChallenges: [],
   completedExams: [],
   savedChallenges: [],
   partiallyCompletedChallenges: [],
@@ -734,6 +749,7 @@ describe('userRoutes', () => {
           // missing in the user document.
           currentChallengeId: '',
           completedChallenges: [],
+          completedDailyCodingChallenges: [],
           completedExams: [],
           completedSurveys: [],
           partiallyCompletedChallenges: [],

--- a/api/src/routes/protected/user.ts
+++ b/api/src/routes/protected/user.ts
@@ -481,6 +481,7 @@ export const userGetRoutes: FastifyPluginCallbackTypebox = (
             about: true,
             acceptedPrivacyTerms: true,
             completedChallenges: true,
+            completedDailyCodingChallenges: true,
             completedExams: true,
             currentChallengeId: true,
             quizAttempts: true,
@@ -565,6 +566,7 @@ export const userGetRoutes: FastifyPluginCallbackTypebox = (
           username,
           usernameDisplay,
           completedChallenges,
+          completedDailyCodingChallenges,
           progressTimestamps,
           twitter,
           profileUI,
@@ -583,6 +585,7 @@ export const userGetRoutes: FastifyPluginCallbackTypebox = (
               currentChallengeId: currentChallengeId ?? '',
               completedChallenges: normalizeChallenges(completedChallenges),
               completedChallengeCount: completedChallenges.length,
+              completedDailyCodingChallenges,
               // This assertion is necessary until the database is normalized.
               calendar: getCalendar(
                 progressTimestamps as ProgressTimestamp[] | null

--- a/api/src/schemas.ts
+++ b/api/src/schemas.ts
@@ -6,6 +6,7 @@ export { backendChallengeCompleted } from './schemas/challenge/backend-challenge
 export { coderoadChallengeCompleted } from './schemas/challenge/coderoad-challenge-completed';
 export { exam } from './schemas/challenge/exam';
 export { examChallengeCompleted } from './schemas/challenge/exam-challenge-completed';
+export { dailyCodingChallengeCompleted } from './schemas/challenge/daily-coding-challenge-completed';
 export { modernChallengeCompleted } from './schemas/challenge/modern-challenge-completed';
 export { msTrophyChallengeCompleted } from './schemas/challenge/ms-trophy-challenge-completed';
 export { projectCompleted } from './schemas/challenge/project-completed';

--- a/api/src/schemas/challenge/daily-coding-challenge-completed.ts
+++ b/api/src/schemas/challenge/daily-coding-challenge-completed.ts
@@ -1,0 +1,31 @@
+import { Type } from '@fastify/type-provider-typebox';
+
+export const dailyCodingChallengeCompleted = {
+  body: Type.Object({
+    id: Type.String({ format: 'objectid', maxLength: 24, minLength: 24 }),
+    challengeType: Type.Number(),
+    language: Type.Union([Type.Literal('javascript'), Type.Literal('python')])
+  }),
+  response: {
+    200: Type.Object({
+      completedDate: Type.Number(),
+      points: Type.Number(),
+      alreadyCompleted: Type.Boolean(),
+      completedDailyCodingChallenges: Type.Array(
+        Type.Object({
+          id: Type.String(),
+          completedDate: Type.Number(),
+          completedLanguages: Type.Array(
+            Type.Union([Type.Literal('javascript'), Type.Literal('python')])
+          )
+        })
+      )
+    }),
+    400: Type.Object({
+      type: Type.Literal('error'),
+      message: Type.Literal(
+        'That does not appear to be a valid challenge submission.'
+      )
+    })
+  }
+};

--- a/api/src/schemas/challenge/daily-coding-challenge-completed.ts
+++ b/api/src/schemas/challenge/daily-coding-challenge-completed.ts
@@ -1,10 +1,14 @@
 import { Type } from '@fastify/type-provider-typebox';
+import { DailyCodingChallengeLanguage } from '@prisma/client';
+
+const languages = Object.values(DailyCodingChallengeLanguage).map(k =>
+  Type.Literal(k)
+);
 
 export const dailyCodingChallengeCompleted = {
   body: Type.Object({
     id: Type.String({ format: 'objectid', maxLength: 24, minLength: 24 }),
-    challengeType: Type.Number(),
-    language: Type.Union([Type.Literal('javascript'), Type.Literal('python')])
+    language: Type.Union(languages)
   }),
   response: {
     200: Type.Object({
@@ -15,9 +19,7 @@ export const dailyCodingChallengeCompleted = {
         Type.Object({
           id: Type.String(),
           completedDate: Type.Number(),
-          completedLanguages: Type.Array(
-            Type.Union([Type.Literal('javascript'), Type.Literal('python')])
-          )
+          languages: Type.Array(Type.Union(languages))
         })
       )
     }),

--- a/api/src/schemas/user/get-session-user.ts
+++ b/api/src/schemas/user/get-session-user.ts
@@ -53,6 +53,15 @@ export const getSessionUser = {
             })
           ),
           completedChallengeCount: Type.Number(),
+          completedDailyCodingChallenges: Type.Array(
+            Type.Object({
+              id: Type.String(),
+              completedDate: Type.Number(),
+              completedLanguages: Type.Array(
+                Type.Union([Type.Literal('javascript'), Type.Literal('python')])
+              )
+            })
+          ),
           currentChallengeId: Type.String(),
           email: Type.String(),
           emailVerified: Type.Boolean(),

--- a/api/src/schemas/user/get-session-user.ts
+++ b/api/src/schemas/user/get-session-user.ts
@@ -1,5 +1,10 @@
 import { Type } from '@fastify/type-provider-typebox';
+import { DailyCodingChallengeLanguage } from '@prisma/client';
 import { examResults, profileUI, savedChallenge } from '../types';
+
+const languages = Object.values(DailyCodingChallengeLanguage).map(k =>
+  Type.Literal(k)
+);
 
 export const getSessionUser = {
   response: {
@@ -57,9 +62,7 @@ export const getSessionUser = {
             Type.Object({
               id: Type.String(),
               completedDate: Type.Number(),
-              completedLanguages: Type.Array(
-                Type.Union([Type.Literal('javascript'), Type.Literal('python')])
-              )
+              languages: Type.Array(Type.Union(languages))
             })
           ),
           currentChallengeId: Type.String(),


### PR DESCRIPTION
Adds an endpoint for daily challenges. 
Adds new `completedDailyCodingChallenges` array to user object in DB that looks like this: `{ id, completedDate, completedLanguages: [ 'javascript', 'python' ] }`
Sends `completedDailyCodingCodingChallenges` array back with `get-session-user`

Most of the changes in the prisma file are from running `prisma format`

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
