### PR TITLE
Fixed typo 'asnwer' to 'answer' in English challenges

### DIFF
--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a534f9fdc15f01ed67d860.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a534f9fdc15f01ed67d860.md
@@ -9,7 +9,7 @@ dashedName: task-114
 
 # --description--
 
-Listen to Tom and asnwer the question.
+Listen to Tom and answer the question.
 
 # --questions--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66a9106281f6032d5fc97104.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-describe-places-and-events/66a9106281f6032d5fc97104.md
@@ -56,7 +56,7 @@ Lisa's answer does not suggest she is leaving.
 
 When someone asks `Do you have a minute?`, they are checking if you are available to talk. 
 
-If you asnwer `Sure, what's up?`, it means you are ready to listen and have time to talk.
+If you answer `Sure, what's up?`, it means you are ready to listen and have time to talk.
 
 # --scene--
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

 Description of Changes:

- Fixed a typo in two English challenge files.
- Replaced "asnwer" with "answer."

Files Updated:
- 66a9106281f6032d5fc97104.md (line 59) in "learn how to describe places and events."
- 65a534f9fdc15f01ed67d860.md (line 12) in "learn how to have a conversation about preferences and motivations."

Closes #60249