### PR TITLE
refactor(client): use shared Module interface

### DIFF
--- a/client/src/templates/Introduction/components/super-block-accordion.tsx
+++ b/client/src/templates/Introduction/components/super-block-accordion.tsx
@@ -11,6 +11,7 @@ import superBlockStructure from '../../../../../curriculum/superblock-structure/
 import { ChapterIcon } from '../../../assets/chapter-icon';
 import { BlockLayouts, BlockTypes } from '../../../../../shared/config/blocks';
 import { FsdChapters } from '../../../../../shared/config/chapters';
+import { type Module } from '../../../../../shared/config/modules';
 import envData from '../../../../config/env.json';
 import Block from './block';
 import CheckMark from './check-mark';
@@ -53,15 +54,6 @@ interface SuperBlockAccordionPropsViewProps {
   chosenBlock: string;
   completedChallengeIds: string[];
 }
-
-type Module = {
-  dashedName: string;
-  comingSoon?: boolean;
-  blocks: {
-    dashedName: string;
-  }[];
-  moduleType?: string;
-};
 
 const modules = superBlockStructure.chapters.flatMap<Module>(
   ({ modules }) => modules


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Updates client to use the shared `Module` interface (the interface was introduced in #59533).

<!-- Feel free to add any additional description of changes below this line -->
