### PR TITLE
fix(client): handle Syntax and Indentation errors from python

### DIFF
--- a/client/src/templates/Challenges/redux/execute-challenge-saga.js
+++ b/client/src/templates/Challenges/redux/execute-challenge-saga.js
@@ -210,7 +210,7 @@ function* executeTests(testRunner, tests, testTimeout = 5000) {
       if (err === 'timeout') {
         newTest.err = 'Test timed out';
         newTest.message = `${newTest.message} (${newTest.err})`;
-      } else if (type) {
+      } else if (type == 'IndentationError' || type == 'SyntaxError') {
         const msgKey =
           type === 'IndentationError'
             ? 'learn.indentation-error'


### PR DESCRIPTION
We have specific messages we want to show when we see these kinds of errors.

It's possible we'll want to distinguish between syntax errors raised during evaluation of learner code and during testing. However, this PR is definitely better than current behaviour where every python assertion causes the 

> Your code raised an error before any tests could run. Please fix it and try again.

log to be shown.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
