### PR TITLE
feat(challenge types): add python lab challenge type

### DIFF
--- a/client/src/templates/Challenges/classic/desktop-layout.tsx
+++ b/client/src/templates/Challenges/classic/desktop-layout.tsx
@@ -231,7 +231,8 @@ const DesktopLayout = (props: DesktopLayoutProps): JSX.Element => {
     challengeType === challengeTypes.multifileCertProject ||
     challengeType === challengeTypes.multifilePythonCertProject ||
     challengeType === challengeTypes.lab ||
-    challengeType === challengeTypes.jsLab;
+    challengeType === challengeTypes.jsLab ||
+    challengeType === challengeTypes.pyLab;
   const isProjectStyle = projectBasedChallenge || isMultifileProject;
   const displayPreviewPane = hasPreview && showPreviewPane;
   const displayPreviewPortal = hasPreview && showPreviewPortal;

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -285,7 +285,8 @@ const Editor = (props: EditorProps): JSX.Element => {
     guides: {
       highlightActiveIndentation:
         props.challengeType === challengeTypes.python ||
-        props.challengeType === challengeTypes.multifilePythonCertProject
+        props.challengeType === challengeTypes.multifilePythonCertProject ||
+        props.challengeType === challengeTypes.pyLab
     },
     minimap: {
       enabled: false
@@ -307,7 +308,8 @@ const Editor = (props: EditorProps): JSX.Element => {
     },
     tabSize:
       props.challengeType !== challengeTypes.python &&
-      props.challengeType !== challengeTypes.multifilePythonCertProject
+      props.challengeType !== challengeTypes.multifilePythonCertProject &&
+      props.challengeType !== challengeTypes.pyLab
         ? 2
         : 4,
     dragAndDrop: true,

--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -172,7 +172,8 @@ const StepPreview = ({
   dimensions?: { width: number; height: number };
 }) => {
   return challengeType === challengeTypes.python ||
-    challengeType === challengeTypes.multifilePythonCertProject ? (
+    challengeType === challengeTypes.multifilePythonCertProject ||
+    challengeType === challengeTypes.pyLab ? (
     <XtermTerminal dimensions={dimensions} xtermFitRef={xtermFitRef} />
   ) : (
     <Preview disableIframe={disableIframe} previewMounted={previewMounted} />

--- a/client/src/templates/Challenges/redux/execute-challenge-saga.js
+++ b/client/src/templates/Challenges/redux/execute-challenge-saga.js
@@ -291,7 +291,8 @@ export function* previewChallengeSaga(action) {
         if (
           challengeData.challengeType === challengeTypes.python ||
           challengeData.challengeType ===
-            challengeTypes.multifilePythonCertProject
+            challengeTypes.multifilePythonCertProject ||
+          challengeData.challengeType === challengeTypes.pyLab
         ) {
           yield updatePython(challengeData);
         } else {
@@ -324,7 +325,8 @@ function* updatePreviewSaga(action) {
   const challengeData = yield select(challengeDataSelector);
   if (
     challengeData.challengeType === challengeTypes.python ||
-    challengeData.challengeType === challengeTypes.multifilePythonCertProject
+    challengeData.challengeType === challengeTypes.multifilePythonCertProject ||
+    challengeData.challengeType === challengeTypes.pyLab
   ) {
     yield updatePython(challengeData);
   } else {

--- a/client/src/templates/Challenges/redux/selectors.js
+++ b/client/src/templates/Challenges/redux/selectors.js
@@ -90,7 +90,8 @@ export const challengeDataSelector = state => {
     challengeType === challengeTypes.lab ||
     challengeType === challengeTypes.js ||
     challengeType === challengeTypes.jsProject ||
-    challengeType === challengeTypes.jsLab
+    challengeType === challengeTypes.jsLab ||
+    challengeType === challengeTypes.pyLab
   ) {
     const { required = [], template = '' } = challengeMetaSelector(state);
     challengeData = {

--- a/client/src/templates/Challenges/utils/build.ts
+++ b/client/src/templates/Challenges/utils/build.ts
@@ -104,7 +104,8 @@ export const buildFunctions = {
   [challengeTypes.python]: buildPythonChallenge,
   [challengeTypes.multifilePythonCertProject]: buildPythonChallenge,
   [challengeTypes.lab]: buildDOMChallenge,
-  [challengeTypes.jsLab]: buildJSChallenge
+  [challengeTypes.jsLab]: buildJSChallenge,
+  [challengeTypes.pyLab]: buildPythonChallenge
 };
 
 export function canBuildChallenge(challengeData: BuildChallengeData): boolean {
@@ -132,7 +133,8 @@ const testRunners = {
   [challengeTypes.python]: getPyTestRunner,
   [challengeTypes.multifileCertProject]: getDOMTestRunner,
   [challengeTypes.multifilePythonCertProject]: getPyTestRunner,
-  [challengeTypes.lab]: getDOMTestRunner
+  [challengeTypes.lab]: getDOMTestRunner,
+  [challengeTypes.pyLab]: getPyTestRunner
 };
 
 export function getTestRunner(
@@ -400,7 +402,8 @@ export function challengeHasPreview({
     challengeType === challengeTypes.multifileCertProject ||
     challengeType === challengeTypes.multifilePythonCertProject ||
     challengeType === challengeTypes.python ||
-    challengeType === challengeTypes.lab
+    challengeType === challengeTypes.lab ||
+    challengeType === challengeTypes.pyLab
   );
 }
 

--- a/client/src/utils/curriculum-layout.ts
+++ b/client/src/utils/curriculum-layout.ts
@@ -13,7 +13,8 @@ const projectBasedChallengeTypes = [
   challengeTypes.codeAllyPractice,
   challengeTypes.multifilePythonCertProject,
   challengeTypes.lab,
-  challengeTypes.jsLab
+  challengeTypes.jsLab,
+  challengeTypes.pyLab
 ];
 
 export const isProjectBased = (

--- a/shared/config/challenge-types.ts
+++ b/shared/config/challenge-types.ts
@@ -26,6 +26,7 @@ const multifilePythonCertProject = 23;
 const generic = 24;
 const lab = 25;
 const jsLab = 26;
+const pyLab = 27;
 
 export const challengeTypes = {
   html,
@@ -55,7 +56,8 @@ export const challengeTypes = {
   multifilePythonCertProject,
   generic,
   lab,
-  jsLab
+  jsLab,
+  pyLab
 };
 
 export const hasNoSolution = (challengeType: number): boolean => {
@@ -111,7 +113,8 @@ export const viewTypes = {
   [multifilePythonCertProject]: 'classic',
   [generic]: 'generic',
   [lab]: 'classic',
-  [jsLab]: 'classic'
+  [jsLab]: 'classic',
+  [pyLab]: 'classic'
 };
 
 // determine the type of submit function to use for the challenge on completion
@@ -145,7 +148,8 @@ export const submitTypes = {
   [multifilePythonCertProject]: 'tests',
   [generic]: 'tests',
   [lab]: 'tests',
-  [jsLab]: 'tests'
+  [jsLab]: 'tests',
+  [pyLab]: 'tests'
 };
 
 export const canSaveToDB = (challengeType: number): boolean =>


### PR DESCRIPTION
Adds a challenge type for python labs. There isn't a type that works for them - the python cert projects are close, the only difference is the buttons in the side panel - those have a button to save user code to the database, this just has the reset button. I think a new challenge type for this is fine - hopefully we can clean some of the things up in there at some point.

To test, just change one of the python cert projects, like the arithmetic formatter, to challenge type 27.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
