### PR TITLE
fix(curriculum): TOP block name

### DIFF
--- a/curriculum/challenges/_meta/top-learn-arrays-and-loops/meta.json
+++ b/curriculum/challenges/_meta/top-learn-arrays-and-loops/meta.json
@@ -1,5 +1,5 @@
 {
-  "name": "TOP Learn Arrays and Loops",
+  "name": "Learn Arrays and Loops",
   "isUpcomingChange": false,
   "dashedName": "top-learn-arrays-and-loops",
   "helpCategory": "Odin",


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

We use `intro.json` as the source of truth for block names (ref: #54955) so I'm updating the `meta.json` file to match that.

This change does not affect the web version as we are already using `intro.json` strings for intro text. However, it does affect mobile as we are using `meta.json` strings instead. I'll fix the string source separately (I'll probably add it to v3 as we are quite close to get this version ready).

<details>
  <summary>Screenshot of the block name currently on mobile</summary>

  
![Screenshot_20250414-171432](https://github.com/user-attachments/assets/4fdce0a9-87a1-4f34-a195-50b57377b2d7)

</details>

<!-- Feel free to add any additional description of changes below this line -->
