### PR TITLE
fix: corrected swapped content lines in CSS layout quiz

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/quiz-css-layout-and-effects/66ed8ff4f45ce3ece4053eb4.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-css-layout-and-effects/66ed8ff4f45ce3ece4053eb4.md
@@ -507,7 +507,7 @@ When an element's `box-sizing` is set to `content-box`, which part of the box mo
 
 #### --distractors--
 
-Content
+Content, padding, border, and margin
 
 ---
 
@@ -519,7 +519,7 @@ Content, padding, and border
 
 #### --answer--
 
-Content, padding, border, and margin
+Content
 
 ### --question--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #60954

<!-- Feel free to add any additional description of changes below this line -->
This PR fixes the incorrect placement of "Content" and "Content, padding, border, and margin" in the CSS layout quiz markdown file, as per issue instructions. Line 510 and 522 have been swapped to reflect the correct order.

