### PR TITLE
fix(curriculum): blank indicators in English challenges

### DIFF
--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a54278a4df6323549e8f9.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a54278a4df6323549e8f9.md
@@ -13,7 +13,7 @@ The word `that` points to something a bit far from you. Imagine you're in a shop
 
 ## --text--
 
-You see a tablet far away and say: `BLANKBLANKBLANK is the tablet I want.`
+You see a tablet far away and say: `BLANK is the tablet I want.`
 
 ## --answers--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc35036d0a00fe17e7cee.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc35036d0a00fe17e7cee.md
@@ -7,7 +7,7 @@ dashedName: task-95
 
 <!--
 AUDIO REFERENCE:
-Tom: Wow, I'm BLANKBLANKBLANKBLANK hungry.
+Tom: Wow, I'm so hungry.
 -->
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd061eb49fb14f672f77f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd061eb49fb14f672f77f.md
@@ -7,7 +7,7 @@ dashedName: task-121
 
 <!--
 AUDIO REFERENCE:
-Sophie: It is nice to BLANKBLANKBLANKBLANKBLANKBLANKBLANKBLANKBLANK from the office.
+Sophie: It is nice to have a break from the office.
 -->
 
 # --description--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR:
- Changes "BLANKBLANKBLANK" to "BLANK" to represent a blank in the question text (we probably missed this when we were cleaning up the use of underscores)
  - Affected challenge: https://www.freecodecamp.org/learn/a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/task-55
- Updates audio references with actual text instead of "BLANK"

<!-- Feel free to add any additional description of changes below this line -->
