### PR TITLE
fix(curriculum): replace assert with assert.equal in cat-ear test hints

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646cf88aa884405a11ea5bcc.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646cf88aa884405a11ea5bcc.md
@@ -14,13 +14,13 @@ Remove the sharp border of the right ear by setting the `border-top-left-radius`
 Your `.cat-right-ear` selector should have a `border-top-left-radius` property set to `90px`. Don't forget to add a semicolon.
 
 ```js
-assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderTopLeftRadius ,'90px')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderTopLeftRadius,'90px')
 ```
 
 Your `.cat-right-ear` selector should have a `border-top-right-radius` property set to `10px`. Don't forget to add a semicolon.
 
 ```js
-assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderTopRightRadius ,'10px')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderTopRightRadius,'10px')
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646cf88aa884405a11ea5bcc.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646cf88aa884405a11ea5bcc.md
@@ -14,13 +14,13 @@ Remove the sharp border of the right ear by setting the `border-top-left-radius`
 Your `.cat-right-ear` selector should have a `border-top-left-radius` property set to `90px`. Don't forget to add a semicolon.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderTopLeftRadius === '90px')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderTopLeftRadius ,'90px')
 ```
 
 Your `.cat-right-ear` selector should have a `border-top-right-radius` property set to `10px`. Don't forget to add a semicolon.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderTopRightRadius === '10px')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderTopRightRadius ,'10px')
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646cf88aa884405a11ea5bcc.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646cf88aa884405a11ea5bcc.md
@@ -14,13 +14,13 @@ Remove the sharp border of the right ear by setting the `border-top-left-radius`
 Your `.cat-right-ear` selector should have a `border-top-left-radius` property set to `90px`. Don't forget to add a semicolon.
 
 ```js
-assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderTopLeftRadius,'90px')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderTopLeftRadius, '90px')
 ```
 
 Your `.cat-right-ear` selector should have a `border-top-right-radius` property set to `10px`. Don't forget to add a semicolon.
 
 ```js
-assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderTopRightRadius,'10px')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderTopRightRadius, '10px')
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #60124

<!-- Feel free to add any additional description of changes below this line -->
Updated the workshop-cat-painting challenge (Step 29):
 Replaced incorrect test assertions using `assert(...) ===` with `assert.equal(...)`, which aligns with project testing standards.
