### PR TITLE
fix(curriculum): use base64 image in mock fetch data

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641da3c6b6fbd742bff6ee40.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641da3c6b6fbd742bff6ee40.md
@@ -24,7 +24,7 @@ Make a `GET` request to this URL: `"https://cdn.freecodecamp.org/curriculum/news
 # --before-all--
 
 ```js
-window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'http://not-a-real-url.nowhere/no-image.jpg', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
+window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
 ```
 
 # --hints--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641da42481d90c4314c99e94.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641da42481d90c4314c99e94.md
@@ -25,7 +25,7 @@ Again, don't terminate the code with a semicolon yet.
 # --before-all--
 
 ```js
-window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'http://not-a-real-url.nowhere/no-image.jpg', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
+window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
 ```
 
 # --hints--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641da465273051435d332b15.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641da465273051435d332b15.md
@@ -14,7 +14,7 @@ Remove `console.log(res)` and implicitly return `res.json()` instead.
 # --before-all--
 
 ```js
-window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'http://not-a-real-url.nowhere/no-image.jpg', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
+window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
 ```
 
 # --hints--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641da4b16937be43ba24c63d.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641da4b16937be43ba24c63d.md
@@ -15,7 +15,7 @@ Chain another `.then()` to the existing `.then()` method. This time, pass in `da
 # --before-all--
 
 ```js
-window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'http://not-a-real-url.nowhere/no-image.jpg', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
+window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
 ```
 
 # --hints--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641da51a9810e74411262fcc.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641da51a9810e74411262fcc.md
@@ -16,7 +16,7 @@ Chain `.catch()` to the last `.then()`. Pass in a callback function with `err` a
 # --before-all--
 
 ```js
-window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'http://not-a-real-url.nowhere/no-image.jpg', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
+window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
 ```
 
 # --hints--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641da5462576784453146ec2.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641da5462576784453146ec2.md
@@ -16,7 +16,7 @@ Use `let` to create 2 variables named `startingIndex` and `endingIndex`, and ass
 # --before-all--
 
 ```js
-window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'http://not-a-real-url.nowhere/no-image.jpg', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
+window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
 ```
 
 # --hints--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641da5abaac81844a54adb03.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641da5abaac81844a54adb03.md
@@ -14,7 +14,7 @@ Create an empty arrow function named `displayAuthors` that takes `authors` as a 
 # --before-all--
 
 ```js
-window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'http://not-a-real-url.nowhere/no-image.jpg', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
+window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
 ```
 
 # --hints--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641da5dd6cd6db44f58b7787.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641da5dd6cd6db44f58b7787.md
@@ -12,7 +12,7 @@ Inside your `displayAuthors` function, chain `.forEach()` to `authors`.
 # --before-all--
 
 ```js
-window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'http://not-a-real-url.nowhere/no-image.jpg', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
+window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
 ```
 
 # --hints--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641da615af82bf454215a992.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641da615af82bf454215a992.md
@@ -14,7 +14,7 @@ For the second parameter, pass in `index`. This will represent the position of e
 # --before-all--
 
 ```js
-window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'http://not-a-real-url.nowhere/no-image.jpg', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
+window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
 ```
 
 # --hints--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641da6570acf7545931ce477.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641da6570acf7545931ce477.md
@@ -15,7 +15,7 @@ Inside your callback function, use the compound assignment operator to append an
 # --before-all--
 
 ```js
-window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'http://not-a-real-url.nowhere/no-image.jpg', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
+window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
 ```
 
 # --hints--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641da6dcb6e4c9463d54c75b.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641da6dcb6e4c9463d54c75b.md
@@ -14,7 +14,7 @@ Also, add a `class` of `"user-card"` to the `div`.
 # --before-all--
 
 ```js
-window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'http://not-a-real-url.nowhere/no-image.jpg', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
+window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
 ```
 
 # --hints--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641da7071d0d45467cd59977.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641da7071d0d45467cd59977.md
@@ -15,7 +15,7 @@ Create an `h2` tag with the `class` `"author-name"`. Then, interpolate `author` 
 # --before-all--
 
 ```js
-window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'http://not-a-real-url.nowhere/no-image.jpg', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
+window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
 ```
 
 # --hints--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641da73b09e7f046c758e0ed.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641da73b09e7f046c758e0ed.md
@@ -14,7 +14,7 @@ First, remove your `console.log()` statement. Then, assign `data` to the `author
 # --before-all--
 
 ```js
