### PR TITLE
fix(curriculum): replace 'tag' with 'element' in cafe-menu challenges 

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-basic-css-by-building-a-cafe-menu/5f356ed6cf6eab5f15f5cfe6.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-basic-css-by-building-a-cafe-menu/5f356ed6cf6eab5f15f5cfe6.md
@@ -31,7 +31,7 @@ You should not change your existing `body` element. Make sure you did not delete
 assert.lengthOf(document.querySelectorAll('body'), 1);
 ```
 
-Your `div` tag should be nested in the `body`.
+Your `div` element should be nested in the `body`.
 
 ```js
 assert.equal(document.querySelector('div')?.parentElement?.tagName, 'BODY');
@@ -79,4 +79,3 @@ h1, h2, p {
   text-align: center;
 }
 ```
-

--- a/curriculum/challenges/english/25-front-end-development/workshop-cafe-menu/5f356ed6cf6eab5f15f5cfe6.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cafe-menu/5f356ed6cf6eab5f15f5cfe6.md
@@ -31,7 +31,7 @@ You should not change your existing `body` element. Make sure you did not delete
 assert.lengthOf(document.querySelectorAll('body'), 1);
 ```
 
-Your `div` tag should be nested in the `body`.
+Your `div` element should be nested in the `body`.
 
 ```js
 assert.equal(document.querySelector('div')?.parentElement?.tagName, 'BODY');
@@ -79,4 +79,3 @@ h1, h2, p {
   text-align: center;
 }
 ```
-


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.


Closes #60025

I have fixed the issue in the documentation where the word "tag" was used incorrectly and replaced it with the correct term "element."

Replaced the word tag with element in the following files:

freeCodeCamp/curriculum/challenges/english/25-front-end-development/workshop-cafe-menu/5f356ed6cf6eab5f15f5cfe6.md, Line 34

freeCodeCamp/curriculum/challenges/english/14-responsive-web-design-22/learn-basic-css-by-building-a-cafe-menu/5f356ed6cf6eab5f15f5cfe6.md, Line 34

This is my first contribution to FreeCodeCamp.