### PR TITLE
Update create-project.ts

### DIFF
--- a/tools/challenge-helper-scripts/create-project.ts
+++ b/tools/challenge-helper-scripts/create-project.ts
@@ -36,49 +36,67 @@ interface CreateProjectArgs {
   superBlock: SuperBlocks;
   block: string;
   helpCategory: string;
-  order: number;
+  order?: number;
   title?: string;
+  isQuiz?: boolean;
 }
 
-async function createProject(
-  superBlock: SuperBlocks,
-  block: string,
-  helpCategory: string,
-  order: number,
-  title?: string
-) {
+async function createProject({
+  superBlock,
+  block,
+  helpCategory,
+  order,
+  title,
+  isQuiz = false
+}: CreateProjectArgs) {
   if (!title) {
     title = block;
   }
-  void updateIntroJson(superBlock, block, title);
+  if (isQuiz) {
+    title = `${title} Quiz`;
+  }
 
-  const challengeId = await createFirstChallenge(superBlock, block);
+  void updateIntroJson(superBlock, block, title, isQuiz);
+
+  const challengeId = await createFirstChallenge(superBlock, block, isQuiz);
   void createMetaJson(
     superBlock,
     block,
     title,
     helpCategory,
     order,
-    challengeId
+    challengeId,
+    isQuiz
   );
-  // TODO: remove once we stop relying on markdown in the client.
-  void createIntroMD(superBlock, block, title);
+  void createIntroMD(superBlock, block, title, isQuiz);
 }
 
 async function updateIntroJson(
   superBlock: SuperBlocks,
   block: string,
-  title: string
+  title: string,
+  isQuiz: boolean
 ) {
   const introJsonPath = path.resolve(
     __dirname,
     '../../client/i18n/locales/english/intro.json'
   );
   const newIntro = await parseJson<IntroJson>(introJsonPath);
-  newIntro[superBlock].blocks[block] = {
-    title,
-    intro: ['', '']
-  };
+  
+  if (isQuiz) {
+    // For quizzes, we add them directly under the certification
+    newIntro[superBlock].blocks[block] = {
+      title,
+      intro: ['', '']
+    };
+  } else {
+    // Original project behavior
+    newIntro[superBlock].blocks[block] = {
+      title,
+      intro: ['', '']
+    };
+  }
+
   void withTrace(
     fs.writeFile,
     introJsonPath,
@@ -91,18 +109,25 @@ async function createMetaJson(
   block: string,
   title: string,
   helpCategory: string,
-  order: number,
-  challengeId: ObjectID
+  order: number | undefined,
+  challengeId: ObjectID,
+  isQuiz: boolean
 ) {
   const metaDir = path.resolve(__dirname, '../../curriculum/challenges/_meta');
   const newMeta = await parseJson<Meta>('./base-meta.json');
+  
   newMeta.name = title;
   newMeta.dashedName = block;
   newMeta.helpCategory = helpCategory;
-  newMeta.order = order;
+  if (!isQuiz && order) {
+    newMeta.order = order;
+  }
   newMeta.superBlock = superBlock;
-  // eslint-disable-next-line @typescript-eslint/no-base-to-string
-  newMeta.challengeOrder = [{ id: challengeId.toString(), title: 'Step 1' }];
+  newMeta.blockType = isQuiz ? 'quiz' : 'project';
+  newMeta.blockLayout = 'link';
+  newMeta.isUpcomingChange = true;
+  newMeta.challengeOrder = [{ id: challengeId.toString(), title: isQuiz ? title : 'Step 1' }];
+
   const newMetaDir = path.resolve(metaDir, block);
   if (!existsSync(newMetaDir)) {
     await withTrace(fs.mkdir, newMetaDir);
@@ -115,7 +140,12 @@ async function createMetaJson(
   );
 }
 
-async function createIntroMD(superBlock: string, block: string, title: string) {
+async function createIntroMD(
+  superBlock: string,
+  block: string,
+  title: string,
+  isQuiz: boolean
+) {
   const introMD = `---
 title: Introduction to the ${title}
 block: ${block}
@@ -124,7 +154,7 @@ superBlock: ${superBlock}
 
 ## Introduction to the ${title}
 
-This is a test for the new project-based curriculum.
+${isQuiz ? 'This is a quiz to test your knowledge.' : 'This is a test for the new project-based curriculum.'}
 `;
   const dirPath = path.resolve(
     __dirname,
@@ -139,7 +169,8 @@ This is a test for the new project-based curriculum.
 
 async function createFirstChallenge(
   superBlock: SuperBlocks,
-  block: string
+  block: string,
+  isQuiz: boolean
 ): Promise<ObjectID> {
   const superBlockSubPath = getSuperBlockSubPath(superBlock);
   const newChallengeDir = path.resolve(
@@ -149,36 +180,74 @@ async function createFirstChallenge(
   if (!existsSync(newChallengeDir)) {
     await withTrace(fs.mkdir, newChallengeDir);
   }
-  // TODO: would be nice if the extension made sense for the challenge, but, at
-  // least until react I think they're all going to be html anyway.
-  const challengeSeeds = {
-    indexhtml: {
-      contents: '',
-      ext: 'html',
-      editableRegionBoundaries: [0, 2]
-    }
-  };
-  // including trailing slash for compatibility with createStepFile
-  return createStepFile({
-    projectPath: newChallengeDir + '/',
-    stepNum: 1,
-    challengeType: 0,
-    challengeSeeds,
-    isFirstChallenge: true
-  });
+
+  if (isQuiz) {
+    const quizContent = `---
+id: {{id}}
+title: ${block.replace('quiz-', '')} Quiz
+challengeType: 8
+dashedName: ${block}
+---
+
+# --description--
+
+To pass the quiz, you must correctly answer at least 18 of the 20 questions below.
+
+# --quizzes--
+
+## --quiz--
+
+### --question--
+
+#### --text--
+
+Question goes here
+
+#### --distractors--
+
+Distractor 1 goes here 
+
+---
+
+Distractor 2 goes here 
+
+---
+
+Distractor 3 goes here 
+
+#### --answer--
+
+answer goes here`;
+
+    const challengeId = new ObjectID();
+    const filePath = path.resolve(newChallengeDir, `${challengeId.toString()}.md`);
+    await withTrace(fs.writeFile, filePath, quizContent, { encoding: 'utf8' });
+    return challengeId;
+  } else {
+    // Original project challenge creation
+    const challengeSeeds = {
+      indexhtml: {
+        contents: '',
+        ext: 'html',
+        editableRegionBoundaries: [0, 2]
+      }
+    };
+    return createStepFile({
+      projectPath: newChallengeDir + '/',
+      stepNum: 1,
+      challengeType: 0,
+      challengeSeeds,
+      isFirstChallenge: true
+    });
+  }
 }
 
 function parseJson<JsonSchema>(filePath: string) {
   return withTrace(fs.readFile, filePath, 'utf8').then(
-    // unfortunately, withTrace does not correctly infer that the third argument
-    // is a string, so it uses the (path, options?) overload and we have to cast
-    // result to string.
     result => JSON.parse(result as string) as JsonSchema
   );
 }
 
-// fs Promise functions return errors, but no stack trace.  This adds back in
-// the stack trace.
 function withTrace<Args extends unknown[], Result>(
   fn: (...x: Args) => Promise<Result>,
   ...args: Args
@@ -188,59 +257,87 @@ function withTrace<Args extends unknown[], Result>(
   });
 }
 
-void prompt([
-  {
-    name: 'superBlock',
-    message: 'Which certification does this belong to?',
-    default: SuperBlocks.RespWebDesign,
-    type: 'list',
-    choices: Object.values(SuperBlocks)
-  },
-  {
-    name: 'block',
-    message: 'What is the dashed name (in kebab-case) for this project?',
-    validate: validateBlockName,
-    filter: (block: string) => {
-      return block.toLowerCase().trim();
+async function main() {
+  const { creationType } = await prompt([
+    {
+      name: 'creationType',
+      message: 'What do you want to create?',
+      type: 'list',
+      choices: [
+        { name: 'Project', value: 'project' },
+        { name: 'Quiz', value: 'quiz' }
+      ]
     }
-  },
-  {
-    name: 'title',
-    default: ({ block }: { block: string }) => block
-  },
-  {
-    name: 'helpCategory',
-    message: 'Choose a help category',
-    default: 'HTML-CSS',
-    type: 'list',
-    choices: helpCategories
-  },
-  {
-    name: 'order',
-    message: 'Which position does this appear in the certificate?',
-    default: 42,
-    validate: (order: string) => {
-      return parseInt(order, 10) > 0
-        ? true
-        : 'Order must be an number greater than zero.';
+  ]);
+
+  const isQuiz = creationType === 'quiz';
+
+  const questions = [
+    {
+      name: 'superBlock',
+      message: 'Which certification does this belong to?',
+      default: SuperBlocks.RespWebDesign,
+      type: 'list',
+      choices: Object.values(SuperBlocks)
     },
-    filter: (order: string) => {
-      return parseInt(order, 10);
+    {
+      name: 'block',
+      message: `What is the dashed name (in kebab-case) for this ${isQuiz ? 'quiz' : 'project'}?`,
+      validate: (input: string) => {
+        if (!input) return 'Please enter a name';
+        if (isQuiz && !input.startsWith('quiz-')) {
+          return 'Quiz names must start with "quiz-"';
+        }
+        return validateBlockName(input);
+      },
+      filter: (block: string) => {
+        return block.toLowerCase().trim();
+      }
+    },
+    {
+      name: 'title',
+      default: ({ block }: { block: string }) => 
+        isQuiz ? block.replace('quiz-', '') : block
+    },
+    {
+      name: 'helpCategory',
+      message: 'Choose a help category',
+      default: 'HTML-CSS',
+      type: 'list',
+      choices: helpCategories
     }
+  ];
+
+  if (!isQuiz) {
+    questions.push({
+      name: 'order',
+      message: 'Which position does this appear in the certificate?',
+      default: 42,
+      validate: (order: string) => {
+        return parseInt(order, 10) > 0
+          ? true
+          : 'Order must be an number greater than zero.';
+      },
+      filter: (order: string) => {
+        return parseInt(order, 10);
+      }
+    });
   }
-])
-  .then(
-    async ({
-      superBlock,
-      block,
-      title,
-      helpCategory,
-      order
-    }: CreateProjectArgs) =>
-      await createProject(superBlock, block, helpCategory, order, title)
-  )
-  .then(() =>
-    console.log(
-      'All set.  Now use pnpm run clean:client in the root and it should be good to go.'
-    )
+
+  const answers = await prompt(questions);
+
+  await createProject({
+    superBlock: answers.superBlock,
+    block: answers.block,
+    title: answers.title,
+    helpCategory: answers.helpCategory,
+    order: answers.order,
+    isQuiz
+  });
+
+  console.log(
+    'All set. Now use pnpm run clean:client in the root and it should be good to go.'
   );
+}
+
+void main();


### PR DESCRIPTION
Closes #59451 

The original create-project.ts script was designed specifically for generating practice projects in the freeCodeCamp curriculum. The new modifications extend this functionality to also support creating quiz content while maintaining all existing project creation capabilities.

The key changes begin with adding a new prompt that asks users whether they want to create a project or quiz. This choice determines the subsequent behavior of the script. For quizzes, we enforce a naming convention requiring all quiz names to start with "quiz-" to maintain consistency across the curriculum.

The script's core functions have been updated to handle both content types. When creating a quiz, it generates different file content, including the specific quiz structure with questions, distractors, and answers. The meta.json file now includes quiz-specific properties like setting the blockType to "quiz" and includes the proper challenge type identifier (8 for quizzes).

For projects, the script maintains all original functionality, including the requirement for an order number, and generates project-specific challenge content. The help category selection remains the same for both content types.

The file generation process has been enhanced to create appropriate introductory content depending on whether it's a quiz or project. Quiz content includes the standard quiz description and template structure, while project content maintains the existing editable regions setup.

These changes allow the single script to handle both content types efficiently while maintaining consistent patterns with the existing codebase. The modifications follow the same patterns for file operations, error handling, and directory structure as the original implementation.
