### PR TITLE
chore: remove DEBUG from .env

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -62,7 +62,6 @@ SHOW_UPCOMING_CHANGES=false
 # Debugging Mode Keys - these should not be used in production
 # ---------------------
 PEER=stuff
-DEBUG=true
 LOCAL_MOCK_AUTH=true
 
 # ---------------------


### PR DESCRIPTION
It's only used in the old api and it works without it. The new api use msw for error tests and it becomes quite noisy if `DEBUG` is `'true'`

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->
