### PR TITLE
fix: dispatch input event for textarea

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-customer-complaint-form/67279fe50237291f80eed8b8.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-customer-complaint-form/67279fe50237291f80eed8b8.md
@@ -219,6 +219,7 @@ Once the value of `#complaint-description` is changed to a valid value, you shou
 ```js
 const field = document.getElementById("complaint-description");
 field.value = "A sentence with at least twenty characters"
+field.dispatchEvent(new Event("input", { bubbles: true }));
 field.dispatchEvent(new Event("change", { bubbles: true }));
 assert.equal(field.style.borderColor, "green");
 ```
@@ -228,6 +229,7 @@ Once the value of `#complaint-description` is changed to an invalid value, you s
 ```js
 const field = document.getElementById("complaint-description");
 field.value = "Not enough chars"
+field.dispatchEvent(new Event("input", { bubbles: true }));
 field.dispatchEvent(new Event("change", { bubbles: true }));
 assert.equal(field.style.borderColor, "red");
 ```
@@ -293,6 +295,7 @@ Once the value of `#solution-description` is changed to a valid value, you shoul
 ```js
 const field = document.getElementById("solution-description");
 field.value = "A sentence with at least twenty characters"
+field.dispatchEvent(new Event("input", { bubbles: true }));
 field.dispatchEvent(new Event("change", { bubbles: true }));
 assert.equal(field.style.borderColor, "green");
 ```
@@ -302,6 +305,7 @@ Once the value of `#solution-description` is changed to an invalid value, you sh
 ```js
 const field = document.getElementById("solution-description");
 field.value = "Not enough chars"
+field.dispatchEvent(new Event("input", { bubbles: true }));
 field.dispatchEvent(new Event("change", { bubbles: true }));
 assert.equal(field.style.borderColor, "red");
 ```


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or Gitpod.

Closes #59740

#### Changes:
- Fixed issue where only "change" event was dispatched for textarea elements.
- Added "input" event dispatch to handle real-time updates on textarea.

#### Additional Description:
This fix ensures that both "change" and "input" events are triggered for the textarea elements in the "Customer Complaint Form" lab, providing proper event handling for the tests.
