### PR TITLE
fix(curriculum): Build a Calorie Counter: Step 79

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-calorie-counter/63c9e51b3a007a1eba1cd0f6.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-calorie-counter/63c9e51b3a007a1eba1cd0f6.md
@@ -36,8 +36,16 @@ assert.match(calculateCalories.toString(), regex);
 You should assign the value of `budgetCalories - consumedCalories + exerciseCalories` to `remainingCalories`.
 
 ```js
+const permutations = [
+  'budgetCalories\\s*-\\s*consumedCalories\\s*\\+\\s*exerciseCalories',
+  'budgetCalories\\s*\\+\\s*exerciseCalories\\s*-\\s*consumedCalories',
+  'exerciseCalories\\s*\\+\\s*budgetCalories\\s*-\\s*consumedCalories',
+  'exerciseCalories\\s*-\\s*consumedCalories\\s*\\+\\s*budgetCalories',
+  '-\\s*consumedCalories\\s*\\+\\s*budgetCalories\\s*\\+\\s*exerciseCalories',
+  '-\\s*consumedCalories\\s*\\+\\s*exerciseCalories\\s*\\+\\s*budgetCalories',
+].join('|');
 const assignRegex = new RegExp(
-  'remainingCalories\\s*=\\s*(?:' + regex.source + ')'
+  'remainingCalories\\s*=\\s*(?:' + permutations + ')'
 );
 assert.match(calculateCalories.toString(), assignRegex);
 ```

--- a/curriculum/challenges/english/25-front-end-development/workshop-calorie-counter/63c9e51b3a007a1eba1cd0f6.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-calorie-counter/63c9e51b3a007a1eba1cd0f6.md
@@ -20,13 +20,26 @@ assert.match(calculateCalories.toString(), /remainingCalories\s*=/);
 You should find the value of `budgetCalories - consumedCalories + exerciseCalories`.
 
 ```js
-assert.match(calculateCalories.toString(), /budgetCalories\s*-\s*consumedCalories\s*\+\s*exerciseCalories/);
+const regex = new RegExp(
+  [
+    'budgetCalories\\s*-\\s*consumedCalories\\s*\\+\\s*exerciseCalories',
+    'budgetCalories\\s*\\+\\s*exerciseCalories\\s*-\\s*consumedCalories',
+    'exerciseCalories\\s*\\+\\s*budgetCalories\\s*-\\s*consumedCalories',
+    'exerciseCalories\\s*-\\s*consumedCalories\\s*\\+\\s*budgetCalories',
+    '-\\s*consumedCalories\\s*\\+\\s*budgetCalories\\s*\\+\\s*exerciseCalories',
+    '-\\s*consumedCalories\\s*\\+\\s*exerciseCalories\\s*\\+\\s*budgetCalories',
+  ].join('|')
+);
+assert.match(calculateCalories.toString(), regex);
 ```
 
 You should assign the value of `budgetCalories - consumedCalories + exerciseCalories` to `remainingCalories`.
 
 ```js
-assert.match(calculateCalories.toString(), /remainingCalories\s*=\s*budgetCalories\s*-\s*consumedCalories\s*\+\s*exerciseCalories/);
+const assignRegex = new RegExp(
+  'remainingCalories\\s*=\\s*(?:' + regex.source + ')'
+);
+assert.match(calculateCalories.toString(), assignRegex);
 ```
 
 # --seed--


### PR DESCRIPTION
test accepts "a - b + c" but not "a + c - b"

used all permutations of possible a+b-c i.e factorial(3) to make a regex and match any one of the possible permuatation.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #60345 

<!-- Feel free to add any additional description of changes below this line -->
