### PR TITLE
fix(curriculum): remove errors in CSS and JS transcripts

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lecture-accessible-media-elements/672a55eb7791559421ff0cd3.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-accessible-media-elements/672a55eb7791559421ff0cd3.md
@@ -1,14 +1,15 @@
 ---
 id: 672a55eb7791559421ff0cd3
 title: What Are Good Ways to Make Audio and Video Content Accessible?
-challengeType: 11
-videoId: KIuKBpihUPg
+# change back to 11 when video is updated
+challengeType: 19
+# videoId: new-id-goes-here-when-ready
 dashedName: what-are-good-ways-to-make-audio-and-video-content-accessible
 ---
 
 # --description--
 
-Watch the video or read the transcript and answer the questions below.
+Read the transcript and answer the questions below.
 
 # --transcript--
 
@@ -32,21 +33,21 @@ To add captions or subtitles to your video or audio content, you can use the `tr
 <!-- Video -->
 <video controls src="video.mp4">
   <track
-      src="captions.vtt" 
-      kind="captions"
-      srclang="en"
-      label="English" 
+    src="captions.vtt" 
+    kind="captions"
+    srclang="en"
+    label="English" 
   />
 </video>
 
 <!-- Audio -->
 <audio controls src="audio.mp3">
-   <track
-       src="captions.vtt"
-       kind="captions"
-       srclang="en"
-       label="English"
-   />
+  <track
+    src="captions.vtt"
+    kind="captions"
+    srclang="en"
+    label="English"
+  />
 </audio>
 ```
 
@@ -54,7 +55,7 @@ The `kind` attribute is used to tell the track element how it should be used. Va
 
 The `srclang` attribute represents the language for the `track` content. The `label` attribute is a descriptive title for the text track that browsers use to identify and display it in the list of available text tracks.
 
-Another important thing to consider is providing a transcript for your audio and video content. A transcript is a text version of all the spoken words in your audio or video. Unlike captions, transcripts don’t need to be synchronized with the media. Transcripts are useful for deaf people and those hard of hearing. They're also beneficial for people who prefer reading instead of watching or listening. Transcripts also make your content searchable, allowing users to quickly find specific parts of your audio or video. If you have a video or audio on a website, you can simply add the captions below the audio or video:
+Another important thing to consider is providing a transcript for your audio and video content. A transcript is a text version of all the spoken words in your audio or video. Unlike captions, transcripts don’t need to be synchronized with the media. Transcripts are useful for deaf people and those hard of hearing. They're also beneficial for people who prefer reading instead of watching or listening. Transcripts also make your content searchable, allowing users to quickly find specific parts of your audio or video. If you have a video or audio on a website, you can simply add the transcript below the audio or video:
 
 ```html
 <audio controls>

--- a/curriculum/challenges/english/25-front-end-development/lecture-css-specificity-the-cascade-algorithm-and-inheritance/672b8ea434ceac23cc90f337.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-css-specificity-the-cascade-algorithm-and-inheritance/672b8ea434ceac23cc90f337.md
@@ -1,8 +1,9 @@
 ---
 id: 672b8ea434ceac23cc90f337
 title: What Is the Specificity for ID Selectors?
-challengeType: 11
-videoId: ZUhV2wrlOXY
+# change back to 11 when video is updated
+challengeType: 19
+# videoId: new-id-goes-here-when-ready
 dashedName: what-is-the-specificity-for-id-selectors
 ---
 
@@ -33,18 +34,6 @@ In this example, the element with the ID `unique` will have its text color set t
 ID selectors have a very high specificity, higher than type selectors and class selectors, but lower than inline styles. The specificity value for an ID selector is `(0, 1, 0, 0)`.
 
 This means that ID selectors can override class selectors and type selectors but can be overridden by inline styles.
-
-ID selectors can be combined with other selectors to create even more specific rules.
-
-Here is an example of combining a `div` type selector with an ID selector called `unique`:
-
-```css
-div#unique {
-  font-size: 20px;
-}
-```
-
-This rule applies only to `div` elements that have the `unique` ID, setting their font size to `20px`.
 
 # --questions--
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-css-specificity-the-cascade-algorithm-and-inheritance/672b8ea434ceac23cc90f337.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-css-specificity-the-cascade-algorithm-and-inheritance/672b8ea434ceac23cc90f337.md
@@ -9,7 +9,7 @@ dashedName: what-is-the-specificity-for-id-selectors
 
 # --description--
 
-Watch the video or read the transcript and answer the questions below.
+Read the transcript and answer the questions below.
 
 # --transcript--
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-understanding-core-javascript-fundamentals/6732c69d82814160951b1aa7.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-understanding-core-javascript-fundamentals/6732c69d82814160951b1aa7.md
@@ -9,7 +9,7 @@ dashedName: what-is-the-number-constructor-and-how-does-it-work-for-type-coercio
 
 # --description--
 
-Watch the video or read the transcript and answer the questions below.
+Read the transcript and answer the questions below.
 
 # --transcript--
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-understanding-core-javascript-fundamentals/6732c69d82814160951b1aa7.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-understanding-core-javascript-fundamentals/6732c69d82814160951b1aa7.md
@@ -1,8 +1,9 @@
 ---
 id: 6732c69d82814160951b1aa7
 title: What Is the Number Constructor, and How Does It Work for Type Coercion?
-challengeType: 11
-videoId: ZY_GdH7FbPI
+# change back to 11 when video is updated
+challengeType: 19
+# videoId: new-id-goes-here-when-ready
 dashedName: what-is-the-number-constructor-and-how-does-it-work-for-type-coercion
 ---
 
@@ -70,7 +71,25 @@ console.log(undefinedNum); // NaN
 console.log(nullNum); // 0
 ```
 
