### PR TITLE
Clarify when combining ID and type selectors is unnecessary

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lecture-css-specificity-the-cascade-algorithm-and-inheritance/672b8ea434ceac23cc90f337.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-css-specificity-the-cascade-algorithm-and-inheritance/672b8ea434ceac23cc90f337.md
@@ -36,6 +36,10 @@ This means that ID selectors can override class selectors and type selectors but
 
 ID selectors can be combined with other selectors to create even more specific rules.
 
+Since IDs are unique in an HTML document, the ID selector alone (e.g., `#unique`) is typically sufficient.
+
+While it’s technically possible to combine an ID selector with a type selector, like `div#unique`, this is usually unnecessary and only sometimes used for clarity or very specific cases.
+
 Here is an example of combining a `div` type selector with an ID selector called `unique`:
 
 ```css
@@ -174,3 +178,4 @@ Consider the highest specificity.
 ## --video-solution--
 
 4
+	


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->
 I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org/).

 I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).

 My pull request targets the main branch of freeCodeCamp.

 I have tested these changes locally on my machine.

Closes #60384


This PR updates the section on ID selectors in the lecture "What Is the Specificity for ID Selectors?" to clarify that combining ID selectors with type selectors (e.g., div#unique) is generally unnecessary. The addition explains that since IDs are unique in a document, #unique is usually sufficient, and combining it with div is mostly for clarity or rare cases.