### PR TITLE
fix(curriculum): FSD-replace assert with assert.equal in cat painting workshop

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646cecc9eb5c4f4f73dafd07.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646cecc9eb5c4f4f73dafd07.md
@@ -14,19 +14,19 @@ Move the left ear into position by setting a position of `absolute`, a `top` of 
 Your `.cat-left-ear` selector should have a `position` property set to `absolute`. Don't forget to add a semicolon.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-left-ear')?.position === 'absolute')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-left-ear')?.position, 'absolute')
 ```
 
 Your `.cat-left-ear` selector should have a `top` property set to `-26px`
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-left-ear')?.top === '-26px')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-left-ear')?.top, '-26px')
 ```
 
 Your `.cat-left-ear` selector should have a `left` property set to `-31px`
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-left-ear')?.left === '-31px')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-left-ear')?.left, '-31px')
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

Closes #60081 

<!-- Feel free to add any additional description of changes below this line -->

I replaced assert() with assert.equal() in the test cases to make the comparisons clearer and more beginner-friendly. This change improves readability and aligns the challenge with testing practices used elsewhere in the curriculum.

This is my first contribution ever!. Please let me know how I can do better. Thank you for your time!
