### PR TITLE
fix: correct setTimeout syntax in Fruit Search App step 15

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-fruit-search-app/6813e49f0a3ec06c1e80c93b.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-fruit-search-app/6813e49f0a3ec06c1e80c93b.md
@@ -109,15 +109,24 @@ export function FruitsSearch() {
     e.preventDefault();
   }
 
---fcc-editable-region--
   useEffect(() => {
     if (query.trim() === '') {
       setResults([]);
       return;
     }
-    const timeoutId = setTimeout(700);
+
+    const timeoutId = setTimeout(async () => {
+      try {
+        const response = await fetch(`https://your-api-url.com?q=${query}`);
+        const data = await response.json();
+        setResults(data);
+      } catch (error) {
+        console.error('Fetch error:', error);
+      }
+    }, 700);
+
+    return () => clearTimeout(timeoutId);
   }, [query]);
---fcc-editable-region--
 
   return (
     <div id="search-container">
@@ -142,4 +151,5 @@ export function FruitsSearch() {
     </div>
   );
 }
+
 ```


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #60889

<!-- Feel free to add any additional description of changes below this line -->

### Summary

This PR fixes a syntax issue in Step 15 of the Fruit Search App challenge. The original line `setTimeout(700)` was missing a required callback function and was syntactically invalid in JavaScript. I replaced it with:

```js
setTimeout(async () => {
  try {
    const response = await fetch(...);
    const data = await response.json();
    setResults(data);
  } catch (error) {
    console.error(error);
  }
}, 700);
