### PR TITLE
Feat(curriculum): Replace summary tasks by review tasks to Blocks 17 A2 curriculum

### DIFF
--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-your-progress-in-weekly-stand-up-meetings/6579dc4332b86017e39b9c03.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-your-progress-in-weekly-stand-up-meetings/6579dc4332b86017e39b9c03.md
@@ -21,7 +21,7 @@ Write the following phrases or words in the correct spot:
 
 ## --sentence--
 
-`Bob: Good morning, everyone. Let's start with our stand-up meeting. Sophie, BLANK ?`
+`Bob: Good morning, everyone. Let's start with our stand-up meeting. Sophie, BLANK?`
 
 `Sophie: Sure, Bob. I could use some help with a coding problem. I've been working on it for a while, and I BLANK a fresh pair of eyes to look at the code. Could you take a look at it after the meeting?`  
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-your-progress-in-weekly-stand-up-meetings/6579dc4332b86017e39b9c03.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-your-progress-in-weekly-stand-up-meetings/6579dc4332b86017e39b9c03.md
@@ -5,228 +5,88 @@ challengeType: 22
 dashedName: task-32
 ---
 
-<!-- (Audio) The whole dialogue. -->
+<!-- REVIEW -->
 
 # --description--
 
-This challenge combines key vocabulary and concepts from the entire dialogue between Bob and Sophie. It helps reinforce learners' understanding of the discussion's context, including expressions of assistance, suggestions, and professional collaboration.
+This is a review of the entire dialogue you just studied.
+
+# --instructions--
+
+Write the following phrases or words in the correct spot:
+
+`I'd appreciate`, `can you begin`, `documentation`, `may need`, `check it out`, `set up a time`, and `brainstorm`.
 
 # --fillInTheBlank--
 
 ## --sentence--
 
-`Bob and Sophie's meeting started with a BLANK -up session, where Sophie expressed needing help with a BLANK problem.`
+`Bob: Good morning, everyone. Let's start with our stand-up meeting. Sophie, BLANK ?`
 
-`Bob offered to BLANK some ideas and BLANK the issue. They planned to BLANK further insights during a code review BLANK .`
+`Sophie: Sure, Bob. I could use some help with a coding problem. I've been working on it for a while, and I BLANK a fresh pair of eyes to look at the code. Could you take a look at it after the meeting?`  
+
+`Bob: Absolutely. I can definitely help you with that. Just share the code with me, and I'll BLANK. I might have a few ideas on how to approach this issue. Mind if I call you later?`  
+
+`Sophie: Not at all. BLANK your input.`  
+
+`Bob: I'd like to suggest something as well. Could you provide more details about the problem, so we can BLANK some potential solutions during the review?`  
+
+`Sophie: Great suggestion. I'll prepare some BLANK, and we can discuss it during the code review.`  
+
+`Bob: Excellent. Let's BLANK for our code review session. When is best for you? I’m sure we’ll gain some valuable insights from our discussion.`
 
 ## --blanks--
 
-`stand`
+`can you begin`
 
 ### --feedback--
 
-Such session is a quick meeting where team members discuss their progress.
+This is a polite way to ask someone to start talking.
 
 ---
 
-`coding`
+`may need`
 
 ### --feedback--
 
-Sophie needed help with a problem related to computer programming.
+This phrase shows possibility and is used when something is not certain but could happen.
 
 ---
 
-`provide`
+`check it out`
 
 ### --feedback--
 
-Bob suggested he could offer, or give, ideas to solve the problem.
+This phrasal verb means to examine something.
 
 ---
 
-`review`
+`I'd appreciate`
 
 ### --feedback--
 
-It means examining or looking over something, in this case, the code.
+This is a polite way to say you would be thankful for help.
 
 ---
 
-`gain`
+`brainstorm`
 
 ### --feedback--
 
-It means to acquire, suggesting they would obtain insights from the review.
+This verb means to think of many ideas quickly.
 
 ---
 
-`session`
+`documentation`
 
 ### --feedback--
 
-It refers to a meeting or period devoted to a specific activity.
+This noun refers to written information that explains something.
 
-# --scene--
+---
 
