### PR TITLE
fix(curriculum): add user image tag and correct grammar in FCC authors pages

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641da803d9892447d059804e.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641da803d9892447d059804e.md
@@ -7,7 +7,7 @@ dashedName: step-17
 
 # --description--
 
-Now create an image tag and give it the `class` `"user-img"`. Use string interpolation to set the `src` attribute to `image` you destructured earlier. Set the `alt` attribute to `author` followed by the text `"avatar"`. Make sure there is a space between the `author` variable and the word `"avatar"`, for example, `"Quincy Larson avatar"`.
+Now create an image tag and give it the `class` `"user-img"`. Use string interpolation to set the `src` attribute to the `image` you destructured earlier. Set the `alt` attribute to `author` followed by the text `"avatar"`. Make sure there is a space between the `author` variable and the word `"avatar"`, for example, `"Quincy Larson avatar"`.
 
 # --before-all--
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-fcc-authors-page/641da803d9892447d059804e.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-fcc-authors-page/641da803d9892447d059804e.md
@@ -179,7 +179,7 @@ const displayAuthors = (authors) => {
     <div id="${index}" class="user-card">
       <h2 class="author-name">${author}</h2>
       --fcc-editable-region--
-
+      <img class="user-img" src="${image}" alt="${author} avatar" />
       --fcc-editable-region--
     </div>
   `;


### PR DESCRIPTION
Description:
This pull request improves the FCC Authors Page by correcting grammar in the instructions, adding “the” before image for better clarity.

Additionally, it adds an image tag with the class user-img and sets the src attribute from the destructured image variable to enhance the user card display.

Testing:
Tested locally by reviewing markdown changes and confirming the wording matches the expected style.

Closes:
Closes #60767

Checklist:

 [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org/).

[x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).

 [x]My pull request targets the main branch of freeCodeCamp.

[x] I have tested these changes either locally on my machine or Gitpod.