### PR TITLE
fix(curriculum): improve the assert methods 

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646c5e727e56e743c9aed4a1.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646c5e727e56e743c9aed4a1.md
@@ -21,19 +21,19 @@ Give `.cat-head` a `position` property of `static`, then set the `top` and `left
 Your `.cat-head` selector should have a `position` property set to `static`. Make sure you add a semicolon.
 
 ```js
-assert.equal(new __helpers.CSSHelp(document)?.getStyle('.cat-head')?.position,'static')
+assert(new __helpers.CSSHelp(document)?.getStyle('.cat-head')?.position === 'static')
 ```
 
 Your `.cat-head` selector should have a `top` property set to `100px`. Make sure you add a semicolon.
 
 ```js
-assert.equal(new __helpers.CSSHelp(document)?.getStyle('.cat-head')?.top, '100px')
+assert(new __helpers.CSSHelp(document)?.getStyle('.cat-head')?.top === '100px')
 ```
 
 Your `.cat-head` selector should have a `left` property set to `100px`. Make sure you add a semicolon.
 
 ```js
-assert.equal(new __helpers.CSSHelp(document)?.getStyle('.cat-head')?.left, '100px')
+assert(new __helpers.CSSHelp(document)?.getStyle('.cat-head')?.left === '100px')
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646c5e727e56e743c9aed4a1.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646c5e727e56e743c9aed4a1.md
@@ -21,19 +21,19 @@ Give `.cat-head` a `position` property of `static`, then set the `top` and `left
 Your `.cat-head` selector should have a `position` property set to `static`. Make sure you add a semicolon.
 
 ```js
-assert(new __helpers.CSSHelp(document)?.getStyle('.cat-head')?.position === 'static')
+assert.equal(new __helpers.CSSHelp(document)?.getStyle('.cat-head')?.position,'static')
 ```
 
 Your `.cat-head` selector should have a `top` property set to `100px`. Make sure you add a semicolon.
 
 ```js
-assert(new __helpers.CSSHelp(document)?.getStyle('.cat-head')?.top === '100px')
+assert.equal(new __helpers.CSSHelp(document)?.getStyle('.cat-head')?.top, '100px')
 ```
 
 Your `.cat-head` selector should have a `left` property set to `100px`. Make sure you add a semicolon.
 
 ```js
-assert(new __helpers.CSSHelp(document)?.getStyle('.cat-head')?.left === '100px')
+assert.equal(new __helpers.CSSHelp(document)?.getStyle('.cat-head')?.left, '100px')
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646c5ffef5598d449b52ec12.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646c5ffef5598d449b52ec12.md
@@ -16,19 +16,19 @@ Inside your `.cat-head` element, create a `div` element with the class `cat-ears
 You should not change the existing `div` element with the class `cat-head`.
 
 ```js
-assert(document.querySelectorAll('div.cat-head').length === 1);
+assert.lengthOf(document.querySelectorAll('div.cat-head'), 1);
 ```
 
 You should create one `div` element inside your `.cat-head` element.
 
 ```js
-assert(document.querySelectorAll('.cat-head div').length === 1);
+assert.lengthOf(document.querySelectorAll('.cat-head div'), 1);
 ```
 
 Your `div` element should have the class `cat-ears`.
 
 ```js
-assert(document.querySelectorAll('.cat-head div')[0]?.getAttribute('class') === 'cat-ears');
+assert.equal(document.querySelectorAll('.cat-head div')[0]?.getAttribute('class'),'cat-ears');
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x ] My pull request targets the `main` branch of freeCodeCamp.
- [x ] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #60001

<!-- Feel free to add any additional description of changes below this line -->

Fixed the assert method in line 31 `assert(a === b) ` to `assert.equal(a,b), in line 19 `assert(a.length, b)` and same for line 25.

