### PR TITLE
fix(curriculum): improve Crowdin compatibility for workshop-nutritional-label

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-nutritional-label/615f7de4487b64919bb4aa5e.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-nutritional-label/615f7de4487b64919bb4aa5e.md
@@ -64,7 +64,7 @@ const zeroPercentSpan = spans.filter(span => span?.innerHTML?.match(/^[\s\n]*0%[
 assert(zeroPercentSpan[0]?.classList?.contains('bold'));
 ```
 
-The text `Cholesterol` should be in a `span` with the class `bold`, and both `Cholesterol` and `0mg` should be wrapped together in another `span` element.
+The `span` element that contains the text `Cholesterol` and the text `0mg` should be wrapped together in another `span` element.
 
 ```js
 const spans = [...document.querySelector('.daily-value.small-text')?.lastElementChild?.querySelectorAll('span')];

--- a/curriculum/challenges/english/25-front-end-development/workshop-nutritional-label/615f7de4487b64919bb4aa5e.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-nutritional-label/615f7de4487b64919bb4aa5e.md
@@ -64,7 +64,7 @@ const zeroPercentSpan = spans.filter(span => span?.innerHTML?.match(/^[\s\n]*0%[
 assert(zeroPercentSpan[0]?.classList?.contains('bold'));
 ```
 
-Both the `Cholesterol` and `0mg` text should be wrapped inside individual `span` elements.
+The text `Cholesterol` should be in a `span` with the class `bold`, and both `Cholesterol` and `0mg` should be wrapped together in another `span` element.
 
 ```js
 const spans = [...document.querySelector('.daily-value.small-text')?.lastElementChild?.querySelectorAll('span')];

--- a/curriculum/challenges/english/25-front-end-development/workshop-nutritional-label/615f7de4487b64919bb4aa5e.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-nutritional-label/615f7de4487b64919bb4aa5e.md
@@ -56,7 +56,7 @@ const zeroPercentSpan = spans.filter(span => span?.innerHTML?.match(/^[\s\n]*0%[
 assert(zeroPercentSpan.length === 1);
 ```
 
-The `span` element that contains the text `0%` should also have its `class` attribute set to `bold`.
+The `span` element that contains the text `0%` should have its `class` attribute set to `bold`.
 
 ```js
 const spans = [...document.querySelector('.daily-value.small-text')?.lastElementChild?.querySelectorAll('span')];

--- a/curriculum/challenges/english/25-front-end-development/workshop-nutritional-label/615f7de4487b64919bb4aa5e.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-nutritional-label/615f7de4487b64919bb4aa5e.md
@@ -40,7 +40,7 @@ const cholesterolSpan = spans.filter(span => span?.innerHTML?.match(/^[\s\n]*Cho
 assert(cholesterolSpan.length === 1);
 ```
 
-Your `Cholesterol` `span` should have the `class` attribute set to `bold`.
+The `span` element that contains the text `Cholesterol` should have its `class` attribute set to `bold`.
 
 ```js
 const spans = [...document.querySelector('.daily-value.small-text')?.lastElementChild?.querySelectorAll('span')];
@@ -56,7 +56,7 @@ const zeroPercentSpan = spans.filter(span => span?.innerHTML?.match(/^[\s\n]*0%[
 assert(zeroPercentSpan.length === 1);
 ```
 
-Your `0%` `span` should have the `class` attribute set to `bold`.
+The `span` element that contains the text `0%` should also have its `class` attribute set to `bold`.
 
 ```js
 const spans = [...document.querySelector('.daily-value.small-text')?.lastElementChild?.querySelectorAll('span')];
@@ -64,7 +64,7 @@ const zeroPercentSpan = spans.filter(span => span?.innerHTML?.match(/^[\s\n]*0%[
 assert(zeroPercentSpan[0]?.classList?.contains('bold'));
 ```
 
-Your `Cholesterol` `span` and your `0mg` text should be wrapped in a `span`.
+Both the `Cholesterol` and `0mg` text should be wrapped inside individual `span` elements.
 
 ```js
 const spans = [...document.querySelector('.daily-value.small-text')?.lastElementChild?.querySelectorAll('span')];


### PR DESCRIPTION
This PR improves Crowdin compatibility for the `workshop-nutritional-label` lesson by rewording lines that contained adjacent backticked elements.

Affected file:
- `curriculum/challenges/english/25-front-end-development/workshop-nutritional-label/615f7de4487b64919bb4aa5e.md`

Changes made:
- Your `Cholesterol` `span` should have the `class` attribute set to `bold`.
- Your `0%` `span` should have the `class` attribute set to `bold`.
- Your `Cholesterol` `span` and your `0mg` text should be wrapped in a `span`.

These have been rewritten to:
- Follow Crowdin compatibility standards

Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org/#/contributing-guide).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/pull-request-guide).
- [x] My pull request targets the main branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

Related to #60039
