### PR TITLE
fix(curriculum): replace assert with assert.equal in cat painting step 29

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646cf88aa884405a11ea5bcc.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646cf88aa884405a11ea5bcc.md
@@ -14,13 +14,13 @@ Remove the sharp border of the right ear by setting the `border-top-left-radius`
 Your `.cat-right-ear` selector should have a `border-top-left-radius` property set to `90px`. Don't forget to add a semicolon.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderTopLeftRadius === '90px')
+assert(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderTopLeftRadius, '90px')
 ```
 
 Your `.cat-right-ear` selector should have a `border-top-right-radius` property set to `10px`. Don't forget to add a semicolon.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderTopRightRadius === '10px')
+assert(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderTopRightRadius, '10px')
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646cf88aa884405a11ea5bcc.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646cf88aa884405a11ea5bcc.md
@@ -14,13 +14,13 @@ Remove the sharp border of the right ear by setting the `border-top-left-radius`
 Your `.cat-right-ear` selector should have a `border-top-left-radius` property set to `90px`. Don't forget to add a semicolon.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderTopLeftRadius, '90px')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderTopLeftRadius, '90px')
 ```
 
 Your `.cat-right-ear` selector should have a `border-top-right-radius` property set to `10px`. Don't forget to add a semicolon.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderTopRightRadius, '10px')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderTopRightRadius, '10px')
 ```
 
 # --seed--


### PR DESCRIPTION
This PR improves assertion clarity in Step 29 of the `workshop-cat-painting` lesson by replacing generic assertions with more specific `assert.equal` methods.

**Affected file:**
- `curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646cf88aa884405a11ea5bcc.md`

**Changes made:**
- Replaced generic `assert(...)` statements with `assert.equal(...)` for better test output and clarity:
  - `borderTopLeftRadius === '90px'` → `assert.equal(..., '90px')`
  - `borderTopRightRadius === '10px'` → `assert.equal(..., '10px')`

These updates follow the current curriculum best practices for test assertions.

---

Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org/#/contributing-guide).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/pull-request-guide).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

Closes #60124
