### PR TITLE
fix(curriculum): correct class name typo in nutrition label step 8

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-typography-by-building-a-nutrition-label/615f50473cc0196c6dd3892a.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-typography-by-building-a-nutrition-label/615f50473cc0196c6dd3892a.md
@@ -9,7 +9,7 @@ dashedName: step-28
 
 You may notice there is still a small border at the bottom of your `.large` element. To reset this, give your `.large, .medium` selector a `border` property set to `0`.
 
-Note: the `medium`(medium) class will be utilized later for the thinner bars of the nutrition label. 
+Note: the `medium` class will be utilized later for the thinner bars of the nutrition label. 
 
 # --hints--
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-nutritional-label/615f50473cc0196c6dd3892a.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-nutritional-label/615f50473cc0196c6dd3892a.md
@@ -9,7 +9,7 @@ dashedName: step-28
 
 You may notice there is still a small border at the bottom of your `.large` element. To reset this, give your `.large, .medium` selector a `border` property set to `0`.
 
-Note: the `medium`(medium) class will be utilized later for the thinner bars of the nutrition label. 
+Note: the `medium` class will be utilized later for the thinner bars of the nutrition label. 
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

Closes #60820

<!-- Feel free to add any additional description of changes below this line -->

This PR fixes a small typo in Step 8 of the "Learn Typography by Building a Nutrition Label" challenge.

**Change made:**
- Replaced `medium`(medium) with `medium` for better clarity and correctness.
