### PR TITLE
feat(curriculum): add review tasks to block 10 of the A2 curriculum

### DIFF
--- a/curriculum/challenges/_meta/learn-how-to-have-a-conversation-about-preferences-and-motivations/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-have-a-conversation-about-preferences-and-motivations/meta.json
@@ -166,120 +166,128 @@
       "title": "Task 39"
     },
     {
+      "id": "6856952328770a0717aa4186",
+      "title": "Task 40"
+    },
+    {
       "id": "658160772584ba319849f910",
       "title": "Dialogue 2: Asking How Someone Feels"
     },
     {
       "id": "65816188f69f4731f852414b",
-      "title": "Task 40"
-    },
-    {
-      "id": "658162d19fa392326fe7a5c7",
       "title": "Task 41"
     },
     {
-      "id": "658163793f65e532b8fa18e6",
+      "id": "658162d19fa392326fe7a5c7",
       "title": "Task 42"
     },
     {
-      "id": "65816435fa555c330f785cbb",
+      "id": "658163793f65e532b8fa18e6",
       "title": "Task 43"
     },
     {
-      "id": "65818f21f6e4f33551f7023a",
+      "id": "65816435fa555c330f785cbb",
       "title": "Task 44"
     },
     {
-      "id": "658191bf5053a835c882fdd3",
+      "id": "65818f21f6e4f33551f7023a",
       "title": "Task 45"
     },
     {
-      "id": "65819284843aab3625cf49e1",
+      "id": "658191bf5053a835c882fdd3",
       "title": "Task 46"
     },
     {
-      "id": "658192efec6fe7366f7b99d2",
+      "id": "65819284843aab3625cf49e1",
       "title": "Task 47"
     },
     {
-      "id": "65819377e2ad2536b3d1e0c0",
+      "id": "658192efec6fe7366f7b99d2",
       "title": "Task 48"
     },
     {
-      "id": "6581944b911c3c3715d35518",
+      "id": "65819377e2ad2536b3d1e0c0",
       "title": "Task 49"
     },
     {
-      "id": "658194a34cb24537624fad0e",
+      "id": "6581944b911c3c3715d35518",
       "title": "Task 50"
     },
     {
-      "id": "6581950a4e5ca237a17d1a02",
+      "id": "658194a34cb24537624fad0e",
       "title": "Task 51"
     },
     {
-      "id": "658195600d516b37e310fbf2",
+      "id": "6581950a4e5ca237a17d1a02",
       "title": "Task 52"
     },
     {
-      "id": "658197767dc3fc387439e067",
+      "id": "658195600d516b37e310fbf2",
       "title": "Task 53"
     },
     {
-      "id": "6581a2a527222938f4f0a9eb",
+      "id": "658197767dc3fc387439e067",
       "title": "Task 54"
     },
     {
-      "id": "6581a32ee97531393b34b783",
+      "id": "6581a2a527222938f4f0a9eb",
       "title": "Task 55"
     },
     {
-      "id": "6581a3ccf2ecd839816c885d",
+      "id": "6581a32ee97531393b34b783",
       "title": "Task 56"
     },
     {
-      "id": "6581a46a402a0d39de6b1932",
+      "id": "6581a3ccf2ecd839816c885d",
       "title": "Task 57"
     },
     {
-      "id": "6581a5c14eb46b3a36f082c6",
+      "id": "6581a46a402a0d39de6b1932",
       "title": "Task 58"
     },
     {
-      "id": "6581a6b50e86ae3a9041f6f1",
+      "id": "6581a5c14eb46b3a36f082c6",
       "title": "Task 59"
     },
     {
-      "id": "6581a7d6af8f2f3aefd232ab",
+      "id": "6581a6b50e86ae3a9041f6f1",
       "title": "Task 60"
     },
     {
-      "id": "6581a95da053653b4593a650",
+      "id": "6581a7d6af8f2f3aefd232ab",
       "title": "Task 61"
     },
     {
-      "id": "6581aa0c6583c53b927defa4",
+      "id": "6581a95da053653b4593a650",
       "title": "Task 62"
     },
     {
-      "id": "6581add0405ccf3bfc3c1d5f",
+      "id": "6581aa0c6583c53b927defa4",
       "title": "Task 63"
     },
     {
-      "id": "65a25ccb31eedb00df74679f",
+      "id": "6581add0405ccf3bfc3c1d5f",
       "title": "Task 64"
     },
     {
-      "id": "65a1f4b78e0174e6ce7272ff",
+      "id": "65a25ccb31eedb00df74679f",
       "title": "Task 65"
     },
     {
-      "id": "65a1f959ca8f18f0e711d596",
+      "id": "65a1f4b78e0174e6ce7272ff",
       "title": "Task 66"
     },
     {
-      "id": "65a1fa60a447d4f36ae16e1e",
+      "id": "65a1f959ca8f18f0e711d596",
       "title": "Task 67"
+    },
+    {
+      "id": "65a1fa60a447d4f36ae16e1e",
+      "title": "Task 68"
+    },
+    {
+      "id": "685699e764bba10bcf0cd5f4",
+      "title": "Task 69"
     },
     {
       "id": "65a351bd69b0b72d7ed24eb5",
@@ -287,95 +295,99 @@
     },
     {
       "id": "65a3524b7cfbc82f51667b0a",
-      "title": "Task 68"
-    },
-    {
-      "id": "65a35281e6f8f4303df075e5",
-      "title": "Task 69"
-    },
-    {
-      "id": "65a352d14f8050311510e2e9",
       "title": "Task 70"
     },
     {
-      "id": "65a35340e8c3ae32030cea01",
+      "id": "65a35281e6f8f4303df075e5",
       "title": "Task 71"
     },
     {
-      "id": "65a3538f615216331ea90f58",
+      "id": "65a352d14f8050311510e2e9",
       "title": "Task 72"
     },
     {
-      "id": "65a35429c637c13540c9be80",
+      "id": "65a35340e8c3ae32030cea01",
       "title": "Task 73"
     },
     {
-      "id": "65a35b30ccc7db44250a72b6",
+      "id": "65a3538f615216331ea90f58",
       "title": "Task 74"
     },
     {
-      "id": "65a35b8a7dd409452ec99d38",
+      "id": "65a35429c637c13540c9be80",
       "title": "Task 75"
     },
     {
-      "id": "65a35c036df46e46187c31a3",
+      "id": "65a35b30ccc7db44250a72b6",
       "title": "Task 76"
     },
     {
-      "id": "65a35c7b9d642f478d6cabba",
+      "id": "65a35b8a7dd409452ec99d38",
       "title": "Task 77"
     },
     {
-      "id": "65a35cf34eb65f48c24ee97e",
+      "id": "65a35c036df46e46187c31a3",
       "title": "Task 78"
     },
     {
-      "id": "65a35d50e8421d49ef07ae09",
+      "id": "65a35c7b9d642f478d6cabba",
       "title": "Task 79"
     },
     {
-      "id": "65a391fe39a2997ea4c0e980",
+      "id": "65a35cf34eb65f48c24ee97e",
       "title": "Task 80"
     },
     {
-      "id": "65a392505010427f98bd8363",
+      "id": "65a35d50e8421d49ef07ae09",
       "title": "Task 81"
     },
     {
-      "id": "65a392b9f8a69480b1063c86",
+      "id": "65a391fe39a2997ea4c0e980",
       "title": "Task 82"
     },
     {
-      "id": "65a393115e989381c5dc0c4c",
+      "id": "65a392505010427f98bd8363",
       "title": "Task 83"
     },
     {
-      "id": "65a3937c171d9182e6bb4bc5",
+      "id": "65a392b9f8a69480b1063c86",
       "title": "Task 84"
     },
     {
-      "id": "65a3948b46f1b6857a598ff7",
+      "id": "65a393115e989381c5dc0c4c",
       "title": "Task 85"
     },
     {
-      "id": "65a39972a4169f0739dd52b8",
+      "id": "65a3937c171d9182e6bb4bc5",
       "title": "Task 86"
     },
     {
-      "id": "65a39a1ed201f80945939c52",
+      "id": "65a3948b46f1b6857a598ff7",
       "title": "Task 87"
     },
     {
-      "id": "65a39a8889842f0a4ed3faa4",
+      "id": "65a39972a4169f0739dd52b8",
       "title": "Task 88"
     },
     {
-      "id": "65a39ae928cfbd0b75cd91c5",
+      "id": "65a39a1ed201f80945939c52",
       "title": "Task 89"
     },
     {
-      "id": "65a39b443701060c7297158e",
+      "id": "65a39a8889842f0a4ed3faa4",
       "title": "Task 90"
+    },
+    {
+      "id": "65a39ae928cfbd0b75cd91c5",
+      "title": "Task 91"
+    },
+    {
+      "id": "65a39b443701060c7297158e",
+      "title": "Task 92"
+    },
+    {
+      "id": "68569b11df2be30cffc397a1",
+      "title": "Task 93"
     },
     {
       "id": "65a3dafe5c945761cef35199",
@@ -383,91 +395,95 @@
     },
     {
       "id": "65a4f2c2d1bbdfbe82cb3fdd",
-      "title": "Task 91"
-    },
-    {
-      "id": "65a4f3c0e87146c0d01a57f8",
-      "title": "Task 92"
-    },
-    {
-      "id": "65a4f4aef1c065c3263c561a",
-      "title": "Task 93"
-    },
-    {
-      "id": "65a4f58e1daa8fc51dafc832",
       "title": "Task 94"
     },
     {
-      "id": "65a4f5fe475701c6697e738b",
+      "id": "65a4f3c0e87146c0d01a57f8",
       "title": "Task 95"
     },
     {
-      "id": "65a4f6ca14fdbfc86041b28a",
+      "id": "65a4f4aef1c065c3263c561a",
       "title": "Task 96"
     },
     {
-      "id": "65a4f87e991076cbb4efd9bc",
+      "id": "65a4f58e1daa8fc51dafc832",
       "title": "Task 97"
     },
     {
-      "id": "65a4f90542fdffcd6533424a",
+      "id": "65a4f5fe475701c6697e738b",
       "title": "Task 98"
     },
     {
-      "id": "65a4ff8554c98dd601a081d4",
+      "id": "65a4f6ca14fdbfc86041b28a",
       "title": "Task 99"
     },
     {
-      "id": "65a5000506fe76d745652a33",
+      "id": "65a4f87e991076cbb4efd9bc",
       "title": "Task 100"
     },
     {
-      "id": "65a5010affb10fd99d166200",
+      "id": "65a4f90542fdffcd6533424a",
       "title": "Task 101"
     },
     {
-      "id": "65a502f63b185addb3117797",
+      "id": "65a4ff8554c98dd601a081d4",
       "title": "Task 102"
     },
     {
-      "id": "65a5034b32a0cfdefbe36156",
+      "id": "65a5000506fe76d745652a33",
       "title": "Task 103"
     },
     {
-      "id": "65a50441ea961ee157da6ff3",
+      "id": "65a5010affb10fd99d166200",
       "title": "Task 104"
     },
     {
-      "id": "65a505250947a4e3777c82ab",
+      "id": "65a502f63b185addb3117797",
       "title": "Task 105"
     },
     {
-      "id": "65a506572b8d62e47a6f1c08",
+      "id": "65a5034b32a0cfdefbe36156",
       "title": "Task 106"
     },
     {
-      "id": "65a507474a05a9e869827a34",
+      "id": "65a50441ea961ee157da6ff3",
       "title": "Task 107"
     },
     {
-      "id": "65a507ad3caccfe9620e868b",
+      "id": "65a505250947a4e3777c82ab",
       "title": "Task 108"
     },
     {
-      "id": "65a5080cafc379ea8d382c42",
+      "id": "65a506572b8d62e47a6f1c08",
       "title": "Task 109"
     },
     {
-      "id": "65a50874fd56ceeb9d8a271f",
+      "id": "65a507474a05a9e869827a34",
       "title": "Task 110"
     },
     {
-      "id": "65a508d77b492aecb63b06b5",
+      "id": "65a507ad3caccfe9620e868b",
       "title": "Task 111"
     },
     {
-      "id": "65a5312db639d2f8fd4c31a7",
+      "id": "65a5080cafc379ea8d382c42",
       "title": "Task 112"
+    },
+    {
+      "id": "65a50874fd56ceeb9d8a271f",
+      "title": "Task 113"
+    },
+    {
+      "id": "65a508d77b492aecb63b06b5",
+      "title": "Task 114"
+    },
+    {
+      "id": "65a5312db639d2f8fd4c31a7",
+      "title": "Task 115"
+    },
+    {
+      "id": "68569bf2a1251a0e84cf8ae4",
+      "title": "Task 116"
     },
     {
       "id": "65a533f54a5afeff6c6bb996",
@@ -475,119 +491,123 @@
     },
     {
       "id": "65a53475949fcc0056b1e479",
-      "title": "Task 113"
-    },
-    {
-      "id": "65a534f9fdc15f01ed67d860",
-      "title": "Task 114"
-    },
-    {
-      "id": "65a73f5e3153ba7bff076a3e",
-      "title": "Task 115"
-    },
-    {
-      "id": "65a7405cef607d7f856cc5ac",
-      "title": "Task 116"
-    },
-    {
-      "id": "65a74152da45e881db4f54dc",
       "title": "Task 117"
     },
     {
-      "id": "65a742367d9803841b422795",
+      "id": "65a534f9fdc15f01ed67d860",
       "title": "Task 118"
     },
     {
-      "id": "65a74339f74217867ec2eb5e",
+      "id": "65a73f5e3153ba7bff076a3e",
       "title": "Task 119"
     },
     {
-      "id": "65a743f03d6688884acb6cb2",
+      "id": "65a7405cef607d7f856cc5ac",
       "title": "Task 120"
     },
     {
-      "id": "65a7455f319ba98b5885cb6a",
+      "id": "65a74152da45e881db4f54dc",
       "title": "Task 121"
     },
     {
-      "id": "65a747a9502c8f8fbcd5dd13",
+      "id": "65a742367d9803841b422795",
       "title": "Task 122"
     },
     {
-      "id": "65a749262ad6c093d2dc8bb1",
+      "id": "65a74339f74217867ec2eb5e",
       "title": "Task 123"
     },
     {
-      "id": "65a74ac67e7fbd97ef282812",
+      "id": "65a743f03d6688884acb6cb2",
       "title": "Task 124"
     },
     {
-      "id": "65a74b5ca72a0c9a0b8e5e99",
+      "id": "65a7455f319ba98b5885cb6a",
       "title": "Task 125"
     },
     {
-      "id": "65a74c672ff11d9c210a8732",
+      "id": "65a747a9502c8f8fbcd5dd13",
       "title": "Task 126"
     },
     {
-      "id": "65a74cd01bc1b59d99c053a8",
+      "id": "65a749262ad6c093d2dc8bb1",
       "title": "Task 127"
     },
     {
-      "id": "65a74dae1b3acd9fad3a068e",
+      "id": "65a74ac67e7fbd97ef282812",
       "title": "Task 128"
     },
     {
-      "id": "65a750a82c2476a6305bf621",
+      "id": "65a74b5ca72a0c9a0b8e5e99",
       "title": "Task 129"
     },
     {
-      "id": "65a751927c4b80a86e6fb1c9",
+      "id": "65a74c672ff11d9c210a8732",
       "title": "Task 130"
     },
     {
-      "id": "65a788ea40f8e6b77d3cc64f",
+      "id": "65a74cd01bc1b59d99c053a8",
       "title": "Task 131"
     },
     {
-      "id": "65a78dadbf033cc11554453d",
+      "id": "65a74dae1b3acd9fad3a068e",
       "title": "Task 132"
     },
     {
-      "id": "65a78e7b5fb9a0c38757cc3e",
+      "id": "65a750a82c2476a6305bf621",
       "title": "Task 133"
     },
     {
-      "id": "65a78f35fab096c5694079db",
+      "id": "65a751927c4b80a86e6fb1c9",
       "title": "Task 134"
     },
     {
-      "id": "65a7917a28aa16ca5a832593",
+      "id": "65a788ea40f8e6b77d3cc64f",
       "title": "Task 135"
     },
     {
-      "id": "6602ec717db2bc1105700d40",
+      "id": "65a78dadbf033cc11554453d",
       "title": "Task 136"
     },
     {
-      "id": "65a792163bf705cb7b6eb255",
+      "id": "65a78e7b5fb9a0c38757cc3e",
       "title": "Task 137"
     },
     {
-      "id": "65a7957981392ed32523e628",
+      "id": "65a78f35fab096c5694079db",
       "title": "Task 138"
     },
     {
-      "id": "65a79822981b3fd86a5cb03b",
+      "id": "65a7917a28aa16ca5a832593",
       "title": "Task 139"
     },
     {
-      "id": "65a7996c848275dbf2083044",
+      "id": "6602ec717db2bc1105700d40",
       "title": "Task 140"
     },
     {
-      "id": "65a79a08cb0594ddd408e4db",
+      "id": "65a792163bf705cb7b6eb255",
       "title": "Task 141"
+    },
+    {
+      "id": "65a7957981392ed32523e628",
+      "title": "Task 142"
+    },
+    {
+      "id": "65a79822981b3fd86a5cb03b",
+      "title": "Task 143"
+    },
+    {
+      "id": "65a7996c848275dbf2083044",
+      "title": "Task 144"
+    },
+    {
+      "id": "65a79a08cb0594ddd408e4db",
+      "title": "Task 145"
+    },
+    {
+      "id": "68569c663b25400f03a3f498",
+      "title": "Task 146"
     }
   ],
   "helpCategory": "English",

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65816188f69f4731f852414b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65816188f69f4731f852414b.md
@@ -1,8 +1,8 @@
 ---
 id: 65816188f69f4731f852414b
