### PR TITLE
chore(client): remove unused class names

### DIFF
--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -191,10 +191,7 @@ class Block extends Component<BlockProps> {
             </div>
             <div className='map-title-completed course-title'>
               <CheckMark isCompleted={isBlockCompleted} />
-              <span
-                aria-hidden='true'
-                className='map-completed-count'
-              >{`${completedCount}/${challenges.length}`}</span>
+              <span aria-hidden='true'>{`${completedCount}/${challenges.length}`}</span>
               <span className='sr-only'>
                 ,{' '}
                 {t('learn.challenges-completed', {

--- a/client/src/templates/Introduction/components/challenges.tsx
+++ b/client/src/templates/Introduction/components/challenges.tsx
@@ -30,7 +30,7 @@ const CheckMark = ({ isCompleted }: { isCompleted: boolean }) =>
 
 const ListChallenge = ({ challenge }: { challenge: ChallengeInfo }) => (
   <Link to={challenge.fields.slug}>
-    <span className='map-badge'>
+    <span>
       <CheckMark isCompleted={challenge.isCompleted} />
     </span>
     {challenge.title}
@@ -40,7 +40,7 @@ const ListChallenge = ({ challenge }: { challenge: ChallengeInfo }) => (
 const CertChallenge = ({ challenge }: { challenge: ChallengeInfo }) => (
   <Link to={challenge.fields.slug}>
     {challenge.title}
-    <span className='map-badge map-project-checkmark'>
+    <span className='map-project-checkmark'>
       <CheckMark isCompleted={challenge.isCompleted} />
     </span>
   </Link>
@@ -107,10 +107,10 @@ function Challenges({
             : t('aria.steps')
         }
       >
-        <ul className={`map-challenges-ul map-challenges-grid `}>
+        <ul className={`map-challenges-ul map-challenges-grid`}>
           {challenges.map(challenge => (
             <li
-              className={`map-challenge-title map-challenge-title-grid ${
+              className={`map-challenge-title ${
                 isProjectBlock
                   ? 'map-project-wrap'
                   : challenge.challengeType === challengeTypes.dialogue

--- a/client/src/templates/Introduction/components/super-block-accordion.tsx
+++ b/client/src/templates/Introduction/components/super-block-accordion.tsx
@@ -48,7 +48,7 @@ interface Challenge {
   superBlock: SuperBlocks;
 }
 
-interface SuperBlockAccordionPropsViewProps {
+interface SuperBlockAccordionProps {
   challenges: Challenge[];
   superBlock: SuperBlocks;
   chosenBlock: string;
@@ -214,7 +214,7 @@ export const SuperBlockAccordion = ({
   superBlock,
   chosenBlock,
   completedChallengeIds
-}: SuperBlockAccordionPropsViewProps) => {
+}: SuperBlockAccordionProps) => {
   const { t } = useTranslation();
   const { allChapters } = useMemo(() => {
     const populateBlocks = (blocks: { dashedName: string }[]) =>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

I came across some unused classes in client, so this PR is to clean them up. I also piggy-backed a change to correct the name of the `SuperBlockAccordion` props interface.

<!-- Feel free to add any additional description of changes below this line -->
