### PR TITLE
fix: change regex to match more valid emails such as ones containing '+'

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-email-masker/66b205e6eacba4c4e54ea434.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-email-masker/66b205e6eacba4c4e54ea434.md
@@ -45,7 +45,7 @@ assert.isDefined(email);
 You should assign a valid email address to your `email` variable.
 
 ```js
-assert.match(email, /^[\w\.-]+@[a-zA-Z\d\.-]+\.[a-zA-Z]{2,}$/);
+assert.match(email, /^[a-zA-Z0-9._%-]+\+?[a-zA-Z0-9._%-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/);
 ```
 
 `maskEmail("apple.pie@example.com")` should return `"a*******e@example.com"`.
@@ -67,6 +67,7 @@ assert.strictEqual(maskEmail("johnappleseed@email.com"), "j***********d@email.co
 assert.strictEqual(maskEmail("john.doe@example.com"), "j******e@example.com");
 assert.strictEqual(maskEmail("jane.smith@sample.org"), "j********h@sample.org");
 assert.strictEqual(maskEmail("michael.jordan@testmail.net"), "m************n@testmail.net");
+assert.strictEqual(maskEmail("m*********m@testmail.net"), "m*********m@testmail.net");
 ```
 
 You should log the output of calling `maskEmail` with `email` as argument.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.
