### PR TITLE
fix(curriculum): remove validation status from feedback texts

### DIFF
--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657b703d0cd20eb51c2fd239.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657b703d0cd20eb51c2fd239.md
@@ -21,7 +21,7 @@ I don't coding on weekends.
 
 ### --feedback--
 
-Incorrect: `coding` should be in the base form `code` when used with `don't.`
+`Coding` should be in the base form `code` when used with `don't.`
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657cb68bf15f349a744b5fba.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657cb68bf15f349a744b5fba.md
@@ -29,7 +29,7 @@ Choose the correct question for asking about a person's personality and characte
 
 ### --feedback--
 
-`What do they like?` is used to inquire about someone's preferences or interests.
+This sentence is used to inquire about someone's preferences or interests.
 
 ---
 
@@ -37,7 +37,7 @@ Choose the correct question for asking about a person's personality and characte
 
 ### --feedback--
 
-`What is they like?` is not grammatically correct in English.
+This sentence is not grammatically correct in English.
 
 ---
 
@@ -49,7 +49,7 @@ Choose the correct question for asking about a person's personality and characte
 
 ### --feedback--
 
-`What do they looks like?` is incorrect; it mixes up the structure for asking about personality with the structure for asking about physical appearance and also uses a plural verb `looks` with a singular pronoun `they.`
+This sentence mixes up the structure for asking about personality with the structure for asking about physical appearance and also uses a plural verb `looks` with a singular pronoun `they.`
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657ce22e1bdf763280ae1e2b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657ce22e1bdf763280ae1e2b.md
@@ -27,7 +27,7 @@ What she likes to do.
 
 ### --feedback--
 
-This option is incorrect because the question does not ask about preferences or likes, but about a location.
+The question does not ask about preferences or likes, but about a location.
 
 ---
 
@@ -35,7 +35,7 @@ The time she works.
 
 ### --feedback--
 
-This option is incorrect because the question does not concern the time of work, but the place.
+The question does not concern the time of work, but the place.
 
 ---
 
@@ -47,7 +47,7 @@ Who she works with.
 
 ### --feedback--
 
-This option is incorrect because the question is about a place, not about the people she works with.
+The question is about a place, not about the people she works with.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657ce9e5593ae449e7ae6073.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-conversation-starters-in-the-break-room/657ce9e5593ae449e7ae6073.md
@@ -23,7 +23,7 @@ She works from home and has meetings.
 
 ### --feedback--
 
-This option is incorrect because there is no mention of Maria working from home, only from her office.
+There is no mention of Maria working from home, only from her office.
 
 ---
 
@@ -31,7 +31,7 @@ She is always in her office.
 
 ### --feedback--
 
-This option is incorrect because the sentence specifically states `most of the time,` which implies that there are times when she is not in her office.
+The sentence specifically states `most of the time`, which implies that there are times when she is not in her office.
 
 ---
 
@@ -39,7 +39,7 @@ She is usually in meetings a lot.
 
 ### --feedback--
 
-This option is incorrect because it does not acknowledge that Maria also spends a significant amount of time working from her office, not just in meetings.
+Maria also spends a significant amount of time working from her office, not just in meetings.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6552939414fdaa21fc734788.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6552939414fdaa21fc734788.md
@@ -26,7 +26,7 @@ Maria is happy Tom visited California.
 
 ### --feedback--
 
-Incorrect. The phrase doesn't comment on Tom's visit to California.
+The phrase doesn't comment on Tom's visit to California.
 
 ---
 
@@ -34,7 +34,7 @@ Maria is greeting Tom on a boat.
 
 ### --feedback--
 
-Incorrect. The dialogue isn't about being on a boat.
+The dialogue isn't about being on a boat.
 
 ---
 
@@ -46,7 +46,7 @@ Maria is introducing Tom to the board of directors.
 
 ### --feedback--
 
-Incorrect. Maria isn't introducing Tom to any board of directors.
+Maria isn't introducing Tom to any board of directors.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6568c68b92a63810a57cffaf.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6568c68b92a63810a57cffaf.md
@@ -27,7 +27,7 @@ Texas
 
 ### --feedback--
 
-Incorrect. `It's` isn't referring to Texas but is rather being compared to it.
+`It's` isn't referring to Texas but is rather being compared to it.
 
 ---
 
@@ -35,7 +35,7 @@ The weather
 
 ### --feedback--
 
-Incorrect. While the weather might be a factor, the dialogue does not specify this.
+While the weather might be a factor, the dialogue does not specify this.
 
 ---
 
@@ -43,7 +43,7 @@ The food
 
 ### --feedback--
 
-Incorrect. There's no mention of food in the dialogue.
+There's no mention of food in the dialogue.
 
 ---
 
@@ -51,7 +51,7 @@ California
 
 ### --feedback--
 
-Correct! In this context, `It's` refers to California, which Tom is describing in relation to Texas.
+In this context, `It's` refers to California, which Tom is describing in relation to Texas.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6568c759cb59e810dfaa1506.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6568c759cb59e810dfaa1506.md
@@ -26,7 +26,7 @@ He feels out of place in California.
 
 ### --feedback--
 
-Incorrect. `I like it here` shows a positive feeling, not feeling out of place.
+`I like it here` shows a positive feeling, not feeling out of place.
 
 ---
 
@@ -34,7 +34,7 @@ He misses Texas a lot.
 
 ### --feedback--
 
-Incorrect. While Tom acknowledges differences from Texas, he doesn't explicitly express missing it in this line.
+While Tom acknowledges differences from Texas, he doesn't explicitly express missing it in this line.
 
 ---
 
