### PR TITLE
fix(curriculum): correct "Psuedocode" typo in TOP lesson C

### DIFF
--- a/curriculum/challenges/english/16-the-odin-project/top-learn-to-solve-problems-and-understand-errors/learn-to-solve-problems-and-understand-errors-lesson-c.md
+++ b/curriculum/challenges/english/16-the-odin-project/top-learn-to-solve-problems-and-understand-errors/learn-to-solve-problems-and-understand-errors-lesson-c.md
@@ -7,7 +7,7 @@ dashedName: learn-to-solve-problems-and-understand-errors-lesson-c
 
 # --description--
 
-## Psuedocode
+## Pseudocode
 
 Pseudocode is writing out the logic for your program in natural language instead of code. It helps you slow down and think through the steps your program will have to go through to solve the problem.
 


### PR DESCRIPTION
Checklist:

- [x ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x ] My pull request targets the `main` branch of freeCodeCamp.
- [x ] I have tested these changes either locally on my machine.

Closes #60555

<!-- Feel free to add any additional description of changes below this line -->

This pull request corrects a small typo in the Learn to Solve Problems and Understand Errors lesson (Lesson C) in the Odin Project curriculum section.
Changed the heading ## Psuedocode -> ## Pseudocode