### PR TITLE
fix(actions): get output correctly in web commit check

### DIFF
--- a/.github/workflows/github-no-web-commits.yml
+++ b/.github/workflows/github-no-web-commits.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Check if commits are made on GitHub Web UI
         id: check-commits
-        if: steps.pr_author.outputs.result.is_allow_listed == 'false'
+        if: steps.pr_author.outputs.is_allow_listed == 'false'
         run: |
           PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
           COMMITS_URL="https://api.github.com/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/commits"
@@ -47,7 +47,7 @@ jobs:
 
       - name: Add comment on PR if commits are made on GitHub Web UI
         uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6
-        if: steps.pr_author.outputs.result.is_allow_listed == 'false' && env.IS_GITHUB_COMMIT == 'true'
+        if: steps.pr_author.outputs.is_allow_listed == 'false' && env.IS_GITHUB_COMMIT == 'true'
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

As far as I can see from my testing `outputs.result` is not a thing and `outputs` is just the stringified version of whatever you assigned to it.

<!-- Feel free to add any additional description of changes below this line -->
