### PR TITLE
fix(curriculum): use correct solution in stand up meeting task 48

### DIFF
--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-your-progress-in-weekly-stand-up-meetings/6579dfd504a9ad385a3a4fd9.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-your-progress-in-weekly-stand-up-meetings/6579dfd504a9ad385a3a4fd9.md
@@ -47,7 +47,7 @@ Sophie is discussing her ideas for improvement, not requesting a break.
 
 ## --video-solution--
 
-1
+2
 
 # --scene--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #59893

<!-- Feel free to add any additional description of changes below this line -->
I fixed the solution to the challenge but I'm pretty sure we need a followup PR to make sure that feedback nodes don't exists on the node containing the correct answer. (Unless there's a good reason to have feedback on the correct answer). 