### PR TITLE
fix(curriculum): misaligned titles

### DIFF
--- a/curriculum/challenges/_meta/lecture-working-with-code-editors-and-ides/meta.json
+++ b/curriculum/challenges/_meta/lecture-working-with-code-editors-and-ides/meta.json
@@ -1,5 +1,5 @@
 {
-  "name": "Working with Code Editors and IDE's",
+  "name": "Working with Code Editors and IDEs",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
   "isUpcomingChange": false,

--- a/curriculum/challenges/_meta/review-react-basics/meta.json
+++ b/curriculum/challenges/_meta/review-react-basics/meta.json
@@ -1,5 +1,5 @@
 {
-  "name": "React Basics",
+  "name": "React Basics Review",
   "blockType": "review",
   "blockLayout": "link",
   "isUpcomingChange": false,


### PR DESCRIPTION
Found a couple misaligned titles after seeing the failing tests:
https://github.com/freeCodeCamp/freeCodeCamp/actions/runs/15360987125/job/43228396047
and
https://github.com/freeCodeCamp/freeCodeCamp/actions/runs/15360987125/job/43228396057

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
