### PR TITLE
fix(gha): remove workflow_run

### DIFF
--- a/.github/workflows/deploy-legacy.yml
+++ b/.github/workflows/deploy-legacy.yml
@@ -2,12 +2,6 @@ name: CD - Deploy API (Legacy) & Clients
 
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows: [CI - Node.js]
-    types:
-      - completed
-    branches:
-      - prod-*
 
 jobs:
   setup-jobs:
@@ -22,17 +16,7 @@ jobs:
       - name: Setup
         id: setup
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_run" && "${{ github.event.workflow_run.conclusion }}" != "success" ]]; then
-            echo "Node.js tests failed in the triggering workflow run. Check logs in its workflow run. Exiting."
-            exit 1
-          fi
-
-          if [[ "${{ github.event_name }}" == "workflow_run" ]]; then
-            BRANCH="${{ github.event.workflow_run.head_branch }}"
-          else
-            BRANCH="${{ github.ref_name }}"
-          fi
-
+          BRANCH="${{ github.ref_name }}"
           echo "Current branch: $BRANCH"
           case "$BRANCH" in
             "prod-current")

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,12 +11,6 @@ on:
           - info
           - warn
         default: info
-  workflow_run:
-    workflows: [CI - Node.js]
-    types:
-      - completed
-    branches:
-      - prod-*
 
 jobs:
   setup-jobs:
@@ -31,19 +25,8 @@ jobs:
       - name: Setup
         id: setup
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_run" && "${{ github.event.workflow_run.conclusion }}" != "success" ]]; then
-            echo "Node.js tests failed in the triggering workflow run. Check logs in its workflow run. Exiting."
-            exit 1
-          fi
-
-          if [[ "${{ github.event_name }}" == "workflow_run" ]]; then
-            BRANCH="${{ github.event.workflow_run.head_branch }}"
-          else
-            BRANCH="${{ github.ref_name }}"
-          fi
-
+          BRANCH="${{ github.ref_name }}"
           echo "Current branch: $BRANCH"
-
           case "$BRANCH" in
             "prod-current")
               echo "site_tld=org" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Unfortunately the `workflow_run` was a pain to manage. Github's documentation is lacking on the behavior and I am seeing interpolation for incorrect branches. Its a mess.

So removing it completely, we could do on-push but that leaves us open to cases where tests may not have passed. So until I have created re-usable workflows for everything we should just use `workflow_dispatch` instead.

