### PR TITLE
fix(client): use translation strings for alt text

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -127,16 +127,19 @@
     "testimonials": {
       "heading": "Here is what our alumni say about freeCodeCamp:",
       "shawn": {
+        "img-alt": "Shawn Wang, a young-looking Asian man, smiling for a selfie with a snow-capped mountain in the background.",
         "location": "<strong>Shawn Wang</strong> in Singapore",
         "occupation": "Software Engineer at <strong>Amazon</strong>",
         "testimony": "\"It's scary to change careers. I only gained confidence that I could code by working through the hundreds of hours of free lessons on freeCodeCamp. Within a year I had a six-figure job as a Software Engineer. <strong>freeCodeCamp changed my life.</strong>\""
       },
       "sarah": {
+        "img-alt": "Sarah Chima, a young-looking Black woman, smiling for the camera while sitting in a chair.",
         "location": "<strong>Sarah Chima</strong> in Nigeria",
         "occupation": "Software Engineer at <strong>ChatDesk</strong>",
         "testimony": "\"<strong>freeCodeCamp was the gateway to my career</strong> as a software developer. The well-structured curriculum took my coding knowledge from a total beginner level to a very confident level. It was everything I needed to land my first dev job at an amazing company.\""
       },
       "emma": {
+        "img-alt": "Emma Bostian, a young-looking White woman, smiling for the camera in front of green foliage.",
         "location": "<strong>Emma Bostian</strong> in Sweden",
         "occupation": "Software Engineer at <strong>Spotify</strong>",
         "testimony": "\"I've always struggled with learning JavaScript. I've taken many courses but freeCodeCamp's course was the one which stuck. Studying JavaScript as well as data structures and algorithms on <strong>freeCodeCamp gave me the skills</strong> and confidence I needed to land my dream job as a software engineer at Spotify.\""

--- a/client/src/components/landing/components/testimonials.tsx
+++ b/client/src/components/landing/components/testimonials.tsx
@@ -28,7 +28,7 @@ const Testimonials = (): JSX.Element => {
             data-playwright-test-label='testimonials-endorser-image-container'
           >
             <LazyImage
-              alt='Shawn Wang, a young-looking Asian man, smiling for a selfie with a snow-capped mountain in the background.'
+              alt={t('landing.testimonials.shawn.img-alt')}
               className='testimonial-image'
               src={shawnImg}
             />
@@ -37,7 +37,6 @@ const Testimonials = (): JSX.Element => {
           <div className='testimonials-footer'>
             <div className='testimonial-meta'>
               <h3 data-playwright-test-label='testimonials-endorser-location'>
-                {' '}
                 <Trans>landing.testimonials.shawn.location</Trans>
               </h3>
               <p data-playwright-test-label='testimonials-endorser-occupation'>
@@ -63,7 +62,7 @@ const Testimonials = (): JSX.Element => {
             data-playwright-test-label='testimonials-endorser-image-container'
           >
             <LazyImage
-              alt='Sarah Chima, a young-looking Black woman, smiling for the camera while sitting in a chair.'
+              alt={t('landing.testimonials.sarah.img-alt')}
               className='testimonial-image'
               src={sarahImg}
             />
@@ -72,7 +71,6 @@ const Testimonials = (): JSX.Element => {
           <div className='testimonials-footer'>
             <div className='testimonial-meta'>
               <h3 data-playwright-test-label='testimonials-endorser-location'>
-                {' '}
                 <Trans>landing.testimonials.sarah.location</Trans>
               </h3>
               <p data-playwright-test-label='testimonials-endorser-occupation'>
@@ -98,7 +96,7 @@ const Testimonials = (): JSX.Element => {
             data-playwright-test-label='testimonials-endorser-image-container'
           >
             <LazyImage
-              alt='Emma Bostian, a young-looking White woman, smiling for the camera in front of green foliage.'
+              alt={t('landing.testimonials.emma.img-alt')}
               className='testimonial-image'
               src={emmaImg}
             />
@@ -107,7 +105,6 @@ const Testimonials = (): JSX.Element => {
           <div className='testimonials-footer'>
             <div className='testimonial-meta'>
               <h3 data-playwright-test-label='testimonials-endorser-location'>
-                {' '}
                 <Trans>landing.testimonials.emma.location</Trans>
               </h3>
               <p data-playwright-test-label='testimonials-endorser-occupation'>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Uses translation strings for the alt text of some images on the landing page.

<!-- Feel free to add any additional description of changes below this line -->
