### PR TITLE
fix: add more tests for completeness

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-loan-qualification-checker/66c8ba975ee7230e29f6c4ad.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-loan-qualification-checker/66c8ba975ee7230e29f6c4ad.md
@@ -19,18 +19,28 @@ Your `getLoanMessage` function should return a string.
 
 ```js
 assert.isString(getLoanMessage(65000, 750));
+assert.isString(getLoanMessage(60000, 750));
+assert.isString(getLoanMessage(65000, 700));
+assert.isString(getLoanMessage(60000, 700));
 ```
 
 Your `getLoanMessage` function should return the string `"You qualify for a duplex, condo, and car loan."`.
 
 ```js
 assert.strictEqual(getLoanMessage(65000, 750), "You qualify for a duplex, condo, and car loan.");
+assert.strictEqual(getLoanMessage(60000, 750), "You qualify for a duplex, condo, and car loan.");
+assert.strictEqual(getLoanMessage(65000, 700), "You qualify for a duplex, condo, and car loan.");
+assert.strictEqual(getLoanMessage(60000, 700), "You qualify for a duplex, condo, and car loan.");
 ```
 
 Your `getLoanMessage` function should return `undefined` if the applicant's annual income and credit score do not meet the requirements for a duplex loan.
 
 ```js
+assert.strictEqual(getLoanMessage(59000, 690), undefined);
 assert.strictEqual(getLoanMessage(59000, 700), undefined);
+assert.strictEqual(getLoanMessage(59000, 750), undefined);
+assert.strictEqual(getLoanMessage(60000, 690), undefined);
+assert.strictEqual(getLoanMessage(65000, 690), undefined);
 ```
  
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-loan-qualification-checker/66c8ba975ee7230e29f6c4ad.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-loan-qualification-checker/66c8ba975ee7230e29f6c4ad.md
@@ -36,11 +36,11 @@ assert.strictEqual(getLoanMessage(60000, 700), "You qualify for a duplex, condo,
 Your `getLoanMessage` function should return `undefined` if the applicant's annual income and credit score do not meet the requirements for a duplex loan.
 
 ```js
-assert.strictEqual(getLoanMessage(59000, 690), undefined);
-assert.strictEqual(getLoanMessage(59000, 700), undefined);
-assert.strictEqual(getLoanMessage(59000, 750), undefined);
-assert.strictEqual(getLoanMessage(60000, 690), undefined);
-assert.strictEqual(getLoanMessage(65000, 690), undefined);
+assert.isUndefined(getLoanMessage(59000, 690));
+assert.isUndefined(getLoanMessage(59000, 700));
+assert.isUndefined(getLoanMessage(59000, 750));
+assert.isUndefined(getLoanMessage(60000, 690));
+assert.isUndefined(getLoanMessage(65000, 690));
 ```
  
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #59605

<!-- Feel free to add any additional description of changes below this line -->

This Pull Request handles - Loan Qualification Checker - Step 3: Incorrect code is passing

The coding challenge was passing on an edge case that was supposed to fail. Looking into the source code, there wasn't enough test cases to cover 100% of all possible paths. I added more test cases to cover all possible solutions.

This satisfies the agreed solution proposed by @ilenia-magoni 

```
For completeness we need 9 tests:

  - need to test with annualIncome higher than minIncomeForDuplex, same, and lower
  - need to test with creditScore higher than minCreditScoreForDuplex, same, and lower

combining these in all possibilities make 9 tests
```

The value for minIncomeForDuplex is 60,000 and minCreditScoreForDuplex is 700.

I also tested on my local machine to make sure that it works. Attached are screenshots before and after the fix.

The reason why we don't check if the test cases that are supposed to fail returns a `string` is because it's supposed to return `undefined`.

## Before Fix
![Before Fix](https://github.com/user-attachments/assets/28b291fa-f288-4c0b-97e1-d5dc6237290e)

## After Fix
![After Fix](https://github.com/user-attachments/assets/22f75960-c0f8-4bfd-ae13-00a85e77d4b6)