-window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'http://not-a-real-url.nowhere/no-image.jpg', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
+window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
 ```
 
 # --hints-- 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641da791d0c34a472b8d15b6.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641da791d0c34a472b8d15b6.md
@@ -14,7 +14,7 @@ Inside your `console.log()` statement, add the text `"Author Data Array:"` as th
 # --before-all--
 
 ```js
-window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'http://not-a-real-url.nowhere/no-image.jpg', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
+window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
 ```
 
 # --hints--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641da7bfbc7f0f477438ad8a.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641da7bfbc7f0f477438ad8a.md
@@ -14,7 +14,7 @@ First, remove the console log statement showing `authorDataArr`. Then, call the 
 # --before-all--
 
 ```js
-window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'http://not-a-real-url.nowhere/no-image.jpg', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
+window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
 ```
 
 # --hints--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641da803d9892447d059804e.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641da803d9892447d059804e.md
@@ -12,13 +12,13 @@ Now create an image tag and give it the `class` `"user-img"`. Use string interpo
 # --before-all--
 
 ```js
-window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'http://not-a-real-url.nowhere/no-image.jpg', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
+window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
 ```    
 
 # --before-all--
 
 ```js
-window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'http://not-a-real-url.nowhere/no-image.jpg', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
+window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
 ```
 
 # --hints--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641da836581c254815f785fe.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641da836581c254815f785fe.md
@@ -14,13 +14,13 @@ Add a paragraph element with the `class` `"bio"`, then interpolate `bio` inside 
 # --before-all--
 
 ```js
-window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'http://not-a-real-url.nowhere/no-image.jpg', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
+window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
 ```
 
 # --before-all--
 
 ```js
-window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'http://not-a-real-url.nowhere/no-image.jpg', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
+window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
 ```
 
 # --hints--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641da86294fd9f485d3c2bf0.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641da86294fd9f485d3c2bf0.md
@@ -14,13 +14,13 @@ Add an anchor element with the `class` `"author-link"`, interpolate `url` as the
 # --before-all--
 
 ```js
-window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'http://not-a-real-url.nowhere/no-image.jpg', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
+window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
 ```
 
 # --before-all--
 
 ```js
-window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'http://not-a-real-url.nowhere/no-image.jpg', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
+window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
 ```
 
 # --hints--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641da895fb7ec648a5bdf19c.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641da895fb7ec648a5bdf19c.md
@@ -14,7 +14,7 @@ Create a `fetchMoreAuthors` function with the arrow function syntax. Don't put a
 # --before-all--
 
 ```js
-window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'http://not-a-real-url.nowhere/no-image.jpg', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
+window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
 ```
 
 # --hints--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641da8db2a036048ebe6999e.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641da8db2a036048ebe6999e.md
@@ -12,7 +12,7 @@ Inside the `fetchMoreAuthors` function, set the `startingIndex` and `endingIndex
 # --before-all--
 
 ```js
-window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'http://not-a-real-url.nowhere/no-image.jpg', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
+window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
 ```
 
 # --hints--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641da97c987a514959ada414.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641da97c987a514959ada414.md
@@ -14,7 +14,7 @@ If you click the `Load More Authors` button after calling the function, it won't
 # --before-all--
 
 ```js
-window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'http://not-a-real-url.nowhere/no-image.jpg', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
+window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
 ```
 
 # --hints--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641da9aceb788e49a73ebcc9.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641da9aceb788e49a73ebcc9.md
@@ -16,7 +16,7 @@ After that, when you click the button you should see 8 more authors.
 # --before-all--
 
 ```js
-window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'http://not-a-real-url.nowhere/no-image.jpg', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
+window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
 ```
 
 # --hints--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641da9ea9b847a49fe6ee9b6.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641da9ea9b847a49fe6ee9b6.md
@@ -16,7 +16,7 @@ Inside the `fetchMoreAuthors` function, write an `if` statement and set the cond
 # --before-all--
 
 ```js
-window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'http://not-a-real-url.nowhere/no-image.jpg', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
+window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
 ```
 
 # --hints--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641daa5ea050f24a7cade6e6.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641daa5ea050f24a7cade6e6.md
@@ -12,7 +12,7 @@ If this condition is met, disable the button by setting its `disabled` property 
 # --before-all--
 
 ```js
-window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'http://not-a-real-url.nowhere/no-image.jpg', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
+window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
 ```
 
 # --hints--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641daa8c2c3e364ac3650b37.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641daa8c2c3e364ac3650b37.md
