### PR TITLE
refactor(client, curriculum): consolidate is-FSD checks

### DIFF
--- a/client/src/redux/donation-saga.js
+++ b/client/src/redux/donation-saga.js
@@ -18,6 +18,7 @@ import {
 import { stringifyDonationEvents } from '../utils/analytics-strings';
 import { stripe } from '../utils/stripe';
 import { PaymentProvider } from '../../../shared/config/donation-settings';
+import { chapterBasedSuperBlocks } from '../../../shared/config/curriculum';
 import {
   getSessionChallengeData,
   saveCurrentCount
@@ -52,7 +53,7 @@ function* showDonateModalSaga() {
   if (
     shouldRequestDonation &&
     recentlyClaimedBlock &&
-    recentlyClaimedBlock.superBlock === 'full-stack-developer'
+    chapterBasedSuperBlocks.includes(recentlyClaimedBlock.superBlock)
   ) {
     yield put(preventBlockDonationRequests());
   } else if (shouldRequestDonation || isModalRecentlyShown) {

--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -8,7 +8,10 @@ import { createSelector } from 'reselect';
 import { Spacer } from '@freecodecamp/ui';
 
 import { challengeTypes } from '../../../../../shared/config/challenge-types';
-import { SuperBlocks } from '../../../../../shared/config/curriculum';
+import {
+  chapterBasedSuperBlocks,
+  SuperBlocks
+} from '../../../../../shared/config/curriculum';
 import envData from '../../../../config/env.json';
 import { isAuditedSuperBlock } from '../../../../../shared/utils/is-audited';
 import Caret from '../../../assets/icons/caret';
@@ -407,7 +410,7 @@ class Block extends Component<BlockProps> {
       !isEmptyBlock && (
         <>
           {layoutToComponent[blockLayout]}
-          {superBlock !== SuperBlocks.FullStackDeveloper && (
+          {!chapterBasedSuperBlocks.includes(superBlock) && (
             <Spacer size='xs' />
           )}
         </>

--- a/client/src/templates/Introduction/super-block-intro.tsx
+++ b/client/src/templates/Introduction/super-block-intro.tsx
@@ -11,7 +11,10 @@ import { bindActionCreators, Dispatch } from 'redux';
 import { createSelector } from 'reselect';
 import { Container, Col, Row, Spacer } from '@freecodecamp/ui';
 
-import { SuperBlocks } from '../../../../shared/config/curriculum';
+import {
+  chapterBasedSuperBlocks,
+  SuperBlocks
+} from '../../../../shared/config/curriculum';
 import DonateModal from '../../components/Donation/donation-modal';
 import Login from '../../components/Header/components/login';
 import Map from '../../components/Map';
@@ -172,8 +175,6 @@ const SuperBlockIntroductionPage = (props: SuperBlockProps) => {
     cert => superBlockToCertMap[superBlock] === cert.certSlug
   );
 
-  const superBlockWithAccordionView = [SuperBlocks.FullStackDeveloper];
-
   const getInitiallyExpandedBlock = (): string => {
     // if coming from breadcrumb click
     if (
@@ -258,7 +259,7 @@ const SuperBlockIntroductionPage = (props: SuperBlockProps) => {
                 {t(`intro:misc-text.courses`)}
               </h2>
               <Spacer size='m' />
-              {superBlockWithAccordionView.includes(superBlock) ? (
+              {chapterBasedSuperBlocks.includes(superBlock) ? (
                 <SuperBlockAccordion
                   challenges={superBlockChallenges}
                   superBlock={superBlock}

--- a/curriculum/get-challenges.js
+++ b/curriculum/get-challenges.js
@@ -15,6 +15,7 @@ const {
 
 const { isAuditedSuperBlock } = require('../shared/utils/is-audited');
 const { createPoly } = require('../shared/utils/polyvinyl');
+const { chapterBasedSuperBlocks } = require('../shared/config/curriculum');
 const {
   getSuperOrder,
   getSuperBlockFromDir,
@@ -287,16 +288,12 @@ async function buildChallenges({ path: filePath }, curriculum, lang) {
   challengeBlock.challenges = [...challengeBlock.challenges, challenge];
 }
 
-function isSuperBlockWithChapters(superBlock) {
-  return superBlock === 'full-stack-developer';
-}
-
 // This is a slightly weird abstraction, but it lets us define helper functions
 // without passing around a ton of arguments.
 function generateChallengeCreator(lang, englishPath, i18nPath) {
   function addMetaToChallenge(challenge, meta) {
     function addChapterAndModuleToChallenge(challenge) {
-      if (isSuperBlockWithChapters(challenge.superBlock)) {
+      if (chapterBasedSuperBlocks.includes(challenge.superBlock)) {
         challenge.chapter = getChapterFromBlock(
           challenge.block,
           fullStackSuperBlockStructure
@@ -329,7 +326,7 @@ function generateChallengeCreator(lang, englishPath, i18nPath) {
     challenge.blockType = meta.blockType;
     challenge.blockLayout = meta.blockLayout;
     challenge.hasEditableBoundaries = !!meta.hasEditableBoundaries;
-    challenge.order = isSuperBlockWithChapters(meta.superBlock)
+    challenge.order = chapterBasedSuperBlocks.includes(meta.superBlock)
       ? getBlockOrder(meta.dashedName, fullStackSuperBlockStructure)
       : meta.order;
 

--- a/curriculum/schema/challenge-schema.js
+++ b/curriculum/schema/challenge-schema.js
@@ -2,7 +2,10 @@ const Joi = require('joi');
 Joi.objectId = require('joi-objectid')(Joi);
 
 const { challengeTypes } = require('../../shared/config/challenge-types');
-const { SuperBlocks } = require('../../shared/config/curriculum');
+const {
+  SuperBlocks,
+  chapterBasedSuperBlocks
+} = require('../../shared/config/curriculum');
 const {
   availableCharacters,
   availableBackgrounds,
@@ -128,7 +131,7 @@ const schema = Joi.object()
     block: Joi.string().regex(slugRE).required(),
     blockId: Joi.objectId(),
     blockType: Joi.when('superBlock', {
-      is: [SuperBlocks.FullStackDeveloper],
+      is: chapterBasedSuperBlocks,
       then: Joi.valid(
         'workshop',
         'lab',
@@ -151,7 +154,7 @@ const schema = Joi.object()
     ).required(),
     challengeOrder: Joi.number(),
     chapter: Joi.string().when('superBlock', {
-      is: 'full-stack-developer',
+      is: chapterBasedSuperBlocks,
       then: Joi.required(),
       otherwise: Joi.optional()
     }),
@@ -211,7 +214,7 @@ const schema = Joi.object()
     isLocked: Joi.bool(),
     isPrivate: Joi.bool(),
     module: Joi.string().when('superBlock', {
-      is: 'full-stack-developer',
+      is: chapterBasedSuperBlocks,
       then: Joi.required(),
       otherwise: Joi.optional()
     }),

--- a/curriculum/schema/meta-schema.js
+++ b/curriculum/schema/meta-schema.js
@@ -1,6 +1,9 @@
 const Joi = require('joi');
 
-const { SuperBlocks } = require('../../shared/config/curriculum');
+const {
+  SuperBlocks,
+  chapterBasedSuperBlocks
+} = require('../../shared/config/curriculum');
 
 const slugRE = new RegExp('^[a-z0-9-]+$');
 const slugWithSlashRE = new RegExp('^[a-z0-9-/]+$');
@@ -33,7 +36,7 @@ const schema = Joi.object()
       .valid(...Object.values(SuperBlocks))
       .required(),
     order: Joi.number().when('superBlock', {
-      is: 'full-stack-developer',
+      is: chapterBasedSuperBlocks,
       then: Joi.forbidden(),
       otherwise: Joi.required()
     }),

--- a/curriculum/test/test-challenges.js
+++ b/curriculum/test/test-challenges.js
@@ -51,7 +51,10 @@ const {
   createContent,
   testId
 } = require('../../client/src/templates/Challenges/utils/frame');
-const { SuperBlocks } = require('../../shared/config/curriculum');
+const {
+  SuperBlocks,
+  chapterBasedSuperBlocks
+} = require('../../shared/config/curriculum');
 const ChallengeTitles = require('./utils/challenge-titles');
 const MongoIds = require('./utils/mongo-ids');
 const createPseudoWorker = require('./utils/pseudo-worker');
@@ -313,11 +316,11 @@ function populateTestsForLang({ lang, challenges, meta, superBlocks }) {
           );
         });
         filteredMeta.forEach((meta, index) => {
-          // Upcoming changes are in developmen so are not required to be in
-          // order. FullStackDeveloper does not use the meta for order.
+          // Upcoming changes are in development so are not required to be in
+          // order. Chapter-based super blocks do not use the meta for order.
           if (
             !meta.isUpcomingChange &&
-            meta.superBlock !== SuperBlocks.FullStackDeveloper
+            !chapterBasedSuperBlocks.includes(meta.superBlock)
           ) {
             it(`${meta.superBlock} ${meta.name} must be in order`, function () {
               assert.equal(meta.order, index);

--- a/shared/config/curriculum.ts
+++ b/shared/config/curriculum.ts
@@ -240,6 +240,9 @@ export const notAuditedSuperBlocks: NotAuditedSuperBlocks = {
 
 Object.freeze(notAuditedSuperBlocks);
 
+export const chapterBasedSuperBlocks = [SuperBlocks.FullStackDeveloper];
+Object.freeze(chapterBasedSuperBlocks);
+
 type Config = {
   showUpcomingChanges: boolean;
 };


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

We have multiple `superBlock === FSD` checks in the codebase, and I found myself adding another one in #59533, so I'm creating a `chapterBasedSuperBlocks` array to replace those checks. The goal is to keep `chapterBasedSuperBlocks` as the single source of truth for all things related to super blocks with chapters.

<!-- Feel free to add any additional description of changes below this line -->
