### PR TITLE
fix(curriculum): use specific chai asserts for euler problems 401-480

### DIFF
--- a/curriculum/challenges/english/18-project-euler/project-euler-problems-401-to-480/problem-419-look-and-say-sequence.md
+++ b/curriculum/challenges/english/18-project-euler/project-euler-problems-401-to-480/problem-419-look-and-say-sequence.md
@@ -35,7 +35,7 @@ Find $A(n)$, $B(n)$ and $C(n)$ for $n = {10}^{12}$. Give your answer modulo $2^{
 `lookAndSaySequence()` should return a string.
 
 ```js
-assert(typeof lookAndSaySequence() === 'string');
+assert.isString(lookAndSaySequence());
 ```
 
 

--- a/curriculum/challenges/english/18-project-euler/project-euler-problems-401-to-480/problem-444-the-roundtable-lottery.md
+++ b/curriculum/challenges/english/18-project-euler/project-euler-problems-401-to-480/problem-444-the-roundtable-lottery.md
@@ -32,7 +32,7 @@ Find $S_{20}({10}^{14})$ and write the answer as a string in scientific notation
 `roundtableLottery()` should return a string.
 
 ```js
-assert(typeof roundtableLottery() === 'string');
+assert.isString(roundtableLottery());
 ```
 
 `roundtableLottery()` should return the string `1.200856722e263`.

--- a/curriculum/challenges/english/18-project-euler/project-euler-problems-401-to-480/problem-461-almost-pi.md
+++ b/curriculum/challenges/english/18-project-euler/project-euler-problems-401-to-480/problem-461-almost-pi.md
@@ -23,7 +23,7 @@ You are given `almostPi(200)` = 6<sup>2</sup> + 75<sup>2</sup> + 89<sup>2</sup> 
 `almostPi` should be a function.
 
 ```js
-assert(typeof almostPi === 'function')
+assert.isFunction(almostPi);
 ```
 
 `almostPi` should return a number.

--- a/curriculum/challenges/english/18-project-euler/project-euler-problems-401-to-480/problem-471-triangle-inscribed-in-ellipse.md
+++ b/curriculum/challenges/english/18-project-euler/project-euler-problems-401-to-480/problem-471-triangle-inscribed-in-ellipse.md
@@ -31,7 +31,7 @@ For $G(10)$ the answer would have been `2.059722222e1`
 `triangleInscribedInEllipse()` should return a string.
 
 ```js
-assert(typeof triangleInscribedInEllipse() === 'string');
+assert.isString(triangleInscribedInEllipse());
 ```
 
 `triangleInscribedInEllipse()` should return the string `1.895093981e31`.

--- a/curriculum/challenges/english/18-project-euler/project-euler-problems-401-to-480/problem-480-the-last-question.md
+++ b/curriculum/challenges/english/18-project-euler/project-euler-problems-401-to-480/problem-480-the-last-question.md
@@ -71,7 +71,7 @@ Give your answer using lowercase characters (no punctuation or space).
 `euler480()` should return a string.
 
 ```js
-assert(typeof euler480() === 'string');
+assert.isString(euler480());
 ```
 
 `euler480()` should return the string `turnthestarson`.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #60584 

<!-- Feel free to add any additional description of changes below this line -->
This PR updates test assertions in the Project Euler curriculum challenges (problems 401-480) to use more specific Chai assertion methods (`assert.isString` and `assert.isFunction`) instead of generic `assert(typeof ...)` checks.
