### PR TITLE
Add MDN link to array indexing description 

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/access-array-data-with-indexes.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/access-array-data-with-indexes.md
@@ -10,7 +10,7 @@ dashedName: access-array-data-with-indexes
 
 We can access the data inside arrays using <dfn>indexes</dfn>.
 
-Array indexes are written in the same bracket notation that strings use, except that instead of specifying a character, they are specifying an entry in the array. Like strings, arrays use <dfn>zero-based</dfn> indexing, so the first element in an array has an index of `0`.
+Array indexes are written in the same bracket notation that strings use, except that instead of specifying a character, they are specifying an entry in the array. Like strings, arrays use <dfn>zero-based</dfn> indexing, so the first element in an array has an index of `0`. Learn more about arrays on [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array).
 
 <br>
 


### PR DESCRIPTION
Added a link to MDN Web Docs in the description of access-array-data-with-indexes.md to help learners explore arrays further.