### PR TITLE
fix(i18n): lowercase "Classes" in JavaScript quiz intro

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -3316,7 +3316,7 @@
       "quiz-javascript-classes": {
         "title": "JavaScript Classes Quiz",
         "intro": [
-          "Test what you've learned about JavaScript Classes with this quiz."
+          "Test what you've learned about JavaScript classes with this quiz."
         ]
       },
       "lecture-understanding-recursion-and-the-call-stack": {


### PR DESCRIPTION
This PR fixes a small typo in the English locale file.

Specifically, it changes the word "Classes" to "classes" in the JavaScript quiz intro text on line 3297 of client/i18n/locales/english/intro.json.

Summary of change:
Changed "Test what you've learned about JavaScript Classes with this quiz."
    to
"Test what you've learned about JavaScript classes with this quiz."

This fix improves consistency with how the term "classes" is typically written in sentence case across the curriculum.

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

Closes #59660
