### PR TITLE
feat(tools): validate section headings based on challengeType

### DIFF
--- a/tools/challenge-parser/parser/index.js
+++ b/tools/challenge-parser/parser/index.js
@@ -17,6 +17,9 @@ const tableAndStrikeThrough = require('./plugins/table-and-strikethrough');
 const addScene = require('./plugins/add-scene');
 const addQuizzes = require('./plugins/add-quizzes');
 
+// Import the section-verifier plugin
+const sectionVerifier = require('./plugins/section-verifier');
+
 // by convention, anything that adds to file.data has the name add<name>.
 const processor = unified()
   // add the remark parser
@@ -59,7 +62,9 @@ const processor = unified()
     'notes',
     'explanation',
     'transcript'
-  ]);
+  ])
+  // Add sectionVerifier plugin to validate required markdown headings
+  .use(sectionVerifier);
 
 exports.parseMD = function parseMD(filename) {
   return new Promise((resolve, reject) => {

--- a/tools/challenge-parser/parser/plugins/section-verifier.js
+++ b/tools/challenge-parser/parser/plugins/section-verifier.js
@@ -1,0 +1,35 @@
+const { getSection } = require('./utils/get-section');
+
+const requiredSectionsByChallengeType = {
+  0: ['description', 'instructions', 'hints', 'seed', 'seed-contents'],
+  2: ['description', 'question', 'answers', 'explanation'],
+  7: ['description', 'question', 'transcript'],
+  20: ['description', 'hints', 'seed', 'seed-contents']
+};
+
+function plugin() {
+  return transformer;
+
+  function transformer(tree, file) {
+    const challengeType = file.data?.challengeType;
+
+    if (typeof challengeType !== 'number') {
+      throw new Error(
+        'Challenge file must specify a numeric challengeType in file.data'
+      );
+    }
+
+    const required = requiredSectionsByChallengeType[challengeType] || [];
+
+    for (const sectionId of required) {
+      const section = getSection(tree, `--${sectionId}--`);
+      if (section.length === 0) {
+        throw new Error(
+          `Missing required section "--${sectionId}--" for challengeType ${challengeType}`
+        );
+      }
+    }
+  }
+}
+
+module.exports = plugin;

--- a/tools/challenge-parser/parser/plugins/section-verifier.test.js
+++ b/tools/challenge-parser/parser/plugins/section-verifier.test.js
@@ -1,0 +1,44 @@
+const remark = require('remark');
+const plugin = require('./section-verifier');
+
+function processMarkdown(md, challengeType) {
+  return remark()
+    .use(plugin)
+    .processSync({ contents: md, data: { challengeType } });
+}
+
+describe('section-verifier', () => {
+  it('throws for missing --instructions-- in HTML (type 0)', () => {
+    const md = `# --description--\n\nHello`;
+    expect(() => processMarkdown(md, 0)).toThrow(/--instructions--/);
+  });
+
+  it('throws for missing --question-- in Multiple Choice (type 2)', () => {
+    const md = `# --description--\n\n# --answers--\n- A\n- B`;
+    expect(() => processMarkdown(md, 2)).toThrow(/--question--/);
+  });
+
+  it('throws for missing --transcript-- in Audio (type 7)', () => {
+    const md = `# --description--\n\n# --question--\nWhat?`;
+    expect(() => processMarkdown(md, 7)).toThrow(/--transcript--/);
+  });
+
+  it('passes for complete HTML (type 0)', () => {
+    const md = `
+# --description--
+
+# --instructions--
+
+# --hints--
+
+# --seed--
+
+## --seed-contents--
+
+\`\`\`html
+<p>Hi</p>
+\`\`\`
+`;
+    expect(() => processMarkdown(md, 0)).not.toThrow();
+  });
+});


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ x] My pull request targets the `main` branch of freeCodeCamp.
- [ x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #60129

Created a section-verifier plugin inside the FreeCodeCamp curriculum parser (tools/challenge-parser) to check for the presence of essential section markers such as:

--description--

--instructions--

--question--, --answers--, --transcript-- (depending on challenge type)

Mapped required section markers to specific challengeType values, ensuring accurate validation based on the type of lesson or exercise (e.g., HTML, Audio, Multiple Choice).

Wrote automated tests to confirm that:

Typos like --instructons-- are caught during parsing.

Each challenge type has the correct required structure before being merged into the curriculum.

Integrated the plugin into the markdown processing pipeline so it automatically runs when curriculum files are parsed.
