### PR TITLE
fix(curriculum): Leap Year Calculator - allow assignment to single declaration

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-leap-year-calculator/66c06fad3475cd92421b9ac2.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-leap-year-calculator/66c06fad3475cd92421b9ac2.md
@@ -77,10 +77,16 @@ You should call the `isLeapYear` function and pass `year` as a parameter.
 assert.match(__helpers.removeJSComments(code), /isLeapYear\(\s*year\s*\)/);
 ```
 
+You should declare a `result` variable.
+
+```js
+assert.isDefined(result);
+```
+
 You should store the result of calling the `isLeapYear` function in a variable named `result`.
 
 ```js
-assert.match(__helpers.removeJSComments(code), /(?:var|let|const)\s+result\s*=\s*isLeapYear\(\s*year\s*\)/);
+assert.match(__helpers.removeJSComments(code), /result\s*=\s*isLeapYear\(\s*year\s*\)/);
 ```
 
 You should output the `result` to the console using `console.log()`.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->

This should allow for a single declaration and multiple function calls. I don't think it causes any issues?

Forum: https://forum.freecodecamp.org/t/build-a-leap-year-calculator-build-a-leap-year-calculator/741811
