### PR TITLE
fix(curriculum): remove white space from hint message in Role Playing Game

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62aa27560def7048d7b4a095.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62aa27560def7048d7b4a095.md
@@ -11,7 +11,7 @@ At the end of the string, before the final quote, insert the new line escape cha
 
 # --hints--
 
-You should add the new line escape character `\n` to your `". Here are the random numbers: "` string.
+You should add the new line escape character `\n` to your `". Here are the random numbers:"` string.
 
 ```js
 assert.match(pick.toString(), /text\.innerText\s*=\s*('|")You picked \1\s*\+\s*guess\s*\+\s*('|")\.\sHere are the random numbers:\\n\2/);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Removed white space after the colon from the hint message.

1. It it not mentioned in the instructions.
2. The assert fails if it is present.
3. It is not present in the seed code.

```js
  text.innerText = "You picked " + guess + ". Here are the random numbers:";
```