### PR TITLE
refactor(external curricula): simplify get intro logic

### DIFF
--- a/tools/scripts/build/build-external-curricula-data.test.ts
+++ b/tools/scripts/build/build-external-curricula-data.test.ts
@@ -10,7 +10,7 @@ import {
 } from './external-data-schema';
 import {
   type Curriculum,
-  type SuperBlockIntro,
+  type CurriculumIntros,
   orderedSuperBlockInfo
 } from './build-external-curricula-data';
 
@@ -20,7 +20,7 @@ const intros = JSON.parse(
     path.resolve(__dirname, '../../../client/i18n/locales/english/intro.json'),
     'utf-8'
   )
-) as SuperBlockIntro;
+) as CurriculumIntros;
 
 describe('external curriculum data build', () => {
   const clientStaticPath = path.resolve(__dirname, '../../../client/static');

--- a/tools/scripts/build/build-external-curricula-data.test.ts
+++ b/tools/scripts/build/build-external-curricula-data.test.ts
@@ -11,6 +11,7 @@ import {
 import {
   type Curriculum,
   type CurriculumIntros,
+  type GeneratedCurriculumProps,
   orderedSuperBlockInfo
 } from './build-external-curricula-data';
 
@@ -111,7 +112,7 @@ ${result.error.message}`);
 
       const fileContent = JSON.parse(
         fileContentJson
-      ) as Curriculum<SuperBlocks>;
+      ) as Curriculum<GeneratedCurriculumProps>;
 
       const superBlock = Object.keys(fileContent)[0] as SuperBlocks;
 

--- a/tools/scripts/build/build-external-curricula-data.test.ts
+++ b/tools/scripts/build/build-external-curricula-data.test.ts
@@ -116,9 +116,6 @@ ${result.error.message}`);
         expect(fileContent[superBlock].blocks[randomBlock].desc).toEqual(
           intros[superBlock].blocks[randomBlock].intro
         );
-        expect(
-          fileContent[superBlock].blocks[randomBlock].challenges.name
-        ).toEqual(intros[superBlock].blocks[randomBlock].title);
       });
   });
 

