### PR TITLE
chore(ui): Migrate lecture quiz to quiz component

### DIFF
--- a/client/src/templates/Challenges/components/multiple-choice-questions.tsx
+++ b/client/src/templates/Challenges/components/multiple-choice-questions.tsx
@@ -1,29 +1,18 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { Spacer } from '@freecodecamp/ui';
-import { Question } from '../../../redux/prop-types';
+import { Quiz, Spacer } from '@freecodecamp/ui';
+import { Question } from '@freecodecamp/ui/dist/quiz/types';
 import ChallengeHeading from './challenge-heading';
-import PrismFormatted from './prism-formatted';
 
 type MultipleChoiceQuestionsProps = {
-  questions: Question[];
-  selectedOptions: (number | null)[];
-  handleOptionChange: (questionIndex: number, answerIndex: number) => void;
-  submittedMcqAnswers: (number | null)[];
-  showFeedback: boolean;
+  questions: Question<number>[];
+  disabled: boolean;
 };
-
-function removeParagraphTags(text: string): string {
-  return text.replace(/^<p>|<\/p>$/g, '');
-}
 
 function MultipleChoiceQuestions({
   questions,
-  selectedOptions,
-  handleOptionChange,
-  submittedMcqAnswers,
-  showFeedback
+  disabled
 }: MultipleChoiceQuestionsProps): JSX.Element {
   const { t } = useTranslation();
 
@@ -34,85 +23,7 @@ function MultipleChoiceQuestions({
           questions.length > 1 ? t('learn.questions') : t('learn.question')
         }
       />
-      {questions.map((question, questionIndex) => (
-        <fieldset key={questionIndex}>
-          <legend className='mcq-question-text'>
-            <PrismFormatted className={'line-numbers'} text={question.text} />
-          </legend>
-          <div className='video-quiz-options'>
-            {question.answers.map(({ answer }, answerIndex) => {
-              const isSubmittedAnswer =
-                submittedMcqAnswers[questionIndex] === answerIndex;
-              const feedback =
-                questions[questionIndex].answers[answerIndex].feedback;
-              const isCorrect =
-                submittedMcqAnswers[questionIndex] ===
-                // -1 because the solution is 1-indexed
-                questions[questionIndex].solution - 1;
-
-              return (
-                <React.Fragment key={answerIndex}>
-                  <label
-                    className={`video-quiz-option-label 
-                      ${showFeedback && isSubmittedAnswer ? 'mcq-hide-border' : ''} 
-                      ${showFeedback && isSubmittedAnswer ? (isCorrect ? 'mcq-correct-border' : 'mcq-incorrect-border') : ''}`}
-                    htmlFor={`mc-question-${questionIndex}-answer-${answerIndex}`}
-                  >
-                    <input
-                      name={`mc-question-${questionIndex}`}
-                      checked={selectedOptions[questionIndex] === answerIndex}
-                      className='sr-only'
-                      onChange={() =>
-                        handleOptionChange(questionIndex, answerIndex)
-                      }
-                      type='radio'
-                      value={answerIndex}
-                      id={`mc-question-${questionIndex}-answer-${answerIndex}`}
-                    />{' '}
-                    <span className='video-quiz-input-visible'>
-                      {selectedOptions[questionIndex] === answerIndex ? (
-                        <span className='video-quiz-selected-input' />
-                      ) : null}
-                    </span>
-                    <PrismFormatted
-                      className={'video-quiz-option'}
-                      text={removeParagraphTags(answer)}
-                      useSpan
-                      noAria
-                    />
-                  </label>
-                  {showFeedback && isSubmittedAnswer && (
-                    <div
-                      className={`video-quiz-option-label mcq-feedback ${isCorrect ? 'mcq-correct' : 'mcq-incorrect'}`}
-                    >
-                      <p>
-                        {isCorrect
-                          ? t('learn.quiz.correct-answer')
-                          : t('learn.quiz.incorrect-answer')}
-                      </p>
-                      {feedback && (
-                        <p>
-                          <PrismFormatted
-                            className={
-                              isCorrect
-                                ? 'mcq-prism-correct'
-                                : 'mcq-prism-incorrect'
-                            }
-                            text={removeParagraphTags(feedback)}
-                            useSpan
-                            noAria
-                          />
-                        </p>
-                      )}
-                    </div>
-                  )}
-                </React.Fragment>
-              );
-            })}
-          </div>
-          <Spacer size='m' />
-        </fieldset>
-      ))}
+      <Quiz questions={questions} disabled={disabled} />
       <Spacer size='m' />
     </>
   );

--- a/client/src/templates/Challenges/generic/show.css
+++ b/client/src/templates/Challenges/generic/show.css
@@ -31,3 +31,14 @@ input[type='checkbox']:checked::before {
 audio {
   background-color: aqua;
 }
+
+.quiz-answer-label {
+  font-weight: normal;
+}
+
+/* Override the bottom margin set in global.css */
+.quiz-question-label p:last-child,
+.quiz-answer-label p:last-child,
+.quiz-feedback-label p:last-child {
+  margin-bottom: 0;
+}

--- a/client/src/templates/Challenges/generic/show.tsx
+++ b/client/src/templates/Challenges/generic/show.tsx
@@ -173,10 +173,16 @@ const ShowGeneric = ({
             <PrismFormatted
               className='quiz-answer-label'
               text={answer.answer}
+              text={answer.answer}
             />
           ),
           value: index + 1, // distractors get values starting from 1
-          feedback: <PrismFormatted text={answer.feedback || ''} />
+          feedback: (
+            <PrismFormatted
+              className='quiz-feedback-label'
+              text={answer.feedback || ''}
+            />
+          )
         }));
 
       const answer = {
@@ -184,13 +190,19 @@ const ShowGeneric = ({
           <PrismFormatted
             className='quiz-answer-label'
             text={question.answers[answerIndex].answer}
+            text={question.answers[answerIndex].answer}
           />
         ),
         value: distractors.length + 1 // correct answer value is after distractors
       };
 
       return {
-        question: <PrismFormatted text={question.text} />,
+        question: (
+          <PrismFormatted
+            className='quiz-question-label'
+            text={question.text}
+          />
+        ),
         answers: shuffleArray([...distractors, answer]),
         correctAnswer: answer.value
       };


### PR DESCRIPTION
- [x ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ x] My pull request targets the `main` branch of freeCodeCamp.
- [ x] I have tested these changes either locally on my machine, or Gitpod.

Closes #60200

Migrate to the `Quiz` component for _Multiple Choice Questions_ components in Generic templates, using the the `useQuiz`.

I notice a different style for the feedback used in `Quiz` component:

New feedback style:
![new](https://github.com/user-attachments/assets/b8ce854d-245a-48b5-98fa-29a8c38ad3b5)

Old feedback style:
![old style](https://github.com/user-attachments/assets/337d73b4-0c70-4031-9db4-3eed0af64795)