-When working with arrays there are a few things to consider, an empty array will return `0`, an array with a single number will return that number, an array with multiple numbers returns `NaN`, and an array with strings will return `undefined`. 
+When working with arrays there are a few things to consider.
+
+An empty array will return `0`. An array with a single number will return that number. An array with multiple numbers returns `NaN`. And an array with string(s) will also return `NaN`.
+
+```js
+const emptyArr = Number([]);
+const arrOneNum = Number([7]);
+const arrMultiNum = Number([7, 36, 12]);
+const arrStr = Number(["str1"]);
+const arrMultiStr = Number(["str1", "str2"]);
+
+console.log(emptyArr); // 0
+console.log(arrOneNum); // 7
+console.log(arrMultiNum); // NaN
+console.log(arrStr); // NaN
+console.log(arrMultiStr); // NaN
+```
+
+When working with objects, the result is always `NaN`.
 
 ```js
 const obj1 = Number({});
@@ -83,8 +102,6 @@ console.log(obj2); // NaN
 console.log(obj3); // NaN
 console.log(obj4); // NaN
 ```
-
-When working with objects, the result is always `NaN`.
 
 In conclusion, you'll mostly use the `Number()` constructor for type conversion more than creating a number or a number object.
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-transforms-overflow-and-filters/672bcc9c4a6dd6d7dd3e6357.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-transforms-overflow-and-filters/672bcc9c4a6dd6d7dd3e6357.md
@@ -9,7 +9,7 @@ dashedName: what-is-the-css-box-model
 
 # --description--
 
-Watch the video or read the transcript and answer the questions below.
+Read the transcript and answer the questions below.
 
 # --transcript--
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-transforms-overflow-and-filters/672bcc9c4a6dd6d7dd3e6357.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-transforms-overflow-and-filters/672bcc9c4a6dd6d7dd3e6357.md
@@ -1,8 +1,9 @@
 ---
 id: 672bcc9c4a6dd6d7dd3e6357
 title: What Is the CSS Box Model, and How Does It Work?
-challengeType: 11
-videoId: nLqcavL4_m0
+# change back to 11 when video is updated
+challengeType: 19
+# videoId: new-id-goes-here-when-ready
 dashedName: what-is-the-css-box-model
 ---
 
@@ -22,13 +23,11 @@ The content area is the innermost part of the box. It's the space that contains 
 
 The padding is the area immediately after the content area. It's the space between the content area and the border of an element. With the padding you can add space around the content to improve it's readability. You can set different values for the top, right, bottom and left padding with the `padding` property.  
 
-This is an example with the `padding` shorthand property, where we set the top padding to fifteen pixels, the left padding to five pixels, the bottom padding to two pixels and the left padding to eight pixels:  
+This is an example with the `padding` shorthand property, where we set the top padding to fifteen pixels, the right padding to five pixels, the bottom padding to two pixels and the left padding to eight pixels:  
 
 ```css
 padding: 15px 5px 2px 8px;
 ```
-
-Where we set the top padding to fifteen pixels, the left padding to five pixels, the bottom padding to two pixels and the left padding to eight pixels.
 
 The border is the outer edge or outline of an element in the CSS box model. It's the visual boundary of the element. You can customize the border style, width, color and other properties using the `border` property. Here's an example where we set the border to a width of five pixels, a solid state and a color of blue: 
 


### PR DESCRIPTION
We have issues open concerning incorrect information in lectures.
https://github.com/freeCodeCamp/freeCodeCamp/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22lecture%20video%22

I prioritized the issues where there was an error and it needed to be updated. Since it will take a while to re record and edit those videos, we do want to just show the transcript for now with the corrections so we don't have lectures live on site with errors. Then when a video is ready, we can add it in a separate PR.

I chose to only prioritize lectures with errors as opposed to lecture with nice to haves additions. Those can wait for the video to be ready. 

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.



