### PR TITLE
fix(curriculum): add backticks to double not notation in quiz-basic-html

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/quiz-basic-html/66df3b712c41c499e9d31e5b.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-basic-html/66df3b712c41c499e9d31e5b.md
@@ -1395,7 +1395,7 @@ Both absolute and relative paths can be used to link to files within the same we
 
 #### --answer--
 
-Relative paths cannot use .. to move up directories, but absolute paths can.
+Relative paths cannot use `..` to move up directories, but absolute paths can.
 
 ### --question--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ x] My pull request targets the `main` branch of freeCodeCamp.
- [x ] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #60957


<!-- Feel free to add any additional description of changes below this line -->
## Description

This pull request adds backticks around the double dot (`..`) notation in the curriculum file `66df3b712c41c499e9d31e5b.md`.  
The change improves Markdown formatting for better readability, as suggested in issue #60957:

**Before:**
```
Relative paths cannot use ..
```

**After:**
```
Relative paths cannot use `..`
```

No other files were changed.