### PR TITLE
fix: replace assert with assert.equal for consistency

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646c5e727e56e743c9aed4a1.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646c5e727e56e743c9aed4a1.md
@@ -21,19 +21,19 @@ Give `.cat-head` a `position` property of `static`, then set the `top` and `left
 Your `.cat-head` selector should have a `position` property set to `static`. Make sure you add a semicolon.
 
 ```js
-assert(new __helpers.CSSHelp(document)?.getStyle('.cat-head')?.position === 'static')
+assert.equal(new __helpers.CSSHelp(document)?.getStyle('.cat-head')?.position, 'static')
 ```
 
 Your `.cat-head` selector should have a `top` property set to `100px`. Make sure you add a semicolon.
 
 ```js
-assert(new __helpers.CSSHelp(document)?.getStyle('.cat-head')?.top === '100px')
+assert.equal(new __helpers.CSSHelp(document)?.getStyle('.cat-head')?.top, '100px')
 ```
 
 Your `.cat-head` selector should have a `left` property set to `100px`. Make sure you add a semicolon.
 
 ```js
-assert(new __helpers.CSSHelp(document)?.getStyle('.cat-head')?.left === '100px')
+assert.equal(new __helpers.CSSHelp(document)?.getStyle('.cat-head')?.left, '100px')
 ```
 
 # --seed--


### PR DESCRIPTION
fix: replace assert === with assert.equal for consistency

Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #60000 

PR updates the test assertions in Cat Painting workshop step 7 to use assert.equal instead of assert with ===. This will ensure consistency with the rest of the codebase and better readability.

This satisfies the agreed solution.

I also tested locally on my machine and it works.
