### PR TITLE
fix(client): space-out the user bio from nav

### DIFF
--- a/client/src/components/profile/__snapshots__/profile.test.tsx.snap
+++ b/client/src/components/profile/__snapshots__/profile.test.tsx.snap
@@ -15,6 +15,9 @@ exports[`<Profile/> renders correctly 1`] = `
       class="bio-container"
     >
       <div
+        class="h-[30px]"
+      />
+      <div
         class="mx-[-15px] "
       >
         <div

--- a/client/src/components/profile/components/camper.tsx
+++ b/client/src/components/profile/components/camper.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { Spacer } from '@freecodecamp/ui';
 import type { User } from '../../../redux/prop-types';
 import { FullWidthRow } from '../../helpers';
 import './camper.css';
@@ -29,6 +30,7 @@ function Camper({
   return (
     <>
       <div className='bio-container'>
+        <Spacer size={'m'} />
         <Bio
           user={user}
           setIsEditing={setIsEditing}


### PR DESCRIPTION
This pr adds some padding to the top of the bio section.

before/after

<img width="1023" alt="Screenshot 2025-04-10 at 2 34 24 PM" src="https://github.com/user-attachments/assets/7f42e648-e4de-42bc-ab70-23f8490fb396" />

The issue does not show up on local builds due to gatsby wrapping the page in default layout twice:
![Screenshot 2025-04-10 at 11 39 43 AM](https://github.com/user-attachments/assets/a9fd2ab4-8e21-4515-88ee-b31750f0c0a8)

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes https://github.com/freeCodeCamp/freeCodeCamp/issues/59664

<!-- Feel free to add any additional description of changes below this line -->