-```json
-{
-  "setup": {
-    "background": "company1-boardroom.png",
-    "characters": [
-      {
-        "character": "Bob",
-        "position": { "x": -25, "y": 0, "z": 1 }
-      },
-      {
-        "character": "Sophie",
-        "position": { "x": 125, "y": 0, "z": 1 }
-      }
-    ],
-    "audio": {
-      "filename": "6.2-1.mp3",
-      "startTime": 1
-    },
-    "alwaysShowDialogue": true
-  },
-  "commands": [
-    {
-      "character": "Bob",
-      "position": { "x": 25, "y": 0, "z": 1 },
-      "startTime": 0
-    },
-    {
-      "character": "Sophie",
-      "position": { "x": 70, "y": 0, "z": 1 },
-      "startTime": 0.5
-    },
-    {
-      "character": "Bob",
-      "startTime": 1,
-      "finishTime": 5.36,
-      "dialogue": {
-        "text": "Good morning, everyone. Let's start with our stand-up meeting. Sophie, can you begin?",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Sophie",
-      "startTime": 6.1,
-      "finishTime": 8.58,
-      "dialogue": {
-        "text": "Sure, Bob. I could use some help with a coding problem.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Sophie",
-      "startTime": 8.98,
-      "finishTime": 13,
-      "dialogue": {
-        "text": "I've been working on it for a while, and I may need a fresh pair of eyes to look at the code.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Sophie",
-      "startTime": 13.38,
-      "finishTime": 14.9,
-      "dialogue": {
-        "text": "Could you take a look at it after the meeting?",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Bob",
-      "startTime": 15.86,
-      "finishTime": 18.08,
-      "dialogue": {
-        "text": "Absolutely. I can definitely help you with that.",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Bob",
-      "startTime": 18.3,
-      "finishTime": 20.36,
-      "dialogue": {
-        "text": "Just share the code with me, and I'll check it out.",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Bob",
-      "startTime": 20.66,
-      "finishTime": 24.74,
-      "dialogue": {
-        "text": "I might have a few ideas on how to approach this issue. Mind if I call you later?",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Sophie",
-      "startTime": 25.32,
-      "finishTime": 27.22,
-      "dialogue": {
-        "text": "Not at all. I'd appreciate your input.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Bob",
-      "startTime": 27.86,
-      "finishTime": 30.04,
-      "dialogue": {
-        "text": "I'd like to suggest something as well.",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Bob",
-      "startTime": 30.54,
-      "finishTime": 35.46,
-      "dialogue": {
-        "text": "Could you provide more details about the problem, so we can brainstorm some potential solutions during the review?",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Sophie",
-      "startTime": 36.24,
-      "finishTime": 40.5,
-      "dialogue": {
-        "text": "Great suggestion. I'll prepare some documentation, and we can discuss it during the code review.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Bob",
-      "startTime": 41.26,
-      "finishTime": 43.68,
-      "dialogue": {
-        "text": "Excellent. Let's set up a time for our code review session.",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Bob",
-      "startTime": 44.02,
-      "finishTime": 48.18,
-      "dialogue": {
-        "text": "When is best for you? I'm sure we'll gain some valuable insights from our discussion.",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Sophie",
-      "position": { "x": 125, "y": 0, "z": 1 },
-      "startTime": 48.68
-    },
-    {
-      "character": "Bob",
-      "position": { "x": -25, "y": 0, "z": 1 },
-      "startTime": 49.18
-    }
-  ]
-}
-```
+`set up a time`
+
+### --feedback--
+
+This phrase means to arrange a meeting.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-your-progress-in-weekly-stand-up-meetings/6579dc4332b86017e39b9c03.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-your-progress-in-weekly-stand-up-meetings/6579dc4332b86017e39b9c03.md
@@ -33,7 +33,7 @@ Write the following phrases or words in the correct spot:
 
 `Sophie: Great suggestion. I'll prepare some BLANK, and we can discuss it during the code review.`  
 
-`Bob: Excellent. Let's BLANK for our code review session. When is best for you? I’m sure we’ll gain some valuable insights from our discussion.`
+`Bob: Excellent. Let's BLANK for our code review session. When is best for you? I'm sure we'll gain some valuable insights from our discussion.`
 
 ## --blanks--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-your-progress-in-weekly-stand-up-meetings/6579df1646568c3268b93637.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-your-progress-in-weekly-stand-up-meetings/6579df1646568c3268b93637.md
@@ -15,7 +15,7 @@ This is a review of the entire dialogue you just studied.
 
 Write the following phrases or words in the correct spot:
 
-`stuck on`, `plate`, `dive in`, `arrange` and `bring up`.
+`stuck on`, `plate`, `dive in`, `arrange`, and `bring up`.
 
 # --fillInTheBlank--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-your-progress-in-weekly-stand-up-meetings/6579df1646568c3268b93637.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-your-progress-in-weekly-stand-up-meetings/6579df1646568c3268b93637.md
@@ -5,184 +5,64 @@ challengeType: 22
 dashedName: task-46
 ---
 