-title: Task 40
+title: Task 41
 challengeType: 22
-dashedName: task-40
+dashedName: task-41
 ---
 
 <!-- (Audio) Alice: Hi, Tom. You look a bit down these days. Is everything okay? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/658162d19fa392326fe7a5c7.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/658162d19fa392326fe7a5c7.md
@@ -1,8 +1,8 @@
 ---
 id: 658162d19fa392326fe7a5c7
-title: Task 41
+title: Task 42
 challengeType: 22
-dashedName: task-41
+dashedName: task-42
 ---
 <!-- (Audio) Tom: Hey, Alice. Yeah, I feel a bit demotivated. -->
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/658163793f65e532b8fa18e6.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/658163793f65e532b8fa18e6.md
@@ -1,8 +1,8 @@
 ---
 id: 658163793f65e532b8fa18e6
-title: Task 42
+title: Task 43
 challengeType: 22
-dashedName: task-42
+dashedName: task-43
 ---
 
 <!-- (Audio) Tom: One thing that really gets to me is working long hours without any breaks. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65816435fa555c330f785cbb.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65816435fa555c330f785cbb.md
@@ -1,8 +1,8 @@
 ---
 id: 65816435fa555c330f785cbb
-title: Task 43
+title: Task 44
 challengeType: 22
