### PR TITLE
fix(learn): correct grammar typo in loan qualification checker step 5

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-loan-qualification-checker/66c8ba975ee7230e29f6c4b0.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-loan-qualification-checker/66c8ba975ee7230e29f6c4b0.md
@@ -7,7 +7,7 @@ dashedName: step-5
 
 # --description--
 
-Now, you should check if the applicant is qualified for a car loan only. If they're, return the string `"You qualify for a car loan."`.
+Now, you should check if the applicant is qualified for a car loan only. If they are qualified, return the string `"You qualify for a car loan."`.
 
 # --hints--
 


### PR DESCRIPTION
This pull request fixes a minor grammar mistake in Step 5 of the Build a Loan Qualification Checker lab.

The original sentence:
“If they're, return the string 'You qualify for a car loan.”

Was unclear because "they're" (they are) was used without a following word, making it incomplete.

This change replaces it with:
“If they are qualified, return the string 'You qualify for a car loan.”

This improves clarity and grammatical correctness.

I have tested these changes locally to ensure the content displays correctly.

Closes #60605
