### PR TITLE
fix(curriculum): update challengeType in multimedia player lab

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-multimedia-player/67fccc2463253b213a000142.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-multimedia-player/67fccc2463253b213a000142.md
@@ -1,7 +1,7 @@
 ---
 id: 67fccc2463253b213a000142
 title: Build a Multimedia Player
-challengeType: 14
+challengeType: 25
 dashedName: lab-multimedia-player
 demoType: onClick
 ---


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #60362 

Changes overview:
Updating the `challengeType` to `25` enables the **"Revert Code"** feature in the multimedia player lab.
- `freeCodeCamp/curriculum/challenges/english/25-front-end-development/lab-multimedia-player/67fccc2463253b213a000142.md`

Happy to be contributing!