### PR TITLE
fix: update cat painting workshop steps 46-47 to use specific asserts

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646de8478d6f796bfbdccfb2.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646de8478d6f796bfbdccfb2.md
@@ -14,13 +14,13 @@ To make the right eye look like an eye, give it a border radius of `60%`. Also, 
 Your `.cat-right-eye` selector should have a `border-radius` property set to `60%`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-right-eye')?.borderRadius === '60%')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-right-eye')?.borderRadius, '60%')
 ```
 
 Your `.cat-right-eye` selector should have a `transform` property set to `rotate(-25deg)`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-right-eye')?.transform === 'rotate(-25deg)')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-right-eye')?.transform, 'rotate(-25deg)')
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646de8d204a3426c7d184372.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-painting/646de8d204a3426c7d184372.md
@@ -16,25 +16,25 @@ Using a class selector, give your `.cat-left-inner-eye` element a width of `10px
 You should have a `.cat-left-inner-eye` selector.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-left-inner-eye'))
+assert.exists(new __helpers.CSSHelp(document).getStyle('.cat-left-inner-eye'))
 ```
 
 Your `.cat-left-inner-eye` selector should have a `width` set to `10px`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-left-inner-eye')?.width === '10px')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-left-inner-eye')?.width, '10px')
 ```
 
 Your `.cat-left-inner-eye` selector should have a `height` set to `20px`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-left-inner-eye')?.height === '20px')
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-left-inner-eye')?.height, '20px')
 ```
 
 Your `.cat-left-inner-eye` selector should have a `background-color` set to `#fff`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cat-left-inner-eye')?.backgroundColor === 'rgb(255, 255, 255)') 
+assert.equal(new __helpers.CSSHelp(document).getStyle('.cat-left-inner-eye')?.backgroundColor, 'rgb(255, 255, 255)')
 ```
 
 # --seed--


### PR DESCRIPTION
I found this in the description field: …ng steps 46-47

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

Closes #60289

<!-- Feel free to add any additional description of changes below this line -->

This pull request updates `assert()` statements in the **Cat Painting Workshop** challenges (steps 46–47) to use more specific assertion methods, improving clarity and consistency:

### ✅ Changes Made

- Replaced:
  - `assert(a === b)` → `assert.equal(a, b)` for style and transformation checks.
  - `assert(a)` → `assert.exists(a)` for element presence validation.

### 📂 Affected Files

- `646de8478d6f796bfbdccfb2.md`
- `646de8d204a3426c7d184372.md`
