### PR TITLE
fix(curriculum): replace assert with assert.exists and assert.equal in cat painting

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/64a3bcbc83e574b58c8ed048.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/64a3bcbc83e574b58c8ed048.md
@@ -14,25 +14,25 @@ As you did in the previous step, use a descendant selector to target the three `
 You should have a `.cat-whiskers-right div` selector.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-whiskers-right div'))
+assert.exists(new __helpers.CSSHelp(document).getStyle('.cat-whiskers-right div'))
 ```
 
 Your `.cat-whiskers-right div` selector should have a `width` set to `40px`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-whiskers-right div')?.width === '40px')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-whiskers-right div')?.width, '40px')
 ```
 
 Your `.cat-whiskers-right div` selector should have a `height` set to `1px`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-whiskers-right div')?.height === '1px')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-whiskers-right div')?.height, '1px')
 ```
 
 Your `.cat-whiskers-right div` selector should have a `background-color` set to `#000`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-whiskers-right div')?.backgroundColor === 'rgb(0, 0, 0)')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-whiskers-right div')?.backgroundColor, 'rgb(0, 0, 0)')
 ```
 
 # --seed--


### PR DESCRIPTION
…ng challenge

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #59991 

<!-- Feel free to add any additional description of changes below this line -->
Replaced assert() with assert.exists() for checking element existence.

Replaced assert() with assert.equal() in places where strict equality checks (===) were used, to match standard assertion usage.

File modified:
curriculum/challenges/english/25-front-end-development/workshop-cat-painting/64a3bcbc83e574b58c8ed048.md

These changes improve code clarity and follow proper testing practices.
