### PR TITLE
fix(curriculum): prevent hardcoding in addition functions

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-calculator/66cc095dfe1682753d2ab030.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-calculator/66cc095dfe1682753d2ab030.md
@@ -21,6 +21,13 @@ Inside your `addTwoAndSeven` function, return the sum of `2` and `7`.
 
 # --hints--
 
+Your `addTwoAndSeven` function should calculate and return the sum of `2` and `7`, not just 
+return `9` directly.
+
+```js
+assert.match(code, /return\s*2\s*\+\s*7\s*;?/);
+```
+
 Your `addTwoAndSeven` function should return the sum of `2` and `7`.
 
 ```js

--- a/curriculum/challenges/english/25-front-end-development/workshop-calculator/66cc095dfe1682753d2ab030.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-calculator/66cc095dfe1682753d2ab030.md
@@ -33,8 +33,6 @@ Your `addTwoAndSeven` function should return the sum using the `+` operator.
 assert.match(code, /return\s*(2\s*\+\s*7|7\s*\+\s*2)\s*;?/);
 ```
 
-
-
 # --seed--
 
 ## --seed-contents--

--- a/curriculum/challenges/english/25-front-end-development/workshop-calculator/66cc095dfe1682753d2ab030.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-calculator/66cc095dfe1682753d2ab030.md
@@ -27,7 +27,7 @@ Your `addTwoAndSeven` function should return the sum of `2` and `7`.
 assert.strictEqual(addTwoAndSeven(), 9);
 ```
 
-Your `addTwoAndSeven` function should calculate and return the sum of `2` and `7`.
+Your `addTwoAndSeven` function should return the sum using the `+` operator.
 
 ```js
 assert.match(code, /return\s*(2\s*\+\s*7|7\s*\+\s*2)\s*;?/);

--- a/curriculum/challenges/english/25-front-end-development/workshop-calculator/66cc095dfe1682753d2ab030.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-calculator/66cc095dfe1682753d2ab030.md
@@ -21,18 +21,19 @@ Inside your `addTwoAndSeven` function, return the sum of `2` and `7`.
 
 # --hints--
 
-Your `addTwoAndSeven` function should calculate and return the sum of `2` and `7`, not just 
-return `9` directly.
-
-```js
-assert.match(code, /return\s*(2\s*\+\s*7|7\s*\+\s*2)\s*;?/);
-```
-
 Your `addTwoAndSeven` function should return the sum of `2` and `7`.
 
 ```js
 assert.strictEqual(addTwoAndSeven(), 9);
 ```
+
+Your `addTwoAndSeven` function should calculate and return the sum of `2` and `7`.
+
+```js
+assert.match(code, /return\s*(2\s*\+\s*7|7\s*\+\s*2)\s*;?/);
+```
+
+
 
 # --seed--
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-calculator/66cc095dfe1682753d2ab030.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-calculator/66cc095dfe1682753d2ab030.md
@@ -25,7 +25,7 @@ Your `addTwoAndSeven` function should calculate and return the sum of `2` and `7
 return `9` directly.
 
 ```js
-assert.match(code, /return\s*2\s*\+\s*7\s*;?/);
+assert.match(code, /return\s*(2\s*\+\s*7|7\s*\+\s*2)\s*;?/);
 ```
 
 Your `addTwoAndSeven` function should return the sum of `2` and `7`.

--- a/curriculum/challenges/english/25-front-end-development/workshop-calculator/66cc0ba5881acb7692cfc4de.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-calculator/66cc0ba5881acb7692cfc4de.md
@@ -27,7 +27,7 @@ Your `addThreeAndFour` function should return the sum of `3` and `4`.
 assert.equal(addThreeAndFour(), 7);
 ```
 
-Your `addThreeAndFour` function should calculate and return the sum of `3` and `4`.
+Your `addThreeAndFour` function should return the sum using the `+` operator.
 
 ```js
 assert.match(code, /return\s*(3\s*\+\s*4|4\s*\+\s*3)\s*;?/);

--- a/curriculum/challenges/english/25-front-end-development/workshop-calculator/66cc0ba5881acb7692cfc4de.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-calculator/66cc0ba5881acb7692cfc4de.md
@@ -21,17 +21,16 @@ You should declare a function called `addThreeAndFour`.
 assert.isFunction(addThreeAndFour);
 ```
 
-Your `addThreeAndFour` function should calculate and return the sum of `3` and `4`, not just return `7` directly.
-
-```js
-assert.match(code, /return\s*(3\s*\+\s*4|4\s*\+\s*3)\s*;?/);
-```
-
-
 Your `addThreeAndFour` function should return the sum of `3` and `4`.
 
 ```js
 assert.equal(addThreeAndFour(), 7);
+```
+
+Your `addThreeAndFour` function should calculate and return the sum of `3` and `4`.
+
+```js
+assert.match(code, /return\s*(3\s*\+\s*4|4\s*\+\s*3)\s*;?/);
 ```
 
 You should call the `addThreeAndFour` function inside a `console.log`.

--- a/curriculum/challenges/english/25-front-end-development/workshop-calculator/66cc0ba5881acb7692cfc4de.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-calculator/66cc0ba5881acb7692cfc4de.md
@@ -21,6 +21,13 @@ You should declare a function called `addThreeAndFour`.
 assert.isFunction(addThreeAndFour);
 ```
 
+Your `addThreeAndFour` function should calculate and return the sum of `3` and `4`, not just return `7` directly.
+
+```js
+assert.match(code, /return\s*3\s*\+\s*4\s*;?/);
+```
+
+
 Your `addThreeAndFour` function should return the sum of `3` and `4`.
 
 ```js

--- a/curriculum/challenges/english/25-front-end-development/workshop-calculator/66cc0ba5881acb7692cfc4de.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-calculator/66cc0ba5881acb7692cfc4de.md
@@ -24,7 +24,7 @@ assert.isFunction(addThreeAndFour);
 Your `addThreeAndFour` function should calculate and return the sum of `3` and `4`, not just return `7` directly.
 
 ```js
-assert.match(code, /return\s*3\s*\+\s*4\s*;?/);
+assert.match(code, /return\s*(3\s*\+\s*4|4\s*\+\s*3)\s*;?/);
 ```
 
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes locally on my machine.

Closes #60189

### Changes Made:
- Updated test cases for `addTwoAndSeven()` and `addThreeAndFour()` in the Calculator Workshop
- Added validation to ensure functions perform actual addition (`2 + 7` and `3 + 4`)
- Prevented hardcoded return values (`9` and `7`) from passing tests
- Maintained all existing challenge requirements