### PR TITLE
chore(curriculum): update HTML chapter to address last issue found in analytics report

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -1738,7 +1738,10 @@
   "full-stack-developer": {
     "title": "Certified Full Stack Developer Curriculum",
     "intro": [
-      "This course offers a comprehensive pathway to becoming a Certified Full Stack Developer, covering the essential technologies for building modern, scalable web applications. You'll master both frontend and backend development through interactive lessons, coding exercises, and real-world projects. On the frontend, you'll work with HTML, CSS, JavaScript, React, and TypeScript to build responsive interfaces, while on the backend, you'll use Git, Npm, Node.js, Python, and relational databases to create robust server-side solutions. The curriculum is designed to equip you with practical skills needed in today's tech industry."
+      "This course provides a comprehensive pathway to becoming a Certified Full Stack Developer, covering all the essential technologies required to build modern, scalable web applications from start to finish.",
+      "Through a blend of interactive lessons, coding exercises, and real-world projects, you will master both frontend and backend development. You'll work with HTML, CSS, and JavaScript to build responsive user interfaces, explore React and TypeScript for advanced web applications, and learn to manage data with relational databases - and on the backend, you'll use Git, Npm, Node.js, and Python to create powerful server-side solutions.",
+      "By the end of this course, you'll have the practical skills and experience to confidently develop complete web applications, preparing you for a successful career as a Full Stack Developer.",
+      "This certification will take you a substantial amount of time and effort to complete. If you start now, you may be ready to start the remaining material and final exam when we launch it in the coming months."
     ],
     "chapters": {
       "html": "HTML",

--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -1738,13 +1738,9 @@
   "full-stack-developer": {
     "title": "Certified Full Stack Developer Curriculum",
     "intro": [
-      "This course provides a comprehensive pathway to becoming a Certified Full Stack Developer, covering all the essential technologies required to build modern, scalable web applications from start to finish.",
-      "Through a blend of interactive lessons, coding exercises, and real-world projects, you will master both frontend and backend development. You'll work with HTML, CSS, and JavaScript to build responsive user interfaces, explore React and TypeScript for advanced web applications, and learn to manage data with relational databases - and on the backend, you'll use Git, Npm, Node.js, and Python to create powerful server-side solutions.",
-      "By the end of this course, you'll have the practical skills and experience to confidently develop complete web applications, preparing you for a successful career as a Full Stack Developer.",
-      "This certification will take you a substantial amount of time and effort to complete. If you start now, you may be ready to start the remaining material and final exam when we launch it in the coming months."
+      "This course offers a comprehensive pathway to becoming a Certified Full Stack Developer, covering the essential technologies for building modern, scalable web applications. You'll master both frontend and backend development through interactive lessons, coding exercises, and real-world projects. On the frontend, you'll work with HTML, CSS, JavaScript, React, and TypeScript to build responsive interfaces, while on the backend, you'll use Git, Npm, Node.js, Python, and relational databases to create robust server-side solutions. The curriculum is designed to equip you with practical skills needed in today's tech industry."
     ],
     "chapters": {
-      "freecodecamp": "Welcome",
       "html": "HTML",
       "css": "CSS",
       "javascript": "JavaScript",
@@ -1755,7 +1751,6 @@
       "exam-certified-full-stack-developer": "Certified Full Stack Developer Exam"
     },
     "modules": {
-      "getting-started-with-freecodecamp": "Getting Started with freeCodeCamp",
       "basic-html": "Basic HTML",
       "semantic-html": "Semantic HTML",
       "html-forms-and-tables": "Forms and Tables",
@@ -1833,10 +1828,17 @@
           "Watch these videos to learn what freeCodeCamp is, and how millions of people have learned to code and gotten developer jobs using it."
         ]
       },
+      "workshop-curriculum-outline": {
+        "title": "Build a Curriculum Outline",
+        "intro": [
+          "Welcome to freeCodeCamp!",
+          "This workshop will serve as your introduction to HTML and coding in general. You will learn about headings and paragraph elements."
+        ]
+      },
       "lecture-what-is-html": {
         "title": "What is HTML?",
         "intro": [
-          "In this lecture video, you will be introduced to HTML (HyperText Markup Language), a markup language for creating web pages.",
+          "In this lecture video, you will learn about HTML (HyperText Markup Language), a markup language for creating web pages.",
           "You will learn about HTML's role on the web, the basic syntax, and what HTML attributes are."
         ]
       },
@@ -2029,10 +2031,7 @@
           "Open up this page to review concepts around the basics of HTML elements, semantic HTML, tables, forms and accessibility."
         ]
       },
-      "qpra": {
-        "title": "30",
-        "intro": []
-      },
+      "qpra": { "title": "30", "intro": [] },
       "lecture-understanding-computer-internet-and-tooling-basics": {
         "title": "Understanding Computer, Internet, and Tooling Basics",
         "intro": [
@@ -3436,10 +3435,7 @@
           "Open up this page to review all of the concepts taught including variables, strings, booleans, functions, objects, arrays, debugging, working with the DOM and more."
         ]
       },
-      "kagw": {
-        "title": "258",
-        "intro": []
-      },
+      "kagw": { "title": "258", "intro": [] },
       "lecture-introduction-to-javascript-libraries-and-frameworks": {
         "title": "Introduction to JavaScript Libraries and Frameworks",
         "intro": [
@@ -3511,14 +3507,8 @@
           "In these lecture videos, you will learn about effects and referencing values with React."
         ]
       },
-      "xdyh": {
-        "title": "270",
-        "intro": []
-      },
-      "vjgg": {
-        "title": "272",
-        "intro": []
-      },
+      "xdyh": { "title": "270", "intro": [] },
+      "vjgg": { "title": "272", "intro": [] },
       "review-react-state-and-hooks": {
         "title": "React State and Hooks Review",
         "intro": [
@@ -3557,10 +3547,7 @@
           "In these lecture videos, you will learn about data fetching and memoization in React."
         ]
       },
-      "ffpt": {
-        "title": "279",
-        "intro": []
-      },
+      "ffpt": { "title": "279", "intro": [] },
       "lab-currency-converter": {
         "title": "Build a Currency Converter",
         "intro": [
@@ -3661,26 +3648,11 @@
           "In these lecture videos, you will learn what TypeScript is and how to use it."
         ]
       },
-      "trvf": {
-        "title": "293",
-        "intro": []
-      },
-      "kwmg": {
-        "title": "294",
-        "intro": []
-      },
-      "nodx": {
-        "title": "295",
-        "intro": []
-      },
-      "erfj": {
-        "title": "296",
-        "intro": []
-      },
-      "muyw": {
-        "title": "297",
-        "intro": []
-      },
+      "trvf": { "title": "293", "intro": [] },
+      "kwmg": { "title": "294", "intro": [] },
+      "nodx": { "title": "295", "intro": [] },
+      "erfj": { "title": "296", "intro": [] },
+      "muyw": { "title": "297", "intro": [] },
       "review-typescript": {
         "title": "Typescript Review",
         "intro": [
@@ -3698,14 +3670,8 @@
           "Review the Front End Libraries concepts to prepare for the upcoming quiz."
         ]
       },