@@ -42,7 +42,7 @@ He is content and feels positive about California.
 
 ### --feedback--
 
-Correct! `I like it here` indicates contentment and positivity about the place.
+`I like it here` indicates contentment and positivity about the place.
 
 ---
 
@@ -50,7 +50,7 @@ He is neutral and has no strong feelings about California.
 
 ### --feedback--
 
-Incorrect. The phrase `I like it here` shows a definite positive sentiment, not neutrality.
+The phrase `I like it here` shows a definite positive sentiment, not neutrality.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a554956201b329a0d182a.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a554956201b329a0d182a.md
@@ -21,7 +21,7 @@ Pick the sentence that uses `this` and `that` correctly.
 
 ### --feedback--
 
-Correct! `This` is for the mouse close by, and `that` for the one farther away.
+`This` is for the mouse close by, and `that` for the one farther away.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d1a520285050552702fc1.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d1a520285050552702fc1.md
@@ -35,7 +35,7 @@ She feels Brian is exaggerating.
 
 ### --feedback--
 
-`Oh, c'mon` is an expression that often means someone thinks a statement is too much or exaggerated. You are correct!
+`Oh, c'mon` is an expression that often means someone thinks a statement is too much or exaggerated.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-analyze-code-documentation/660695c672854899d6862834.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-analyze-code-documentation/660695c672854899d6862834.md
@@ -23,7 +23,7 @@ She is happy with the class and finds the documentation easy
 
 ### --feedback--
 
-This option is incorrect because Sophie finds the class complex and the documentation confusing, not easy.
+Sophie finds the class complex and the documentation confusing, not easy.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-analyze-code-documentation/660696cce3e4e79af4612466.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-analyze-code-documentation/660696cce3e4e79af4612466.md
@@ -23,7 +23,7 @@ Write new properties for the class
 
 ### --feedback--
 
-This option is incorrect. Brian's advice is to begin by understanding the class, not by writing new properties.
+Brian's advice is to begin by understanding the class, not by writing new properties.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-analyze-code-documentation/6606977e8f0b509bdac39012.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-analyze-code-documentation/6606977e8f0b509bdac39012.md
@@ -23,7 +23,7 @@ Start writing new functions immediately
 
 ### --feedback--
 
-This option is incorrect. Brian suggests reading existing methods and functions first, not writing new ones immediately.
+Brian suggests reading existing methods and functions first, not writing new ones immediately.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/65f3a5733a199c21ca589173.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/65f3a5733a199c21ca589173.md
@@ -36,7 +36,7 @@ No projects at all
 
 ### --feedback--
 
-Brian did talk about working on projects, so this option isn't correct.
+Brian did talk about working on projects.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/6636159376b91532f4f8e49b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/6636159376b91532f4f8e49b.md
@@ -23,7 +23,7 @@ For large teams with specialized skills in coding
 
 ### --feedback--
 
-This option is incorrect. Sarah points out that low-code development is more beneficial for teams with limited coding resources, not those that are large and highly specialized.
+Sarah points out that low-code development is more beneficial for teams with limited coding resources, not those that are large and highly specialized.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/663621cf8781e93738b3e30f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/663621cf8781e93738b3e30f.md
@@ -27,7 +27,7 @@ To ignore the new tools and continue with their current methods
 
 ### --feedback--
 
-This option is incorrect. Sarah is suggesting to explore the new tools, not ignore them.
+Sarah is suggesting to explore the new tools, not ignore them.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/6636242c12c019384fd78b5a.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/6636242c12c019384fd78b5a.md
@@ -23,7 +23,7 @@ No, because he thinks it's a waste of time.
 
 ### --feedback--
 
-This option is incorrect. Brian's response `I'm on it` implies that he is already taking action, which shows agreement, not rejection.
+Brian's response `I'm on it` implies that he is already taking action, which shows agreement, not rejection.
 
 ---
 
@@ -35,7 +35,7 @@ No, he is asking for more time to think about it.
 
 ### --feedback--
 
-This is incorrect. Brian's immediate response of `I'm on it` suggests readiness to act, not hesitation.
+Brian's immediate response of `I'm on it` suggests readiness to act, not hesitation.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/6636ebb50b24c83f130344f4.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/6636ebb50b24c83f130344f4.md
@@ -43,7 +43,7 @@ Which of the following sentences correctly uses the preposition `without`?
 
 ### --feedback--
 
-This sentence is grammatically incorrect. `Without` cannot be used in this context.
+`Without` cannot be used in this context.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/6636f20df76124410fe597e9.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/6636f20df76124410fe597e9.md
@@ -31,7 +31,7 @@ It is about using more servers in computing.
 
 ### --feedback--
 
-This statement is incorrect; `serverless computing` involves using fewer, if any, visible servers to the developer.
+`Serverless computing` involves using fewer, if any, visible servers to the developer.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/663897f00196a953f16499c6.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/663897f00196a953f16499c6.md
@@ -41,7 +41,7 @@ This is correct because `any` should be used in negative statements or questions
 
 ### --feedback--
 
-This sentence is incorrect. `Any` should not be used in affirmative statements without a conditional or negative context.
+`Any` should not be used in affirmative statements without a conditional or negative context.
 
 ---
 
@@ -49,7 +49,7 @@ This sentence is incorrect. `Any` should not be used in affirmative statements w
 
 ### --feedback--
 
-This use of `any` is incorrect. It should be `All students are welcome to join the club` if referring to every student without restriction.
+It should be `All students are welcome to join the club` if referring to every student without restriction.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/663897f00196a953f16499c6.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/663897f00196a953f16499c6.md
@@ -29,7 +29,7 @@ Which of the following sentences correctly uses the word `any`?
 
 ### --feedback--
 
