### PR TITLE
feat(tools): add section verifier

### DIFF
--- a/tools/challenge-parser/parser/__fixtures__/no-instructions.md
+++ b/tools/challenge-parser/parser/__fixtures__/no-instructions.md
@@ -1,0 +1,81 @@
+# --description--
+
+Paragraph 1
+
+```html
+code example
+```
+
+# --hi--
+
+Paragraph 0
+
+```html
+code example 0
+```
+
+# --hints--
+
+First hint
+
+```js
+// test code
+```
+
+Second hint with <code>code</code>
+
+```js
+// more test code
+```
+
+Third *hint* with <code>code</code> and `inline code`
+
+```js
+// more test code
+if(let x of xs) {
+  console.log(x);
+}
+```
+
+# --seed--
+
+## --seed-contents--
+
+```html
+<html>
+  <body>
+  </body>
+</html>
+```
+
+```css
+body {
+  background: green;
+}
+```
+
+```js
+var x = 'y';
+```
+
+
+# --solutions--
+
+::id{#html-key}
+
+```html
+<html>
+  <body>
+  </body>
+</html>
+```
+
+```css
+body {
+  background: white;
+}
+```
+
+```js
+var x = 'y';
+``

--- a/tools/challenge-parser/parser/index.js
+++ b/tools/challenge-parser/parser/index.js
@@ -17,7 +17,7 @@ const restoreDirectives = require('./plugins/restore-directives');
 const tableAndStrikeThrough = require('./plugins/table-and-strikethrough');
 const addScene = require('./plugins/add-scene');
 const addQuizzes = require('./plugins/add-quizzes');
-
+const sectionVerifier = require('./plugins/section-verifier');
 // by convention, anything that adds to file.data has the name add<name>.
 const processor = unified()
   // add the remark parser
@@ -55,13 +55,15 @@ const processor = unified()
   .use(addQuizzes)
   .use(addBeforeHook)
   .use(addTests)
+
   .use(addText, [
     'description',
     'instructions',
     'notes',
     'explanation',
     'transcript'
-  ]);
+  ])
+  .use(sectionVerifier, ['description', 'instructions']);
 
 exports.parseMD = function parseMD(filename) {
   return new Promise((resolve, reject) => {

--- a/tools/challenge-parser/parser/plugins/section-verifier.js
+++ b/tools/challenge-parser/parser/plugins/section-verifier.js
@@ -1,0 +1,23 @@
+const { getSection } = require('./utils/get-section');
+
+function plugin(sectionIds) {
+  if (!sectionIds || !Array.isArray(sectionIds) || sectionIds.length <= 0) {
+    throw new Error(
+      'sectionVerifier must have an array of section ids supplied'
+    );
+  }
+
+  return transformer;
+
+  function transformer(tree) {
+    for (const sectionId of sectionIds) {
+      const section = getSection(tree, `--${sectionId}--`);
+
+      if (section.length == 0) {
+        throw Error(`This file must contain a ${sectionId} section.`);
+      }
+    }
+  }
+}
+
+module.exports = plugin;

--- a/tools/challenge-parser/parser/plugins/section-verifier.test.js
+++ b/tools/challenge-parser/parser/plugins/section-verifier.test.js
@@ -1,0 +1,23 @@
+const parseFixture = require('../__fixtures__/parse-fixture');
+
+const sectionVerifier = require('./section-verifier');
+
+describe('section-verifier plugin', () => {
+  let noInstructionsAST;
+
+  const plugin = sectionVerifier(['description', 'instructions']);
+
+  beforeAll(async () => {
+    noInstructionsAST = await parseFixture('no-instructions.md');
+  });
+
+  it('returns a function', () => {
+    expect(typeof plugin).toEqual('function');
+  });
+
+  it('should throw an error if the instructions section is missing', () => {
+    expect(() => plugin(noInstructionsAST)).toThrow(
+      `This file must contain a instructions section.`
+    );
+  });
+});


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related to #60129

<!-- Feel free to add any additional description of changes below this line -->

This is my take on what a section verifier plugin should probably look like. A big problem (as of the first version), is that some challenge types are not supposed to have these sections and the other fixtures don't work with the seed verifier plugin. 