-dashedName: task-43
+dashedName: task-44
 ---
 <!-- (Audio) Tom: It's exhausting, and it feels like I'm constantly running without knowing where I'm going. -->
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65818f21f6e4f33551f7023a.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65818f21f6e4f33551f7023a.md
@@ -1,8 +1,8 @@
 ---
 id: 65818f21f6e4f33551f7023a
-title: Task 44
+title: Task 45
 challengeType: 19
-dashedName: task-44
+dashedName: task-45
 ---
 
 <!-- (Audio) Tom: Hey Alice, yeah, I feel a bit demotivated. One thing that really gets to me is working long hours without any breaks. It's exhausting, and it feels like I'm constantly running without knowing where I'm going. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/658191bf5053a835c882fdd3.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/658191bf5053a835c882fdd3.md
@@ -1,8 +1,8 @@
 ---
 id: 658191bf5053a835c882fdd3
-title: Task 45
+title: Task 46
 challengeType: 19
-dashedName: task-45
+dashedName: task-46
 ---
 
 <!-- (Audio) Alice: I totally get that, Tom. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65819284843aab3625cf49e1.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65819284843aab3625cf49e1.md
@@ -1,8 +1,8 @@
 ---
 id: 65819284843aab3625cf49e1
-title: Task 46
+title: Task 47
 challengeType: 22
-dashedName: task-46
+dashedName: task-47
 ---
 
 <!-- (Audio) Alice: I totally get that, Tom. Working overtime all the time can be draining. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/658192efec6fe7366f7b99d2.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/658192efec6fe7366f7b99d2.md
@@ -1,8 +1,8 @@
 ---
 id: 658192efec6fe7366f7b99d2
-title: Task 47
+title: Task 48
 challengeType: 22
-dashedName: task-47
+dashedName: task-48
 ---
 
 <!-- (Audio) Alice: Personally, I hate dealing with office politics. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65819377e2ad2536b3d1e0c0.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65819377e2ad2536b3d1e0c0.md
@@ -1,8 +1,8 @@
 ---
 id: 65819377e2ad2536b3d1e0c0
-title: Task 48
+title: Task 49
 challengeType: 22
-dashedName: task-48
+dashedName: task-49
 ---
 
 <!-- (Audio) Alice: It's frustrating when people are constantly trying to beat each other instead of working together as a team. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/6581944b911c3c3715d35518.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/6581944b911c3c3715d35518.md
@@ -1,8 +1,8 @@
 ---
 id: 6581944b911c3c3715d35518
-title: Task 49
+title: Task 50
 challengeType: 19
-dashedName: task-49
+dashedName: task-50
 ---
 
 <!-- (Audio) Alice: I totally get that, Tom. Working overtime all the time can be draining. Personally, I hate dealing with office politics. It's frustrating when people are constantly trying to beat each other instead of working together as a team. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/658194a34cb24537624fad0e.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/658194a34cb24537624fad0e.md
@@ -1,8 +1,8 @@
 ---
 id: 658194a34cb24537624fad0e
-title: Task 50
+title: Task 51
 challengeType: 22
-dashedName: task-50
+dashedName: task-51
 ---
 
 <!-- (Audio) Tom: You're right, Alice. Dealing with office politics is never fun. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/6581950a4e5ca237a17d1a02.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/6581950a4e5ca237a17d1a02.md
@@ -1,8 +1,8 @@
 ---
 id: 6581950a4e5ca237a17d1a02
-title: Task 51
+title: Task 52
 challengeType: 22
-dashedName: task-51
+dashedName: task-52
 ---
 
 <!-- (Audio) Tom: Another thing that gets to me is having too many meetings. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/658195600d516b37e310fbf2.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/658195600d516b37e310fbf2.md
@@ -1,8 +1,8 @@
 ---
 id: 658195600d516b37e310fbf2
-title: Task 52
+title: Task 53
 challengeType: 19
-dashedName: task-52
+dashedName: task-53
 ---
 
 <!-- (Audio) Tom: Another thing that gets to me is having too many meetings. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/658197767dc3fc387439e067.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/658197767dc3fc387439e067.md
@@ -1,8 +1,8 @@
 ---
 id: 658197767dc3fc387439e067
-title: Task 53
+title: Task 54
 challengeType: 22
-dashedName: task-53
+dashedName: task-54
 ---
 
 <!-- (Audio) Tom: Sometimes, it feels like we're meeting for no reason, and it's hard to find time to actually work on projects. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/6581a2a527222938f4f0a9eb.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/6581a2a527222938f4f0a9eb.md
@@ -1,8 +1,8 @@
 ---
 id: 6581a2a527222938f4f0a9eb
-title: Task 54
+title: Task 55
 challengeType: 19
-dashedName: task-54
+dashedName: task-55
 ---
 <!-- (Audio) Tom: Sometimes, it feels like we're meeting for no reason, and it's hard to find time to actually work on projects. -->
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/6581a32ee97531393b34b783.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/6581a32ee97531393b34b783.md
@@ -1,8 +1,8 @@
 ---
 id: 6581a32ee97531393b34b783
-title: Task 55
+title: Task 56
 challengeType: 22
-dashedName: task-55
+dashedName: task-56
 ---
 
 <!-- (Audio) Alice: I hear you, Tom. Sitting in meetings for hours can be discouraging. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/6581a3ccf2ecd839816c885d.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/6581a3ccf2ecd839816c885d.md
@@ -1,8 +1,8 @@
 ---
 id: 6581a3ccf2ecd839816c885d
-title: Task 56
+title: Task 57
 challengeType: 19
-dashedName: task-56
+dashedName: task-57
 ---
 
 <!-- (Audio) Alice: I hear you, Tom. Sitting in meetings for hours can be discouraging. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/6581a46a402a0d39de6b1932.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/6581a46a402a0d39de6b1932.md
@@ -1,8 +1,8 @@
 ---
 id: 6581a46a402a0d39de6b1932
-title: Task 57
+title: Task 58
 challengeType: 22
-dashedName: task-57
+dashedName: task-58
 ---
 
 <!-- (Audio) Alice: For me, what really annoys me is having to do a bunch of repetitive tasks without any variation. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/6581a5c14eb46b3a36f082c6.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/6581a5c14eb46b3a36f082c6.md
@@ -1,8 +1,8 @@
 ---
 id: 6581a5c14eb46b3a36f082c6
-title: Task 58
+title: Task 59
 challengeType: 22
-dashedName: task-58
+dashedName: task-59
 ---
 <!-- (Audio) Alice: It feels like I'm wasting my skills and creativity. -->
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/6581a6b50e86ae3a9041f6f1.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/6581a6b50e86ae3a9041f6f1.md
@@ -1,8 +1,8 @@
 ---
 id: 6581a6b50e86ae3a9041f6f1
-title: Task 59
+title: Task 60
 challengeType: 19
-dashedName: task-59
+dashedName: task-60
 ---
 
 <!-- (Audio) Alice: For me, what really annoys me is having to do a bunch of repetitive tasks without any variation. It feels like I'm wasting my skills and creativity. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/6581a7d6af8f2f3aefd232ab.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/6581a7d6af8f2f3aefd232ab.md
@@ -1,8 +1,8 @@
 ---
 id: 6581a7d6af8f2f3aefd232ab
-title: Task 60
+title: Task 61
 challengeType: 19
-dashedName: task-60
+dashedName: task-61
 ---
 
 <!-- (Audio) Alice: I hear you, Tom. Sitting in meetings for hours can be discouraging. For me, what really annoys me is having to do a bunch of repetitive tasks without any variation. It feels like I'm wasting my skills and creativity. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/6581a95da053653b4593a650.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/6581a95da053653b4593a650.md
@@ -1,8 +1,8 @@
 ---
 id: 6581a95da053653b4593a650
-title: Task 61
+title: Task 62
 challengeType: 22
-dashedName: task-61
+dashedName: task-62
 ---
 
 <!-- (Audio) Tom: That does sound frustrating, Alice. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/6581aa0c6583c53b927defa4.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/6581aa0c6583c53b927defa4.md
@@ -1,8 +1,8 @@
 ---
 id: 6581aa0c6583c53b927defa4
-title: Task 62
+title: Task 63
 challengeType: 22
-dashedName: task-62
+dashedName: task-63
 ---
 
 <!-- (Audio) Tom: That does sound frustrating, Alice. Repeating the same tasks over and over can be demotivating. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/6581add0405ccf3bfc3c1d5f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/6581add0405ccf3bfc3c1d5f.md
@@ -1,8 +1,8 @@
 ---
 id: 6581add0405ccf3bfc3c1d5f
-title: Task 63
+title: Task 64
 challengeType: 22
-dashedName: task-63
+dashedName: task-64
 ---
 
 <!-- (Audio) Tom "Thanks for listening, by the way. It feels good to talk about these things." -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a1f4b78e0174e6ce7272ff.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a1f4b78e0174e6ce7272ff.md
@@ -1,8 +1,8 @@
 ---
 id: 65a1f4b78e0174e6ce7272ff
-title: Task 65
+title: Task 66
 challengeType: 19
