### PR TITLE
fix(curriculum): correct 'such us' to 'such as'

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lecture-importance-of-semantic-html/672995d673bd3237200b9e7c.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-importance-of-semantic-html/672995d673bd3237200b9e7c.md
@@ -40,7 +40,7 @@ Let's take the same example as before, but add the `title` attribute. It will be
 <p><abbr title="HyperText Markup Language">HTML</abbr> is the foundation of the web.</p>
 ```
 
-Usually, the style of the abbreviation element will change when you add this attribute. The specific style will depend on the browser. Some browsers may display a dotted underline, while others may convert the contents to small caps, or even assign certain default styles, such us a dotted underline. When the user hovers over the acronym with the mouse, the full form is displayed as a tooltip.
+Usually, the style of the abbreviation element will change when you add this attribute. The specific style will depend on the browser. Some browsers may display a dotted underline, while others may convert the contents to small caps, or even assign certain default styles, such as a dotted underline. When the user hovers over the acronym with the mouse, the full form is displayed as a tooltip.
 
 While you don't necessarily need to use the abbreviation element for every abbreviation, or acronym on your web page, it's recommended for those that might be unclear and those that might need additional context.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #60980 

<!-- Feel free to add any additional description of changes below this line -->

## Description
This PR fixes a small typo in the **"How Do You Display Abbreviations and Acronyms in HTML?"** lecture.

### Change made:
- Replaced "such us" with "such as"

## Related Issue
Closes #60980

## Screenshots (optional)
![Screenshot from 2025-06-22 23-33-50](https://github.com/user-attachments/assets/33dff77a-0ad6-4ed7-8b7a-2ebc1903298f)


