### PR TITLE
fix(curriculum): add indentation to CSS examples in transform property lecture transcript

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-transforms-overflow-and-filters/672bcc8ccc976fd791610f43.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-transforms-overflow-and-filters/672bcc8ccc976fd791610f43.md
@@ -22,13 +22,13 @@ Let's explore some common transform functions. Here's an example of a box elemen
 
 ```css
 body {
-border: 2px solid black;
+    border: 2px solid black;
 }
 
 .box {
-width: 200px;
-height: 200px;
-background-color: red;
+    width: 200px;
+    height: 200px;
+    background-color: red;
 }
 ```
 
@@ -38,14 +38,14 @@ The `translate` function moves an element from its current position. Here's an u
 
 ```css
 body {
-border: 2px solid black;
+    border: 2px solid black;
 }
 
 .box {
-width: 200px;
-height: 200px;
-background-color: red;
-transform: translate(50px, 100px);
+    width: 200px;
+    height: 200px;
+    background-color: red;
+    transform: translate(50px, 100px);
 }
 ```
 
@@ -55,11 +55,11 @@ The `rotate` function rotates an element around a fixed point and this is an exa
 
 ```css
 .box {
-margin: 100px;
-width: 200px;
-height: 200px;
-background-color: red;
-transform: rotate(45deg);
+    margin: 100px;
+    width: 200px;
+    height: 200px;
+    background-color: red;
+    transform: rotate(45deg);
 }
 ```
 
@@ -69,11 +69,11 @@ The `scale` function allows you to change the size of an element. Here's an exam
 
 ```css
 .box {
-margin: 100px;
-width: 200px;
-height: 200px;
-background-color: red;
-transform: scale(1.5, 2);
+    margin: 100px;
+    width: 200px;
+    height: 200px;
+    background-color: red;
+    transform: scale(1.5, 2);
 }
 ```
 
@@ -83,11 +83,11 @@ You can combine multiple transformations in a single declaration:
 
 ```css
 .box {
-margin: 100px;
-width: 200px;
-height: 200px;
-background-color: red;
-transform: translate(50px, 50px) rotate(45deg) scale(1.5);
+    margin: 100px;
+    width: 200px;
+    height: 200px;
+    background-color: red;
+    transform: translate(50px, 50px) rotate(45deg) scale(1.5);
 }
 ```
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-transforms-overflow-and-filters/672bcc8ccc976fd791610f43.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-transforms-overflow-and-filters/672bcc8ccc976fd791610f43.md
@@ -22,13 +22,13 @@ Let's explore some common transform functions. Here's an example of a box elemen
 
 ```css
 body {
-    border: 2px solid black;
+  border: 2px solid black;
 }
 
 .box {
-    width: 200px;
-    height: 200px;
-    background-color: red;
+  width: 200px;
+  height: 200px;
+  background-color: red;
 }
 ```
 
@@ -38,14 +38,14 @@ The `translate` function moves an element from its current position. Here's an u
 
 ```css
 body {
-    border: 2px solid black;
+  border: 2px solid black;
 }
 
 .box {
-    width: 200px;
-    height: 200px;
-    background-color: red;
-    transform: translate(50px, 100px);
+  width: 200px;
+  height: 200px;
+  background-color: red;
+  transform: translate(50px, 100px);
 }
 ```
 
@@ -55,11 +55,11 @@ The `rotate` function rotates an element around a fixed point and this is an exa
 
 ```css
 .box {
-    margin: 100px;
-    width: 200px;
-    height: 200px;
-    background-color: red;
-    transform: rotate(45deg);
+  margin: 100px;
+  width: 200px;
+  height: 200px;
+  background-color: red;
+  transform: rotate(45deg);
 }
 ```
 
@@ -69,11 +69,11 @@ The `scale` function allows you to change the size of an element. Here's an exam
 
 ```css
 .box {
-    margin: 100px;
-    width: 200px;
-    height: 200px;
-    background-color: red;
-    transform: scale(1.5, 2);
+  margin: 100px;
+  width: 200px;
+  height: 200px;
+  background-color: red;
+  transform: scale(1.5, 2);
 }
 ```
 
@@ -83,11 +83,11 @@ You can combine multiple transformations in a single declaration:
 
 ```css
 .box {
-    margin: 100px;
-    width: 200px;
-    height: 200px;
-    background-color: red;
-    transform: translate(50px, 50px) rotate(45deg) scale(1.5);
+  margin: 100px;
+  width: 200px;
+  height: 200px;
+  background-color: red;
+  transform: translate(50px, 50px) rotate(45deg) scale(1.5);
 }
 ```
 


### PR DESCRIPTION
Properly indented all CSS code examples in the transcript for the “What Is the CSS Transform Property, and How Does It Work?” lecture.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #59939 

<!-- Feel free to add any additional description of changes below this line -->
