### PR TITLE
fix(curriculum): use specific assert methods in hotel feedback form workshop

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a930b20f589b6664c51cb0.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a930b20f589b6664c51cb0.md
@@ -30,7 +30,7 @@ assert.isNotNull(document.querySelector('fieldset input'));
 You should not create a new `input` element.
 
 ```js
-assert.strictEqual(document.querySelectorAll('fieldset input').length, 1);
+assert.lengthOf(document.querySelectorAll('fieldset input').length, 1);
 ```
 
 Your `input` element should have a `type` attribute with the value of `"text"`.

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a930b20f589b6664c51cb0.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a930b20f589b6664c51cb0.md
@@ -30,7 +30,7 @@ assert.isNotNull(document.querySelector('fieldset input'));
 You should not create a new `input` element.
 
 ```js
-assert.lengthOf(document.querySelectorAll('fieldset input').length, 1);
+assert.lengthOf(document.querySelectorAll('fieldset input'), 1);
 ```
 
 Your `input` element should have a `type` attribute with the value of `"text"`.

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a93730719e1f68410cce54.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a93730719e1f68410cce54.md
@@ -28,7 +28,7 @@ assert.isNotNull(document.querySelector('fieldset input'));
 You should not create a new `input` element.
 
 ```js
-assert.strictEqual(document.querySelectorAll('fieldset input').length, 1);
+assert.lengthOf(document.querySelectorAll('fieldset input').length, 1);
 ```
 
 Your `input` element should have a `name` attribute with the value of `"name"`.

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a93730719e1f68410cce54.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a93730719e1f68410cce54.md
@@ -28,7 +28,7 @@ assert.isNotNull(document.querySelector('fieldset input'));
 You should not create a new `input` element.
 
 ```js
-assert.lengthOf(document.querySelectorAll('fieldset input').length, 1);
+assert.lengthOf(document.querySelectorAll('fieldset input'), 1);
 ```
 
 Your `input` element should have a `name` attribute with the value of `"name"`.

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a93bbe65a26169dbf3bc39.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a93bbe65a26169dbf3bc39.md
@@ -16,7 +16,7 @@ Start by adding a new `label` element with the text `Email address (required):` 
 You should have a `label` element.
 
 ```js
-assert.lengthOf(document.querySelectorAll('fieldset label').length, 2);
+assert.lengthOf(document.querySelectorAll('fieldset label'), 2);
 ```
 
 Your `label` element should have the text `Email address (required):`.

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a93bbe65a26169dbf3bc39.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a93bbe65a26169dbf3bc39.md
@@ -16,7 +16,7 @@ Start by adding a new `label` element with the text `Email address (required):` 
 You should have a `label` element.
 
 ```js
-assert.strictEqual(document.querySelectorAll('fieldset label').length, 2);
+assert.lengthOf(document.querySelectorAll('fieldset label').length, 2);
 ```
 
 Your `label` element should have the text `Email address (required):`.

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a9401c9d660d6bb15993e2.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a9401c9d660d6bb15993e2.md
@@ -18,7 +18,7 @@ The `for` attribute should be set to `"age"`.
 You should have a `label` element.
 
 ```js
-assert.strictEqual(document.querySelectorAll('fieldset label').length, 3);
+assert.lengthOf(document.querySelectorAll('fieldset label').length, 3);
 ```
 
 Your `label` element should have a `for` attribute set to `"age"`.

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a9401c9d660d6bb15993e2.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a9401c9d660d6bb15993e2.md
@@ -18,7 +18,7 @@ The `for` attribute should be set to `"age"`.
 You should have a `label` element.
 
 ```js
-assert.lengthOf(document.querySelectorAll('fieldset label').length, 3);
+assert.lengthOf(document.querySelectorAll('fieldset label'), 3);
 ```
 
 Your `label` element should have a `for` attribute set to `"age"`.

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a94ea5df66236ebed260e8.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a94ea5df66236ebed260e8.md
@@ -18,13 +18,13 @@ Inside the `fieldset` element, add a `legend` element with the text of `Was this
 You should have a `fieldset` element.
 
 ```js
-assert.strictEqual(document.querySelectorAll('fieldset').length, 2);
+assert.lengthOf(document.querySelectorAll('fieldset').length, 2);
 ```
 
 You should have a `legend` element inside of your `fieldset` element.
 
 ```js
