### PR TITLE
fix(curriculum): fsd chapter order

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -3736,167 +3736,6 @@
       },
       "rdzk": { "title": "301", "intro": [] },
       "vtpz": { "title": "302", "intro": [] },
-      "workshop-bash-boilerplate": {
-        "title": "Build a Boilerplate",
-        "intro": [
-          "The terminal allows you to send text commands to your computer that can manipulate the file system, run programs, automate tasks, and much more.",
-          "In this 170-lesson workshop, you will learn terminal commands by creating a website boilerplate using only the command line."
-        ]
-      },
-      "review-bash-commands": {
-        "title": "Bash Commands Review",
-        "intro": [
-          "Review the Bash Commands concepts to prepare for the upcoming quiz."
-        ]
-      },
-      "quiz-bash-commands": {
-        "title": "Bash Commands Quiz",
-        "intro": ["Test what you've learned bash commands with this quiz."]
-      },
-      "voks": { "title": "306", "intro": [] },
-      "workshop-database-of-video-game-characters": {
-        "title": "Build a Database of Video Game Characters",
-        "intro": [
-          "A relational database organizes data into tables that are linked together through relationships.",
-          "In this 165-lesson workshop, you will learn the basics of a relational database by creating a PostgreSQL database filled with video game characters."
-        ]
-      },
-      "lab-celestial-bodies-database": {
-        "title": "Build a Celestial Bodies Database",
-        "intro": [
-          "For this project, you will build a database of celestial bodies using PostgreSQL."
-        ]
-      },
-      "review-relational-database": {
-        "title": "Relational Database Review",
-        "intro": [
-          "Review the Relational Database concepts to prepare for the upcoming quiz."
-        ]
-      },
-      "quiz-relational-database": {
-        "title": "Relational Database Quiz",
-        "intro": [
-          "Test what you've learned on relational databases with this quiz."
-        ]
-      },
-      "pexz": { "title": "311", "intro": [] },
-      "workshop-bash-five-programs": {
-        "title": "Build Five Programs",
-        "intro": [
-          "Bash scripts combine terminal commands and logic into programs that can execute or automate tasks, and much more.",
-          "In this 220-lesson workshop, you will learn more terminal commands and how to use them within Bash scripts by creating five small programs."
-        ]
-      },
-      "review-bash-scripting": {
-        "title": "Bash Scripting Review",
-        "intro": [
-          "Review the bash scripting concepts you've learned to prepare for the upcoming quiz."
-        ]
-      },
-      "quiz-bash-scripting": {
-        "title": "Bash Scripting Quiz",
-        "intro": ["Test what you've learned on bash scripting in this quiz."]
-      },
-      "tkgg": { "title": "315", "intro": [] },
-      "workshop-sql-student-database-part-1": {
-        "title": "Build a Student Database: Part 1",
-        "intro": [
-          "SQL, or Structured Query Language, is the language for communicating with a relational database.",
-          "In this 140-lesson workshop, you will create a Bash script that uses SQL to enter information about your computer science students into PostgreSQL."
-        ]
-      },
-      "workshop-sql-student-database-part-2": {
-        "title": "Build a Student Database: Part 2",
-        "intro": [
-          "SQL join commands are used to combine information from multiple tables in a relational database",
-          "In this 140-lesson workshop, you will complete your student database while diving deeper into SQL commands."
-        ]
-      },
-      "lab-world-cup-database": {
-        "title": "Build a World Cup Database",
-        "intro": [
-          "For this project, you will create a Bash script that enters information from World Cup games into PostgreSQL, then query the database for useful statistics."
-        ]
-      },
-      "workshop-kitty-ipsum-translator": {
-        "title": "Build a Kitty Ipsum Translator",
-        "intro": [
-          "There's more to Bash commands than you might think.",
-          "In this 140-lesson workshop, you will learn some more complex commands, and the details of how commands work."
-        ]
-      },
-      "workshop-bike-rental-shop": {
-        "title": "Build a Bike Rental Shop",
-        "intro": [
-          "In this 210-lesson workshop, you will build an interactive Bash program that stores rental information for your bike rental shop using PostgreSQL."
-        ]
-      },
-      "lab-salon-appointment-scheduler": {
-        "title": "Build a Salon Appointment Scheduler",
-        "intro": [
-          "For this lab, you will create an interactive Bash program that uses PostgreSQL to track the customers and appointments for your salon."
-        ]
-      },
-      "review-bash-and-sql": {
-        "title": "Bash and SQL Review",
-        "intro": [
-          "Review the Bash and SQL concepts to prepare for the upcoming quiz."
-        ]
-      },
-      "quiz-bash-and-sql": {
-        "title": "Bash and SQL Quiz",
-        "intro": ["Test what you've learned in this quiz on Bash and SQL."]
-      },
-      "eeez": { "title": "324", "intro": [] },
-      "workshop-castle": {
-        "title": "Build a Castle",
-        "intro": [
-          "Nano is a program that allows you to edit files right in the terminal.",
-          "In this 40-lesson workshop, you will learn how to edit files in the terminal with Nano while building a castle."
-        ]
-      },
-      "review-nano": {
-        "title": "Nano Review",
-        "intro": ["Review the Nano concepts to prepare for the upcoming quiz."]
-      },
-      "quiz-nano": {
-        "title": "Nano Quiz",
-        "intro": ["Test what you've learned on Nano with this quiz ."]
-      },
-      "rhhl": { "title": "328", "intro": [] },
-      "workshop-sql-reference-object": {
-        "title": "Build an SQL Reference Object",
-        "intro": [
-          "Git is a version control system that keeps track of all the changes you make to your codebase.",
-          "In this 240-lesson workshop, you will learn how Git keeps track of your code by creating an object containing commonly used SQL commands."
-        ]
-      },
-      "lab-periodic-table-database": {
-        "title": "Build a Periodic Table Database",
-        "intro": [
-          "For this lab, you will create a Bash script to get information about chemical elements from a periodic table database."
-        ]
-      },
-      "lab-number-guessing-game": {
-        "title": "Build a Number Guessing Game",
-        "intro": [
-          "For this lab, you will use Bash scripting, PostgreSQL, and Git to create a number guessing game that runs in the terminal and saves user information."
-        ]
-      },
-      "review-git": {
-        "title": "Git Review",
-        "intro": ["Review Git concepts to prepare for the upcoming quiz."]
-      },
-      "quiz-git": {
-        "title": "Git Quiz",
-        "intro": ["Test what you've learned on Git with this quiz."]
-      },
-      "review-relational-databases": {
-        "title": "Relational Databases Review",
-        "intro": [
-          "Review relational databases concepts to prepare for the upcoming quiz."
-        ]
-      },
       "lecture-introduction-to-python": {
         "title": "Introduction to Python",
         "intro": ["Learn about Introduction to Python in these lectures."]
@@ -4194,6 +4033,167 @@
       "review-python": {
         "title": "Python Review",
         "intro": ["Review Python concepts to prepare for the upcoming exam."]
+      },
+      "workshop-bash-boilerplate": {
+        "title": "Build a Boilerplate",
+        "intro": [
+          "The terminal allows you to send text commands to your computer that can manipulate the file system, run programs, automate tasks, and much more.",
+          "In this 170-lesson workshop, you will learn terminal commands by creating a website boilerplate using only the command line."
+        ]
+      },
+      "review-bash-commands": {
+        "title": "Bash Commands Review",
+        "intro": [
+          "Review the Bash Commands concepts to prepare for the upcoming quiz."
+        ]
+      },
+      "quiz-bash-commands": {
+        "title": "Bash Commands Quiz",
+        "intro": ["Test what you've learned bash commands with this quiz."]
+      },
+      "voks": { "title": "306", "intro": [] },
+      "workshop-database-of-video-game-characters": {
+        "title": "Build a Database of Video Game Characters",
+        "intro": [
+          "A relational database organizes data into tables that are linked together through relationships.",
+          "In this 165-lesson workshop, you will learn the basics of a relational database by creating a PostgreSQL database filled with video game characters."
+        ]
+      },
+      "lab-celestial-bodies-database": {
+        "title": "Build a Celestial Bodies Database",
+        "intro": [
+          "For this project, you will build a database of celestial bodies using PostgreSQL."
+        ]
+      },
+      "review-relational-database": {
+        "title": "Relational Database Review",
+        "intro": [
+          "Review the Relational Database concepts to prepare for the upcoming quiz."
+        ]
+      },
+      "quiz-relational-database": {
+        "title": "Relational Database Quiz",
+        "intro": [
+          "Test what you've learned on relational databases with this quiz."
+        ]
+      },
+      "pexz": { "title": "311", "intro": [] },
+      "workshop-bash-five-programs": {
+        "title": "Build Five Programs",
+        "intro": [
+          "Bash scripts combine terminal commands and logic into programs that can execute or automate tasks, and much more.",
+          "In this 220-lesson workshop, you will learn more terminal commands and how to use them within Bash scripts by creating five small programs."
+        ]
+      },
+      "review-bash-scripting": {
+        "title": "Bash Scripting Review",
+        "intro": [
+          "Review the bash scripting concepts you've learned to prepare for the upcoming quiz."
+        ]
+      },
+      "quiz-bash-scripting": {
+        "title": "Bash Scripting Quiz",
+        "intro": ["Test what you've learned on bash scripting in this quiz."]
+      },
+      "tkgg": { "title": "315", "intro": [] },
+      "workshop-sql-student-database-part-1": {
+        "title": "Build a Student Database: Part 1",
+        "intro": [
+          "SQL, or Structured Query Language, is the language for communicating with a relational database.",
+          "In this 140-lesson workshop, you will create a Bash script that uses SQL to enter information about your computer science students into PostgreSQL."
+        ]
+      },
+      "workshop-sql-student-database-part-2": {
+        "title": "Build a Student Database: Part 2",
+        "intro": [
+          "SQL join commands are used to combine information from multiple tables in a relational database",
+          "In this 140-lesson workshop, you will complete your student database while diving deeper into SQL commands."
+        ]
+      },
+      "lab-world-cup-database": {
+        "title": "Build a World Cup Database",
+        "intro": [
+          "For this project, you will create a Bash script that enters information from World Cup games into PostgreSQL, then query the database for useful statistics."
+        ]
+      },
+      "workshop-kitty-ipsum-translator": {
+        "title": "Build a Kitty Ipsum Translator",
+        "intro": [
+          "There's more to Bash commands than you might think.",
+          "In this 140-lesson workshop, you will learn some more complex commands, and the details of how commands work."
+        ]
+      },
+      "workshop-bike-rental-shop": {
+        "title": "Build a Bike Rental Shop",
+        "intro": [
+          "In this 210-lesson workshop, you will build an interactive Bash program that stores rental information for your bike rental shop using PostgreSQL."
+        ]
+      },
+      "lab-salon-appointment-scheduler": {
+        "title": "Build a Salon Appointment Scheduler",
+        "intro": [
+          "For this lab, you will create an interactive Bash program that uses PostgreSQL to track the customers and appointments for your salon."
+        ]
+      },
+      "review-bash-and-sql": {
+        "title": "Bash and SQL Review",
+        "intro": [
+          "Review the Bash and SQL concepts to prepare for the upcoming quiz."
+        ]
+      },
+      "quiz-bash-and-sql": {
+        "title": "Bash and SQL Quiz",
+        "intro": ["Test what you've learned in this quiz on Bash and SQL."]
+      },
+      "eeez": { "title": "324", "intro": [] },
+      "workshop-castle": {
+        "title": "Build a Castle",
+        "intro": [
+          "Nano is a program that allows you to edit files right in the terminal.",
+          "In this 40-lesson workshop, you will learn how to edit files in the terminal with Nano while building a castle."
+        ]
+      },
+      "review-nano": {
+        "title": "Nano Review",
+        "intro": ["Review the Nano concepts to prepare for the upcoming quiz."]
+      },
+      "quiz-nano": {
+        "title": "Nano Quiz",
+        "intro": ["Test what you've learned on Nano with this quiz ."]
+      },
+      "rhhl": { "title": "328", "intro": [] },
+      "workshop-sql-reference-object": {
+        "title": "Build an SQL Reference Object",
+        "intro": [
+          "Git is a version control system that keeps track of all the changes you make to your codebase.",
+          "In this 240-lesson workshop, you will learn how Git keeps track of your code by creating an object containing commonly used SQL commands."
+        ]
+      },
+      "lab-periodic-table-database": {
+        "title": "Build a Periodic Table Database",
+        "intro": [
+          "For this lab, you will create a Bash script to get information about chemical elements from a periodic table database."
+        ]
+      },
+      "lab-number-guessing-game": {
+        "title": "Build a Number Guessing Game",
+        "intro": [
+          "For this lab, you will use Bash scripting, PostgreSQL, and Git to create a number guessing game that runs in the terminal and saves user information."
+        ]
+      },
+      "review-git": {
+        "title": "Git Review",
+        "intro": ["Review Git concepts to prepare for the upcoming quiz."]
+      },
+      "quiz-git": {
+        "title": "Git Quiz",
+        "intro": ["Test what you've learned on Git with this quiz."]
+      },
+      "review-relational-databases": {
+        "title": "Relational Databases Review",
+        "intro": [
+          "Review relational databases concepts to prepare for the upcoming quiz."
+        ]
       },
       "exam-certified-full-stack-developer": {
         "title": "Certified Full Stack Developer Exam",

--- a/curriculum/superblock-structure/full-stack.json
+++ b/curriculum/superblock-structure/full-stack.json
@@ -1190,129 +1190,6 @@
       ]
     },
     {
-      "dashedName": "relational-databases",
-      "comingSoon": true,
-      "modules": [
-        {
-          "dashedName": "bash-fundamentals",
-          "blocks": [
-            {
-              "dashedName": "workshop-bash-boilerplate"
-            },
-            {
-              "dashedName": "review-bash-commands"
-            },
-            {
-              "dashedName": "quiz-bash-commands"
-            }
-          ]
-        },
-        {
-          "dashedName": "relational-databases",
-          "blocks": [
-            {
-              "dashedName": "workshop-database-of-video-game-characters"
-            },
-            {
-              "dashedName": "lab-celestial-bodies-database"
-            },
-            {
-              "dashedName": "review-relational-database"
-            },
-            {
-              "dashedName": "quiz-relational-database"
-            }
-          ]
-        },
-        {
-          "dashedName": "bash-scripting",
-          "blocks": [
-            {
-              "dashedName": "workshop-bash-five-programs"
-            },
-            {
-              "dashedName": "review-bash-scripting"
-            },
-            {
-              "dashedName": "quiz-bash-scripting"
-            }
-          ]
-        },
-        {
-          "dashedName": "sql-and-bash",
-          "blocks": [
-            {
-              "dashedName": "workshop-sql-student-database-part-1"
-            },
-            {
-              "dashedName": "workshop-sql-student-database-part-2"
-            },
-            {
-              "dashedName": "lab-world-cup-database"
-            },
-            {
-              "dashedName": "workshop-kitty-ipsum-translator"
-            },
-            {
-              "dashedName": "workshop-bike-rental-shop"
-            },
-            {
-              "dashedName": "lab-salon-appointment-scheduler"
-            },
-            {
-              "dashedName": "review-bash-and-sql"
-            },
-            {
-              "dashedName": "quiz-bash-and-sql"
-            }
-          ]
-        },
-        {
-          "dashedName": "nano",
-          "blocks": [
-            {
-              "dashedName": "workshop-castle"
-            },
-            {
-              "dashedName": "review-nano"
-            },
-            {
-              "dashedName": "quiz-nano"
-            }
-          ]
-        },
-        {
-          "dashedName": "git",
-          "blocks": [
-            {
-              "dashedName": "workshop-sql-reference-object"
-            },
-            {
-              "dashedName": "lab-periodic-table-database"
-            },
-            {
-              "dashedName": "lab-number-guessing-game"
-            },
-            {
-              "dashedName": "review-git"
-            },
-            {
-              "dashedName": "quiz-git"
-            }
-          ]
-        },
-        {
-          "moduleType": "review",
-          "dashedName": "review-relational-databases",
-          "blocks": [
-            {
-              "dashedName": "review-relational-databases"
-            }
-          ]
-        }
-      ]
-    },
-    {
       "dashedName": "python",
       "comingSoon": true,
       "modules": [
@@ -1441,6 +1318,129 @@
           "comingSoon": true,
           "dashedName": "exam-python",
           "blocks": []
+        }
+      ]
+    },
+    {
+      "dashedName": "relational-databases",
+      "comingSoon": true,
+      "modules": [
+        {
+          "dashedName": "bash-fundamentals",
+          "blocks": [
+            {
+              "dashedName": "workshop-bash-boilerplate"
+            },
+            {
+              "dashedName": "review-bash-commands"
+            },
+            {
+              "dashedName": "quiz-bash-commands"
+            }
+          ]
+        },
+        {
+          "dashedName": "relational-databases",
+          "blocks": [
+            {
+              "dashedName": "workshop-database-of-video-game-characters"
+            },
+            {
+              "dashedName": "lab-celestial-bodies-database"
+            },
+            {
+              "dashedName": "review-relational-database"
+            },
+            {
+              "dashedName": "quiz-relational-database"
+            }
+          ]
+        },
+        {
+          "dashedName": "bash-scripting",
+          "blocks": [
+            {
+              "dashedName": "workshop-bash-five-programs"
+            },
+            {
+              "dashedName": "review-bash-scripting"
+            },
+            {
+              "dashedName": "quiz-bash-scripting"
+            }
+          ]
+        },
+        {
+          "dashedName": "sql-and-bash",
+          "blocks": [
+            {
+              "dashedName": "workshop-sql-student-database-part-1"
+            },
+            {
+              "dashedName": "workshop-sql-student-database-part-2"
+            },
+            {
+              "dashedName": "lab-world-cup-database"
+            },
+            {
+              "dashedName": "workshop-kitty-ipsum-translator"
+            },
+            {
+              "dashedName": "workshop-bike-rental-shop"
+            },
+            {
+              "dashedName": "lab-salon-appointment-scheduler"
+            },
+            {
+              "dashedName": "review-bash-and-sql"
+            },
+            {
+              "dashedName": "quiz-bash-and-sql"
+            }
+          ]
+        },
+        {
+          "dashedName": "nano",
+          "blocks": [
+            {
+              "dashedName": "workshop-castle"
+            },
+            {
+              "dashedName": "review-nano"
+            },
+            {
+              "dashedName": "quiz-nano"
+            }
+          ]
+        },
+        {
+          "dashedName": "git",
+          "blocks": [
+            {
+              "dashedName": "workshop-sql-reference-object"
+            },
+            {
+              "dashedName": "lab-periodic-table-database"
+            },
+            {
+              "dashedName": "lab-number-guessing-game"
+            },
+            {
+              "dashedName": "review-git"
+            },
+            {
+              "dashedName": "quiz-git"
+            }
+          ]
+        },
+        {
+          "moduleType": "review",
+          "dashedName": "review-relational-databases",
+          "blocks": [
+            {
+              "dashedName": "review-relational-databases"
+            }
+          ]
         }
       ]
     },


### PR DESCRIPTION
This swaps the order of the RDB and Python chapters in the Full stack cert.

It changes the `full-stack.json` and `intro.json` files, so it may cause conflicts on a number of PR's that touch those. That's fine, we can merge this whenever and I can help fix those if needed - and we can continue to merge those as normal as well and I can fix this if needed.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #59343

<!-- Feel free to add any additional description of changes below this line -->
