### PR TITLE
fix(curriculum): wrap 'new Object()' in backticks in working-with-objects …

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-objects/6732b758194c97257d23fc72.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-objects/6732b758194c97257d23fc72.md
@@ -116,7 +116,7 @@ Remember that the `Object()` constructor creates an object wrapper for primitive
 
 ## --text--
 
-What's the difference between new `Object()` and `{}`?
+What's the difference between `new Object()` and `{}`?
 
 ## --answers--
 


### PR DESCRIPTION
fix(60486): wrap `new Object()` in backticks in the “Working with Objects” lecture

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes locally on my machine.

### Description
This PR fixes a visual formatting issue in the “Working with Objects” lecture quiz question. The inline code styling was inconsistent—only `Object()` was wrapped in backticks, making it look like `Object()` vs `{}` instead of `new Object()` vs `{}`. This change wraps the full expression in backticks so the question now reads correctly.

### Changes
```diff
- What's the difference between new `Object()` and `{}`?
+ What's the difference between `new Object()` and `{}`?