-assert.strictEqual(document.querySelectorAll('fieldset legend').length, 2);
+assert.lengthOf(document.querySelectorAll('fieldset legend').length, 2);
 ```
 
 Your `legend` element should have the text of `Was this your first time at our hotel?`.

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a94ea5df66236ebed260e8.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a94ea5df66236ebed260e8.md
@@ -18,13 +18,13 @@ Inside the `fieldset` element, add a `legend` element with the text of `Was this
 You should have a `fieldset` element.
 
 ```js
-assert.lengthOf(document.querySelectorAll('fieldset').length, 2);
+assert.lengthOf(document.querySelectorAll('fieldset'), 2);
 ```
 
 You should have a `legend` element inside of your `fieldset` element.
 
 ```js
-assert.lengthOf(document.querySelectorAll('fieldset legend').length, 2);
+assert.lengthOf(document.querySelectorAll('fieldset legend'), 2);
 ```
 
 Your `legend` element should have the text of `Was this your first time at our hotel?`.

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a9521bc70162712caf118d.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a9521bc70162712caf118d.md
@@ -29,7 +29,7 @@ Below your `label` element, add a `radio` button with the `id` set to `"yes-opti
 You should have a `label` element below your `legend` element.
 
 ```js
-assert(document.querySelector('fieldset:nth-of-type(2) legend + label'));
+assert.exists(document.querySelector('fieldset:nth-of-type(2) legend + label'));
 ```
 
 Your `label` element should have a `for` attribute set to `"yes-option"`.
@@ -47,7 +47,7 @@ assert.strictEqual(document.querySelector('fieldset:nth-of-type(2) legend + labe
 You should have a `radio` button below your `label` element.
 
 ```js
-assert(document.querySelector('fieldset:nth-of-type(2) label + input[type="radio"]'));
+assert.exists(document.querySelector('fieldset:nth-of-type(2) label + input[type="radio"]'));
 ```
 
 Your `radio` button should have an `id` attribute set to `"yes-option"`.

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a954b2bcddba72076c1857.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a954b2bcddba72076c1857.md
@@ -36,7 +36,7 @@ assert.strictEqual(document.querySelector('fieldset:nth-of-type(2) input[type="r
 You should have a second `input` below your second `label` element.
 
 ```js
-assert.strictEqual(document.querySelectorAll('fieldset:nth-of-type(2) label + input').length, 2);
+assert.lengthOf(document.querySelectorAll('fieldset:nth-of-type(2) label + input').length, 2);
 ```
 
 Your `input` should have a `type` of `radio`.

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a954b2bcddba72076c1857.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a954b2bcddba72076c1857.md
@@ -36,7 +36,7 @@ assert.strictEqual(document.querySelector('fieldset:nth-of-type(2) input[type="r
 You should have a second `input` below your second `label` element.
 
 ```js
-assert.lengthOf(document.querySelectorAll('fieldset:nth-of-type(2) label + input').length, 2);
+assert.lengthOf(document.querySelectorAll('fieldset:nth-of-type(2) label + input'), 2);
 ```
 
 Your `input` should have a `type` of `radio`.

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a9577022877d72d8f43b4f.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a9577022877d72d8f43b4f.md
@@ -18,13 +18,13 @@ Inside the `fieldset` element, add a `legend` element with the text `Why did you
 You should a `fieldset` element.
 
 ```js
-assert.strictEqual(document.querySelectorAll('fieldset').length, 3);
+assert.lengthOf(document.querySelectorAll('fieldset').length, 3);
 ```
 
 You should have a `legend` element inside the `fieldset` element.
 
 ```js
-assert.strictEqual(document.querySelectorAll('fieldset:nth-of-type(3) legend').length, 1);
+assert.lengthOf(document.querySelectorAll('fieldset:nth-of-type(3) legend').length, 1);
 ```
 
 Your `legend` element should have the text of `Why did you choose to stay at our hotel? (Check all that apply)`. Double check for spelling errors and spacing issues.

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a9577022877d72d8f43b4f.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a9577022877d72d8f43b4f.md
@@ -18,13 +18,13 @@ Inside the `fieldset` element, add a `legend` element with the text `Why did you
 You should a `fieldset` element.
 
 ```js