@@ -14,13 +14,13 @@ Add a `div` element above the author's bio and give it the `class` `"purple-divi
 # --before-all--
 
 ```js
-window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'http://not-a-real-url.nowhere/no-image.jpg', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
+window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
 ```
 
 # --before-all--
 
 ```js
-window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'http://not-a-real-url.nowhere/no-image.jpg', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
+window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
 ```
 
 # --hints--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641daabed8d0584b1150c953.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641daabed8d0584b1150c953.md
@@ -14,7 +14,7 @@ Within the paragraph element, replace `bio` with a ternary operator. For the con
 # --before-all--
 
 ```js
-window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'http://not-a-real-url.nowhere/no-image.jpg', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
+window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
 ```
 
 # --hints--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641daae5e18eae4b562633e4.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641daae5e18eae4b562633e4.md
@@ -14,7 +14,7 @@ Inside the `.catch()`, remove the `console.error()` and set the `innerHTML` of t
 # --before-all--
 
 ```js
-window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'http://not-a-real-url.nowhere/no-image.jpg', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
+window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
 ```
 
 # --hints--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641dab13c1b6f14b9828e6b1.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641dab13c1b6f14b9828e6b1.md
@@ -16,7 +16,7 @@ With that, your author page is complete!
 # --before-all--
 
 ```js
-window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'http://not-a-real-url.nowhere/no-image.jpg', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
+window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
 ```
 
 # --hints--

--- a/curriculum/challenges/english/25-front-end-development/workshop-fcc-authors-page/641da3c6b6fbd742bff6ee40.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-fcc-authors-page/641da3c6b6fbd742bff6ee40.md
@@ -20,7 +20,7 @@ Make a `GET` request to this URL: `"https://cdn.freecodecamp.org/curriculum/news
 # --before-all--
 
 ```js
-window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'http://not-a-real-url.nowhere/no-image.jpg', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
+window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
 ```
 
 # --hints--

--- a/curriculum/challenges/english/25-front-end-development/workshop-fcc-authors-page/641da42481d90c4314c99e94.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-fcc-authors-page/641da42481d90c4314c99e94.md
@@ -25,7 +25,7 @@ Again, don't terminate the code with a semicolon yet.
 # --before-all--
 
 ```js
-window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'http://not-a-real-url.nowhere/no-image.jpg', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
+window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
 ```
 
 # --hints--

--- a/curriculum/challenges/english/25-front-end-development/workshop-fcc-authors-page/641da465273051435d332b15.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-fcc-authors-page/641da465273051435d332b15.md
@@ -14,7 +14,7 @@ Remove `console.log(res)` and implicitly return `res.json()` instead.
 # --before-all--
 
 ```js
-window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'http://not-a-real-url.nowhere/no-image.jpg', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
+window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
 ```
 
 # --hints--

--- a/curriculum/challenges/english/25-front-end-development/workshop-fcc-authors-page/641da4b16937be43ba24c63d.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-fcc-authors-page/641da4b16937be43ba24c63d.md
@@ -14,7 +14,7 @@ Chain another `.then()` to the existing `.then()` method. This time, pass in `da
 # --before-all--
 
 ```js
-window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'http://not-a-real-url.nowhere/no-image.jpg', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
+window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
 ```
 
 # --hints--

--- a/curriculum/challenges/english/25-front-end-development/workshop-fcc-authors-page/641da51a9810e74411262fcc.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-fcc-authors-page/641da51a9810e74411262fcc.md
@@ -16,7 +16,7 @@ Chain `.catch()` to the last `.then()`. Pass in a callback function with `err` a
 # --before-all--
 
 ```js
-window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'http://not-a-real-url.nowhere/no-image.jpg', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
+window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
 ```
 
 # --hints--

--- a/curriculum/challenges/english/25-front-end-development/workshop-fcc-authors-page/641da5462576784453146ec2.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-fcc-authors-page/641da5462576784453146ec2.md
@@ -18,7 +18,7 @@ Then, create an `authorDataArr` variable and assign it an empty array.
 # --before-all--
 
 ```js
-window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'http://not-a-real-url.nowhere/no-image.jpg', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
+window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
 ```
 
 # --hints--

--- a/curriculum/challenges/english/25-front-end-development/workshop-fcc-authors-page/641da5abaac81844a54adb03.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-fcc-authors-page/641da5abaac81844a54adb03.md
@@ -27,7 +27,7 @@ The card should have the following structure:
 # --before-all--
 
 ```js
-window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'http://not-a-real-url.nowhere/no-image.jpg', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
+window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
 ```
 
 # --hints--

