### PR TITLE
fix: remove duplicate validation status in some MCQ challenges

### DIFF
--- a/client/src/templates/Challenges/components/multiple-choice-questions.tsx
+++ b/client/src/templates/Challenges/components/multiple-choice-questions.tsx
@@ -85,11 +85,13 @@ function MultipleChoiceQuestions({
                     <div
                       className={`video-quiz-option-label mcq-feedback ${isCorrect ? 'mcq-correct' : 'mcq-incorrect'}`}
                     >
-                      <p>
-                        {isCorrect
-                          ? t('learn.quiz.correct-answer')
-                          : t('learn.quiz.incorrect-answer')}
-                      </p>
+                      {!feedback && (
+                        <p>
+                          {isCorrect
+                            ? t('learn.quiz.correct-answer')
+                            : t('learn.quiz.incorrect-answer')}
+                        </p>
+                      )}
                       {feedback && (
                         <p>
                           <PrismFormatted


### PR DESCRIPTION

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.



Closes #60179

To avoid displaying duplicate validation statuses in some MCQ challenges, I first check if feedback already exists. If not, I show the default correct/incorrect messages; otherwise, I display the provided feedback.