-<!-- (Audio) The whole dialogue. -->
+<!-- REVIEW -->
 
 # --description--
 
-This challenge encapsulates the key points from the dialogue between Bob and Sophie. It incorporates vocabulary related to problem-solving, teamwork, and professional collaboration in a work setting.
+This is a review of the entire dialogue you just studied.
+
+# --instructions--
+
+Write the following phrases or words in the correct spot:
+
+`stuck on`, `plate`, `dive in`, `arrange` and `bring up`.
 
 # --fillInTheBlank--
 
 ## --sentence--
 
-`In the morning meeting, Sophie wanted to BLANK up a coding issue she was BLANK with. Bob, showing willingness to help, agreed to BLANK a look at her code and BLANK the possibility of a code review session to BLANK ideas. Sophie appreciated the suggestion, acknowledging they BLANK BLANK from each other.`
+`Bob: Good morning, team. Let's start our stand-up meeting. What's on your BLANK today?` 
+
+`Sophie: Good morning, Bob. I'd like to BLANK a coding issue. I've been BLANK it for a while. Would you mind taking a look at my code? I think a fresh pair of eyes could help.`  
+
+`Bob: Of course. I’d be happy to help. Just share the code with me, and I'll BLANK. We might want to set up a short code review session after the meeting to exchange ideas and solutions. It could benefit the entire team.` 
+
+`Sophie: That's a great idea. Let's BLANK this. We can definitely learn from each other.`
 
 ## --blanks--
 
-`bring`
+`plate`
 
-### --feedback--
-
-It means to start discussing a topic, here referring to Sophie's coding issue.
+This word is part of an expression. In that context it refers to the tasks or responsibilities someone has to do at the moment.
 
 ---
 
-`stuck`
+`bring up`
 
 ### --feedback--
 
-It implies facing difficulty, relating to Sophie's challenge with the coding issue.
+This phrasal verb means to mention or introduce a topic.
 
 ---
 
-`take`
+`stuck on`
 
 ### --feedback--
 
-It suggests examining or reviewing something closely.
+This phrase means having trouble making progress with something.
 
 ---
 
-`discuss`
+`dive in`
 
 ### --feedback--
 
-It implies having a conversation to share and explore thoughts.
+This phrase means to start doing something with energy and focus.
 
 ---
 
-`exchange`
+`arrange`
 
 ### --feedback--
 
-It means to give and receive, here referring to sharing ideas and solutions.
-
----
-
-`could`
-
-### --feedback--
-
-It indicates possibility or potential, here suggesting the benefit of learning from each other.
-
----
-
-`learn`
-
-### --feedback--
-
-It means to acquire knowledge or skill, emphasizing the collaborative learning process.
-
-# --scene--
-
-```json
-{
-  "setup": {
-    "background": "company1-boardroom.png",
-    "characters": [
-      {
-        "character": "Bob",
-        "position": {
-          "x": 50,
-          "y": 15,
-          "z": 1.2
-        },
-        "opacity": 0
-      },
-      {
-        "character": "Sophie",
-        "position": {
-          "x": 50,
-          "y": 0,
-          "z": 1.4
-        },
-        "opacity": 0
-      }
-    ],
-    "audio": {
-      "filename": "6.2-2.mp3",
-      "startTime": 1,
-      "startTimestamp": 0,
-      "finishTimestamp": 28.92
-    }
-  },
-  "commands": [
-    {
-      "character": "Bob",
-      "opacity": 1,
-      "startTime": 0
-    },
-    {
-      "character": "Bob",
-      "startTime": 1,
-      "finishTime": 5.08,
-      "dialogue": {
-        "text": "Good morning team. Let's start our stand-up meeting. What's on your plate today?",
-        "align": "center"
-      }
-    },
-    {
-      "character": "Bob",
-      "opacity": 0,
-      "startTime": 5.43
-    },
-    {
-      "character": "Sophie",
-      "opacity": 1,
-      "startTime": 5.43
-    },
-    {
-      "character": "Sophie",
-      "startTime": 5.78,
-      "finishTime": 14.34,
-      "dialogue": {
-        "text": "Good morning, Bob. I'd like to bring up a coding issue. I've been stuck on it for a while Would you mind taking a look at my code? I think a fresh pair of eyes could help",
-        "align": "center"
-      }
-    },
-    {
-      "character": "Sophie",
-      "opacity": 0,
-      "startTime": 14.34
-    },
-    {
-      "character": "Bob",
-      "opacity": 1,
-      "startTime": 14.34
-    },
-    {
-      "character": "Bob",
-      "startTime": 14.34,
-      "finishTime": 25.72,
-      "dialogue": {
-        "text": "of course I'd be happy to help just share the code with me and I'll dive in We might want to set up a short code review session after the meeting to exchange ideas and solutions It could benefit the entire team.",
-        "align": "center"
-      }
-    },
-    {
-      "character": "Bob",
-      "opacity": 0,
-      "startTime": 25.98
-    },
-    {
-      "character": "Sophie",
-      "opacity": 1,
-      "startTime": 25.98
-    },
-    {
-      "character": "Sophie",
-      "startTime": 26.24,
-      "finishTime": 29.92,
-      "dialogue": {
-        "text": "That's a great idea. Let's arrange this we can definitely learn from each other",
-        "align": "center"
-      }
-    },
-    {
-      "character": "Sophie",
-      "opacity": 0,
-      "startTime": 30.42
-    }
-  ]
-}
-```
+This verb means to organize or plan something.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-your-progress-in-weekly-stand-up-meetings/6579df1646568c3268b93637.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-your-progress-in-weekly-stand-up-meetings/6579df1646568c3268b93637.md
@@ -25,7 +25,7 @@ Write the following phrases or words in the correct spot:
 
 `Sophie: Good morning, Bob. I'd like to BLANK a coding issue. I've been BLANK it for a while. Would you mind taking a look at my code? I think a fresh pair of eyes could help.`  
 
