### PR TITLE
fix(curriculum): use assert.equal in cat painting workshop

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646dd6f9caa862627dd87772.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646dd6f9caa862627dd87772.md
@@ -14,19 +14,19 @@ Move the inner ear into position with a `position` property set to `absolute`, a
 Your `.cat-left-inner-ear` selector should have a `position` property set to `absolute`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-left-inner-ear')?.position === 'absolute')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-left-inner-ear')?.position, 'absolute')
 ```
 
 Your `.cat-left-inner-ear` selector should have a `top` property set to `22px`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-left-inner-ear')?.top === '22px')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-left-inner-ear')?.top, '22px')
 ```
 
 Your `.cat-left-inner-ear` selector should have a `left` property set to `-20px`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-left-inner-ear')?.left === '-20px')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-left-inner-ear')?.left, '-20px')
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646dd7cfd0cfac630c1dd520.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646dd7cfd0cfac630c1dd520.md
@@ -14,25 +14,25 @@ To remove all the pointed edges of the ear, set a bottom-right and bottom-left b
 Your `.cat-left-inner-ear` selector should have a `border-bottom-right-radius` property set to `40%`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-left-inner-ear')?.borderBottomRightRadius === '40%')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-left-inner-ear')?.borderBottomRightRadius, '40%')
 ```
 
 Your `.cat-left-inner-ear` selector should have a `border-bottom-left-radius` property set to `40%`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-left-inner-ear')?.borderBottomLeftRadius === '40%')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-left-inner-ear')?.borderBottomLeftRadius, '40%')
 ```
 
 Your `.cat-left-inner-ear` selector should have a `border-top-left-radius` property set to `90px`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-left-inner-ear')?.borderTopLeftRadius === '90px')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-left-inner-ear')?.borderTopLeftRadius, '90px')
 ```
 
 Your `.cat-left-inner-ear` selector should have a `border-top-right-radius` property set to `10px`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-left-inner-ear')?.borderTopRightRadius === '10px')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-left-inner-ear')?.borderTopRightRadius, '10px')
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #60160 

<!-- Feel free to add any additional description of changes below this line -->

Replaced assert() with assert.equal() in the Cat Painting Workshop steps 34–35 to align with best practices and improve test clarity and tested changes as well.
