### PR TITLE
chore(client,curriculum): add test to catch meta misname

### DIFF
--- a/client/i18n/locales.test.ts
+++ b/client/i18n/locales.test.ts
@@ -95,25 +95,32 @@ describe('Intro file name test:', () => {
     for (const superBlock of superblocks) {
       const blocks = Object.keys(typedIntro[superBlock].blocks);
       blocks.forEach(block => {
-        const exists = fs.existsSync(
-          `${__dirname}/../../curriculum/challenges/_meta/${block}/meta.json`
-        );
-        expect(exists).toBeTruthy();
+        if (typedIntro[superBlock].blocks[block].intro.length > 0) {
+          const exists = fs.existsSync(
+            `${__dirname}/../../curriculum/challenges/_meta/${block}/meta.json`
+          );
+          expect(exists).toBeTruthy();
+        }
       });
     }
   });
 
   test('Every block name matches in the meta.json and intro.json', () => {
+    const typedIntro = intro as unknown as Intro;
     const superblocks = Object.values(SuperBlocks);
     for (const superBlock of superblocks) {
       const blocks = Object.keys(typedIntro[superBlock].blocks);
       blocks.forEach(block => {
-        const metaContent = fs.readFileSync(
-          `${__dirname}/../../curriculum/challenges/_meta/${block}/meta.json`,
-          { encoding: 'utf-8' }
-        );
-        const metaJSON = JSON.parse(metaContent) as ChallengeMeta;
-        expect(metaJSON.name).toBe(typedIntro[superBlock].blocks[block].title);
+        if (typedIntro[superBlock].blocks[block].intro.length > 0) {
+          const metaContent = fs.readFileSync(
+            `${__dirname}/../../curriculum/challenges/_meta/${block}/meta.json`,
+            { encoding: 'utf-8' }
+          );
+          const metaJSON = JSON.parse(metaContent) as ChallengeMeta;
+          expect(metaJSON.name).toBe(
+            typedIntro[superBlock].blocks[block].title
+          );
+        }
       });
     }
   });

--- a/client/i18n/locales.test.ts
+++ b/client/i18n/locales.test.ts
@@ -19,10 +19,6 @@ interface Intro {
   };
 }
 
-interface ChallengeMeta {
-  name: string;
-}
-
 const filesThatShouldExist = [
   {
     name: 'translations.json'
@@ -86,42 +82,4 @@ describe('Intro file structure tests:', () => {
       expect(typedIntro[superBlock].blocks[block].intro).toBeInstanceOf(Array);
     });
   }
-});
-
-describe('Intro file name test:', () => {
-  const typedIntro = intro as unknown as Intro;
-  test('Every block listed in intro.json has a challenge meta file', () => {
-    const superblocks = Object.values(SuperBlocks);
-    for (const superBlock of superblocks) {
-      const blocks = Object.keys(typedIntro[superBlock].blocks);
-      blocks.forEach(block => {
-        if (typedIntro[superBlock].blocks[block].intro.length > 0) {
-          const exists = fs.existsSync(
-            `${__dirname}/../../curriculum/challenges/_meta/${block}/meta.json`
-          );
-          expect(exists).toBeTruthy();
-        }
-      });
-    }
-  });
-
-  test('Every block name matches in the meta.json and intro.json', () => {
-    const typedIntro = intro as unknown as Intro;
-    const superblocks = Object.values(SuperBlocks);
-    for (const superBlock of superblocks) {
-      const blocks = Object.keys(typedIntro[superBlock].blocks);
-      blocks.forEach(block => {
-        if (typedIntro[superBlock].blocks[block].intro.length > 0) {
-          const metaContent = fs.readFileSync(
-            `${__dirname}/../../curriculum/challenges/_meta/${block}/meta.json`,
-            { encoding: 'utf-8' }
-          );
-          const metaJSON = JSON.parse(metaContent) as ChallengeMeta;
-          expect(metaJSON.name).toBe(
-            typedIntro[superBlock].blocks[block].title
-          );
-        }
-      });
-    }
-  });
 });

--- a/client/i18n/locales.test.ts
+++ b/client/i18n/locales.test.ts
@@ -19,6 +19,10 @@ interface Intro {
   };
 }
 
+interface ChallengeMeta {
+  name: string;
+}
+
 const filesThatShouldExist = [
   {
     name: 'translations.json'
@@ -82,4 +86,35 @@ describe('Intro file structure tests:', () => {
       expect(typedIntro[superBlock].blocks[block].intro).toBeInstanceOf(Array);
     });
   }
+});
+
+describe('Intro file name test:', () => {
+  const typedIntro = intro as unknown as Intro;
+  test('Every block listed in intro.json has a challenge meta file', () => {
+    const superblocks = Object.values(SuperBlocks);
+    for (const superBlock of superblocks) {
+      const blocks = Object.keys(typedIntro[superBlock].blocks);
+      blocks.forEach(block => {
+        const exists = fs.existsSync(
+          `${__dirname}/../../curriculum/challenges/_meta/${block}/meta.json`
+        );
+        expect(exists).toBeTruthy();
+      });
+    }
+  });
+
+  test('Every block name matches in the meta.json and intro.json', () => {
+    const superblocks = Object.values(SuperBlocks);
+    for (const superBlock of superblocks) {
+      const blocks = Object.keys(typedIntro[superBlock].blocks);
+      blocks.forEach(block => {
+        const metaContent = fs.readFileSync(
+          `${__dirname}/../../curriculum/challenges/_meta/${block}/meta.json`,
+          { encoding: 'utf-8' }
+        );
+        const metaJSON = JSON.parse(metaContent) as ChallengeMeta;
+        expect(metaJSON.name).toBe(typedIntro[superBlock].blocks[block].title);
+      });
+    }
+  });
 });