-This is correct because `any` should be used in negative statements or questions.
+`Any` should be used in negative statements or questions.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/6638a9a5dee1ac5b6a9db7d9.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/6638a9a5dee1ac5b6a9db7d9.md
@@ -31,7 +31,7 @@ In marketing strategies to increase sales
 
 ### --feedback--
 
-This choice is incorrect. Sarah does not mention using AI in marketing or for sales purposes.
+Sarah does not mention using AI in marketing or for sales purposes.
 
 ---
 
@@ -43,7 +43,7 @@ In customer service to speed up response times
 
 ### --feedback--
 
-Incorrect. The audio indicates that AI is used for code-related tasks, not customer service.
+The audio indicates that AI is used for code-related tasks, not customer service.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/6638abe5e8d43a5c7ed9d320.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/6638abe5e8d43a5c7ed9d320.md
@@ -23,7 +23,7 @@ Continue their current methods without change
 
 ### --feedback--
 
-This option is incorrect because Bob suggests trying a new method, indicating a change is likely.
+Bob suggests trying a new method, indicating a change is likely.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-document-code-for-a-project/65e5d1128a3a2137ff818dd6.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-document-code-for-a-project/65e5d1128a3a2137ff818dd6.md
@@ -27,7 +27,7 @@ Which sentence correctly uses `Anyone who` in a technology context?
 
 ### --feedback--
 
-This sentence is grammatically incorrect. A correct usage would be, `Anyone who knows the solution, please fix this bug.`
+A grammatically correct usage would be, `Anyone who knows the solution, please fix this bug.`
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617528c1b07688acdfea4e9.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617528c1b07688acdfea4e9.md
@@ -23,7 +23,7 @@ He is unhappy with the new design and wants to change it.
 
 ### --feedback--
 
-This choice is incorrect. Bob expresses a positive opinion about the design, not dissatisfaction.
+Bob expresses a positive opinion about the design, not dissatisfaction.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617562f72eb2a9387252430.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617562f72eb2a9387252430.md
@@ -27,7 +27,7 @@ He strongly disagrees and insists on keeping the current color scheme.
 
 ### --feedback--
 
-This option is incorrect. Bob's response shows understanding and agreement with Sophie's point, not strong disagreement.
+Bob's response shows understanding and agreement with Sophie's point, not strong disagreement.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/661757150c7a75961a574a39.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/661757150c7a75961a574a39.md
@@ -23,7 +23,7 @@ He will disregard Sophie's feedback and make the changes himself.
 
 ### --feedback--
 
-This option is incorrect. Bob acknowledges Sophie's feedback and plans to share it with Tom for further action.
+Bob acknowledges Sophie's feedback and plans to share it with Tom for further action.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/66175792ec93b19771c55c62.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/66175792ec93b19771c55c62.md
@@ -25,7 +25,7 @@ She thinks the design is perfect and doesn't need any changes.
 
 ### --feedback--
 
-This option is incorrect. Sophie's comments suggest she sees areas for improvement, not that the design is perfect.
+Sophie's comments suggest she sees areas for improvement, not that the design is perfect.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617962704224fe969a76811.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617962704224fe969a76811.md
@@ -27,7 +27,7 @@ Because the web app is newer than the mobile app
 
 ### --feedback--
 
-This option is incorrect. Sarah's reason for prioritizing the web app is its larger user base, not its newness.
+Sarah's reason for prioritizing the web app is its larger user base, not its newness.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/66179829f664e3ee9b42ce5f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/66179829f664e3ee9b42ce5f.md
@@ -23,7 +23,7 @@ Yes, he completely agrees and wants to focus only on the web app
 
 ### --feedback--
 
-This choice is incorrect. Brian suggests a compromise by equally allocating resources to both platforms, not solely focusing on the web app.
+Brian suggests a compromise by equally allocating resources to both platforms, not solely focusing on the web app.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617b1efe920c2ffea40b54d.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617b1efe920c2ffea40b54d.md
@@ -27,7 +27,7 @@ She suggests continuing with the current methodology without any changes.
 
 ### --feedback--
 
-This option is incorrect. Sarah's statement clearly indicates a proposal for a change to agile methodology.
+Sarah's statement clearly indicates a proposal for a change to agile methodology.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617b2b0388c600232500e28.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617b2b0388c600232500e28.md
@@ -29,7 +29,7 @@ Agile and Waterfall are both equally effective, and there's no clear preference.
 
 ### --feedback--
 
-This choice is incorrect. The sentence shows a clear preference for Waterfall despite acknowledging Agile's efficiency.
+The sentence shows a clear preference for Waterfall despite acknowledging Agile's efficiency.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617b3d0e2de65050f11351c.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617b3d0e2de65050f11351c.md
@@ -23,7 +23,7 @@ Because it is a newer and more innovative method
 
 ### --feedback--
 
-This choice is incorrect. Bob's preference is based on Waterfall offering a more structured approach, not its novelty.
+Bob's preference is based on Waterfall offering a more structured approach, not its novelty.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617b41fe23fc0066e715317.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617b41fe23fc0066e715317.md
@@ -23,7 +23,7 @@ Which sentence correctly uses `strongly` and `strengths`?
 
 ### --feedback--
 
-This is incorrect. `Weakly` is the opposite of `strongly`, and `weaknesses` is the opposite of `strengths`.
+`Weakly` is the opposite of `strongly`, and `weaknesses` is the opposite of `strengths`.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617bae50ecd231987654d2e.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617bae50ecd231987654d2e.md
@@ -23,7 +23,7 @@ He realized Agile is more cost-effective than other methods.
 
 ### --feedback--
 
