### PR TITLE
fix(curriculum): update assertion methods in cat painting workshop

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646c48df8674cf2b91020ecc.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646c48df8674cf2b91020ecc.md
@@ -25,7 +25,7 @@ const link = document.querySelector("head>link");
 assert.equal(link?.getAttribute("rel"), "stylesheet");
 const href = link?.getAttribute("data-href");
 console.log(href)
-assert(href === "./styles.css" || href === "styles.css");
+assert.oneOf(href, ["./styles.css", "styles.css"]);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646c5d7057c45f432fcdd46c.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646c5d7057c45f432fcdd46c.md
@@ -14,7 +14,7 @@ Using a class selector, give the `.cat-head` element a width of `205px` and a he
 You should have a `.cat-head` selector.
 
 ```js
-assert(new __helpers.CSSHelp(document)?.getStyle('.cat-head'))
+assert.exists(new __helpers.CSSHelp(document)?.getStyle('.cat-head'))
 ```
 
 Your `.cat-head` selector should have a `width` set to `205px`.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #60022

<!-- Feel free to add any additional description of changes below this line -->
This PR updates two assertions across two different steps in the "Workshop Cat Painting" curriculum challenges for improved clarity and correctness.
![image](https://github.com/user-attachments/assets/e19c51a2-735a-41b9-92f2-c015ec246913)

