### PR TITLE
fix: update location.hash when following links in preview

### DIFF
--- a/client/src/templates/Challenges/utils/frame.ts
+++ b/client/src/templates/Challenges/utils/frame.ts
@@ -133,11 +133,7 @@ const createHeader = (id = mainPreviewId) =>
         else if (href.match(/^#.+/)) {
           e.preventDefault();
           const scrollId = href.substring(1);
-          const scrollElem = document.getElementById(scrollId);
-
-          if (scrollElem) {
-            scrollElem.scrollIntoView();
-          }
+          window.location.hash = scrollId;
         }
       }
     }, false);


### PR DESCRIPTION
This way the :target psuedoselector will now select the element whose id
matches the hash

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes https://github.com/freeCodeCamp/freeCodeCamp/issues/60340

<!-- Feel free to add any additional description of changes below this line -->
