### PR TITLE
fix(curriculum): only sanitize task id with removeSpecialChars

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-todo-app/67168a7243b6396cb69c1bdf.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-todo-app/67168a7243b6396cb69c1bdf.md
@@ -7,9 +7,9 @@ dashedName: step-67
 
 # --description--
 
-Finally, it is time to call the `removeSpecialChars` on the `id`, `title`, and `description` properties in your `taskObj`. 
+Finally, it is time to call the `removeSpecialChars` on the `id` property in your `taskObj`. 
 
-This will remove issues with broken task data. 
+This will help prevent issues caused by special characters in HTML element IDs. 
 
 With that you have completed the project. 
 
@@ -19,18 +19,6 @@ You should call `removeSpecialChars` on `titleInput.value` when assigning the `i
 
 ```js
 assert.match(code,  /\s*id:\s*`\$\{removeSpecialChars\(titleInput\.value\)\.toLowerCase\(\s*\)\.split\(\s*('|")\s{1}\1\s*\)\.join\(\s*('|")-\2\s*\)\}-\$\{Date\.now\(\s*\)\}`\s*/)
-```
-
-You should call `removeSpecialChars` on `titleInput.value` when assigning the `title`. 
-
-```js
-assert.match(code,  /\s*title:\s*removeSpecialChars\(titleInput\.value\)\s*/,)
-```
-
-You should call `removeSpecialChars` on `descriptionInput.value` when assigning the `description`. 
-
-```js
-assert.match(code,  /\s*description:\s*removeSpecialChars\(descriptionInput\.value\)\s*/)
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-todo-app/67168a7243b6396cb69c1bdf.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-todo-app/67168a7243b6396cb69c1bdf.md
@@ -686,7 +686,7 @@ const addOrUpdateTask = () => {
   const dataArrIndex = taskData.findIndex((item) => item.id === currentTask.id);
   const taskObj = {
     id: `${removeSpecialChars(titleInput.value).toLowerCase().split(" ").join("-")}-${Date.now()}`,
-    title:titleInput.value ,
+    title: titleInput.value ,
     date: dateInput.value,
     description: descriptionInput.value,
   };

--- a/curriculum/challenges/english/25-front-end-development/workshop-todo-app/67168a7243b6396cb69c1bdf.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-todo-app/67168a7243b6396cb69c1bdf.md
@@ -686,7 +686,7 @@ const addOrUpdateTask = () => {
   const dataArrIndex = taskData.findIndex((item) => item.id === currentTask.id);
   const taskObj = {
     id: `${removeSpecialChars(titleInput.value).toLowerCase().split(" ").join("-")}-${Date.now()}`,
-    title: titleInput.value ,
+    title: titleInput.value,
     date: dateInput.value,
     description: descriptionInput.value,
   };

--- a/curriculum/challenges/english/25-front-end-development/workshop-todo-app/67168a7243b6396cb69c1bdf.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-todo-app/67168a7243b6396cb69c1bdf.md
@@ -686,9 +686,9 @@ const addOrUpdateTask = () => {
   const dataArrIndex = taskData.findIndex((item) => item.id === currentTask.id);
   const taskObj = {
     id: `${removeSpecialChars(titleInput.value).toLowerCase().split(" ").join("-")}-${Date.now()}`,
-    title:removeSpecialChars(titleInput.value) ,
+    title:titleInput.value ,
     date: dateInput.value,
-    description: removeSpecialChars(descriptionInput.value),
+    description: descriptionInput.value,
   };
 
   if (dataArrIndex === -1) {


### PR DESCRIPTION
- [ x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ x] My pull request targets the `main` branch of freeCodeCamp.
- [ x] I have tested these changes either locally on my machine, or Gitpod.


Closes #60471

This PR updates the final step of the Todo App workshop to only apply removeSpecialChars to the id property of a task object, instead of also applying it to the title and description.

**Changes Made**
- Updated step description to mention sanitization only for id.
- Removed unnecessary hint assertions for title and description.
