### PR TITLE
fix(curriculum): accept let and var declaration in Color picker lab

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-color-picker/67bf4350777ac6ffdc027745.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-color-picker/67bf4350777ac6ffdc027745.md
@@ -132,10 +132,8 @@ assert.strictEqual(mostCertainlyAnInput.value, "#ffffff");
 The initial value of your `#color-input` should be managed by your `useState` hook.
 
 ```js
-const declaredState = code.match(/const\s*\[\s*(.*)\s*,.*\]\s*=\s*useState/);
-console.log(declaredState);
+const declaredState = code.match(/(?:const|let|var)\s*\[\s*(.*)\s*,.*\]\s*=\s*useState/);
 const declaredStateVar = declaredState?.[1];
-console.log(declaredStateVar);
 const regex = new RegExp(`value\s*=\s*\{\s*${declaredStateVar}\s*}`);
 assert.match(code, regex);
 ```


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

- - -
- Allows `let` and `var` declarations for the destructuring of `useState`.
- Additionally removes two leftover `console.log` calls.