### PR TITLE
fix(curriculum): lack of support of MathJax in FSD cert

### DIFF
--- a/client/src/utils/math-jax.ts
+++ b/client/src/utils/math-jax.ts
@@ -12,7 +12,8 @@ const superBlocksWithMathJax = [
   SuperBlocks.JsAlgoDataStruct,
   SuperBlocks.ProjectEuler,
   SuperBlocks.RosettaCode,
-  SuperBlocks.SciCompPy
+  SuperBlocks.SciCompPy,
+  SuperBlocks.FullStackDeveloper
 ];
 
 const configure = () => {


### PR DESCRIPTION
We had an issue where MathJax wasn't working in the FSD cert. But it turns out we forgot to include the full stack developer option in the `superBlocksWithMathJax` array. Tested it locally and now Python labs using MathJax work as expected

<img width="552" alt="Screenshot 2025-05-01 at 1 21 47 PM" src="https://github.com/user-attachments/assets/87936865-d3fa-42cb-8ac6-0584b10167ab" />


Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.


