### PR TITLE
🔥 Add repeat quiz logic with page reload on fail

### DIFF
--- a/client/src/templates/Challenges/quiz/show.tsx
+++ b/client/src/templates/Challenges/quiz/show.tsx
@@ -236,6 +236,9 @@ const ShowQuiz = ({
     void navigate(exitPathname);
     closeExitQuizModal();
   };
+  const handleRepeatQuiz = () => {
+    window.location.reload();
+  };
 
   const onWindowClose = useCallback(
     (event: BeforeUnloadEvent) => {
@@ -337,24 +340,37 @@ const ShowQuiz = ({
                 {errorMessage}
               </div>
               <Spacer size='m' />
-              {!isPassed ? (
+              {hasSubmitted && validated ? (
+                correctAnswerCount >= 18 ? (
+                  <>
+                    <h3>Congratulations! You passed the quiz.</h3>
+                    <Button
+                      block
+                      variant='success'
+                      onClick={handleExitQuizModalBtnClick}
+                    >
+                      {t('buttons.exit-quiz')}
+                    </Button>
+                  </>
+                ) : (
+                  <>
+                    <h3>Oops! You didn’t pass. Try again!</h3>
+                    <Button block variant='primary' onClick={handleRepeatQuiz}>
+                      Repeat the quiz
+                    </Button>
+                  </>
+                )
+              ) : (
                 <Button
-                  block={true}
+                  block
                   variant='primary'
                   onClick={handleFinishQuiz}
                   disabled={hasSubmitted}
                 >
                   {t('buttons.finish-quiz')}
                 </Button>
-              ) : (
-                <Button
-                  block={true}
-                  variant='primary'
-                  onClick={handleSubmitAndGo}
-                >
-                  {t('buttons.submit-and-go')}
-                </Button>
               )}
+
               <Spacer size='xxs' />
               <Button block={true} variant='primary' onClick={handleExitQuiz}>
                 {t('buttons.exit-quiz')}


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.


This PR adds a **"Repeat the Quiz"** feature that resets the quiz state by refreshing the page when the user scores below 18/20.

If the user fails the quiz, a clear message is now displayed:  
**"Oops! You didn’t pass. Try again!"**  
This ensures that users who may not have read the score above are explicitly informed they didn’t pass — and can retake the quiz until they succeed.

✅ This improves the user flow  
✅ Encourages retry without confusion  
✅ Prevents silent failures

![image](https://github.com/user-attachments/assets/3c1ae42d-63c6-474f-bd6c-e2704a403545)

