### PR TITLE
fix(curriculum): correct grammar in loan qualification checker step 5

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-password-generator/66f53dc2c5bd6a11d6c3282f.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-password-generator/66f53dc2c5bd6a11d6c3282f.md
@@ -82,7 +82,7 @@ const length2 = 10;
 const password3 = generatePassword(length2);
 assert.lengthOf(password3, length2);
 assert.equal(password3.length, generatePassword(length2).length);
-assert.match(__helpers.removeJSComments(code), /(let|const)\s+password\s*=\s*generatePassword\(\d+\)\;/);
+assert.match(__helpers.removeJSComments(code), /(let|const|var)\s+password\s*=\s*generatePassword\(\d+\)\;/);
 ```
 
 You should log a single string combining `Generated password:` and the `password` separated by a single space using `+` or a template literal.

--- a/curriculum/challenges/english/25-front-end-development/workshop-calorie-counter/63c9ebb7b12bca3025b0a935.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-calorie-counter/63c9ebb7b12bca3025b0a935.md
@@ -17,7 +17,7 @@ Your `for...of` loop should iterate through the `inputContainers` array. The loo
 
 ```js
 const clearForm = code.split("function clearForm()")[1];
-assert.match(clearForm, /for\s*\(\s*(const|let)\s+container\s+of\s+inputContainers\s*\)/);
+assert.match(clearForm, /for\s*\(\s*(const|let|var)\s+container\s+of\s+inputContainers\s*\)/);
 ```
 
 Your `for...of` loop should set the `innerHTML` property of `container` to an empty string.

--- a/curriculum/challenges/english/25-front-end-development/workshop-loan-qualification-checker/66c8ba975ee7230e29f6c4b0.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-loan-qualification-checker/66c8ba975ee7230e29f6c4b0.md
@@ -7,7 +7,7 @@ dashedName: step-5
 
 # --description--
 
-Now, you should check if the applicant is qualified for a car loan only. If they're, return the string `"You qualify for a car loan."`.
+Now, you should check if the applicant is qualified for a car loan only. If they are qualified, return the string `"You qualify for a car loan."`.
 
 # --hints--
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-music-player/674735e3b28351b8b8f05807.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-music-player/674735e3b28351b8b8f05807.md
@@ -68,7 +68,7 @@ try {
 You should assign your `find` call to a variable named `song`.
 
 ```js
-assert.match(__helpers.removeJSComments(code), /(const|let)\s+song\s*=\s*userData\s*\.\s*songs\s*\.\s*find\s*\(.+\)/)
+assert.match(__helpers.removeJSComments(code), /(const|let|var)\s+song\s*=\s*userData\s*\.\s*songs\s*\.\s*find\s*\(.+\)/)
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-music-player/67517ef2fae05b65108212db.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-music-player/67517ef2fae05b65108212db.md
@@ -33,7 +33,7 @@ assert.match(__helpers.removeJSComments(code), /document\.getElementById\(\s*`so
 You should assign your `getElementById()` to a `songToHighlight` variable.
 
 ```js
-assert.match(__helpers.removeJSComments(code), /(const|let)\s+songToHighlight\s*=\s*document\.getElementById\(\s*`song-\$\{userData\.currentSong\?\.id\}`\s*\)\s*;?\s*\}\s*;?/)
+assert.match(__helpers.removeJSComments(code), /(const|let|var)\s+songToHighlight\s*=\s*document\.getElementById\(\s*`song-\$\{userData\.currentSong\?\.id\}`\s*\)\s*;?\s*\}\s*;?/)
 ```
 
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/6734a772196245601e4b80e0.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/6734a772196245601e4b80e0.md
@@ -22,7 +22,7 @@ assert.exists(getBallerina);
 Your `getBallerina` variable should have the value of `catalog.get(ballerina)`.
 
 ```js
-assert.match(__helpers.removeJSComments(code), /(const|let)\s+getBallerina\s*=\s*catalog\s*\.\s*get\s*\(\s*ballerina\s*\)/);
+assert.match(__helpers.removeJSComments(code), /(const|let|var)\s+getBallerina\s*=\s*catalog\s*\.\s*get\s*\(\s*ballerina\s*\)/);
 ```
 
 You should log your `getBallerina` variable to the console.

--- a/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/6737a1a073a0d14c6544d301.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-plant-nursery-catalog/6737a1a073a0d14c6544d301.md
@@ -23,7 +23,7 @@ assert.exists(plantsSet);
 You should call `displayPlantsSet` and assign it to `plantsSet`.
 
 ```js
