### PR TITLE
chore: remove fcc-10 GB flag

### DIFF
--- a/client/config/growthbook-features-default.json
+++ b/client/config/growthbook-features-default.json
@@ -94,8 +94,5 @@
         "name": "prod-show-benefits"
       }
     ]
-  },
-  "fcc-10": {
-    "defaultValue": true
   }
 }


### PR DESCRIPTION
I believe this is no longer needed. It looks like [the use of it was removed here.](https://github.com/freeCodeCamp/freeCodeCamp/pull/57957/files#diff-ca84381f8f1cf99c57c16af6bd9c1e02e3821a33fd822996d532d9dd9323c468L137)

If this is the case, we can also remove the flag from the GB dashboard.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
