### PR TITLE
fix(external curricula): use strings for superblock stages

### DIFF
--- a/tools/scripts/build/build-external-curricula-data-v2.test.ts
+++ b/tools/scripts/build/build-external-curricula-data-v2.test.ts
@@ -20,7 +20,8 @@ import {
   type GeneratedBlockBasedCurriculumProps,
   type GeneratedChapterBasedCurriculumProps,
   type ChapterBasedCurriculumIntros,
-  orderedSuperBlockInfo
+  orderedSuperBlockInfo,
+  OrderedSuperBlocks
 } from './build-external-curricula-data-v2';
 
 const VERSION = 'v2';
@@ -55,15 +56,24 @@ describe('external curriculum data build', () => {
   });
 
   test('the available-superblocks file should have the correct structure', async () => {
+    const filteredSuperBlockStages: string[] = Object.keys(SuperBlockStage)
+      .filter(key => isNaN(Number(key))) // Filter out numeric keys to get only the names
+      .filter(name => name !== 'Upcoming' && name !== 'Next') // Filter out 'Upcoming' and 'Next'
+      .map(name => name.toLowerCase());
+
     const validateAvailableSuperBlocks = availableSuperBlocksValidator();
-    const availableSuperblocks: unknown = JSON.parse(
+    const availableSuperblocks = JSON.parse(
       await fs.promises.readFile(
         `${clientStaticPath}/curriculum-data/${VERSION}/available-superblocks.json`,
         'utf-8'
       )
-    );
+    ) as { superblocks: OrderedSuperBlocks };
 
     const result = validateAvailableSuperBlocks(availableSuperblocks);
+
+    expect(Object.keys(availableSuperblocks.superblocks)).toHaveLength(
+      filteredSuperBlockStages.length
+    );
 
     if (result.error) {
       throw Error(

--- a/tools/scripts/build/build-external-curricula-data-v2.test.ts
+++ b/tools/scripts/build/build-external-curricula-data-v2.test.ts
@@ -75,6 +75,10 @@ describe('external curriculum data build', () => {
       filteredSuperBlockStages.length
     );
 
+    expect(Object.keys(availableSuperblocks.superblocks)).toEqual(
+      expect.arrayContaining(filteredSuperBlockStages)
+    );
+
     if (result.error) {
       throw Error(
         `file: available-superblocks.json
@@ -273,23 +277,35 @@ ${result.error.message}`);
   });
 
   test('All public SuperBlocks should be present in the SuperBlock object', () => {
-    const stages = Object.keys(orderedSuperBlockInfo).map(
-      key => Number(key) as SuperBlockStage
-    );
+    // Create a mapping from string to shared/config SuperBlockStage enum value
+    // so we can look up the enum value by string.
+    const superBlockStageStringMap: Record<string, SuperBlockStage> = {
+      core: SuperBlockStage.Core,
+      english: SuperBlockStage.English,
+      professional: SuperBlockStage.Professional,
+      extra: SuperBlockStage.Extra,
+      legacy: SuperBlockStage.Legacy,
+      upcoming: SuperBlockStage.Upcoming,
+      next: SuperBlockStage.Next
+    };
 
-    expect(stages).not.toContain(SuperBlockStage.Next);
-    expect(stages).not.toContain(SuperBlockStage.Upcoming);
+    const stages = Object.keys(orderedSuperBlockInfo);
+
+    expect(stages).not.toContain('next');
+    expect(stages).not.toContain('upcoming');
 
     for (const stage of stages) {
       const superBlockDashedNames = orderedSuperBlockInfo[stage].map(
         superBlock => superBlock.dashedName
       );
 
+      const stageValueInNum = superBlockStageStringMap[stage];
+
       expect(superBlockDashedNames).toEqual(
-        expect.arrayContaining(superBlockStages[stage])
+        expect.arrayContaining(superBlockStages[stageValueInNum])
       );
       expect(superBlockDashedNames).toHaveLength(
-        superBlockStages[stage].length
+        superBlockStages[stageValueInNum].length
       );
     }
   });

--- a/tools/scripts/build/build-external-curricula-data-v2.ts
+++ b/tools/scripts/build/build-external-curricula-data-v2.ts
@@ -2,10 +2,7 @@ import { mkdirSync, writeFileSync, readFileSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { submitTypes } from '../../../shared/config/challenge-types';
 import { type ChallengeNode } from '../../../client/src/redux/prop-types';
-import {
-  SuperBlocks,
-  SuperBlockStage
-} from '../../../shared/config/curriculum';
+import { SuperBlocks } from '../../../shared/config/curriculum';
 import fullStackSuperBlockStructure from '../../../curriculum/superblock-structure/full-stack.json';
 import type { Chapter } from '../../../shared/config/chapters';
 
@@ -83,6 +80,16 @@ interface GeneratedBlock {
   dashedName: string;
   intro: string;
   meta: Record<string, unknown>;
+}
+
+// This enum is based on the `SuperBlockStage` enum in shared/config,
+// but with string value instead of number.
+enum SuperBlockStage {
+  Core = 'core',
+  English = 'english',
+  Professional = 'professional',
+  Extra = 'extra',
+  Legacy = 'legacy'
 }
 
 const ver = 'v2';

--- a/tools/scripts/build/build-external-curricula-data-v2.ts
+++ b/tools/scripts/build/build-external-curricula-data-v2.ts
@@ -92,6 +92,11 @@ enum SuperBlockStage {
   Legacy = 'legacy'
 }
 
+export type OrderedSuperBlocks = Record<
+  string,
+  Array<{ dashedName: SuperBlocks; public: boolean; title: string }>
+>;
+
 const ver = 'v2';
 
 const staticFolderPath = resolve(__dirname, '../../../client/static');
@@ -104,10 +109,7 @@ const intros = JSON.parse(
   readFileSync(blockIntroPath, 'utf-8')
 ) as CurriculumIntros;
 
-export const orderedSuperBlockInfo: Record<
-  string,
-  Array<{ dashedName: SuperBlocks; public: boolean; title: string }>
-> = {
+export const orderedSuperBlockInfo: OrderedSuperBlocks = {
   [SuperBlockStage.Core]: [
     {
       dashedName: SuperBlocks.FullStackDeveloper,


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

The curricula data for mobile is using the [SuperBlockStage enum](https://github.com/freeCodeCamp/freeCodeCamp/blob/main/shared/config/curriculum.ts#L80-L88) from config. The name of the super block stages are "0", "1", "2" as a result, which is hard for mobile to tell which group is supposed to be. /client doesn't have this issue because it can use `SuperBlockStage.Core`, `SuperBlockStage.English`, etc. directly.

This PR changes the super block stages in the external data to use string value.

<details>
<summary>Generated data</summary>

<img width="234" alt="Screenshot 2025-06-10 at 18 09 58" src="https://github.com/user-attachments/assets/ccfd9d06-fcc3-4874-94e1-e3bc83dee7c9" />

</details>




<!-- Feel free to add any additional description of changes below this line -->
