### PR TITLE
feat(api): log growthbook initialization failures

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -2,7 +2,6 @@ import fastifyAccepts from '@fastify/accepts';
 import fastifySwagger from '@fastify/swagger';
 import fastifySwaggerUI from '@fastify/swagger-ui';
 import type { TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
-import { GrowthBook } from '@growthbook/growthbook';
 import Ajv from 'ajv';
 import addFormats from 'ajv-formats';
 import uriResolver from 'fast-uri';
@@ -59,12 +58,6 @@ type FastifyInstanceWithTypeProvider = FastifyInstance<
   FastifyBaseLogger,
   TypeBoxTypeProvider
 >;
-
-declare module 'fastify' {
-  interface FastifyInstance {
-    gb: GrowthBook;
-  }
-}
 
 // Options that fastify uses
 const ajv = new Ajv({

--- a/api/src/plugins/growth-book.test.ts
+++ b/api/src/plugins/growth-book.test.ts
@@ -1,0 +1,29 @@
+import Fastify, { type FastifyInstance } from 'fastify';
+import growthBook from './growth-book';
+
+const captureException = jest.fn();
+
+describe('growth-book', () => {
+  let fastify: FastifyInstance;
+  beforeAll(() => {
+    fastify = Fastify();
+    // @ts-expect-error we're mocking the Sentry plugin
+    fastify.Sentry = { captureException };
+  });
+
+  afterAll(async () => {
+    await fastify.close();
+  });
+
+  it('should log the error if the GrowthBook initialization fails', async () => {
+    const spy = jest.spyOn(fastify.log, 'error');
+
+    await fastify.register(growthBook, {
+      apiHost: 'invalid-url',
+      clientKey: 'invalid-key'
+    });
+
+    expect(spy).toHaveBeenCalledWith('Failed to initialize GrowthBook');
+    expect(captureException).toHaveBeenCalled();
+  });
+});

--- a/api/src/plugins/growth-book.test.ts
+++ b/api/src/plugins/growth-book.test.ts
@@ -23,7 +23,7 @@ describe('growth-book', () => {
       clientKey: 'invalid-key'
     });
 
-    expect(spy).toHaveBeenCalledWith('Failed to initialize GrowthBook');
+    expect(spy).toHaveBeenCalled();
     expect(captureException).toHaveBeenCalled();
   });
 });

--- a/api/src/plugins/growth-book.ts
+++ b/api/src/plugins/growth-book.ts
@@ -13,10 +13,7 @@ const growthBook: FastifyPluginAsync<Options> = async (fastify, options) => {
   const res = await gb.init({ timeout: 3000 });
 
   if (res.error) {
-    fastify.log.error(
-      { error: res.error.message },
-      'Failed to initialize GrowthBook'
-    );
+    fastify.log.error(res.error, 'Failed to initialize GrowthBook');
     fastify.Sentry.captureException(res.error);
   }
 

--- a/api/src/plugins/growth-book.ts
+++ b/api/src/plugins/growth-book.ts
@@ -2,9 +2,20 @@ import { GrowthBook, Options } from '@growthbook/growthbook';
 import { FastifyPluginAsync } from 'fastify';
 import fp from 'fastify-plugin';
 
+declare module 'fastify' {
+  interface FastifyInstance {
+    gb: GrowthBook;
+  }
+}
+
 const growthBook: FastifyPluginAsync<Options> = async (fastify, options) => {
   const gb = new GrowthBook(options);
-  await gb.init({ timeout: 3000 });
+  const res = await gb.init({ timeout: 3000 });
+
+  if (res.error) {
+    fastify.log.error('Failed to initialize GrowthBook');
+    fastify.Sentry.captureException(res.error);
+  }
 
   fastify.decorate('gb', gb);
 

--- a/api/src/plugins/growth-book.ts
+++ b/api/src/plugins/growth-book.ts
@@ -13,7 +13,7 @@ const growthBook: FastifyPluginAsync<Options> = async (fastify, options) => {
   const res = await gb.init({ timeout: 3000 });
 
   if (res.error) {
-    fastify.log.error('Failed to initialize GrowthBook');
+    fastify.log.error({ error: res.error }, 'Failed to initialize GrowthBook');
     fastify.Sentry.captureException(res.error);
   }
 

--- a/api/src/plugins/growth-book.ts
+++ b/api/src/plugins/growth-book.ts
@@ -13,7 +13,10 @@ const growthBook: FastifyPluginAsync<Options> = async (fastify, options) => {
   const res = await gb.init({ timeout: 3000 });
 
   if (res.error) {
-    fastify.log.error({ error: res.error }, 'Failed to initialize GrowthBook');
+    fastify.log.error(
+      { error: res.error.message },
+      'Failed to initialize GrowthBook'
+    );
     fastify.Sentry.captureException(res.error);
   }
 


### PR DESCRIPTION
Growthbook doesn't throw during initialization, so if we want to know about any problems we have to inspect the response.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
