### PR TITLE
fix(api): log error correctly and differentiate logs

### DIFF
--- a/api/src/plugins/auth0.ts
+++ b/api/src/plugins/auth0.ts
@@ -112,7 +112,7 @@ export const auth0Client: FastifyPluginCallbackTypebox = fp(
         if (error instanceof Error && error.message === 'Invalid state') {
           logger.error('Auth failed: invalid state');
         } else {
-          logger.error(error, 'Auth failed');
+          logger.error(error, 'Failed to get access token from Auth0');
           fastify.Sentry.captureException(error);
         }
         // It's important _not_ to redirect to /signin here, as that could
@@ -135,7 +135,7 @@ export const auth0Client: FastifyPluginCallbackTypebox = fp(
           throw Error(msg);
         }
       } catch (error) {
-        logger.error({ error }, 'Auth failed');
+        logger.error(error, 'Failed to get userinfo from Auth0');
         fastify.Sentry.captureException(error);
         return reply.redirect('/signin');
       }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

`logger.error(error, message)` is the way to go. The other approach logs `{ error: {}}`. 

<!-- Feel free to add any additional description of changes below this line -->
