### PR TITLE
fix(curriculum): correct 'it's' to 'its' in RPS workshop step 12

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-rps-game/66cf35a75f891ab4f4e5497b.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-rps-game/66cf35a75f891ab4f4e5497b.md
@@ -11,7 +11,7 @@ If you try to play the game, you will see that you can play for an infinite amou
 
 In your `showResults` function, if the player has reached three points, update the `winnerMsgElement` to `"Player has won the game!"`. If the computer has reached three points, update the `winnerMsgElement` to `"Computer has won the game!"`.
 
-If there is a winner, show the `resetGameBtn` button by settings it's `display` to `block` and hide the `optionsContainer` by setting it's `display` to `none`.
+If there is a winner, show the `resetGameBtn` button by setting its `display` to `block` and hide the `optionsContainer` by setting its `display` to `none`.
 
 Now, try to play the game and see if the winner message is displayed when a player reaches three points.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #60267 

<!-- Feel free to add any additional description of changes below this line -->
Fixes #60267 by correcting "it's" → "its" in Step 12 of the Rock, Paper, Scissors workshop.
- Updated grammatical error in instructional text.
- Verified via repository-wide search for similar typos.
