### PR TITLE
feat(curriculum): add review tasks to block 14 of the A2 curriculum

### DIFF
--- a/curriculum/challenges/_meta/learn-how-to-use-code-related-concepts-and-terms/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-use-code-related-concepts-and-terms/meta.json
@@ -90,68 +90,76 @@
       "title": "Task 20"
     },
     {
+      "id": "685916f5a78e6c0f9dd7e751",
+      "title": "Task 21"
+    },
+    {
       "id": "6632fd7b0b9f8087ff8aa3ba",
       "title": "Dialogue 2: Asking about Functions"
     },
     {
       "id": "665632c4ace6cb00ab832023",
-      "title": "Task 21"
-    },
-    {
-      "id": "6632fe1b6548f7887488a767",
       "title": "Task 22"
     },
     {
-      "id": "6633008b3377e5894cf71629",
+      "id": "6632fe1b6548f7887488a767",
       "title": "Task 23"
     },
     {
-      "id": "663301c3812e2e89c08dcc31",
+      "id": "6633008b3377e5894cf71629",
       "title": "Task 24"
     },
     {
-      "id": "6633032bf786ff8a61b0c482",
+      "id": "663301c3812e2e89c08dcc31",
       "title": "Task 25"
     },
     {
-      "id": "66330444cf1ea28af44e980d",
+      "id": "6633032bf786ff8a61b0c482",
       "title": "Task 26"
     },
     {
-      "id": "663308af5363be8c4a5c68b9",
+      "id": "66330444cf1ea28af44e980d",
       "title": "Task 27"
     },
     {
-      "id": "66330dac56ad868d51d5698c",
+      "id": "663308af5363be8c4a5c68b9",
       "title": "Task 28"
     },
     {
-      "id": "66330fc6d2e3c38e148c8789",
+      "id": "66330dac56ad868d51d5698c",
       "title": "Task 29"
     },
     {
-      "id": "66331263a35e868f3dade3de",
+      "id": "66330fc6d2e3c38e148c8789",
       "title": "Task 30"
     },
     {
-      "id": "66331384245d028fd8b1be23",
+      "id": "66331263a35e868f3dade3de",
       "title": "Task 31"
     },
     {
-      "id": "663315286b7cff907e92ae25",
+      "id": "66331384245d028fd8b1be23",
       "title": "Task 32"
     },
     {
-      "id": "663316fdcce39d9144ae40cd",
+      "id": "663315286b7cff907e92ae25",
       "title": "Task 33"
     },
     {
-      "id": "6633203e58595e93ef54ba3b",
+      "id": "663316fdcce39d9144ae40cd",
       "title": "Task 34"
     },
     {
-      "id": "6633261bb572f2953f5abd13",
+      "id": "6633203e58595e93ef54ba3b",
       "title": "Task 35"
+    },
+    {
+      "id": "6633261bb572f2953f5abd13",
+      "title": "Task 36"
+    },
+    {
+      "id": "685917530d8061101ef7e3f0",
+      "title": "Task 37"
     },
     {
       "id": "66334fd916a3a697e1d2c631",
@@ -159,67 +167,71 @@
     },
     {
       "id": "663350023c7cb898358af702",
-      "title": "Task 36"
-    },
-    {
-      "id": "6633511c7b197798ad5fd703",
-      "title": "Task 37"
-    },
-    {
-      "id": "663352b4860f03995736b6cd",
       "title": "Task 38"
     },
     {
-      "id": "663354f60aafd69a4c0138da",
+      "id": "6633511c7b197798ad5fd703",
       "title": "Task 39"
     },
     {
-      "id": "66339d408258519c61151a64",
+      "id": "663352b4860f03995736b6cd",
       "title": "Task 40"
     },
     {
-      "id": "66339e21256f099cd722292f",
+      "id": "663354f60aafd69a4c0138da",
       "title": "Task 41"
     },
     {
-      "id": "66339f1995bdea9d4aa28cd8",
+      "id": "66339d408258519c61151a64",
       "title": "Task 42"
     },
     {
-      "id": "6633a14f17a4669e1c980d91",
+      "id": "66339e21256f099cd722292f",
       "title": "Task 43"
     },
     {
-      "id": "6633a2a86218659eb77fb9a1",
+      "id": "66339f1995bdea9d4aa28cd8",
       "title": "Task 44"
     },
     {
-      "id": "6633a45ce837ac9f95394eab",
+      "id": "6633a14f17a4669e1c980d91",
       "title": "Task 45"
     },
     {
-      "id": "6633a64567c725a05a94b68f",
+      "id": "6633a2a86218659eb77fb9a1",
       "title": "Task 46"
     },
     {
-      "id": "6633a97f928771a163b59745",
+      "id": "6633a45ce837ac9f95394eab",
       "title": "Task 47"
     },
     {
-      "id": "6633aa9cf90591a1f63a431e",
+      "id": "6633a64567c725a05a94b68f",
       "title": "Task 48"
     },
     {
-      "id": "6633abfc050e82a29a76dd42",
+      "id": "6633a97f928771a163b59745",
       "title": "Task 49"
     },
     {
-      "id": "6633ad387b6914a3313339b3",
+      "id": "6633aa9cf90591a1f63a431e",
       "title": "Task 50"
     },
     {
-      "id": "6633ae85f1fb7aa3ca13234d",
+      "id": "6633abfc050e82a29a76dd42",
       "title": "Task 51"
+    },
+    {
+      "id": "6633ad387b6914a3313339b3",
+      "title": "Task 52"
+    },
+    {
+      "id": "6633ae85f1fb7aa3ca13234d",
+      "title": "Task 53"
+    },
+    {
+      "id": "685917c4259afc10d195c229",
+      "title": "Task 54"
     }
   ],
   "helpCategory": "English",

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/6632fe1b6548f7887488a767.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/6632fe1b6548f7887488a767.md
@@ -1,8 +1,8 @@
 ---
 id: 6632fe1b6548f7887488a767
