### PR TITLE
feat(GHA): run on workflow completion

### DIFF
--- a/.github/workflows/deploy-legacy.yml
+++ b/.github/workflows/deploy-legacy.yml
@@ -2,9 +2,16 @@ name: CD - Deploy API (Legacy) & Clients
 
 on:
   workflow_dispatch:
+  workflow_run:
+    workflows: [CI - Node.js]
+    types:
+      - completed
+    branches:
+      - prod-*
 
 jobs:
   setup-jobs:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     name: Setup Jobs
     runs-on: ubuntu-22.04
     outputs:


### PR DESCRIPTION
This triggers a run on workflow completion for the Node.js tests which themselves run on push. But we may just go back to using a `on.push` event if this becomes a gotcha.

The idea is to only start a deployment on the prod-* branches if the tests pass.