### PR TITLE
fix(curriculum): update step 33 of cat painting workshop to use assert.equal

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646dd556d524bc61c0139bd6.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646dd556d524bc61c0139bd6.md
@@ -16,25 +16,25 @@ Using a class selector, give your `.cat-left-inner-ear` element a left and right
 You should have a `.cat-left-inner-ear` selector.
 
 ```js 
-assert(new __helpers.CSSHelp(document).getStyle('.cat-left-inner-ear'))
+assert.exists(new __helpers.CSSHelp(document).getStyle('.cat-left-inner-ear'))
 ```
 
 Your `.cat-left-inner-ear` selector should have a `border-left` property set to `20px solid transparent`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-left-inner-ear')?.borderLeft === '20px solid transparent')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-left-inner-ear')?.borderLeft, '20px solid transparent')
 ```
 
 Your `.cat-left-inner-ear` selector should have a `border-right` property set to `20px solid transparent`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-left-inner-ear')?.borderRight === '20px solid transparent')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-left-inner-ear')?.borderRight, '20px solid transparent')
 ```
 
 Your `.cat-left-inner-ear` selector should have a `border-bottom` property set to `40px solid #3b3b4f`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-left-inner-ear')?.borderBottom === '40px solid rgb(59, 59, 79)')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-left-inner-ear')?.borderBottom, '40px solid rgb(59, 59, 79)')
 ```
 
 # --seed--


### PR DESCRIPTION
This PR updates the test assertions in step 33 of the Cat Painting Workshop challenge to align with proper use of the assert.equal() method, as outlined in the issue.

replace the use of:`assert(a === b)` 

with the preferred method:`assert.equal(a, b)`

Specifically, the following updates were made to file:
[[freeCodeCamp/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646dd556d524bc61c0139bd6.md](https://github.com/freeCodeCamp/freeCodeCamp/blob/dc5c7893b50b92795da3fcedf74e0f38cdc745ed/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646dd556d524bc61c0139bd6.md#L19)]

Updated the tests targeting the .cat-left-inner-ear selector:

Existence check added using assert.exists(...) to confirm the element is present in the DOM.

borderLeft now checked using assert.equal(...).

borderRight now checked using assert.equal(...).

borderBottom now checked using assert.equal(...).

These changes improve test consistency, align with the instructional intent of the issue, and maintain clarity of feedback in case of test failures.


Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #60209

<!-- Feel free to add any additional description of changes below this line -->
Testing
All updated assertions were validated locally using the freeCodeCamp development environment.

Confirmed the .cat-left-inner-ear styling is verified correctly.

Confirmed visual rendering of the cat ears remains intact.
![Screenshot_blank_test](https://github.com/user-attachments/assets/e74da4c3-ad2e-49f1-aca0-69db6e862969)
![Screenshot_tests_successful](https://github.com/user-attachments/assets/abb52842-33a3-4982-9a99-e67ac795c33e)
![Screenshot_code](https://github.com/user-attachments/assets/04fc9956-a141-43d3-961e-3d0ab8da2f4d)

