### PR TITLE
fix: add backticks to '..' in relative path explanation

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/quiz-basic-html/66df3b712c41c499e9d31e5b.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-basic-html/66df3b712c41c499e9d31e5b.md
@@ -1395,7 +1395,7 @@ Both absolute and relative paths can be used to link to files within the same we
 
 #### --answer--
 
-Relative paths cannot use .. to move up directories, but absolute paths can.
+Relative paths cannot use `..` to move up directories, but absolute paths can.
 
 ### --question--
 


### PR DESCRIPTION
fix: add backticks to '..' in relative path explanation
This PR fixes [#60957](https://github.com/freeCodeCamp/freeCodeCamp/issues/60957) by adding backticks around `..` in the relative path explanation line to ensure correct formatting.

