### PR TITLE
fix: replace assert() with assert.equal() in workshop-cat-painting hints

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646cf88aa884405a11ea5bcc.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646cf88aa884405a11ea5bcc.md
@@ -14,13 +14,13 @@ Remove the sharp border of the right ear by setting the `border-top-left-radius`
 Your `.cat-right-ear` selector should have a `border-top-left-radius` property set to `90px`. Don't forget to add a semicolon.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderTopLeftRadius === '90px')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderTopLeftRadius, '90px')
 ```
 
 Your `.cat-right-ear` selector should have a `border-top-right-radius` property set to `10px`. Don't forget to add a semicolon.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderTopRightRadius === '10px')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-right-ear')?.borderTopRightRadius, '10px')
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

Closes #60124

<!-- Feel free to add any additional description of changes below this line -->

## Summary

This PR updates Step 29 of the Cat Painting workshop to use specific assertion methods, replacing `assert(... === ...)` with `assert.equal(...)` in the hints section, as requested in #60124. This change aligns with freeCodeCamp’s preferred assertion style and improves code clarity.

## Details

- Updated two hint lines in `646cf88aa884405a11ea5bcc.md`:
  - Replaced `assert(... === ...)` with `assert.equal(...)` for both `borderTopLeftRadius` and `borderTopRightRadius`.
- No other changes were made.

Thank you for maintaining this project and for the opportunity to contribute!