-title: Task 22
+title: Task 23
 challengeType: 22
-dashedName: task-22
+dashedName: task-23
 ---
 
 <!-- (Audio) Sarah: Functions are like small, reusable tasks that you can use in your code. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/6633008b3377e5894cf71629.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/6633008b3377e5894cf71629.md
@@ -1,8 +1,8 @@
 ---
 id: 6633008b3377e5894cf71629
-title: Task 23
+title: Task 24
 challengeType: 19
-dashedName: task-23
+dashedName: task-24
 ---
 
 <!-- (Audio) Sarah: Functions are like small, reusable tasks that you can use in your code. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/663301c3812e2e89c08dcc31.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/663301c3812e2e89c08dcc31.md
@@ -1,8 +1,8 @@
 ---
 id: 663301c3812e2e89c08dcc31
-title: Task 24
+title: Task 25
 challengeType: 22
-dashedName: task-24
+dashedName: task-25
 ---
 
 <!-- (Audio) Tom: Thanks for explaining, Sarah. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/6633032bf786ff8a61b0c482.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/6633032bf786ff8a61b0c482.md
@@ -1,8 +1,8 @@
 ---
 id: 6633032bf786ff8a61b0c482
-title: Task 25
+title: Task 26
 challengeType: 19
-dashedName: task-25
+dashedName: task-26
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/66330444cf1ea28af44e980d.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/66330444cf1ea28af44e980d.md
@@ -1,8 +1,8 @@
 ---
 id: 66330444cf1ea28af44e980d
-title: Task 26
+title: Task 27
 challengeType: 22
-dashedName: task-26
+dashedName: task-27
 ---
 
 <!-- (Audio) Tom: I see many functions in our code, but I'm not sure what each of these does. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/663308af5363be8c4a5c68b9.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/663308af5363be8c4a5c68b9.md
@@ -1,8 +1,8 @@
 ---
 id: 663308af5363be8c4a5c68b9
-title: Task 27
+title: Task 28
 challengeType: 19
