### PR TITLE
chore(api): add user's id to errors sent to Sentry

### DIFF
--- a/api/src/plugins/auth.ts
+++ b/api/src/plugins/auth.ts
@@ -67,6 +67,11 @@ const auth: FastifyPluginCallback = (fastify, _options, done) => {
     };
 
     if (isExpired(accessToken)) return setAccessDenied(req, TOKEN_EXPIRED);
+    // We're using token.userId since it's possible for the user record to be
+    // malformed and for prisma to throw while trying to find the user.
+    fastify.Sentry.setUser({
+      id: accessToken.userId
+    });
 
     const user = await fastify.prisma.user.findUnique({
       where: { id: accessToken.userId }
@@ -142,6 +147,12 @@ const auth: FastifyPluginCallback = (fastify, _options, done) => {
         message: 'Token not found'
       };
     }
+    // We're using token.userId since it's possible for the user record to be
+    // malformed and for prisma to throw while trying to find the user.
+
+    fastify.Sentry.setUser({
+      id: token.userId
+    });
 
     const user = await fastify.prisma.user.findUnique({
       where: { id: token.userId }

--- a/api/src/plugins/auth.ts
+++ b/api/src/plugins/auth.ts
@@ -69,7 +69,7 @@ const auth: FastifyPluginCallback = (fastify, _options, done) => {
     if (isExpired(accessToken)) return setAccessDenied(req, TOKEN_EXPIRED);
     // We're using token.userId since it's possible for the user record to be
     // malformed and for prisma to throw while trying to find the user.
-    fastify.Sentry.setUser({
+    fastify.Sentry?.setUser({
       id: accessToken.userId
     });
 
@@ -150,7 +150,7 @@ const auth: FastifyPluginCallback = (fastify, _options, done) => {
     // We're using token.userId since it's possible for the user record to be
     // malformed and for prisma to throw while trying to find the user.
 
-    fastify.Sentry.setUser({
+    fastify.Sentry?.setUser({
       id: token.userId
     });
 


### PR DESCRIPTION
This should make it easier to find users with malformed user documents.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->