-assert.lengthOf(document.querySelectorAll('fieldset').length, 3);
+assert.lengthOf(document.querySelectorAll('fieldset'), 3);
 ```
 
 You should have a `legend` element inside the `fieldset` element.
 
 ```js
-assert.lengthOf(document.querySelectorAll('fieldset:nth-of-type(3) legend').length, 1);
+assert.lengthOf(document.querySelectorAll('fieldset:nth-of-type(3) legend'), 1);
 ```
 
 Your `legend` element should have the text of `Why did you choose to stay at our hotel? (Check all that apply)`. Double check for spelling errors and spacing issues.

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a95d0eff8168747805f1f3.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a95d0eff8168747805f1f3.md
@@ -32,7 +32,7 @@ Below your `label` element, add a checkbox input with the `id`, `name` and `valu
 You should have a `label` element below your `legend`.
 
 ```js
-assert.strictEqual(document.querySelector("fieldset:nth-of-type(3) legend + label"));
+assert.exists(document.querySelector("fieldset:nth-of-type(3) legend + label"));
 ```
 
 Your `label` element should have the text of `Social Media Ads`.

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a95d0eff8168747805f1f3.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a95d0eff8168747805f1f3.md
@@ -32,7 +32,7 @@ Below your `label` element, add a checkbox input with the `id`, `name` and `valu
 You should have a `label` element below your `legend`.
 
 ```js
-assert(document.querySelector("fieldset:nth-of-type(3) legend + label"));
+assert.strictEqual(document.querySelector("fieldset:nth-of-type(3) legend + label"));
 ```
 
 Your `label` element should have the text of `Social Media Ads`.

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a96127422411756204bc1b.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a96127422411756204bc1b.md
@@ -34,7 +34,7 @@ assert.strictEqual(document.querySelector('fieldset:nth-of-type(3) input[type="c
 You should have a checkbox `input` below your `label`.
 
 ```js
-assert(document.querySelector("fieldset:nth-of-type(3) label + input:nth-of-type(2)[type='checkbox']"));
+assert.exists(document.querySelector("fieldset:nth-of-type(3) label + input:nth-of-type(2)[type='checkbox']"));
 ```
 
 Your checkbox should have an `id` set to `"recommendation"`.

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a962954f4e0d76223b37ed.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a962954f4e0d76223b37ed.md
@@ -32,7 +32,7 @@ assert.strictEqual(document.querySelectorAll('fieldset:nth-of-type(3) label')[2]
 You should have a third checkbox `input` after your `label`.
 
 ```js 
-assert(document.querySelector("fieldset:nth-of-type(3) label + input:nth-of-type(3)[type='checkbox']"));
+assert.exists(document.querySelector("fieldset:nth-of-type(3) label + input:nth-of-type(3)[type='checkbox']"));
 ```
 
 Your third checkbox input should have an `id` set to `"location"`.
@@ -68,7 +68,7 @@ assert.strictEqual(document.querySelector('fieldset:nth-of-type(3) input[value="
 You should have a fourth checkbox `input` below your `label`.
 
 ```js 
-assert(document.querySelector("fieldset:nth-of-type(3) label + input:nth-of-type(4)[type='checkbox']"));
+assert.exists(document.querySelector("fieldset:nth-of-type(3) label + input:nth-of-type(4)[type='checkbox']"));
 ```
 
 You should have a fourth checkbox `input` with an `id` of `"reputation"`.

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a9689b1bf24b7750898a1b.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a9689b1bf24b7750898a1b.md
@@ -30,7 +30,7 @@ assert.strictEqual(document.querySelectorAll('fieldset:nth-of-type(3) label')[4]
 You should have a fifth checkbox `input` below your `label`.
 
 ```js
-assert(document.querySelector("fieldset:nth-of-type(3) label + input:nth-of-type(5)[type='checkbox']"));
+assert.exists(document.querySelector("fieldset:nth-of-type(3) label + input:nth-of-type(5)[type='checkbox']"));
 ```   
 
 You should have a checkbox input with an `id` of `"price"`.

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a969951120be7818d8ee49.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a969951120be7818d8ee49.md
@@ -18,13 +18,13 @@ Below the `legend` element, add a `label` element with the text `How was the ser
 You should have a `fieldset` element.
 
 ```js
-assert.strictEqual(document.querySelectorAll('fieldset').length, 4);
+assert.lengthOf(document.querySelectorAll('fieldset').length, 4);
 ```
 
 Your `fieldset` should have a `legend` element.
 
 ```js
-assert.strictEqual(document.querySelectorAll('fieldset:nth-of-type(4) legend').length, 1);
+assert.lengthOf(document.querySelectorAll('fieldset:nth-of-type(4) legend').length, 1);
 ```
 
 Your legend should have the text `Ratings`.
