### PR TITLE
fix(curriculum): correct typo 'strech' to 'stretch' in Task 9

### DIFF
--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/6556c24670683b8d6d80bb32.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-your-morning-or-evening-routine/6556c24670683b8d6d80bb32.md
@@ -9,7 +9,7 @@ dashedName: task-9
 
 # --description--
 
-To `stretch` is to extend your arms and legs as much as you can. You normally strech before and after doing sets of exercises or running.
+To `stretch` is to extend your arms and legs as much as you can. You normally stretch before and after doing sets of exercises or running.
 Example: `I love stretching a little after running around the park.`
 
 Listen to Sarah and fill in the words that help to sequence activities clearly.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #60541

<!-- Feel free to add any additional description of changes below this line -->
Corrected a typo in Task 9 of the lesson “Learn How to Discuss Your Morning or Evening Routine”. Replaced "strech" with the correct spelling "stretch" in the sentence:  
> "You normally strech before and after doing sets of exercises or running."  
Now reads:  
> "You normally stretch before and after doing sets of exercises or running."