### PR TITLE
fix(curriculum): better wording in workshop-todo-app

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-todo-app/64ec9343769e8f85c1e17e05.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-todo-app/64ec9343769e8f85c1e17e05.md
@@ -19,7 +19,7 @@ const matched = __helpers.removeJSComments(splitted).match(/<div(?<attributes>.*
 assert.match(matched?.groups.attributes, /\s+class\s*=\s*('|")task\1(\s|$)/);
 ```
 
-Your `div` element should have the `id` `${id}`.
+Your `div` element should have an `id` of `${id}`.
 
 ```js
 const splitted = code.split(/tasksContainer\s*\.\s*innerHTML\s*\+=\s*`/)[1]


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related to #60039

<!-- Feel free to add any additional description of changes below this line -->