### PR TITLE
chore(curriculum): rename project to memory light game

### DIFF
--- a/client/config/cert-and-project-map.ts
+++ b/client/config/cert-and-project-map.ts
@@ -566,8 +566,8 @@ const allStandardCerts = [
       },
       {
         id: 'bd7158d8c442eddfaeb5bd1c',
-        title: 'Build a Simon Game',
-        link: `${legacyFrontEndTakeHomeBase}/build-a-simon-game`,
+        title: 'Build a Memory Light Game',
+        link: `${legacyFrontEndTakeHomeBase}/build-a-memory-light-game`,
         certSlug: Certification.LegacyFrontEnd
       }
     ]

--- a/client/serve/serve.json
+++ b/client/serve/serve.json
@@ -106,6 +106,10 @@
     {
       "source": "/learn/project-euler/project-euler-problems-1-to-100/problem-1-multiples-of-3-and-5",
       "destination": "/learn/project-euler/project-euler-problems-1-to-100/problem-1-multiples-of-3-or-5"
+    },
+    {
+      "source": "/learn/coding-interview-prep/take-home-projects/build-a-simon-game",
+      "destination": "/learn/coding-interview-prep/take-home-projects/build-a-memory-light-game"
     }
   ]
 }

--- a/client/src/__mocks__/edges.json
+++ b/client/src/__mocks__/edges.json
@@ -19167,11 +19167,11 @@
     "node": {
       "challenge": {
         "fields": {
-          "slug": "/learn/coding-interview-prep/take-home-projects/build-a-simon-game",
+          "slug": "/learn/coding-interview-prep/take-home-projects/build-a-memory-light-game",
           "blockName": "Take Home Projects"
         },
         "id": "bd7158d8c442eddfaeb5bd1c",
-        "title": "Build a Simon Game"
+        "title": "Build a Memory Light Game"
       }
     }
   },

--- a/curriculum/challenges/_meta/take-home-projects/meta.json
+++ b/curriculum/challenges/_meta/take-home-projects/meta.json
@@ -28,7 +28,7 @@
     },
     {
       "id": "bd7158d8c442eddfaeb5bd1c",
-      "title": "Build a Simon Game"
+      "title": "Build a Memory Light Game"
     },
     {
       "id": "bd7156d8c242eddfaeb5bd13",

--- a/curriculum/challenges/english/00-certifications/legacy-front-end-certification/legacy-front-end-certification.yml
+++ b/curriculum/challenges/english/00-certifications/legacy-front-end-certification/legacy-front-end-certification.yml
@@ -23,4 +23,4 @@ tests:
   - id: bd7158d8c442eedfaeb5bd1c
     title: Build a Tic Tac Toe Game
   - id: bd7158d8c442eddfaeb5bd1c
-    title: Build a Simon Game
+    title: Build a Memory Light Game

--- a/curriculum/challenges/english/10-coding-interview-prep/take-home-projects/build-a-simon-game.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/take-home-projects/build-a-simon-game.md
@@ -33,7 +33,7 @@ Fulfill the below user stories and get all of the tests to pass. Use whichever l
 - `https://cdn.freecodecamp.org/curriculum/take-home-projects/memory-light-game/sound-1.mp3`
 - `https://cdn.freecodecamp.org/curriculum/take-home-projects/memory-light-game/sound-2.mp3`
 - `https://cdn.freecodecamp.org/curriculum/take-home-projects/memory-light-game/sound-3.mp3`
-- `https://cdn.freecodecamp.org/curriculum/take-home-projects/memory-light-game/sound-4.mp3`.
+- `https://cdn.freecodecamp.org/curriculum/take-home-projects/memory-light-game/sound-4.mp3`
 
 When you are finished, include a link to your project on CodePen and click the "I've completed this challenge" button.
 

--- a/curriculum/challenges/english/10-coding-interview-prep/take-home-projects/build-a-simon-game.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/take-home-projects/build-a-simon-game.md
@@ -1,9 +1,9 @@
 ---
 id: bd7158d8c442eddfaeb5bd1c
-title: Build a Simon Game
+title: Build a Memory Light Game
 challengeType: 3
 forumTopicId: 302357
-dashedName: build-a-simon-game
+dashedName: build-a-memory-light-game
 ---
 
 # --description--
@@ -28,7 +28,12 @@ Fulfill the below user stories and get all of the tests to pass. Use whichever l
 
 **User Story:** I can win the game by getting a series of 20 steps correct. I am notified of my victory, then the game starts over.
 
-**Hint:** Here are mp3s you can use for each button: `https://cdn.freecodecamp.org/curriculum/take-home-projects/simonSound1.mp3`, `https://cdn.freecodecamp.org/curriculum/take-home-projects/simonSound2.mp3`, `https://cdn.freecodecamp.org/curriculum/take-home-projects/simonSound3.mp3`, `https://cdn.freecodecamp.org/curriculum/take-home-projects/simonSound4.mp3`.
+**Hint:** Here are mp3s you can use for each button:
+
+- `https://cdn.freecodecamp.org/curriculum/take-home-projects/memory-light-game/sound-1.mp3`
+- `https://cdn.freecodecamp.org/curriculum/take-home-projects/memory-light-game/sound-2.mp3`
+- `https://cdn.freecodecamp.org/curriculum/take-home-projects/memory-light-game/sound-3.mp3`
+- `https://cdn.freecodecamp.org/curriculum/take-home-projects/memory-light-game/sound-4.mp3`.
 
 When you are finished, include a link to your project on CodePen and click the "I've completed this challenge" button.
 


### PR DESCRIPTION
Renames the project to memory light game

How I tested the redirect:

Build the client with `pnpm build:client`
Copy the `client/serve/serve.json` file to the `client/public` folder
`cd client` && `pnpm serve-ci`

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Ref: https://github.com/freeCodeCamp/CurriculumExpansion/issues/765

<!-- Feel free to add any additional description of changes below this line -->
