### PR TITLE
chore: update assertions to use assert.isString for Project Euler

### DIFF
--- a/curriculum/challenges/english/18-project-euler/project-euler-problems-201-to-300/problem-220-heighway-dragon.md
+++ b/curriculum/challenges/english/18-project-euler/project-euler-problems-201-to-300/problem-220-heighway-dragon.md
@@ -28,7 +28,7 @@ What is the position of the cursor after ${10}^{12}$ steps in $D_{50}$? Give you
 `heighwayDragon()` should return a string.
 
 ```js
-assert(typeof heighwayDragon() === 'string');
+assert.isString(heighwayDragon());
 ```
 
 `heighwayDragon()` should return the string `139776,963904`.

--- a/curriculum/challenges/english/18-project-euler/project-euler-problems-201-to-300/problem-236-luxury-hampers.md
+++ b/curriculum/challenges/english/18-project-euler/project-euler-problems-201-to-300/problem-236-luxury-hampers.md
@@ -36,7 +36,7 @@ What's the largest possible value of $m$? Give your answer as a string with frac
 `luxuryHampers()` should return a string.
 
 ```js
-assert(typeof luxuryHampers() === 'string');
+assert.isString(luxuryHampers());
 ```
 
 `luxuryHampers()` should return the string `123/59`.

--- a/curriculum/challenges/english/18-project-euler/project-euler-problems-201-to-300/problem-284-steady-squares.md
+++ b/curriculum/challenges/english/18-project-euler/project-euler-problems-201-to-300/problem-284-steady-squares.md
@@ -21,7 +21,7 @@ Find the sum of the digits of all the $n$-digit steady squares in the base 14 nu
 `steadySquares()` should return a string.
 
 ```js
-assert(typeof steadySquares() === 'string');
+assert.isString(steadySquares());
 ```
 
 `steadySquares()` should return the string `5a411d7b`.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod. - 

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #60586

<!-- Feel free to add any additional description of changes below this line -->
Title: chore: update assertions to use assert.isString for Project Euler problems 220, 236, and 284

Description:
Fixes #60586

Updated test assertions in Project Euler problems 220, 236, and 284 to use `assert.isString` instead of `assert(typeof ... === 'string')` as per issue #60586. 