### PR TITLE
fix(curriculum): fix tests for steps 28 and 45 of the BST lesson

### DIFF
--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-tree-traversal-by-building-a-binary-search-tree/65c644829cfb63acf3479d09.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-tree-traversal-by-building-a-binary-search-tree/65c644829cfb63acf3479d09.md
@@ -14,13 +14,13 @@ Insert the nodes in the list `nodes` into the `bst` instance by iterating over t
 You should have a `for node in nodes` loop.
 
 ```js
-assert.match(code, /for\s+node\s+in\s+nodes/);
+({ test: () => (runPython(`assert _Node(_code).find_for_loops()[0].find_for_vars().is_equivalent("node") and _Node(_code).find_for_loops()[0].find_for_iter().is_equivalent("nodes")`)) });
 ```
 
 You should have `bst.insert(node)` inside the `for` loop.
 
 ```js
-assert.match(code, /bst\.insert/);
+({ test: () => (runPython(`assert _Node(_code).find_for("node", "nodes").find_body().is_equivalent("bst.insert(node)")`)) })
 ```
 
 # --seed--

--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-tree-traversal-by-building-a-binary-search-tree/65ca089e848eca0672b9cd77.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-tree-traversal-by-building-a-binary-search-tree/65ca089e848eca0672b9cd77.md
@@ -16,7 +16,12 @@ Add a `_min_value` call after your `elif` block, passing `node.right` as the arg
 You should assign `self._min_value(node.right)` to `node.key` after your `elif` block.
 
 ```js
-assert.match(code, /node\.key\s*=\s*self\._min_value\(\s*node\.right\s*\)/);
+({ test: () => (runPython(`
+import ast
+
+assign_after_elif = _Node(_code).find_class("BinarySearchTree").find_function("_delete").find_ifs()[1].tree.orelse[0].orelse[1]
+assign_code = ast.get_source_segment(_code, assign_after_elif)
+assert _Node(assign_code).is_equivalent("node.key = self._min_value(node.right)")`)) })
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #59270 

<!-- Feel free to add any additional description of changes below this line -->

These changes fix the tests for steps 28 and 45 of the "Learn Tree Traversal by Building a Binary Search Tree" lesson. The tests for step 28 have been updated to check if nodes are correctly inserted inside the loop. The test for step 45 has been updated to check if the code is placed correctly after the `elif` block. Additionally, these tests have been updated to use AST-based helpers to accurately test the Python code.

### Step 45 explanation

Since the changes for step 45 are harder to understand at first glance, I'll explain how the test works with the new changes. Here is the related code:

```
({ test: () => (runPython(`
import ast

assign_after_elif = _Node(_code).find_class("BinarySearchTree").find_function("_delete").find_ifs()[1].tree.orelse[0].orelse[1]
assign_code = ast.get_source_segment(_code, assign_after_elif)
assert _Node(assign_code).is_equivalent("node.key = self._min_value(node.right)")`)) })
```

For reference, here is the solution code with line numbers in step 45:

```
41 def _delete(self, node, key):
42    if node is None:
43        return node
44    if key < node.key:
45        node.left = self._delete(node.left, key)
46    elif key > node.key:
47        node.right = self._delete(node.right, key) 
48    else:
49        if node.left is None:
50            return node.right
51        elif node.right is None:
52            return node.left
53        node.key = self._min_value(node.right)
```

By splitting the new code onto multiple lines, we can see how it reaches the assignment on Line 53:

```
_Node(_code).find_class("BinarySearchTree") # locates the BinarySearchTree class on Line 12
.find_function("_delete") # locates the _delete function on Line 41
.find_ifs()[1] # locates the second group of if statements starting on Line 44
.tree.orelse[0] # locates the elif block on Line 46
.orelse[1] # within the else block on Line 48, locates the assignment statement
```

After that, `ast.get_source_segment()` retrieves the assignment code as a string. Then, the code string is used to create an instance of `_Node` to check for equivalence.

### Additional considerations

From what I found, the AST-based helper methods cannot directly reach `node.key = self._min_value(node.right)` after the `elif` block. That line of code is treated as an assignment under the `else` block. Since it's not treated as part of the `body` of the `else` block, `find_body()` and `find_bodies()` will not contain that line of code.  Because of this, I opted for the approach described above to confirm the solution is in the correct location (and correct indentation).