### PR TITLE
refactor(api): organise tooling

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,5 +8,4 @@ docker/**/Dockerfile
 **/*docker-compose*
 **/node_modules
 .eslintcache
-api/__mocks__
-api/src/exam-environment/seed
+

--- a/api/package.json
+++ b/api/package.json
@@ -72,10 +72,10 @@
     "test": "jest --force-exit",
     "prisma": "dotenv -e ../.env prisma",
     "postinstall": "prisma generate",
-    "generate-exams": "tsx src/exam-environment/generate/index.ts",
-    "deprecate-exam": "tsx src/exam-environment/generate/deprecate.ts",
-    "insert-exam": "tsx src/exam-environment/generate/insert.ts",
-    "seed:env-exam": "tsx src/exam-environment/seed/index.ts"
+    "generate-exams": "tsx tools/exam-environment/generate/index.ts",
+    "deprecate-exam": "tsx tools/exam-environment/generate/deprecate.ts",
+    "insert-exam": "tsx tools/exam-environment/generate/insert.ts",
+    "seed:env-exam": "tsx tools/exam-environment/seed/index.ts"
   },
   "version": "0.0.1"
 }

--- a/api/tools/exam-environment/generate/deprecate.ts
+++ b/api/tools/exam-environment/generate/deprecate.ts
@@ -1,5 +1,5 @@
 import { PrismaClient } from '@prisma/client';
-import { MONGOHQ_URL } from '../../utils/env';
+import { MONGOHQ_URL } from '../../../src/utils/env';
 
 const args = process.argv.slice(2);
 const ENV_EXAM_ID = args[0];

--- a/api/tools/exam-environment/generate/index.ts
+++ b/api/tools/exam-environment/generate/index.ts
@@ -1,6 +1,6 @@
 import { PrismaClient } from '@prisma/client';
-import { generateExam } from '../utils/exam';
-import { MONGOHQ_URL } from '../../utils/env';
+import { generateExam } from '../../../src/exam-environment/utils/exam';
+import { MONGOHQ_URL } from '../../../src/utils/env';
 
 const args = process.argv.slice(2);
 const ENV_EXAM_ID = args[0];

--- a/api/tools/exam-environment/generate/insert.ts
+++ b/api/tools/exam-environment/generate/insert.ts
@@ -1,6 +1,6 @@
 import { readFile } from 'fs/promises';
 import { EnvExam, PrismaClient } from '@prisma/client';
-import { MONGOHQ_URL } from '../../utils/env';
+import { MONGOHQ_URL } from '../../../src/utils/env';
 
 const args = process.argv.slice(2);
 const EXAM_JSON_PATH = args[0];

--- a/api/tools/exam-environment/seed/index.ts
+++ b/api/tools/exam-environment/seed/index.ts
@@ -1,6 +1,6 @@
 import { PrismaClient } from '@prisma/client';
 import * as mocks from '../../../__mocks__/env-exam';
-import { MONGOHQ_URL } from '../../utils/env';
+import { MONGOHQ_URL } from '../../../src/utils/env';
 
 const prisma = new PrismaClient({
   datasources: {

--- a/api/tsconfig.build.json
+++ b/api/tsconfig.build.json
@@ -6,5 +6,5 @@
     "noEmit": false
   },
   "include": ["src"],
-  "exclude": ["**/*.test.*", "**/__mocks__/*", "**/__tests__/*", "./tools/**/*"]
+  "exclude": ["**/*.test.*"]
 }

--- a/api/tsconfig.build.json
+++ b/api/tsconfig.build.json
@@ -6,5 +6,5 @@
     "noEmit": false
   },
   "include": ["src"],
-  "exclude": ["**/*.test.*", "**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/*.test.*", "**/__mocks__/*", "**/__tests__/*", "./tools/**/*"]
 }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Putting all the tooling into ./tools both makes some organisational sense (it's not 'src', exactly) and makes it easier to ignore when it comes to building, because it is no-longer picked up by typescript.

While it was possible to exclude it with .dockerignore, this wasn't desirable because it meant that the build script behaved differently when run as part of the image build from when it is run independently.

What ended up happening was that the __mock__ files would be included transitively (via seed/index.ts) and fail to compile due to other files missing.

Now we skip the mocks and the tooling whenever we build (inside and outside of images).

<!-- Feel free to add any additional description of changes below this line -->