-dashedName: task-27
+dashedName: task-28
 ---
 
 <!-- (Audio) Tom: Thanks for explaining, Sarah. I see many functions in our code, but I'm not sure what each of those does. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/66330dac56ad868d51d5698c.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/66330dac56ad868d51d5698c.md
@@ -1,8 +1,8 @@
 ---
 id: 66330dac56ad868d51d5698c
-title: Task 28
+title: Task 29
 challengeType: 22
-dashedName: task-28
+dashedName: task-29
 ---
 
 <!-- (Audio) Sarah: No problem, Tom. To understand them, you can look at their names and comments. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/66330fc6d2e3c38e148c8789.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/66330fc6d2e3c38e148c8789.md
@@ -1,8 +1,8 @@
 ---
 id: 66330fc6d2e3c38e148c8789
-title: Task 29
+title: Task 30
 challengeType: 22
-dashedName: task-29
+dashedName: task-30
 ---
 
 <!-- (Audio) Sarah: Comments explain that function's purpose. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/66331263a35e868f3dade3de.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/66331263a35e868f3dade3de.md
@@ -1,8 +1,8 @@
 ---
 id: 66331263a35e868f3dade3de
-title: Task 30
+title: Task 31
 challengeType: 19
-dashedName: task-30
+dashedName: task-31
 ---
 
 <!-- (Audio) Sarah: No problem, Tom. To understand them, you can look at their names and comments. Comments explain that function's purpose. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/66331384245d028fd8b1be23.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/66331384245d028fd8b1be23.md
@@ -1,8 +1,8 @@
 ---
 id: 66331384245d028fd8b1be23
-title: Task 31
+title: Task 32
 challengeType: 19
-dashedName: task-31
+dashedName: task-32
 ---
 
 <!-- (Audio) Sarah: No problem, Tom. To understand them, you can look at their names and comments. Comments explain that function's purpose. Tom: Got it. So that means I should read the function names and comments to know what those functions do. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/663315286b7cff907e92ae25.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/663315286b7cff907e92ae25.md
@@ -1,8 +1,8 @@
 ---
 id: 663315286b7cff907e92ae25
-title: Task 32
+title: Task 33
 challengeType: 22
-dashedName: task-32
+dashedName: task-33
 ---
 
 <!-- (Audio) Tom: Got it. So that means I should read the function names and comments to know what those functions do. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/663316fdcce39d9144ae40cd.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/663316fdcce39d9144ae40cd.md
@@ -1,8 +1,8 @@
 ---
 id: 663316fdcce39d9144ae40cd
-title: Task 33
+title: Task 34
 challengeType: 22
-dashedName: task-33
+dashedName: task-34
 ---
 
 <!-- (Audio) Tom: Got it. So that means I should read the function names and comments to know what these functions do. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/6633203e58595e93ef54ba3b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/6633203e58595e93ef54ba3b.md
@@ -1,8 +1,8 @@
 ---
 id: 6633203e58595e93ef54ba3b
-title: Task 34
+title: Task 35
 challengeType: 19
-dashedName: task-34
+dashedName: task-35
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/6633261bb572f2953f5abd13.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/6633261bb572f2953f5abd13.md
@@ -1,8 +1,8 @@
 ---
 id: 6633261bb572f2953f5abd13
-title: Task 35
+title: Task 36
 challengeType: 19
-dashedName: task-35
+dashedName: task-36
 ---
 
 <!-- (Audio) Tom: Got it. So that means I should read the function names and comments to know what these functions do. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/663350023c7cb898358af702.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/663350023c7cb898358af702.md
@@ -1,8 +1,8 @@
 ---
 id: 663350023c7cb898358af702
-title: Task 36
+title: Task 38
 challengeType: 22
-dashedName: task-36
+dashedName: task-38
 ---
 
 <!-- (Audio) Tom: Hey, Sophie, I'm working on a project that uses many variables. I'm not sure how to manage them all. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/6633511c7b197798ad5fd703.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/6633511c7b197798ad5fd703.md
@@ -1,8 +1,8 @@
 ---
 id: 6633511c7b197798ad5fd703
-title: Task 37
+title: Task 39
 challengeType: 19
