### PR TITLE
fix(curriculum): input component self-closing tags

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a930b20f589b6664c51cb0.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a930b20f589b6664c51cb0.md
@@ -12,7 +12,7 @@ When a user provides their full name, the `input` will accept plaintext.
 In the previous lecture videos, you learned how to work with the `type` attribute like this:
 
 ```html
-<input type="text">
+<input type="text" />
 ```
 
 For your existing `input` element, add a `type` attribute set to `"text"`. 
@@ -72,7 +72,7 @@ assert.strictEqual(input?.getAttribute('id'), 'full-name');
           <legend>Personal Information</legend>
           <label for="full-name">Name (required):</label>
         --fcc-editable-region--
-          <input>
+          <input />
         --fcc-editable-region--
         </fieldset>
       </form>

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a93730719e1f68410cce54.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a93730719e1f68410cce54.md
@@ -12,7 +12,7 @@ The `name` attribute is used to identify form data after it has been submitted t
 Here is an example of how to use the `name` attribute:
 
 ```html
-<input type="email" name="email">
+<input type="email" name="email" />
 ```
 
 Add a `name` attribute to the `input` element with the value of `"name"`.
@@ -63,7 +63,7 @@ assert.strictEqual(input?.getAttribute('name'), 'name');
           <legend>Personal Information</legend>
           <label for="full-name">Name (required):</label>
 --fcc-editable-region--
-          <input type="text" id="full-name">
+          <input type="text" id="full-name" />
 --fcc-editable-region--
         </fieldset>
       </form>

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a937e74920ba68ebe5e86d.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a937e74920ba68ebe5e86d.md
@@ -10,7 +10,7 @@ dashedName: step-12
 In the previous lecture videos, you learned how to work with the `placeholder` and `required` attributes like this:
 
 ```html
-<input type="text" placeholder="Ex. John Doe" required>
+<input type="text" placeholder="Ex. John Doe" required />
 ```
 
 For your existing `input` element, add a `placeholder` attribute with the value of `"Ex. John Doe"`.
@@ -62,7 +62,7 @@ assert.isNotNull(document.querySelector('fieldset input[required]'));
           <legend>Personal Information</legend>
           <label for="full-name">Name (required):</label>
 --fcc-editable-region--
