### PR TITLE
fix(curriculum): typo in music player workshop step 3

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-music-player/674724ff8af92f7733e6d980.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-music-player/674724ff8af92f7733e6d980.md
@@ -7,7 +7,7 @@ dashedName: step-3
 
 # --description--
 
-Next, create an ampty array named `allSongs` to store all the songs.
+Next, create an empty array named `allSongs` to store all the songs.
 
 # --hints--
 


### PR DESCRIPTION
…ayer step-3

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #60127

<!-- Feel free to add any additional description of changes below this line -->
Fixed a typo in the step-3 description of the workshop-music-player lesson.
Changed 'ampty' to 'empty' for correct spelling and clarity.