-This choice is incorrect. Bob's agreement is based on the team's familiarity with Agile, not cost-effectiveness.
+Bob's agreement is based on the team's familiarity with Agile, not cost-effectiveness.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/661f906d5019b63f27af438c.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/661f906d5019b63f27af438c.md
@@ -23,7 +23,7 @@ He has completed understanding the code structure and is ready to proceed.
 
 ### --feedback--
 
-This choice is incorrect. Tom indicates that he is still in the process of understanding the code structure.
+Tom indicates that he is still in the process of understanding the code structure.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/661f92a4f77e0740906355cb.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/661f92a4f77e0740906355cb.md
@@ -23,7 +23,7 @@ She suggests that the code should not be changed.
 
 ### --feedback--
 
-This choice is incorrect. Sarah is suggesting a specific change – consistent formatting.
+Sarah is suggesting a specific change – consistent formatting.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625136b87a56a3913122eb5.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625136b87a56a3913122eb5.md
@@ -23,7 +23,7 @@ She tried solving a bug and is asking for a code review.
 
 ### --feedback--
 
-This choice is incorrect. Sophie is working on optimization, not bug solving, and she's asking if Brian has experience with similar challenges.
+Sophie is working on optimization, not bug solving, and she's asking if Brian has experience with similar challenges.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/662514383f43d53b748dff42.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/662514383f43d53b748dff42.md
@@ -23,7 +23,7 @@ He suggests outsourcing the optimization due to its complexity.
 
 ### --feedback--
 
-This option is incorrect. Brian's advice is about breaking down the function, not outsourcing.
+Brian's advice is about breaking down the function, not outsourcing.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/6610056e633ce41466b6c5bc.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/6610056e633ce41466b6c5bc.md
@@ -23,7 +23,7 @@ She fixed bugs in the app's code.
 
 ### --feedback--
 
-This choice is incorrect. Sarah's work was focused on design aspects, not on fixing coding bugs.
+Sarah's work was focused on design aspects, not on fixing coding bugs.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/66100646290700150caff732.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/66100646290700150caff732.md
@@ -27,7 +27,7 @@ He was on vacation.
 
 ### --feedback--
 
-This option is incorrect as Bob mentions he was busy testing a new feature and finding issues.
+Bob mentions he was busy testing a new feature and finding issues.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/661216bbf6d9a51b409172a8.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/661216bbf6d9a51b409172a8.md
@@ -23,7 +23,7 @@ She organized a meeting to discuss the report.
 
 ### --feedback--
 
-This choice is incorrect. `Gathered` in this context refers to collecting data, not organizing meetings.
+`Gathered` in this context refers to collecting data, not organizing meetings.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/6612181d89fdfc1c2f44309d.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/6612181d89fdfc1c2f44309d.md
@@ -43,7 +43,7 @@ The team needs to start over with the project.
 
 ### --feedback--
 
-This option is incorrect as it contradicts the client's satisfaction with the current progress.
+This option contradicts the client's satisfaction with the current progress.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/6612181d89fdfc1c2f44309d.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/6612181d89fdfc1c2f44309d.md
@@ -23,7 +23,7 @@ The client requested major changes to the project.
 
 ### --feedback--
 
-This choice is incorrect. Bob mentioned that the client expressed satisfaction, not a request for major changes.
+Bob mentioned that the client expressed satisfaction, not a request for major changes.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/66121954a1cde81cd252ef26.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/66121954a1cde81cd252ef26.md
@@ -27,7 +27,7 @@ The team will achieve their goals in the future.
 
 ### --feedback--
 
-This option is incorrect because `have achieved` refers to accomplishments already made, not future goals.
+`Have achieved` refers to accomplishments already made, not future goals.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/66121b3a462fe01da4816b39.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/66121b3a462fe01da4816b39.md
@@ -23,7 +23,7 @@ To take a break and relax for the next week
 
 ### --feedback--
 
-This choice is incorrect. Bob emphasizes continuing the good work and communicating, not taking a break.
+Bob emphasizes continuing the good work and communicating, not taking a break.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/66122b7d6f1f182bb1fe0338.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/66122b7d6f1f182bb1fe0338.md
@@ -43,7 +43,7 @@ He was on leave for personal reasons.
 
 ### --feedback--
 
-This option is incorrect as Brian mentioned actively working on project documentation and attending a training session.
+Brian mentioned actively working on project documentation and attending a training session.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/66122b7d6f1f182bb1fe0338.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/66122b7d6f1f182bb1fe0338.md
@@ -23,7 +23,7 @@ He developed a new software feature.
 
 ### --feedback--
 
-This choice is incorrect. Brian's focus was on documentation and training, not on developing new software features.
+Brian's focus was on documentation and training, not on developing new software features.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/661254cf9474ed2da90fec1b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/661254cf9474ed2da90fec1b.md
@@ -23,7 +23,7 @@ Updating the user manual helped him, and he learned about the new software featu
 
 ### --feedback--
 
-This choice is incorrect. While updating the user manual was part of his work, it was the training session that helped him understand customer issues and learn new strategies.
+While updating the user manual was part of his work, it was the training session that helped him understand customer issues and learn new strategies.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/661254cf9474ed2da90fec1b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/661254cf9474ed2da90fec1b.md
@@ -43,7 +43,7 @@ Working on the project documentation helped him, and he learned about project ma
 
 ### --feedback--
 
