### PR TITLE
fix(curriculum): add 100% max-width requirement to business card lab

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-business-card/6690e10ebe2181212abc9652.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-business-card/6690e10ebe2181212abc9652.md
@@ -19,7 +19,7 @@ Fulfill the user stories below and get all the tests to pass to complete the lab
 1. You should have a `div` with the `class` `business-card`. 
 1. The `business-card` `class` should be `300px` wide and it should have any background color of your choice. There should be a `padding` of `20px` all around and a top `margin` of `100px`. The text should be center aligned and the font size should be `16px`. The left and right margins should be set to `auto`.
 1. Inside the `business-card` `div`, there should be an `img` element with the `class` `profile-image`. You can set the image source to `https://cdn.freecodecamp.org/curriculum/labs/flower.jpg` if you like. There should be an `alt` with a meaningful description.
-1. The `profile-image` `class` should have a `max-width` of `100%`.
+1. The `profile-image` selector should have a `max-width` of `100%`.
 1. Inside the `business-card` `div`, after the `img` element, you should have three `p` elements with the `class` `full-name`, `designation`, and `company`, respectively.
 1. The first `p` element should contain your name.
 1. The second `p` element should contain your designation.
@@ -161,7 +161,7 @@ The `alt` attribute of the image should be set to a meaningful description.
 assert.isAbove(document.querySelectorAll('img')[0].alt.length, 0);
 ```
 
-Your `.profile-image` `class` should have a `max-width` of `100%`.
+Your `.profile-image` selector should have a `max-width` of `100%`.
 
 ```js
 assert.equal(new __helpers.CSSHelp(document).getStyle('.profile-image').getPropVal('max-width'), '100%');

--- a/curriculum/challenges/english/25-front-end-development/lab-business-card/6690e10ebe2181212abc9652.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-business-card/6690e10ebe2181212abc9652.md
@@ -19,6 +19,7 @@ Fulfill the user stories below and get all the tests to pass to complete the lab
 1. You should have a `div` with the `class` `business-card`. 
 1. The `business-card` `class` should be `300px` wide and it should have any background color of your choice. There should be a `padding` of `20px` all around and a top `margin` of `100px`. The text should be center aligned and the font size should be `16px`. The left and right margins should be set to `auto`.
 1. Inside the `business-card` `div`, there should be an `img` element with the `class` `profile-image`. You can set the image source to `https://cdn.freecodecamp.org/curriculum/labs/flower.jpg` if you like. There should be an `alt` with a meaningful description.
+1. The `profile-image` `class` should have a `max-width` of `100%`.
 1. Inside the `business-card` `div`, after the `img` element, you should have three `p` elements with the `class` `full-name`, `designation`, and `company`, respectively.
 1. The first `p` element should contain your name.
 1. The second `p` element should contain your designation.
@@ -158,6 +159,12 @@ The `alt` attribute of the image should be set to a meaningful description.
 
 ```js
 assert.isAbove(document.querySelectorAll('img')[0].alt.length, 0);
+```
+
+Your `.profile-image` `class` should have a `max-width` of `100%`.
+
+```js
+assert.equal(new __helpers.CSSHelp(document).getStyle('.profile-image').getPropVal('max-width'), '100%');
 ```
 
 Inside the `.business-card` element, after the `img` element, there should be a `p` element with the `class` `full-name`.
@@ -362,6 +369,7 @@ body {
 }
 
 .profile-image {
+    max-width: 100%;
     width: 150px;
     height: 150px;
     margin-bottom: 10px;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #59506

<!-- Feel free to add any additional description of changes below this line -->

This update adds the requirement of max-width: 100% for the `.profile-image` class in the Design a Business Card lab. This requirement was added to the user stories and tests in the Markdown file. Additionally, the solution in the Markdown file was updated to pass the new requirement.