### PR TITLE
fix: assert-equal-workshop-cat-painting-left

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646cef0c2b98915094df7099.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646cef0c2b98915094df7099.md
@@ -14,13 +14,13 @@ Those edges are too sharp for an ear. So, set the `border-top-left-radius` to `9
 Your `.cat-left-ear` selector should have a `border-top-left-radius` property set to `90px`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-left-ear')?.borderTopLeftRadius === '90px')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-left-ear')?.borderTopLeftRadius, '90px')
 ```
 
 Your `.cat-left-ear` selector should have a `border-top-right-radius` property set to `10px`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-left-ear')?.borderTopRightRadius === '10px')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-left-ear')?.borderTopRightRadius, '10px')
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #60102

<!-- Feel free to add any additional description of changes below this line -->
Made a simple tweak to change the 2 strict assert calls to instead use assert.equal when comparing various properties of 'cat-left-ear'. This provides a slightly less strict version of equality required to pass.
