### PR TITLE
chore(curriculum): update assertions in cat painting workshop steps 38-39

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646ddab8afd73764f5241bbf.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646ddab8afd73764f5241bbf.md
@@ -14,25 +14,25 @@ As you did for the left inner ear, remove the sharp edges of the right inner ear
 Your `.cat-right-inner-ear` selector should have a `border-bottom-right-radius` property set to `40%`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-right-inner-ear')?.borderBottomRightRadius === '40%')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-right-inner-ear')?.borderBottomRightRadius, '40%')
 ```
 
 Your `.cat-right-inner-ear` selector should have a `border-bottom-left-radius` property set to `40%`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-right-inner-ear')?.borderBottomLeftRadius === '40%')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-right-inner-ear')?.borderBottomLeftRadius, '40%')
 ```
 
 Your `.cat-right-inner-ear` selector should have a `border-top-left-radius` property set to `90px`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-right-inner-ear')?.borderTopLeftRadius === '90px')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-right-inner-ear')?.borderTopLeftRadius, '90px')
 ```
 
 Your `.cat-right-inner-ear` selector should have a `border-top-right-radius` property set to `10px`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-right-inner-ear')?.borderTopRightRadius === '10px')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-right-inner-ear')?.borderTopRightRadius, '10px')
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646ddab8afd73764f5241bbf.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646ddab8afd73764f5241bbf.md
@@ -14,25 +14,25 @@ As you did for the left inner ear, remove the sharp edges of the right inner ear
 Your `.cat-right-inner-ear` selector should have a `border-bottom-right-radius` property set to `40%`.
 
 ```js
-assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-right-inner-ear')?.borderBottomRightRadius, '40%')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-right-inner-ear')?.borderBottomRightRadius, '40%');
 ```
 
 Your `.cat-right-inner-ear` selector should have a `border-bottom-left-radius` property set to `40%`.
 
 ```js
-assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-right-inner-ear')?.borderBottomLeftRadius, '40%')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-right-inner-ear')?.borderBottomLeftRadius, '40%');
 ```
 
 Your `.cat-right-inner-ear` selector should have a `border-top-left-radius` property set to `90px`.
 
 ```js
-assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-right-inner-ear')?.borderTopLeftRadius, '90px')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-right-inner-ear')?.borderTopLeftRadius, '90px');
 ```
 
 Your `.cat-right-inner-ear` selector should have a `border-top-right-radius` property set to `10px`.
 
 ```js
-assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-right-inner-ear')?.borderTopRightRadius, '10px')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-right-inner-ear')?.borderTopRightRadius, '10px');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646ddb61ff08366570cc5902.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646ddb61ff08366570cc5902.md
@@ -16,25 +16,25 @@ Create a `div` element with the class `cat-eyes`. Inside the `.cat-eyes` element
 You should create a `div` element with the class `cat-eyes`.
 
 ```js
-assert(document.querySelectorAll('.cat-eyes').length === 1);
+assert.lengthOf(document.querySelectorAll('.cat-eyes'), 1);
 ```
 
 You should create two `div` elements inside the `.cat-eyes` element.
 
 ```js
-assert(document.querySelectorAll('.cat-eyes div').length === 2);
+assert.lengthOf(document.querySelectorAll('.cat-eyes div'), 2);
 ```
 
 The first `div` element inside the `.cat-eyes` element should have the class `cat-left-eye`.
 
 ```js
-assert(document.querySelectorAll('.cat-eyes div')[0].classList.contains('cat-left-eye'));
+assert.isTrue(document.querySelectorAll('.cat-eyes div')[0].classList.contains('cat-left-eye'));
 ```
 
 The second `div` element inside the `.cat-eyes` element should have the class `cat-right-eye`.
 
 ```js
-assert(document.querySelectorAll('.cat-eyes div')[1].classList.contains('cat-right-eye'));
+assert.isTrue(document.querySelectorAll('.cat-eyes div')[1].classList.contains('cat-right-eye'));
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

---

Closes #60181

---

Changes :

### 1. Cat Right Inner Ear Step Challenge  
**File:** `646ddab8afd73764f5241bbf.md`  
**Change:** Replaced `assert(... === ...)` with `assert.equal(...)`

| Line | Before                            | After                             |
|------|-----------------------------------|-----------------------------------|
| 17   | `assert(... === '40%')`           | `assert.equal(..., '40%');`        |
| 23   | `assert(... === '40%')`           | `assert.equal(..., '40%');`        |
| 29   | `assert(... === '90px')`          | `assert.equal(..., '90px');`       |
| 35   | `assert(... === '10px')`          | `assert.equal(..., '10px');`       |

---

### 2. Cat Eyes Step Challenge  
**File:** `646ddlb61ff08366570cc5902.md`  
**Change:** Replaced general DOM length and class checks with `assert.lengthOf(...)` and `assert.isTrue(...)`

| Line | Before                                                         | After                                                                  |
|------|----------------------------------------------------------------|------------------------------------------------------------------------|
| 19   | `assert(document.querySelectorAll('.cat-eyes').length === 1);` | `assert.lengthOf(document.querySelectorAll('.cat-eyes'), 1);`         |
| 25   | `assert(document.querySelectorAll('.cat-eyes div').length === 2);` | `assert.lengthOf(document.querySelectorAll('.cat-eyes div'), 2);` |
| 31   | `assert(...contains('cat-left-eye'))`                          | `assert.isTrue(...contains('cat-left-eye'))`                           |
| 37   | `assert(...contains('cat-right-eye'))`                         | `assert.isTrue(...contains('cat-right-eye'))`                          |

---