### PR TITLE
fix(curriculum): improve Crowdin compatibility for workshop-city-skyline

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-city-skyline/5d822fd413a79914d39e98d5.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-city-skyline/5d822fd413a79914d39e98d5.md
@@ -11,7 +11,7 @@ Center the parts of your building by turning the `.bb1` element into a flexbox p
 
 # --hints--
 
-You should not change the `.bb1` `width` or `height` properties.
+You should not change the `width` or `height` properties of the element with a `class` attribute of `bb1`.
 
 ```js
 const bb1Style = new __helpers.CSSHelp(document).getStyle('.bb1');

--- a/curriculum/challenges/english/25-front-end-development/workshop-city-skyline/5d822fd413a79914d39e98d5.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-city-skyline/5d822fd413a79914d39e98d5.md
@@ -11,7 +11,7 @@ Center the parts of your building by turning the `.bb1` element into a flexbox p
 
 # --hints--
 
-You should not change the `width` or `height` properties of the element with a `class` attribute of `bb1`.
+You should not change the `width` or `height` properties of the `.bb1` element.
 
 ```js
 const bb1Style = new __helpers.CSSHelp(document).getStyle('.bb1');

--- a/curriculum/challenges/english/25-front-end-development/workshop-city-skyline/5d822fd413a79914d39e9939.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-city-skyline/5d822fd413a79914d39e9939.md
@@ -11,7 +11,7 @@ At the top of the sky gradient color list, where you would put a direction for t
 
 # --hints--
 
-You should give the `.sky` `radial-gradient` a direction of `circle closest-corner at 15% 15%`.
+You should give the `radial-gradient` value in the CSS rule with a `class` value of `sky` a direction of `circle closest-corner at 15% 15%`.
 
 ```js
 assert.match(new __helpers.CSSHelp(document).getStyle(".sky")?.background, /radial-gradient\(circle closest-corner at 15% 15%, rgb\(255, 207, 51\)|( 0%), rgb\(255, 207, 51\) 20%, rgb\(255, 255, 102\) 21%, rgb\(187, 238, 255\) 100%\)/);

--- a/curriculum/challenges/english/25-front-end-development/workshop-city-skyline/5d822fd413a79914d39e9939.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-city-skyline/5d822fd413a79914d39e9939.md
@@ -11,7 +11,7 @@ At the top of the sky gradient color list, where you would put a direction for t
 
 # --hints--
 
-You should give the `radial-gradient` value in the CSS rule with a `class` value of `sky` a direction of `circle closest-corner at 15% 15%`.
+You should give the `.sky` element a `radial-gradient` of `circle closest-corner at 15% 15%`.
 
 ```js
 assert.match(new __helpers.CSSHelp(document).getStyle(".sky")?.background, /radial-gradient\(circle closest-corner at 15% 15%, rgb\(255, 207, 51\)|( 0%), rgb\(255, 207, 51\) 20%, rgb\(255, 255, 102\) 21%, rgb\(187, 238, 255\) 100%\)/);


### PR DESCRIPTION
Description:
This PR updates the content in `workshop-city-skyline` to improve Crowdin translation compatibility by fixing adjacent inline code formatting issues.

Changes:
- Updated workshop-city-skyline
  - `5d822fd413a79914d39e98d5.md`
  - `5d822fd413a79914d39e9939.md`

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related to: https://github.com/freeCodeCamp/freeCodeCamp/issues/60039

<!-- Feel free to add any additional description of changes below this line -->
