### PR TITLE
chore(curriculum): update Project Euler problems 301–400 to use assert.isString()

### DIFF
--- a/curriculum/challenges/english/18-project-euler/project-euler-problems-301-to-400/problem-329-prime-frog.md
+++ b/curriculum/challenges/english/18-project-euler/project-euler-problems-301-to-400/problem-329-prime-frog.md
@@ -25,7 +25,7 @@ Give your answer as a string as a fraction `p/q` in reduced form.
 `primeFrog()` should return a string.
 
 ```js
-assert(typeof primeFrog() === 'string');
+asset.isString(primeFrog());
 ```
 
 `primeFrog()` should return the string `199740353/29386561536000`.

--- a/curriculum/challenges/english/18-project-euler/project-euler-problems-301-to-400/problem-336-maximix-arrangements.md
+++ b/curriculum/challenges/english/18-project-euler/project-euler-problems-301-to-400/problem-336-maximix-arrangements.md
@@ -29,7 +29,7 @@ Find the ${2011}^{\text{th}}$ lexicographic maximix arrangement for eleven carri
 `maximixArrangements()` should return a string.
 
 ```js
-assert(typeof maximixArrangements() === 'string');
+asset.isString(maximixArrangements());
 ```
 
 `maximixArrangements()` should return the string `CAGBIHEFJDK`.

--- a/curriculum/challenges/english/18-project-euler/project-euler-problems-301-to-400/problem-380-amazing-mazes.md
+++ b/curriculum/challenges/english/18-project-euler/project-euler-problems-301-to-400/problem-380-amazing-mazes.md
@@ -25,7 +25,7 @@ When giving your answer, use a lowercase e to separate mantissa and exponent. E.
 `amazingMazes()` should return a string.
 
 ```js
-assert(typeof amazingMazes() === 'string');
+asset.isString(amazingMazes());
 ```
 
 `amazingMazes()` should return the string `6.3202e25093`.

--- a/curriculum/challenges/english/18-project-euler/project-euler-problems-301-to-400/problem-399-squarefree-fibonacci-numbers.md
+++ b/curriculum/challenges/english/18-project-euler/project-euler-problems-301-to-400/problem-399-squarefree-fibonacci-numbers.md
@@ -31,7 +31,7 @@ If it happens that the conjecture is false, then the accepted answer to this pro
 `squarefreeFibonacciNumbers()` should return a string.
 
 ```js
-assert(typeof squarefreeFibonacciNumbers() === 'string');
+asset.isString(squarefreeFibonacciNumbers());
 ```
 
 `squarefreeFibonacciNumbers()` should return the string `1508395636674243,6.5e27330467`.


### PR DESCRIPTION
This PR updates the test files for Project Euler problems 301 to 400. Specifically, it replaces general `assert(...)` statements with specific `assert.isString(...)` statements for better clarity and consistency.

This aligns with FreeCodeCamp's preferred testing style and improves test readability.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #60585

<!-- Feel free to add any additional description of changes below this line -->