-`Bob: Of course. I’d be happy to help. Just share the code with me, and I'll BLANK. We might want to set up a short code review session after the meeting to exchange ideas and solutions. It could benefit the entire team.` 
+`Bob: Of course. I'd be happy to help. Just share the code with me, and I'll BLANK. We might want to set up a short code review session after the meeting to exchange ideas and solutions. It could benefit the entire team.` 
 
 `Sophie: That's a great idea. Let's BLANK this. We can definitely learn from each other.`
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-your-progress-in-weekly-stand-up-meetings/6579e1cd6c8b6248fa62ed48.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-your-progress-in-weekly-stand-up-meetings/6579e1cd6c8b6248fa62ed48.md
@@ -27,9 +27,9 @@ Write the following phrases or words in the correct spot:
 
 `Bob: I agree with you. It might help to have a clear style guide for each language. Also, I would BLANK we regularly review and update these guidelines as our projects evolve.`  
 
-`Sophie: Yeah, consistency is essential. I’ll BLANK and start with defining those coding standards.`
+`Sophie: Yeah, consistency is essential. I'll BLANK and start with defining those coding standards.`
   
-`Bob: Great. I’m happy for you BLANK that effort if that’s ok with you.`
+`Bob: Great. I'm happy for you BLANK that effort if that's ok with you.`
 
 ## --blanks--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-your-progress-in-weekly-stand-up-meetings/6579e1cd6c8b6248fa62ed48.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-your-progress-in-weekly-stand-up-meetings/6579e1cd6c8b6248fa62ed48.md
@@ -5,205 +5,76 @@ challengeType: 22
 dashedName: task-59
 ---
 
-<!-- (Audio) The whole dialogue. -->
+<!-- REVIEW -->
 
 # --description--
 
-This challenge recaps the key points of the dialogue between Bob and Sophie. It focuses on their discussion about coding practices and teamwork in a professional setting.
+This is a review of the entire dialogue you just studied.
+
+# --instructions--
+
+Write the following phrases or words in the correct spot:
+
+`to suggest`, `advise that`, `recommend`, `go ahead`, `to lead`, and `get started`.
 
 # --fillInTheBlank--
 
 ## --sentence--
 
-`In the team meeting, Bob initiated the discussion, asking Sophie about her BLANK for the day. Sophie expressed her desire to BLANK up an idea about coding BLANK and suggested creating guidelines for consistency. Bob BLANK with her and proposed having a BLANK guide for coding standards. They discussed the BLANK of regularly updating these guidelines and agreed on the BLANK of having clear, consistent practices. Sophie was ready to BLANK the task of defining these standards, and Bob showed his BLANK for her to lead the effort.`
+`Bob: Good morning, team. Let's BLANK with our meeting. Sophie, what's on your agenda today?` 
+
+`Sophie: Good morning, everyone. I've had some ideas about improving our coding practices. I would like BLANK we create coding guidelines to ensure consistency across our projects. I BLANK that we start by defining coding standards for different programming languages we use.` 
+
+`Bob: I agree with you. It might help to have a clear style guide for each language. Also, I would BLANK we regularly review and update these guidelines as our projects evolve.`  
+
+`Sophie: Yeah, consistency is essential. I’ll BLANK and start with defining those coding standards.`
+  
+`Bob: Great. I’m happy for you BLANK that effort if that’s ok with you.`
 
 ## --blanks--
 
