### PR TITLE
fix(curriculum): make spacing requirement less strict in Movie Review Page

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-movie-review-page/67ef8f695db52583424bd118.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-movie-review-page/67ef8f695db52583424bd118.md
@@ -83,7 +83,7 @@ const spanEl = document.querySelector("main p:nth-of-type(2) span");
 const fullRatingText = document.querySelector("main p:nth-of-type(2)")?.textContent.replace(/\s+/g, ' ').trim();
 
 assert.match(spanEl?.innerText, /^[⭐☆]{10}$/);
-assert.match(fullRatingText, /Movie Rating:?\s*[⭐☆]{10}\s+\(\d+(?:\.\d+)?\/10\)$/);
+assert.match(fullRatingText, /Movie Rating:?\s?[⭐☆]{10}\s+\(\d+(?:\.\d+)?\/10\)$/);
 ```
 
 The `span` element inside the rating paragraph should have an `aria-hidden` attribute set to `true`.

--- a/curriculum/challenges/english/25-front-end-development/lab-movie-review-page/67ef8f695db52583424bd118.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-movie-review-page/67ef8f695db52583424bd118.md
@@ -62,7 +62,7 @@ const paragraphs = document.querySelectorAll("main p");
 assert.isAtLeast(paragraphs.length, 2);
 ```
 
-Inside the second `p` element, you should have a `strong` element with the text `Movie Rating:`.
+Inside the second `p` element, you should have a `strong` element with the text `Movie Rating: `.
 
 ```js
 const strongEl = document.querySelector("main p:nth-of-type(2) strong");
@@ -83,7 +83,7 @@ const spanEl = document.querySelector("main p:nth-of-type(2) span");
 const fullRatingText = document.querySelector("main p:nth-of-type(2)")?.textContent.replace(/\s+/g, ' ').trim();
 
 assert.match(spanEl?.innerText, /^[⭐☆]{10}$/);
-assert.match(fullRatingText, /Movie Rating:\s+[⭐☆]{10}\s+\(\d+(?:\.\d+)?\/10\)$/);
+assert.match(fullRatingText, /Movie Rating:?\s*[⭐☆]{10}\s+\(\d+(?:\.\d+)?\/10\)$/);
 ```
 
 The `span` element inside the rating paragraph should have an `aria-hidden` attribute set to `true`.


### PR DESCRIPTION
Checklist:

- [x ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x ] My pull request targets the `main` branch of freeCodeCamp.
- [x ] I have tested these changes either locally on my machine, or Gitpod.

###Description

Fixed missing space in the `Movie Rating: ` label and updated the star test to make the colon and space optional in the full rating text match.

Closes #60457

