### PR TITLE
fix(curriculum): replace assert === with assert.equal for consistency

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646c5d7057c45f432fcdd46c.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646c5d7057c45f432fcdd46c.md
@@ -20,25 +20,25 @@ assert(new __helpers.CSSHelp(document)?.getStyle('.cat-head'))
 Your `.cat-head` selector should have a `width` set to `205px`.
 
 ```js
-assert(new __helpers.CSSHelp(document)?.getStyle('.cat-head')?.width === '205px');
+assert.equal(new __helpers.CSSHelp(document)?.getStyle('.cat-head')?.width, '205px');
 ```
 
 Your `.cat-head` selector should have a `height` set to `180px`.
 
 ```js
-assert(new __helpers.CSSHelp(document)?.getStyle('.cat-head')?.height === '180px')
+assert.equal(new __helpers.CSSHelp(document)?.getStyle('.cat-head')?.height,'180px')
 ```
 
 Your `.cat-head` selector should have a `border` set to `1px solid #000`.
 
 ```js
-assert(new __helpers.CSSHelp(document)?.getStyle('.cat-head')?.border === '1px solid rgb(0, 0, 0)')
+assert.equal(new __helpers.CSSHelp(document)?.getStyle('.cat-head')?.border, '1px solid rgb(0, 0, 0)')
 ```
 
 Your `.cat-head` selector should have a `border-radius` set to `46%`.
 
 ```js
-assert(new __helpers.CSSHelp(document)?.getStyle(".cat-head")?.borderRadius === '46%')
+assert.equal(new __helpers.CSSHelp(document)?.getStyle(".cat-head")?.borderRadius, '46%')
 ```
 
 


### PR DESCRIPTION
fix: replace assert === with assert.equal for consistency

Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

Closes #59998 

PR updates the test assertions in Cat Painting workshop step 5 to use assert.equal instead of assert with ===. This will ensure consistency with the rest of the codebase and better readability.

This satisfies the agreed solution proposed on the original issue.

I also tested locally on my machine and it works.
