### PR TITLE
fix(curriculum): use assert.exists and assert.equal in cat painting workshop

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646c586be7180e40ddf74ff6.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646c586be7180e40ddf74ff6.md
@@ -14,13 +14,13 @@ Give your `body` element a `background-color` of `#c9d2fc`.
 You should have a `body` selector.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('body'));
+assert.exists(new __helpers.CSSHelp(document).getStyle('body'));
 ```
 
 Your `body` selector should have a `background-color` property set to `#c9d2fc`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('body')?.backgroundColor === 'rgb(201, 210, 252)');
+assert.equal(new __helpers.CSSHelp(document).getStyle('body')?.backgroundColor, 'rgb(201, 210, 252)');
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

Closes #60057 

Replaced general `assert()` statements with more specific `assert.exists()` and `assert.equal()` in the cat painting workshop. These changes improve readability and testing accuracy.
