### PR TITLE
fix: update Task 71 expected answer from 'speeding' to 'speeding up'

### DIFF
--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-express-agreement/67b2bb2c55db7018a4719406.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-how-to-express-agreement/67b2bb2c55db7018a4719406.md
@@ -19,7 +19,7 @@ Listen to the audio and complete the sentence below.
 
 ## --blanks--
 
-`speeding`
+`speeding up`
 
 ### --feedback-- 
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ ] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

This PR resolves issue [#60424](https://github.com/freeCodeCamp/freeCodeCamp/issues/60424) by updating the expected answer in Task 71 of the "Learn How to Express Agreement" lesson.

The current task accepts "speeding" as the correct answer, but the audio says "speeding up," which confused users. This change makes the lesson match the audio and improves the learning experience.
