### PR TITLE
fix(curriculum): inconsistent value attribute between steps 9 to 12 in superhero application form

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-superhero-application-form/680900675ae3d54ee19590c9.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-superhero-application-form/680900675ae3d54ee19590c9.md
@@ -19,51 +19,60 @@ Inside your `select` element, you need to create options for the user to choose 
 | `Ancient artifact discovery`    |
 | `Other`                         |
 
+The first option (`Select one`) should have an empty string as its `value` attribute (i.e., `value=''`). This acts as a placeholder in the UI.
+
 # --hints--
 
-Your should create the first `option` element with the text `Select one` inside your `select` element.
+You should create the first `option` element with the text `Select one` inside your `select` element.
 
 ```js
 const optionEls = document?.querySelectorAll("select > option");
 assert.equal(optionEls[0]?.textContent, "Select one");
 ```
 
-Your should create a second `option` element with the text `Bitten by a strange creature` inside your `select` element.
+You should give the first `option` element a `value` attribute with an empty string.
+
+```js
+const optionEls = document?.querySelectorAll("select > option");
+assert.equal(optionEls[0]?.getAttribute('value'), '');
+```
+
+You should create a second `option` element with the text `Bitten by a strange creature` inside your `select` element.
 
 ```js
 const optionEls = document?.querySelectorAll("select > option");
 assert.equal(optionEls[1]?.textContent, "Bitten by a strange creature");
 ```
 
-Your should create a third `option` element with the text `Radioactive exposure` inside your `select` element.
+You should create a third `option` element with the text `Radioactive exposure` inside your `select` element.
 
 ```js
 const optionEls = document?.querySelectorAll("select > option");
 assert.equal(optionEls[2]?.textContent, "Radioactive exposure");
 ```
 
-Your should create a fourth `option` element with the text `Science experiment` inside your `select` element.
+You should create a fourth `option` element with the text `Science experiment` inside your `select` element.
 
 ```js
 const optionEls = document?.querySelectorAll("select > option");
 assert.equal(optionEls[3]?.textContent, "Science experiment");
 ```
 
-Your should create a fifth `option` element with the text `Alien heritage` inside your `select` element.
+You should create a fifth `option` element with the text `Alien heritage` inside your `select` element.
 
 ```js
 const optionEls = document?.querySelectorAll("select > option");
 assert.equal(optionEls[4]?.textContent, "Alien heritage");
 ```
 
-Your should create a sixth `option` element with the text `Ancient artifact discovery` inside your `select` element.
+You should create a sixth `option` element with the text `Ancient artifact discovery` inside your `select` element.
 
 ```js
 const optionEls = document?.querySelectorAll("select > option");
 assert.equal(optionEls[5]?.textContent, "Ancient artifact discovery");
 ```
 
-Your should create a seventh `option` element with the text `Other` inside your `select` element.
+You should create a seventh `option` element with the text `Other` inside your `select` element.
 
 ```js
 const optionEls = document?.querySelectorAll("select > option");

--- a/curriculum/challenges/english/25-front-end-development/workshop-superhero-application-form/680900675ae3d54ee19590cb.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-superhero-application-form/680900675ae3d54ee19590cb.md
@@ -219,7 +219,7 @@ export const SuperheroForm = () => {
         <label className='section column'>
           How did you get your powers?
           <select>
-            <option>
+            <option value=''>
               Select one
             </option>
           --fcc-editable-region--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #60750

<!-- Feel free to add any additional description of changes below this line -->

### Changes Description:
- Corrected typo in each hint (`Your` → `You`)
- Fixed inconsistent value attribute across the steps:
  - **Step 9**: Extended the instruction and added a test case to check for `value=''` on the first `<option>`
  - **Step 11**: Added `value=''` to the seed code for the first `<option>`

### Step 9 Updates:

**Updated Instruction**:

![instr](https://github.com/user-attachments/assets/8857907d-3f94-4072-869f-b7fdeeb33c8d)

**Test Case Previews**:

_Fail_:

![fail](https://github.com/user-attachments/assets/4e5a4cc0-437c-41e9-8305-cf15f352e900)

_Success_:

![succ](https://github.com/user-attachments/assets/e477a9fe-c1d0-42a4-8e36-826815387260)