### PR TITLE
feat(learn): show confirmation dialog when leaving page with unsaved changes

### DIFF
--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -366,12 +366,22 @@ function ShowClassic({
     if (!challengeFiles) return;
 
     for (let index = 0; index < challengeFiles.length; index++) {
-      const hasChangedContentAfterSave =
-        savedChallengeFiles &&
-        savedChallengeFiles[index]?.contents != challengeFiles[index]?.contents;
+      const currentContent = challengeFiles[index]?.contents;
+      const savedContent = savedChallengeFiles?.[index]?.contents;
 
-      if (!savedChallengeFiles || hasChangedContentAfterSave) {
+      if (!savedContent && currentContent) {
         isFileSaved = false;
+        break;
+      }
+
+      if (savedContent && !currentContent) {
+        isFileSaved = false;
+        break;
+      }
+
+      if (savedContent && currentContent !== savedContent) {
+        isFileSaved = false;
+        break;
       }
     }
 
@@ -479,9 +489,6 @@ function ShowClassic({
     });
     challengeMounted(challengeMeta.id);
     setIsAdvancing(false);
-
-    /* window.addEventListener('beforeunload', stopWindowCloseRef.current);
-    window.addEventListener('popstate', stopBrowserBackRef.current); */
   };
 
   const renderInstructionsPanel = ({


### PR DESCRIPTION
- [ x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ x] My pull request targets the `main` branch of freeCodeCamp.
- [ x] I have tested these changes either locally on my machine, or Gitpod.

Closes #46810

This PR implements logic to detect unsaved changes in challenge files and warn users before they navigate away, close the tab, or go back in their browser. This ensures that user-generated content is not lost accidentally.

Made unsaved edits and attempted to:

- Click internal links → Prompted. 
- Close the tab → Prompted. 
- Use browser back button → Prompted.