-dashedName: task-65
+dashedName: task-66
 ---
 
 <!-- (Audio) Tom: Thanks for listening, by the way. It feels good to talk about these things. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a1f959ca8f18f0e711d596.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a1f959ca8f18f0e711d596.md
@@ -1,8 +1,8 @@
 ---
 id: 65a1f959ca8f18f0e711d596
-title: Task 66
+title: Task 67
 challengeType: 22
-dashedName: task-66
+dashedName: task-67
 ---
 
 <!-- (Audio) Alice: Of course, Tom. We all have our moments of demotivation, and it's good to share and support each other. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a1fa60a447d4f36ae16e1e.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a1fa60a447d4f36ae16e1e.md
@@ -1,8 +1,8 @@
 ---
 id: 65a1fa60a447d4f36ae16e1e
-title: Task 67
+title: Task 68
 challengeType: 19
-dashedName: task-67
+dashedName: task-68
 ---
 <!-- (Audio) Alice: Of course, Tom. We all have our moments of demotivation, and it's good to share and support each other. -->
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a25ccb31eedb00df74679f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a25ccb31eedb00df74679f.md
@@ -1,8 +1,8 @@
 ---
 id: 65a25ccb31eedb00df74679f
-title: Task 64
+title: Task 65
 challengeType: 22
-dashedName: task-64
+dashedName: task-65
 ---
 
 <!-- (Audio) Tom: Thanks for listening, by the way. It feels good to talk about these things. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a3524b7cfbc82f51667b0a.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a3524b7cfbc82f51667b0a.md
@@ -1,8 +1,8 @@
 ---
 id: 65a3524b7cfbc82f51667b0a
-title: Task 68
+title: Task 70
 challengeType: 22
-dashedName: task-68
+dashedName: task-70
 ---
 
 <!-- (Audio) Brian: Hey Lisa, what motivated you to choose a career in tech? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a35281e6f8f4303df075e5.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a35281e6f8f4303df075e5.md
@@ -1,8 +1,8 @@
 ---
 id: 65a35281e6f8f4303df075e5
-title: Task 69
+title: Task 71
 challengeType: 19
-dashedName: task-69
+dashedName: task-71
 ---
 
 <!-- (Audio) Brian: Hey, Lisa, what motivated you to choose a career in tech? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a352d14f8050311510e2e9.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a352d14f8050311510e2e9.md
@@ -1,8 +1,8 @@
 ---
 id: 65a352d14f8050311510e2e9
-title: Task 70
+title: Task 72
 challengeType: 22
-dashedName: task-70
+dashedName: task-72
 ---
 
 <!-- (Audio) Lisa: One of my main motivations was the financial stability that tech jobs can provide. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a35340e8c3ae32030cea01.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a35340e8c3ae32030cea01.md
@@ -1,8 +1,8 @@
 ---
 id: 65a35340e8c3ae32030cea01
-title: Task 71
+title: Task 73
 challengeType: 22
-dashedName: task-71
+dashedName: task-73
 ---
 
 <!-- (Audio) Lisa: One of my main motivations was the financial stability that tech jobs can provide. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a3538f615216331ea90f58.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a3538f615216331ea90f58.md
@@ -1,8 +1,8 @@
 ---
 id: 65a3538f615216331ea90f58
-title: Task 72
+title: Task 74
 challengeType: 19
-dashedName: task-72
+dashedName: task-74
 ---
 
 <!-- (Audio) Brian: Hey Lisa, what motivated you to choose a career in tech? Lisa: One of my main motivations was the financial stability that tech jobs can provide. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a35429c637c13540c9be80.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a35429c637c13540c9be80.md
@@ -1,8 +1,8 @@
 ---
 id: 65a35429c637c13540c9be80
-title: Task 73
+title: Task 75
 challengeType: 22
-dashedName: task-73
+dashedName: task-75
 ---
 
 <!-- (Audio) Lisa: It allows me to plan for my future with confidence. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a35b30ccc7db44250a72b6.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a35b30ccc7db44250a72b6.md
@@ -1,8 +1,8 @@
 ---
 id: 65a35b30ccc7db44250a72b6
-title: Task 74
+title: Task 76
 challengeType: 22
-dashedName: task-74
+dashedName: task-76
 ---
 
 <!-- (Audio) Lisa: In other fields, it's much more difficult to achieve this stability. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a35b8a7dd409452ec99d38.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a35b8a7dd409452ec99d38.md
@@ -1,8 +1,8 @@
 ---
 id: 65a35b8a7dd409452ec99d38
-title: Task 75
+title: Task 77
 challengeType: 19
-dashedName: task-75
+dashedName: task-77
 ---
 
 <!-- (Audio) Lisa: One of my main motivations was the financial stability that tech jobs can provide. It allows me to plan for my future with confidence. In other fields, it's much more difficult to achieve this stability. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a35c036df46e46187c31a3.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a35c036df46e46187c31a3.md
@@ -1,8 +1,8 @@
 ---
 id: 65a35c036df46e46187c31a3
-title: Task 76
+title: Task 78
 challengeType: 19
-dashedName: task-76
+dashedName: task-78
 ---
 
 <!-- (Audio) Lisa: One of my main motivations was the financial stability that tech jobs can provide. It allows me to plan for my future with confidence. In other fields, it's much more difficult to achieve this stability. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a35c7b9d642f478d6cabba.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a35c7b9d642f478d6cabba.md
@@ -1,8 +1,8 @@
 ---
 id: 65a35c7b9d642f478d6cabba
-title: Task 77
+title: Task 79
 challengeType: 22
-dashedName: task-77
+dashedName: task-79
 ---
 
 <!-- (Audio) Brian: Financial stability is certainly important, Lisa. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a35cf34eb65f48c24ee97e.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a35cf34eb65f48c24ee97e.md
@@ -1,8 +1,8 @@
 ---
 id: 65a35cf34eb65f48c24ee97e
-title: Task 78
+title: Task 80
 challengeType: 22
-dashedName: task-78
+dashedName: task-80
 ---
 
 <!-- (Audio) Brian: For me, it was the opportunity to collaborate with experts from many fields and have different perspectives. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a35d50e8421d49ef07ae09.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a35d50e8421d49ef07ae09.md
@@ -1,8 +1,8 @@
 ---
 id: 65a35d50e8421d49ef07ae09
-title: Task 79
+title: Task 81
 challengeType: 19
-dashedName: task-79
+dashedName: task-81
 ---
 
 <!-- (Audio) Brian: Financial stability is certainly important, Lisa. For me, it was the opportunity to collaborate with experts from many fields and have different perspectives. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a391fe39a2997ea4c0e980.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a391fe39a2997ea4c0e980.md
@@ -1,8 +1,8 @@
 ---
 id: 65a391fe39a2997ea4c0e980
-title: Task 80
+title: Task 82
 challengeType: 22
-dashedName: task-80
+dashedName: task-82
 ---
 
 <!-- (Audio) Lisa: Collaborating with diverse teams can be exciting, Brian. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a392505010427f98bd8363.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a392505010427f98bd8363.md
@@ -1,8 +1,8 @@
 ---
 id: 65a392505010427f98bd8363
-title: Task 81
+title: Task 83
 challengeType: 22
-dashedName: task-81
+dashedName: task-83
 ---
 
 <!-- (Audio) Lisa: Another thing was the chance to be part of projects that push the limits of innovation and creativity. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a392b9f8a69480b1063c86.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a392b9f8a69480b1063c86.md
@@ -1,8 +1,8 @@
 ---
 id: 65a392b9f8a69480b1063c86
-title: Task 82
+title: Task 84
 challengeType: 19
-dashedName: task-82
+dashedName: task-84
 ---
 
 <!-- (Audio) Lisa: Collaborating with diverse teams can be exciting, Brian. Another thing was the chance to be part of projects that push the limits of innovation and creativity. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a393115e989381c5dc0c4c.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a393115e989381c5dc0c4c.md
@@ -1,8 +1,8 @@
 ---
 id: 65a393115e989381c5dc0c4c
-title: Task 83
+title: Task 85
 challengeType: 19
-dashedName: task-83
+dashedName: task-85
 ---
 
 <!-- (Audio) Lisa: Collaborating with diverse teams can be exciting, Brian. Another thing was the chance to be part of projects that push the limits of innovation and creativity. Brian: I'm with you on that one. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a3937c171d9182e6bb4bc5.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a3937c171d9182e6bb4bc5.md
@@ -1,8 +1,8 @@
 ---
 id: 65a3937c171d9182e6bb4bc5
-title: Task 84
+title: Task 86
 challengeType: 22
-dashedName: task-84
+dashedName: task-86
 ---
 
 <!-- (Audio) Brian: I'm also interested in the flexibility that tech roles offer. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a3948b46f1b6857a598ff7.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a3948b46f1b6857a598ff7.md
@@ -1,8 +1,8 @@
 ---
 id: 65a3948b46f1b6857a598ff7
-title: Task 85
+title: Task 87
 challengeType: 22
-dashedName: task-85
+dashedName: task-87
 ---
 
 <!-- (Audio) Brian: I'm also interested in the flexibility that tech roles offer. They allow us to balance our jobs with personal interests and hobbies. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a39972a4169f0739dd52b8.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a39972a4169f0739dd52b8.md
@@ -1,8 +1,8 @@
 ---
 id: 65a39972a4169f0739dd52b8
-title: Task 86
+title: Task 88
 challengeType: 19
