### PR TITLE
fix(learn): highlight variables in sort method quiz

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-higher-order-functions-and-callbacks/673362d7f94d551edb532d24.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-higher-order-functions-and-callbacks/673362d7f94d551edb532d24.md
@@ -164,7 +164,7 @@ Consider how JavaScript handles different data types when comparing.
 
 ## --text--
 
-What should a compare function return if a should come after b?
+What should a compare function return if `a` should come after `b`?
 
 ## --answers--
 


### PR DESCRIPTION
This PR fixes a minor formatting issue in the final quiz question of the **sort method** lecture.

- Adds backticks around `a` and `b` to properly highlight them as variables.

Closes #59686

### Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.
