### PR TITLE
fix(curriculum): missing note in JS A11y

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -1856,6 +1856,12 @@
       "certified-full-stack-developer-exam": "Certified Full Stack Developer Exam"
     },
     "module-intros": {
+      "js-a11y": {
+        "note": "Coming Fall 2025",
+        "intro": [
+          "In this module, you will learn how to work with the aria-expanded, aria-live and aria-controls attributes inside of your HTML, CSS and JavaScript applications."
+        ]
+      },
       "css-libraries-and-frameworks": {
         "note": "Coming Fall 2025",
         "intro": [


### PR DESCRIPTION
## Before

<img width="876" alt="Screenshot 2025-06-19 at 2 30 04 PM" src="https://github.com/user-attachments/assets/3661ff4c-c82f-4565-8bce-464e7ca4302e" />


## After


<img width="869" alt="Screenshot 2025-06-19 at 2 30 17 PM" src="https://github.com/user-attachments/assets/65535e9b-4c1c-4246-b0eb-85642265ec07" />



Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #60938


<!-- Feel free to add any additional description of changes below this line -->
