### PR TITLE
refactor(client): use different challenges component in different blocks

### DIFF
--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -456,7 +456,7 @@ export class Block extends Component<BlockProps> {
       [BlockLayouts.LegacyLink]: LegacyLinkBlock,
       [BlockLayouts.LegacyChallengeList]: LegacyChallengeListBlock,
       [BlockLayouts.LegacyChallengeGrid]: LegacyChallengeGridBlock,
-      [BlockLayouts.DialogueGrid]: LegacyChallengeGridBlock
+      [BlockLayouts.DialogueGrid]: TaskGridBlock
     };
 
     return (

--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -28,7 +28,7 @@ import CheckMark from './check-mark';
 import {
   GridMapChallenges,
   ChallengesList,
-  ChallengesWithDialogs
+  ChallengesWithDialogues
 } from './challenges';
 import BlockLabel from './block-label';
 import BlockIntros from './block-intros';
@@ -328,7 +328,7 @@ export class Block extends Component<BlockProps> {
 
               <div id={`${block}-panel`}>
                 <BlockIntros intros={blockIntroArr} />
-                <ChallengesWithDialogs
+                <ChallengesWithDialogues
                   challenges={extendedChallenges}
                   blockTitle={blockTitle}
                 />

--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -25,7 +25,11 @@ import {
   BlockTypes
 } from '../../../../../shared-dist/config/blocks';
 import CheckMark from './check-mark';
-import Challenges from './challenges';
+import {
+  GridMapChallenges,
+  ChallengesList,
+  ChallengesWithDialogs
+} from './challenges';
 import BlockLabel from './block-label';
 import BlockIntros from './block-intros';
 import BlockHeader from './block-header';
@@ -202,7 +206,7 @@ export class Block extends Component<BlockProps> {
             </div>
           </button>
           {isExpanded && (
-            <Challenges
+            <ChallengesList
               challenges={extendedChallenges}
               isProjectBlock={isProjectBlock}
             />
@@ -234,7 +238,7 @@ export class Block extends Component<BlockProps> {
             )}
           </div>
           <BlockIntros intros={blockIntroArr} />
-          <Challenges
+          <ChallengesList
             challenges={extendedChallenges}
             isProjectBlock={isProjectBlock}
           />
@@ -277,10 +281,56 @@ export class Block extends Component<BlockProps> {
 
               <div id={`${block}-panel`}>
                 <BlockIntros intros={blockIntroArr} />
-                <Challenges
+                <GridMapChallenges
                   challenges={extendedChallenges}
                   isProjectBlock={isProjectBlock}
-                  isGridMap={true}
+                  blockTitle={blockTitle}
+                />
+              </div>
+            </>
+          )}
+        </div>
+      </ScrollableAnchor>
+    );
+
+    /**
+     * TaskGridBlock displays tasks in a grid and dialogues separately.
+     * This layout is used for task-based blocks.
+     * Example: https://www.freecodecamp.org/learn/a2-english-for-developers/#learn-greetings-in-your-first-day-at-the-office
+     */
+    const TaskGridBlock = (
+      <ScrollableAnchor id={block}>
+        <div className={`block block-grid ${isExpanded ? 'open' : ''}`}>
+          <BlockHeader
+            blockDashed={block}
+            blockTitle={blockTitle}
+            blockType={blockType}
+            completedCount={completedCount}
+            courseCompletionStatus={courseCompletionStatus()}
+            handleClick={this.handleBlockClick}
+            isCompleted={isBlockCompleted}
+            isExpanded={isExpanded}
+            percentageCompleted={percentageCompleted}
+          />
+
+          {isExpanded && (
+            <>
+              {!isAudited && (
+                <div className='tags-wrapper'>
+                  <Link
+                    className='cert-tag'
+                    to={t('links:help-translate-link-url')}
+                  >
+                    {t('misc.translation-pending')}
+                  </Link>
+                </div>
+              )}
+
+              <div id={`${block}-panel`}>
+                <BlockIntros intros={blockIntroArr} />
+                <ChallengesWithDialogs
+                  challenges={extendedChallenges}
+                  isProjectBlock={isProjectBlock}
                   blockTitle={blockTitle}
                 />
               </div>
@@ -379,12 +429,18 @@ export class Block extends Component<BlockProps> {
                 id={`${block}-panel`}
                 className={isGridBlock ? 'challenge-grid-block-panel' : ''}
               >
-                <Challenges
-                  challenges={extendedChallenges}
-                  isProjectBlock={false}
-                  isGridMap={isGridBlock}
-                  blockTitle={blockTitle}
-                />
+                {isGridBlock ? (
+                  <GridMapChallenges
+                    challenges={extendedChallenges}
+                    blockTitle={blockTitle}
+                    isProjectBlock={isProjectBlock}
+                  />
+                ) : (
+                  <ChallengesList
+                    challenges={extendedChallenges}
+                    isProjectBlock={isProjectBlock}
+                  />
+                )}
               </div>
             </div>
           )}

--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -205,12 +205,7 @@ export class Block extends Component<BlockProps> {
               </span>
             </div>
           </button>
-          {isExpanded && (
-            <ChallengesList
-              challenges={extendedChallenges}
-              isProjectBlock={isProjectBlock}
-            />
-          )}
+          {isExpanded && <ChallengesList challenges={extendedChallenges} />}
         </div>
       </ScrollableAnchor>
     );
@@ -238,10 +233,7 @@ export class Block extends Component<BlockProps> {
             )}
           </div>
           <BlockIntros intros={blockIntroArr} />
-          <ChallengesList
-            challenges={extendedChallenges}
-            isProjectBlock={isProjectBlock}
-          />
+          <ChallengesList challenges={extendedChallenges} />
         </div>
       </ScrollableAnchor>
     );
@@ -435,10 +427,7 @@ export class Block extends Component<BlockProps> {
                     isProjectBlock={isProjectBlock}
                   />
                 ) : (
-                  <ChallengesList
-                    challenges={extendedChallenges}
-                    isProjectBlock={isProjectBlock}
-                  />
+                  <ChallengesList challenges={extendedChallenges} />
                 )}
               </div>
             </div>

--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -330,7 +330,6 @@ export class Block extends Component<BlockProps> {
                 <BlockIntros intros={blockIntroArr} />
                 <ChallengesWithDialogs
                   challenges={extendedChallenges}
-                  isProjectBlock={isProjectBlock}
                   blockTitle={blockTitle}
                 />
               </div>

--- a/client/src/templates/Introduction/components/challenges.tsx
+++ b/client/src/templates/Introduction/components/challenges.tsx
@@ -76,20 +76,24 @@ export function ChallengesList({
   );
 }
 // Step or Task challenge
-const GridChallenge = ({ challenge }: { challenge: ChallengeInfo }) => {
+const GridChallenge = ({
+  challenge,
+  isTask = false
+}: {
+  challenge: ChallengeInfo;
+  isTask?: boolean;
+}) => {
   const { t } = useTranslation();
 
   return (
     <Link
       to={challenge.fields.slug}
       className={`map-grid-item ${
-        +challenge.isCompleted ? 'challenge-completed' : ''
+        challenge.isCompleted ? 'challenge-completed' : ''
       }`}
     >
       <span className='sr-only'>
-        {challenge.superBlock === SuperBlocks.A2English
-          ? t('aria.task')
-          : t('aria.step')}
+        {isTask ? t('aria.task') : t('aria.step')}
       </span>
       <span>{challenge.stepNumber}</span>
       <span className='sr-only'>
@@ -191,7 +195,7 @@ export const ChallengesWithDialogs = ({
               {challenge.challengeType === challengeTypes.dialogue ? (
                 <ListChallenge challenge={challenge} />
               ) : (
-                <GridChallenge challenge={challenge} />
+                <GridChallenge challenge={challenge} isTask />
               )}
             </li>
           ))}

--- a/client/src/templates/Introduction/components/challenges.tsx
+++ b/client/src/templates/Introduction/components/challenges.tsx
@@ -20,13 +20,14 @@ interface ChallengeInfo {
 
 interface ChallengesProps {
   challenges: ChallengeInfo[];
-  isProjectBlock: boolean;
 }
 
-interface GridMapChallengesProps {
-  challenges: ChallengeInfo[];
+interface BlockTitleProps {
+  blockTitle: string;
+}
+
+interface IsProjectBlockProps {
   isProjectBlock: boolean;
-  blockTitle?: string | null;
 }
 
 const CheckMark = ({ isCompleted }: { isCompleted: boolean }) =>
@@ -53,7 +54,7 @@ const CertChallenge = ({ challenge }: { challenge: ChallengeInfo }) => (
 export function ChallengesList({
   challenges,
   isProjectBlock
-}: ChallengesProps): JSX.Element {
+}: ChallengesProps & { isProjectBlock: boolean }): JSX.Element {
   return (
     <ul className={`map-challenges-ul`}>
       {challenges.map(challenge => (
@@ -101,10 +102,7 @@ const GridChallenge = ({ challenge }: { challenge: ChallengeInfo }) => {
 const LinkToFirstIncompleteChallenge = ({
   challenges,
   blockTitle
-}: {
-  challenges: ChallengeInfo[];
-  blockTitle?: string | null;
-}) => {
+}: ChallengesProps & BlockTitleProps) => {
   const { t } = useTranslation();
 
   const firstIncompleteChallenge = challenges.find(
@@ -130,7 +128,7 @@ export const GridMapChallenges = ({
   challenges,
   blockTitle,
   isProjectBlock
-}: GridMapChallengesProps) => {
+}: ChallengesProps & BlockTitleProps & IsProjectBlockProps) => {
   const { t } = useTranslation();
 
   return (
@@ -173,7 +171,7 @@ export const GridMapChallenges = ({
 export const ChallengesWithDialogs = ({
   challenges,
   blockTitle
-}: GridMapChallengesProps) => {
+}: ChallengesProps & BlockTitleProps) => {
   const { t } = useTranslation();
 
   return (

--- a/client/src/templates/Introduction/components/challenges.tsx
+++ b/client/src/templates/Introduction/components/challenges.tsx
@@ -168,7 +168,7 @@ export const GridMapChallenges = ({
   );
 };
 
-export const ChallengesWithDialogs = ({
+export const ChallengesWithDialogues = ({
   challenges,
   blockTitle
 }: ChallengesProps & BlockTitleProps) => {

--- a/client/src/templates/Introduction/components/challenges.tsx
+++ b/client/src/templates/Introduction/components/challenges.tsx
@@ -118,7 +118,7 @@ const LinkToFirstIncompleteChallenge = ({
         {!isChallengeStarted
           ? t('buttons.start-project')
           : t('buttons.resume-project')}{' '}
-        {blockTitle && <span className='sr-only'>{blockTitle}</span>}
+        <span className='sr-only'>{blockTitle}</span>
       </ButtonLink>
     </div>
   ) : null;
@@ -137,11 +137,7 @@ export const GridMapChallenges = ({
         challenges={challenges}
         blockTitle={blockTitle}
       />
-      <nav
-        aria-label={
-          blockTitle ? t('aria.steps-for', { blockTitle }) : t('aria.steps')
-        }
-      >
+      <nav aria-label={t('aria.steps-for', { blockTitle })}>
         <ul className={`map-challenges-ul map-challenges-grid`}>
           {challenges.map(challenge => (
             <li
@@ -180,14 +176,8 @@ export const ChallengesWithDialogs = ({
         challenges={challenges}
         blockTitle={blockTitle}
       />
-      <nav
-        aria-label={
-          blockTitle
-            ? t('aria.dialogues-and-tasks-for', { blockTitle })
-            : t('aria.steps')
-        }
-      >
-        <ul className={`map-challenges-ul map-challenges-grid `}>
+      <nav aria-label={t('aria.dialogues-and-tasks-for', { blockTitle })}>
+        <ul className={`map-challenges-ul map-challenges-grid`}>
           {challenges.map(challenge => (
             <li
               className={`map-challenge-title map-challenge-title-grid ${

--- a/client/src/templates/Introduction/components/challenges.tsx
+++ b/client/src/templates/Introduction/components/challenges.tsx
@@ -51,25 +51,16 @@ const CertChallenge = ({ challenge }: { challenge: ChallengeInfo }) => (
   </Link>
 );
 
-export function ChallengesList({
-  challenges,
-  isProjectBlock
-}: ChallengesProps & { isProjectBlock: boolean }): JSX.Element {
+export function ChallengesList({ challenges }: ChallengesProps): JSX.Element {
   return (
     <ul className={`map-challenges-ul`}>
       {challenges.map(challenge => (
         <li
-          className={`map-challenge-title ${
-            isProjectBlock ? 'map-project-wrap' : 'map-challenge-wrap'
-          }`}
+          className={'map-challenge-title map-challenge-wrap'}
           id={challenge.dashedName}
           key={'map-challenge' + challenge.fields.slug}
         >
-          {!isProjectBlock ? (
-            <ListChallenge challenge={challenge} />
-          ) : (
-            <CertChallenge challenge={challenge} />
-          )}
+          <ListChallenge challenge={challenge} />
         </li>
       ))}
     </ul>


### PR DESCRIPTION
This means we have more components, but they are simpler.

While I was here, I fixed an a11y bug: B1 English "tasks" were referred to as "steps".

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->



<!-- Feel free to add any additional description of changes below this line -->
