### PR TITLE
Feat/add save alert for projects

### DIFF
--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -236,7 +236,6 @@ function ShowClassic({
   executeChallenge,
   previewMounted
 }: ShowClassicProps) {
-  // console.log('Classic Alondra');
   const { t } = useTranslation();
   const curLocation = useLocation();
   const [showExitModal, setShowExitModal] = useState(false);
@@ -587,7 +586,7 @@ function ShowClassic({
             <Modal.Body alignment='center'>
               Are you sure you want to leave? Any unsaved changes will be lost.
             </Modal.Body>
-            <Spacer size='m' />
+            <Spacer size='xxs' />
             <Modal.Footer>
               <Button
                 block


### PR DESCRIPTION
- [ ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org/).
- [ ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ ] My pull request targets the main branch of freeCodeCamp.
- [ ]  I have tested these changes either locally on my machine, or Gitpod.

Closes #54796 

This PR implements a confirmation modal on certification project pages that warns users if they attempt to leave the page without saving their code.

Unlike regular challenges, certification projects on FreeCodeCamp do not automatically save code unless the user manually clicks the “Save your Code” button. To help prevent accidental data loss, this PR adds a modal that prompts users to confirm their decision to leave when unsaved progress is detected.

Displayed a confirmation modal with the message:
“Are you sure you want to leave? Any unsaved changes will be lost.”

Modal includes two actions:

“Yes, I want to leave the project” — confirms navigation.

“I would like to continue working” — cancels navigation.

Navigate to:
/learn/responsive-web-design/basic-web-design-certification-project

How to Test:

Edit the code without clicking “Save your Code”.

Attempt to leave the page (click another route or close the tab).

Confirm the modal appears and:

Clicking “Yes” allows navigation.

Clicking “I would like to continue working” cancels it.
