### PR TITLE
refactor: use canSaveToDB function more

### DIFF
--- a/client/src/templates/Challenges/redux/completion-epic.js
+++ b/client/src/templates/Challenges/redux/completion-epic.js
@@ -16,6 +16,7 @@ import {
   msTrophyVerified
 } from '../../../utils/error-messages';
 import {
+  canSaveToDB,
   challengeTypes,
   submitTypes
 } from '../../../../../shared/config/challenge-types';
@@ -116,8 +117,7 @@ function submitModern(type, state) {
       let body;
       if (
         block === 'javascript-algorithms-and-data-structures-projects' ||
-        challengeType === challengeTypes.multifileCertProject ||
-        challengeType === challengeTypes.multifilePythonCertProject
+        canSaveToDB(challengeType)
       ) {
         body = standardizeRequestBody({ id, challengeType, challengeFiles });
       } else {

--- a/client/src/templates/Challenges/redux/execute-challenge-saga.js
+++ b/client/src/templates/Challenges/redux/execute-challenge-saga.js
@@ -14,7 +14,10 @@ import {
   takeLatest
 } from 'redux-saga/effects';
 
-import { challengeTypes } from '../../../../../shared/config/challenge-types';
+import {
+  canSaveToDB,
+  challengeTypes
+} from '../../../../../shared/config/challenge-types';
 import { createFlashMessage } from '../../../components/Flash/redux';
 import { FlashMessages } from '../../../components/Flash/redux/flash-messages';
 import {
@@ -70,11 +73,8 @@ function* executeCancellableChallengeSaga(payload) {
   const { challengeType, id } = yield select(challengeMetaSelector);
   const { challengeFiles } = yield select(challengeDataSelector);
 
-  // if multifileCertProject, see if body/code size is submittable
-  if (
-    challengeType === challengeTypes.multifileCertProject ||
-    challengeType === challengeTypes.multifilePythonCertProject
-  ) {
+  // if canSaveToDB, see if body/code size is submittable
+  if (canSaveToDB(challengeType)) {
     const body = standardizeRequestBody({ id, challengeFiles, challengeType });
     const bodySizeInBytes = getStringSizeInBytes(body);
 


### PR DESCRIPTION
Minor refactor - use the existing `canSaveToDB` function in a few places that we can. There's a few places in the API we might be able to use this as well, but I left those for now since they are checking the challenge ID and not the type.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
