### PR TITLE
Fix typo: request ➔ requests in perceived performance lesson

### DIFF
--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-regular-expressions-by-building-a-password-generator/6565bd4265158360de8e2ae7.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-regular-expressions-by-building-a-password-generator/6565bd4265158360de8e2ae7.md
@@ -7,9 +7,13 @@ dashedName: step-59
 
 # --description--
 
-Turn the expression inside your `for` loop into an `if` statement. Use the expression you wrote in the previous step as the `if` condition.
+Turn the expression `constraint <= len(re.findall(pattern, password))` inside your `for` loop into an `if` statement. 
 
-Inside the new conditional statement, increment the `count` value by `1`.
+Use this expression as the `if` condition.
+
+**Do not use `count = 0` as the condition** — that expression was used to initialize a counter and should not be turned into an `if` statement.
+
+Inside the new `if` block, increment the `count` value by `1`.
 
 # --hints--
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-understanding-performance-in-web-applications/67d2f759154eac7b4d5cb1bf.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-understanding-performance-in-web-applications/67d2f759154eac7b4d5cb1bf.md
@@ -111,7 +111,7 @@ Which of the following is an example of preloading?
 
 ## --answers--
 
-Fetching the next page before a user request it.
+Fetching the next page before a user requests it.
 
 ---
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ x ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ x ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ x ] My pull request targets the `main` branch of freeCodeCamp.
- [ x ] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
Fixed a minor typo where "request" was corrected to "requests" in the perceived performance lesson to ensure correct subject-verb agreement.

