### PR TITLE
fix(curriculum): combined sentences and added examples

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-currency-converter/67eaa957114d373deb3a9149.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-currency-converter/67eaa957114d373deb3a9149.md
@@ -33,9 +33,9 @@ const goodMapping = {
 };
 ```
 
-6. Your `CurrencyConverter` component should memoize the calculation of the converted amounts for the **from** currency such that a change in the **to** `select` option will not recalculate the converted amounts.
-7. Your `CurrencyConverter` component should render an element showing the converted amount in the format `XX.XX CCC`, where `XX.XX` is the converted amount and `CCC` is the currency code.
-8. The converted amount should be rounded to two decimal places.
+5. Your `CurrencyConverter` component should memoize the calculation of the converted amounts for the **from** currency such that a change in the **to** `select` option will not recalculate the converted amounts.
+6. Your `CurrencyConverter` component should render an element showing the converted amount in the format `XX.XX CCC`, where `XX.XX` is the converted amount and `CCC` is the currency code.
+7. The converted amount should be rounded to two decimal places.
 
 # --hints--
 

--- a/curriculum/challenges/english/25-front-end-development/lab-currency-converter/67eaa957114d373deb3a9149.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-currency-converter/67eaa957114d373deb3a9149.md
@@ -17,21 +17,21 @@ demoType: onClick
 3. Your `CurrencyConverter` component should render two `select` elements to choose the currency to convert **from** and **to**.
 4. Your `select` element should include options for **at least** `USD`, `EUR`, `GBP`, and `JPY`. You may use any exchange rate, provided there is no one-to-one mapping between the currencies. Here are some examples of good and bad mappings:
 
-      ```js
-      const badMapping = {
-          USD: 1,
-          EUR: 1,
-          GBP: 1,
-          JPY: 1
-      };
+   ```js
+   const badMapping = {
+       USD: 1,
+       EUR: 1,
+       GBP: 1,
+       JPY: 1
+   };
       
-      const goodMapping = {
-          USD: 1,
-          EUR: 0.92,
-          GBP: 0.78,
-          JPY: 156.7
-      };
-      ```
+   const goodMapping = {
+       USD: 1,
+       EUR: 0.92,
+       GBP: 0.78,
+       JPY: 156.7
+   };
+   ```
 
 5. Your `CurrencyConverter` component should memoize the calculation of the converted amounts for the **from** currency such that a change in the **to** `select` option will not recalculate the converted amounts.
 6. Your `CurrencyConverter` component should render an element showing the converted amount in the format `XX.XX CCC`, where `XX.XX` is the converted amount and `CCC` is the currency code.

--- a/curriculum/challenges/english/25-front-end-development/lab-currency-converter/67eaa957114d373deb3a9149.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-currency-converter/67eaa957114d373deb3a9149.md
@@ -17,21 +17,21 @@ demoType: onClick
 3. Your `CurrencyConverter` component should render two `select` elements to choose the currency to convert **from** and **to**.
 4. Your `select` element should include options for **at least** `USD`, `EUR`, `GBP`, and `JPY`. You may use any exchange rate, provided there is no one-to-one mapping between the currencies. Here are some examples of good and bad mappings:
 
-```js
-const badMapping = {
-    USD: 1,
-    EUR: 1,
-    GBP: 1,
-    JPY: 1
-};
-
-const goodMapping = {
-    USD: 1,
-    EUR: 0.92,
-    GBP: 0.78,
-    JPY: 156.7
-};
-```
+      ```js
+      const badMapping = {
+          USD: 1,
+          EUR: 1,
+          GBP: 1,
+          JPY: 1
+      };
+      
+      const goodMapping = {
+          USD: 1,
+          EUR: 0.92,
+          GBP: 0.78,
+          JPY: 156.7
+      };
+      ```
 
 5. Your `CurrencyConverter` component should memoize the calculation of the converted amounts for the **from** currency such that a change in the **to** `select` option will not recalculate the converted amounts.
 6. Your `CurrencyConverter` component should render an element showing the converted amount in the format `XX.XX CCC`, where `XX.XX` is the converted amount and `CCC` is the currency code.

--- a/curriculum/challenges/english/25-front-end-development/lab-currency-converter/67eaa957114d373deb3a9149.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-currency-converter/67eaa957114d373deb3a9149.md
@@ -15,11 +15,27 @@ demoType: onClick
 1. Your `CurrencyConverter` component should render an `input` element to accept the amount to be converted from.
 2. Your `input` element should accept numbers.
 3. Your `CurrencyConverter` component should render two `select` elements to choose the currency to convert **from** and **to**.
-4. Your `select` element should include options for **at least** `USD`, `EUR`, `GBP`, and `JPY`.
-   1. You may use any exchange rate, provided there is no one-to-one mapping between the currencies.
-5. Your `CurrencyConverter` component should memoize the calculation of the converted amounts for the **from** currency such that a change in the **to** `select` option will not recalculate the converted amounts.
-6. Your `CurrencyConverter` component should render an element showing the converted amount in the format `XX.XX CCC`, where `XX.XX` is the converted amount and `CCC` is the currency code.
-7. The converted amount should be rounded to two decimal places.
+4. Your `select` element should include options for **at least** `USD`, `EUR`, `GBP`, and `JPY`. You may use any exchange rate, provided there is no one-to-one mapping between the currencies. Here are some examples of good and bad mappings:
+
+```js
+const badMapping = {
+    USD: 1,
+    EUR: 1,
+    GBP: 1,
+    JPY: 1
+};
+
+const goodMapping = {
+    USD: 1,
+    EUR: 0.92,
+    GBP: 0.78,
+    JPY: 156.7
+};
+```
+
+6. Your `CurrencyConverter` component should memoize the calculation of the converted amounts for the **from** currency such that a change in the **to** `select` option will not recalculate the converted amounts.
+7. Your `CurrencyConverter` component should render an element showing the converted amount in the format `XX.XX CCC`, where `XX.XX` is the converted amount and `CCC` is the currency code.
+8. The converted amount should be rounded to two decimal places.
 
 # --hints--
 


### PR DESCRIPTION
…xamples

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #60848

<!-- Feel free to add any additional description of changes below this line -->

- I took the sentence "You may use any exchange rate, provided there is no one-to-one mapping between the currencies.", and made it follow the sentence in user story 4, removing the awkward numbered bullet point.
- I added the sentence "Here are some examples of good and bad mappings:" at the end of user story 4.
- I then gave the user examples of good and bad mappings:
```
```js
const badMapping = {
    USD: 1,
    EUR: 1,
    GBP: 1,
    JPY: 1
};

const goodMapping = {
    USD: 1,
    EUR: 0.92,
    GBP: 0.78,
    JPY: 156.7
};
```