### PR TITLE
chore(curriculum): update steps 5–7 in magazine workshop to use specific asserts

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/614387cbefeeba5f3654a291.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/614387cbefeeba5f3654a291.md
@@ -25,19 +25,19 @@ assert.exists(document.querySelector('div'));
 Your `div` element should come after your `header` element.
 
 ```js
-assert(document.querySelector('div')?.previousElementSibling?.localName === 'header');
+assert.equal(document.querySelector('div')?.previousElementSibling?.localName, 'header');
 ```
 
 Your `div` element should have the `class` set to `author`.
 
 ```js
-assert(document.querySelector('div')?.className === 'author');
+assert.equal(document.querySelector('div')?.className, 'author');
 ```
 
 You should create two new `p` elements.
 
 ```js
-assert(document.querySelectorAll('p')?.length === 3);
+assert.lengthOf(document.querySelectorAll('p'), 3);
 ```
 
 Your two new `p` elements should be within your `div` element.
@@ -49,25 +49,25 @@ assert.exists(document.querySelector('div')?.querySelectorAll('p')?.length === 2
 Your first new `p` element should have a `class` set to `author-name`.
 
 ```js
-assert(document.querySelector('div')?.querySelector('p')?.className === 'author-name');
+assert.equal(document.querySelector('div')?.querySelector('p')?.className, 'author-name');
 ```
 
 Your first new `p` element should have the text `By freeCodeCamp`.
 
 ```js
-assert(document.querySelector('div')?.querySelector('p')?.innerText === 'By freeCodeCamp');
+assert.equal(document.querySelector('div')?.querySelector('p')?.innerText, 'By freeCodeCamp');
 ```
 
 Your second new `p` element should have a `class` set to `publish-date`.
 
 ```js
-assert(document.querySelector('div')?.querySelectorAll('p')?.[1]?.className === 'publish-date');
+assert.equal(document.querySelector('div')?.querySelectorAll('p')?.[1]?.className, 'publish-date');
 ```
 
 Your second new `p` element should have the text `March 7, 2019`.
 
 ```js
-assert(document.querySelector('div')?.querySelectorAll('p')?.[1]?.innerText === 'March 7, 2019');
+assert.equal(document.querySelector('div')?.querySelectorAll('p')?.[1]?.innerText, 'March 7, 2019');
 ```
 
 You should create a new `a` element.
@@ -79,25 +79,25 @@ assert.exists(document.querySelector('a'));
 Your `a` element should be within your first new `p` element.
 
 ```js
-assert(document.querySelector('div')?.querySelector('p')?.firstElementChild?.localName === 'a');
+assert.equal(document.querySelector('div')?.querySelector('p')?.firstElementChild?.localName, 'a');
 ```
 
 Your `a` element should have the `href` set to `https://freecodecamp.org`.
 
 ```js
-assert(document.querySelector('div')?.querySelector('p')?.firstElementChild?.getAttribute('href') === 'https://freecodecamp.org');
+assert.equal(document.querySelector('div')?.querySelector('p')?.firstElementChild?.getAttribute('href'), 'https://freecodecamp.org');
 ```
 
 Your `a` element should have the `target` set to `_blank`.
 
 ```js
-assert(document.querySelector('div')?.querySelector('p')?.firstElementChild?.getAttribute('target') === '_blank');
+assert.equal(document.querySelector('div')?.querySelector('p')?.firstElementChild?.getAttribute('target'), '_blank');
 ```
 
 Your `a` element should surround the text `freeCodeCamp`.
 
 ```js
-assert(document.querySelector('div')?.querySelector('p')?.firstElementChild?.innerText === 'freeCodeCamp');
+assert.equal(document.querySelector('div')?.querySelector('p')?.firstElementChild?.innerText, 'freeCodeCamp');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/614e0e588f0e8a772a8a81a6.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/614e0e588f0e8a772a8a81a6.md
@@ -16,7 +16,7 @@ You will remove this later on when you have worked on the CSS.
 Your `img` element should have a `width` attribute set to `400`.
 
 ```js
-assert(document.querySelector('img')?.getAttribute('width') === '400');
+assert.equal(document.querySelector('img')?.getAttribute('width'), '400');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6169cd8a558aa8434e0ad7f6.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6169cd8a558aa8434e0ad7f6.md
@@ -14,7 +14,7 @@ The `Referer` HTTP header contains information about the address or URL of a pag
 Your `a` element should have the `rel` set to `noreferrer`.
 
 ```js
-assert(document.querySelector('div')?.querySelector('p')?.firstElementChild?.getAttribute('rel') === 'noreferrer');
+assert.equal(document.querySelector('div')?.querySelector('p')?.firstElementChild?.getAttribute('rel'), 'noreferrer');
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #60945

<!-- Feel free to add any additional description of changes below this line -->

This PR updates assertions in steps 5–7 of the magazine workshop challenges to use specific Chai `assert.equal` and `assert.lengthOf` methods instead of the generic `assert(...)`.