-      "rdzk": {
-        "title": "301",
-        "intro": []
-      },
-      "vtpz": {
-        "title": "302",
-        "intro": []
-      },
+      "rdzk": { "title": "301", "intro": [] },
+      "vtpz": { "title": "302", "intro": [] },
       "workshop-bash-boilerplate": {
         "title": "Build a Boilerplate",
         "intro": [
@@ -3723,10 +3689,7 @@
         "title": "Bash Commands Quiz",
         "intro": ["Test what you've learned bash commands with this quiz."]
       },
-      "voks": {
-        "title": "306",
-        "intro": []
-      },
+      "voks": { "title": "306", "intro": [] },
       "workshop-database-of-video-game-characters": {
         "title": "Build a Database of Video Game Characters",
         "intro": [
@@ -3752,10 +3715,7 @@
           "Test what you've learned on relational databases with this quiz."
         ]
       },
-      "pexz": {
-        "title": "311",
-        "intro": []
-      },
+      "pexz": { "title": "311", "intro": [] },
       "workshop-bash-five-programs": {
         "title": "Build Five Programs",
         "intro": [
@@ -3773,10 +3733,7 @@
         "title": "Bash Scripting Quiz",
         "intro": ["Test what you've learned on bash scripting in this quiz."]
       },
-      "tkgg": {
-        "title": "315",
-        "intro": []
-      },
+      "tkgg": { "title": "315", "intro": [] },
       "workshop-sql-student-database-part-1": {
         "title": "Build a Student Database: Part 1",
         "intro": [
@@ -3826,10 +3783,7 @@
         "title": "Bash and SQL Quiz",
         "intro": ["Test what you've learned in this quiz on Bash and SQL."]
       },
-      "eeez": {
-        "title": "324",
-        "intro": []
-      },
+      "eeez": { "title": "324", "intro": [] },
       "workshop-castle": {
         "title": "Build a Castle",
         "intro": [
@@ -3845,10 +3799,7 @@
         "title": "Nano Quiz",
         "intro": ["Test what you've learned on Nano with this quiz ."]
       },
-      "rhhl": {
-        "title": "328",
-        "intro": []
-      },
+      "rhhl": { "title": "328", "intro": [] },
       "workshop-sql-reference-object": {
         "title": "Build an SQL Reference Object",
         "intro": [
@@ -4045,10 +3996,7 @@
         "title": "Placeholder - Waiting for title",
         "intro": [""]
       },
-      "lab-placeholder-oop-3": {
-        "title": "",
-        "intro": [""]
-      },
+      "lab-placeholder-oop-3": { "title": "", "intro": [""] },
       "review-object-oriented-programming": {
         "title": "Object Oriented Programming Review",
         "intro": [
@@ -4102,14 +4050,8 @@
         "title": "Build a Bisection Method",
         "intro": [""]
       },
-      "workshop-merge-sort": {
-        "title": "Build a Merge Sort",
-        "intro": [""]
-      },
-      "lab-quick-sort": {
-        "title": "Build a Quick Sort",
-        "intro": [""]
-      },
+      "workshop-merge-sort": { "title": "Build a Merge Sort", "intro": [""] },
+      "lab-quick-sort": { "title": "Build a Quick Sort", "intro": [""] },
       "lab-selection-sort": {
         "title": "Build a Selection Sort",
         "intro": [""]

--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -1833,7 +1833,7 @@
         ]
       },
       "lecture-welcome-to-freecodecamp": {
-        "title": "Welcome message from Quincy Larson",
+        "title": "Welcome Message from Quincy Larson",
         "intro": [
           "Hear from Quincy Larson, the founder and teacher of freeCodeCamp.",
           "Quincy will welcome you to the platform and talk about how the certification works. Quincy will also provide tips on how to learn effectively."
@@ -1847,7 +1847,7 @@
         ]
       },
       "lecture-what-is-html": {
-        "title": "Understanding HTML attributes and the HTML boilerplate",
+        "title": "Understanding HTML Attributes and the HTML Boilerplate",
         "intro": [
           "In these lecture videos, you will learn more about HTML (HyperText Markup Language), a markup language for creating web pages.",
           "You will learn about HTML's role on the web, the HTML boilerplate and what HTML attributes are."

--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -1822,17 +1822,18 @@
       "exam-python": "Python Exam"
     },
     "blocks": {
-      "lecture-welcome-to-freecodecamp": {
-        "title": "Welcome to freeCodeCamp",
-        "intro": [
-          "Watch these videos to learn what freeCodeCamp is, and how millions of people have learned to code and gotten developer jobs using it."
-        ]
-      },
       "workshop-curriculum-outline": {
         "title": "Build a Curriculum Outline",
         "intro": [
           "Welcome to freeCodeCamp!",
           "This workshop will serve as your introduction to HTML and coding in general. You will learn about headings and paragraph elements."
+        ]
+      },
+      "lecture-welcome-to-freecodecamp": {
+        "title": "Welcome message from Quincy Larson",
+        "intro": [
+          "Hear from Quincy Larson, the founder and teacher of freeCodeCamp.",
+          "Quincy will welcome you to the platform and talk about how the certification works. Quincy will also provide tips on how to learn effectively."
         ]
       },
       "lecture-what-is-html": {

--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -1840,14 +1840,14 @@
         "title": "Debug Camperbot's Profile Page",
         "intro": [
           "Camperbot is learning how to code too and needs some help with their HTML.",
-          "In this lab, you will help camperbot find and fix the errors in their code."
+          "In this lab, you will help Camperbot find and fix the errors in their code."
         ]
       },
       "lecture-what-is-html": {
-        "title": "What is HTML?",
+        "title": "Understanding HTML attributes and the HTML boilerplate",
         "intro": [
-          "In this lecture video, you will learn about HTML (HyperText Markup Language), a markup language for creating web pages.",
-          "You will learn about HTML's role on the web, the basic syntax, and what HTML attributes are."
+          "In these lecture videos, you will learn more about HTML (HyperText Markup Language), a markup language for creating web pages.",
+          "You will learn about HTML's role on the web, the HTML boilerplate and what HTML attributes are."
         ]
       },
       "workshop-cat-photo-app": {

--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -1836,6 +1836,13 @@
           "Quincy will welcome you to the platform and talk about how the certification works. Quincy will also provide tips on how to learn effectively."
         ]
       },
+      "lab-debug-camperbots-profile-page": {
+        "title": "Debug Camperbot's Profile Page",
+        "intro": [
+          "Camperbot is learning how to code too and needs some help with their HTML.",
+          "In this lab, you will help camperbot find and fix the errors in their code."
+        ]
+      },
       "lecture-what-is-html": {
         "title": "What is HTML?",
         "intro": [

--- a/client/src/pages/learn/full-stack-developer/lab-debug-camperbots-profile-page/index.md
+++ b/client/src/pages/learn/full-stack-developer/lab-debug-camperbots-profile-page/index.md
@@ -1,0 +1,9 @@
+---
+title: Introduction to the Debug Camperbot's Profile Page
+block: lab-debug-camperbots-profile-page
+superBlock: full-stack-developer
+---
+
+## Introduction to the Debug Camperbot's Profile Page
+
+In this lab, you will help Camperbot debug the errors in their HTML.

--- a/client/src/pages/learn/full-stack-developer/workshop-curriculum-outline/index.md
+++ b/client/src/pages/learn/full-stack-developer/workshop-curriculum-outline/index.md
@@ -1,0 +1,9 @@
+---
+title: Introduction to the Build a Curriculum Outline
+block: workshop-curriculum-outline
+superBlock: full-stack-developer
+---
+
+## Introduction to the Build a Curriculum Outline
+
+Welcome to freeCodeCamp! This is your first introduction to HTML and coding in general.

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -783,7 +783,7 @@ const Editor = (props: EditorProps): JSX.Element => {
     descContainer.appendChild(desc);
     desc.innerHTML = description;
     Prism.hooks.add('complete', enhancePrismAccessibility);
-    console.log(props.block);
+
     // To reduce confusion on the first workshop. Will need to find a better solution.
     if (props.block !== 'workshop-curriculum-outline') {
       Prism.hooks.add('complete', makePrismCollapsible);

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -783,7 +783,11 @@ const Editor = (props: EditorProps): JSX.Element => {
     descContainer.appendChild(desc);
     desc.innerHTML = description;
     Prism.hooks.add('complete', enhancePrismAccessibility);
-    Prism.hooks.add('complete', makePrismCollapsible);
+    console.log(props.block);
+    // To reduce confusion on the first workshop. Will need to find a better solution.
+    if (props.block !== 'workshop-curriculum-outline') {
+      Prism.hooks.add('complete', makePrismCollapsible);
+    }
     Prism.highlightAllUnder(desc);
 
     // Since the description can be resized without React knowing about it, the

--- a/curriculum/challenges/_meta/lab-debug-camperbots-profile-page/meta.json
+++ b/curriculum/challenges/_meta/lab-debug-camperbots-profile-page/meta.json
@@ -1,0 +1,11 @@
+{
+  "name": "Debug Camperbot's Profile Page",
+  "blockType": "lab",
+  "blockLayout": "link",
+  "isUpcomingChange": false,
+  "usesMultifileEditor": true,
+  "dashedName": "lab-debug-camperbots-profile-page",
+  "superBlock": "full-stack-developer",
+  "challengeOrder": [{ "id": "6823f9df49cc206af5471a30", "title": "Debug Camperbot's Profile Page" }],
+  "helpCategory": "HTML-CSS"
+}

--- a/curriculum/challenges/_meta/lecture-what-is-html/meta.json
+++ b/curriculum/challenges/_meta/lecture-what-is-html/meta.json
@@ -6,7 +6,7 @@
   "challengeOrder": [
     {
       "id": "66f6db08d55022680a3cfbc9",
-      "title": "What Is HTML, and What Role Does It Play on the Web?"
+      "title": "What Role Does HTML Play on the Web?"
     },
     {
       "id": "6708143cab2b583ecd3324f5",

--- a/curriculum/challenges/_meta/workshop-curriculum-outline/meta.json
+++ b/curriculum/challenges/_meta/workshop-curriculum-outline/meta.json
@@ -13,32 +13,40 @@
       "title": "Step 1"
     },
     {
-      "id": "682ba2318000b62f179bdf04",
+      "id": "682cd206883fc7b25eb539c5",
       "title": "Step 2"
     },
     {
-      "id": "6823c1a0bcada44f32bf0bdc",
+      "id": "682cd20b883fc7b25eb539c6",
       "title": "Step 3"
     },
     {
-      "id": "6823d6244511f252c8300eed",
+      "id": "682ba2318000b62f179bdf04",
       "title": "Step 4"
     },
     {
-      "id": "6823d9ac8bdc3853df65a1ff",
+      "id": "6823c1a0bcada44f32bf0bdc",
       "title": "Step 5"
     },
     {
-      "id": "6823e036ea4b71553558c01b",
+      "id": "6823d6244511f252c8300eed",
       "title": "Step 6"
     },
     {
-      "id": "6823e169fda14755fbf00445",
+      "id": "6823d9ac8bdc3853df65a1ff",
       "title": "Step 7"
     },
     {
-      "id": "6823e637c1c0ed56f781b4fc",
+      "id": "6823e036ea4b71553558c01b",
       "title": "Step 8"
+    },
+    {
+      "id": "6823e169fda14755fbf00445",
+      "title": "Step 9"
+    },
+    {
+      "id": "6823e637c1c0ed56f781b4fc",
+      "title": "Step 10"
     }
   ],
   "helpCategory": "HTML-CSS"

--- a/curriculum/challenges/_meta/workshop-curriculum-outline/meta.json
+++ b/curriculum/challenges/_meta/workshop-curriculum-outline/meta.json
@@ -1,0 +1,41 @@
+{
+  "name": "Build a Curriculum Outline",
+  "isUpcomingChange": false,
+  "usesMultifileEditor": true,
+  "hasEditableBoundaries": true,
+  "blockType": "workshop",
+  "blockLayout": "challenge-grid",
+  "dashedName": "workshop-curriculum-outline",
+  "superBlock": "full-stack-developer",
+  "challengeOrder": [
+    {
+      "id": "6823ac607bfdbc46331b2559",
+      "title": "Step 1"
+    },
+    {
+      "id": "6823c1a0bcada44f32bf0bdc",
+      "title": "Step 2"
+    },
+    {
+      "id": "6823d6244511f252c8300eed",
+      "title": "Step 3"
+    },
+    {
+      "id": "6823d9ac8bdc3853df65a1ff",
+      "title": "Step 4"
+    },
+    {
+      "id": "6823e036ea4b71553558c01b",
+      "title": "Step 5"
+    },
+    {
+      "id": "6823e169fda14755fbf00445",
+      "title": "Step 6"
+    },
+    {
+      "id": "6823e637c1c0ed56f781b4fc",
+      "title": "Step 7"
+    }
+  ],
+  "helpCategory": "HTML-CSS"
+}

--- a/curriculum/challenges/_meta/workshop-curriculum-outline/meta.json
+++ b/curriculum/challenges/_meta/workshop-curriculum-outline/meta.json
@@ -13,28 +13,32 @@
       "title": "Step 1"
     },
     {
-      "id": "6823c1a0bcada44f32bf0bdc",
+      "id": "682ba2318000b62f179bdf04",
       "title": "Step 2"
     },
     {
-      "id": "6823d6244511f252c8300eed",
+      "id": "6823c1a0bcada44f32bf0bdc",
       "title": "Step 3"
     },
     {
-      "id": "6823d9ac8bdc3853df65a1ff",
+      "id": "6823d6244511f252c8300eed",
       "title": "Step 4"
     },
     {
-      "id": "6823e036ea4b71553558c01b",
+      "id": "6823d9ac8bdc3853df65a1ff",
       "title": "Step 5"
     },
     {
-      "id": "6823e169fda14755fbf00445",
+      "id": "6823e036ea4b71553558c01b",
       "title": "Step 6"
     },
     {
-      "id": "6823e637c1c0ed56f781b4fc",
+      "id": "6823e169fda14755fbf00445",
       "title": "Step 7"
+    },
+    {
+      "id": "6823e637c1c0ed56f781b4fc",
+      "title": "Step 8"
     }
   ],
   "helpCategory": "HTML-CSS"

--- a/curriculum/challenges/english/25-front-end-development/lab-debug-camperbots-profile-page/6823f9df49cc206af5471a30.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-debug-camperbots-profile-page/6823f9df49cc206af5471a30.md
@@ -10,7 +10,7 @@ dashedName: lab-debug-camperbots-profile-page
 
 Camperbot just started learning how to code and is trying to build a profile page. They asked a friend to look over their code so far and their friend said it had tons of errors.
 
-Your job is to fix all of Camperbot's errors so they can continue to build their profile page. Complete the items in the user stories below and click "Run the Tests" to see if you fixed all the bugs.
+Your job is to fix all of Camperbot's errors so they can continue to build their profile page. Complete the items in the user stories below and click "Run the Tests" to see if you fixed all the errors.
 
 **User Stories:**
 

--- a/curriculum/challenges/english/25-front-end-development/lab-debug-camperbots-profile-page/6823f9df49cc206af5471a30.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-debug-camperbots-profile-page/6823f9df49cc206af5471a30.md
@@ -3,28 +3,88 @@ id: 6823f9df49cc206af5471a30
 title: Debug Camperbot's Profile Page
 challengeType: 25
 dashedName: lab-debug-camperbots-profile-page
-demoType: onClick
+# Purposefully removed the demo type because I don't want any example to show since this is a debugging project.
 ---
 
 # --description--
 
 Camperbot just started learning how to code and is trying to build a profile page. They asked a friend to look over their code so far and their friend said it had tons of errors.
 
-Your job is to fix all of camperbot's errors so they can continue to build their profile page.
+Your job is to fix all of Camperbot's errors so they can continue to build their profile page.
 
 **User Stories:**
 
 1. Camperbot is not following best practices and has multiple `h1` elements on the page. Remove all `h1` elements except for the first one.
-1. Camperbot is trying to use a `heading2` element. But that element does not exist. Fix that mistake so it uses the correct heading element for subheadings just below an `h1`. 
-1. Camperbot is trying to add some paragraphs but is using the wrong element. Fix these errors to use the correct HTML element for paragraphs.
-1. Camperbot is using an `h3` element for the `Background and Interests` subheading but it has a syntax error. Spot the issue and resolve it. 
+2. Camperbot is trying to use a `heading2` element. But that element does not exist in HTML. Fix that mistake so it uses the correct second level heading element. 
+3. Camperbot is trying to add some paragraphs but is using the wrong element. Fix these errors to use the correct HTML element for paragraphs.
+4. Camperbot is using an `h3` element for the `Background and Interests` subheading but it has a syntax error. Spot the issue and resolve it. 
 
 # --hints--
 
-Test 1
+You should only have one `h1` on the page.
 
 ```js
+assert.lengthOf(document.querySelectorAll("h1"), 1);
+```
 
+You should not remove the `<h1>Hello from Camperbot!</h1>` from the page.
+
+```js
+assert.strictEqual(document.querySelector("h1:first-of-type")?.innerText, "Hello from Camperbot!");
+```
+
+You should have a valid `h2` element on the page.
+
+```js
+assert.exists(document.querySelector("h2"));
+```
+
+You should not change the `About` text for the `h2` element.
+
+```js
+assert.strictEqual(document.querySelector("h2")?.innerText, "About");
+```
+
+Your first paragraph element should have a valid opening tag. Remember that `p` elements have opening tags using this syntax: `<elementName>`.
+
+```js
+assert.match(code, /<p>\s*My\s+name/);
+```
+
+Your first paragraph element should have a valid closing tag. Remember that `p` elements have closing tags using this syntax: `</elementName>`.
+
+```js
+assert.match(code, /new\s+things\.<\/p>/);
+```
+
+Your second paragraph element should have a valid opening tag. Remember that `p` elements have opening tags using this syntax: `<elementName>`.
+
+```js
+assert.match(code, /<p>\s*I\s+enjoy/);
+```
+
+Your second paragraph element should have a valid closing tag. Remember that `p` elements have closing tags using this syntax: `</elementName>`.
+
+```js
+assert.match(code, /solving\s+puzzles\.<\/p>/);
+```
+
+Your first valid paragraph element should have the text `My name is Camperbot and I love reading and learning new things.`. Double check your spelling.
+
+```js
+assert.strictEqual(document.querySelector("p:first-of-type")?.innerText, "My name is Camperbot and I love reading and learning new things.");
+```
+
+Your `h3` element should have a valid closing tag. Remember that `h3` elements have closing tags using this syntax: `</elementName>`.
+
+```js
+assert.match(code, /<\/h3\>/);
+```
+
+Your second valid paragraph element should have the text `I enjoy solving puzzles.`. Double check your spelling.
+
+```js
+assert.strictEqual(document.querySelector("h3 + p")?.innerText, "I enjoy solving puzzles.");
 ```
 
 # --seed--
@@ -41,7 +101,7 @@ Test 1
 <pp>My name is Camperbot and I love reading and learning new things.<pp>
 
 <h3>Background and Interests<h3>
-<pp>I enjoy coding, exploring new technologies, and solving puzzles.<pp>
+<pp>I enjoy solving puzzles.<pp>
 
 <h1>Stay Curious!</h1>
 ```
@@ -56,5 +116,5 @@ Test 1
 <p>My name is Camperbot and I love reading and learning new things.</p>
 
 <h3>Background and Interests</h3>
-<p>I enjoy coding, exploring new technologies, and solving puzzles.</p>
+<p>I enjoy solving puzzles.</p>
 ```

--- a/curriculum/challenges/english/25-front-end-development/lab-debug-camperbots-profile-page/6823f9df49cc206af5471a30.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-debug-camperbots-profile-page/6823f9df49cc206af5471a30.md
@@ -102,8 +102,6 @@ assert.strictEqual(document.querySelector("h3 + p")?.innerText, "I enjoy solving
 
 <h3>Background and Interests<h3>
 <pp>I enjoy solving puzzles.<pp>
-
-<h1>Stay Curious!</h1>
 ```
 
 # --solutions--

--- a/curriculum/challenges/english/25-front-end-development/lab-debug-camperbots-profile-page/6823f9df49cc206af5471a30.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-debug-camperbots-profile-page/6823f9df49cc206af5471a30.md
@@ -1,0 +1,60 @@
+---
+id: 6823f9df49cc206af5471a30
+title: Debug Camperbot's Profile Page
+challengeType: 25
+dashedName: lab-debug-camperbots-profile-page
+demoType: onClick
+---
+
+# --description--
+
+Camperbot just started learning how to code and is trying to build a profile page. They asked a friend to look over their code so far and their friend said it had tons of errors.
+
+Your job is to fix all of camperbot's errors so they can continue to build their profile page.
+
+**User Stories:**
+
+1. Camperbot is not following best practices and has multiple `h1` elements on the page. Remove all `h1` elements except for the first one.
+1. Camperbot is trying to use a `heading2` element. But that element does not exist. Fix that mistake so it uses the correct heading element for subheadings just below an `h1`. 
+1. Camperbot is trying to add some paragraphs but is using the wrong element. Fix these errors to use the correct HTML element for paragraphs.
+1. Camperbot is using an `h3` element for the `Background and Interests` subheading but it has a syntax error. Spot the issue and resolve it. 
+
+# --hints--
+
+Test 1
+
+```js
+
+```
+
+# --seed--
+
+## --seed-contents--
+
+```html
+<h1>Hello from Camperbot!</h1>
+
+<h1>Welcome!</h1>
+
+<heading2>About</heading2>
+
+<pp>My name is Camperbot and I love reading and learning new things.<pp>
+
+<h3>Background and Interests<h3>
+<pp>I enjoy coding, exploring new technologies, and solving puzzles.<pp>
+
+<h1>Stay Curious!</h1>
+```
+
+# --solutions--
+
+```html
+<h1>Hello from Camperbot!</h1>
+
+<h2>About</h2>
+
+<p>My name is Camperbot and I love reading and learning new things.</p>
+
+<h3>Background and Interests</h3>
+<p>I enjoy coding, exploring new technologies, and solving puzzles.</p>
+```

--- a/curriculum/challenges/english/25-front-end-development/lab-debug-camperbots-profile-page/6823f9df49cc206af5471a30.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-debug-camperbots-profile-page/6823f9df49cc206af5471a30.md
@@ -10,7 +10,7 @@ dashedName: lab-debug-camperbots-profile-page
 
 Camperbot just started learning how to code and is trying to build a profile page. They asked a friend to look over their code so far and their friend said it had tons of errors.
 
-Your job is to fix all of Camperbot's errors so they can continue to build their profile page.
+Your job is to fix all of Camperbot's errors so they can continue to build their profile page. Complete the items in the user stories below and click "Run the Tests" to see if you fixed all the bugs.
 
 **User Stories:**
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-what-is-html/66f6db08d55022680a3cfbc9.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-what-is-html/66f6db08d55022680a3cfbc9.md
@@ -1,6 +1,6 @@
 ---
 id: 66f6db08d55022680a3cfbc9
-title: What Is HTML, and What Role Does It Play on the Web?
+title: What Role Does HTML Play on the Web?
 challengeType: 11
 videoId: Me-GFJKL-9E
 dashedName: what-is-html
@@ -12,7 +12,7 @@ Watch the video or read the transcript and answer the questions below.
 
 # --transcript--
 
-What Is HTML, and What Role Does It Play on the Web?
+What Role Does HTML Play on the Web?
 
 HTML, which stands for Hypertext Markup Language, is a markup language for creating web pages. When you visit a website and see content like paragraphs, headings, links, images, and videos; that's HTML. HTML represents the content and structure of a webpage through the use of elements. Here's an example of a paragraph element:
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-photo-app/5dc174fcf86c76b9248c6eb2.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-photo-app/5dc174fcf86c76b9248c6eb2.md
@@ -8,18 +8,9 @@ demoType: onLoad
 
 # --description--
 
-In this workshop, you will learn how to work with basic HTML elements like headings, paragraphs, and lists by building a cat photo app. 
+In this workshop, you will continue working with basic HTML elements like headings, paragraphs, and lists by building a cat photo app. 
 
-The first element you will learn about is the `h1` element. The `h1` element is a heading element and is used for the main heading of a webpage.
-
-```html
-<h1>This is a main heading</h1>
-```
-
-Add an `h1` element with the text of `CatPhotoApp` and watch
-the change in the browser preview.
-
-When you are done, press the "Check Your Code" button to see if it's correct.
+Begin the workshop by adding an `h1` element with the text of `CatPhotoApp`.
 
 # --hints--
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-photo-app/5dc1798ff86c76b9248c6eb3.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-photo-app/5dc1798ff86c76b9248c6eb3.md
@@ -7,19 +7,6 @@ dashedName: step-2
 
 # --description--
 
-The `h1` through `h6` heading elements are used to signify the importance of content below them. The lower the number, the higher the importance, so `h2` elements have less importance than `h1` elements. 
-
-```html
-<h1>most important heading element</h1>
-<h2>second most important heading element</h2>
-<h3>third most important heading element</h3>
-<h4>fourth most important heading element</h4>
-<h5>fifth most important heading element</h5>
-<h6>least important heading element</h6>
-```
-
-Only use one `h1` element per page and place lower-importance headings below higher-importance headings.
-
 Below the `h1` element, add an `h2` element with this text:
 
 `Cat Photos`

--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-photo-app/5dc17d3bf86c76b9248c6eb4.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-photo-app/5dc17d3bf86c76b9248c6eb4.md
@@ -7,7 +7,7 @@ dashedName: step-3
 
 # --description--
 
-The `p` element is used to create a paragraph of text on websites. Create a `p` element below your `h2` element and give it the following text:
+Create a `p` element below your `h2` element and give it the following text:
 
 `Everyone loves cute cats online!`
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/6823ac607bfdbc46331b2559.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/6823ac607bfdbc46331b2559.md
@@ -8,16 +8,24 @@ demoType: onLoad
 
 # --description--
 
-HTML stands for HyperText Markup Language and it represents the content and structure of a web page. In this workshop, you will write the HTML code for a curriculum outline.
+HTML stands for HyperText Markup Language and it represents the content and structure of a web page. In this workshop, you will write the HTML code for a partial curriculum outline.
 
-This is your code editor where you can write HTML code. Write the text `Welcome to freeCodeCamp` in the editor. When are you done, click the "check your code" button to see if it's correct. 
+This is your code editor where you can write HTML code. Write the following text in the editor:
+
+```md
+Welcome to freeCodeCamp
+```
+
+When are you done, click the "check your code" button to see if it's correct. 
 
 # --hints--
 
-You should have the text `Welcome to freeCodeCamp`. Double check for spelling and proper casing.
+You should have the text `Welcome to freeCodeCamp`. Double check for spelling.
 
 ```js
-assert.match(code, /Welcome\s+to\s+freeCodeCamp/)
+// purposefully providing forgiveness in spacing and casing to remove some friction and 
+// keep camper retention this early on. 
+assert.match(code, /Welcome\s*to\s*freeCodeCamp/i)
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/6823ac607bfdbc46331b2559.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/6823ac607bfdbc46331b2559.md
@@ -1,0 +1,73 @@
+---
+id: 6823ac607bfdbc46331b2559
+title: Step 1
+challengeType: 0
+dashedName: step-1
+demoType: onLoad
+---
+
+# --description--
+
+In this workshop, you will begin practicing HTML by building out the first few sections of a curriculum outline. HTML stands for HyperText Markup Language and it represents the content and structure of a web page. 
+
+The first element you will learn about is the `h1` element.
+
+The `h1` element is a heading element and represents the main title for a web page. It is best practice to only use one `h1` element per page.
+
+Here is an example:
+
+```html
+<h1>I am the main title</h1>
+```
+
+`h1` elements have an opening tag(`<h1>`) and a closing tag `</h1>`.
+
+Add an `h1` element with the text of `Welcome to freeCodeCamp`.
+
+When you are done, press the "Check Your Code" button to see if it's correct.
+
+# --hints--
+
+
+Your `h1` element should have an opening tag. Opening tags have this syntax: `<elementName>`.
+
+```js
+assert.exists(document.querySelector("h1"));
+```
+
+Your `h1` element should have a closing tag. Closing tags have this syntax: `</elementName>`.
+
+```js
+assert.match(code, /<\/h1\>/);
+```
+
+Your `h1` element's text should be `Welcome to freeCodeCamp`. You have either omitted the text, have a typo, or it is not between the `h1` element's opening and closing tags.
+
+```js
+assert.equal(document.querySelector("h1")?.innerText, "Welcome to freeCodeCamp");
+```
+
+You appear to be using a browser extension that is modifying the page. Be sure to turn off all browser extensions.
+
+```js
+if(__checkForBrowserExtensions){
+  assert.isAtMost(document.querySelectorAll("script").length, 2);
+  assert.equal(document.querySelectorAll("style").length, 1);
+  assert.equal(document.querySelectorAll("link").length, 0);
+}
+```
+
+# --seed--
+
+## --seed-contents--
+
+```html
+<html>
+  <body>
+--fcc-editable-region--
+
+--fcc-editable-region--
+  </body>
+</html> 
+```
+

--- a/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/6823ac607bfdbc46331b2559.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/6823ac607bfdbc46331b2559.md
@@ -8,53 +8,16 @@ demoType: onLoad
 
 # --description--
 
-In this workshop, you will begin practicing HTML by building out the first few sections of a curriculum outline. HTML stands for HyperText Markup Language and it represents the content and structure of a web page. 
+HTML stands for HyperText Markup Language and it represents the content and structure of a web page. In this workshop, you will write the HTML code for a curriculum outline.
 
-The first element you will learn about is the `h1` element.
-
-The `h1` element is a heading element and represents the main title for a web page. It is best practice to only use one `h1` element per page.
-
-Here is an example:
-
-```html
-<h1>I am the main title</h1>
-```
-
-`h1` elements have an opening tag(`<h1>`) and a closing tag `</h1>`.
-
-Add an `h1` element with the text of `Welcome to freeCodeCamp`.
-
-When you are done, press the "Check Your Code" button to see if it's correct.
+This is your code editor where you can write HTML code. Write the text `Welcome to freeCodeCamp` in the editor. When are you done, click the "check your code" button to see if it's correct. 
 
 # --hints--
 
-
-Your `h1` element should have an opening tag. Opening tags have this syntax: `<elementName>`.
-
-```js
-assert.exists(document.querySelector("h1"));
-```
-
-Your `h1` element should have a closing tag. Closing tags have this syntax: `</elementName>`.
+You should have the text `Welcome to freeCodeCamp`. Double check for spelling and proper casing.
 
 ```js
-assert.match(code, /<\/h1\>/);
-```
-
-Your `h1` element's text should be `Welcome to freeCodeCamp`. You have either omitted the text, have a typo, or it is not between the `h1` element's opening and closing tags.
-
-```js
-assert.equal(document.querySelector("h1")?.innerText, "Welcome to freeCodeCamp");
-```
-
-You appear to be using a browser extension that is modifying the page. Be sure to turn off all browser extensions.
-
-```js
-if(__checkForBrowserExtensions){
-  assert.isAtMost(document.querySelectorAll("script").length, 2);
-  assert.equal(document.querySelectorAll("style").length, 1);
-  assert.equal(document.querySelectorAll("link").length, 0);
-}
+assert.match(code, /Welcome\s+to\s+freeCodeCamp/)
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/6823c1a0bcada44f32bf0bdc.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/6823c1a0bcada44f32bf0bdc.md
@@ -1,25 +1,19 @@
 ---
 id: 6823c1a0bcada44f32bf0bdc
-title: Step 3
+title: Step 5
 challengeType: 0
-dashedName: step-3
+dashedName: step-5
 ---
 
 # --description--
 
-The next HTML element you will learn about is the `h2` element. `h2` elements represent subheadings. 
+An `h1` element is the main heading of a webpage and you should only use one per page. `h2` elements represent subheadings. You can have multiple per page and they look like this:
 
 ```html
 <h2>I am a subheading.</h2>
 ```
 
-Unlike the `h1` element, you can use multiple `h2` elements per page. 
-
-Below your `h1` element, add an `h2` element with the following text:
-
-```md
-Full Stack Curriculum
-```
+Turn the `Full Stack Curriculum` text into an `h2` element by surrounding it with opening and closing `h2` tags.
 
 # --hints--
 
@@ -32,15 +26,15 @@ assert.exists(document.querySelector("h2"));
 Your `h2` element should have a closing tag. Closing tags have this syntax: `</elementName>`.
 
 ```js
-assert.match(code, /<\/h2\>/);
+assert.match(code, /<\/h2\s*\>/);
 ```
 
-Your `h2` element's text should be `Full Stack Curriculum`. You can copy the text from the instructions.
+Your `h2` element's text should be `Full Stack Curriculum`.
 
 ```js
-// purposefully removing friction for early users to improve retention
-// this is forgiving of spaces and casing.
-assert.match(code, /Full\s*Stack\s*Curriculum/i);
+// purposefully removing friction for early users to help improve retention in early lessons
+// this if very forgiving of spaces and casing
+assert.match(code, /\<h2\s*\>\s*Full\s*Stack\s*Curriculum\s*\<\/h2\s*\>/i);
 ```
 
 Your `h2` element should be below your `h1` element. 
@@ -54,12 +48,9 @@ assert.exists(document.querySelector("h1 + h2"));
 ## --seed-contents--
 
 ```html
-<html>
-  <body>
-    --fcc-editable-region--
-    <h1>Welcome to freeCodeCamp</h1>
-    
-    --fcc-editable-region--
-  </body>
-</html>  
+<h1>Welcome to freeCodeCamp</h1>
+--fcc-editable-region--
+Full Stack Curriculum
+--fcc-editable-region--
+Learn the skills to become a full stack developer
 ```

--- a/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/6823c1a0bcada44f32bf0bdc.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/6823c1a0bcada44f32bf0bdc.md
@@ -15,7 +15,11 @@ The next HTML element you will learn about is the `h2` element. `h2` elements re
 
 Unlike the `h1` element, you can use multiple `h2` elements per page. 
 
-Below your `h1` element, add an `h2` element with the text `Certified Full Stack Developer Certification`.
+Below your `h1` element, add an `h2` element with the following text:
+
+```md
+Full Stack Curriculum
+```
 
 # --hints--
 
@@ -31,10 +35,12 @@ Your `h2` element should have a closing tag. Closing tags have this syntax: `</e
 assert.match(code, /<\/h2\>/);
 ```
 
-Your `h2` element's text should be `Certified Full Stack Developer Certification`. You have either omitted the text, have a typo, or it is not between the `h2` element's opening and closing tags.
+Your `h2` element's text should be `Full Stack Curriculum`. You can copy the text from the instructions.
 
 ```js
-assert.equal(document.querySelector("h2")?.innerText, "Certified Full Stack Developer Certification");
+// purposefully removing friction for early users to improve retention
+// this is forgiving of spaces and casing.
+assert.match(code, /Full\s*Stack\s*Curriculum/i);
 ```
 
 Your `h2` element should be below your `h1` element. 

--- a/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/6823c1a0bcada44f32bf0bdc.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/6823c1a0bcada44f32bf0bdc.md
@@ -1,0 +1,59 @@
+---
+id: 6823c1a0bcada44f32bf0bdc
+title: Step 2
+challengeType: 0
+dashedName: step-2
+---
+
+# --description--
+
+The next HTML element you will learn about is the `h2` element. `h2` elements represent subheadings. 
+
+```html
+<h2>I am a subheading.</h2>
+```
+
+Unlike the `h1` element, you can use multiple `h2` elements per page. 
+
+Below your `h1` element, add an `h2` element with the text `Certified Full Stack Developer Certification`.
+
+# --hints--
+
+Your `h2` element should have an opening tag. Opening tags have this syntax: `<elementName>`.
+
+```js
+assert.exists(document.querySelector("h2"));
+```
+
+Your `h2` element should have a closing tag. Closing tags have this syntax: `</elementName>`.
+
+```js
+assert.match(code, /<\/h2\>/);
+```
+
+Your `h2` element's text should be `Certified Full Stack Developer Certification`. You have either omitted the text, have a typo, or it is not between the `h2` element's opening and closing tags.
+
+```js
+assert.equal(document.querySelector("h2")?.innerText, "Certified Full Stack Developer Certification");
+```
+
+Your `h2` element should be below your `h1` element. 
+
+```js
+assert.exists(document.querySelector("h1 + h2"));
+```
+
+# --seed--
+
+## --seed-contents--
+
+```html
+<html>
+  <body>
+    --fcc-editable-region--
+    <h1>Welcome to freeCodeCamp</h1>
+    
+    --fcc-editable-region--
+  </body>
+</html>  
+```

--- a/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/6823c1a0bcada44f32bf0bdc.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/6823c1a0bcada44f32bf0bdc.md
@@ -1,8 +1,8 @@
 ---
 id: 6823c1a0bcada44f32bf0bdc
-title: Step 2
+title: Step 3
 challengeType: 0
-dashedName: step-2
+dashedName: step-3
 ---
 
 # --description--

--- a/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/6823d6244511f252c8300eed.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/6823d6244511f252c8300eed.md
@@ -13,7 +13,11 @@ When you need to add a paragraph to a web page, you can use the `p` element like
 <p>I am a paragraph element.</p>
 ```
 
-Below your `h2` element, add a `p` element with the text `In this certification, you will learn all of the skills to become a full stack developer.`.
+Below your `h2` element, add a `p` element with the following text:
+
+```md
+Learn all of the skills to become a full stack developer
+```
 
 # --hints--
 
@@ -29,10 +33,12 @@ Your `p` element should have a closing tag. Closing tags have this syntax: `</el
 assert.match(code, /<\/p\>/);
 ```
 
-Your `p` element's text should be `In this certification, you will learn all of the skills to become a full stack developer.`. You have either omitted the text, have a typo, or forgot the period.
+Your `p` element's text should be `Learn all of the skills to become a full stack developer`. You can copy the text from the instructions. 
 
 ```js
-assert.equal(document.querySelector("p")?.innerText, "In this certification, you will learn all of the skills to become a full stack developer.");
+// purposefully removing friction for early users to help improve retention in early lessons
+// this if very forgiving of spaces and casing
+assert.match(code, /Learn\s*all\s*of\s*the\s*skills\s*to\s*become\s*a\s*full\s*stack\s*developer/i);
 ```
 
 Your `p` element should be below your `h2` element. 
@@ -50,7 +56,7 @@ assert.exists(document.querySelector("h2 + p"));
   <body>
 --fcc-editable-region--
     <h1>Welcome to freeCodeCamp</h1>
-    <h2>Certified Full Stack Developer Certification</h2>
+    <h2>Full Stack Curriculum</h2>
 
 --fcc-editable-region--
   </body>

--- a/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/6823d6244511f252c8300eed.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/6823d6244511f252c8300eed.md
@@ -1,8 +1,8 @@
 ---
 id: 6823d6244511f252c8300eed
-title: Step 4
+title: Step 6
 challengeType: 0
-dashedName: step-4
+dashedName: step-6
 ---
 
 # --description--
@@ -13,11 +13,7 @@ When you need to add a paragraph to a web page, you can use the `p` element like
 <p>I am a paragraph element.</p>
 ```
 
-Below your `h2` element, add a `p` element with the following text:
-
-```md
-Learn all of the skills to become a full stack developer
-```
+Turn your `Learn all of the skills to become a full stack developer` into a paragraph element.
 
 # --hints--
 
@@ -30,15 +26,15 @@ assert.exists(document.querySelector("p"));
 Your `p` element should have a closing tag. Closing tags have this syntax: `</elementName>`.
 
 ```js
-assert.match(code, /<\/p\>/);
+assert.match(code, /<\/p\s*\>/);
 ```
 
-Your `p` element's text should be `Learn all of the skills to become a full stack developer`. You can copy the text from the instructions. 
+Your `p` element's text should be `Learn the skills to become a full stack developer`.
 
 ```js
 // purposefully removing friction for early users to help improve retention in early lessons
 // this if very forgiving of spaces and casing
-assert.match(code, /Learn\s*all\s*of\s*the\s*skills\s*to\s*become\s*a\s*full\s*stack\s*developer/i);
+assert.match(code, /\<p\s*\>\s*Learn\s*the\s*skills\s*to\s*become\s*a\s*full\s*stack\s*developer\s*\<\/p\s*\>/i);
 ```
 
 Your `p` element should be below your `h2` element. 
@@ -52,13 +48,9 @@ assert.exists(document.querySelector("h2 + p"));
 ## --seed-contents--
 
 ```html
-<html>
-  <body>
+<h1>Welcome to freeCodeCamp</h1>
+<h2>Full Stack Curriculum</h2>
 --fcc-editable-region--
-    <h1>Welcome to freeCodeCamp</h1>
-    <h2>Full Stack Curriculum</h2>
-
+Learn the skills to become a full stack developer
 --fcc-editable-region--
-  </body>
-</html>  
 ```

--- a/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/6823d6244511f252c8300eed.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/6823d6244511f252c8300eed.md
@@ -1,0 +1,58 @@
+---
+id: 6823d6244511f252c8300eed
+title: Step 3
+challengeType: 0
+dashedName: step-3
+---
+
+# --description--
+
+When you need to add a paragraph to a web page, you can use the `p` element like this:
+
+```html
+<p>I am a paragraph element.</p>
+```
+
+Below your `h2` element, add a `p` element with the text `In this certification, you will learn all of the skills to become a full stack developer.`.
+
+# --hints--
+
+Your `p` element should have an opening tag. Opening tags have this syntax: `<elementName>`.
+
+```js
+assert.exists(document.querySelector("p"));
+```
+
+Your `p` element should have a closing tag. Closing tags have this syntax: `</elementName>`.
+
+```js
+assert.match(code, /<\/p\>/);
+```
+
+Your `p` element's text should be `In this certification, you will learn all of the skills to become a full stack developer.`. You have either omitted the text, have a typo, or forgot the period.
+
+```js
+assert.equal(document.querySelector("p")?.innerText, "In this certification, you will learn all of the skills to become a full stack developer.");
+```
+
+Your `p` element should be below your `h2` element. 
+
+```js
+assert.exists(document.querySelector("h2 + p"));
+```
+
+# --seed--
+
+## --seed-contents--
+
+```html
+<html>
+  <body>
+--fcc-editable-region--
+    <h1>Welcome to freeCodeCamp</h1>
+    <h2>Certified Full Stack Developer Certification</h2>
+
+--fcc-editable-region--
+  </body>
+</html>  
+```

--- a/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/6823d6244511f252c8300eed.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/6823d6244511f252c8300eed.md
@@ -1,8 +1,8 @@
 ---
 id: 6823d6244511f252c8300eed
-title: Step 3
+title: Step 4
 challengeType: 0
-dashedName: step-3
+dashedName: step-4
 ---
 
 # --description--

--- a/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/6823d9ac8bdc3853df65a1ff.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/6823d9ac8bdc3853df65a1ff.md
@@ -1,0 +1,63 @@
+---
+id: 6823d9ac8bdc3853df65a1ff
+title: Step 4
+challengeType: 0
+dashedName: step-4
+---
+
+# --description--
+
+There are a total of six heading elements in HTML. 
+
+Here is the list of heading elements in order of most important to least:
+
+```html
+<h1>Heading level 1</h1>
+<h2>Heading level 2</h2>
+<h3>Heading level 3</h3>
+<h4>Heading level 4</h4>
+<h5>Heading level 5</h5>
+<h6>Heading level 6</h6>
+```
+
+Most of the time you will be using `h1`, `h2` and `h3` elements with the occasional use of the `h4` and maybe `h5` elements. Very rarely will you be using an `h6` element. 
+
+Below your `p` element, add an `h3` element with the text `Introduction to HTML`.
+
+# --hints--
+
+Your `h3` element should have an opening tag. Opening tags have this syntax: `<elementName>`.
+
+```js
+assert.exists(document.querySelector("h3"));
+```
+
+Your `h3` element should have a closing tag. Closing tags have this syntax: `</elementName>`.
+
+```js
+assert.match(code, /<\/h3\>/);
+```
+
+Your `h3` element's text should be `Introduction to HTML`. You have either omitted the text, have a typo, or forgot the period.
+
+```js
+assert.equal(document.querySelector("h3")?.innerText, "Introduction to HTML");
+```
+
+# --seed--
+
+## --seed-contents--
+
+```html
+<html>
+  <body>
+    <h1>Welcome to freeCodeCamp</h1>
+    <h2>Certified Full Stack Developer Certification</h2>
+    <p>In this certification, you will learn all of the skills to become a full stack developer.</p>
+
+    --fcc-editable-region--
+
+    --fcc-editable-region--
+  </body>
+</html>  
+```

--- a/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/6823d9ac8bdc3853df65a1ff.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/6823d9ac8bdc3853df65a1ff.md
@@ -1,8 +1,8 @@
 ---
 id: 6823d9ac8bdc3853df65a1ff
-title: Step 4
+title: Step 5
 challengeType: 0
-dashedName: step-4
+dashedName: step-5
 ---
 
 # --description--

--- a/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/6823d9ac8bdc3853df65a1ff.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/6823d9ac8bdc3853df65a1ff.md
@@ -22,7 +22,11 @@ Here is the list of heading elements in order of most important to least:
 
 Most of the time you will be using `h1`, `h2` and `h3` elements with the occasional use of the `h4` and maybe `h5` elements. Very rarely will you be using an `h6` element. 
 
-Below your `p` element, add an `h3` element with the text `Introduction to HTML`.
+Below your `p` element, add an `h3` element with the following text:
+
+```md
+Introduction to HTML
+```
 
 # --hints--
 
@@ -38,10 +42,12 @@ Your `h3` element should have a closing tag. Closing tags have this syntax: `</e
 assert.match(code, /<\/h3\>/);
 ```
 
-Your `h3` element's text should be `Introduction to HTML`. You have either omitted the text, have a typo, or forgot the period.
+Your `h3` element's text should be `Introduction to HTML`. You can copy the text from the instructions. 
 
 ```js
-assert.equal(document.querySelector("h3")?.innerText, "Introduction to HTML");
+// purposefully removing friction for early users to help improve retention in early lessons
+// this if very forgiving of spaces and casing
+assert.match(code, /Introduction\s*to\s*HTML/i);
 ```
 
 # --seed--
@@ -52,8 +58,8 @@ assert.equal(document.querySelector("h3")?.innerText, "Introduction to HTML");
 <html>
   <body>
     <h1>Welcome to freeCodeCamp</h1>
-    <h2>Certified Full Stack Developer Certification</h2>
-    <p>In this certification, you will learn all of the skills to become a full stack developer.</p>
+    <h2>Full Stack Curriculum</h2>
+    <p>Learn all of the skills to become a full stack developer</p>
 
     --fcc-editable-region--
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/6823d9ac8bdc3853df65a1ff.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/6823d9ac8bdc3853df65a1ff.md
@@ -1,15 +1,13 @@
 ---
 id: 6823d9ac8bdc3853df65a1ff
-title: Step 5
+title: Step 7
 challengeType: 0
-dashedName: step-5
+dashedName: step-7
 ---
 
 # --description--
 
-There are a total of six heading elements in HTML. 
-
-Here is the list of heading elements in order of most important to least:
+There are six heading elements in HTML. Here are all of them in order from most important to least:
 
 ```html
 <h1>Heading level 1</h1>
@@ -20,9 +18,7 @@ Here is the list of heading elements in order of most important to least:
 <h6>Heading level 6</h6>
 ```
 
-Most of the time you will be using `h1`, `h2` and `h3` elements with the occasional use of the `h4` and maybe `h5` elements. Very rarely will you be using an `h6` element. 
-
-Below your `p` element, add an `h3` element with the following text:
+Below your `p` element, add an `h3` element that displays the following text:
 
 ```md
 Introduction to HTML
@@ -39,7 +35,7 @@ assert.exists(document.querySelector("h3"));
 Your `h3` element should have a closing tag. Closing tags have this syntax: `</elementName>`.
 
 ```js
-assert.match(code, /<\/h3\>/);
+assert.match(code, /<\/h3\s*\>/);
 ```
 
 Your `h3` element's text should be `Introduction to HTML`. You can copy the text from the instructions. 
@@ -47,7 +43,7 @@ Your `h3` element's text should be `Introduction to HTML`. You can copy the text
 ```js
 // purposefully removing friction for early users to help improve retention in early lessons
 // this if very forgiving of spaces and casing
-assert.match(code, /Introduction\s*to\s*HTML/i);
+assert.match(code, /\<h3\s*\>\s*Introduction\s*to\s*HTML\s*\<\/h3\s*\>/i);
 ```
 
 # --seed--
@@ -55,15 +51,11 @@ assert.match(code, /Introduction\s*to\s*HTML/i);
 ## --seed-contents--
 
 ```html
-<html>
-  <body>
-    <h1>Welcome to freeCodeCamp</h1>
-    <h2>Full Stack Curriculum</h2>
-    <p>Learn all of the skills to become a full stack developer</p>
+<h1>Welcome to freeCodeCamp</h1>
+<h2>Full Stack Curriculum</h2>
+<p>Learn the skills to become a full stack developer</p>
 
-    --fcc-editable-region--
+--fcc-editable-region--
 
-    --fcc-editable-region--
-  </body>
-</html>  
+--fcc-editable-region--
 ```

--- a/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/6823e036ea4b71553558c01b.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/6823e036ea4b71553558c01b.md
@@ -7,7 +7,11 @@ dashedName: step-6
 
 # --description--
 
-Next, add another `p` element with the text `HTML stands for HyperText Markup Language and it represents the content and structure of a webpage.`.
+Next, add another `p` element with the following text:
+
+```md
+HTML represents the content and structure of a webpage
+```
 
 # --hints--
 
@@ -17,11 +21,12 @@ You should have a second `p` element.
 assert.lengthOf(document.querySelectorAll("p"), 2);
 ```
 
-Your `p` element should have the text `HTML stands for HyperText Markup Language and it represents the content and structure of a webpage.`
+Your `p` element should have the text `HTML represents the content and structure of a webpage`. You can copy the text from the instructions. 
 
 ```js
-const lastParaEl = document.querySelector("p:last-of-type");
-assert.strictEqual(lastParaEl?.innerText, "HTML stands for HyperText Markup Language and it represents the content and structure of a webpage.");
+// purposefully removing friction for early users to help improve retention in early lessons
+// this if very forgiving of spaces and casing
+assert.match(code, /HTML\s*represents\s*the\s*content\s*and\s*structure\s*of\s*a\s*webpage/i);
 ```
 
 # --seed--
@@ -32,8 +37,8 @@ assert.strictEqual(lastParaEl?.innerText, "HTML stands for HyperText Markup Lang
 <html>
   <body>
     <h1>Welcome to freeCodeCamp</h1>
-    <h2>Certified Full Stack Developer Certification</h2>
-    <p>In this certification, you will learn all of the skills to become a full stack developer.</p>
+    <h2>Full Stack Curriculum</h2>
+    <p>Learn all of the skills to become a full stack developer</p>
 
     <h3>Introduction to HTML</h3>
     --fcc-editable-region--

--- a/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/6823e036ea4b71553558c01b.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/6823e036ea4b71553558c01b.md
@@ -1,13 +1,15 @@
 ---
 id: 6823e036ea4b71553558c01b
-title: Step 6
+title: Step 8
 challengeType: 0
-dashedName: step-6
+dashedName: step-8
 ---
 
 # --description--
 
-Next, add another `p` element with the following text:
+Notice that each heading looks a little different in the preview. Same with the paragraph.
+
+Next, add another `p` element that displays the following text:
 
 ```md
 HTML represents the content and structure of a webpage
@@ -21,12 +23,12 @@ You should have a second `p` element.
 assert.lengthOf(document.querySelectorAll("p"), 2);
 ```
 
-Your `p` element should have the text `HTML represents the content and structure of a webpage`. You can copy the text from the instructions. 
+Your `p` element should have the text `HTML represents the content and structure of a webpage`. You can copy the text from the instructions.
 
 ```js
 // purposefully removing friction for early users to help improve retention in early lessons
 // this if very forgiving of spaces and casing
-assert.match(code, /HTML\s*represents\s*the\s*content\s*and\s*structure\s*of\s*a\s*webpage/i);
+assert.match(code, /\<p\s*\>\s*HTML\s*represents\s*the\s*content\s*and\s*structure\s*of\s*a\s*webpage\s*\<\/p\s*\>/i);
 ```
 
 # --seed--
@@ -34,16 +36,12 @@ assert.match(code, /HTML\s*represents\s*the\s*content\s*and\s*structure\s*of\s*a
 ## --seed-contents--
 
 ```html
-<html>
-  <body>
-    <h1>Welcome to freeCodeCamp</h1>
-    <h2>Full Stack Curriculum</h2>
-    <p>Learn all of the skills to become a full stack developer</p>
+<h1>Welcome to freeCodeCamp</h1>
+<h2>Full Stack Curriculum</h2>
+<p>Learn the skills to become a full stack developer</p>
 
-    <h3>Introduction to HTML</h3>
-    --fcc-editable-region--
+<h3>Introduction to HTML</h3>
+--fcc-editable-region--
 
-    --fcc-editable-region--
-  </body>
-</html>  
+--fcc-editable-region--
 ```

--- a/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/6823e036ea4b71553558c01b.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/6823e036ea4b71553558c01b.md
@@ -1,8 +1,8 @@
 ---
 id: 6823e036ea4b71553558c01b
-title: Step 5
+title: Step 6
 challengeType: 0
-dashedName: step-5
+dashedName: step-6
 ---
 
 # --description--

--- a/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/6823e036ea4b71553558c01b.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/6823e036ea4b71553558c01b.md
@@ -1,0 +1,44 @@
+---
+id: 6823e036ea4b71553558c01b
+title: Step 5
+challengeType: 0
+dashedName: step-5
+---
+
+# --description--
+
+Next, add another `p` element with the text `HTML stands for HyperText Markup Language and it represents the content and structure of a webpage.`.
+
+# --hints--
+
+You should have a second `p` element.
+
+```js
+assert.lengthOf(document.querySelectorAll("p"), 2);
+```
+
+Your `p` element should have the text `HTML stands for HyperText Markup Language and it represents the content and structure of a webpage.`
+
+```js
+const lastParaEl = document.querySelector("p:last-of-type");
+assert.strictEqual(lastParaEl?.innerText, "HTML stands for HyperText Markup Language and it represents the content and structure of a webpage.");
+```
+
+# --seed--
+
+## --seed-contents--
+
+```html
+<html>
+  <body>
+    <h1>Welcome to freeCodeCamp</h1>
+    <h2>Certified Full Stack Developer Certification</h2>
+    <p>In this certification, you will learn all of the skills to become a full stack developer.</p>
+
+    <h3>Introduction to HTML</h3>
+    --fcc-editable-region--
+
+    --fcc-editable-region--
+  </body>
+</html>  
+```

--- a/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/6823e169fda14755fbf00445.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/6823e169fda14755fbf00445.md
@@ -1,0 +1,62 @@
+---
+id: 6823e169fda14755fbf00445
+title: Step 6
+challengeType: 0
+dashedName: step-6
+---
+
+# --description--
+
+Now it is time to add another `h3` and `p` element to the page.
+
+Add an `h3` element with the text `Introduction to CSS`.
+
+Then below that `h3` element, add a `p` element with the text `CSS stands for Cascading Style Sheets and it represents the styles for a web page.`.
+
+# --hints--
+
+You should add a second `h3` element to the page.
+
+```js
+assert.lengthOf(document.querySelectorAll("h3"), 2);
+```
+
+Your `h3` element's text should be `Introduction to CSS`. You have either omitted the text, have a typo, or forgot the period.
+
+```js
+assert.equal(document.querySelector("h3")?.innerText, "Introduction to CSS");
+```
+
+You should add a third `p` element to the page.
+
+```js
+assert.lengthOf(document.querySelectorAll("p"), 3);
+```
+
+Your `p` element should have the text `CSS stands for Cascading Style Sheets and it represents the styles for a web page.`
+
+```js
+const lastParaEl = document.querySelector("p:last-of-type");
+assert.strictEqual(lastParaEl?.innerText, "CSS stands for Cascading Style Sheets and it represents the styles for a web page.");
+```
+
+# --seed--
+
+## --seed-contents--
+
+```html
+<html>
+  <body>
+    <h1>Welcome to freeCodeCamp</h1>
+    <h2>Certified Full Stack Developer Certification</h2>
+    <p>In this certification, you will learn all of the skills to become a full stack developer.</p>
+
+    <h3>Introduction to HTML</h3>
+    <p>HTML stands for HyperText Markup Language and it represents the content and structure of a webpage.</p>
+
+    --fcc-editable-region--
+
+    --fcc-editable-region--
+  </body>
+</html>  
+```

--- a/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/6823e169fda14755fbf00445.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/6823e169fda14755fbf00445.md
@@ -1,20 +1,24 @@
 ---
 id: 6823e169fda14755fbf00445
-title: Step 7
+title: Step 9
 challengeType: 0
-dashedName: step-7
+dashedName: step-9
 ---
 
 # --description--
 
-Now it is time to add another `h3` and `p` element to the page.
+You're getting the hang of it. Now it is time to add another `h3` and `p` element to the page.
 
-Add an `h3` element with the text `Introduction to CSS`.
-
-Then below that `h3` element, add a `p` element with the following text:
+First, add an `h3` element with the text:
 
 ```md
-CSS represents the styles for a web page
+Introduction to CSS
+```
+
+Then, below that `h3` element, add a `p` element with the following text:
+
+```md
+CSS is used to style a webpage
 ```
 
 # --hints--
@@ -30,7 +34,7 @@ Your `h3` element's text should be `Introduction to CSS`.
 ```js
 // purposefully removing friction for early users to help improve retention in early lessons
 // this if very forgiving of spaces and casing
-assert.match(code, /Introduction\s*to\s*CSS/i);
+assert.match(code, /\<h3\s*\>\s*Introduction\s*to\s*CSS\s*\<\/h3\s*\>/i);
 ```
 
 You should add a third `p` element to the page.
@@ -39,12 +43,12 @@ You should add a third `p` element to the page.
 assert.lengthOf(document.querySelectorAll("p"), 3);
 ```
 
-Your `p` element should have the text `CSS represents the styles for a web page`. You can copy the text from the instructions. 
+Your `p` element should have the text `CSS is used to style a webpage`. You can copy the text from the instructions.
 
 ```js
 // purposefully removing friction for early users to help improve retention in early lessons
 // this if very forgiving of spaces and casing
-assert.match(code, /CSS\s*represents\s*the\s*styles\s*for\s*a\s*web\s*page/i);
+assert.match(code, /\<p\s*\>\s*CSS\s*is\s*used\s*to\s*style\s*a\s*webpage\s*\<\/p\s*\>/i);
 ```
 
 # --seed--
@@ -52,18 +56,14 @@ assert.match(code, /CSS\s*represents\s*the\s*styles\s*for\s*a\s*web\s*page/i);
 ## --seed-contents--
 
 ```html
-<html>
-  <body>
-    <h1>Welcome to freeCodeCamp</h1>
-    <h2>Full Stack Curriculum</h2>
-    <p>Learn all of the skills to become a full stack developer</p>
+<h1>Welcome to freeCodeCamp</h1>
+<h2>Full Stack Curriculum</h2>
+<p>Learn the skills to become a full stack developer</p>
 
-    <h3>Introduction to HTML</h3>
-    <p>HTML represents the content and structure of a webpage</p>
+<h3>Introduction to HTML</h3>
+<p>HTML represents the content and structure of a webpage</p>
 
-    --fcc-editable-region--
+--fcc-editable-region--
 
-    --fcc-editable-region--
-  </body>
-</html>  
+--fcc-editable-region--
 ```

--- a/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/6823e169fda14755fbf00445.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/6823e169fda14755fbf00445.md
@@ -1,8 +1,8 @@
 ---
 id: 6823e169fda14755fbf00445
-title: Step 6
+title: Step 7
 challengeType: 0
-dashedName: step-6
+dashedName: step-7
 ---
 
 # --description--

--- a/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/6823e169fda14755fbf00445.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/6823e169fda14755fbf00445.md
@@ -11,7 +11,11 @@ Now it is time to add another `h3` and `p` element to the page.
 
 Add an `h3` element with the text `Introduction to CSS`.
 
-Then below that `h3` element, add a `p` element with the text `CSS stands for Cascading Style Sheets and it represents the styles for a web page.`.
+Then below that `h3` element, add a `p` element with the following text:
+
+```md
+CSS represents the styles for a web page
+```
 
 # --hints--
 
@@ -21,10 +25,12 @@ You should add a second `h3` element to the page.
 assert.lengthOf(document.querySelectorAll("h3"), 2);
 ```
 
-Your `h3` element's text should be `Introduction to CSS`. You have either omitted the text, have a typo, or forgot the period.
+Your `h3` element's text should be `Introduction to CSS`. 
 
 ```js
-assert.equal(document.querySelector("h3:last-of-type")?.innerText, "Introduction to CSS");
+// purposefully removing friction for early users to help improve retention in early lessons
+// this if very forgiving of spaces and casing
+assert.match(code, /Introduction\s*to\s*CSS/i);
 ```
 
 You should add a third `p` element to the page.
@@ -33,11 +39,12 @@ You should add a third `p` element to the page.
 assert.lengthOf(document.querySelectorAll("p"), 3);
 ```
 
-Your `p` element should have the text `CSS stands for Cascading Style Sheets and it represents the styles for a web page.`
+Your `p` element should have the text `CSS represents the styles for a web page`. You can copy the text from the instructions. 
 
 ```js
-const lastParaEl = document.querySelector("p:last-of-type");
-assert.strictEqual(lastParaEl?.innerText, "CSS stands for Cascading Style Sheets and it represents the styles for a web page.");
+// purposefully removing friction for early users to help improve retention in early lessons
+// this if very forgiving of spaces and casing
+assert.match(code, /CSS\s*represents\s*the\s*styles\s*for\s*a\s*web\s*page/i);
 ```
 
 # --seed--
@@ -48,11 +55,11 @@ assert.strictEqual(lastParaEl?.innerText, "CSS stands for Cascading Style Sheets
 <html>
   <body>
     <h1>Welcome to freeCodeCamp</h1>
-    <h2>Certified Full Stack Developer Certification</h2>
-    <p>In this certification, you will learn all of the skills to become a full stack developer.</p>
+    <h2>Full Stack Curriculum</h2>
+    <p>Learn all of the skills to become a full stack developer</p>
 
     <h3>Introduction to HTML</h3>
-    <p>HTML stands for HyperText Markup Language and it represents the content and structure of a webpage.</p>
+    <p>HTML represents the content and structure of a webpage</p>
 
     --fcc-editable-region--
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/6823e169fda14755fbf00445.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/6823e169fda14755fbf00445.md
@@ -24,7 +24,7 @@ assert.lengthOf(document.querySelectorAll("h3"), 2);
 Your `h3` element's text should be `Introduction to CSS`. You have either omitted the text, have a typo, or forgot the period.
 
 ```js
-assert.equal(document.querySelector("h3")?.innerText, "Introduction to CSS");
+assert.equal(document.querySelector("h3:last-of-type")?.innerText, "Introduction to CSS");
 ```
 
 You should add a third `p` element to the page.

--- a/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/6823e637c1c0ed56f781b4fc.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/6823e637c1c0ed56f781b4fc.md
@@ -1,8 +1,8 @@
 ---
 id: 6823e637c1c0ed56f781b4fc
-title: Step 7
+title: Step 8
 challengeType: 0
-dashedName: step-7
+dashedName: step-8
 ---
 
 # --description--

--- a/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/6823e637c1c0ed56f781b4fc.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/6823e637c1c0ed56f781b4fc.md
@@ -11,7 +11,11 @@ For the last step of the workshop, you will add another `h3` and `p` element to 
 
 Add an `h3` element with the text `Introduction to JavaScript`.
 
-Then below that `h3` element, add a `p` element with the text `JavaScript is used for the interactivity on the webpage.`.
+Then below that `h3` element, add a `p` element with the following text:
+
+```md
+JavaScript is used for the interactivity on the webpage
+```
 
 # --hints--
 
@@ -21,10 +25,12 @@ You should add a third `h3` element to the page.
 assert.lengthOf(document.querySelectorAll("h3"), 3);
 ```
 
-Your `h3` element's text should be `Introduction to JavaScript`. You have either omitted the text, have a typo, or forgot the period.
+Your `h3` element's text should be `Introduction to JavaScript`. 
 
 ```js
-assert.equal(document.querySelector("h3:last-of-type")?.innerText, "Introduction to JavaScript");
+// purposefully removing friction for early users to help improve retention in early lessons
+// this if very forgiving of spaces and casing
+assert.match(code, /Introduction\s*to\s*JavaScript/i);
 ```
 
 You should add a fourth `p` element to the page.
@@ -33,11 +39,12 @@ You should add a fourth `p` element to the page.
 assert.lengthOf(document.querySelectorAll("p"), 4);
 ```
 
-Your `p` element should have the text `JavaScript is used for the interactivity on the webpage.`
+Your `p` element should have the text `JavaScript is used for the interactivity on the webpage`
 
 ```js
-const lastParaEl = document.querySelector("p:last-of-type");
-assert.strictEqual(lastParaEl?.innerText, "JavaScript is used for the interactivity on the webpage.");
+// purposefully removing friction for early users to help improve retention in early lessons
+// this if very forgiving of spaces and casing
+assert.match(code, /JavaScript\s*is\s*used\s*for\s*the\s*interactivity\s*on\s*the\s*webpage/i);
 ```
 
 # --seed--
@@ -48,14 +55,14 @@ assert.strictEqual(lastParaEl?.innerText, "JavaScript is used for the interactiv
 <html>
   <body>
     <h1>Welcome to freeCodeCamp</h1>
-    <h2>Certified Full Stack Developer Certification</h2>
-    <p>In this certification, you will learn all of the skills to become a full stack developer.</p>
+    <h2>Full Stack Curriculum</h2>
+    <p>Learn all of the skills to become a full stack developer</p>
 
     <h3>Introduction to HTML</h3>
-    <p>HTML stands for HyperText Markup Language and it represents the content and structure of a webpage.</p>
+    <p>HTML represents the content and structure of a webpage</p>
 
     <h3>Introduction to CSS</h3>
-    <p>CSS stands for Cascading Style Sheets and it represents the styles for a web page.</p>
+    <p>CSS represents the styles for a web page</p>
 
     --fcc-editable-region--
 
@@ -70,17 +77,17 @@ assert.strictEqual(lastParaEl?.innerText, "JavaScript is used for the interactiv
 <html>
   <body>
     <h1>Welcome to freeCodeCamp</h1>
-    <h2>Certified Full Stack Developer Certification</h2>
-    <p>In this certification, you will learn all of the skills to become a full stack developer.</p>
+    <h2>Full Stack Curriculum</h2>
+    <p>Learn all of the skills to become a full stack developer</p>
 
     <h3>Introduction to HTML</h3>
-    <p>HTML stands for HyperText Markup Language and it represents the content and structure of a webpage.</p>
+    <p>HTML represents the content and structure of a webpage</p>
 
     <h3>Introduction to CSS</h3>
-    <p>CSS stands for Cascading Style Sheets and it represents the styles for a web page.</p>
+    <p>CSS represents the styles for a web page</p>
 
     <h3>Introduction to JavaScript</h3>
-    <p>JavaScript is used for the interactivity on the webpage.</p>
+    <p>JavaScript is used for the interactivity on the webpage</p>
   </body>
 </html> 
 ```

--- a/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/6823e637c1c0ed56f781b4fc.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/6823e637c1c0ed56f781b4fc.md
@@ -1,20 +1,24 @@
 ---
 id: 6823e637c1c0ed56f781b4fc
-title: Step 8
+title: Step 10
 challengeType: 0
-dashedName: step-8
+dashedName: step-10
 ---
 
 # --description--
 
 For the last step of the workshop, you will add another `h3` and `p` element to the page.
 
-Add an `h3` element with the text `Introduction to JavaScript`.
-
-Then below that `h3` element, add a `p` element with the following text:
+First, add an `h3` element with the text:
 
 ```md
-JavaScript is used for the interactivity on the webpage
+Introduction to JavaScript
+```
+
+Then, below that `h3` element, add a `p` element with the following text:
+
+```md
+JavaScript adds interactivity to a webpage
 ```
 
 # --hints--
@@ -25,12 +29,12 @@ You should add a third `h3` element to the page.
 assert.lengthOf(document.querySelectorAll("h3"), 3);
 ```
 
-Your `h3` element's text should be `Introduction to JavaScript`. 
+Your `h3` element's text should be `Introduction to JavaScript`.
 
 ```js
 // purposefully removing friction for early users to help improve retention in early lessons
 // this if very forgiving of spaces and casing
-assert.match(code, /Introduction\s*to\s*JavaScript/i);
+assert.match(code, /\<h3\s*\>\s*Introduction\s*to\s*JavaScript\s*\<\/h3\s*\>/i);
 ```
 
 You should add a fourth `p` element to the page.
@@ -39,12 +43,12 @@ You should add a fourth `p` element to the page.
 assert.lengthOf(document.querySelectorAll("p"), 4);
 ```
 
-Your `p` element should have the text `JavaScript is used for the interactivity on the webpage`
+Your `p` element should have the text `JavaScript adds interactivity to a webpage`
 
 ```js
 // purposefully removing friction for early users to help improve retention in early lessons
 // this if very forgiving of spaces and casing
-assert.match(code, /JavaScript\s*is\s*used\s*for\s*the\s*interactivity\s*on\s*the\s*webpage/i);
+assert.match(code, /\<p\s*\>\s*JavaScript\s*adds\s*interactivity\s*to\s*a\s*web\s*page\s*\<\/p\s*\>/i);
 ```
 
 # --seed--
@@ -52,42 +56,34 @@ assert.match(code, /JavaScript\s*is\s*used\s*for\s*the\s*interactivity\s*on\s*th
 ## --seed-contents--
 
 ```html
-<html>
-  <body>
-    <h1>Welcome to freeCodeCamp</h1>
-    <h2>Full Stack Curriculum</h2>
-    <p>Learn all of the skills to become a full stack developer</p>
+<h1>Welcome to freeCodeCamp</h1>
+<h2>Full Stack Curriculum</h2>
+<p>Learn the skills to become a full stack developer</p>
 
-    <h3>Introduction to HTML</h3>
-    <p>HTML represents the content and structure of a webpage</p>
+<h3>Introduction to HTML</h3>
+<p>HTML represents the content and structure of a webpage</p>
 
-    <h3>Introduction to CSS</h3>
-    <p>CSS represents the styles for a web page</p>
+<h3>Introduction to CSS</h3>
+<p>CSS is used to style a webpage</p>
 
-    --fcc-editable-region--
+--fcc-editable-region--
 
-    --fcc-editable-region--
-  </body>
-</html>  
+--fcc-editable-region--
 ```
 
 # --solutions--
 
 ```html
-<html>
-  <body>
-    <h1>Welcome to freeCodeCamp</h1>
-    <h2>Full Stack Curriculum</h2>
-    <p>Learn all of the skills to become a full stack developer</p>
+<h1>Welcome to freeCodeCamp</h1>
+<h2>Full Stack Curriculum</h2>
+<p>Learn all of the skills to become a full stack developer</p>
 
-    <h3>Introduction to HTML</h3>
-    <p>HTML represents the content and structure of a webpage</p>
+<h3>Introduction to HTML</h3>
+<p>HTML represents the content and structure of a webpage</p>
 
-    <h3>Introduction to CSS</h3>
-    <p>CSS represents the styles for a web page</p>
+<h3>Introduction to CSS</h3>
+<p>CSS is used to style a webpage</p>
 
-    <h3>Introduction to JavaScript</h3>
-    <p>JavaScript is used for the interactivity on the webpage</p>
-  </body>
-</html> 
+<h3>Introduction to JavaScript</h3>
+<p>JavaScript adds interactivity to a webpage</p>
 ```

--- a/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/6823e637c1c0ed56f781b4fc.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/6823e637c1c0ed56f781b4fc.md
@@ -1,0 +1,86 @@
+---
+id: 6823e637c1c0ed56f781b4fc
+title: Step 7
+challengeType: 0
+dashedName: step-7
+---
+
+# --description--
+
+For the last step of the workshop, you will add another `h3` and `p` element to the page.
+
+Add an `h3` element with the text `Introduction to JavaScript`.
+
+Then below that `h3` element, add a `p` element with the text `JavaScript is used for the interactivity on the webpage.`.
+
+# --hints--
+
+You should add a third `h3` element to the page.
+
+```js
+assert.lengthOf(document.querySelectorAll("h3"), 3);
+```
+
+Your `h3` element's text should be `Introduction to JavaScript`. You have either omitted the text, have a typo, or forgot the period.
+
+```js
+assert.equal(document.querySelector("h3:last-of-type")?.innerText, "Introduction to JavaScript");
+```
+
+You should add a fourth `p` element to the page.
+
+```js
+assert.lengthOf(document.querySelectorAll("p"), 4);
+```
+
+Your `p` element should have the text `JavaScript is used for the interactivity on the webpage.`
+
+```js
+const lastParaEl = document.querySelector("p:last-of-type");
+assert.strictEqual(lastParaEl?.innerText, "JavaScript is used for the interactivity on the webpage.");
+```
+
+# --seed--
+
+## --seed-contents--
+
+```html
+<html>
+  <body>
+    <h1>Welcome to freeCodeCamp</h1>
+    <h2>Certified Full Stack Developer Certification</h2>
+    <p>In this certification, you will learn all of the skills to become a full stack developer.</p>
+
+    <h3>Introduction to HTML</h3>
+    <p>HTML stands for HyperText Markup Language and it represents the content and structure of a webpage.</p>
+
+    <h3>Introduction to CSS</h3>
+    <p>CSS stands for Cascading Style Sheets and it represents the styles for a web page.</p>
+
+    --fcc-editable-region--
+
+    --fcc-editable-region--
+  </body>
+</html>  
+```
+
+# --solutions--
+
+```html
+<html>
+  <body>
+    <h1>Welcome to freeCodeCamp</h1>
+    <h2>Certified Full Stack Developer Certification</h2>
+    <p>In this certification, you will learn all of the skills to become a full stack developer.</p>
+
+    <h3>Introduction to HTML</h3>
+    <p>HTML stands for HyperText Markup Language and it represents the content and structure of a webpage.</p>
+
+    <h3>Introduction to CSS</h3>
+    <p>CSS stands for Cascading Style Sheets and it represents the styles for a web page.</p>
+
+    <h3>Introduction to JavaScript</h3>
+    <p>JavaScript is used for the interactivity on the webpage.</p>
+  </body>
+</html> 
+```

--- a/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/682ba2318000b62f179bdf04.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/682ba2318000b62f179bdf04.md
@@ -1,24 +1,21 @@
 ---
 id: 682ba2318000b62f179bdf04
-title: Step 2
+title: Step 4
 challengeType: 0
-dashedName: step-2
+dashedName: step-4
 ---
 
 # --description--
 
-HTML is made of elements. The first one you will learn about is the `h1` element. It's the main
-heading element of a web page and it looks like this:
+HTML is made up of elements. The first one you will use is the `h1` element:
 
 ```html
-<h1>Welcome to freeCodeCamp</h1> 
+<h1>Welcome to freeCodeCamp</h1>
 ```
 
-`h1` elements have an opening tag (`<h1>`) and a closing tag (`</h1>`) with the text in between the tags.
+It starts with an opening tag (`<h1>`), ends with a closing tag (`</h1>`), and has the text it will display in between the tags.
 
-Turn your `Welcome to freeCodeCamp` text into an `h1` element by adding opening and closing `h1` tags.
-
-When done correctly, you should see an enlarged text display on the screen.
+Turn your `Welcome to freeCodeCamp` text into an `h1` element by adding an opening tag in front of it, and a closing tag after it.
 
 # --hints--
 
@@ -31,13 +28,15 @@ assert.exists(document.querySelector("h1"));
 Your `h1` element should have a closing tag. Closing tags have this syntax: `</elementName>`.
 
 ```js
-assert.match(code, /<\/h1\>/);
+assert.match(code, /<\/h1\s*\>/);
 ```
 
 Your `h1` element's text should be `Welcome to freeCodeCamp`. You have either omitted the text, have a typo, or it is not between the `h1` element's opening and closing tags.
 
 ```js
-assert.equal(document.querySelector("h1")?.innerText, "Welcome to freeCodeCamp");
+// purposefully removing friction for early users to help improve retention in early lessons
+// this if very forgiving of spaces and casing
+assert.match(code, /\<h1\s*\>\s*Welcome\s*to\s*freeCodeCamp\s*\<\/h1\s*\>/i);
 ```
 
 You appear to be using a browser extension that is modifying the page. Be sure to turn off all browser extensions.
@@ -55,11 +54,9 @@ if(__checkForBrowserExtensions){
 ## --seed-contents--
 
 ```html
-<html>
-  <body>
 --fcc-editable-region--
-    Welcome to freeCodeCamp
+Welcome to freeCodeCamp
 --fcc-editable-region--
-  </body>
-</html> 
+Full Stack Curriculum
+Learn the skills to become a full stack developer
 ```

--- a/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/682ba2318000b62f179bdf04.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/682ba2318000b62f179bdf04.md
@@ -1,0 +1,65 @@
+---
+id: 682ba2318000b62f179bdf04
+title: Step 2
+challengeType: 0
+dashedName: step-2
+---
+
+# --description--
+
+HTML is made of elements. The first one you will learn about is the `h1` element. It's the main
+heading element of a web page and it looks like this:
+
+```html
+<h1>Welcome to freeCodeCamp</h1> 
+```
+
+`h1` elements have an opening tag (`<h1>`) and a closing tag (`</h1>`) with the text in between the tags.
+
+Turn your `Welcome to freeCodeCamp` text into an `h1` element by adding opening and closing `h1` tags.
+
+When done correctly, you should see an enlarged text display on the screen.
+
+# --hints--
+
+Your `h1` element should have an opening tag. Opening tags have this syntax: `<elementName>`.
+
+```js
+assert.exists(document.querySelector("h1"));
+```
+
+Your `h1` element should have a closing tag. Closing tags have this syntax: `</elementName>`.
+
+```js
+assert.match(code, /<\/h1\>/);
+```
+
+Your `h1` element's text should be `Welcome to freeCodeCamp`. You have either omitted the text, have a typo, or it is not between the `h1` element's opening and closing tags.
+
+```js
+assert.equal(document.querySelector("h1")?.innerText, "Welcome to freeCodeCamp");
+```
+
+You appear to be using a browser extension that is modifying the page. Be sure to turn off all browser extensions.
+
+```js
+if(__checkForBrowserExtensions){
+  assert.isAtMost(document.querySelectorAll("script").length, 2);
+  assert.equal(document.querySelectorAll("style").length, 1);
+  assert.equal(document.querySelectorAll("link").length, 0);
+}
+```
+
+# --seed--
+
+## --seed-contents--
+
+```html
+<html>
+  <body>
+--fcc-editable-region--
+    Welcome to freeCodeCamp
+--fcc-editable-region--
+  </body>
+</html> 
+```

--- a/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/682cd206883fc7b25eb539c5.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/682cd206883fc7b25eb539c5.md
@@ -1,31 +1,30 @@
 ---
-id: 6823ac607bfdbc46331b2559
-title: Step 1
+id: 682cd206883fc7b25eb539c5
+title: Step 2
 challengeType: 0
-dashedName: step-1
-demoType: onLoad
+dashedName: step-2
 ---
 
 # --description--
 
-Welcome to your code editor, where you can write HTML code.
+Notice that the HTML code you write in the editor shows up in the preview.
 
-Find line 1 in the editor and type this text:
+Below the text you added, type the following on line 2:
 
 ```md
-Welcome to freeCodeCamp
+Full Stack Curriculum
 ```
 
 When you are done, click the "check your code" button to see if it's correct.
 
 # --hints--
 
-You should have the text `Welcome to freeCodeCamp` in your editor. Double-check for spelling.
+You should have the text `Full Stack Curriculum` in your editor. Double-check for spelling.
 
 ```js
 // purposefully providing forgiveness in spacing and casing to remove some friction and
 // keep camper retention this early on.
-assert.match(code, /welcome\s*to\s*freecodecamp/i)
+assert.match(code, /full\s*stack\s*curriculum/i)
 ```
 
 # --seed--
@@ -33,6 +32,7 @@ assert.match(code, /welcome\s*to\s*freecodecamp/i)
 ## --seed-contents--
 
 ```html
+Welcome to freeCodeCamp
 --fcc-editable-region--
 
 --fcc-editable-region--

--- a/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/682cd20b883fc7b25eb539c6.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/682cd20b883fc7b25eb539c6.md
@@ -1,0 +1,39 @@
+---
+id: 682cd20b883fc7b25eb539c6
+title: Step 3
+challengeType: 0
+dashedName: step-3
+---
+
+# --description--
+
+HTML stands for HyperText Markup Language. It represents the content and structure of a webpage. In this workshop, you will write the HTML code for a curriculum outline.
+
+Below the other two lines of text, add:
+
+```md
+Learn the skills to become a full stack developer
+```
+
+# --hints--
+
+You should have the text `Learn the skills to become a full stack developer` in your editor. Double-check for spelling.
+
+```js
+// purposefully providing forgiveness in spacing and casing to remove some friction and
+// keep camper retention this early on.
+assert.match(code, /learn\s*the\s*skills\s*to\s*become\s*a\s*full\s*stack\s*developer/i)
+```
+
+# --seed--
+
+## --seed-contents--
+
+```html
+Welcome to freeCodeCamp
+Full Stack Curriculum
+--fcc-editable-region--
+
+--fcc-editable-region--
+```
+

--- a/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/682cd20b883fc7b25eb539c6.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-curriculum-outline/682cd20b883fc7b25eb539c6.md
@@ -7,7 +7,7 @@ dashedName: step-3
 
 # --description--
 
-HTML stands for HyperText Markup Language. It represents the content and structure of a webpage. In this workshop, you will write the HTML code for a curriculum outline.
+HTML stands for HyperText Markup Language. It represents the content and structure of a webpage. In this workshop, you will write the HTML code for a partial curriculum outline.
 
 Below the other two lines of text, add:
 

--- a/curriculum/superblock-structure/full-stack.json
+++ b/curriculum/superblock-structure/full-stack.json
@@ -1,24 +1,14 @@
 {
   "chapters": [
     {
-      "dashedName": "freecodecamp",
-      "modules": [
-        {
-          "dashedName": "getting-started-with-freecodecamp",
-          "blocks": [
-            {
-              "dashedName": "lecture-welcome-to-freecodecamp"
-            }
-          ]
-        }
-      ]
-    },
-    {
       "dashedName": "html",
       "modules": [
         {
           "dashedName": "basic-html",
           "blocks": [
+            {
+              "dashedName": "workshop-curriculum-outline"
+            },
             {
               "dashedName": "lecture-what-is-html"
             },

--- a/curriculum/superblock-structure/full-stack.json
+++ b/curriculum/superblock-structure/full-stack.json
@@ -10,6 +10,9 @@
               "dashedName": "workshop-curriculum-outline"
             },
             {
+              "dashedName": "lecture-welcome-to-freecodecamp"
+            },
+            {
               "dashedName": "lecture-what-is-html"
             },
             {

--- a/curriculum/superblock-structure/full-stack.json
+++ b/curriculum/superblock-structure/full-stack.json
@@ -13,6 +13,9 @@
               "dashedName": "lecture-welcome-to-freecodecamp"
             },
             {
+              "dashedName": "lab-debug-camperbots-profile-page"
+            },
+            {
               "dashedName": "lecture-what-is-html"
             },
             {

--- a/e2e/donation-modal.spec.ts
+++ b/e2e/donation-modal.spec.ts
@@ -355,11 +355,11 @@ test.describe('Donation modal appearance logic - Certified user claiming a new m
   }) => {
     test.setTimeout(40000);
 
-    // Go to the last lecture of the Welcome to freeCodeCamp block.
+    // Go to the last lecture of the Code Editors block.
     // This lecture is not added to the seed data, so it is not completed.
     // By completing this lecture, we claim both the block and its module.
     await page.goto(
-      '/learn/full-stack-developer/lecture-welcome-to-freecodecamp/how-can-you-build-effective-learning-habits-and-work-smarter'
+      '/learn/full-stack-developer/lecture-working-with-code-editors-and-ides/what-are-some-good-vs-code-extensions-you-can-use-in-your-editor'
     );
 
     // Wait for the page content to render
@@ -372,9 +372,9 @@ test.describe('Donation modal appearance logic - Certified user claiming a new m
       .locator("div[class='video-quiz-options']")
       .all();
 
-    await radioGroups[0].getByRole('radio').nth(2).click({ force: true });
+    await radioGroups[0].getByRole('radio').nth(1).click({ force: true });
     await radioGroups[1].getByRole('radio').nth(2).click({ force: true });
-    await radioGroups[2].getByRole('radio').nth(3).click({ force: true });
+    await radioGroups[2].getByRole('radio').nth(1).click({ force: true });
 
     await page.getByRole('button', { name: /Check your answer/ }).click();
     await page.getByRole('button', { name: /Submit and go/ }).click();
@@ -392,9 +392,7 @@ test.describe('Donation modal appearance logic - Certified user claiming a new m
     // Second part of the modal.
     // Use `slowExpect` as we need to wait 20s for this part to show up.
     await slowExpect(
-      donationModal.getByText(
-        'Nicely done. You just completed Getting Started with freeCodeCamp.'
-      )
+      donationModal.getByText('Nicely done. You just completed Code Editors.')
     ).toBeVisible();
   });
 });

--- a/e2e/super-block-page.spec.ts
+++ b/e2e/super-block-page.spec.ts
@@ -175,22 +175,22 @@ test.describe('Super Block Page - Authenticated User', () => {
 
       await page.goto('/learn/full-stack-developer');
 
-      // First chapter
+      // HTML chapter
       await expect(
-        page.getByTestId('chapter-button').filter({ hasText: /Welcome/ })
+        page.getByTestId('chapter-button').filter({ hasText: /HTML/ })
       ).toHaveAttribute('aria-expanded', 'true');
 
       // First module
       await expect(
         page.getByRole('button', {
-          name: /Getting Started with freeCodeCamp/
+          name: /Basic HTML/
         })
       ).toHaveAttribute('aria-expanded', 'true');
 
       // First block
       await expect(
         page.getByRole('button', {
-          name: /Lecture Welcome to freeCodeCamp/
+          name: /Build a Curriculum Outline/
         })
       ).toHaveAttribute('aria-expanded', 'true');
 
@@ -203,16 +203,6 @@ test.describe('Super Block Page - Authenticated User', () => {
 
       // Go back to the super block page
       await page.goto('/learn/full-stack-developer');
-
-      // The entire first chapter is collapsed
-      await expect(
-        page.getByTestId('chapter-button').filter({ hasText: /Welcome/ })
-      ).toHaveAttribute('aria-expanded', 'false');
-
-      // HTML chapter
-      await expect(
-        page.getByTestId('chapter-button').filter({ hasText: /HTML/ })
-      ).toHaveAttribute('aria-expanded', 'true');
 
       // Semantic HTML module
       await expect(
@@ -262,20 +252,20 @@ test.describe('Super Block Page - Unauthenticated User', () => {
 
       // First chapter
       await expect(
-        page.getByTestId('chapter-button').filter({ hasText: /Welcome/ })
+        page.getByTestId('chapter-button').filter({ hasText: /HTML/ })
       ).toHaveAttribute('aria-expanded', 'true');
 
       // First module
       await expect(
         page.getByRole('button', {
-          name: 'Getting Started with freeCodeCamp'
+          name: 'Basic HTML'
         })
       ).toHaveAttribute('aria-expanded', 'true');
 
       // First block
       await expect(
         page.getByRole('button', {
-          name: 'Lecture Welcome to freeCodeCamp'
+          name: 'Build a Curriculum Outline'
         })
       ).toHaveAttribute('aria-expanded', 'true');
     });

--- a/e2e/super-block-page.spec.ts
+++ b/e2e/super-block-page.spec.ts
@@ -163,7 +163,7 @@ test.describe('Super Block Page - Authenticated User', () => {
       // What is HTML block
       await expect(
         page.getByRole('button', {
-          name: /Lecture What is HTML/
+          name: /Lecture Understanding HTML Attributes and the HTML Boilerplate/
         })
       ).toHaveAttribute('aria-expanded', 'true');
     });
@@ -183,7 +183,7 @@ test.describe('Super Block Page - Authenticated User', () => {
       // First module
       await expect(
         page.getByRole('button', {
-          name: /Basic HTML/
+          name: /Basic HTML \d+ of \d+ steps complete/
         })
       ).toHaveAttribute('aria-expanded', 'true');
 
@@ -258,7 +258,7 @@ test.describe('Super Block Page - Unauthenticated User', () => {
       // First module
       await expect(
         page.getByRole('button', {
-          name: 'Basic HTML'
+          name: /Basic HTML \d+ of \d+ steps complete/
         })
       ).toHaveAttribute('aria-expanded', 'true');
 

--- a/tools/scripts/seed/user-data.js
+++ b/tools/scripts/seed/user-data.js
@@ -12263,6 +12263,22 @@ module.exports.fullyCertifiedUser = {
     {
       completedDate: 1729240849345,
       id: '6763500bd5a85d5898cc21a9'
+    },
+    {
+      completedDate: 1729240849345,
+      id: '672d26269456511aa3db614d'
+    },
+    {
+      completedDate: 1729240849345,
+      id: '672d45583fd75a504136fbbb'
+    },
+    {
+      completedDate: 1729240849345,
+      id: '672d45651d83b450801efb3a'
+    },
+    {
+      completedDate: 1729240849345,
+      id: '672d456f4ac35950b300e93f'
     }
   ],
   completedExams: [


### PR DESCRIPTION
This change relates to this open issue here https://github.com/freeCodeCamp/freeCodeCamp/issues/60366

Mainly this last point here

> Users don’t go to the FSD first challenge at the same rate as RWD.

This is in line with the feedback we are getting on the forum and discord. A lot of people feel like the FSD cert is more structured then the earlier ones but get the impression that there isn't much practice which is false. There is actually more practice with the additional labs and workshops.

The camper has to click through the HTML chapter a few times and watch the HTML lecture videos before they can begin coding. 

This PR does the following:

- removes the welcome chapter and instead places Quincy's videos as the second block in the HTML chapter
- add a small HTML workshop as the very first thing they see and it is opened by default
- also adds a small HTML debugging lab based on what they learned in the workshop as well as address common syntax errors beginners deal with
- updated e2e tests to remove testing for welcome chapter

With these changes, here is what the camper will see in the curriculum map now, which communicates the correct message that freeCodeCamp is still an interactive platform

<img width="738" alt="Screenshot 2025-05-15 at 10 33 49 AM" src="https://github.com/user-attachments/assets/b4e10415-65c1-403b-b52f-8fc6048ea63a" />


Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.


