### PR TITLE
fix(ui): update section names in downloaded solutions

### DIFF
--- a/client/src/templates/Challenges/components/completion-modal.test.tsx
+++ b/client/src/templates/Challenges/components/completion-modal.test.tsx
@@ -14,8 +14,7 @@ import {
   isBlockNewlyCompletedSelector
 } from '../redux/selectors';
 import { buildChallenge, getTestRunner } from '../utils/build';
-import CompletionModal from './completion-modal';
-
+import CompletionModal, { combineFileData } from './completion-modal';
 jest.mock('../../../analytics');
 jest.mock('../../../utils/fire-confetti');
 jest.mock('../../../components/Progress');
@@ -146,6 +145,33 @@ describe('<CompletionModal />', () => {
       expect(
         getCompletedPercentage(fakeCompletedChallengesIds, currentBlockIds, id)
       ).toBe(100);
+    });
+  });
+
+  describe('File Download Content', () => {
+    it('Should label each section appropriately', () => {
+      const indexHtml = {
+        name: 'index',
+        ext: 'html',
+        contents: 'some html elements'
+      };
+      const stylesCSS = {
+        name: 'styles',
+        ext: 'css',
+        contents: 'some css styles'
+      };
+      const scriptJS = {
+        name: 'script',
+        ext: 'js',
+        contents: 'some javascript'
+      };
+      const result = combineFileData([indexHtml, stylesCSS, scriptJS]);
+      expect(result).toContain('** start of index.html **');
+      expect(result).toContain('** end of index.html **');
+      expect(result).toContain('** start of styles.css **');
+      expect(result).toContain('** end of styles.css **');
+      expect(result).toContain('** start of script.js **');
+      expect(result).toContain('** end of script.js **');
     });
   });
 });

--- a/client/src/templates/Challenges/components/completion-modal.tsx
+++ b/client/src/templates/Challenges/components/completion-modal.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import React, { Component } from 'react';
 import type { TFunction } from 'i18next';
 import { withTranslation } from 'react-i18next';
@@ -71,6 +70,13 @@ interface CompletionModalState {
   downloadURL: null | string;
 }
 
+interface DownloadableChallengeFile {
+  name: string;
+  ext: string;
+  contents: string;
+  fileKey: string;
+}
+
 class CompletionModal extends Component<
   CompletionModalsProps,
   CompletionModalState
@@ -100,17 +106,18 @@ class CompletionModal extends Component<
     }
     let newURL = null;
     if (challengeFiles?.length) {
-      const filesForDownload = challengeFiles
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .reduce<string>((allFiles, currentFile: any) => {
-          const beforeText = `** start of ${currentFile.path} **\n\n`;
-          const afterText = `\n\n** end of ${currentFile.path} **\n\n`;
+      const filesForDownload = challengeFiles.reduce<string>(
+        (allFiles, currentFile: DownloadableChallengeFile) => {
+          const beforeText = `** start of ${currentFile.name + '.' + currentFile.ext} **\n\n`;
+          const afterText = `\n\n** end of ${currentFile.name + '.' + currentFile.ext} **\n\n`;
           allFiles +=
             challengeFiles.length > 1
               ? `${beforeText}${currentFile.contents}${afterText}`
               : currentFile.contents;
           return allFiles;
-        }, '');
+        },
+        ''
+      );
       const blob = new Blob([filesForDownload], {
         type: 'text/json'
       });

--- a/client/src/templates/Challenges/components/completion-modal.tsx
+++ b/client/src/templates/Challenges/components/completion-modal.tsx
@@ -74,7 +74,6 @@ interface DownloadableChallengeFile {
   name: string;
   ext: string;
   contents: string;
-  fileKey: string;
 }
 
 class CompletionModal extends Component<
@@ -106,19 +105,8 @@ class CompletionModal extends Component<
     }
     let newURL = null;
     if (challengeFiles?.length) {
-      const filesForDownload = challengeFiles.reduce<string>(
-        (allFiles, currentFile: DownloadableChallengeFile) => {
-          const beforeText = `** start of ${currentFile.name + '.' + currentFile.ext} **\n\n`;
-          const afterText = `\n\n** end of ${currentFile.name + '.' + currentFile.ext} **\n\n`;
-          allFiles +=
-            challengeFiles.length > 1
-              ? `${beforeText}${currentFile.contents}${afterText}`
-              : currentFile.contents;
-          return allFiles;
-        },
-        ''
-      );
-      const blob = new Blob([filesForDownload], {
+      const allFileContents = combineFileData(challengeFiles);
+      const blob = new Blob([allFileContents], {
         type: 'text/json'
       });
       newURL = URL.createObjectURL(blob);
@@ -249,3 +237,18 @@ export default connect(
   mapStateToProps,
   mapDispatchToProps
 )(withTranslation()(CompletionModal));
+
+export function combineFileData(challengeFiles: DownloadableChallengeFile[]) {
+  return challengeFiles.reduce<string>(function (
+    allFiles: string,
+    currentFile: DownloadableChallengeFile
+  ) {
+    const beforeText = `** start of ${currentFile.name + '.' + currentFile.ext} **\n\n`;
+    const afterText = `\n\n** end of ${currentFile.name + '.' + currentFile.ext} **\n\n`;
+    allFiles +=
+      challengeFiles.length > 0
+        ? `${beforeText}${currentFile.contents}${afterText}`
+        : currentFile.contents;
+    return allFiles;
+  }, '');
+}


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #59921

<!-- Feel free to add any additional description of changes below this line -->
The reason why this was broken is that `path` doesn't exist on the file object when it is passed into the Completion Modal. I don't exactly know why but that's why I made a new local interface. 