### PR TITLE
fix(curriculum): getRandomLunch regex and array modification check

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-lunch-picker-program/66db529d37ad966480ebb633.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-lunch-picker-program/66db529d37ad966480ebb633.md
@@ -312,17 +312,17 @@ try {
   // check that it correctly outputs the first item
   Math.random = () => 0;
   getRandomLunch(testLunches);
-  assert.strictEqual(regex.test(tempArr[0]), true);
+  assert.strictEqual(tempArr[0], `Randomly selected lunch: ${testLunches[0]}`);
 
   // second item 
   Math.random = () => 0.4;
   getRandomLunch(testLunches);
-  assert.strictEqual(regex.test(tempArr[1]), true);
+  assert.strictEqual(tempArr[1], `Randomly selected lunch: ${testLunches[1]}`);
 
   // third item
   Math.random = () => 0.8;
   getRandomLunch(testLunches);
-  assert.strictEqual(regex.test(tempArr[2]), true);
+  assert.strictEqual(tempArr[2], `Randomly selected lunch: ${testLunches[2]}`);
 } finally {
   // restore Math.random
   Math.random = tempRandom;
@@ -345,19 +345,10 @@ function checkIfArrayIsModified(original, callback) {
 }
 
 try {
-  console.log = () => {}; // Suppress console output for this test
+  console.log = () => {};
   
-  Math.random = () => 0;
-  const isModified1 = checkIfArrayIsModified(testLunches, getRandomLunch);
-  assert.strictEqual(isModified1, false);
-
-  Math.random = () => 0.4;
-  const isModified2 = checkIfArrayIsModified(testLunches, getRandomLunch);
-  assert.strictEqual(isModified2, false);
-
-  Math.random = () => 0.8;
-  const isModified3 = checkIfArrayIsModified(testLunches, getRandomLunch);
-  assert.strictEqual(isModified3, false);
+  const isModified = checkIfArrayIsModified(testLunches, getRandomLunch);
+  assert.isFalse(isModified);
 } finally {
   // restore Math.random
   Math.random = tempRandom;

--- a/curriculum/challenges/english/25-front-end-development/lab-lunch-picker-program/66db529d37ad966480ebb633.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-lunch-picker-program/66db529d37ad966480ebb633.md
@@ -297,7 +297,7 @@ try {
 }
 ```
 
-When the input array is not empty, the function `getRandomLunch` should log a string in the format `"Randomly selected lunch: [Lunch Item]"` to the console.
+When the input array is not empty, the function `getRandomLunch` should log a string in the format `"Randomly selected lunch: [Lunch Item]"` to the console. Additionally, your function `getRandomLunch` should not modify the input array.
 
 ```js
 const testLunches = ["Fish", "Fries", "Roast"];
@@ -305,23 +305,36 @@ const tempRandom = Math.random;
 const tempArr = [];
 const temp = console.log;
 
+// Helper function that returns whether the input array to a function was modified
+function checkIfArrayIsModified(original, callback) {
+  const arrayCopy = [...original];
+  callback(original);
+  return !(original.length === arrayCopy.length && original.every((value, index) => value === arrayCopy[index]));
+}
+
 try {
+  let isModified; 
+  const regex = /Randomly selected lunch: \w+/  // Output format to compare results with
+
   console.log = obj => tempArr.push(obj);
 
-  // check that it correctly outputs the first item
+  // check that it correctly outputs the first item and that the original array was not modified by getRandomLunch()
   Math.random = () => 0;
-  getRandomLunch(testLunches);
-  assert.strictEqual(tempArr[0], `Randomly selected lunch: ${testLunches[0]}`);
+  isModified = checkIfArrayIsModified(testLunches, getRandomLunch);
+  assert.strictEqual(regex.test(tempArr[0]), true);
+  assert.strictEqual(isModified, false);
 
-  // second item
+  // second item 
   Math.random = () => 0.4;
-  getRandomLunch(testLunches);
-  assert.strictEqual(tempArr[1], `Randomly selected lunch: ${testLunches[1]}`);
+  isModified = checkIfArrayIsModified(testLunches, getRandomLunch);
+  assert.strictEqual(regex.test(tempArr[1]), true);
+  assert.strictEqual(isModified, false);
 
   // third item
   Math.random = () => 0.8;
-  getRandomLunch(testLunches);
-  assert.strictEqual(tempArr[2], `Randomly selected lunch: ${testLunches[2]}`);
+  isModified = checkIfArrayIsModified(testLunches, getRandomLunch);
+  assert.strictEqual(regex.test(tempArr[2]), true);
+  assert.strictEqual(isModified, false);
 
 } finally {
   // restore Math.random

--- a/curriculum/challenges/english/25-front-end-development/lab-lunch-picker-program/66db529d37ad966480ebb633.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-lunch-picker-program/66db529d37ad966480ebb633.md
@@ -311,17 +311,20 @@ try {
 
   // check that it correctly outputs the first item
   Math.random = () => 0;
-  getRandomLunch(testLunches);
+  const testLunches1 = testLunches.slice();
+  getRandomLunch(testLunches1);
   assert.strictEqual(tempArr[0], `Randomly selected lunch: ${testLunches[0]}`);
 
   // second item 
   Math.random = () => 0.4;
-  getRandomLunch(testLunches);
+  const testLunches2 = testLunches.slice();
+  getRandomLunch(testLunches2);
   assert.strictEqual(tempArr[1], `Randomly selected lunch: ${testLunches[1]}`);
 
   // third item
   Math.random = () => 0.8;
-  getRandomLunch(testLunches);
+  const testLunches3 = testLunches.slice();
+  getRandomLunch(testLunches3);
   assert.strictEqual(tempArr[2], `Randomly selected lunch: ${testLunches[2]}`);
 } finally {
   // restore Math.random
@@ -334,7 +337,6 @@ The function `getRandomLunch` should not modify the input array.
 
 ```js
 const testLunches = ["Fish", "Fries", "Roast"];
-const tempRandom = Math.random;
 const temp = console.log;
 
 // Helper function that returns whether the input array to a function was modified
@@ -350,8 +352,6 @@ try {
   const isModified = checkIfArrayIsModified(testLunches, getRandomLunch);
   assert.isFalse(isModified);
 } finally {
-  // restore Math.random
-  Math.random = tempRandom;
   console.log = temp;
 }
 ```

--- a/curriculum/challenges/english/25-front-end-development/lab-lunch-picker-program/66db529d37ad966480ebb633.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-lunch-picker-program/66db529d37ad966480ebb633.md
@@ -297,12 +297,44 @@ try {
 }
 ```
 
-When the input array is not empty, the function `getRandomLunch` should log a string in the format `"Randomly selected lunch: [Lunch Item]"` to the console. Additionally, your function `getRandomLunch` should not modify the input array.
+When the input array is not empty, the function `getRandomLunch` should log a string in the format `"Randomly selected lunch: [Lunch Item]"` to the console.
 
 ```js
 const testLunches = ["Fish", "Fries", "Roast"];
 const tempRandom = Math.random;
 const tempArr = [];
+const temp = console.log;
+
+try {
+  console.log = obj => tempArr.push(obj);
+  const regex = /Randomly selected lunch: \w+/  // Output format to compare results with
+
+  // check that it correctly outputs the first item
+  Math.random = () => 0;
+  getRandomLunch(testLunches);
+  assert.strictEqual(regex.test(tempArr[0]), true);
+
+  // second item 
+  Math.random = () => 0.4;
+  getRandomLunch(testLunches);
+  assert.strictEqual(regex.test(tempArr[1]), true);
+
+  // third item
+  Math.random = () => 0.8;
+  getRandomLunch(testLunches);
+  assert.strictEqual(regex.test(tempArr[2]), true);
+} finally {
+  // restore Math.random
+  Math.random = tempRandom;
+  console.log = temp;
+}
+```
+
+The function `getRandomLunch` should not modify the input array.
+
+```js
+const testLunches = ["Fish", "Fries", "Roast"];
+const tempRandom = Math.random;
 const temp = console.log;
 
 // Helper function that returns whether the input array to a function was modified
@@ -313,29 +345,19 @@ function checkIfArrayIsModified(original, callback) {
 }
 
 try {
-  let isModified; 
-  const regex = /Randomly selected lunch: \w+/  // Output format to compare results with
-
-  console.log = obj => tempArr.push(obj);
-
-  // check that it correctly outputs the first item and that the original array was not modified by getRandomLunch()
+  console.log = () => {}; // Suppress console output for this test
+  
   Math.random = () => 0;
-  isModified = checkIfArrayIsModified(testLunches, getRandomLunch);
-  assert.strictEqual(regex.test(tempArr[0]), true);
-  assert.strictEqual(isModified, false);
+  const isModified1 = checkIfArrayIsModified(testLunches, getRandomLunch);
+  assert.strictEqual(isModified1, false);
 
-  // second item 
   Math.random = () => 0.4;
-  isModified = checkIfArrayIsModified(testLunches, getRandomLunch);
-  assert.strictEqual(regex.test(tempArr[1]), true);
-  assert.strictEqual(isModified, false);
+  const isModified2 = checkIfArrayIsModified(testLunches, getRandomLunch);
+  assert.strictEqual(isModified2, false);
 
-  // third item
   Math.random = () => 0.8;
-  isModified = checkIfArrayIsModified(testLunches, getRandomLunch);
-  assert.strictEqual(regex.test(tempArr[2]), true);
-  assert.strictEqual(isModified, false);
-
+  const isModified3 = checkIfArrayIsModified(testLunches, getRandomLunch);
+  assert.strictEqual(isModified3, false);
 } finally {
   // restore Math.random
   Math.random = tempRandom;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #60119

<!-- Feel free to add any additional description of changes below this line -->
I fixed the overly strict getRandomLunch() test by replacing its exact string equality check with a regex match (/^Randomly selected lunch: \w+/) so it only validates the required output format, and added a test to ensure getRandomLunch() doesn’t mutate the input array. This aligns the test with the lab instructions, prevents false failures, and makes the feedback clearer.
