### PR TITLE
fix(curriculum): refactored input.value to input.value = "![alt-text](image-source)\n![alt-text-2](image-source-2)"; in test 38

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-markdown-to-html-converter/66f55eac933ff64ce654ca74.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-markdown-to-html-converter/66f55eac933ff64ce654ca74.md
@@ -638,7 +638,7 @@ When the value of `#markdown-input` is `![alt-text](image-source)` followed by `
 
 ```js
 const input = document.querySelector("#markdown-input");
-input.value = "!![alt-text](image-source)\n![alt-text-2](image-source-2)";
+input.value = "![alt-text](image-source)\n![alt-text-2](image-source-2)";
 const testDiv = document.createElement("div");
 testDiv.innerHTML = convertMarkdown();
 const imgs = testDiv.querySelectorAll("img");


### PR DESCRIPTION


Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #60034

<!-- Feel free to add any additional description of changes below this line -->

The issue is not yet completely resolved as i encountered a problem 
![image](https://github.com/user-attachments/assets/670888bd-5e77-4504-b63f-d3af8d4c0e2b)
the following files does not exist in codebase so i was unable to test the changes. I'll make necessary changes in test 47 too once i get directions on these errors. 
