### PR TITLE
fix(curriculum): remove references to non-existent code examples

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/review-css-colors/671a90c1cf517678b130419e.md
+++ b/curriculum/challenges/english/25-front-end-development/review-css-colors/671a90c1cf517678b130419e.md
@@ -18,7 +18,7 @@ dashedName: review-css-colors
 - **Color Wheel**: The color wheel is a circular diagram that shows how colors relate to each other. It's an essential tool for designers because it helps them to select color combinations.
 - **Analogous Color Schemes**: These color schemes create cohesive and soothing experiences. They have analogous colors, which are adjacent to each other in the color wheel.
 - **Complementary Color Schemes**: These color schemes create high contrast and visual impact. Their colors are located on the opposite ends of the color wheel, relative to each other.
-- **Triadic Color Scheme**: This color scheme has vibrant colors. They are made from colors that are approximately equidistant from each other. If they are connected, they form an equilateral triangle on the color wheel, as you can see in this example.
+- **Triadic Color Scheme**: This color scheme has vibrant colors. They are made from colors that are approximately equidistant from each other. If they are connected, they form an equilateral triangle on the color wheel.
 - **Monochromatic Color Scheme**: For this color scheme, all the colors are derived from the same base color by adjusting its lightness, darkness, and saturation. This evokes a feeling of unity and harmony while still creating contrast.
 
 ## Different Ways to Work with Colors in CSS

--- a/curriculum/challenges/english/25-front-end-development/review-css-flexbox/671a940c69cdee833d4cc312.md
+++ b/curriculum/challenges/english/25-front-end-development/review-css-flexbox/671a940c69cdee833d4cc312.md
@@ -25,7 +25,7 @@ dashedName: review-css-flexbox
 - **`flex-wrap: nowrap;`**: This is the default value. Flex items won't be wrapped onto a new line, even if their width exceed the container's width.
 - **`flex-wrap: wrap;`**: This property will wrap the items when they exceed the width of their container.
 - **`flex-wrap: wrap-reverse;`**: This property will wrap flex items in reverse order.
-- **`flex-flow` Property**: This property is a shorthand property for `flex-direction` and `flex-wrap`. In this example, we set `flex-direction` to `column` and `flex-wrap` to `wrap-reverse`.
+- **`flex-flow` Property**: This property is a shorthand property for `flex-direction` and `flex-wrap`.
 
 ```css
 flex-flow: column wrap-reverse;

--- a/curriculum/challenges/english/25-front-end-development/review-css/671a9a0a140c2b9d6a75629f.md
+++ b/curriculum/challenges/english/25-front-end-development/review-css/671a9a0a140c2b9d6a75629f.md
@@ -207,7 +207,7 @@ Review the concepts below to prepare for the upcoming exam.
 - **Color Wheel**: The color wheel is a circular diagram that shows how colors relate to each other. It's an essential tool for designers because it helps them to select color combinations.
 - **Analogous Color Schemes**: These color schemes create cohesive and soothing experiences. They have analogous colors, which are adjacent to each other in the color wheel.
 - **Complementary Color Schemes**: These color schemes create high contrast and visual impact. Their colors are located on the opposite ends of the color wheel, relative to each other.
-- **Triadic Color Scheme**: This color scheme has vibrant colors. They are made from colors that are approximately equidistant from each other. If they are connected, they form an equilateral triangle on the color wheel, like you can see in this example.
+- **Triadic Color Scheme**: This color scheme has vibrant colors. They are made from colors that are approximately equidistant from each other. If they are connected, they form an equilateral triangle on the color wheel.
 - **Monochromatic Color Scheme**: For this color scheme, all the colors are derived from the same base color by adjusting its lightness, darkness, and saturation. This evokes a feeling of unity and harmony while still creating contrast.
 
 ## Different Ways to Work with Colors in CSS
@@ -298,7 +298,7 @@ Review the concepts below to prepare for the upcoming exam.
 - **`flex-wrap: nowrap;`**: This is the default value. Flex items won't be wrapped onto a new line, even if their width exceed the container's width.
 - **`flex-wrap: wrap;`**: This property will wrap the items when they exceed the width of their container.
 - **`flex-wrap: wrap-reverse;`**: This property will wrap flex items in reverse order.
-- **`flex-flow` Property**: This property is a shorthand property for `flex-direction` and `flex-wrap`. In this example, we set `flex-direction` to `column` and `flex-wrap` to `wrap-reverse`.
+- **`flex-flow` Property**: This property is a shorthand property for `flex-direction` and `flex-wrap`.
 
 ## The `justify-content` Property
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Some items on CSS review pages have "see this code example" but the code examples aren't provided. I assume the definitions were copied from the lecture transcript but weren't cleaned up.

<!-- Feel free to add any additional description of changes below this line -->