-dashedName: task-86
+dashedName: task-88
 ---
 
 <!-- (Audio) Brian: I'm also interested in the flexibility that tech roles offer. They allow us to balance our jobs with personal interests and hobbies. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a39a1ed201f80945939c52.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a39a1ed201f80945939c52.md
@@ -1,8 +1,8 @@
 ---
 id: 65a39a1ed201f80945939c52
-title: Task 87
+title: Task 89
 challengeType: 22
-dashedName: task-87
+dashedName: task-89
 ---
 <!-- (Audio) Lisa: Yeah. Also, the satisfaction of solving complex problems and finding practical solutions is really thrilling. -->
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a39a8889842f0a4ed3faa4.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a39a8889842f0a4ed3faa4.md
@@ -1,8 +1,8 @@
 ---
 id: 65a39a8889842f0a4ed3faa4
-title: Task 88
+title: Task 90
 challengeType: 19
-dashedName: task-88
+dashedName: task-90
 ---
 
 <!-- (Audio) Lisa: Yeah. Also, the satisfaction of solving complex problems and finding practical solutions is really thrilling. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a39ae928cfbd0b75cd91c5.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a39ae928cfbd0b75cd91c5.md
@@ -1,8 +1,8 @@
 ---
 id: 65a39ae928cfbd0b75cd91c5
-title: Task 89
+title: Task 91
 challengeType: 22
-dashedName: task-89
+dashedName: task-91
 ---
 
 <!-- (Audio) Brian: Knowing that we solved problems is really exciting, Lisa. I hope we keep getting as much motivation from it as we can. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a39b443701060c7297158e.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a39b443701060c7297158e.md
@@ -1,8 +1,8 @@
 ---
 id: 65a39b443701060c7297158e
-title: Task 90
+title: Task 92
 challengeType: 19
-dashedName: task-90
+dashedName: task-92
 ---
 <!-- (Audio) Brian: Knowing that we solved problems is really exciting, Lisa. I hope we keep getting as much motivation from it as we can. -->
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a4f2c2d1bbdfbe82cb3fdd.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a4f2c2d1bbdfbe82cb3fdd.md
@@ -1,8 +1,8 @@
 ---
 id: 65a4f2c2d1bbdfbe82cb3fdd
-title: Task 91
+title: Task 94
 challengeType: 22
-dashedName: task-91
+dashedName: task-94
 ---
 
 <!-- (Audio) Bob: Hey, Sarah, do you know what really gets me excited about tech? It's all those amazing gadgets! -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a4f3c0e87146c0d01a57f8.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a4f3c0e87146c0d01a57f8.md
@@ -1,8 +1,8 @@
 ---
 id: 65a4f3c0e87146c0d01a57f8
-title: Task 92
+title: Task 95
 challengeType: 19
-dashedName: task-92
+dashedName: task-95
 ---
 
 <!-- (Audio) Bob: Hey, Sarah, do you know what really gets me excited about tech? It's all those amazing gadgets! -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a4f4aef1c065c3263c561a.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a4f4aef1c065c3263c561a.md
@@ -1,8 +1,8 @@
 ---
 id: 65a4f4aef1c065c3263c561a
-title: Task 93
+title: Task 96
 challengeType: 22
-dashedName: task-93
+dashedName: task-96
 ---
 
 <!-- (Audio) Sarah: I can see your enthusiasm, Bob! -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a4f58e1daa8fc51dafc832.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a4f58e1daa8fc51dafc832.md
@@ -1,8 +1,8 @@
 ---
 id: 65a4f58e1daa8fc51dafc832
-title: Task 94
+title: Task 97
 challengeType: 22
-dashedName: task-94
+dashedName: task-97
 ---
 
 <!-- (Audio) Sarah: I can see your enthusiasm, Bob! Tell me, which gadgets are your absolute favorites? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a4f5fe475701c6697e738b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a4f5fe475701c6697e738b.md
@@ -1,8 +1,8 @@
 ---
 id: 65a4f5fe475701c6697e738b
-title: Task 95
+title: Task 98
 challengeType: 22
-dashedName: task-95
+dashedName: task-98
 ---
 
 <!-- (Audio) Bob: Well, one of my favorite gadgets is the smartwatch. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a4f6ca14fdbfc86041b28a.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a4f6ca14fdbfc86041b28a.md
@@ -1,8 +1,8 @@
 ---
 id: 65a4f6ca14fdbfc86041b28a
-title: Task 96
+title: Task 99
 challengeType: 22
-dashedName: task-96
+dashedName: task-99
 ---
 
 <!-- (Audio) Bob: I love how it keeps me connected, tracks my health, and even helps me stay organized with reminders and notifications. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a4f87e991076cbb4efd9bc.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a4f87e991076cbb4efd9bc.md
@@ -1,8 +1,8 @@
 ---
 id: 65a4f87e991076cbb4efd9bc
-title: Task 97
+title: Task 100
 challengeType: 22
-dashedName: task-97
+dashedName: task-100
 ---
 
 <!-- (Audio) Bob: I love how it keeps me connected, tracks my health, and even helps me stay organized with reminders and notifications. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a4f90542fdffcd6533424a.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a4f90542fdffcd6533424a.md
@@ -1,8 +1,8 @@
 ---
 id: 65a4f90542fdffcd6533424a
-title: Task 98
+title: Task 101
 challengeType: 19
-dashedName: task-98
+dashedName: task-101
 ---
 
 <!-- (Audio) Bob: Well, one of my favorite gadgets is the smartwatch. I love how it keeps me connected, tracks my health, and even helps me stay organized with reminders and notifications. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a4ff8554c98dd601a081d4.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a4ff8554c98dd601a081d4.md
@@ -1,8 +1,8 @@
 ---
 id: 65a4ff8554c98dd601a081d4
-title: Task 99
+title: Task 102
 challengeType: 22
-dashedName: task-99
+dashedName: task-102
 ---
 
 <!-- (Audio) Sarah: Smartwatches are cool. I'm more into smartphones. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a5000506fe76d745652a33.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a5000506fe76d745652a33.md
@@ -1,8 +1,8 @@
 ---
 id: 65a5000506fe76d745652a33
-title: Task 100
+title: Task 103
 challengeType: 22
-dashedName: task-100
+dashedName: task-103
 ---
 <!-- (Audio) Sarah: The camera quality, the speed, and the number of apps available are what I like the most. -->
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a5010affb10fd99d166200.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a5010affb10fd99d166200.md
@@ -1,8 +1,8 @@
 ---
 id: 65a5010affb10fd99d166200
-title: Task 101
+title: Task 104
 challengeType: 19
-dashedName: task-101
+dashedName: task-104
 ---
 <!-- (Audio) Sarah: Smartwatches are cool. I'm more into smartphones. The camera quality, the speed, and the number of apps available are what I like the most. -->
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a502f63b185addb3117797.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a502f63b185addb3117797.md
@@ -1,8 +1,8 @@
 ---
 id: 65a502f63b185addb3117797
-title: Task 102
+title: Task 105
 challengeType: 22
-dashedName: task-102
+dashedName: task-105
 ---
 
 <!-- (Audio) Bob: Oh, smartphones are fantastic too, Sarah. Gadgets like these are transforming our daily lives. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a5034b32a0cfdefbe36156.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a5034b32a0cfdefbe36156.md
@@ -1,8 +1,8 @@
 ---
 id: 65a5034b32a0cfdefbe36156
-title: Task 103
+title: Task 106
 challengeType: 19
-dashedName: task-103
+dashedName: task-106
 ---
 <!-- (Audio) Bob: Oh, smartphones are fantastic too, Sarah. Gadgets like these are transforming our daily lives. -->
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a50441ea961ee157da6ff3.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a50441ea961ee157da6ff3.md
@@ -1,8 +1,8 @@
 ---
 id: 65a50441ea961ee157da6ff3
-title: Task 104
+title: Task 107
 challengeType: 22
-dashedName: task-104
+dashedName: task-107
 ---
 
 <!-- (Audio) Bob: But you know what my obsession is these days? Drones! -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a505250947a4e3777c82ab.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a505250947a4e3777c82ab.md
@@ -1,8 +1,8 @@
 ---
 id: 65a505250947a4e3777c82ab
-title: Task 105
+title: Task 108
 challengeType: 22
-dashedName: task-105
+dashedName: task-108
 ---
 
 <!-- (Audio) Bob: I love capturing stunning aerial shots and exploring new angles for photography. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a506572b8d62e47a6f1c08.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a506572b8d62e47a6f1c08.md
@@ -1,8 +1,8 @@
 ---
 id: 65a506572b8d62e47a6f1c08
-title: Task 106
+title: Task 109
 challengeType: 22
-dashedName: task-106
+dashedName: task-109
 ---
 
 <!-- (Audio) Bob: I love capturing stunning aerial shots and exploring new angles for photography. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a507474a05a9e869827a34.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a507474a05a9e869827a34.md
@@ -1,8 +1,8 @@
 ---
 id: 65a507474a05a9e869827a34
-title: Task 107
+title: Task 110
 challengeType: 22
-dashedName: task-107
+dashedName: task-110
 ---
 
 <!-- (Audio) Bob: I love capturing stunning aerial shots and exploring new angles for photography. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a507ad3caccfe9620e868b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a507ad3caccfe9620e868b.md
@@ -1,8 +1,8 @@
 ---
 id: 65a507ad3caccfe9620e868b
-title: Task 108
+title: Task 111
 challengeType: 19
