### PR TITLE
refactor: use specific assert methods in Cat Painting Workshop tests (#60161)

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646dd8c79ec23463a3d0e356.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646dd8c79ec23463a3d0e356.md
@@ -14,25 +14,26 @@ It's time to work on the right inner ear. Using a class selector, give your `.ca
 You should have a `.cat-right-inner-ear` selector.
 
 ```js 
-assert(new __helpers.CSSHelp(document).getStyle('.cat-right-inner-ear'))
+assert.exists(new __helpers.CSSHelp(document).getStyle('.cat-right-inner-ear'))
 ```
 
 Your `.cat-right-inner-ear` selector should have a `border-left` property set to `20px solid transparent`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-right-inner-ear')?.borderLeft === '20px solid transparent')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-right-inner-ear')?.borderLeft,'20px solid transparent')
+
 ```
 
 Your `.cat-right-inner-ear` selector should have a `border-right` property set to `20px solid transparent`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-right-inner-ear')?.borderRight === '20px solid transparent')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-right-inner-ear')?.borderRight,'20px solid transparent')
 ```
 
 Your `.cat-right-inner-ear` selector should have a `border-bottom` property set to `40px solid #3b3b4f`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-right-inner-ear')?.borderBottom === '40px solid rgb(59, 59, 79)')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-right-inner-ear')?.borderBottom,'40px solid rgb(59, 59, 79)')
 ```
 
 # --seed--


### PR DESCRIPTION
refactor: use specific assert methods in Cat Painting Workshop tests (#60161)

Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

Closes #60161

This PR updates tests in the Cat Painting Workshop to use specific assertion methods for clarity and correctness:

- Replaced `assert()` with `assert.exists()` for existence checks
- Converted comparisons using `===` into `assert.equal(a, b)` for better test readability

These changes are scoped only to the `cat-right-inner-ear` style tests across steps 36–37.

