### PR TITLE
chore(curriculum): update lightbox viewer tests to accept 100vh/100vw and class-based display  ✅ Description:

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-lightbox-viewer/66db57ad34c7089b9b41bfd6.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-lightbox-viewer/66db57ad34c7089b9b41bfd6.md
@@ -128,8 +128,11 @@ assert.equal(new __helpers.CSSHelp(document).getStyle('.lightbox')?.position, 'f
 Your `.lightbox` element should cover the entire viewport.
 
 ```js
-assert.equal(new __helpers.CSSHelp(document).getStyle('.lightbox')?.width, '100%');
-assert.equal(new __helpers.CSSHelp(document).getStyle('.lightbox')?.height, '100%');
+const width = new __helpers.CSSHelp(document).getStyle('.lightbox')?.width;
+assert.ok(['100%', '100vw'].includes(width));
+const height = new __helpers.CSSHelp(document).getStyle('.lightbox')?.height;
+assert.ok(['100%', '100vh'].includes(height));
+
 ```
 
 Your `.lightbox` element should be aligned with top left corner of the container.
@@ -231,7 +234,9 @@ background.dispatchEvent(new Event('click'));
 // await new Promise(resolve => setTimeout(resolve, 100)); // Adjust timeout as needed
 
 // Assert that the lightbox is hidden after clicking outside
-assert.strictEqual(getComputedDisplay(lightbox), 'none');
+const display = window.getComputedStyle(document.querySelector('.lightbox')).display;
+assert.equal(display, 'none');
+
 ```
 
 When your `.lightbox` element is visible and you click the `.lightbox` element, the `.lightbox` elements `display` should be set back to `none`.


### PR DESCRIPTION
### chore(curriculum): relax lightbox viewer tests to support 100vh/100vw and class-based display

✅ **Checklist**  
- [x] I have read and followed the contribution guidelines.  
- [x] I have read and followed the how to open a pull request guide.  
- [x] My pull request targets the `main` branch of freeCodeCamp.  
- [x] I have tested these changes either locally on my machine, or Gitpod.  

🔗 **Closes**  
Closes #60208

📝 **Description**  
This PR updates the Lightbox Viewer lab tests to:

- Accept `100vh` / `100vw` for height and width (instead of only `100%`)
- Accept visibility toggling via class-based CSS (`.show { display: flex; }`) instead of requiring `element.style.display`

This allows for greater flexibility and modern CSS practices without breaking expected behavior.
