### PR TITLE
fix(a11y): update PrismFormatted usage for quiz question text

### DIFF
--- a/client/src/templates/Challenges/quiz/show.tsx
+++ b/client/src/templates/Challenges/quiz/show.tsx
@@ -174,7 +174,6 @@ const ShowQuiz = ({
             className='quiz-question-label'
             text={question.text}
           />
-
         ),
         answers: shuffleArray([...distractors, answer]),
         correctAnswer: answer.value

--- a/client/src/templates/Challenges/quiz/show.tsx
+++ b/client/src/templates/Challenges/quiz/show.tsx
@@ -172,10 +172,9 @@ const ShowQuiz = ({
         question: (
           <PrismFormatted
             className='quiz-question-label'
-            text={removeParagraphTags(question.text)}
-            useSpan
-            noAria
+            text={question.text}
           />
+
         ),
         answers: shuffleArray([...distractors, answer]),
         correctAnswer: answer.value


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #60719

<!-- Feel free to add any additional description of changes below this line -->

This PR fixes how quiz question text is announced by screen readers.

### Changes:
- Replaced:
  ```tsx
  <PrismFormatted 
    className='quiz-question-label' 
    text={removeParagraphTags(question.text)} 
    useSpan 
    noAria 
  />

