### PR TITLE
fix(curriculum): Improved specificity of ARIA answer

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/quiz-html-accessibility/66ed9026f45ce3ece4053ebb.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-html-accessibility/66ed9026f45ce3ece4053ebb.md
@@ -184,7 +184,7 @@ This attribute is used to hide an element only to keyboard users.
 
 #### --answer--
 
-This attribute is used to hide an element from people using assistive technologies.
+This attribute is used to hide an element from assistive technologies.
 
 ### --question--
 

--- a/curriculum/challenges/english/25-front-end-development/review-html-accessibility/671a87a39b88245a579c2271.md
+++ b/curriculum/challenges/english/25-front-end-development/review-html-accessibility/671a87a39b88245a579c2271.md
@@ -72,7 +72,7 @@ There are six main categories of ARIA roles:
 <button type="button" id="search-btn">Search</button>
 ```
 
-- **`aria-hidden` attribute**: Used to hide an element from assistive technology such as screen readers. For example, this can be used to hide decorative images that do not provide any meaningful content.
+- **`aria-hidden` attribute**: Used to hide an element from assistive technologies such as screen readers. For example, this can be used to hide decorative images that do not provide any meaningful content.
 
 ```html
 <button>

--- a/curriculum/challenges/english/25-front-end-development/review-html-accessibility/671a87a39b88245a579c2271.md
+++ b/curriculum/challenges/english/25-front-end-development/review-html-accessibility/671a87a39b88245a579c2271.md
@@ -72,7 +72,7 @@ There are six main categories of ARIA roles:
 <button type="button" id="search-btn">Search</button>
 ```
 
-- **`aria-hidden` attribute**: Used to hide an element from people using assistive technology such as screen readers. For example, this can be used to hide decorative images that do not provide any meaningful content.
+- **`aria-hidden` attribute**: Used to hide an element from assistive technology such as screen readers. For example, this can be used to hide decorative images that do not provide any meaningful content.
 
 ```html
 <button>


### PR DESCRIPTION
The answer marked as correct for this should reference how ARIA attributes affect how assistive technology accesses the content.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->

`ARIA-hidden` isn't meant to hide content from the **people** using assistive technologies, it's meant to hide content from the Accessibility API, thus removing it from the **assistive technologies** themselves. This is a bit of a pedantic change, but one I think would be helpful for users new to accessibility, because it doesn't make assumptions about users. Many screen reader users have some amount of sight, so the content wouldn't be hidden from them, it would just not be read to them from via their assistive technology.

closes #59808
