### PR TITLE
fix: handle when userinfo has no email address

### DIFF
--- a/api/src/plugins/auth0.test.ts
+++ b/api/src/plugins/auth0.test.ts
@@ -208,13 +208,18 @@ describe('auth0 plugin', () => {
         token: 'any token'
       });
       userinfoSpy.mockResolvedValueOnce(Promise.reject(Error('any error')));
+      const returnTo = 'https://www.freecodecamp.org/espanol/learn';
 
       const res = await fastify.inject({
         method: 'GET',
-        url: '/auth/auth0/callback?state=valid'
+        url: '/auth/auth0/callback?state=valid',
+        cookies: { 'login-returnto': sign(returnTo) }
       });
 
-      expect(res.headers.location).toMatch('/signin');
+      expect(res.headers.location).toMatch(
+        returnTo +
+          `?${formatMessage({ type: 'danger', content: 'flash.generic-error' })}`
+      );
       expect(res.statusCode).toBe(302);
       expect(await fastify.prisma.user.count()).toBe(0);
     });
@@ -224,13 +229,18 @@ describe('auth0 plugin', () => {
         token: 'any token'
       });
       userinfoSpy.mockResolvedValueOnce(Promise.resolve({}));
+      const returnTo = 'https://www.freecodecamp.org/espanol/learn';
 
       const res = await fastify.inject({
         method: 'GET',
-        url: '/auth/auth0/callback?state=valid'
+        url: '/auth/auth0/callback?state=valid',
+        cookies: { 'login-returnto': sign(returnTo) }
       });
 
-      expect(res.headers.location).toMatch('/signin');
+      expect(res.headers.location).toMatch(
+        returnTo +
+          `?${formatMessage({ type: 'danger', content: 'flash.no-email-in-userinfo' })}`
+      );
       expect(res.statusCode).toBe(302);
       expect(await fastify.prisma.user.count()).toBe(0);
     });

--- a/api/src/plugins/auth0.ts
+++ b/api/src/plugins/auth0.ts
@@ -144,13 +144,18 @@ export const auth0Client: FastifyPluginCallbackTypebox = fp(
         logger.info(`Auth0 userinfo: ${JSON.stringify(userinfo)}`);
         email = userinfo.email;
         if (typeof email !== 'string') {
-          const msg = `Invalid userinfo email: ${JSON.stringify(userinfo)}`;
-          throw Error(msg);
+          return reply.redirectWithMessage(returnTo, {
+            type: 'danger',
+            content: 'flash.no-email-in-userinfo'
+          });
         }
       } catch (error) {
         logger.error(error, 'Failed to get userinfo from Auth0');
         fastify.Sentry.captureException(error);
-        return reply.redirect('/signin');
+        return reply.redirectWithMessage(returnTo, {
+          type: 'danger',
+          content: 'flash.generic-error'
+        });
       }
 
       const { id, acceptedPrivacyTerms } = await findOrCreateUser(

--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -852,6 +852,7 @@
     "edit-my-profile": "Edit my profile"
   },
   "flash": {
+    "no-email-in-userinfo": "We could not retrieve an email from your chosen provider. Please try another provider or use the 'Continue with Email' option.",
     "honest-first": "To claim a certification, you must first agree to our academic honesty policy",
     "really-weird": "Something really weird happened, if it happens again, please consider raising an issue on https://github.com/freeCodeCamp/freeCodeCamp/issues/new",
     "generic-error": "Something went wrong. Please try again in a moment or contact support@freecodecamp.org if the error persists.",


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

I've also stopped it redirecting to /signin since that just loops until we hit Auth0's rate limits.

Closes https://github.com/freeCodeCamp/freeCodeCamp/issues/60466

<!-- Feel free to add any additional description of changes below this line -->
