### PR TITLE
fix(curriculum): updated cat-painting-workshop steps 42-43 to specific assert methods

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646ddf888632fa67f1180940.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646ddf888632fa67f1180940.md
@@ -14,19 +14,19 @@ Move the left eye into position with a `position` property of `absolute`, a `top
 Your `.cat-left-eye` selector should have a `position` property set to `absolute`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-left-eye')?.position === 'absolute')
+assert.equal( new __helpers.CSSHelp(document).getStyle('.cat-left-eye')?.position, 'absolute')
 ```
 
 Your `.cat-left-eye` selector should have a `top` property set to `54px`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-left-eye')?.top === '54px')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-left-eye')?.top, '54px')
 ```
 
 Your `.cat-left-eye` selector should have a `left` property set to `39px`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-left-eye')?.left === '39px')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-left-eye')?.left, '39px')
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646de5dc8988076a1d992afd.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646de5dc8988076a1d992afd.md
@@ -14,13 +14,13 @@ To make the left eye look like an eye, give it a border radius of `60%`. Also, u
 Your `.cat-left-eye` selector should have a `border-radius` property set to `60%`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-left-eye')?.borderRadius === '60%')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-left-eye')?.borderRadius, '60%')
 ```
 
 Your `.cat-left-eye` selector should have a `transform` property set to `rotate(25deg)`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-left-eye')?.transform === 'rotate(25deg)')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-left-eye')?.transform, 'rotate(25deg)')
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes [#60245](https://github.com/freeCodeCamp/freeCodeCamp/issues/60245)

<!-- Feel free to add any additional description of changes below this line -->
Changes overview:
 Assert methods from assert(a === b) to assert.equal(a, b) in the following files:
-  freeCodeCamp/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646de5dc8988076a1d992afd.md
- freeCodeCamp/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646ddf888632fa67f1180940.md

Thanks!