### PR TITLE
fix: improve hint text in Moon Orbit Lab challenge

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-moon-orbit/66a37f37ef5823a313de8c26.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-moon-orbit/66a37f37ef5823a313de8c26.md
@@ -124,7 +124,7 @@ You should have a `div` with the class `orbit` inside the `.space` element.
 assert.exists(document.querySelector('div.space div.orbit'));
 ```
 
-The `orbit` class `div` should come after the `earth` class `div`.
+The `.orbit` element should come after the `.earth` element.
 
 ```js
 assert.isTrue(document.querySelector('.earth')?.nextElementSibling?.classList?.contains('orbit'));

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef2d357676e50e4691658.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef2d357676e50e4691658.md
@@ -7,7 +7,8 @@ dashedName: step-2
 
 # --description--
 
-Inside the `return`, remove the empty string, then create a `div` element with a `className` of `card`.
+Inside the `return` statement, remove the empty string, then create a `div` element with a `className` of `card`.
+
 
 # --hints--
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef2d357676e50e4691658.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef2d357676e50e4691658.md
@@ -111,7 +111,7 @@ body {
 export function Card({ name, title, bio }) {
   return (
   --fcc-editable-region--
-    ""
+   <div className="card"></div>
   --fcc-editable-region--
   )
 }

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef2d357676e50e4691658.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef2d357676e50e4691658.md
@@ -7,7 +7,7 @@ dashedName: step-2
 
 # --description--
 
-Inside the return, remove the empty string, then create a `div` element with a `className` of `card`.
+Inside the `return`, remove the empty string, then create a `div` element with a `className` of `card`.
 
 # --hints--
 
@@ -111,7 +111,7 @@ body {
 export function Card({ name, title, bio }) {
   return (
   --fcc-editable-region--
-  ""
+    ""
   --fcc-editable-region--
   )
 }

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef2d357676e50e4691658.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef2d357676e50e4691658.md
@@ -112,8 +112,9 @@ body {
 export function Card({ name, title, bio }) {
   return (
   --fcc-editable-region--
-   <div className="card"></div>
+    ""
   --fcc-editable-region--
-  )
+  );
 }
+
 ```


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

Closes #60849 

Updated unclear hint to use clearer CSS selector terminology as per issue. 