-dashedName: task-108
+dashedName: task-111
 ---
 
 <!-- (Audio) But you know what my obsession is these days? Drones! I love capturing stunning aerial shots and exploring new angles for photography. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a5080cafc379ea8d382c42.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a5080cafc379ea8d382c42.md
@@ -1,8 +1,8 @@
 ---
 id: 65a5080cafc379ea8d382c42
-title: Task 109
+title: Task 112
 challengeType: 22
-dashedName: task-109
+dashedName: task-112
 ---
 
 <!-- (Audio) Sarah: Drones are an open door for exciting possibilities, Bob. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a50874fd56ceeb9d8a271f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a50874fd56ceeb9d8a271f.md
@@ -1,8 +1,8 @@
 ---
 id: 65a50874fd56ceeb9d8a271f
-title: Task 110
+title: Task 113
 challengeType: 22
-dashedName: task-110
+dashedName: task-113
 ---
 
 <!-- (Audio) Sarah: Your passion for tech gadgets is contagious. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a508d77b492aecb63b06b5.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a508d77b492aecb63b06b5.md
@@ -1,8 +1,8 @@
 ---
 id: 65a508d77b492aecb63b06b5
-title: Task 111
+title: Task 114
 challengeType: 22
-dashedName: task-111
+dashedName: task-114
 ---
 
 <!-- (Audio) Sarah: It's amazing how these innovations keep making our lives more interesting and connected. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a5312db639d2f8fd4c31a7.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a5312db639d2f8fd4c31a7.md
@@ -1,8 +1,8 @@
 ---
 id: 65a5312db639d2f8fd4c31a7
-title: Task 112
+title: Task 115
 challengeType: 19
-dashedName: task-112
+dashedName: task-115
 ---
 <!-- (Audio) Sarah: Drones are an open door for exciting possibilities, Bob. Your passion for tech gadgets is contagious. It's amazing how these innovations keep making our lives more interesting and connected. -->
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a53475949fcc0056b1e479.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a53475949fcc0056b1e479.md
@@ -1,8 +1,8 @@
 ---
 id: 65a53475949fcc0056b1e479
-title: Task 113
+title: Task 117
 challengeType: 22
-dashedName: task-113
+dashedName: task-117
 ---
 
 <!-- (Audio) Tom: Hey, Sophie, what motivates you to work on open-source software projects in your free time? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a534f9fdc15f01ed67d860.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a534f9fdc15f01ed67d860.md
@@ -1,8 +1,8 @@
 ---
 id: 65a534f9fdc15f01ed67d860
-title: Task 114
+title: Task 118
 challengeType: 19
-dashedName: task-114
+dashedName: task-118
 ---
 
 <!-- (Audio) Tom: Hey, Sophie, what motivates you to work on open-source software projects in your free time? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a73f5e3153ba7bff076a3e.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a73f5e3153ba7bff076a3e.md
@@ -1,8 +1,8 @@
 ---
 id: 65a73f5e3153ba7bff076a3e
-title: Task 115
+title: Task 119
 challengeType: 22
-dashedName: task-115
+dashedName: task-119
 ---
 <!-- (Audio) Sophie: Well, I love contributing to open-source projects! I really like the sense of community and collaboration. -->
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a7405cef607d7f856cc5ac.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a7405cef607d7f856cc5ac.md
@@ -1,8 +1,8 @@
 ---
 id: 65a7405cef607d7f856cc5ac
-title: Task 116
+title: Task 120
 challengeType: 19
-dashedName: task-116
+dashedName: task-120
 ---
 <!-- (Audio) Sophie: Well, I love contributing to open-source projects! I really like the sense of community and collaboration. -->
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a74152da45e881db4f54dc.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a74152da45e881db4f54dc.md
@@ -1,8 +1,8 @@
 ---
 id: 65a74152da45e881db4f54dc
-title: Task 117
+title: Task 121
 challengeType: 22
-dashedName: task-117
+dashedName: task-121
 ---
 
 <!-- (Audio) Sophie: It's incredible how people from around the world come together to create something amazing. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a742367d9803841b422795.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a742367d9803841b422795.md
@@ -1,8 +1,8 @@
 ---
 id: 65a742367d9803841b422795
-title: Task 118
+title: Task 122
 challengeType: 19
-dashedName: task-118
+dashedName: task-122
 ---
 
 <!-- (Audio) Sophie: It's incredible how people from around the world come together to create something amazing. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a74339f74217867ec2eb5e.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a74339f74217867ec2eb5e.md
@@ -1,8 +1,8 @@
 ---
 id: 65a74339f74217867ec2eb5e
-title: Task 119
+title: Task 123
 challengeType: 22
-dashedName: task-119
+dashedName: task-123
 ---
 
 <!-- (Audio) Tom: Yeah, I checked out some open-source projects, but I admit that I have problems with the amount of time it can take to contribute. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a743f03d6688884acb6cb2.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a743f03d6688884acb6cb2.md
@@ -1,8 +1,8 @@
 ---
 id: 65a743f03d6688884acb6cb2
-title: Task 120
+title: Task 124
 challengeType: 22
-dashedName: task-120
+dashedName: task-124
 ---
 
 <!-- (Audio) Tom: Sometimes it can be so time-consuming. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a7455f319ba98b5885cb6a.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a7455f319ba98b5885cb6a.md
@@ -1,8 +1,8 @@
 ---
 id: 65a7455f319ba98b5885cb6a
-title: Task 121
+title: Task 125
 challengeType: 19
-dashedName: task-121
+dashedName: task-125
 ---
 
 <!-- (Audio) Tom: Yeah. I checked some open-source projects, but I admit that I have problems with the amount of time it can take to contribute. Sometimes, it can be so time-consuming. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a747a9502c8f8fbcd5dd13.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a747a9502c8f8fbcd5dd13.md
@@ -1,8 +1,8 @@
 ---
 id: 65a747a9502c8f8fbcd5dd13
-title: Task 122
+title: Task 126
 challengeType: 22
-dashedName: task-122
+dashedName: task-126
 ---
 
 <!-- (Audio) Sophie: I understand, Tom. It can be a commitment. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a749262ad6c093d2dc8bb1.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a749262ad6c093d2dc8bb1.md
@@ -1,8 +1,8 @@
 ---
 id: 65a749262ad6c093d2dc8bb1
-title: Task 123
+title: Task 127
 challengeType: 22
-dashedName: task-123
+dashedName: task-127
 ---
 
 <!-- (Audio) Sophie: But I can't stand seeing this great software being private. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a74ac67e7fbd97ef282812.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a74ac67e7fbd97ef282812.md
@@ -1,8 +1,8 @@
 ---
 id: 65a74ac67e7fbd97ef282812
-title: Task 124
+title: Task 128
 challengeType: 22
-dashedName: task-124
+dashedName: task-128
 ---
 
 <!-- (Audio) Sophie: But I can't stand seeing this great software being private. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a74b5ca72a0c9a0b8e5e99.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a74b5ca72a0c9a0b8e5e99.md
@@ -1,8 +1,8 @@
 ---
 id: 65a74b5ca72a0c9a0b8e5e99
-title: Task 125
+title: Task 129
 challengeType: 22
-dashedName: task-125
+dashedName: task-129
 ---
 
 <!-- (Audio) Sophie: Open source is all about transparency and accessibility, and that's something I truly believe in. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a74c672ff11d9c210a8732.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a74c672ff11d9c210a8732.md
@@ -1,8 +1,8 @@
 ---
 id: 65a74c672ff11d9c210a8732
-title: Task 126
+title: Task 130
 challengeType: 19
-dashedName: task-126
+dashedName: task-130
 ---
 
 <!-- (Audio) Sophie: I understand, Tom. It can be a commitment. But I can't stand seeing this great software being private. Open source is all about transparency and accessibility, and that's something I truly believe in. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a74cd01bc1b59d99c053a8.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a74cd01bc1b59d99c053a8.md
@@ -1,8 +1,8 @@
 ---
 id: 65a74cd01bc1b59d99c053a8
-title: Task 127
+title: Task 131
 challengeType: 22
-dashedName: task-127
+dashedName: task-131
 ---
 
 <!-- (Audio) Tom: Yeah, transparency is a strong motivator for many developers. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a74dae1b3acd9fad3a068e.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a74dae1b3acd9fad3a068e.md
@@ -1,8 +1,8 @@
 ---
 id: 65a74dae1b3acd9fad3a068e
-title: Task 128
+title: Task 132
 challengeType: 22
-dashedName: task-128
+dashedName: task-132
 ---
 
 <!-- (Audio) Tom: For me, I like the idea of practicing my skills and getting recognition for my contributions. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a750a82c2476a6305bf621.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a750a82c2476a6305bf621.md
@@ -1,8 +1,8 @@
 ---
 id: 65a750a82c2476a6305bf621
-title: Task 129
+title: Task 133
 challengeType: 22
-dashedName: task-129
+dashedName: task-133
 ---
 
 <!-- (Audio) Tom: It's a fantastic way to show what you're capable of. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a751927c4b80a86e6fb1c9.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a751927c4b80a86e6fb1c9.md
@@ -1,8 +1,8 @@
 ---
 id: 65a751927c4b80a86e6fb1c9
-title: Task 130
+title: Task 134
 challengeType: 19
-dashedName: task-130
+dashedName: task-134
 ---
 
 <!-- (Audio) Tom: Yeah, transparency is a strong motivator for many developers. For me, I like the idea of practicing my skills and getting recognition for my contributions. It's a fantastic way to show what you're capable of. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a788ea40f8e6b77d3cc64f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a788ea40f8e6b77d3cc64f.md
