### PR TITLE
fix(curriculum): replace assert with assert.equal in cat painting workshop

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646cecc9eb5c4f4f73dafd07.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646cecc9eb5c4f4f73dafd07.md
@@ -14,19 +14,19 @@ Move the left ear into position by setting a position of `absolute`, a `top` of 
 Your `.cat-left-ear` selector should have a `position` property set to `absolute`. Don't forget to add a semicolon.
 
 ```js
-assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-left-ear')?.position === 'absolute')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat--left-ear')?.position, 'absolute');
 ```
 
 Your `.cat-left-ear` selector should have a `top` property set to `-26px`
 
 ```js
-assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-left-ear')?.top === '-26px')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-left-ear')?.top, '-26px');
 ```
 
 Your `.cat-left-ear` selector should have a `left` property set to `-31px`
 
 ```js
-assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-left-ear')?.left === '-31px')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-left-ear')?.left, '-31px')
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646cecc9eb5c4f4f73dafd07.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646cecc9eb5c4f4f73dafd07.md
@@ -14,13 +14,13 @@ Move the left ear into position by setting a position of `absolute`, a `top` of 
 Your `.cat-left-ear` selector should have a `position` property set to `absolute`. Don't forget to add a semicolon.
 
 ```js
-assert.equal(new __helpers.CSSHelp(document).getStyle('.cat--left-ear')?.position, 'absolute');
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat--left-ear')?.position, 'absolute')
 ```
 
 Your `.cat-left-ear` selector should have a `top` property set to `-26px`
 
 ```js
-assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-left-ear')?.top, '-26px');
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-left-ear')?.top, '-26px')
 ```
 
 Your `.cat-left-ear` selector should have a `left` property set to `-31px`

--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646cecc9eb5c4f4f73dafd07.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646cecc9eb5c4f4f73dafd07.md
@@ -14,19 +14,19 @@ Move the left ear into position by setting a position of `absolute`, a `top` of 
 Your `.cat-left-ear` selector should have a `position` property set to `absolute`. Don't forget to add a semicolon.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-left-ear')?.position === 'absolute')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-left-ear')?.position === 'absolute')
 ```
 
 Your `.cat-left-ear` selector should have a `top` property set to `-26px`
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-left-ear')?.top === '-26px')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-left-ear')?.top === '-26px')
 ```
 
 Your `.cat-left-ear` selector should have a `left` property set to `-31px`
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-left-ear')?.left === '-31px')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-left-ear')?.left === '-31px')
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ x ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ x ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ x ] My pull request targets the `main` branch of freeCodeCamp.
- [ x ] I have tested these changes either locally on my machine, or Gitpod.

Closes #60081

This PR updates the test cases in the "Cat Painting Workshop" to use the more specific assert.equal() method instead of the general assert() with the === operator, as requested in [Issue #60081](https://github.com/freeCodeCamp/freeCodeCamp/issues/60081).
