### PR TITLE
refactor: update assertions in eye challenge for issue #60181

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646ddb61ff08366570cc5902.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646ddb61ff08366570cc5902.md
@@ -16,25 +16,25 @@ Create a `div` element with the class `cat-eyes`. Inside the `.cat-eyes` element
 You should create a `div` element with the class `cat-eyes`.
 
 ```js
-assert(document.querySelectorAll('.cat-eyes').length === 1);
+assert.lengthOf(document.querySelectorAll('.cat-eyes'), 1);
 ```
 
 You should create two `div` elements inside the `.cat-eyes` element.
 
 ```js
-assert(document.querySelectorAll('.cat-eyes div').length === 2);
+assert.lengthOf(document.querySelectorAll('.cat-eyes div'), 2);
 ```
 
 The first `div` element inside the `.cat-eyes` element should have the class `cat-left-eye`.
 
 ```js
-assert(document.querySelectorAll('.cat-eyes div')[0].classList.contains('cat-left-eye'));
+assert.isTrue(document.querySelectorAll('.cat-eyes div')[0].classList.contains('cat-left-eye'));
 ```
 
 The second `div` element inside the `.cat-eyes` element should have the class `cat-right-eye`.
 
 ```js
-assert(document.querySelectorAll('.cat-eyes div')[1].classList.contains('cat-right-eye'));
+assert.isTrue(document.querySelectorAll('.cat-eyes div')[1].classList.contains('cat-right-eye'));
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

---

Closes #60181

---

Changes:

This PR updates the assertion methods in the cat-eyes step challenge,
located in the file 646ddlb61ff08366570cc5902.md.

Replaced `length ===` and `contains(...)` checks with more specific `assert.lengthOf(...)` and `assert.isTrue(...)` methods.

| Line | Before                                                                 | After                                                                 |
|------|----------------------------------------------------|---------------------------------------------------------|
| 19   | `assert(document.querySelectorAll('.cat-eyes').length === 1);`        | `assert.lengthOf(document.querySelectorAll('.cat-eyes'), 1);`        |
| 25   | `assert(document.querySelectorAll('.cat-eyes div').length === 2);`    | `assert.lengthOf(document.querySelectorAll('.cat-eyes div'), 2);`    |
| 31   | `assert(...contains('cat-left-eye'))`                                 | `assert.isTrue(...contains('cat-left-eye'))`                         |
| 37   | `assert(...contains('cat-right-eye'))`                                | `assert.isTrue(...contains('cat-right-eye'))`                        |