### PR TITLE
Update tests to use specific asserts

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641da803d9892447d059804e.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-fetch-and-promises-by-building-an-fcc-authors-page/641da803d9892447d059804e.md
@@ -7,7 +7,7 @@ dashedName: step-17
 
 # --description--
 
-Now create an image tag and give it the `class` `"user-img"`. Use string interpolation to set the `src` attribute to `image` you destructured earlier. Set the `alt` attribute to `author` followed by the text `"avatar"`. Make sure there is a space between the `author` variable and the word `"avatar"`, for example, `"Quincy Larson avatar"`.
+Now create an image tag and give it the `class` `"user-img"`. Use string interpolation to set the `src` attribute to the `image` you destructured earlier. Set the `alt` attribute to `author` followed by the text `"avatar"`. Make sure there is a space between the `author` variable and the word `"avatar"`, for example, `"Quincy Larson avatar"`.
 
 # --before-all--
 

--- a/curriculum/challenges/english/18-project-euler/project-euler-problems-1-to-100/problem-21-amicable-numbers.md
+++ b/curriculum/challenges/english/18-project-euler/project-euler-problems-1-to-100/problem-21-amicable-numbers.md
@@ -21,7 +21,7 @@ Evaluate the sum of all the amicable numbers under `n`.
 `sumAmicableNum(1000)` should return a number.
 
 ```js
-assert(typeof sumAmicableNum(1000) === 'number');
+assert.isNumber(sumAmicableNum(1000));
 ```
 
 `sumAmicableNum(1000)` should return 504.

--- a/curriculum/challenges/english/18-project-euler/project-euler-problems-1-to-100/problem-22-names-scores.md
+++ b/curriculum/challenges/english/18-project-euler/project-euler-problems-1-to-100/problem-22-names-scores.md
@@ -19,7 +19,7 @@ What is the total of all the name scores in the array?
 `namesScores(test1)` should return a number.
 
 ```js
-assert(typeof namesScores(test1) === 'number');
+assert.isNumber(namesScores(test1));
 ```
 
 `namesScores(test1)` should return 791.

--- a/curriculum/challenges/english/18-project-euler/project-euler-problems-1-to-100/problem-23-non-abundant-sums.md
+++ b/curriculum/challenges/english/18-project-euler/project-euler-problems-1-to-100/problem-23-non-abundant-sums.md
@@ -21,31 +21,31 @@ Find the sum of all positive integers &lt;= `n` which cannot be written as the s
 `sumOfNonAbundantNumbers(10000)` should return a number.
 
 ```js
-assert(typeof sumOfNonAbundantNumbers(10000) === 'number');
+assert.isNumber(sumOfNonAbundantNumbers(10000));
 ```
 
 `sumOfNonAbundantNumbers(10000)` should return 3731004.
 
 ```js
-assert(sumOfNonAbundantNumbers(10000) === 3731004);
+assert.strictEqual(sumOfNonAbundantNumbers(10000), 3731004);
 ```
 
 `sumOfNonAbundantNumbers(15000)` should return 4039939.
 
 ```js
-assert(sumOfNonAbundantNumbers(15000) === 4039939);
+assert.strictEqual(sumOfNonAbundantNumbers(15000), 4039939);
 ```
 
 `sumOfNonAbundantNumbers(20000)` should return 4159710.
 
 ```js
-assert(sumOfNonAbundantNumbers(20000) === 4159710);
+assert.strictEqual(sumOfNonAbundantNumbers(20000), 4159710);
 ```
 
 `sumOfNonAbundantNumbers(28123)` should return 4179871.
 
 ```js
-assert(sumOfNonAbundantNumbers(28123) === 4179871);
+assert.strictEqual(sumOfNonAbundantNumbers(28123), 4179871);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/18-project-euler/project-euler-problems-1-to-100/problem-24-lexicographic-permutations.md
+++ b/curriculum/challenges/english/18-project-euler/project-euler-problems-1-to-100/problem-24-lexicographic-permutations.md
@@ -19,13 +19,13 @@ What is the `n`th lexicographic permutation of the digits 0, 1, 2, 3, 4, 5, 6, 7
 `lexicographicPermutations(699999)` should return a number.
 
 ```js
