### PR TITLE
fix(curriculum): correct typo in js-loan-qual-workshop

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-loan-qualification-checker/66c8ba975ee7230e29f6c4b0.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-loan-qualification-checker/66c8ba975ee7230e29f6c4b0.md
@@ -7,7 +7,7 @@ dashedName: step-5
 
 # --description--
 
-Now, you should check if the applicant is qualified for a car loan only. If they're, return the string `"You qualify for a car loan."`.
+Now, you should check if the applicant is qualified for a car loan only. If they are, return the string `"You qualify for a car loan."`.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:


- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org/).

- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).

- [x] My pull request targets the main branch of freeCodeCamp.

- [x] I have tested these changes either locally on my machine, or Gitpod.




Closes #60605

Description:

This PR fixes a small typo in the "JavaScript Loan Qualification Workshop" lesson (Step 5). Changed "they're" to "they are".
This improves the clarity and professionalism of the lesson.
