### PR TITLE
fix(cirriculum): missing word in fill in the blank answer

### DIFF
--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-express-decisions-based-on-comparisons/67d7e7c498fa77541d1ef239.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-express-decisions-based-on-comparisons/67d7e7c498fa77541d1ef239.md
@@ -47,7 +47,7 @@ This two-word phrase refers to difficulties in sharing or understanding informat
 
 `On the one hand, working remotely is convenient.` – This sentence presents the benefit of remote work.  
 
-`cause communication problems` means to create difficulties in how people exchange information. For example:  
+`Cause communication problems` means to create difficulties in how people exchange information. For example:  
 
 `A weak internet connection can cause communication problems during online meetings.` – This means a poor connection can make it harder to communicate effectively.  
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-express-decisions-based-on-comparisons/67d7e7c498fa77541d1ef239.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-express-decisions-based-on-comparisons/67d7e7c498fa77541d1ef239.md
@@ -27,7 +27,7 @@ This four-word phrase is used to introduce one side of an argument or comparison
 
 ---
 
-`cause`
+`also cause`
 
 ### --feedback--
 
@@ -47,7 +47,7 @@ This two-word phrase refers to difficulties in sharing or understanding informat
 
 `On the one hand, working remotely is convenient.` – This sentence presents the benefit of remote work.  
 
-`Cause communication problems` means to create difficulties in how people exchange information. For example:  
+`Also cause communication problems` means to create difficulties in how people exchange information. For example:  
 
 `A weak internet connection can cause communication problems during online meetings.` – This means a poor connection can make it harder to communicate effectively.  
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-express-decisions-based-on-comparisons/67d7e7c498fa77541d1ef239.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-express-decisions-based-on-comparisons/67d7e7c498fa77541d1ef239.md
@@ -15,7 +15,7 @@ Listen to the audio and complete the sentence below.
 
 ## --sentence--
 
-`I see. So, BLANK, outsourcing is faster, but it could BLANK BLANK.`
+`I see. So, BLANK, outsourcing is faster, but it could also BLANK BLANK.`
 
 ## --blanks--
 
@@ -27,7 +27,7 @@ This four-word phrase is used to introduce one side of an argument or comparison
 
 ---
 
-`also cause`
+`cause`
 
 ### --feedback--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-express-decisions-based-on-comparisons/67d7e7c498fa77541d1ef239.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-express-decisions-based-on-comparisons/67d7e7c498fa77541d1ef239.md
@@ -5,7 +5,7 @@ challengeType: 22
 dashedName: task-124
 ---
 
-<!-- (Audio) Brian: I see. So, on the one hand, outsourcing is faster, but it could cause communication problems. -->
+<!-- (Audio) Brian: I see. So, on the one hand, outsourcing is faster, but it could also cause communication problems. -->
 
 # --instructions--
 
@@ -47,7 +47,7 @@ This two-word phrase refers to difficulties in sharing or understanding informat
 
 `On the one hand, working remotely is convenient.` – This sentence presents the benefit of remote work.  
 
-`Also cause communication problems` means to create difficulties in how people exchange information. For example:  
+`cause communication problems` means to create difficulties in how people exchange information. For example:  
 
 `A weak internet connection can cause communication problems during online meetings.` – This means a poor connection can make it harder to communicate effectively.  
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ x] My pull request targets the `main` branch of freeCodeCamp.
- [x ] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #59705 

<!-- Feel free to add any additional description of changes below this line -->

I have modified the file 67d7e7c498fa77541d1ef239.md so that when user enter 'also cause', "correct answer' pop up appears.