### PR TITLE
fix(curriculum): change "aria" to all caps

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -1998,7 +1998,7 @@
         "title": "Build a Checkout Page",
         "intro": [
           "In this lab, you'll create an accessible checkout page.",
-          "You'll practice concepts like <code>alt</code> attributes and aria roles."
+          "You'll practice concepts like <code>alt</code> attributes and ARIA roles."
         ]
       },
       "lab-movie-review-page": {

--- a/curriculum/challenges/english/25-front-end-development/lecture-importance-of-accessibility-and-good-html-structure/672a54bc58319c8fe6f78ad4.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-importance-of-accessibility-and-good-html-structure/672a54bc58319c8fe6f78ad4.md
@@ -46,7 +46,7 @@ You do not need to use `aria-hidden` when:
 
 In these three cases, the element is already removed from the DOM and thus hidden from the accessibility tree, so the `aria-hidden` attribute is not necessary.
 
-As with using any aria attributes, you should always test with assistive technologies, and preferably having people with disabilities test your work, to make sure that it's easy to understand, even with these hidden elements.
+As with using any ARIA attributes, you should always test with assistive technologies, and preferably having people with disabilities test your work, to make sure that it's easy to understand, even with these hidden elements.
 
 You should also know that setting `aria-hidden` to `false` will not expose the element to assistive technologies if any of its parents has this attribute set to `true`.
 


### PR DESCRIPTION
Checklist:
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

Closes #60428 

Description:

This pull request addresses issue #60428 by correcting the casing of the acronym "ARIA" to its standard uppercase form. 