### PR TITLE
fix(client): heatmap button size

### DIFF
--- a/client/src/components/profile/components/heat-map.tsx
+++ b/client/src/components/profile/components/heat-map.tsx
@@ -146,6 +146,7 @@ class HeatMapInner extends Component<HeatMapInnerProps, HeatMapInnerState> {
           />
           <ReactTooltip className='react-tooltip' effect='solid' html={true} />
           <Row className='text-center'>
+            <Spacer size='xs' />
             <button
               className='heatmap-nav-btn'
               disabled={!pages[this.state.pageIndex - 1]}
@@ -170,7 +171,7 @@ class HeatMapInner extends Component<HeatMapInnerProps, HeatMapInnerState> {
               &gt;
             </button>
           </Row>
-          <Spacer size='m' />
+          <Spacer size='xs' />
         </section>
       </FullWidthRow>
     );

--- a/client/src/components/profile/components/heatmap.css
+++ b/client/src/components/profile/components/heatmap.css
@@ -1,5 +1,7 @@
 .heatmap-nav-btn {
   margin: 0 20px;
+  width: 44px;
+  height: 44px;
 }
 
 .react-calendar-heatmap-month-label {


### PR DESCRIPTION
Makes the buttons the same size as the timeline buttons - mentioned here: https://github.com/freeCodeCamp/freeCodeCamp/issues/59555 - also adjusts the spacers.

<img width="697" alt="Screenshot 2025-04-03 at 10 49 33 AM" src="https://github.com/user-attachments/assets/113ff7c1-0f46-4e75-b70e-0497d2431bdf" />

I tested this by replacing [this line](https://github.com/freeCodeCamp/freeCodeCamp/blob/main/client/src/components/profile/components/heat-map.tsx#L182) with this:

```
  const calendar = [
    { date: new Date(), count: 1 },
    { date: new Date(2024, 1, 0), count: 1 }
  ];
```

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #59571

<!-- Feel free to add any additional description of changes below this line -->
