### PR TITLE
fix(curriculum): correct aria-label hint in music player step 43

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-music-player/6752edba757ff96404faf9e9.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-music-player/6752edba757ff96404faf9e9.md
@@ -27,7 +27,7 @@ setPlayButtonAccessibleText();
 assert.equal(playButton.getAttribute("aria-label"), "Play Cruising for a Musing");
 ```
 
- When `userData.currentSong` is `null`, `setPlayButtonAccessibleText` should set the `aria-label` attribute of the play button to `Play` followed by a space and title of the first song in your playlist.
+ When `userData.currentSong` is `null`, `setPlayButtonAccessibleText` should set the `aria-label` attribute of the play button to `Play`.
  
  ```js
 userData.currentSong = null;


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

Closes #60131 

This PR fixes an inconsistency in Step 43 of the "Build a Music Player" workshop. The instructional text previously stated that the aria-label should include the title of the first song when `userData.currentSong` is null, but the actual expected behavior (and test assertion) is that the label should simply be "Play".

- Updated the test hint text to correctly reflect the behavior
- Verified that the hint is displayed when the test fails