-This option is incorrect as it was the training session, not just working on documentation, that helped Brian gain insights into customer issues.
+It was the training session, not just working on documentation, that helped Brian gain insights into customer issues.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/661255c3b6ea612e984a62b8.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/661255c3b6ea612e984a62b8.md
@@ -23,7 +23,7 @@ She emphasizes the importance of team collaboration and asks about Brian's team 
 
 ### --feedback--
 
-This choice is incorrect. Maria focuses on customer knowledge and inquires about Brian's long-term goals, not team management.
+Maria focuses on customer knowledge and inquires about Brian's long-term goals, not team management.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/661256fe823f142fb9858beb.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/661256fe823f142fb9858beb.md
@@ -23,7 +23,7 @@ Starting a new project from scratch
 
 ### --feedback--
 
-This option is incorrect. Brian's focus is on updating existing documentation and improving customer support, not starting a new project.
+Brian's focus is on updating existing documentation and improving customer support, not starting a new project.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/6612693507cbd43269ae64e0.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/6612693507cbd43269ae64e0.md
@@ -24,7 +24,7 @@ She is unhappy with Brian's progress and demands immediate improvement.
 
 ### --feedback--
 
-This choice is incorrect. Maria's words are supportive and encouraging, not critical.
+Maria's words are supportive and encouraging, not critical.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/6612727ec0a11b390b8e92cb.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/6612727ec0a11b390b8e92cb.md
@@ -23,7 +23,7 @@ She started a new job this week.
 
 ### --feedback--
 
-This option is incorrect as Sarah's statement refers to ongoing work keeping her busy, not starting a new job.
+Sarah's statement refers to ongoing work keeping her busy, not starting a new job.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657d5dc51cf88187cbf7d27c.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657d5dc51cf88187cbf7d27c.md
@@ -35,7 +35,7 @@ The verb form is incorrect for the present perfect tense.
 
 ### --feedback--
 
-The subject-verb agreement is incorrect. It should be `have`, not `has`, for the subject `I`.
+The subject-verb agreement should be `have`, not `has`, for the subject `I`.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657fbde9a43e35ec1ebafe56.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657fbde9a43e35ec1ebafe56.md
@@ -23,7 +23,7 @@ Declining an invitation
 
 ### --feedback--
 
-This option is incorrect because the phrase is not a response indicating refusal; instead, it is an invitation being extended.
+The phrase is not a response indicating refusal; instead, it is an invitation being extended.
 
 ---
 
@@ -35,7 +35,7 @@ Expressing gratitude
 
 ### --feedback--
 
-This option is incorrect because the phrase is more about offering an invitation than expressing thanks.
+The phrase is more about offering an invitation than expressing thanks.
 
 ---
 
@@ -43,7 +43,7 @@ Asking for information
 
 ### --feedback--
 
-This option is incorrect because the phrase is not seeking information; rather, it is an invitation to join an event.
+The phrase is not seeking information; rather, it is an invitation to join an event.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6613d6c3e74a984d6fcbd013.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6613d6c3e74a984d6fcbd013.md
@@ -27,7 +27,7 @@ Because they are still considering other options
 
 ### --feedback--
 
-This option is incorrect. Brian's use of `will` indicates a decision has been made, not that they are still considering.
+Brian's use of `will` indicates a decision has been made, not that they are still considering.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6613d803f9d4884e2a882a99.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6613d803f9d4884e2a882a99.md
@@ -23,7 +23,7 @@ They need to review the project plans again for clarity.
 
 ### --feedback--
 
-This option is incorrect. `On the same page` implies that they already have clarity and agreement, not that they need further review.
+`On the same page` implies that they already have clarity and agreement, not that they need further review.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6614b3e52a6aca60bc3417fb.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6614b3e52a6aca60bc3417fb.md
@@ -23,7 +23,7 @@ Yes, he is proposing email marketing as a replacement for social media marketing
 
 ### --feedback--
 
-This choice is incorrect. Brian uses `also` in his statement, indicating an addition, not a replacement.
+Brian uses `also` in his statement, indicating an addition, not a replacement.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6614b53003e92d6182e98978.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6614b53003e92d6182e98978.md
@@ -39,7 +39,7 @@ It will focus solely on traditional marketing methods.
 
 ### --feedback--
 
-This option is incorrect as Brian specifically mentions combining social media and email marketing, which are digital strategies.
+Brian specifically mentions combining social media and email marketing, which are digital strategies.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6614b572f81cb561d4ac39da.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6614b572f81cb561d4ac39da.md
@@ -23,7 +23,7 @@ They will start working on the plan next week and meet the week after.
 
 ### --feedback--
 
-This choice is incorrect. Sophie implies that they will start working on it now and meet next week for an update.
+Sophie implies that they will start working on it now and meet next week for an update.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6614be2a21b4426bfcd25919.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6614be2a21b4426bfcd25919.md
@@ -23,7 +23,7 @@ The conference is happening this week.
 
 ### --feedback--
 
-This choice is incorrect. Sarah mentions the conference is scheduled for next month, not this week.
+Sarah mentions the conference is scheduled for next month, not this week.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6614be98fc11336c52aa3093.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6614be98fc11336c52aa3093.md
@@ -31,7 +31,7 @@ Because it's a unique and innovative way to present
 
 ### --feedback--
 
-This option is incorrect. Bob suggests a slide deck because it's a standard, not a unique, format.
+Bob suggests a slide deck because it's a standard, not a unique, format.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6614c0ec11b55c6d849fbe3a.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6614c0ec11b55c6d849fbe3a.md
@@ -23,7 +23,7 @@ Yes, she completely agrees and wants to follow his suggestion.
 
 ### --feedback--
 
