### PR TITLE
fix: rephrased confusing instruction in bookmark manager app

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-bookmark-manager-app/66def5467aee701733aaf8cc.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-bookmark-manager-app/66def5467aee701733aaf8cc.md
@@ -24,7 +24,7 @@ Fulfill the user stories below and get all the tests to pass to complete the lab
 1. You should have a function named `displayOrHideCategory` that toggles the `hidden` class on `#main-section` and `#bookmark-list-section`.
 1. When you click `#view-category-button`, you should update the inner text of `.category-name` to be the value of the selected option from `#category-dropdown`, modify the inner HTML of `#category-list` according to the user stories below, and call the `displayOrHideCategory` function.
 1. If none of the bookmarks in local storage have the category, you should set the inner HTML of the `#category-list` to a `p` element with the text `No Bookmarks Found`.
-1. If one or more bookmarks in local storage have the selected category, you should add a radio button with `id` and `value` attributes, and set to the bookmark name to the `#category-list`'s inner HTML for each of those bookmarks. Additionally, each radio button should have the same `name` attribute.
+1. If one or more bookmarks in local storage have the selected category, add a radio button for each bookmark to the innerHTML of the #category-list. Give each radio button an id and value set to the bookmark name, and a name that's the same for all the buttons.
 1. Each radio button should have a corresponding label containing an anchor element with the bookmark name and the `href` attribute set to the bookmark URL.
 1. When you click the `#close-list-button`, you should run your function to hide the `#bookmark-list-section` and display the main section.
 1. When you click the `#delete-bookmark-button`, you should delete the bookmark corresponding to the selected radio button and appropriate category from the local storage and update the displayed bookmark list.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #60346 

<!-- Feel free to add any additional description of changes below this line -->
Rephrased the instruction for better clarity as discussed in Issue #60346.
