### PR TITLE
fix: improve hint text for Moon Orbit lab

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-moon-orbit/66a37f37ef5823a313de8c26.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-moon-orbit/66a37f37ef5823a313de8c26.md
@@ -124,7 +124,7 @@ You should have a `div` with the class `orbit` inside the `.space` element.
 assert.exists(document.querySelector('div.space div.orbit'));
 ```
 
-The `orbit` class `div` should come after the `earth` class `div`.
+ The `.orbit` element should come after the `.earth` element.
 
 ```js
 assert.isTrue(document.querySelector('.earth')?.nextElementSibling?.classList?.contains('orbit'));

--- a/curriculum/challenges/english/25-front-end-development/lab-moon-orbit/66a37f37ef5823a313de8c26.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-moon-orbit/66a37f37ef5823a313de8c26.md
@@ -124,7 +124,7 @@ You should have a `div` with the class `orbit` inside the `.space` element.
 assert.exists(document.querySelector('div.space div.orbit'));
 ```
 
- The `.orbit` element should come after the `.earth` element.
+The `.orbit` element should come after the `.earth` element.
 
 ```js
 assert.isTrue(document.querySelector('.earth')?.nextElementSibling?.classList?.contains('orbit'));


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #60849 

<!-- Feel free to add any additional description of changes below this line -->
This PR updates the hint text in the Moon Orbit lab challenge to use clearer and more consistent terminology, as suggested in issue #60849. My first contribution to the project <3

