### PR TITLE
fix(curriculum): return empty string in Reusable Profile Card Component

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef11f75254548672d998c.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef11f75254548672d998c.md
@@ -10,7 +10,6 @@ demoType: onLoad
 
 In this project, you will learn how to work with props by building a reusable profile card component.
 
-
 Start by using the `export` keyword to create a `Card` functional component with `name`, `title`, and `bio` as the props. Don't forget to make sure they're all wrapped in curly braces. That way, you destructure them instead of accessing them from `props`.
 
 Also, return a pair of parentheses with an empty string inside for now.

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef11f75254548672d998c.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef11f75254548672d998c.md
@@ -39,7 +39,7 @@ Your `Card` component should return an empty string.
 const functionRegex = __helpers.functionRegex("Card", null, { capture: true });
 const match = code.match(functionRegex);
 const functionDefinition = match[0];
-assert.match(functionDefinition, /\s*{\s*return\s*\(\s*(''|""|``)\s*\)\s*}/);
+assert.match(functionDefinition, /\s*{\s*return\s*\(\s*(''|""|``)\s*\)\s*}|\s*=>\s*[(\2)]/);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef11f75254548672d998c.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef11f75254548672d998c.md
@@ -10,6 +10,7 @@ demoType: onLoad
 
 In this project, you will learn how to work with props by building a reusable profile card component.
 
+
 Start by using the `export` keyword to create a `Card` functional component with `name`, `title`, and `bio` as the props. Don't forget to make sure they're all wrapped in curly braces. That way, you destructure them instead of accessing them from `props`.
 
 Also, return a pair of parentheses with an empty string inside for now.

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef11f75254548672d998c.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef11f75254548672d998c.md
@@ -39,7 +39,7 @@ Your `Card` component should return an empty string.
 const functionRegex = __helpers.functionRegex("Card", null, { capture: true });
 const match = code.match(functionRegex);
 const functionDefinition = match[0];
-assert.match(functionDefinition, /\s*{\s*return\s*\(\s*(''|""|``)\s*\)\s*}|\s*=>\s*[(\2)]/);
+assert.match(functionDefinition, /\s*{\s*return\s*\(\s*(''|""|``)\s*\)\s*}|\s*=>\s*\(\s*(''|""|``)\s*\)/);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef11f75254548672d998c.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef11f75254548672d998c.md
@@ -16,7 +16,7 @@ Also, return a pair of parentheses with an empty string inside for now.
 
 # --hints--
 
-You should create and export a `Card` functional component. Don't forget to return an empty string inside it.
+You should create and export a `Card` functional component.
 
 ```js
 assert.isFunction(window.index.Card);
@@ -31,6 +31,15 @@ const functionDefinition = match[0];
 assert.match(functionDefinition, /\{[^{]*name[^{]*\}/);
 assert.match(functionDefinition, /\{[^{]*title[^{]*\}/);
 assert.match(functionDefinition, /\{[^{]*bio[^{]*\}/);
+```
+
+Your `Card` component should return an empty string.
+
+```js
+const functionRegex = __helpers.functionRegex("Card", null, { capture: true });
+const match = code.match(functionRegex);
+const functionDefinition = match[0];
+assert.match(functionDefinition, /\s*{\s*return\s*\(\s*(''|""|``)\s*\)\s*}/);
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #60796

<!-- Feel free to add any additional description of changes below this line -->

![image](https://github.com/user-attachments/assets/86decc30-c3d3-4415-b144-0c23a4dfd9c7)

![image](https://github.com/user-attachments/assets/9b09694e-11be-4be8-bb3b-229b202ae686)
