### PR TITLE
fix: update assert methods to assert.exists() and assert.equal()

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-intermediate-css-by-building-a-cat-painting/646de6a97b50a86ac487de86.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-intermediate-css-by-building-a-cat-painting/646de6a97b50a86ac487de86.md
@@ -16,25 +16,25 @@ Using a class selector, give your `.cat-right-eye` element a width of `30px` and
 You should have a `.cat-right-eye` selector.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-right-eye'))
+assert.exists(new __helpers.CSSHelp(document).getStyle('.cat-right-eye'))
 ```
 
 Your `.cat-right-eye` selector should have a `width` set to `30px`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-right-eye')?.width === '30px')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-right-eye')?.width , '30px')
 ```
 
 Your `.cat-right-eye` selector should have a `height` set to `40px`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-right-eye')?.height === '40px')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-right-eye')?.height ,'40px')
 ```
 
 Your `.cat-right-eye` selector should have a `background-color` set to `#000`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-right-eye')?.backgroundColor === 'rgb(0, 0, 0)')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-right-eye')?.backgroundColor ,'rgb(0, 0, 0)')
 ```
 
 # --seed--

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-intermediate-css-by-building-a-cat-painting/646de7b64467e96b7d35b5cd.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-intermediate-css-by-building-a-cat-painting/646de7b64467e96b7d35b5cd.md
@@ -14,19 +14,19 @@ Move the right eye into position with a `position` property of `absolute`, a `to
 Your `.cat-right-eye` selector should have a `position` property set to `absolute`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-right-eye')?.position === 'absolute')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-right-eye')?.position , 'absolute')
 ```
 
 Your `.cat-right-eye` selector should have a `top` property set to `54px`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-right-eye')?.top === '54px')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-right-eye')?.top , '54px')
 ```
 
 Your `.cat-right-eye` selector should have a `left` property set to `134px`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-right-eye')?.left === '134px')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-right-eye')?.left , '134px')
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

Closes #60246

Changes overview:
Assert methods from assert(a === b) to assert.equal(a, b)  and assert() to assert.exists() in the following files:

   -  `freeCodeCamp/curriculum/challenges/english/25-front-end-development/workshop-cat- 
       painting/646de6a97b50a86ac487de86.md`
   -  `freeCodeCamp/curriculum/challenges/english/25-front-end-development/workshop-cat- 
       painting/646de7b64467e96b7d35b5cd.md`

Thanks!