### PR TITLE
fix(client, curriculum): mismatched block titles

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -1290,7 +1290,7 @@
         ]
       },
       "top-build-a-rock-paper-scissors-game": {
-        "title": "Build a Rock Paper Scissor Game",
+        "title": "Build a Rock Paper Scissors Game",
         "intro": [
           "Put your JavaScript skills to the test by building a Rock Paper Scissors game."
         ]

--- a/curriculum/challenges/_meta/lecture-welcome-to-freecodecamp/meta.json
+++ b/curriculum/challenges/_meta/lecture-welcome-to-freecodecamp/meta.json
@@ -1,5 +1,5 @@
 {
-  "name": "Welcome to freeCodeCamp",
+  "name": "Welcome Message from Quincy Larson",
   "blockType": "lecture",
   "blockLayout": "challenge-list",
   "isUpcomingChange": false,


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR 
- Fixes the remaining mismatched block titles
- Closes #60632

For context, we have a test for the mobile curricula data script that randomly selects a block in the generated data and compares the block's `meta.name` property against the `title` property in `intro.json`. That's why mismatches have been randomly found.

I updated the test locally and run against all blocks to find all of the remaining mismatches, so this PR should be the last.

<!-- Feel free to add any additional description of changes below this line -->