-dashedName: task-37
+dashedName: task-39
 ---
 
 <!-- (Audio) Tom: Hey, Sophie, I'm working on a project that uses many variables. I'm not sure how to manage them all. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/663352b4860f03995736b6cd.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/663352b4860f03995736b6cd.md
@@ -1,8 +1,8 @@
 ---
 id: 663352b4860f03995736b6cd
-title: Task 38
+title: Task 40
 challengeType: 22
-dashedName: task-38
+dashedName: task-40
 ---
 
 <!-- (Audio) Sophie: Variables help you store information in your code, like names, numbers, and more. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/663354f60aafd69a4c0138da.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/663354f60aafd69a4c0138da.md
@@ -1,8 +1,8 @@
 ---
 id: 663354f60aafd69a4c0138da
-title: Task 39
+title: Task 41
 challengeType: 22
-dashedName: task-39
+dashedName: task-41
 ---
 
 <!-- (Audio) Sophie: You can use the equals symbol to assign values to them. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/66339d408258519c61151a64.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/66339d408258519c61151a64.md
@@ -1,8 +1,8 @@
 ---
 id: 66339d408258519c61151a64
-title: Task 40
+title: Task 42
 challengeType: 19
-dashedName: task-40
+dashedName: task-42
 ---
 
 <!-- (Audio) Sophie: Variables help you store information in your code, like names, numbers, and more. You can use the equals symbol to assign values to them. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/66339e21256f099cd722292f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/66339e21256f099cd722292f.md
@@ -1,8 +1,8 @@
 ---
 id: 66339e21256f099cd722292f
-title: Task 41
+title: Task 43
 challengeType: 19
-dashedName: task-41
+dashedName: task-43
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/66339f1995bdea9d4aa28cd8.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/66339f1995bdea9d4aa28cd8.md
@@ -1,8 +1,8 @@
 ---
 id: 66339f1995bdea9d4aa28cd8
-title: Task 42
+title: Task 44
 challengeType: 22
-dashedName: task-42
+dashedName: task-44
 ---
 
 <!-- (Audio) Tom: Thanks, Sophie. I'm also using many constants in my project. But what's the difference between variables and constants?

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/6633a14f17a4669e1c980d91.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/6633a14f17a4669e1c980d91.md
@@ -1,8 +1,8 @@
 ---
 id: 6633a14f17a4669e1c980d91
-title: Task 43
+title: Task 45
 challengeType: 19
-dashedName: task-43
+dashedName: task-45
 ---
 
 <!-- (Audio) Tom: Thanks, Sophie. I'm also using many constants in my project. But what's the difference between variables and constants? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/6633a2a86218659eb77fb9a1.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/6633a2a86218659eb77fb9a1.md
@@ -1,8 +1,8 @@
 ---
 id: 6633a2a86218659eb77fb9a1
-title: Task 44
+title: Task 46
 challengeType: 22
-dashedName: task-44
+dashedName: task-46
 ---
 
 <!-- (Audio) Sophie: Great question, Tom. Variables can change their values, but constants stay the same. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/6633a45ce837ac9f95394eab.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/6633a45ce837ac9f95394eab.md
@@ -1,8 +1,8 @@
 ---
 id: 6633a45ce837ac9f95394eab
-title: Task 45
+title: Task 47
 challengeType: 19
-dashedName: task-45
+dashedName: task-47
 ---
 
 <!-- (Audio) Sophie: Great question, Tom. Variables can change their values, but constants stay the same. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/6633a64567c725a05a94b68f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/6633a64567c725a05a94b68f.md
@@ -1,8 +1,8 @@
 ---
 id: 6633a64567c725a05a94b68f
-title: Task 46
+title: Task 48
 challengeType: 22
-dashedName: task-46
+dashedName: task-48
 ---
 
 <!-- (Audio) Sophie: Think of variables as containers that you can fill and empty, and constants as locked boxes that keep the same contents. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/6633a97f928771a163b59745.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/6633a97f928771a163b59745.md
@@ -1,8 +1,8 @@
 ---
 id: 6633a97f928771a163b59745
