### PR TITLE
fix(curriculum): element references in Storytelling App

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-storytelling-app/671fa1717ba9ea1a5fa028e0.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-storytelling-app/671fa1717ba9ea1a5fa028e0.md
@@ -7,7 +7,7 @@ dashedName: step-2
 
 # --description--
 
-Create a `main` element with a class of `story-container`. Inside the `story-container`, create a `div` with a class of `btn-container`.
+Create a `main` element with a class of `story-container`. Inside the `.story-container` element, create a `div` with a class of `btn-container`.
 
 # --hints--
 
@@ -17,7 +17,7 @@ You should have a `main` element with a class of `story-container`.
 assert.exists(document.querySelector('main.story-container'));
 ```
 
-Inside the `story-container` element, you should have a `div` with a class of `btn-container`.
+Inside the `.story-container` element, you should have a `div` with a class of `btn-container`.
 
 ```js
 assert.exists(document.querySelector('main.story-container div.btn-container'));

--- a/curriculum/challenges/english/25-front-end-development/workshop-storytelling-app/671fa22e99042b1e91fe9d2e.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-storytelling-app/671fa22e99042b1e91fe9d2e.md
@@ -11,7 +11,7 @@ Inside the `.btn-container` , create three buttons for each type of story. Give 
 
 # --hints--
 
-Inside the `btn-container` div, you should have three buttons.
+Inside the `.btn-container` element, you should have three buttons.
 
 ```js
 assert.lengthOf(document.querySelectorAll('.btn-container > button') ,3);

--- a/curriculum/challenges/english/25-front-end-development/workshop-storytelling-app/671fa47e415d88263d349a10.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-storytelling-app/671fa47e415d88263d349a10.md
@@ -17,7 +17,7 @@ You should create a `script` element.
 assert.lengthOf(document.querySelectorAll('script'), 3);
 ```
 
-Your `script` element should have an `src` attribute set to `script.js`.
+Your `script` element should have a `src` attribute set to `script.js`.
 
 ```js
 const script = document.querySelector("script[data-src$='script.js']");

--- a/curriculum/challenges/english/25-front-end-development/workshop-storytelling-app/671fa537114e412950b62089.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-storytelling-app/671fa537114e412950b62089.md
@@ -17,7 +17,7 @@ You should have a `storyContainer` variable.
 assert.isDefined(storyContainer);
 ```
 
-You should select the `div` with the class `story-container` using the `querySelector` method and store it in the `storyContainer` variable.
+You should select the `.story-container` element using the `querySelector` method and store it in the `storyContainer` variable.
 
 ```js
 assert.deepEqual(storyContainer, document.querySelector(".story-container"));

--- a/curriculum/challenges/english/25-front-end-development/workshop-storytelling-app/671fa769540d152e53327f4b.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-storytelling-app/671fa769540d152e53327f4b.md
@@ -18,7 +18,7 @@ assert.isDefined(scaryStoryBtn);
 assert.deepEqual(scaryStoryBtn, document.getElementById("scary-btn"));
 ```
 
-You should select the `#funny-btn`  button using the `getElementById` method and store it in the `funnyStoryBtn` variable.
+You should select the `#funny-btn` button using the `getElementById` method and store it in the `funnyStoryBtn` variable.
 
 ```js
 assert.isDefined(funnyStoryBtn);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR:
- Is a follow-up to #60354—the description was updated but the hint text wasn't
- Fixes a couple of minor random issues I found in the workshop

<!-- Feel free to add any additional description of changes below this line -->
