### PR TITLE
fix(api): catch GB init errors on prod only

### DIFF
--- a/api/src/plugins/growth-book.test.ts
+++ b/api/src/plugins/growth-book.test.ts
@@ -1,6 +1,13 @@
 import Fastify, { type FastifyInstance } from 'fastify';
 import growthBook from './growth-book';
 
+// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+jest.mock('../utils/env', () => ({
+  ...jest.requireActual('../utils/env'),
+  // We're only interested in the production behaviour
+  FREECODECAMP_NODE_ENV: 'production'
+}));
+
 const captureException = jest.fn();
 
 describe('growth-book', () => {

--- a/api/src/plugins/growth-book.ts
+++ b/api/src/plugins/growth-book.ts
@@ -2,6 +2,8 @@ import { GrowthBook, Options } from '@growthbook/growthbook';
 import { FastifyPluginAsync } from 'fastify';
 import fp from 'fastify-plugin';
 
+import { FREECODECAMP_NODE_ENV } from '../utils/env';
+
 declare module 'fastify' {
   interface FastifyInstance {
     gb: GrowthBook;
@@ -12,7 +14,7 @@ const growthBook: FastifyPluginAsync<Options> = async (fastify, options) => {
   const gb = new GrowthBook(options);
   const res = await gb.init({ timeout: 3000 });
 
-  if (res.error) {
+  if (res.error && FREECODECAMP_NODE_ENV === 'production') {
     fastify.log.error(res.error, 'Failed to initialize GrowthBook');
     fastify.Sentry.captureException(res.error);
   }


### PR DESCRIPTION
This change adds a check for the environment, the errors are thrown in local development otherwise.