### PR TITLE
fix(client): add redirects for renamed projects

### DIFF
--- a/client/serve/serve.json
+++ b/client/serve/serve.json
@@ -110,6 +110,14 @@
     {
       "source": "/learn/coding-interview-prep/take-home-projects/build-a-simon-game",
       "destination": "/learn/coding-interview-prep/take-home-projects/build-a-memory-light-game"
+    },
+    {
+      "source": "/learn/relational-database/learn-relational-databases-by-building-a-mario-database/build-a-mario-database",
+      "destination": "/learn/relational-database/learn-relational-databases-by-building-a-database-of-video-game-characters/build-a-database-of-video-game-characters"
+    },
+    {
+      "source": "/learn/relational-database/learn/javascript-algorithms-and-data-structures-v8/build-a-pokemon-search-app-project/build-a-pokemon-search-app",
+      "destination": "/learn/javascript-algorithms-and-data-structures-v8/build-an-rpg-creature-search-app-project/build-an-rpg-creature-search-app"
     }
   ]
 }


### PR DESCRIPTION
This adds redirects for two projects that were renamed.

How I tested this:

Build the client with `pnpm build:client`
Copy the `client/serve/serve.json` file to the `client/public` folder
`cd client` && `pnpm serve-ci`
Navigate to the source link in your browser, get redirected to the new project

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes https://github.com/freeCodeCamp/freeCodeCamp/issues/59020

Closes https://github.com/freeCodeCamp/freeCodeCamp/issues/59021

<!-- Feel free to add any additional description of changes below this line -->
