### PR TITLE
fix(client,i18n): prevent unwanted line breaks in Japanese and Chinese block labels

### DIFF
--- a/client/src/templates/Introduction/intro.css
+++ b/client/src/templates/Introduction/intro.css
@@ -24,6 +24,7 @@
   border: 1px solid;
   position: relative;
   top: 1px;
+  word-break: keep-all;
 }
 
 .block-header:hover .block-label {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

In Japanese and Chinese, there were unwanted line breaks in the block labels for the new FSD certification when the block title is long or when you resize the window. Adding `word-break: keep-all;` will prevent this issue.

Japanese:
![ja_label](https://github.com/user-attachments/assets/66fc8bde-1387-462c-9cc5-3565a881886f)

Chinese:
![chinese_labels](https://github.com/user-attachments/assets/1f336324-6e9f-4ee3-b2ff-392d59a64ea1)

