### PR TITLE
fix(client): show ab test for fsd only

### DIFF
--- a/client/src/templates/Introduction/components/super-block-intro.tsx
+++ b/client/src/templates/Introduction/components/super-block-intro.tsx
@@ -222,7 +222,10 @@ function SuperBlockIntro({
 
   const showFSDnewIntro = useFeatureIsOn('fsd-new-intro');
 
-  const showIntroTopB = completedChallenges.length === 0 && showFSDnewIntro;
+  const showIntroTopB =
+    completedChallenges.length === 0 &&
+    superBlock === SuperBlocks.FullStackDeveloper &&
+    showFSDnewIntro;
 
   return (
     <>


### PR DESCRIPTION
This PR makes sure the super block intro AB test is only displayed for the FSD superblock.


Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
