### PR TITLE
Removed word both from instructions

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a962954f4e0d76223b37ed.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a962954f4e0d76223b37ed.md
@@ -9,11 +9,11 @@ dashedName: step-24
 
 Next, add another `label` element with the text of `Location` and the `for` attribute set to `"location"`. 
 
-For the checkbox `input`, both the `id`, `name` and `value` attributes should be set to `"location"`.
+For the checkbox `input`, the `id`, `name` and `value` attributes should be set to `"location"`.
 
 Below that `input` element, add another `label` element with the text of `Reputation` and the `for` attribute set to `"reputation"`. 
 
-For the checkbox `input`, both the `id`, `name` and `value` attributes should be set to `"reputation"`.
+For the checkbox `input`, the `id`, `name` and `value` attributes should be set to `"reputation"`.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #60965 

<!-- Feel free to add any additional description of changes below this line -->

removed inappropriate word 'both' from file path : curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a962954f4e0d76223b37ed.md