-title: Task 47
+title: Task 49
 challengeType: 19
-dashedName: task-47
+dashedName: task-49
 ---
 
 <!-- (Audio) Sophie: Think of variables as containers you can fill and empty, and constants as locked boxes that keep the same contents. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/6633aa9cf90591a1f63a431e.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/6633aa9cf90591a1f63a431e.md
@@ -1,8 +1,8 @@
 ---
 id: 6633aa9cf90591a1f63a431e
-title: Task 48
+title: Task 50
 challengeType: 19
-dashedName: task-48
+dashedName: task-50
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/6633abfc050e82a29a76dd42.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/6633abfc050e82a29a76dd42.md
@@ -1,8 +1,8 @@
 ---
 id: 6633abfc050e82a29a76dd42
-title: Task 49
+title: Task 51
 challengeType: 19
-dashedName: task-49
+dashedName: task-51
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/6633ad387b6914a3313339b3.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/6633ad387b6914a3313339b3.md
@@ -1,8 +1,8 @@
 ---
 id: 6633ad387b6914a3313339b3
-title: Task 50
+title: Task 52
 challengeType: 22
-dashedName: task-50
+dashedName: task-52
 ---
 
 <!-- (Audio) Tom: I see. So that means I can change the values in these variables, but I can't touch the values in these constants. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/6633ae85f1fb7aa3ca13234d.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/6633ae85f1fb7aa3ca13234d.md
@@ -1,8 +1,8 @@
 ---
 id: 6633ae85f1fb7aa3ca13234d
-title: Task 51
+title: Task 53
 challengeType: 19
-dashedName: task-51
+dashedName: task-53
 ---
 
 <!-- (Audio) Tom: I see. So that means I can change the values in these variables, but I can't change the values in these constants. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/665632c4ace6cb00ab832023.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/665632c4ace6cb00ab832023.md
@@ -1,8 +1,8 @@
 ---
 id: 665632c4ace6cb00ab832023
-title: Task 21
+title: Task 22
 challengeType: 19
-dashedName: task-21
+dashedName: task-22
 ---
 
 <!-- (Audio) Tom: Sarah, I'm learning about functions in programming and I'm not sure how to use them. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/685916f5a78e6c0f9dd7e751.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/685916f5a78e6c0f9dd7e751.md
