### PR TITLE
test(external curricula): run test on all chapters and modules

### DIFF
--- a/tools/scripts/build/build-external-curricula-data-v2.test.ts
+++ b/tools/scripts/build/build-external-curricula-data-v2.test.ts
@@ -224,38 +224,26 @@ ${result.error.message}`);
         superBlock
       ] as ChapterBasedCurriculumIntros[SuperBlocks];
 
-      // Randomly pick a chapter.
-      const chapters = superBlockData.chapters.filter(
-        ({ comingSoon }) => !comingSoon
-      );
-      const randomChapterIndex = Math.floor(Math.random() * chapters.length);
-      const randomChapter = chapters[randomChapterIndex];
-
-      // Randomly pick a module.
-      const modules = randomChapter.modules.filter(
-        ({ comingSoon }) => !comingSoon
-      );
-      const randomModuleIndex = Math.floor(Math.random() * modules.length);
-      const randomModule = modules[randomModuleIndex];
-
-      // Randomly pick a block.
-      // const blocks = randomModule.blocks;
-      // const randomBlockIndex = Math.floor(Math.random() * blocks.length);
-      // const randomBlock = blocks[randomBlockIndex];
-
       // Check super block data
       expect(superBlockData.intro).toEqual(superBlockIntros.intro);
 
-      // Check chapter data
-      expect(superBlockData.chapters[randomChapterIndex].name).toEqual(
-        superBlockIntros.chapters[randomChapter.dashedName]
-      );
+      // Loop through all chapters
+      superBlockData.chapters
+        .filter(({ comingSoon }) => !comingSoon)
+        .forEach(chapter => {
+          expect(chapter.name).toEqual(
+            superBlockIntros.chapters[chapter.dashedName]
+          );
 
-      // Check module data
-      expect(
-        superBlockData.chapters[randomChapterIndex].modules[randomModuleIndex]
-          .name
-      ).toEqual(superBlockIntros.modules[randomModule.dashedName]);
+          // Loop through all modules in the chapter
+          chapter.modules
+            .filter(({ comingSoon }) => !comingSoon)
+            .forEach(module => {
+              expect(module.name).toEqual(
+                superBlockIntros.modules[module.dashedName]
+              );
+            });
+        });
 
       // Temporary skip these checks to keep CI stable.
       // TODO: uncomment these once https://github.com/freeCodeCamp/freeCodeCamp/issues/60660 is completed.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR updates an external curricula data's test to run on all chapters and modules, instead of selecting one of them randomly. The test meant to be a sanity check hence only one item is checked, but the randomness has made CI unstable so I'm just making the test run on all items instead.

<!-- Feel free to add any additional description of changes below this line -->
