### PR TITLE
fix(curriculum): allow for new lines in element text in Design a Movie Review Page

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-movie-review-page/67ef8f695db52583424bd118.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-movie-review-page/67ef8f695db52583424bd118.md
@@ -122,7 +122,7 @@ Your `h2` should have the text `Cast Members`.
 
 ```js
 const h2 = document.querySelector("h2");
-assert.equal(h2?.textContent, "Cast Members");
+assert.equal(h2?.textContent.trim(), "Cast Members");
 ```
 
 You should have a `ul` element after the `h2`.

--- a/curriculum/challenges/english/25-front-end-development/lab-movie-review-page/67ef8f695db52583424bd118.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-movie-review-page/67ef8f695db52583424bd118.md
@@ -36,7 +36,7 @@ Inside the `main` element, you should have an `h1` element containing the movie 
 
 ```js
 const h1 = document.querySelector("main > h1");
-assert.isAbove(h1?.innerText.length, 0);
+assert.isAbove(h1?.innerText.trim().length, 0);
 ```
 
 Below the `h1` element, you should have an `img` element with a descriptive `alt` attribute.
@@ -52,7 +52,7 @@ You should have a `p` element after the image that contains the movie descriptio
 ```js
 const description = document.querySelector("main img + p");
 assert.isNotNull(description);
-assert.isNotEmpty(description.innerText);
+assert.isNotEmpty(description.innerText.trim());
 ```
 
 You should have another `p` element that contains the rating.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR is related to #60690, but does not close.

<!-- Feel free to add any additional description of changes below this line -->

https://www.freecodecamp.org/learn/full-stack-developer/lab-movie-review-page/design-a-movie-review-page

Added `.trim()` to the assert matching the text content of the h2 element. Initially, if we did this:
```
<h2>
  Cast Members
</h2>
```
The test was failing, as you can see in the attached screenshot. After making the change, the test is passing.

Before:
![cmwtrim](https://github.com/user-attachments/assets/695427b1-2f49-4e7b-b923-eef7bf6da974)

After:
![cmtrim](https://github.com/user-attachments/assets/74ba1d9c-472a-42f7-8ef0-70daf25799f7)