@@ -36,7 +36,7 @@ assert.strictEqual(document.querySelectorAll('fieldset:nth-of-type(4) legend')[0
 Your `fieldset` should have a `label` element below the `legend`.
 
 ```js
-assert.strictEqual(document.querySelectorAll('fieldset:nth-of-type(4) legend + label').length, 1);
+assert.lengthOf(document.querySelectorAll('fieldset:nth-of-type(4) legend + label').length, 1);
 ```
 
 Your `label` should have the text `How was the service?`.

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a969951120be7818d8ee49.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a969951120be7818d8ee49.md
@@ -18,13 +18,13 @@ Below the `legend` element, add a `label` element with the text `How was the ser
 You should have a `fieldset` element.
 
 ```js
-assert.lengthOf(document.querySelectorAll('fieldset').length, 4);
+assert.lengthOf(document.querySelectorAll('fieldset'), 4);
 ```
 
 Your `fieldset` should have a `legend` element.
 
 ```js
-assert.lengthOf(document.querySelectorAll('fieldset:nth-of-type(4) legend').length, 1);
+assert.lengthOf(document.querySelectorAll('fieldset:nth-of-type(4) legend'), 1);
 ```
 
 Your legend should have the text `Ratings`.
@@ -36,7 +36,7 @@ assert.strictEqual(document.querySelectorAll('fieldset:nth-of-type(4) legend')[0
 Your `fieldset` should have a `label` element below the `legend`.
 
 ```js
-assert.lengthOf(document.querySelectorAll('fieldset:nth-of-type(4) legend + label').length, 1);
+assert.lengthOf(document.querySelectorAll('fieldset:nth-of-type(4) legend + label'), 1);
 ```
 
 Your `label` should have the text `How was the service?`.

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a96b01f33ef178dfca9e42.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a96b01f33ef178dfca9e42.md
@@ -28,19 +28,19 @@ Start by adding a `select` element with the `name` and `id` attributes set to `"
 Your `fieldset` should have a `select` element.
 
 ```js
-assert(document.querySelector('fieldset:nth-of-type(4) select'));
+assert.exists(document.querySelector('fieldset:nth-of-type(4) select'));
 ```
 
 Your `select` element should have a `name` attribute set to `"service"`.
 
 ```js
-assert(document.querySelector('select[name="service"]'));
+assert.exists(document.querySelector('select[name="service"]'));
 ```
 
 Your `select` element should have an `id` attribute set to `"service"`.
 
 ```js
-assert(document.querySelector('select[id="service"]'));
+assert.exists(document.querySelector('select[id="service"]'));
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a972137acd1179fa3fe8a0.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a972137acd1179fa3fe8a0.md
@@ -30,7 +30,7 @@ Inside your `select` element, add the following five `option` elements with thes
 You should have an `option` element with the value set to `"poor"`.
 
 ```js
-assert(document.querySelector('option[value="poor"]'));
+assert.exists(document.querySelector('option[value="poor"]'));
 ```
 
 Your `option` element with the `value` of `"poor"` should have the text `Poor`.
@@ -42,7 +42,7 @@ assert.strictEqual(document.querySelector('option[value="poor"]')?.textContent, 
 You should have an `option` element with the `value` set to `"satisfactory"`.
 
 ```js
-assert(document.querySelector('option[value="satisfactory"]'));
+assert.exists(document.querySelector('option[value="satisfactory"]'));
 ```
 
 Your `option` element with the `value` of `"satisfactory"` should have the text `Satisfactory`.
@@ -54,7 +54,7 @@ assert.strictEqual(document.querySelector('option[value="satisfactory"]')?.textC
 You should have an `option` element with the `value` set to `"good"`.
 
 ```js
-assert(document.querySelector('option[value="good"]'));
+assert.exists(document.querySelector('option[value="good"]'));
 ```
 
 Your `option` element with the `value` of `"good"` should have the text `Good`.
@@ -67,7 +67,7 @@ assert.strictEqual(document.querySelector('option[value="good"]')?.textContent, 
 You should have an `option` element with the value set to `"very-good"`.
 
 ```js
-assert(document.querySelector('option[value="very-good"]'));
+assert.exists(document.querySelector('option[value="very-good"]'));
 ```
 
 Your `option` element with the `value` of `"very-good"` should have the text `Very Good`.
@@ -79,7 +79,7 @@ assert.strictEqual(document.querySelector('option[value="very-good"]')?.textCont
 You should have an `option` element with the value set to `"excellent"`.
 
 ```js
-assert(document.querySelector('option[value="excellent"]'));
+assert.exists(document.querySelector('option[value="excellent"]'));
 ```
 
 Your `option` element with the `value` of `"excellent"` should have the text `Excellent`.

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a975260401487af226b290.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a975260401487af226b290.md
@@ -22,7 +22,7 @@ Inside your `select` element, add the `selected` attribute to the `option` eleme
 Your `option` element with the value of `"excellent"` should have the `selected` attribute.
 
 ```js
-assert(document.querySelector('option[value="excellent"][selected]'));
+assert.exists(document.querySelector('option[value="excellent"][selected]'));
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a975c259525b7bc2d5c776.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a975c259525b7bc2d5c776.md
@@ -18,7 +18,7 @@ Below your `label` element, add a `select` element with an `id` and `name` set t
 You should have a `label` element with the `for` attribute set to `"food"`.
 
 ```js
-assert(document.querySelector('label[for="food"]'));
+assert.exists(document.querySelector('label[for="food"]'));
 ```
 
 Your `label` should have the text `How was the food?`.
@@ -30,13 +30,13 @@ assert.strictEqual(document.querySelector('label[for="food"]')?.textContent, 'Ho
 You should have a `select` element with the `id` set to `"food"` below your `label`.
 
 ```js
-assert(document.querySelector('label + select#food'));
+assert.exists(document.querySelector('label + select#food'));
 ```
 
 Your `select` element should have the `name` attribute set to `"food"`.
 
 ```js
-assert(document.querySelector('label + select[name="food"]'));
+assert.exists(document.querySelector('label + select[name="food"]'));
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a97ca8c4cbae7d0bb6e0ad.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a97ca8c4cbae7d0bb6e0ad.md
@@ -33,7 +33,7 @@ Don't forget to add the `selected` attribute to the `option` element with the va
 You should have an `option` element with the value set to `"poor"`.
 
 ```js
-assert(document.querySelector('fieldset:nth-of-type(4) select#food option[value="poor"]'));
+assert.exists(document.querySelector('fieldset:nth-of-type(4) select#food option[value="poor"]'));
 ```
 
 Your `option` with the `value` of `"poor"` should have the text `"Poor"`.
@@ -45,7 +45,7 @@ assert.strictEqual(document.querySelector('fieldset:nth-of-type(4) select#food o
 You should have an `option` element with the `value` set to `"satisfactory"`.
 
 ```js
-assert(document.querySelector('fieldset:nth-of-type(4) select#food option[value="satisfactory"]'));
+assert.exists(document.querySelector('fieldset:nth-of-type(4) select#food option[value="satisfactory"]'));
 ```
 
 Your `option` with the `value` of `"satisfactory"` should have the text `"Satisfactory"`.
@@ -57,7 +57,7 @@ assert.strictEqual(document.querySelector('fieldset:nth-of-type(4) select#food o
 You should have an `option` element with the `value` set to `"good"`.
 
 ```js
-assert(document.querySelector('fieldset:nth-of-type(4) select#food option[value="good"]'));
+assert.exists(document.querySelector('fieldset:nth-of-type(4) select#food option[value="good"]'));
 ```
 
 Your `option` with the `value` of `"good"` should have the text `"Good"`.
@@ -70,7 +70,7 @@ assert.strictEqual(document.querySelector('fieldset:nth-of-type(4) select#food o
 You should have an `option` element with the value set to `"very-good"`.
 
 ```js
-assert(document.querySelector('fieldset:nth-of-type(4) select#food option[value="very-good"]'));
+assert.exists(document.querySelector('fieldset:nth-of-type(4) select#food option[value="very-good"]'));
 ```
 
 Your `option` with the `value` of `"very-good"` should have the text `"Very Good"`.
@@ -82,7 +82,7 @@ assert.strictEqual(document.querySelector('fieldset:nth-of-type(4) select#food o
 You should have an `option` element with the value set to `"excellent"`.
 
 ```js
-assert(document.querySelector('fieldset:nth-of-type(4) select#food option[value="excellent"]'));
+assert.exists(document.querySelector('fieldset:nth-of-type(4) select#food option[value="excellent"]'));
 ```
 
 Your `option` with the `value` of `"excellent"` should have the text `"Excellent"`.
@@ -95,7 +95,7 @@ assert.strictEqual(document.querySelector('fieldset:nth-of-type(4) select#food o
 You should have an `option` element with the `selected` attribute set to `"excellent"`.
 
 ```js
-assert(document.querySelector('fieldset:nth-of-type(4) select#food option[value="excellent"][selected]'));
+assert.exists(document.querySelector('fieldset:nth-of-type(4) select#food option[value="excellent"][selected]'));
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a97f40ddd40d7deb0618b7.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a97f40ddd40d7deb0618b7.md
@@ -16,7 +16,7 @@ Start by adding a `label` element with the text of `Other Comments?` and a `for`
 You should have a `label` with a `for` attribute set to `"comments"`.
 
 ```js
-assert(document.querySelector('label[for="comments"]'));
+assert.exists(document.querySelector('label[for="comments"]'));
 ```
 
 Your `label` should have the text `Other Comments?`.

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a9824ac5d9f77ec304969f.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a9824ac5d9f77ec304969f.md
@@ -26,7 +26,7 @@ Below your `label` element, add a `textarea` element. In the next step, you will
 You should have a `textarea` element below your label.
 
 ```js
-assert(document.querySelector('label + textarea'));
+assert.exists(document.querySelector('label + textarea'));
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a9836b339fed7f9a8fe35a.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a9836b339fed7f9a8fe35a.md
@@ -16,25 +16,25 @@ For the `cols` attribute set the value to `30` and for the `rows` attribute set 
 Your `textarea` element should have an `id` attribute set to `"comments"`.
 
 ```js
-assert(document.querySelector('textarea#comments'));
+assert.exists(document.querySelector('textarea#comments'));
 ```
 
 Your `textarea` element should have a `name` attribute set to `"comments"`.
 
 ```js
-assert(document.querySelector('textarea[name="comments"]'));
+assert.exists(document.querySelector('textarea[name="comments"]'));
 ```
 
 Your `textarea` element should have a `cols` attribute set to `"30"`.
 
 ```js
-assert(document.querySelector('textarea[cols="30"]'));
+assert.exists(document.querySelector('textarea[cols="30"]'));
 ```
 
 Your `textarea` element should have a `rows` attribute set to `"10"`.
 
 ```js
-assert(document.querySelector('textarea[rows="10"]'));
+assert.exists(document.querySelector('textarea[rows="10"]'));
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a9843525e9fa8046d709b7.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a9843525e9fa8046d709b7.md
@@ -20,13 +20,13 @@ And with that, your hotel feedback form is complete!
 You should have a `button` inside your form.
 
 ```js
-assert(document.querySelector('form button'));
+assert.exists(document.querySelector('form button'));
 ```
 
 Your button should be set to the `type` of `"submit"`.
 
 ```js
-assert(document.querySelector('button[type="submit"]'));
+assert.exists(document.querySelector('button[type="submit"]'));
 ```
 
 Your button should have the text content of `Submit`.

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66ad24c7eb8c121000c603a6.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66ad24c7eb8c121000c603a6.md
@@ -22,7 +22,7 @@ Add the `checked` attribute to the checkbox input with the `id` of `"reputation"
 Your checkbox input with the `id` of `"reputation"` should have the `checked` attribute.
 
 ```js
-assert(document.querySelector("input#reputation[checked]"));
+assert.exists(document.querySelector("input#reputation[checked]"));
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes  #59859

<!-- Feel free to add any additional description of changes below this line -->


**Modifications:** 
- Utilize .lengthOf method instead of .strictEqual for readability and gives better failure messages for debugging. 
- Utilize .exists to check if the select element exists 