-`agenda`
+`get started`
 
 ### --feedback--
 
-It refers to the planned tasks or topics for the day.
+This means to begin doing something.
 
 ---
 
-`bring`
+`to suggest`
 
 ### --feedback--
 
-It means to start discussing a particular topic, in this case, coding practices.
+This phrase is used to share a new idea or proposal.
 
 ---
 
-`practices`
+`recommend`
 
 ### --feedback--
 
-These are the methods and standards used in writing code.
+This verb is used when giving a strong idea or advice about what to do.
 
 ---
 
-`agreed`
+`advise that`
 
 ### --feedback--
 
-It means Bob shows agreement with Sophie's suggestion about coding guidelines. Use the verb in the past.
+This phrase is used when giving a formal or helpful suggestion.
 
 ---
 
-`style`
+`go ahead`
 
 ### --feedback--
 
-It refers to a set of standards for writing and designing code.
+This phrase means to begin or continue with a plan.
 
 ---
 
-`importance`
+`to lead`
 
 ### --feedback--
 
-It means how much something matters or how valuable it is.
-
----
-
-`benefits`
-
-### --feedback--
-
-It refers to the positive outcome of maintaining clear coding standards. Use the plural form.
-
----
-
-`lead`
-
-### --feedback--
-
-It means to take charge of or oversee the activity.
-
----
-
-`support`
-
-### --feedback--
-
-It indicates Bob's encouragement and approval for Sophie leading the effort.
-
-# --scene--
-
-```json
-{
-  "setup": {
-    "background": "company1-boardroom.png",
-    "characters": [
-      {
-        "character": "Bob",
-        "position": { "x": -25, "y": 0, "z": 1 }
-      },
-      {
-        "character": "Sophie",
-        "position": { "x": 125, "y": 0, "z": 1 }
-      }
-    ],
-    "audio": {
-      "filename": "6.2-3.mp3",
-      "startTime": 1
-    },
-    "alwaysShowDialogue": true
-  },
-  "commands": [
-    {
-      "character": "Bob",
-      "position": { "x": 25, "y": 0, "z": 1 },
-      "startTime": 0
-    },
-    {
-      "character": "Sophie",
-      "position": { "x": 70, "y": 0, "z": 1 },
-      "startTime": 0.5
-    },
-    {
-      "character": "Bob",
-      "startTime": 1,
-      "finishTime": 5.74,
-      "dialogue": {
-        "text": "Good morning, team. Let's get started with our meeting. Sophie, what's on your agenda today?",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Sophie",
-      "startTime": 6.42,
-      "finishTime": 10.18,
-      "dialogue": {
-        "text": "Good morning, everyone. I've had some ideas about improving our coding practices.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Sophie",
-      "startTime": 10.72,
-      "finishTime": 15.58,
-      "dialogue": {
-        "text": "I would like to suggest that we create coding guidelines to ensure consistency across our projects.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Sophie",
-      "startTime": 16.32,
-      "finishTime": 20.56,
-      "dialogue": {
-        "text": "I recommend that we start by defining coding standards for different programming languages we use.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Bob",
-      "startTime": 21.08,
-      "finishTime": 24.56,
-      "dialogue": {
-        "text": "I agree with you. It might help to have a clear style guide for each language.",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Bob",
-      "startTime": 24.88,
-      "finishTime": 30.14,
-      "dialogue": {
-        "text": "Also, I would advise that we regularly review and update these guidelines as our projects evolve.",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Sophie",
-      "startTime": 30.14,
-      "finishTime": 35.08,
-      "dialogue": {
-        "text": "Yeah, consistency is essential. I'll go ahead and start with defining those coding standards.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Bob",
-      "startTime": 35.3,
-      "finishTime": 38.56,
-      "dialogue": {
-        "text": "Great. I'm happy for you to lead that effort if that's ok with you.",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Sophie",
-      "position": { "x": 125, "y": 0, "z": 1 },
-      "startTime": 39.06
-    },
-    {
-      "character": "Bob",
-      "position": { "x": -25, "y": 0, "z": 1 },
-      "startTime": 39.56
-    }
-  ]
-}
-```
+This phrase means to be in charge of a task or activity.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->
Closes #60687 

<!-- Feel free to add any additional description of changes below this line -->


The EC team found that "summary tasks" were ineffective and confusing for learners, as noted in the related issue. In the B1 curriculum, we replaced them with "review tasks."

This PR is part of a series to apply the same changes to the A2 curriculum. This one covers Block 17.

Related to #55293 
