### PR TITLE
fix(i18n): fixed typo in intro.json

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -3117,7 +3117,7 @@
       "lab-lightbox-viewer": {
         "title": "Build a Lightbox Viewer",
         "intro": [
-          "In this lab, you'll build a lighbox viewer for viewing images in a focused mode.",
+          "In this lab, you'll build a lightbox viewer for viewing images in a focused mode.",
           "You'll practice click events and toggling classes."
         ]
       },


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

Closes #60680

I used Gitpod for both editing the codebase and testing.

The typo was found in client/i18n/locales/english/intro.json
The typo "lighbox" is on line 3120 in the current repo, though it says line 3114 in the Issue. 

The line previously read:
"In this lab, you'll build a lighbox viewer for viewing images in a focused mode.",
