### PR TITLE
fix(a11y): make code examples in quiz accessible

### DIFF
--- a/client/src/templates/Challenges/quiz/show.css
+++ b/client/src/templates/Challenges/quiz/show.css
@@ -9,3 +9,15 @@
 .quiz-challenge-container div[role='radiogroup'] label p:last-child {
   margin-bottom: 0;
 }
+
+/* Quiz question text and option text have the <p> tag removed
+   so the HTML can be semantically correct. 
+   This also removes the `p` styles that the text should have,
+   so we need to clone the CSS of the `p` element here. */
+.quiz-question-label,
+.quiz-answer-label {
+  line-height: 1.5rem;
+  font-weight: 400;
+  font-size: 1rem;
+  margin: 0 0 1.2rem;
+}

--- a/client/src/templates/Challenges/quiz/show.tsx
+++ b/client/src/templates/Challenges/quiz/show.tsx
@@ -85,6 +85,8 @@ interface ShowQuizProps {
   closeFinishQuizModal: () => void;
 }
 
+const removeParagraphTags = (text: string) => text.replace(/^<p>|<\/p>$/g, '');
+
 const ShowQuiz = ({
   challengeMounted,
   data: {
@@ -143,7 +145,12 @@ const ShowQuiz = ({
       const distractors = question.distractors.map((distractor, index) => {
         return {
           label: (
-            <PrismFormatted className='quiz-answer-label' text={distractor} />
+            <PrismFormatted
+              className='quiz-answer-label'
+              text={removeParagraphTags(distractor)}
+              useSpan
+              noAria
+            />
           ),
           value: index + 1
         };
@@ -153,14 +160,23 @@ const ShowQuiz = ({
         label: (
           <PrismFormatted
             className='quiz-answer-label'
-            text={question.answer}
+            text={removeParagraphTags(question.answer)}
+            useSpan
+            noAria
           />
         ),
         value: 4
       };
 
       return {
-        question: <PrismFormatted text={question.text} />,
+        question: (
+          <PrismFormatted
+            className='quiz-question-label'
+            text={removeParagraphTags(question.text)}
+            useSpan
+            noAria
+          />
+        ),
         answers: shuffleArray([...distractors, answer]),
         correctAnswer: answer.value
       };


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR updates the quiz UI to:
- Use `useSpan` in PrismFormatted
  - By default PrismFormatted renders a div, but we use the `label` element in quiz options, and it's not semantically correct to have a `div` inside a `label`
- Remove the outer `p` from question and option text
  - Similar to the one above, `p` shouldn't be in `label`
- Use `noAria` in PrismFormatted
  - By default PrismFormatted has role `region`, and `label` isn't meant to contain landmarks so the PrismFormatted content is ignored. So we set `noAria` to remove the `region` role.
- Closes #60493

Bruce applied these changes to the MCQ UI a long time ago (#51748) so we don't have the issue there. But this was overlooked when I implemented the quiz UI.

---

Not sure how much we can help on the component side since the `Quiz` component takes a `ReactNode` for question and option labels.

The actual quiz implementation is still up to the consumers. But I think I can at least create a `Quiz.Label` component to wrap around `PrismFormatted` with all the props it should have, and write a usage guide. 

<!-- Feel free to add any additional description of changes below this line -->
