### PR TITLE
fix(curriculum): make spaces optional in movie rating test

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-movie-review-page/67ef8f695db52583424bd118.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-movie-review-page/67ef8f695db52583424bd118.md
@@ -83,7 +83,7 @@ const spanEl = document.querySelector("main p:nth-of-type(2) span");
 const fullRatingText = document.querySelector("main p:nth-of-type(2)")?.textContent.replace(/\s+/g, ' ').trim();
 
 assert.match(spanEl?.innerText, /^[⭐☆]{10}$/);
-assert.match(fullRatingText, /Movie Rating:?\s?[⭐☆]{10}\s*\(\s*\d+(?:\.\d+)?\s*\/\s*10\s*\)$/);
+assert.match(fullRatingText, /Movie Rating:?\s*[⭐☆]{10}\s*\(\s*\d+(?:\.\d+)?\s*\/\s*10\s*\)$/);
 ```
 
 The `span` element inside the rating paragraph should have an `aria-hidden` attribute set to `true`.

--- a/curriculum/challenges/english/25-front-end-development/lab-movie-review-page/67ef8f695db52583424bd118.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-movie-review-page/67ef8f695db52583424bd118.md
@@ -83,7 +83,7 @@ const spanEl = document.querySelector("main p:nth-of-type(2) span");
 const fullRatingText = document.querySelector("main p:nth-of-type(2)")?.textContent.replace(/\s+/g, ' ').trim();
 
 assert.match(spanEl?.innerText, /^[⭐☆]{10}$/);
-assert.match(fullRatingText, /Movie Rating:\s+[⭐☆]{10}\s+\(\d+(?:\.\d+)?\/10\)$/);
+assert.match(fullRatingText, /Movie Rating:\s*[⭐☆]{10}\s*\(\s*\d+(?:\.\d+)?\s*\/\s*10\s*\)$/);
 ```
 
 The `span` element inside the rating paragraph should have an `aria-hidden` attribute set to `true`.


### PR DESCRIPTION
Hello,

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #60523

<!-- Feel free to add any additional description of changes below this line -->
This change updates the test regex for the Movie Rating challenge to make spaces optional around the colon, stars, numbers, and parentheses. I verified the change locally to ensure it works as expected. Thank you!