### PR TITLE
Fix: Add missing "up" in Task 71 (issue #60424)

### DIFF
--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-express-agreement/67b2bb2c55db7018a4719406.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-express-agreement/67b2bb2c55db7018a4719406.md
@@ -15,7 +15,7 @@ Listen to the audio and complete the sentence below.
 
 ## --sentence--
 
-`Yes, let's work on BLANK the BLANK BLANK. It'll make the app run faster.`
+`Yes, let's work on BLANK BLANK the BLANK BLANK. It'll make the app run faster.`
 
 ## --blanks--
 
@@ -23,7 +23,15 @@ Listen to the audio and complete the sentence below.
 
 ### --feedback-- 
 
-These two words together refer to making something go faster or improving efficiency. The first word is a verb in its `-ing` form, and the second word is a preposition that indicates an increase in speed. 
+This word refer to making something go faster or improving efficiency. This word is a verb in its `-ing` form. 
+
+---
+
+`up`
+
+### --feedback-- 
+
+This preposition forms a phrasal verb with "speeding" to indicate increasing performance or speed.
 
 ---
 


### PR DESCRIPTION
This pull request fixes Task 71 in the "B1 English for Developers" curriculum.

The audio says "speeding up the database queries", but the original challenge only accepted "speeding", leaving out the word "up".

I updated the sentence and added "up" as a separate blank so that the exercise matches the audio and is grammatically correct.

Fixes #60424
