### PR TITLE
fix(curriculum): clarify that block-level elements start on a new line in Basic CSS review

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/review-basic-css/671a887a7e62c75e9ab1ee4a.md
+++ b/curriculum/challenges/english/25-front-end-development/review-basic-css/671a887a7e62c75e9ab1ee4a.md
@@ -122,7 +122,7 @@ ul ~ p {
 ## Inline, Block, and Inline-Block Level Elements
 
 - **Inline Level Elements**: Inline elements only take up as much width as they need and do not start on a new line. These elements flow within the content, allowing text and other inline elements to appear alongside them. Common inline elements are `span`, `anchor`, and `img` elements.
-- **Block Level Elements**: Block level elements that take up the full width available to them by default, stretching across the width of their container. Some common block-level elements are `div`, `paragraph`, and `section` elements.
+- **Block Level Elements**: Block-level elements start on a new line and take up the full width available to them by default, stretching across the width of their container. Some common block-level elements are `div`, `paragraph`, and `section` elements.
 - **Inline-Block Level Elements**: You can set an element to `inline-block` by using the `display` property. These elements behave like inline elements but can have a `width` and `height` set like block-level elements. 
 
 ## Margin and Padding


### PR DESCRIPTION
This PR updates the Basic CSS review content to clarify that block-level elements start on a new line, aligning the review text with the quiz explanation.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #59777 

<!-- Feel free to add any additional description of changes below this line -->
