### PR TITLE
fix: only log if the request has an Origin header

### DIFF
--- a/api/src/plugins/cors.test.ts
+++ b/api/src/plugins/cors.test.ts
@@ -32,4 +32,16 @@ describe('cors', () => {
       expect(spy).not.toHaveBeenCalled();
     });
   });
+
+  it('should not log if the origin is undefined', async () => {
+    const logger = fastify.log.child({ req: { url: '/api/some-endpoint' } });
+    const spies = LOG_LEVELS.map(level => jest.spyOn(logger, level));
+    await fastify.inject({
+      url: '/api/some-endpoint'
+    });
+
+    spies.forEach(spy => {
+      expect(spy).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/api/src/plugins/cors.ts
+++ b/api/src/plugins/cors.ts
@@ -22,7 +22,7 @@ const cors: FastifyPluginCallback = (fastify, _options, done) => {
       // @fastify/cors instead.
       void reply.header('Access-Control-Allow-Origin', HOME_LOCATION);
 
-      if (!req.url?.startsWith('/status/')) {
+      if (origin && !req.url?.startsWith('/status/')) {
         logger.info(`Received request from disallowed origin: ${origin}`);
       }
     }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Otherwise the console fills up with useless logs when using it in development.

<!-- Feel free to add any additional description of changes below this line -->