--- a/curriculum/challenges/english/25-front-end-development/workshop-fcc-authors-page/641da73b09e7f046c758e0ed.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-fcc-authors-page/641da73b09e7f046c758e0ed.md
@@ -14,7 +14,7 @@ First, remove your `console.log()` statement. Then, assign `data` to the `author
 # --before-all--
 
 ```js
-window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'http://not-a-real-url.nowhere/no-image.jpg', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
+window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
 ```
 
 # --hints-- 

--- a/curriculum/challenges/english/25-front-end-development/workshop-fcc-authors-page/641da791d0c34a472b8d15b6.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-fcc-authors-page/641da791d0c34a472b8d15b6.md
@@ -14,7 +14,7 @@ Inside your `console.log()` statement, add the text `"Author Data Array:"` as th
 # --before-all--
 
 ```js
-window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'http://not-a-real-url.nowhere/no-image.jpg', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
+window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
 ```
 
 # --hints--

--- a/curriculum/challenges/english/25-front-end-development/workshop-fcc-authors-page/641da7bfbc7f0f477438ad8a.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-fcc-authors-page/641da7bfbc7f0f477438ad8a.md
@@ -14,7 +14,7 @@ First, remove the console log statement showing `authorDataArr`. Then, call the 
 # --before-all--
 
 ```js
-window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'http://not-a-real-url.nowhere/no-image.jpg', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
+window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
 ```
 
 # --hints--

--- a/curriculum/challenges/english/25-front-end-development/workshop-fcc-authors-page/641da803d9892447d059804e.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-fcc-authors-page/641da803d9892447d059804e.md
@@ -12,7 +12,7 @@ Now create an image tag and give it the `class` `"user-img"`. Use string interpo
 # --before-all--
 
 ```js
-window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'http://not-a-real-url.nowhere/no-image.jpg', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
+window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
 ```    
 
 # --hints--
@@ -44,7 +44,7 @@ assert.include(document.querySelector('img')?.className, "user-img");
 You should set the `src` attribute of your `img` element to `${image}`.
 
 ```js
