### PR TITLE
fix(GHA): improve specificity of concurrency

### DIFF
--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -7,15 +7,12 @@ on:
       - completed
   # TODO: refactor with a workflow_call
   pull_request:
-    paths-ignore:
-      - 'docs/**'
     branches:
       - 'main'
-      - 'next-**'
-      - 'e2e-**'
+      - 'temp-**' # Temporary branches allowed on Upstream
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.workflow_run.head_branch || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/e2e-third-party.yml
+++ b/.github/workflows/e2e-third-party.yml
@@ -6,13 +6,12 @@ on:
   push:
     branches:
       - 'prod-**'
-    paths-ignore:
-      - 'docs/**'
+
   # to test this ad-hoc
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.workflow_run.head_branch || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/github-labeler.yaml
+++ b/.github/workflows/github-labeler.yaml
@@ -6,7 +6,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.workflow_run.head_branch || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/i18n-validate-builds.yml
+++ b/.github/workflows/i18n-validate-builds.yml
@@ -5,7 +5,7 @@ on:
       - main
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.workflow_run.head_branch || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/i18n-validate-prs.yml
+++ b/.github/workflows/i18n-validate-prs.yml
@@ -5,7 +5,7 @@ on:
       - main
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.workflow_run.head_branch || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/node.js-tests.yml
+++ b/.github/workflows/node.js-tests.yml
@@ -10,13 +10,13 @@ on:
   pull_request:
     branches:
       - 'main'
-      - 'next-**'
+      - 'temp-**' # Temporary branches allowed on Upstream
   # Run on Merge Queue
   merge_group:
     types: [checks_requested]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.workflow_run.head_branch || github.ref }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
This PR improves the `concurrency` clause for canceling runs, and while there using `temp-**` branches on fCC proper is now allowed for one-off workflow tests needed from time to time.