-This choice is incorrect. Sarah acknowledges Bob's idea but suggests an alternative approach.
+Sarah acknowledges Bob's idea but suggests an alternative approach.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-basic-programming-vocabulary-in-conversations/6629e0281f1f63c107adeeb1.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-basic-programming-vocabulary-in-conversations/6629e0281f1f63c107adeeb1.md
@@ -29,7 +29,7 @@ This sentence Present Perfect tense, not Present Perfect Continuous tense.
 
 ### --feedback--
 
-This sentence is grammatically incorrect. The correct verb form should be `eating`.
+The grammatically correct verb form should be `eating`.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-basic-programming-vocabulary-in-conversations/662b8975b11107146a49ec58.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-basic-programming-vocabulary-in-conversations/662b8975b11107146a49ec58.md
@@ -27,7 +27,7 @@ Sarah has solved the problem with her code.
 
 ### --feedback--
 
-This option is incorrect, as Sarah explicitly mentions she cannot figure out what's wrong, indicating the problem is not yet solved.
+Sarah explicitly mentions she cannot figure out what's wrong, indicating the problem is not yet solved.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-basic-programming-vocabulary-in-conversations/662efee6946fda26f424c1a5.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-basic-programming-vocabulary-in-conversations/662efee6946fda26f424c1a5.md
@@ -23,7 +23,7 @@ She says she isn't working on much code at all.
 
 ### --feedback--
 
-This option is incorrect. Sarah actually indicates that she is working on a lot of code.
+Sarah actually indicates that she is working on a lot of code.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-basic-programming-vocabulary-in-conversations/662f053a70bb3a2a154993c0.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-basic-programming-vocabulary-in-conversations/662f053a70bb3a2a154993c0.md
@@ -23,7 +23,7 @@ It is a command used to end a program.
 
 ### --feedback--
 
-This is incorrect. An `extension` is not a command but a software add-on that enhances functionality.
+An `extension` is not a command but a software add-on that enhances functionality.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-basic-programming-vocabulary-in-conversations/662f062232f1962aa082710a.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-basic-programming-vocabulary-in-conversations/662f062232f1962aa082710a.md
@@ -32,7 +32,7 @@ It is a type of computer virus.
 
 ### --feedback--
 
-Incorrect. A `plugin` is a legitimate software component, not a virus. It is intended to add functionality to software.
+A `plugin` is a legitimate software component, not a virus. It is intended to add functionality to software.
 
 ---
 
@@ -44,7 +44,7 @@ It is a standalone application that does not require other software to function.
 
 ### --feedback--
 
-This is incorrect because a `plugin` is not standalone; it requires another program to operate and adds functionality to it.
+A `plugin` is not standalone; it requires another program to operate and adds functionality to it.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-basic-programming-vocabulary-in-conversations/662f31024608f337c0bf53a9.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-basic-programming-vocabulary-in-conversations/662f31024608f337c0bf53a9.md
@@ -23,7 +23,7 @@ Tom knows a lot about it and uses it all the time.
 
 ### --feedback--
 
-This is not correct. Tom said he doesn't know much and hasn't used it in his work.
+Tom said he doesn't know much and hasn't used it in his work.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-basic-programming-vocabulary-in-conversations/662f66ed185bc53e6171be3c.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-basic-programming-vocabulary-in-conversations/662f66ed185bc53e6171be3c.md
@@ -23,7 +23,7 @@ Sarah is not willing to recommend any book at this time.
 
 ### --feedback--
 
-This answer is incorrect as Sarah clearly expresses her willingness to recommend a book by mentioning it.
+Sarah clearly expresses her willingness to recommend a book by mentioning it.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/66325752419d337dc13ffd83.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/66325752419d337dc13ffd83.md
@@ -23,7 +23,7 @@ He thinks choosing data types is not important.
 
 ### --feedback--
 
-This is not right because Jake's words show he knows it's important to pick the right data types for the information.
+Jake's words show he knows it's important to pick the right data types for the information.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/66325752419d337dc13ffd83.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/66325752419d337dc13ffd83.md
@@ -43,7 +43,7 @@ He believes all data types are the same.
 
 ### --feedback--
 
-This is incorrect. Jake talks about picking the right data types for different kinds of information, which means he knows they are not all the same.
+Jake talks about picking the right data types for different kinds of information, which means he knows they are not all the same.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/6633008b3377e5894cf71629.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/6633008b3377e5894cf71629.md
@@ -35,7 +35,7 @@ As one-time use commands that are not saved
 
 ### --feedback--
 
-This is not right. Sarah describes functions as reusable, meaning they can be used more than once.
+Sarah describes functions as reusable, meaning they can be used more than once.
 
 ---
 
@@ -43,7 +43,7 @@ As unnecessary parts of programming that should be avoided
 
 ### --feedback--
 
-This is incorrect because Sarah highlights functions as beneficial and reusable, which contradicts them being unnecessary.
+Sarah highlights functions as beneficial and reusable, which contradicts them being unnecessary.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/6633008b3377e5894cf71629.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/6633008b3377e5894cf71629.md
@@ -27,7 +27,7 @@ As large, complex operations that are difficult to manage
 
 ### --feedback--
 
-This choice is incorrect. Sarah specifically mentions that functions are small and reusable, not large and complex.
+Sarah specifically mentions that functions are small and reusable, not large and complex.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/663308af5363be8c4a5c68b9.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/663308af5363be8c4a5c68b9.md
@@ -23,7 +23,7 @@ He is unsure how to code.
 
 ### --feedback--
 
-This is incorrect. Tom's uncertainty is about understanding the functions in the existing code, not about his ability to code in general.
+Tom's uncertainty is about understanding the functions in the existing code, not about his ability to code in general.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/66331263a35e868f3dade3de.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/66331263a35e868f3dade3de.md
@@ -23,7 +23,7 @@ By memorizing the code of each function
 
 ### --feedback--
 