--- a/tools/scripts/build/build-external-curricula-data.test.ts
+++ b/tools/scripts/build/build-external-curricula-data.test.ts
@@ -62,61 +62,69 @@ ${result.error.message}`
     }
   });
 
-  test('the files generated should have the correct schema', async () => {
+  test('the super block files generated should have the correct schema', async () => {
     const fileArray = (
       await readdirp.promise(`${clientStaticPath}/curriculum-data/${VERSION}`, {
-        directoryFilter: ['!challenges']
+        directoryFilter: ['!challenges'],
+        fileFilter: entry => {
+          // The directory contains super block files and other curriculum-related files.
+          // We're only interested in super block ones.
+          const superBlocks = Object.values(SuperBlocks);
+          return superBlocks.includes(entry.basename);
+        }
       })
     ).map(file => file.path);
 
-    fileArray
-      .filter(fileInArray => fileInArray !== 'available-superblocks.json')
-      .forEach(fileInArray => {
-        const fileContent = fs.readFileSync(
-          `${clientStaticPath}/curriculum-data/${VERSION}/${fileInArray}`,
-          'utf-8'
-        );
+    fileArray.forEach(fileInArray => {
+      const fileContent = fs.readFileSync(
+        `${clientStaticPath}/curriculum-data/${VERSION}/${fileInArray}`,
+        'utf-8'
+      );
 
-        const result = validateSuperBlock(JSON.parse(fileContent));
+      const result = validateSuperBlock(JSON.parse(fileContent));
 
-        if (result.error) {
-          throw Error(`file: ${fileInArray}
+      if (result.error) {
+        throw Error(`file: ${fileInArray}
 ${result.error.message}`);
-        }
-      });
+      }
+    });
   });
 
   test('super blocks and blocks should have the correct data', async () => {
     const superBlockFiles = (
       await readdirp.promise(`${clientStaticPath}/curriculum-data/${VERSION}`, {
-        directoryFilter: ['!challenges']
+        directoryFilter: ['!challenges'],
+        fileFilter: entry => {
+          // The directory contains super block files and other curriculum-related files.
+          // We're only interested in super block ones.
+          const superBlocks = Object.values(SuperBlocks);
+          return superBlocks.includes(entry.basename);
+        }
       })
     ).map(file => file.path);
 
-    superBlockFiles
-      .filter(file => file !== 'available-superblocks.json')
-      .forEach(file => {
-        const fileContentJson = fs.readFileSync(
-          `${clientStaticPath}/curriculum-data/${VERSION}/${file}`,
-          'utf-8'
-        );
+    superBlockFiles.forEach(file => {
+      const fileContentJson = fs.readFileSync(
+        `${clientStaticPath}/curriculum-data/${VERSION}/${file}`,
+        'utf-8'
+      );
 
-        const fileContent = JSON.parse(
-          fileContentJson
-        ) as Curriculum<SuperBlocks>;
+      const fileContent = JSON.parse(
+        fileContentJson
+      ) as Curriculum<SuperBlocks>;
 
-        const superBlock = Object.keys(fileContent)[0] as SuperBlocks;
+      const superBlock = Object.keys(fileContent)[0] as SuperBlocks;
 
-        // Randomly pick a block to check its data.
-        const blocks = Object.keys(fileContent[superBlock].blocks);
-        const randomBlockIndex = Math.floor(Math.random() * blocks.length);
-        const randomBlock = blocks[randomBlockIndex];
+      // Randomly pick a block to check its data.
+      const blocks = Object.keys(fileContent[superBlock].blocks);
+      const randomBlockIndex = Math.floor(Math.random() * blocks.length);
+      const randomBlock = blocks[randomBlockIndex];
 
-        expect(fileContent[superBlock].intro).toEqual(intros[superBlock].intro);
-        expect(fileContent[superBlock].blocks[randomBlock].desc).toEqual(
-          intros[superBlock].blocks[randomBlock].intro
-        );
-      });
+      expect(fileContent[superBlock].intro).toEqual(intros[superBlock].intro);
+      expect(fileContent[superBlock].blocks[randomBlock].desc).toEqual(
+        intros[superBlock].blocks[randomBlock].intro
+      );
+    });
   });
 
   test('All public SuperBlocks should be present in the SuperBlock object', () => {

--- a/tools/scripts/build/build-external-curricula-data.ts
+++ b/tools/scripts/build/build-external-curricula-data.ts
@@ -4,24 +4,26 @@ import { submitTypes } from '../../../shared/config/challenge-types';
 import { type ChallengeNode } from '../../../client/src/redux/prop-types';
 import { SuperBlocks } from '../../../shared/config/curriculum';
 
-type Intro = { [keyValue in SuperBlocks]: IntroProps };
+export type SuperBlockIntro = {
+  [keyValue in SuperBlocks]: {
+    title: string;
+    intro: string[];
+    blocks: Record<string, { title: string; intro: string[] }>;
+  };
+};
+
 export type Curriculum<T> = {
   [keyValue in SuperBlocks]: T extends CurriculumProps
     ? CurriculumProps
     : GeneratedCurriculumProps;
 };
 
-interface IntroProps extends CurriculumProps {
-  title: string;
-  intro: string[];
-}
-
 export interface CurriculumProps {
   intro: string[];
   blocks: Record<string, Block<ChallengeNode['challenge'][]>>;
 }
 
-interface GeneratedCurriculumProps {
+export interface GeneratedCurriculumProps {
   intro: string[];
   blocks: Record<string, Block<Record<string, unknown>>>;
 }
@@ -71,6 +73,9 @@ export function buildExtCurriculumData(
     __dirname,
     '../../../client/i18n/locales/english/intro.json'
   );
+  const intros = JSON.parse(
+    readFileSync(blockIntroPath, 'utf-8')
+  ) as SuperBlockIntro;
 
   mkdirSync(dataPath, { recursive: true });
 
@@ -85,7 +90,7 @@ export function buildExtCurriculumData(
     writeToFile('available-superblocks', {
       superblocks: orderedSuperBlockInfo.map(x => ({
         ...x,
-        title: getSuperBlockTitle(x.dashedName)
+        title: intros[x.dashedName].title
       }))
     });
 
@@ -96,7 +101,7 @@ export function buildExtCurriculumData(
       if (blockNames.length === 0) continue;
 
       superBlock[superBlockKey] = <GeneratedCurriculumProps>{};
-      superBlock[superBlockKey].intro = getSuperBlockDescription(superBlockKey);
+      superBlock[superBlockKey].intro = intros[superBlockKey]['intro'];
       superBlock[superBlockKey].blocks = {};
 
       for (const blockName of blockNames) {
@@ -105,7 +110,7 @@ export function buildExtCurriculumData(
         >{};
 
         superBlock[superBlockKey]['blocks'][blockName]['desc'] =
-          getBlockDescription(superBlockKey, blockName);
+          intros[superBlockKey]['blocks'][blockName]['intro'];
 
         superBlock[superBlockKey]['blocks'][blockName]['challenges'] =
           curriculum[superBlockKey]['blocks'][blockName]['meta'];
@@ -129,30 +134,6 @@ export function buildExtCurriculumData(
     const filePath = `${dataPath}/${ver}/${fileName}.json`;
     mkdirSync(dirname(filePath), { recursive: true });
     writeFileSync(filePath, JSON.stringify(data, null, 2));
-  }
-
-  function getBlockDescription(
-    superBlockKeys: SuperBlocks,
-    blockKey: string
-  ): string[] {
-    const intros = JSON.parse(readFileSync(blockIntroPath, 'utf-8')) as Intro;
-
-    return intros[superBlockKeys]['blocks'][blockKey]['intro'];
-  }
-
-  function getSuperBlockDescription(superBlockKey: SuperBlocks): string[] {
-    const superBlockIntro = JSON.parse(
-      readFileSync(blockIntroPath, 'utf-8')
-    ) as Intro;
-    return superBlockIntro[superBlockKey]['intro'];
-  }
-
-  function getSuperBlockTitle(superBlock: SuperBlocks): string {
-    const superBlocks = JSON.parse(
-      readFileSync(blockIntroPath, 'utf-8')
-    ) as Intro;
-
-    return superBlocks[superBlock].title;
   }
 
   function getSubmitTypes() {

--- a/tools/scripts/build/build-external-curricula-data.ts
+++ b/tools/scripts/build/build-external-curricula-data.ts
@@ -4,7 +4,7 @@ import { submitTypes } from '../../../shared/config/challenge-types';
 import { type ChallengeNode } from '../../../client/src/redux/prop-types';
 import { SuperBlocks } from '../../../shared/config/curriculum';
 
-export type SuperBlockIntro = {
+export type CurriculumIntros = {
   [keyValue in SuperBlocks]: {
     title: string;
     intro: string[];
@@ -75,7 +75,7 @@ export function buildExtCurriculumData(
   );
   const intros = JSON.parse(
     readFileSync(blockIntroPath, 'utf-8')
-  ) as SuperBlockIntro;
+  ) as CurriculumIntros;
 
   mkdirSync(dataPath, { recursive: true });
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR:
- Updates the external curricula build script to simplify the logic of getting the intro text of blocks and super blocks.
- Adds a test case to ensure we have the correct intro text in the generated data.
- Is related to #59533

<!-- Feel free to add any additional description of changes below this line -->