@@ -1,8 +1,8 @@
 ---
 id: 65a788ea40f8e6b77d3cc64f
-title: Task 131
+title: Task 135
 challengeType: 22
-dashedName: task-131
+dashedName: task-135
 ---
 
 <!-- (Audio) Sophie: Also, when software becomes obsolete because it's no longer maintained, there isn't much you can do to save it. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a78dadbf033cc11554453d.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a78dadbf033cc11554453d.md
@@ -1,8 +1,8 @@
 ---
 id: 65a78dadbf033cc11554453d
-title: Task 132
+title: Task 136
 challengeType: 22
-dashedName: task-132
+dashedName: task-136
 ---
 
 <!-- (Audio) Sophie: Also, when software becomes obsolete because it's no longer maintained, there isn't much you can do to save it. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a78e7b5fb9a0c38757cc3e.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a78e7b5fb9a0c38757cc3e.md
@@ -1,8 +1,8 @@
 ---
 id: 65a78e7b5fb9a0c38757cc3e
-title: Task 133
+title: Task 137
 challengeType: 19
-dashedName: task-133
+dashedName: task-137
 ---
 
 <!-- (Audio) Sophie: Also, when software becomes obsolete because it's no longer maintained, there isn't much you can do to save it. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a78f35fab096c5694079db.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a78f35fab096c5694079db.md
@@ -1,8 +1,8 @@
 ---
 id: 65a78f35fab096c5694079db
-title: Task 134
+title: Task 138
 challengeType: 22
-dashedName: task-134
+dashedName: task-138
 ---
 
 <!-- (Audio) Sophie: With open source, there's always a chance for continuous improvement. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a7917a28aa16ca5a832593.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a7917a28aa16ca5a832593.md
@@ -1,8 +1,8 @@
 ---
 id: 65a7917a28aa16ca5a832593
-title: Task 135
+title: Task 139
 challengeType: 22
-dashedName: task-135
+dashedName: task-139
 ---
 
 <!-- (Audio) Sophie: With open source, there's always a chance for continuous improvement. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a792163bf705cb7b6eb255.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a792163bf705cb7b6eb255.md
@@ -1,8 +1,8 @@
 ---
 id: 65a792163bf705cb7b6eb255
-title: Task 137
+title: Task 141
 challengeType: 22
-dashedName: task-137
+dashedName: task-141
 ---
 
 <!-- (Audio) Tom: That's true. The sustainability of open-source projects is something I'm growing to appreciate more. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a7957981392ed32523e628.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a7957981392ed32523e628.md
@@ -1,8 +1,8 @@
 ---
 id: 65a7957981392ed32523e628
-title: Task 138
+title: Task 142
 challengeType: 22
-dashedName: task-138
+dashedName: task-142
 ---
 
 <!-- (Audio) Tom: That's true. The sustainability of open-source projects is something I'm growing to appreciate more. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a79822981b3fd86a5cb03b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a79822981b3fd86a5cb03b.md
@@ -1,8 +1,8 @@
 ---
 id: 65a79822981b3fd86a5cb03b
-title: Task 139
+title: Task 143
 challengeType: 19
-dashedName: task-139
+dashedName: task-143
 ---
 
 <!-- (Audio) Tom: That's true. The sustainability of open-source projects is something I'm growing to appreciate more. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a7996c848275dbf2083044.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a7996c848275dbf2083044.md
@@ -1,8 +1,8 @@
 ---
 id: 65a7996c848275dbf2083044
-title: Task 140
+title: Task 144
 challengeType: 22
-dashedName: task-140
+dashedName: task-144
 ---
 
 <!-- (Audio) Tom: Thanks for sharing your motivations. I think I'll see if I can find a project to dedicate some spare time to. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a79a08cb0594ddd408e4db.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/65a79a08cb0594ddd408e4db.md
@@ -1,8 +1,8 @@
 ---
 id: 65a79a08cb0594ddd408e4db
-title: Task 141
+title: Task 145
 challengeType: 19
-dashedName: task-141
+dashedName: task-145
 ---
 
 <!-- (Audio) Tom: Thanks for sharing your motivations. I think I'll see if I can find a project to dedicate some spare time to. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/6602ec717db2bc1105700d40.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/6602ec717db2bc1105700d40.md
@@ -1,8 +1,8 @@
 ---
 id: 6602ec717db2bc1105700d40
-title: Task 136
+title: Task 140
 challengeType: 19
-dashedName: task-136
+dashedName: task-140
 ---
 
 <!-- (Audio) Sophie: Also, when software becomes obsolete because it's no longer maintained, there isn't much you can do to save it. With open source, there's always a chance for continuous improvement. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/6856952328770a0717aa4186.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/6856952328770a0717aa4186.md
@@ -1,0 +1,94 @@
+---
+id: 6856952328770a0717aa4186
+title: Task 40
+challengeType: 22
+dashedName: task-40
+---
+
+<!-- REVIEW -->
+
+# --description--
+
+This is a review of the entire dialogue you just studied.
+
+# --instructions--
+
+Place the following phrases in the correct spot:
+
+`demotivating`, `motivating`, `excited`, `demotivates`, `motivates`, `problem`, and `motivation`.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`Brian: Hey Maria, I have a question... Do you know what BLANK the team? How about you? What makes you feel motivated?`
+
+`Maria: Hi Brian! Well, one thing that really motivates me is learning new things. I love exploring many new technologies and improving my skills. It keeps me BLANK about our projects.`
+
+`Brian: That's great to hear, Maria. Learning and growing professionally motivates me a lot. But you know what BLANK me sometimes? Dealing with many tight deadlines and feeling like I'm rushing to complete tasks.`
+
+`Maria: I can understand that, Brian. Racing against the clock can be BLANK. Well, collaborating with our creative team and brainstorming many ideas really inspires me. It's where we generate our best concepts.`
+
+`Brian: I agree, Maria. Collaboration and creativity are great. The BLANK is encountering many technical issues that slow our progress down. It is really frustrating.`
+
+`Maria: Yeah, technical glitches are complicated and there's not much we can do other than try to solve them. But do you know what else is great? Seeing the team's enthusiasm after solving these issues. When you see the team inspired, it can boost your BLANK.`
+
+`Brian: Yeah. Wow. You know what? This was really a BLANK talk. Thanks for sharing your thoughts.`
+
+`Maria: Anytime. It's good to have these discussions. It reminds us of what keeps us going.`
+
+## --blanks--
+
+`motivates`
+
+### --feedback--
+
+This verb means to make someone want to do something or work harder.
+
+---
+
+`excited`
+
+### --feedback--
+
+This word means very happy or full of energy about something.
+
+---
+
+`demotivates`
+
+### --feedback--
+
+This verb means to make someone feel less interested or less willing to do something.
+
+---
+
+`demotivating`
+
+### --feedback--
+
+This describes something that makes a person feel less interested or less willing to continue.
+
+---
+
+`problem`
+
+### --feedback--
+
+This noun means something that is difficult or needs to be fixed.
+
+---
+
+`motivation`
+
+### --feedback--
+
+This noun means the reason why someone wants to do something.
+
+---
+
+`motivating`
+
+### --feedback--
+
+This describes something that gives you a reason or energy to do something.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/6856952328770a0717aa4186.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/6856952328770a0717aa4186.md
@@ -13,7 +13,7 @@ This is a review of the entire dialogue you just studied.
 
 # --instructions--
 
-Place the following phrases in the correct spot:
+Write the following words or phrases in the correct spot:
 
 `demotivating`, `motivating`, `excited`, `demotivates`, `motivates`, `problem`, and `motivation`.
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/685699e764bba10bcf0cd5f4.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/685699e764bba10bcf0cd5f4.md
@@ -1,0 +1,92 @@
+---
+id: 685699e764bba10bcf0cd5f4
+title: Task 69
+challengeType: 22
+dashedName: task-69
+---
+
+<!-- REVIEW -->
+
+# --description--
+
+This is a review of the entire dialogue you just studied.
+
+# --instructions--
+
+Place the following phrases in the correct spot:
+
+`Dealing with`, `demotivated`, `frustrating`, `support`, `for no reason`, `instead of`, and `annoys`.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`Alice: Hi Tom, you look a bit down these days. Is everything okay?`
+
+`Tom: Hey Alice, yeah, I feel a bit BLANK. One thing that really gets to me is working long hours without any breaks. It's exhausting, and it feels like I'm constantly running without knowing where I'm going.`
+
+`Alice: I totally get that, Tom. Working overtime all the time can be draining. Personally, I hate dealing with office politics. It's frustrating when people are constantly trying to beat each other BLANK working together as a team.`
+
+`Tom: You're right, Alice. BLANK office politics is never fun. Another thing that gets to me is having too many meetings. Sometimes, it feels like we're meeting BLANK, and it's hard to find time to actually work on projects.`
+
+`Alice: I hear you, Tom. Sitting in meetings for hours can be discouraging. For me, what really BLANK me is having to do a bunch of repetitive tasks without any variation. It feels like I'm wasting my skills and creativity.`
+
+`Tom: That does sound BLANK, Alice. Repeating the same tasks over and over can be demotivating. Thanks for listening, by the way. It feels good to talk about these things.`
+
+`Alice: Of course, Tom. We all have our moments of demotivation, and it's good to share and BLANK each other.`
+
+## --blanks--
+
+`demotivated`
+
+### --feedback--
+
+This means feeling like you don't want to do something anymore.
+
+---
+
+`instead of`
+
+### --feedback--
+
+This phrase means choosing one thing and not the other.
+
+---
+
+`Dealing with`
+
+### --feedback--
+
+This means doing something to fix or manage a situation.
+
+---
+
+`for no reason`
+
+### --feedback--
+
+This means something happens without a clear or known cause.
+
+---
+
+`annoys`
+
+### --feedback--
+
+This verb means to make someone a little angry or bothered.
+
+---
+
+`frustrating`
+
+### --feedback--
+
+This describes something that makes you feel upset because it's not going the way you want.
+
+---
+
+`support`
+
+### --feedback--
+
+As a verb, it means to help or show that you agree with someone or something.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/685699e764bba10bcf0cd5f4.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/685699e764bba10bcf0cd5f4.md
@@ -13,7 +13,7 @@ This is a review of the entire dialogue you just studied.
 
 # --instructions--
 