-          <input type="text" id="full-name" name="name">
+          <input type="text" id="full-name" name="name" />
 --fcc-editable-region--
         </fieldset>
       </form>

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a93bbe65a26169dbf3bc39.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a93bbe65a26169dbf3bc39.md
@@ -55,7 +55,7 @@ assert.strictEqual(document.querySelector('fieldset label[for="email"]')?.getAtt
         <fieldset>
           <legend>Personal Information</legend>
           <label for="full-name">Name (required):</label>
-          <input type="text" id="full-name" name="name" placeholder="Ex. John Doe" required>
+          <input type="text" id="full-name" name="name" placeholder="Ex. John Doe" required />
 --fcc-editable-region--
           
 --fcc-editable-region--

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a93c95bc58e26a8fe95818.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a93c95bc58e26a8fe95818.md
@@ -75,7 +75,7 @@ assert.strictEqual(document.querySelector('input#email')?.getAttribute('placehol
         <fieldset>
           <legend>Personal Information</legend>
           <label for="full-name">Name (required):</label>
-          <input type="text" id="full-name" name="name" placeholder="Ex. John Doe" required>
+          <input type="text" id="full-name" name="name" placeholder="Ex. John Doe" required />
         --fcc-editable-region--
           <label for="email">Email address (required):</label>
           

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a9401c9d660d6bb15993e2.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a9401c9d660d6bb15993e2.md
@@ -57,7 +57,7 @@ assert.strictEqual(document.querySelector('label[for="age"]')?.textContent, "Age
         <fieldset>
           <legend>Personal Information</legend>
           <label for="full-name">Name (required):</label>
-          <input type="text" id="full-name" name="name" placeholder="Ex. John Doe" required size="20">
+          <input type="text" id="full-name" name="name" placeholder="Ex. John Doe" required size="20" />
 
           <label for="email">Email address (required):</label>
           <input

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a9419e2d18476c645ce693.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a9419e2d18476c645ce693.md
@@ -12,7 +12,7 @@ The number `input` is used to create a numeric input field.
 Here is an example of a number input field:
 
 ```html
-<input type="number" id="age" name="age" min="18" max="100">
+<input type="number" id="age" name="age" min="18" max="100" />
 ```
 
 The `min` and `max` attributes are used to set the minimum and maximum values that can be entered in the input field.
@@ -77,7 +77,7 @@ assert.isNotNull(document.querySelector('label + input[max="100"]'));
         <fieldset>
           <legend>Personal Information</legend>
           <label for="full-name">Name (required):</label>
-          <input type="text" id="full-name" name="name" placeholder="Ex. John Doe" required size="20">
+          <input type="text" id="full-name" name="name" placeholder="Ex. John Doe" required size="20" />
 
           <label for="email">Email address (required):</label>
           <input

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a94ea5df66236ebed260e8.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a94ea5df66236ebed260e8.md
@@ -57,7 +57,7 @@ assert.strictEqual(document.querySelectorAll('fieldset legend')[1]?.textContent,
         <fieldset>
           <legend>Personal Information</legend>
           <label for="full-name">Name (required):</label>
-          <input type="text" id="full-name" name="name" placeholder="Ex. John Doe" required size="20">
+          <input type="text" id="full-name" name="name" placeholder="Ex. John Doe" required size="20" />
 
           <label for="email">Email address (required):</label>
           <input

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a9521bc70162712caf118d.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a9521bc70162712caf118d.md
@@ -12,9 +12,9 @@ If you want users to select one option from a list of options, you can use a set
 Here is an example of two radio buttons:
 
 ```html
-<input type="radio" id="yes" name="first-time">
+<input type="radio" id="yes" name="first-time" />
 <label for="yes">Yes</label>
-<input type="radio" id="no" name="first-time">
+<input type="radio" id="no" name="first-time" />
 <label for="no">No</label>
 ```
 
@@ -86,7 +86,7 @@ assert.strictEqual(document.querySelector('fieldset:nth-of-type(2) label + input
         <fieldset>
           <legend>Personal Information</legend>
           <label for="full-name">Name (required):</label>
-          <input type="text" id="full-name" name="name" placeholder="Ex. John Doe" required size="20">
+          <input type="text" id="full-name" name="name" placeholder="Ex. John Doe" required size="20" />
 
           <label for="email">Email address (required):</label>
           <input

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66ad24c7eb8c121000c603a6.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66ad24c7eb8c121000c603a6.md
@@ -12,7 +12,7 @@ To make a checkbox input checked by default, you can add the `checked` attribute
 Here is an example of using the `checked` attribute:
 
 ```html
-<input checked type="checkbox" id="checked" name="checked">
+<input checked type="checkbox" id="checked" name="checked" />
 ```
 
 Add the `checked` attribute to the checkbox input with the `id` of `"reputation"` to make it checked by default.
@@ -49,7 +49,7 @@ assert.exists(document.querySelector("input#reputation[checked]"));
         <fieldset>
           <legend>Personal Information</legend>
           <label for="full-name">Name (required):</label>
-          <input type="text" id="full-name" name="name" placeholder="Ex. John Doe" required size="20">
+          <input type="text" id="full-name" name="name" placeholder="Ex. John Doe" required size="20" />
 
           <label for="email">Email address (required):</label>
           <input

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/67a51d3a8a6fe123b77b0c6e.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/67a51d3a8a6fe123b77b0c6e.md
@@ -57,7 +57,7 @@ assert.strictEqual(label2?.getAttribute('size'), '20');
           <legend>Personal Information</legend>
           <label for="full-name">Name (required):</label>
 --fcc-editable-region--
-          <input type="text" id="full-name" name="name" placeholder="Ex. John Doe" required>
+          <input type="text" id="full-name" name="name" placeholder="Ex. John Doe" required />
           <label for="email">Email address (required):</label>
           <input
             placeholder="example@email.com"


### PR DESCRIPTION
Checklist:
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
~~- [ ] I have tested these changes either locally on my machine, or Gitpod.~~ (I have not I edited them on my iphone 😅👉🏻👉🏻)

This is a natural change. A friend was going through this resource and ran into inconsistent element termination for the `<input />` elements in the `Hotel Feedback Form`

So this PR is a natural PR (attempting to) adjust them such that they are consistent across the code samples.

For more on the `<input />` element see [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input)