@@ -1,0 +1,88 @@
+---
+id: 685916f5a78e6c0f9dd7e751
+title: Task 21
+challengeType: 22
+dashedName: task-21
+---
+
+<!-- REVIEW -->
+
+# --description--
+
+This is a review of the entire dialogue you just studied.
+
+# --instructions--
+
+Place the following phrases in the correct spot:
+
+`documentation`, `int`, `matches`, `data types`, `string`, `computer`, and `store`.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`Jake: Sarah, can you explain BLANK to me? I'm a bit confused.`
+
+`Sarah: Sure. Data types are fundamental in programming. You use them to tell the BLANK what kind of data you're working with.`
+
+`Jake: Thanks, but I see many data types listed in the BLANK. How do I know which one to choose?`
+
+`Sarah: Good question. You usually choose data types based on the kind of information you want to BLANK. For example, if you're working with text, you'd use this data type: BLANK. If it's whole numbers, you'd choose BLANK.`
+
+`Jake: Ah, I see. So this means I should pick the data type that BLANK the information I want to work with.`
+
+## --blanks--
+
+`data types`
+
+### --feedback--
+
+Different kinds of information you can use in code, like numbers or text.
+
+---
+
+`computer`
+
+### --feedback--
+
+A machine that follows instructions to do tasks like calculations or showing information.
+
+---
+
+`documentation`
+
+### --feedback--
+
+Helpful information that explains how to use code, tools, or programs.
+
+---
+
+`store`
+
+### --feedback--
+
+To keep information in a variable or memory for later use.
+
+---
+
+`string`
+
+### --feedback--
+
+A type of data that includes text, like words or sentences.
+
+---
+
+`int`
+
+### --feedback--
+
+Short for `integer`, this is a data type for whole numbers.
+
+---
+
+`matches`
+
+### --feedback--
+
+This means two things are the same or go together correctly.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/685917530d8061101ef7e3f0.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/685917530d8061101ef7e3f0.md
@@ -1,0 +1,80 @@
+---
+id: 685917530d8061101ef7e3f0
+title: Task 37
+challengeType: 22
+dashedName: task-37
+---
+
+<!-- REVIEW -->
+
+# --description--
+
+This is a review of the entire dialogue you just studied.
+
+# --instructions--
+
+Place the following phrases in the correct spot:
+
+`functions`, `names`, `in our code`, `reusable tasks`, `purpose`, and `comments`.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`Tom: Sarah, I'm learning about BLANK in programming and I'm not sure how to use them.`
+
+`Sarah: Functions are like small BLANK that you can use in your code.`
+
+`Tom: Thanks for explaining, Sarah. I see many functions BLANK but I'm not sure what each of these does.`
+
+`Sarah: No problem, Tom. To understand them, you can look at their names and BLANK. Comments explain that function's BLANK.`
+
+`Tom: Got it. So that means I should read the function BLANK and comments to know what these functions do.`
+
+## --blanks--
+
+`functions`
+
+### --feedback--
+
+Parts of code that do a job and can be used again and again.
+
+---
+
+`reusable tasks`
+
+### --feedback--
+
+Jobs in code you can do many times without writing them again.
+
+---
+
+`in our code`
+
+### --feedback--
+
+This means inside the program or script you are writing.
+
+---
+
+`comments`
+
+### --feedback--
+
+Notes in the code to explain what it does. The computer doesn't read them.
+
+---
+
+`purpose`
+
+### --feedback--
+
+The reason why something is done or exists.
+
+---
+
+`names`
+
+### --feedback--
+
+Words you use to identify things like variables, functions, or classes.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/685917c4259afc10d195c229.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-use-code-related-concepts-and-terms/685917c4259afc10d195c229.md
@@ -1,0 +1,80 @@
+---
+id: 685917c4259afc10d195c229
+title: Task 54
+challengeType: 22
+dashedName: task-54
+---
+
+<!-- REVIEW -->
+
+# --description--
+
+This is a review of the entire dialogue you just studied.
+
+# --instructions--
+
+Place the following phrases in the correct spot:
+
+`values`, `equals symbol`, `containers`, `constants`, `contents`, and `variables`.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`Tom: Hey, Sophie. I'm working on a project that uses many BLANK. I'm not sure how to manage them all.`
+
+`Sophie: Variables help you store information in your code, like names, numbers, and more. You can use the BLANK to assign values to them.`
+
+`Tom: Thanks, Sophie. I'm also using many BLANK in my project. But what's the difference between variables and constants?`
+
+`Sophie: Great question, Tom. Variables can change their BLANK, but constants stay the same. Think of variables as BLANK that you can fill and empty, and constants as locked boxes that keep the same BLANK.`
+
+`Tom: I see. So that means I can change the values in these variables, but I can't touch the values in these constants.`
+
+## --blanks--
+
+`variables`
+
+### --feedback--
+
+Names that hold information, like numbers or words, in a program.
+
+---
+
+`equals symbol`
+
+### --feedback--
+
+The `=` sign used to give a value to a variable.
+
+---
+
+`constants`
+
+### --feedback--
+
+Values that do not change while the program is running.
+
+---
+
+`values`
+
+### --feedback--
+
+The information stored in variables, like `5`, `"hello"`, or `true`.
+
+---
+
+`containers`
+
+### --feedback--
+
+Things like variables that hold or carry information in a program.
+
+---
+
+`contents`
+
+### --feedback--
+
+The information or value inside a container or variable.


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

Related to https://github.com/freeCodeCamp/freeCodeCamp/issues/55293

The EC team found that "summary tasks" were ineffective and confusing for learners, as noted in the related issue. In the B1 curriculum, we replaced them with "review tasks."

This PR is part of a series to apply the same changes to the A2 curriculum. To keep reviews easier, I'm splitting the updates into multiple PRs. This one covers Block 14.
