### PR TITLE
fix(client): add tabindex only to <pre> elements with horizontal scroll for accessibility

### DIFF
--- a/client/src/templates/Challenges/components/prism-formatted.tsx
+++ b/client/src/templates/Challenges/components/prism-formatted.tsx
@@ -27,6 +27,15 @@ function PrismFormatted({
     if (instructionsRef.current) {
       Prism.hooks.add('complete', enhancePrismAccessibility);
       Prism.highlightAllUnder(instructionsRef.current);
+
+      const preElements = instructionsRef.current.querySelectorAll('pre');
+      preElements.forEach((pre: HTMLPreElement) => {
+        if (pre.scrollWidth > pre.clientWidth) {
+          pre.setAttribute('tabIndex', '0');
+        } else {
+          pre.removeAttribute('tabIndex');
+        }
+      });
     }
   }, []);
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #59290

<!-- Feel free to add any additional description of changes below this line -->
Ensures that only `<pre>` blocks with horizontal scrollbars receive a tab stop.