-This is incorrect. Sarah advises looking at the names and comments associated with the functions, not memorizing their code.
+Sarah advises looking at the names and comments associated with the functions, not memorizing their code.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/66331384245d028fd8b1be23.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/66331384245d028fd8b1be23.md
@@ -23,7 +23,7 @@ That he should rewrite the functions
 
 ### --feedback--
 
-This is incorrect. Tom's use of `that` does not imply rewriting but understanding the existing functions as explained by Sarah.
+Tom's use of `that` does not imply rewriting but understanding the existing functions as explained by Sarah.
 
 ---
 
@@ -35,7 +35,7 @@ That he should ignore the comments
 
 ### --feedback--
 
-Incorrect. Tom acknowledges the importance of reading comments, not ignoring them, as they help explain the function's purpose.
+Tom acknowledges the importance of reading comments, not ignoring them, as they help explain the function's purpose.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/6633203e58595e93ef54ba3b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/6633203e58595e93ef54ba3b.md
@@ -21,7 +21,7 @@ Which sentence uses `what` correctly?
 
 ### --feedback--
 
-This is incorrect. The correct structure should be `She knows what he likes`, without the auxiliary verb `does` in the clause.
+The correct structure should be `She knows what he likes`, without the auxiliary verb `does` in the clause.
 
 ---
 
@@ -41,7 +41,7 @@ This sentence incorrectly ends with a question mark as it is not a question but 
 
 ### --feedback--
 
-This is incorrect. The correct question form is `What is your name?` or `Tell me what your name is.`
+The correct question form is `What is your name?` or `Tell me what your name is.`
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/6633261bb572f2953f5abd13.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/6633261bb572f2953f5abd13.md
@@ -23,7 +23,7 @@ He will write new functions.
 
 ### --feedback--
 
-This is incorrect. Tom's focus is on understanding existing functions, not creating new ones.
+Tom's focus is on understanding existing functions, not creating new ones.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/6633511c7b197798ad5fd703.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/6633511c7b197798ad5fd703.md
@@ -23,7 +23,7 @@ He is working on a software that uses many variables but can't decide which prog
 
 ### --feedback--
 
-This option isn't correct. Tom's problem is not about choosing a programming language, but about managing many variables.
+Tom's problem is not about choosing a programming language, but about managing many variables.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/66339d408258519c61151a64.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/66339d408258519c61151a64.md
@@ -39,7 +39,7 @@ Variables control program flow and use commands to modify data.
 
 ### --feedback--
 
-This option is incorrect as it misrepresents variables as controlling program flow, which is not their primary function.
+This option misrepresents variables as controlling program flow, which is not their primary function.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/6633a14f17a4669e1c980d91.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/6633a14f17a4669e1c980d91.md
@@ -23,7 +23,7 @@ How to define constants in his project
 
 ### --feedback--
 
-This option isn't correct. Tom is asking about the distinction between two concepts, not how to define constants.
+Tom is asking about the distinction between two concepts, not how to define constants.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/6633a97f928771a163b59745.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/6633a97f928771a163b59745.md
@@ -43,7 +43,7 @@ Variables are always changing, and constants are never used more than once.
 
 ### --feedback--
 
-This option is incorrect as it suggests constants are never used more than once, which is not true. They are used repeatedly but their values do not change.
+Constants are used repeatedly but their values do not change.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/6633ae85f1fb7aa3ca13234d.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/6633ae85f1fb7aa3ca13234d.md
@@ -27,7 +27,7 @@ Variables and constants both need regular updates to stay effective.
 
 ### --feedback--
 
-This option is incorrect because constants do not change or need updates; they remain the same, unlike variables which can be updated.
+Constants do not change or need updates; they remain the same, unlike variables which can be updated.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657e59605c6f688785fbb46d.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-introductions-in-an-online-team-meeting/657e59605c6f688785fbb46d.md
@@ -28,7 +28,7 @@ She is thanking David and ending the meeting.
 
 ### --feedback--
 
-This choice is incorrect. Maria is not ending the meeting. 
+Maria is not ending the meeting. 
 
 ---
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-clarify-misunderstandings/67e7daa349ab984882c0f60e.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-clarify-misunderstandings/67e7daa349ab984882c0f60e.md
@@ -23,7 +23,7 @@ It is about making code more difficult to manage by exposing all details.
 
 ### --feedback--
 
-Sophie emphasizes making code easier to work with, not harder, so this option is incorrect.
+Sophie emphasizes making code easier to work with, not harder.
 
 ---
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-express-concerns/67c99cf91ca2a0d46a0789a2.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-express-concerns/67c99cf91ca2a0d46a0789a2.md
@@ -49,7 +49,7 @@ The team is working at maximum efficiency and doesn't need changes.
 
 ### --feedback--  
 
-The text mentions that the team is struggling with workload and stress, so this is not correct.
+The text mentions that the team is struggling with workload and stress.
 
 ---  
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-express-decisions-based-on-comparisons/67c45d89b3e95f78bbafae99.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-express-decisions-based-on-comparisons/67c45d89b3e95f78bbafae99.md
@@ -41,7 +41,7 @@ The word `more` is unnecessary because `easy` changes to `easier` in the compara
 
 ### --feedback--
 
-`Gooder` is incorrect. The correct comparative form of `good` is `better`.
+The correct comparative form of `good` is `better`.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/670570ad97d26e1d6bad572d.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/670570ad97d26e1d6bad572d.md
@@ -40,7 +40,7 @@ He updated the credentials.
 
 ### --feedback--
 
