### PR TITLE
fix: replace assert with assert.lengthOf and assert.isTrue in cat painting workshop

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646ce8bb4b35544d501c7184.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646ce8bb4b35544d501c7184.md
@@ -14,25 +14,25 @@ Inside your `.cat-ears` element, create two `div` elements with the classes `cat
 You should not change the existing `div` element with the class `cat-ears`.
 
 ```js
-assert(document.querySelectorAll('div.cat-ears').length === 1);
+assert.lengthOf(document.querySelectorAll('div.cat-ears'), 1);
 ```
 
 You should create two `div` elements inside your `.cat-ears` element.
 
 ```js
-assert(document.querySelectorAll('.cat-ears div').length === 2);
+assert.lengthOf(document.querySelectorAll('.cat-ears div'), 2);
 ```
 
 Your first `div` element should have the class `cat-left-ear`.
 
 ```js
-assert(document.querySelectorAll('.cat-ears div')[0]?.classList.contains('cat-left-ear'));
+assert.isTrue(document.querySelectorAll('.cat-ears div')[0]?.classList.contains('cat-left-ear'));
 ```
 
 Your second `div` element should have the class `cat-right-ear`.
 
 ```js
-assert(document.querySelectorAll('.cat-ears div')[1]?.classList.contains('cat-right-ear'));
+assert.isTrue(document.querySelectorAll('.cat-ears div')[1]?.classList.contains('cat-right-ear'));
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

Closes #60058 

Replaced `assert()` statements with `assert.lengthOf()` and `assert.isTrue()` in the cat painting workshop. These changes improve the accuracy of the tests.