### PR TITLE
chore(curriculum): test input and label are linked

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-job-application-form/66faac4139dbbd5dd632c860.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-job-application-form/66faac4139dbbd5dd632c860.md
@@ -20,6 +20,7 @@ demoType: onClick
 1. You should have a `fieldset` element with class of `radio-group`.
 1. Inside `.radio-group` you should have a set of `input` elements with the type `radio` and relevant labels for selecting availability options (e.g., Full-Time, Part-Time). The group `name` should be `availability`.
 1. You should have a `textarea` element with the id `message` for entering a message.
+1. You should associate every `input` element with a `label` element. 
 1. You should have a `button` element with the type `submit` for submitting the form.
 1. Add a `:focus` pseudo-class to the `input` and `textarea` elements to change their border color when focused.
 1. The `input`, `select` and `textarea` elements should have an `:invalid` pseudo-class that changes the border color to red when invalid input is detected.
@@ -81,6 +82,18 @@ You should have a `textarea` element with the id `message` for entering a messag
 
 ```js
 assert.isNotEmpty(document.querySelectorAll("div.container > form textarea#message"));
+```
+
+You should associate every `input` element with a `label` element. 
+
+```js
+const els = document.querySelectorAll('input');
+assert.isNotEmpty(els);
+els.forEach(input => {
+  const label = document.querySelector(`label[for="${input.id}"]`) || input.parentElement;
+  assert.exists(label); 
+  assert.equal(label.tagName, "LABEL");
+})
 ```
 
 You should have a `button` element with the type `submit` for submitting the form.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #60900

<!-- Feel free to add any additional description of changes below this line -->
I've updated the user stories so campers know to link the input elements with label elements, and added an appropriate test for it. 