### PR TITLE
fix(a11y): hide decorative images from screen readers

### DIFF
--- a/client/src/assets/icons/cap.tsx
+++ b/client/src/assets/icons/cap.tsx
@@ -9,6 +9,7 @@ function FreeIcon(
       height='60'
       viewBox='0 0 61 60'
       fill='none'
+      aria-hidden='true'
       {...props}
     >
       <path

--- a/client/src/assets/icons/community.tsx
+++ b/client/src/assets/icons/community.tsx
@@ -9,6 +9,7 @@ function CommunityIcon(
       height='60'
       viewBox='0 0 60 60'
       fill='none'
+      aria-hidden='true'
       {...props}
     >
       <path

--- a/client/src/assets/icons/curriculum.tsx
+++ b/client/src/assets/icons/curriculum.tsx
@@ -9,6 +9,7 @@ function CurriculumIcon(
       height='60'
       viewBox='0 0 60 60'
       fill='none'
+      aria-hidden='true'
       {...props}
     >
       <path

--- a/client/src/assets/icons/free.tsx
+++ b/client/src/assets/icons/free.tsx
@@ -9,6 +9,7 @@ function FreeIcon(
       height='60'
       viewBox='0 0 60 60'
       fill='none'
+      aria-hidden='true'
       {...props}
     >
       <path


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

On the landing page, we have 4 icons that are for decorative purpose. They should have `aria-hidden='true'` so that screen readers won't announce them to non-sighted users.

<details>
  <summary>Screenshot of the section (just so you know where the icons are located)</summary>
  
  <img width="1233" alt="Screenshot 2025-04-17 at 14 02 07" src="https://github.com/user-attachments/assets/a7b7bf35-aca9-49c1-a0c4-5d1a3d7df68d" />

</details>

<!-- Feel free to add any additional description of changes below this line -->
