### PR TITLE
chore(curriculum): relax lightbox viewer tests to support 100vh/100vw and class-based display

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-lightbox-viewer/66db57ad34c7089b9b41bfd6.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-lightbox-viewer/66db57ad34c7089b9b41bfd6.md
@@ -131,6 +131,7 @@ Your `.lightbox` element should cover the entire viewport.
 const style = new __helpers.CSSHelp(document).getStyle('.lightbox');
 assert(['100%', '100vw'].includes(style?.width));
 assert(['100%', '100vh'].includes(style?.height));
+
 ```
 
 Your `.lightbox` element should be aligned with top left corner of the container.

--- a/curriculum/challenges/english/25-front-end-development/lab-lightbox-viewer/66db57ad34c7089b9b41bfd6.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-lightbox-viewer/66db57ad34c7089b9b41bfd6.md
@@ -128,8 +128,9 @@ assert.equal(new __helpers.CSSHelp(document).getStyle('.lightbox')?.position, 'f
 Your `.lightbox` element should cover the entire viewport.
 
 ```js
-assert.equal(new __helpers.CSSHelp(document).getStyle('.lightbox')?.width, '100%');
-assert.equal(new __helpers.CSSHelp(document).getStyle('.lightbox')?.height, '100%');
+const style = new __helpers.CSSHelp(document).getStyle('.lightbox');
+assert(['100%', '100vw'].includes(style?.width));
+assert(['100%', '100vh'].includes(style?.height));
 ```
 
 Your `.lightbox` element should be aligned with top left corner of the container.
@@ -231,7 +232,8 @@ background.dispatchEvent(new Event('click'));
 // await new Promise(resolve => setTimeout(resolve, 100)); // Adjust timeout as needed
 
 // Assert that the lightbox is hidden after clicking outside
-assert.strictEqual(getComputedDisplay(lightbox), 'none');
+const computed = window.getComputedStyle(lightbox);
+assert.strictEqual(computed.display, 'none');
 ```
 
 When your `.lightbox` element is visible and you click the `.lightbox` element, the `.lightbox` elements `display` should be set back to `none`.

--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646de8478d6f796bfbdccfb2.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646de8478d6f796bfbdccfb2.md
@@ -14,13 +14,13 @@ To make the right eye look like an eye, give it a border radius of `60%`. Also, 
 Your `.cat-right-eye` selector should have a `border-radius` property set to `60%`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-right-eye')?.borderRadius === '60%')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-right-eye')?.borderRadius, '60%')
 ```
 
 Your `.cat-right-eye` selector should have a `transform` property set to `rotate(-25deg)`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-right-eye')?.transform === 'rotate(-25deg)')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-right-eye')?.transform, 'rotate(-25deg)')
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646de8d204a3426c7d184372.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646de8d204a3426c7d184372.md
@@ -16,25 +16,26 @@ Using a class selector, give your `.cat-left-inner-eye` element a width of `10px
 You should have a `.cat-left-inner-eye` selector.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-left-inner-eye'))
+assert.exists(new __helpers.CSSHelp(document).getStyle('.cat-left-inner-eye'))
 ```
 
 Your `.cat-left-inner-eye` selector should have a `width` set to `10px`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-left-inner-eye')?.width === '10px')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-left-inner-eye')?.width, '10px')
 ```
 
 Your `.cat-left-inner-eye` selector should have a `height` set to `20px`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-left-inner-eye')?.height === '20px')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-left-inner-eye')?.height, '20px')
 ```
 
 Your `.cat-left-inner-eye` selector should have a `background-color` set to `#fff`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-left-inner-eye')?.backgroundColor === 'rgb(255, 255, 255)') 
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-left-inner-eye')?.backgroundColor, 'rgb(255, 255, 255)')
+ 
 ```
 
 # --seed--


### PR DESCRIPTION
### chore(curriculum): relax lightbox viewer tests to support 100vh/100vw and class-based display

#### ✅ Checklist

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

#### 🔗 Closes
Closes #60208

#### 📝 Description

This PR updates the Lightbox Viewer lab tests to:

- Accept `100vh` / `100vw` for height and width (instead of only `100%`).
- Accept visibility toggling via class-based CSS (`.show { display: flex; }`) instead of requiring `element.style.display`.

This allows for greater flexibility and modern CSS practices without breaking expected behavior.