-assert.equal(document.querySelector('img')?.getAttribute('src'), 'http://not-a-real-url.nowhere/no-image.jpg');
+assert.equal(document.querySelector('img')?.getAttribute('src'), 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==');
 ```
 
 You should set the `alt` attribute of your `img` element to `${author} avatar`.

--- a/curriculum/challenges/english/25-front-end-development/workshop-fcc-authors-page/641da836581c254815f785fe.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-fcc-authors-page/641da836581c254815f785fe.md
@@ -14,7 +14,7 @@ Add a paragraph element with the `class` `"bio"`, then interpolate `bio` inside 
 # --before-all--
 
 ```js
-window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'http://not-a-real-url.nowhere/no-image.jpg', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
+window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
 ```    
 
 # --hints--

--- a/curriculum/challenges/english/25-front-end-development/workshop-fcc-authors-page/641da86294fd9f485d3c2bf0.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-fcc-authors-page/641da86294fd9f485d3c2bf0.md
@@ -14,7 +14,7 @@ Add an anchor element with the `class` `"author-link"`, interpolate `url` as the
 # --before-all--
 
 ```js
-window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'http://not-a-real-url.nowhere/no-image.jpg', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
+window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
 ```
 
 # --hints--

--- a/curriculum/challenges/english/25-front-end-development/workshop-fcc-authors-page/641da895fb7ec648a5bdf19c.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-fcc-authors-page/641da895fb7ec648a5bdf19c.md
@@ -14,7 +14,7 @@ Create a `fetchMoreAuthors` function with the arrow function syntax. Don't put a
 # --before-all--
 
 ```js
-window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'http://not-a-real-url.nowhere/no-image.jpg', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
+window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
 ```    
 
 # --hints--

--- a/curriculum/challenges/english/25-front-end-development/workshop-fcc-authors-page/641da8db2a036048ebe6999e.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-fcc-authors-page/641da8db2a036048ebe6999e.md
@@ -12,7 +12,7 @@ Inside the `fetchMoreAuthors` function, set the `startingIndex` and `endingIndex
 # --before-all--
 
 ```js
-window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'http://not-a-real-url.nowhere/no-image.jpg', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
+window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
 ```
 
 # --hints--

--- a/curriculum/challenges/english/25-front-end-development/workshop-fcc-authors-page/641da97c987a514959ada414.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-fcc-authors-page/641da97c987a514959ada414.md
@@ -14,7 +14,7 @@ If you click the `Load More Authors` button after calling the function, it won't
 # --before-all--
 
 ```js
-window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'http://not-a-real-url.nowhere/no-image.jpg', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
+window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
 ```
 
 # --hints--

--- a/curriculum/challenges/english/25-front-end-development/workshop-fcc-authors-page/641da9aceb788e49a73ebcc9.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-fcc-authors-page/641da9aceb788e49a73ebcc9.md
@@ -16,7 +16,7 @@ After that, when you click the button you should see 8 more authors.
 # --before-all--
 
 ```js
-window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'http://not-a-real-url.nowhere/no-image.jpg', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
+window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
 ```
 
 # --hints--

--- a/curriculum/challenges/english/25-front-end-development/workshop-fcc-authors-page/641da9ea9b847a49fe6ee9b6.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-fcc-authors-page/641da9ea9b847a49fe6ee9b6.md
@@ -16,7 +16,7 @@ Inside the `fetchMoreAuthors` function, write an `if` statement and set the cond
 # --before-all--
 
 ```js
-window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'http://not-a-real-url.nowhere/no-image.jpg', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
+window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
 ```
 
 # --hints--

--- a/curriculum/challenges/english/25-front-end-development/workshop-fcc-authors-page/641daa5ea050f24a7cade6e6.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-fcc-authors-page/641daa5ea050f24a7cade6e6.md
@@ -12,7 +12,7 @@ If this condition is met, disable the button by setting its `disabled` property 
 # --before-all--
 
 ```js
-window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'http://not-a-real-url.nowhere/no-image.jpg', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
+window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
 ```
 
 # --hints--

--- a/curriculum/challenges/english/25-front-end-development/workshop-fcc-authors-page/641daa8c2c3e364ac3650b37.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-fcc-authors-page/641daa8c2c3e364ac3650b37.md
@@ -14,7 +14,7 @@ Add a `div` element above the author's bio and give it the `class` `"purple-divi
 # --before-all--
 
 ```js
-window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'http://not-a-real-url.nowhere/no-image.jpg', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
+window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
 ```
 
 # --hints--

--- a/curriculum/challenges/english/25-front-end-development/workshop-fcc-authors-page/641daabed8d0584b1150c953.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-fcc-authors-page/641daabed8d0584b1150c953.md
@@ -14,7 +14,7 @@ Within the paragraph element, replace `bio` with a ternary operator. For the con
 # --before-all--
 
 ```js
-window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'http://not-a-real-url.nowhere/no-image.jpg', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
+window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
 ```
 
 # --hints--

--- a/curriculum/challenges/english/25-front-end-development/workshop-fcc-authors-page/641daae5e18eae4b562633e4.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-fcc-authors-page/641daae5e18eae4b562633e4.md
@@ -14,7 +14,7 @@ Inside the `.catch()`, remove the `console.error()` and set the `innerHTML` of t
 # --before-all--
 
 ```js
-window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'http://not-a-real-url.nowhere/no-image.jpg', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
+window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
 ```
 
 # --hints--

--- a/curriculum/challenges/english/25-front-end-development/workshop-fcc-authors-page/641dab13c1b6f14b9828e6b1.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-fcc-authors-page/641dab13c1b6f14b9828e6b1.md
@@ -16,7 +16,7 @@ With that, your author page is complete!
 # --before-all--
 
 ```js
-window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'http://not-a-real-url.nowhere/no-image.jpg', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
+window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
 ```
 
 # --hints--


### PR DESCRIPTION
A couple PR's added some dummy data in a mock fetch for some curriculum tests (https://github.com/freeCodeCamp/freeCodeCamp/pull/59001 & https://github.com/freeCodeCamp/freeCodeCamp/pull/59099) including a fake URL to an image. In the challenges, that image is trying to be loaded when you run the tests. Using a base 64 string for the image makes it so browsers don't try to fetch the image.

To test, go to [step 18 of the authors page on production](https://freecodecamp.org/learn/javascript-algorithms-and-data-structures-v8/learn-fetch-and-promises-by-building-an-fcc-authors-page/step-18), open the network tab in the dev tools and run the tests. You will see a request to `http://not-a-real-url.nowhere/no-image.jpg`. This seemed to be causing an issue for at least one user - see [conversation on the forum](https://forum.freecodecamp.org/t/learn-fetch-and-promises-by-building-an-fcc-authors-page-step-17/742873/19)

With this PR, you will still see a request to `data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==`, but it's handled by the browser and doesn't actually try to get the image from an external resource - so it shouldn't cause any errors like that.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
