### PR TITLE
fix: lint error in frame-runner

### DIFF
--- a/tools/client-plugins/browser-scripts/frame-runner.ts
+++ b/tools/client-plugins/browser-scripts/frame-runner.ts
@@ -10,6 +10,9 @@ const frameDocument = document as FrameDocument;
 frameDocument.__initTestFrame = initTestFrame;
 
 async function initTestFrame(e: InitTestFrameArg = { code: {} }) {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const code = (e.code.contents || '').slice();
+
   const editableContents = (e.code.editableContents || '').slice();
   // __testEditable allows test authors to run tests against a transitory dom
   // element built using only the code in the editable region.

--- a/tools/client-plugins/browser-scripts/frame-runner.ts
+++ b/tools/client-plugins/browser-scripts/frame-runner.ts
@@ -10,8 +10,6 @@ const frameDocument = document as FrameDocument;
 frameDocument.__initTestFrame = initTestFrame;
 
 async function initTestFrame(e: InitTestFrameArg = { code: {} }) {
-  const code = (e.code.contents || '').slice();
-
   const editableContents = (e.code.editableContents || '').slice();
   // __testEditable allows test authors to run tests against a transitory dom
   // element built using only the code in the editable region.


### PR DESCRIPTION
Fixes lint error not caught in https://github.com/freeCodeCamp/freeCodeCamp/pull/59442

(lint is failing on main)

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
