### PR TITLE
fix(curriculum): change text for test 24 of Customer Complaint Form

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-customer-complaint-form/67279fe50237291f80eed8b8.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-customer-complaint-form/67279fe50237291f80eed8b8.md
@@ -262,7 +262,7 @@ const fieldset = document.getElementById("solutions-group");
 assert.equal(fieldset.style.borderColor, "green");
 ```
 
-When all of the checkboxes from `#complaints-group` are changed to the unchecked state, you should set `#complaints-group`'s border color to `red`.
+When the form is submitted and all of the radio buttons from `#solutions-group` are in the unchecked state, you should set `#solutions-group`'s border color to `red`.
 
 ```js
 document.getElementById("refund").checked = false;


### PR DESCRIPTION
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

Closes #60104

This PR addresses an issue where the test description for test 24 was a duplicate of test 16. Both originally read:

`"When all of the checkboxes from #complaints-group are changed to the unchecked state, you should set #complaints-group's border color to red."`

The description for test 24 has now been updated to correctly state:

`"When the form is submitted and all of the radio buttons from #solutions-group are in the unchecked state, you should set #solutions-group's border color to red."`

This change ensures clarity and accuracy in test documentation.

**Changes**:

Updated test 24 description to refer to `#solutions-group`.