-Place the following phrases in the correct spot:
+Write the following words or phrases in the correct spot:
 
 `Dealing with`, `demotivated`, `frustrating`, `support`, `for no reason`, `instead of`, and `annoys`.
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/68569b11df2be30cffc397a1.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/68569b11df2be30cffc397a1.md
@@ -13,7 +13,7 @@ This is a review of the entire dialogue you just studied.
 
 # --instructions--
 
-Place the following phrases in the correct spot:
+Write the following words or phrases in the correct spot:
 
 `thrilling`, `opportunity to`, `interested in`, `exciting`, `motivation`, and `with confidence`.
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/68569b11df2be30cffc397a1.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/68569b11df2be30cffc397a1.md
@@ -1,0 +1,84 @@
+---
+id: 68569b11df2be30cffc397a1
+title: Task 93
+challengeType: 22
+dashedName: task-93
+---
+
+<!-- REVIEW -->
+
+# --description--
+
+This is a review of the entire dialogue you just studied.
+
+# --instructions--
+
+Place the following phrases in the correct spot:
+
+`thrilling`, `opportunity to`, `interested in`, `exciting`, `motivation`, and `with confidence`.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`Brian: Hey Lisa, what motivated you to choose a career in tech?`
+
+`Lisa: One of my main motivations was the financial stability that tech jobs can provide. It allows me to plan for my future BLANK. In other fields, it's much more difficult to achieve this stability.`
+
+`Brian: Financial stability is certainly important, Lisa. For me, it was the BLANK collaborate with experts from many fields and have different perspectives.`
+
+`Lisa: Collaborating with diverse teams can be BLANK, Brian. Another thing was the chance to be part of projects that push the limits of innovation and creativity.`
+
+`Brian: I'm with you on that one. I'm also BLANK the flexibility that tech roles offer. They allow us to balance our jobs with personal interests and hobbies.`
+
+`Lisa: Yeah. Also, the satisfaction of solving complex problems and finding practical solutions is really BLANK.`
+
+`Brian: Knowing that we solved problems is really exciting, Lisa. I hope we keep getting as much BLANK from it as we can.`
+
+## --blanks--
+
+`with confidence`
+
+### --feedback--
+
+This means doing something without fear or doubt.
+
+---
+
+`opportunity to`
+
+### --feedback--
+
+This means having a chance to do something.
+
+---
+
+`exciting`
+
+### --feedback--
+
+This describes something that makes you feel happy and full of energy.
+
+---
+
+`interested in`
+
+### --feedback--
+
+This means you want to know more about something or enjoy it.
+
+---
+
+`thrilling`
+
+### --feedback--
+
+This means very exciting or full of strong feelings.
+
+---
+
+`motivation`
+
+### --feedback--
+
+This is the reason why someone wants to do something or work hard.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/68569bf2a1251a0e84cf8ae4.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/68569bf2a1251a0e84cf8ae4.md
@@ -1,0 +1,82 @@
+---
+id: 68569bf2a1251a0e84cf8ae4
+title: Task 116
+challengeType: 22
+dashedName: task-116
+---
+
+<!-- REVIEW -->
+
+# --description--
+
+This is a review of the entire dialogue you just studied.
+
+# --instructions--
+
+Place the following phrases in the correct spot:
+
+`enthusiasm`, `passion`, `the most`, `gadgets`, `these days`, and `connected`.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`Bob: Hey, Sarah, do you know what really gets me excited about tech? It's all those amazing BLANK!`
+
+`Sarah: I can see your BLANK, Bob! Tell me, which tech gadgets are your absolute favorites?`
+
+`Bob: Well, one of my favorite gadgets is the smartwatch. I love how it keeps me BLANK, tracks my health, and even helps me stay organized with reminders and notifications.`
+
+`Sarah: Smartwatches are cool. I'm more into smartphones. The camera quality, the speed, and the number of apps available are what I like BLANK.`
+
+`Bob: Oh, smartphones are fantastic too, Sarah. Gadgets like these are transforming our daily lives. But you know what my obsession is BLANK? Drones! I love capturing stunning aerial shots and exploring new angles for photography.`
+
+`Sarah: Drones are an open door for exciting possibilities, Bob. Your BLANK for tech gadgets is contagious. It's amazing how these innovations keep making our lives more interesting and connected.`
+
+## --blanks--
+
+`gadgets`
+
+### --feedback--
+
+Small electronic tools like phones or smartwatches.
+
+---
+
+`enthusiasm`
+
+### --feedback--
+
+A strong feeling of excitement and interest in something.
+
+---
+
+`connected`
+
+### --feedback--
+
+This means being in touch or in communication with others.
+
+---
+
+`the most`
+
+### --feedback--
+
+Used to show the highest level or amount of something.
+
+---
+
+`these days`
+
+### --feedback--
+
+This means now or in the present time.
+
+---
+
+`passion`
+
+### --feedback--
+
+A strong love or interest in doing something.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/68569bf2a1251a0e84cf8ae4.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/68569bf2a1251a0e84cf8ae4.md
@@ -13,7 +13,7 @@ This is a review of the entire dialogue you just studied.
 
 # --instructions--
 
-Place the following phrases in the correct spot:
+Write the following words or phrases in the correct spot:
 
 `enthusiasm`, `passion`, `the most`, `gadgets`, `these days`, and `connected`.
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/68569c663b25400f03a3f498.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/68569c663b25400f03a3f498.md
@@ -13,7 +13,7 @@ This is a review of the entire dialogue you just studied.
 
 # --instructions--
 
-Place the following phrases in the correct spot:
+Write the following words or phrases in the correct spot:
 
 `commitment`, `motivations`, `sense of`, `work on`, `amount of`, `no longer`, and `transparency`.
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/68569c663b25400f03a3f498.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-have-a-conversation-about-preferences-and-motivations/68569c663b25400f03a3f498.md
@@ -1,0 +1,92 @@
+---
+id: 68569c663b25400f03a3f498
+title: Task 146
+challengeType: 22
+dashedName: task-146
+---
+
+<!-- REVIEW -->
+
+# --description--
+
+This is a review of the entire dialogue you just studied.
+
+# --instructions--
+
+Place the following phrases in the correct spot:
+
+`commitment`, `motivations`, `sense of`, `work on`, `amount of`, `no longer`, and `transparency`.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`Tom: Hey, Sophie, what motivates you to BLANK open-source software projects in your free time?`
+
+`Sophie: Well, I love contributing to open-source projects! I really like the BLANK community and collaboration. It's incredible how people from around the world come together to create something amazing.`
+
+`Tom: Yeah. I checked out some open-source projects, but I admit that I have problems with the BLANK time it can take to contribute. Sometimes, it can be so time-consuming.`
+
+`Sophie: I understand, Tom. It can be a BLANK. But I can't stand seeing this great software being private. Open source is all about transparency and accessibility, and that's something I truly believe in.`
+
+`Tom: Yeah, BLANK is a strong motivator for many developers. For me, I like the idea of practicing my skills and getting recognition for my contributions. It's a fantastic way to show what you're capable of.`
+
+`Sophie: Also, when software becomes obsolete because it's BLANK maintained, there isn't much you can do to save it. With open source, there's always a chance for continuous improvement.`
+
+`Tom: That's true. The sustainability of open-source projects is something I'm growing to appreciate more. Thanks for sharing your BLANK. I think I'll see if I can find a project to dedicate some spare time to.`
+
+## --blanks--
+
+`work on`
+
+### --feedback--
+
+This means to spend time trying to improve or complete something.
+
+---
+
+`sense of`
+
+### --feedback--
+
+This phrase means a strong feeling or understanding of something.
+
+---
+
+`amount of`
+
+### --feedback--
+
+This means how much of something there is.
+
+---
+
+`commitment`
+
+### --feedback--
+
+This means being dedicated and willing to give time and effort to something.
+
+---
+
+`transparency`
+
+### --feedback--
+
+This means being open and honest, not hiding anything.
+
+---
+
+`no longer`
+
+### --feedback--
+
+This means something that used to happen, but does not happen now.
+
+---
+
+`motivations`
+
+### --feedback--
+
+These are the reasons why someone wants to do something.


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

Related to https://github.com/freeCodeCamp/freeCodeCamp/issues/55293

The EC team found that "summary tasks" were ineffective and confusing for learners, as noted in the related issue. In the B1 curriculum, we replaced them with "review tasks."

This PR is part of a series to apply the same changes to the A2 curriculum. To keep reviews easier, I'm splitting the updates into multiple PRs. This one covers Block 10.
