### PR TITLE
fix(a11y): hide Fail icon from screen readers

### DIFF
--- a/client/src/assets/icons/fail.tsx
+++ b/client/src/assets/icons/fail.tsx
@@ -10,6 +10,7 @@ function RedFail(): JSX.Element {
       viewBox='0 0 200 200'
       width='50'
       xmlns='http://www.w3.org/2000/svg'
+      aria-hidden='true'
     >
       <g>
         <title>{t('icons.fail')}</title>

--- a/client/src/templates/Challenges/classic/lower-jaw.tsx
+++ b/client/src/templates/Challenges/classic/lower-jaw.tsx
@@ -140,7 +140,7 @@ const LowerJawTips = ({
         className='test-status fade-in'
         aria-hidden={showFeedback}
       >
-        <Fail aria-hidden='true' />
+        <Fail />
         <p>{learnEncouragementText}</p>
       </div>
       <div


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

I was testing [a workshop challenge](https://www.freecodecamp.org/learn/full-stack-developer/workshop-cat-photo-app/step-18) with VoiceOver and noticed that the X icon in the lower jaw is announced as "image". It looks like the icon is supposed to be hidden but is announced here because the lower jaw component passes `aria-hidden={true}` to the icon, but the icon component doesn't forward the prop down to the SVG, so the attribute isn't applied.

We have another usage of the icon in lab test suite, and the icon is also hidden via its container: 

https://github.com/freeCodeCamp/freeCodeCamp/blob/181321d90dffd8ed2e27fd76eebd5dbc013b9730/client/src/templates/Challenges/components/test-suite.tsx#L53-L55

Given that the icon is purely for decoration in all of its usages, I'm setting `aria-hidden='true'` directly to the SVG.

<!-- Feel free to add any additional description of changes below this line -->
