### PR TITLE
fix(curriculum): improve Crowdin wording for workshop-recipe-ingredient-converter

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-recipe-ingredient-converter/67353880ed1f52ba28c8eb56.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-recipe-ingredient-converter/67353880ed1f52ba28c8eb56.md
@@ -13,7 +13,7 @@ Time to see your curried function in action. Here's how you might call our examp
 const dinner = tikkaMasala("curry powder")("tofu")("onion");
 ```
 
-Declare a `gramsResult` variable, and assign it the result of using your curried function to convert `2` `cup`s to `gram`.
+Declare a `gramsResult` variable, and assign it the result of using your curried function to convert 2 cups to `gram`.
 
 Log that value to the console.
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-recipe-ingredient-converter/67353880ed1f52ba28c8eb56.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-recipe-ingredient-converter/67353880ed1f52ba28c8eb56.md
@@ -13,7 +13,7 @@ Time to see your curried function in action. Here's how you might call our examp
 const dinner = tikkaMasala("curry powder")("tofu")("onion");
 ```
 
-Declare a `gramsResult` variable, and assign it the result of using your curried function to convert 2 cups to `gram`.
+Declare a `gramsResult` variable, and assign it the result of using your curried function to convert `2` units of the measure `cup` to `gram`.
 
 Log that value to the console.
 


### PR DESCRIPTION
This PR improves Crowdin compatibility for the `workshop-recipe-ingredient-converter` lesson by rewording a line that previously contained adjacent backticked elements.

Affected file:
- `curriculum/challenges/english/25-front-end-development/workshop-recipe-ingredient-converter/67353880ed1f52ba28c8eb56.md`

Change made:
- Rephrased a sentence to remove adjacent backticks around `2` and `cup`, ensuring it remains Crowdin-compatible while preserving instructional clarity.


This avoids adjacent code elements that can break translation via Crowdin.

Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org/#/contributing-guide).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/pull-request-guide).
- [x] My pull request targets the main branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

Related to #60039