--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -145,12 +145,6 @@
           "In this course, you'll build a quiz webpage. You'll learn accessibility tools such as keyboard shortcuts, ARIA attributes, and design best practices."
         ]
       },
-      "learn-intermediate-css-by-building-a-picasso-painting": {
-        "title": "Learn Intermediate CSS by Building a Picasso Painting",
-        "intro": [
-          "In this course, you'll learn how to use some intermediate CSS techniques by coding your own Picasso painting webpage. You'll learn about SVG icons, CSS positioning, and review other CSS skills you've learned."
-        ]
-      },
       "learn-responsive-web-design-by-building-a-piano": {
         "title": "Learn Responsive Web Design by Building a Piano",
         "intro": [

--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -3765,7 +3765,7 @@
         ]
       },
       "lab-rpg-character": {
-        "title": "Build an RPG character",
+        "title": "Build an RPG Character",
         "intro": [
           "In this lab you will practice basic python by building an RPG character."
         ]

--- a/curriculum/challenges/_meta/lab-fortune-teller/meta.json
+++ b/curriculum/challenges/_meta/lab-fortune-teller/meta.json
@@ -1,5 +1,5 @@
 {
-  "name": "Build a Fortune Teller App",
+  "name": "Build a Fortune Teller",
   "blockType": "lab",
   "blockLayout": "link",
   "isUpcomingChange": false,

--- a/curriculum/challenges/_meta/lab-truncate-string/meta.json
+++ b/curriculum/challenges/_meta/lab-truncate-string/meta.json
@@ -1,5 +1,5 @@
 {
-  "name": "Implement the Truncate a String Algorithm",
+  "name": "Implement the Truncate String Algorithm",
   "isUpcomingChange": false,
   "usesMultifileEditor": true,
   "blockType": "lab",

--- a/curriculum/challenges/_meta/lecture-what-is-html/meta.json
+++ b/curriculum/challenges/_meta/lecture-what-is-html/meta.json
@@ -1,5 +1,5 @@
 {
-  "name": "What is HTML?",
+  "name": "Understanding HTML Attributes and the HTML Boilerplate",
   "isUpcomingChange": false,
   "dashedName": "lecture-what-is-html",
   "superBlock": "full-stack-developer",

--- a/tools/challenge-helper-scripts/block-name-match.test.ts
+++ b/tools/challenge-helper-scripts/block-name-match.test.ts
@@ -1,0 +1,58 @@
+import fs from 'fs';
+import intro from '../../client/i18n/locales/english/intro.json';
+import { SuperBlocks } from '../../shared/config/curriculum';
+
+interface Intro {
+  [key: string]: {
+    title: string;
+    intro: string[];
+    blocks: {
+      [block: string]: {
+        title: string;
+        intro: string[];
+      };
+    };
+  };
+}
+
+interface ChallengeMeta {
+  name: string;
+}
+
+describe('Intro file name test:', () => {
+  const typedIntro = intro as unknown as Intro;
+  test('Every block listed in intro.json has a challenge meta file', () => {
+    const superblocks = Object.values(SuperBlocks);
+    for (const superBlock of superblocks) {
+      const blocks = Object.keys(typedIntro[superBlock].blocks);
+      blocks.forEach(block => {
+        if (typedIntro[superBlock].blocks[block].intro.length > 0) {
+          const exists = fs.existsSync(
+            `${__dirname}/../../curriculum/challenges/_meta/${block}/meta.json`
+          );
+          expect(exists).toBeTruthy();
+        }
+      });
+    }
+  });
+
+  test('Every block name matches in the meta.json and intro.json', () => {
+    const typedIntro = intro as unknown as Intro;
+    const superblocks = Object.values(SuperBlocks);
+    for (const superBlock of superblocks) {
+      const blocks = Object.keys(typedIntro[superBlock].blocks);
+      blocks.forEach(block => {
+        if (typedIntro[superBlock].blocks[block].intro.length > 0) {
+          const metaContent = fs.readFileSync(
+            `${__dirname}/../../curriculum/challenges/_meta/${block}/meta.json`,
+            { encoding: 'utf-8' }
+          );
+          const metaJSON = JSON.parse(metaContent) as ChallengeMeta;
+          expect(metaJSON.name).toBe(
+            typedIntro[superBlock].blocks[block].title
+          );
+        }
+      });
+    }
+  });
+});


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #60660

<!-- Feel free to add any additional description of changes below this line -->
I'm still trying to decide if this is the spot the test should ultimately end up. I have yet to re-enable the CI tests because there are still additional block names that don't match up and I am lacking context for some of them. 