### PR TITLE
fix(curriculum): updated assert methods in cat painting workshop step 17

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646c5ffef5598d449b52ec12.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646c5ffef5598d449b52ec12.md
@@ -16,19 +16,19 @@ Inside your `.cat-head` element, create a `div` element with the class `cat-ears
 You should not change the existing `div` element with the class `cat-head`.
 
 ```js
-assert(document.querySelectorAll('div.cat-head').length === 1);
+assert.lengthOf(document.querySelectorAll('div.cat-head'), 1);
 ```
 
 You should create one `div` element inside your `.cat-head` element.
 
 ```js
-assert(document.querySelectorAll('.cat-head div').length === 1);
+assert.lengthOf(document.querySelectorAll('.cat-head div'), 1);
 ```
 
 Your `div` element should have the class `cat-ears`.
 
 ```js
-assert(document.querySelectorAll('.cat-head div')[0]?.getAttribute('class') === 'cat-ears');
+assert.equals(document.querySelectorAll('.cat-head div')[0]?.getAttribute('class'), 'cat-ears');
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

- [ X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X ] My pull request targets the `main` branch of freeCodeCamp.
- [X ] I have tested these changes either locally on my machine, or Gitpod.

Closes #60001

Fixed the assert methods in cat painting workshop step 17 on line 31 (`assert(a === b)` to `assert.equal(a, b)`) and on lines 19 and 25 (`assert(a.length === n)` to `assert.lengthOf(a, n)`). I have tested these changes locally using a mock test to ensure that the updated assert methods correctly identify that the .cat-ears div is inside the .cat-head div and that it is the only div inside of the .cat-head div.
