### PR TITLE
fix(api): warn if growthbook fails in development

### DIFF
--- a/api/src/plugins/growth-book.test.ts
+++ b/api/src/plugins/growth-book.test.ts
@@ -1,6 +1,12 @@
 import Fastify, { type FastifyInstance } from 'fastify';
 import growthBook from './growth-book';
 
+// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+jest.mock('../utils/env', () => ({
+  ...jest.requireActual('../utils/env'),
+  FREECODECAMP_NODE_ENV: 'production'
+}));
+
 const captureException = jest.fn();
 
 describe('growth-book', () => {

--- a/api/src/plugins/growth-book.ts
+++ b/api/src/plugins/growth-book.ts
@@ -1,6 +1,7 @@
 import { GrowthBook, Options } from '@growthbook/growthbook';
 import { FastifyPluginAsync } from 'fastify';
 import fp from 'fastify-plugin';
+import { FREECODECAMP_NODE_ENV } from '../utils/env';
 
 declare module 'fastify' {
   interface FastifyInstance {
@@ -13,8 +14,15 @@ const growthBook: FastifyPluginAsync<Options> = async (fastify, options) => {
   const res = await gb.init({ timeout: 3000 });
 
   if (res.error) {
-    fastify.log.error(res.error, 'Failed to initialize GrowthBook');
-    fastify.Sentry.captureException(res.error);
+    if (FREECODECAMP_NODE_ENV !== 'production') {
+      fastify.log.warn(
+        options,
+        'Failed to initialize GrowthBook. If you intended to use it, please check the options.'
+      );
+    } else {
+      fastify.log.error(res.error, 'Failed to initialize GrowthBook');
+      fastify.Sentry.captureException(res.error);
+    }
   }
 
   fastify.decorate('gb', gb);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Starting the server in development shouldn't show errors by default, so I downgraded it to a warning.

<!-- Feel free to add any additional description of changes below this line -->