-assert.match(__helpers.removeJSComments(code), /(const|let)\s+plantsSet\s*=\s*displayPlantsSet\s*\(\s*\)/)
+assert.match(__helpers.removeJSComments(code), /(const|let|var)\s+plantsSet\s*=\s*displayPlantsSet\s*\(\s*\)/)
 ```
 
 You should log `plantsSet` to the console.

--- a/curriculum/challenges/english/25-front-end-development/workshop-superhero-application-form/680900675ae3d54ee19590c3.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-superhero-application-form/680900675ae3d54ee19590c3.md
@@ -16,7 +16,7 @@ For now, create the variables and setters for `heroName` and `realName`. Both sh
 You should use the array destructuring syntax to set a `heroName` state variable and a `setHeroName` setter.
 
 ```js
-assert.match(code, /(const|let)\s+\[\s*heroName\s*,\s*setHeroName\s*\]/);
+assert.match(code, /(const|let|var)\s+\[\s*heroName\s*,\s*setHeroName\s*\]/);
 ```
 
 Your `heroName` and `setHeroName` should use the `useState` hook.

--- a/curriculum/challenges/english/25-front-end-development/workshop-superhero-application-form/680900675ae3d54ee19590d0.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-superhero-application-form/680900675ae3d54ee19590d0.md
@@ -16,7 +16,7 @@ Inside the function, destructure `value` and `checked` from `e.target` to get th
 You should create an `handlePowersChange` function with an `e` parameter.
 
 ```js
-assert.match(code, /(const|let)\s+handlePowersChange\s*=\s*(e|\(\s*e\s*\))\s*=>\s*{/)
+assert.match(code, /(const|let|var)\s+handlePowersChange\s*=\s*(e|\(\s*e\s*\))\s*=>\s*{/)
 ```
 
 You should destructure `value` and `checked` from `e.target`.

--- a/curriculum/challenges/english/25-front-end-development/workshop-superhero-application-form/680fc849a6f2be0a8597c593.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-superhero-application-form/680fc849a6f2be0a8597c593.md
@@ -14,7 +14,7 @@ Now, create the state variables and setters for `powerSource` and `powers`. `pow
 You should use array destructuring to set a `powerSource` state variable and a `setPowerSource` setter.
 
 ```js
-assert.match(code, /(const|let)\s+\[\s*powerSource\s*,\s*setPowerSource\s*\]/);
+assert.match(code, /(const|let|var)\s+\[\s*powerSource\s*,\s*setPowerSource\s*\]/);
 ```
 
 Your `powerSource` and `setPowerSource` should use the `useState` hook.

--- a/curriculum/challenges/english/25-front-end-development/workshop-superhero-application-form/68149b101d905a6fc2fcd6d8.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-superhero-application-form/68149b101d905a6fc2fcd6d8.md
@@ -16,7 +16,7 @@ The function needs an array argument. In the function parameter, use a ternary o
 You should use a ternary operator to check if `checked` is true. If it is, spread in the existing `powers` and `value` into an array. If it is not, filter out the `value` from `powers`.
 
 ```js
-assert.match(code, /(const|let)\s*{\s*(value\s*,\s*checked|checked\s*,\s*value)\s*}\s*=\s*e\s*\.\s*target\s*;?\s*setPowers\s*\(\s*checked\s*\?\s*\[\s*\.\.\.powers\s*,\s*value\s*\]\s*:\s*powers\s*\.\s*filter\s*\(\s*(p|\(\s*p\s*\))\s*=>\s*p\s*!==?\s*value\s*\)\s*\)/)
+assert.match(code, /(const|let|var)\s*{\s*(value\s*,\s*checked|checked\s*,\s*value)\s*}\s*=\s*e\s*\.\s*target\s*;?\s*setPowers\s*\(\s*checked\s*\?\s*\[\s*\.\.\.powers\s*,\s*value\s*\]\s*:\s*powers\s*\.\s*filter\s*\(\s*(p|\(\s*p\s*\))\s*=>\s*p\s*!==?\s*value\s*\)\s*\)/)
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-toggle-text-app/67cd49e05693111a41771f29.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-toggle-text-app/67cd49e05693111a41771f29.md
@@ -26,7 +26,7 @@ Then assign the `useState` hook with an initial value of `false`.
 You should use the array destructuring syntax for the `isVisible` and `setIsVisible` variables. Refer back to the example.
 
 ```js
-assert.match(code, /(const|let)\s+\[\s*(isVisible)\s*,\s*(setIsVisible)\s*\]\s*/);
+assert.match(code, /(const|let|var)\s+\[\s*(isVisible)\s*,\s*(setIsVisible)\s*\]\s*/);
 ```
 
 You should use the `useState` hook.


### PR DESCRIPTION
This fixes a small grammar issue in the Loan Qualification Checker workshop.

Original sentence:
> "If they're, return the string 'You qualify for a car loan.'"

Updated to:
> "If they are qualified, return the string 'You qualify for a car loan.'"

This improves readability and clarity for learners.

Closes #60605
