### PR TITLE
chore(curriculum): remove unused .green class from global.css

### DIFF
--- a/client/src/components/layouts/global.css
+++ b/client/src/components/layouts/global.css
@@ -214,9 +214,7 @@ p {
   text-align: center !important;
 }
 
-.green-text {
-  color: var(--secondary-color);
-}
+
 
 a {
   color: inherit;

--- a/client/src/components/layouts/global.css
+++ b/client/src/components/layouts/global.css
@@ -214,8 +214,6 @@ p {
   text-align: center !important;
 }
 
-
-
 a {
   color: inherit;
   text-decoration: underline;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.



Closes #60956 

<!-- Feel free to add any additional description of changes below this line -->

This pull request removes the unused .green-text CSS class from the global.css file. The style is not used anywhere in the codebase and was marked for removal in the issue 