### PR TITLE
fix(curriculum): typo in lecture about styling special input elements

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lecture-best-practices-for-styling-forms/672bca660aa9f9ce9b2b2787.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-best-practices-for-styling-forms/672bca660aa9f9ce9b2b2787.md
@@ -14,7 +14,7 @@ Watch the video or read the transcript and answer the questions below.
 
 Let's learn about some of the common issues when trying to style special input elements like the `datetime-local` and `color` inputs.
 
-These special type of inputs rely on complex pseudo-elements to create things like the date and color pickers. This presents a significant challenge for styling these inputs. One challenge is that the default styling is entirely browser-dependent, so the CSS you write to make the picker look the way intend may be entirely different on another browser. 
+These special types of inputs rely on complex pseudo-elements to create things like the date and color pickers. This presents a significant challenge for styling these inputs. One challenge is that the default styling is entirely browser-dependent, so the CSS you write to make the picker look the way intend may be entirely different on another browser. 
 
 Another may be the complexity of the pseudo-element. Consider the date selector; there are a lot of moving parts here and the complex structure of the pseudo-element might pose a significant challenge in applying styling to the right areas.
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

Closes #60055 

<!-- Feel free to add any additional description of changes below this line -->

Fixed a small typo in the "Best Practices for Styling Forms" lecture.  
Changed "These special type of inputs" to "These special types of inputs."
