### PR TITLE
fix: make landing e2e test specific

### DIFF
--- a/e2e/landing.spec.ts
+++ b/e2e/landing.spec.ts
@@ -100,6 +100,18 @@ test.describe('Landing Top - Variation A', () => {
       translations.landing['h2-heading'].replace(/<\/?strong>/g, '')
     );
   });
+
+  test('Hero image should have  a description', async ({ isMobile, page }) => {
+    const captionText = page.getByText(
+      translations.landing['hero-img-description']
+    );
+
+    if (isMobile) {
+      await expect(captionText).toBeHidden();
+    } else {
+      await expect(captionText).toBeVisible();
+    }
+  });
 });
 
 test.describe('Landing Page', () => {
@@ -130,23 +142,15 @@ test.describe('Landing Page', () => {
     }
   });
 
-  test('Hero image should have an alt and a description', async ({
-    isMobile,
-    page
-  }) => {
+  test('Hero image should have an alt', async ({ isMobile, page }) => {
     const campersImage = page.getByAltText(
       translations.landing['hero-img-alt']
-    );
-    const captionText = page.getByText(
-      translations.landing['hero-img-description']
     );
 
     if (isMobile) {
       await expect(campersImage).toBeHidden();
-      await expect(captionText).toBeHidden();
     } else {
       await expect(campersImage).toBeVisible();
-      await expect(captionText).toBeVisible();
     }
   });
 


### PR DESCRIPTION
This PR makes sure e2e only tests what is available on variation A of the landing page and what is available on all variations.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
