### PR TITLE
fix: remove duplicate (medium) in instructional note

### DIFF
--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/6638a7713695f25abd3f3c02.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/6638a7713695f25abd3f3c02.md
@@ -13,7 +13,8 @@ The verb `improve` means to make something better or to enhance its quality. It'
 
 For example, `We can improve our coding skills by practicing regularly.`
 
-The phrase `spend time on` is used to describe the action of using time for a particular purpose or activity. It implies that time is like a resource that can be used for various activities, emphasizing the investment of time in those activities. The past participle of `spend` is `spent`. When followed by an action, the verb is in the `-ing` form (gerund),
+The phrase `spend time on` is used to describe the action of using time for a particular purpose or activity. It implies that time is like a resource that can be used for various activities, emphasizing the investment of time in those activities. The past participle of `spend` is `spent`. When followed by an action, the verb takes the `-ing` form (a gerund), as in the sentence `She spent time on debugging.`
+
 
 Examples are `I spend a lot of time on my hobbies.` and `I spend a lot of time reading books.`
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-nutritional-label/615f50473cc0196c6dd3892a.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-nutritional-label/615f50473cc0196c6dd3892a.md
@@ -9,7 +9,7 @@ dashedName: step-28
 
 You may notice there is still a small border at the bottom of your `.large` element. To reset this, give your `.large, .medium` selector a `border` property set to `0`.
 
-Note: the `medium`(medium) class will be utilized later for the thinner bars of the nutrition label. 
+Note: the `medium` class will be utilized later for the thinner bars of the nutrition label. 
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #60820


This pull request removes the redundant (medium) text from the instructional note to improve clarity.