### PR TITLE
fix(curriculum): updated cat painting workshop to use specific assert methods steps1 and 5 #60022

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646c48df8674cf2b91020ecc.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646c48df8674cf2b91020ecc.md
@@ -25,7 +25,7 @@ const link = document.querySelector("head>link");
 assert.equal(link?.getAttribute("rel"), "stylesheet");
 const href = link?.getAttribute("data-href");
 console.log(href)
-assert(href === "./styles.css" || href === "styles.css");
+assert.oneOf(href, ["./styles.css", "styles.css"]);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646c5d7057c45f432fcdd46c.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646c5d7057c45f432fcdd46c.md
@@ -14,7 +14,7 @@ Using a class selector, give the `.cat-head` element a width of `205px` and a he
 You should have a `.cat-head` selector.
 
 ```js
-assert(new __helpers.CSSHelp(document)?.getStyle('.cat-head'))
+assert.exists(new __helpers.CSSHelp(document)?.getStyle('.cat-head'))
 ```
 
 Your `.cat-head` selector should have a `width` set to `205px`.


### PR DESCRIPTION
1. **Replace `assert()` with `assert.exists()`**  
   - **File:** `freeCodeCamp/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646c5d7057c45f432fcdd46c.md`
   - **Line:** 17
   - **Change:**  
     Updated
     ```javascript
     assert(new __helpers.CSSHelp(document)?.getStyle('.cat-head'))
     ```
     to

     ```javascript
     assert.exists(new __helpers.CSSHelp(document)?.getStyle('.cat-head'))
     ```

2. **Replace manual `assert()` check with `assert.oneOf()`**
   - **File:** `freeCodeCamp/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646c48df8674cf2b91020ecc.md`
   - **Line:** 28
   - **Change:**  
     Updated
     ```javascript
     assert(href === "./styles.css" || href === "styles.css");
     ```
     to

     ```javascript
     assert.oneOf(href, ["./styles.css", "styles.css"]);
     ```