-This is incorrect because James updated the credentials later.
+James updated the credentials later.
 
 ---
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/6705725e2814c91dd738e8f4.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-talk-about-past-experiences/6705725e2814c91dd738e8f4.md
@@ -36,7 +36,7 @@ The error logs were not updated.
 
 ### --feedback--
 
-This is incorrect because the issue wasn't related to the logs.
+The issue wasn't related to the logs.
 
 ---
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-use-conditionals/677fb3e018bb121af7f62359.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-use-conditionals/677fb3e018bb121af7f62359.md
@@ -21,7 +21,7 @@ Which sentence is grammatically correct?
 
 ### --feedback--
 
-This is incorrect because `don't backed up` is not a valid verb form.
+`Don't backed up` is not a valid verb form.
 
 ---
 
@@ -41,7 +41,7 @@ This is grammatically correct but expresses a different meaning. It's a `Second 
 
 ### --feedback--
 
-This is incorrect because `can lost` is not a valid verb phrase.
+`Can lost` is not a valid verb phrase.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-use-modal-verbs/67d7e64ac5180e76037508b9.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-use-modal-verbs/67d7e64ac5180e76037508b9.md
@@ -53,6 +53,6 @@ In questions, modal verbs like `can`, `could`, and `should` come before the subj
 
 For example, in `Should we report this issue?` and `Might he know the password?` The modal verb comes first, and the main verb stays in its base form.
 
-You can't use `do` or `does` with a modal verb. You don't say `Do you can reset the system?` Instead, say `Can you reset the system?`
+Using `do` or `does` with a modal verb is incorrect. You don't say `Do you can reset the system?` Instead, say `Can you reset the system?`
 
 Word order is important in English questions. Saying `You can help me?` sounds unnatural because the subject and the modal verb are not in the right order. The correct form is `Can you help me?`

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-use-modal-verbs/67d7e64ac5180e76037508b9.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-use-modal-verbs/67d7e64ac5180e76037508b9.md
@@ -53,6 +53,6 @@ In questions, modal verbs like `can`, `could`, and `should` come before the subj
 
 For example, in `Should we report this issue?` and `Might he know the password?` The modal verb comes first, and the main verb stays in its base form.
 
-Using `do` or `does` with a modal verb is incorrect. You don't say `Do you can reset the system?` Instead, say `Can you reset the system?`
+You can't use `do` or `does` with a modal verb. You don't say `Do you can reset the system?` Instead, say `Can you reset the system?`
 
 Word order is important in English questions. Saying `You can help me?` sounds unnatural because the subject and the modal verb are not in the right order. The correct form is `Can you help me?`

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-use-modal-verbs/67d7f74458730e7e1411fc57.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-use-modal-verbs/67d7f74458730e7e1411fc57.md
@@ -21,7 +21,7 @@ Which sentence is grammatically correct?
 
 ### --feedback--
 
-`Don't can` is incorrect. Modal verbs do not use `do` or `does` for negation.
+Modal verbs do not use `do` or `does` for negation.
 
 ---
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/67164ce44ebb6446ec498fbd.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/67164ce44ebb6446ec498fbd.md
@@ -21,7 +21,7 @@ Which option correctly forms a question in the `Present Perfect Continuous` tens
 
 ### --feedback--
 
-This structure is incorrect. The word `been` is missing after `they`.
+The word `been` is missing after `they`.
 
 ---
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/6716531210ee374ae822fe83.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/6716531210ee374ae822fe83.md
@@ -23,7 +23,7 @@ No, Sophie doesn't on the screen reader updates.
 
 ### --feedback--
 
-Incorrect. Sophie is involved in the updates.
+Sophie is involved in the updates.
 
 ---
 
@@ -31,7 +31,7 @@ Yes, Sophie started working on them last week.
 
 ### --feedback--
 
-Incorrect. Sophie mentioned that she started working a few months ago, not last week.
+Sophie mentioned that she started working a few months ago, not last week.
 
 ---
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671f9e83b440da8486fdf76e.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/671f9e83b440da8486fdf76e.md
@@ -43,7 +43,7 @@ The development team stopped working on the issue.
 
 ### --feedback--
 
-James indicates that they are actively investigating the problem, so this is incorrect.
+James indicates that they are actively investigating the problem.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/6720f2d525d22693e3fe2a99.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/6720f2d525d22693e3fe2a99.md
@@ -39,7 +39,7 @@ The problem is fully solved now.
 
 ### --feedback--
 
-James clearly states that they haven't found a final solution yet, so this is incorrect.
+James clearly states that they haven't found a final solution yet.
 
 ---
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/6720f45ff33dd69a10d14e9d.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/6720f45ff33dd69a10d14e9d.md
@@ -61,10 +61,6 @@ James says that testing is still needed on different devices.
 
 The captions are showing better on most devices.
 
-### --feedback--
-
-This answer is correct.
-
 ## --video-solution--
 
 4

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672e0ec28d829ee2b5e909f3.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672e0ec28d829ee2b5e909f3.md
@@ -23,7 +23,7 @@ He thinks the activities were very successful.
 
 ### --feedback--
 
-James mentions that the activities were not as effective as they had expected, so this is not correct.
+James mentions that the activities were not as effective as they had expected.
 
 ---
 
@@ -43,7 +43,7 @@ He thinks the activities covered all relevant scenarios.
 
 ### --feedback--
 
-James actually suggests that some scenarios were not relevant enough, so this option is not correct.
+James actually suggests that some scenarios were not relevant enough.
 
 ## --video-solution--
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.


Closes #60179 

Now the issue is completely fixed.