-assert(typeof lexicographicPermutations(699999) === 'number');
+assert.isNumber(lexicographicPermutations(699999));
 ```
 
 `lexicographicPermutations(699999)` should return 1938246570.
 
 ```js
-assert(lexicographicPermutations(699999) == 1938246570);
+assert.strictEqual(lexicographicPermutations(699999), 1938246570);
 ```
 
 `lexicographicPermutations(899999)` should return 2536987410.
@@ -37,13 +37,13 @@ assert(lexicographicPermutations(899999) == 2536987410);
 `lexicographicPermutations(900000)` should return 2537014689.
 
 ```js
-assert(lexicographicPermutations(900000) == 2537014689);
+assert.strictEqual(lexicographicPermutations(900000), 2537014689);
 ```
 
 `lexicographicPermutations(999999)` should return 2783915460.
 
 ```js
-assert(lexicographicPermutations(999999) == 2783915460);
+assert.strictEqual(lexicographicPermutations(999999), 2783915460);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/18-project-euler/project-euler-problems-1-to-100/problem-25-1000-digit-fibonacci-number.md
+++ b/curriculum/challenges/english/18-project-euler/project-euler-problems-1-to-100/problem-25-1000-digit-fibonacci-number.md
@@ -25,7 +25,7 @@ What is the index of the first term in the Fibonacci sequence to contain `n` dig
 `digitFibonacci(5)` should return a number.
 
 ```js
-assert(typeof digitFibonacci(5) === 'number');
+assert.isNumber(digitFibonacci(5));
 ```
 
 `digitFibonacci(5)` should return 21.

--- a/curriculum/challenges/english/25-front-end-development/workshop-fcc-authors-page/641da803d9892447d059804e.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-fcc-authors-page/641da803d9892447d059804e.md
@@ -7,7 +7,7 @@ dashedName: step-12
 
 # --description--
 
-Now create an image tag and give it a `class` attribute of `"user-img"`. Use string interpolation to set the `src` attribute to `image` you destructured earlier. Set the `alt` attribute to `author` followed by the text `"avatar"`. Make sure there is a space between the `author` variable and the word `"avatar"`, for example, `"Quincy Larson avatar"`.
+Now create an image tag and give it a `class` attribute of `"user-img"`. Use string interpolation to set the `src` attribute to the `image` you destructured earlier. Set the `alt` attribute to `author` followed by the text `"avatar"`. Make sure there is a space between the `author` variable and the word `"avatar"`, for example, `"Quincy Larson avatar"`.
 
 # --before-all--
 


### PR DESCRIPTION
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

Closes #60742

### Description

This pull request updates the tests in the Project Euler problems 21-25 challenges to use specific assertion methods as recommended by the issue #60742.

- Replaces generic `assert` calls with `assert.isNumber()` where applicable to check types.
- Replaces equality checks with `assert.strictEqual()` for better assertion clarity.
- Adds missing semicolons where needed.

### Files updated:

- `curriculum/challenges/english/18-project-euler/project-euler-problems-1-to-100/problem-21-amicable-numbers.md`
- `curriculum/challenges/english/18-project-euler/project-euler-problems-1-to-100/problem-22-names-scores.md`
- `curriculum/challenges/english/18-project-euler/project-euler-problems-1-to-100/problem-23-non-abundant-sums.md`
- `curriculum/challenges/english/18-project-euler/project-euler-problems-1-to-100/problem-24-lexicographic-permutations.md`
- `curriculum/challenges/english/18-project-euler/project-euler-problems-1-to-100/problem-25-1000-digit-fibonacci-number.md`

---

Thank you for reviewing this contribution! Please let me know if any further changes are needed.