### PR TITLE
fix(curriculum): clarify wording in css flexbox quiz questions

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/quiz-css-flexbox/66ed8fe7f45ce3ece4053eb2.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-css-flexbox/66ed8fe7f45ce3ece4053eb2.md
@@ -408,45 +408,45 @@ Which `justify-content` value spaces items equally along the main axis while lea
 
 #### --text--
 
-Which value for `align-items` will make it so items are directly against the cross-axis start?
+Which of the following results in the items being aligned at the start of the cross axis?
 
 #### --distractors--
 
-`flex-end`
+`align-items: flex-starts;`
 
 ---
 
-`baseline`
+`align-items: baseline;`
 
 ---
 
-`first-baseline`
+`align-items: first-baseline;`
 
 #### --answer--
 
-`flex-start`
+`align-items: flex-start;`
 
 ### --question--
 
 #### --text--
 
-Which value for `align-items` will make it so items are directly against the cross-axis end?
+Which of the following results in the items being aligned at the end of the cross axis?
 
 #### --distractors--
 
-`flex-start`
+`align-items: flex-ends;`
 
 ---
 
-`baseline`
+`align-items: end;`
 
 ---
 
-`last-baseline`
+`align-items: flex-ending;`
 
 #### --answer--
 
-`flex-end`
+`align-items: flex-end;`
 
 ### --question--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #60611

<!-- Feel free to add any additional description of changes below this line -->

**Description**: Updated unclear wording in two CSS Flexbox quiz questions to improve clarity.

**Affected Page**: https://www.freecodecamp.org/learn/full-stack-developer/quiz-css-flexbox/quiz-css-flexbox

**Test Result**: (Screenshot shows test with one correct and one incorrect option selected.)
![Test Result](https://github.com/user-attachments/assets/7c0f25e4-2595-47e2-8bd8-ce23820f28e7)

