### PR TITLE
fix(curriculum): changed 'preceeded' to 'preceded'

### DIFF
--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-express-concerns/67c5fe2b3b2cc825412e2839.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-express-concerns/67c5fe2b3b2cc825412e2839.md
@@ -51,7 +51,7 @@ Tell him if she needs anything.
 
 # --explanation--
 
-`Let me know`, preceeded by a conditional sentence, like `If you need anything`, is a common way to offer help. It makes the offer open-ended, meaning the person can ask for help if they find it necessary. For example:
+`Let me know`, preceded by a conditional sentence, like `If you need anything`, is a common way to offer help. It makes the offer open-ended, meaning the person can ask for help if they find it necessary. For example:
 
 `If you have any questions, just let me know.` - This means you are available to answer questions when needed.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #59531

<!-- Feel free to add any additional description of changes below this line -->
Changed 'preceeded' to 'preceded' in [freeCodeCamp/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-express-concerns/67c5fe2b3b2cc825412e2839.md](https://github.com/freeCodeCamp/freeCodeCamp/blob/90d60707898123e5d8e65fe18c6a6c356c7c11cb/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-express-concerns/67c5fe2b3b2cc825412e2839.md#L54)
