### PR TITLE
feat(curriculum): add review tasks to block 15 of the A2 curriculum

### DIFF
--- a/curriculum/challenges/_meta/learn-how-to-discuss-tech-trends-and-updates/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-discuss-tech-trends-and-updates/meta.json
@@ -98,68 +98,76 @@
       "title": "Task 22"
     },
     {
+      "id": "6859214362dab4169311ce7c",
+      "title": "Task 23"
+    },
+    {
       "id": "6636263059a6703a80ee06aa",
       "title": "Dialogue 2: Discussing Serverless Computing"
     },
     {
       "id": "663626ee2c3a803af8cc2fd6",
-      "title": "Task 23"
-    },
-    {
-      "id": "66362781eb0d663b5eabc353",
       "title": "Task 24"
     },
     {
-      "id": "6636285e6fcb733bdffaa986",
+      "id": "66362781eb0d663b5eabc353",
       "title": "Task 25"
     },
     {
-      "id": "6636ebb50b24c83f130344f4",
+      "id": "6636285e6fcb733bdffaa986",
       "title": "Task 26"
     },
     {
-      "id": "6636ee901c0de13ff4f02edc",
+      "id": "6636ebb50b24c83f130344f4",
       "title": "Task 27"
     },
     {
-      "id": "6636f20df76124410fe597e9",
+      "id": "6636ee901c0de13ff4f02edc",
       "title": "Task 28"
     },
     {
-      "id": "6636f36bfde85f41809044c9",
+      "id": "6636f20df76124410fe597e9",
       "title": "Task 29"
     },
     {
-      "id": "6636f47542d2a4421a433d8e",
+      "id": "6636f36bfde85f41809044c9",
       "title": "Task 30"
     },
     {
-      "id": "6636f652561a9842e74b032a",
+      "id": "6636f47542d2a4421a433d8e",
       "title": "Task 31"
     },
     {
-      "id": "6636f834a7b32443a43fa4e0",
+      "id": "6636f652561a9842e74b032a",
       "title": "Task 32"
     },
     {
-      "id": "6636f90f25a10b442185e3b8",
+      "id": "6636f834a7b32443a43fa4e0",
       "title": "Task 33"
     },
     {
-      "id": "6638478a5f79414a5126bca3",
+      "id": "6636f90f25a10b442185e3b8",
       "title": "Task 34"
     },
     {
-      "id": "66384b3e267aef4c6daf5279",
+      "id": "6638478a5f79414a5126bca3",
       "title": "Task 35"
     },
     {
-      "id": "66384d37bfbd344d5c647fbd",
+      "id": "66384b3e267aef4c6daf5279",
       "title": "Task 36"
     },
     {
-      "id": "66384eb6677d974e02af573b",
+      "id": "66384d37bfbd344d5c647fbd",
       "title": "Task 37"
+    },
+    {
+      "id": "66384eb6677d974e02af573b",
+      "title": "Task 38"
+    },
+    {
+      "id": "685921b21282d316f55adc7f",
+      "title": "Task 39"
     },
     {
       "id": "6638510e8311f74fec51b839",
@@ -167,63 +175,67 @@
     },
     {
       "id": "663855865f5d53510f9cd9a5",
-      "title": "Task 38"
-    },
-    {
-      "id": "663856f8cf403151ac9d9e8a",
-      "title": "Task 39"
-    },
-    {
-      "id": "663897f00196a953f16499c6",
       "title": "Task 40"
     },
     {
-      "id": "6638994f7dbcb3548e458202",
+      "id": "663856f8cf403151ac9d9e8a",
       "title": "Task 41"
     },
     {
-      "id": "66389a37bc8a4b5539eab451",
+      "id": "663897f00196a953f16499c6",
       "title": "Task 42"
     },
     {
-      "id": "66389c04cffc4f55e6e0f798",
+      "id": "6638994f7dbcb3548e458202",
       "title": "Task 43"
     },
     {
-      "id": "66389e09cec2fa569567b15a",
+      "id": "66389a37bc8a4b5539eab451",
       "title": "Task 44"
     },
     {
-      "id": "66389ee34417c057109ed5f6",
+      "id": "66389c04cffc4f55e6e0f798",
       "title": "Task 45"
     },
     {
-      "id": "6638a163d5757f57e5270598",
+      "id": "66389e09cec2fa569567b15a",
       "title": "Task 46"
     },
     {
-      "id": "6638a290bc4a5458dd6ebf07",
+      "id": "66389ee34417c057109ed5f6",
       "title": "Task 47"
     },
     {
-      "id": "6638a5aaf619a15a1c5cfe6f",
+      "id": "6638a163d5757f57e5270598",
       "title": "Task 48"
     },
     {
-      "id": "6638a7713695f25abd3f3c02",
+      "id": "6638a290bc4a5458dd6ebf07",
       "title": "Task 49"
     },
     {
-      "id": "6638a9a5dee1ac5b6a9db7d9",
+      "id": "6638a5aaf619a15a1c5cfe6f",
       "title": "Task 50"
     },
     {
-      "id": "6638aa72831d185bdac55c12",
+      "id": "6638a7713695f25abd3f3c02",
       "title": "Task 51"
     },
     {
-      "id": "6638abe5e8d43a5c7ed9d320",
+      "id": "6638a9a5dee1ac5b6a9db7d9",
       "title": "Task 52"
+    },
+    {
+      "id": "6638aa72831d185bdac55c12",
+      "title": "Task 53"
+    },
+    {
+      "id": "6638abe5e8d43a5c7ed9d320",
+      "title": "Task 54"
+    },
+    {
+      "id": "685921ea5a8eb9174d88d209",
+      "title": "Task 55"
     }
   ],
   "helpCategory": "English",

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/663626ee2c3a803af8cc2fd6.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/663626ee2c3a803af8cc2fd6.md
@@ -1,8 +1,8 @@
 ---
 id: 663626ee2c3a803af8cc2fd6
-title: Task 23
+title: Task 24
 challengeType: 19
-dashedName: task-23
+dashedName: task-24
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/66362781eb0d663b5eabc353.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/66362781eb0d663b5eabc353.md
@@ -1,8 +1,8 @@
 ---
 id: 66362781eb0d663b5eabc353
-title: Task 24
+title: Task 25
 challengeType: 19
-dashedName: task-24
+dashedName: task-25
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/6636285e6fcb733bdffaa986.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/6636285e6fcb733bdffaa986.md
@@ -1,8 +1,8 @@
 ---
 id: 6636285e6fcb733bdffaa986
-title: Task 25
+title: Task 26
 challengeType: 22
-dashedName: task-25
+dashedName: task-26
 ---
 
 <!-- (Audio) Tom: Lisa, do you know what this serverless computing trend is all about? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/6636ebb50b24c83f130344f4.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/6636ebb50b24c83f130344f4.md
@@ -1,8 +1,8 @@
 ---
 id: 6636ebb50b24c83f130344f4
-title: Task 26
+title: Task 27
 challengeType: 19
-dashedName: task-26
+dashedName: task-27
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/6636ee901c0de13ff4f02edc.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/6636ee901c0de13ff4f02edc.md
@@ -1,8 +1,8 @@
 ---
 id: 6636ee901c0de13ff4f02edc
-title: Task 27
+title: Task 28
 challengeType: 22
-dashedName: task-27
+dashedName: task-28
 ---
 
 <!-- (Audio) Lisa: Serverless computing is an interesting concept, Tom. It's when we run code without managing servers, like having computer helpers. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/6636f20df76124410fe597e9.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/6636f20df76124410fe597e9.md
@@ -1,8 +1,8 @@
 ---
 id: 6636f20df76124410fe597e9
-title: Task 28
+title: Task 29
 challengeType: 19
-dashedName: task-28
+dashedName: task-29
 ---
 
 <!-- (Audio) Lisa: Serverless computing is an interesting concept, Tom. It's when we run code without managing servers, like having computer  helpers. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/6636f36bfde85f41809044c9.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/6636f36bfde85f41809044c9.md
@@ -1,8 +1,8 @@
 ---
 id: 6636f36bfde85f41809044c9
-title: Task 29
+title: Task 30
 challengeType: 19
-dashedName: task-29
+dashedName: task-30
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/6636f47542d2a4421a433d8e.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/6636f47542d2a4421a433d8e.md
@@ -1,8 +1,8 @@
 ---
 id: 6636f47542d2a4421a433d8e
-title: Task 30
+title: Task 31
 challengeType: 19
-dashedName: task-30
+dashedName: task-31
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/6636f652561a9842e74b032a.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/6636f652561a9842e74b032a.md
@@ -1,8 +1,8 @@
 ---
 id: 6636f652561a9842e74b032a
-title: Task 31
+title: Task 32
 challengeType: 22
-dashedName: task-31
+dashedName: task-32
 ---
 
 <!-- (Audio) Lisa: It's one of those trends that's making cloud computing even more convenient. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/6636f834a7b32443a43fa4e0.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/6636f834a7b32443a43fa4e0.md
@@ -1,8 +1,8 @@
 ---
 id: 6636f834a7b32443a43fa4e0
-title: Task 32
+title: Task 33
 challengeType: 19
-dashedName: task-32
+dashedName: task-33
 ---
 
 <!-- (Audio) Lisa: Serverless computing is an interesting concept, Tom. It's when we run code without managing servers, like having computer helpers. It's one of those trends that's making cloud computing even more convenient. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/6636f90f25a10b442185e3b8.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/6636f90f25a10b442185e3b8.md
@@ -1,8 +1,8 @@
 ---
 id: 6636f90f25a10b442185e3b8
-title: Task 33
+title: Task 34
 challengeType: 22
-dashedName: task-33
+dashedName: task-34
 ---
 
 <!-- (Audio) Tom: That sounds cool. Do you think we can use it for our upcoming project? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/6638478a5f79414a5126bca3.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/6638478a5f79414a5126bca3.md
@@ -1,8 +1,8 @@
 ---
 id: 6638478a5f79414a5126bca3
-title: Task 34
+title: Task 35
 challengeType: 22
-dashedName: task-34
+dashedName: task-35
 ---
 
 <!-- (Audio) Lisa: It's especially useful when we need to handle variable workloads and want to save on server management tasks. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/66384b3e267aef4c6daf5279.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/66384b3e267aef4c6daf5279.md
@@ -1,8 +1,8 @@
 ---
 id: 66384b3e267aef4c6daf5279
-title: Task 35
+title: Task 36
 challengeType: 22
-dashedName: task-35
+dashedName: task-36
 ---
 
 <!-- (Audio) Lisa: It's especially useful when we need to handle variable workloads and want to save on server management tasks. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/66384d37bfbd344d5c647fbd.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/66384d37bfbd344d5c647fbd.md
@@ -1,8 +1,8 @@
 ---
 id: 66384d37bfbd344d5c647fbd
-title: Task 36
+title: Task 37
 challengeType: 22
-dashedName: task-36
+dashedName: task-37
 ---
 
 <!-- (Audio) Lisa: It's especially useful when we need to handle variable workloads and want to save on server management tasks. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/66384eb6677d974e02af573b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/66384eb6677d974e02af573b.md
@@ -1,8 +1,8 @@
 ---
 id: 66384eb6677d974e02af573b
-title: Task 37
+title: Task 38
 challengeType: 19
-dashedName: task-37
+dashedName: task-38
 ---
 
 <!-- (Audio) Lisa: It's especially useful when we need to handle variable workloads and want to save on server management tasks. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/663855865f5d53510f9cd9a5.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/663855865f5d53510f9cd9a5.md
@@ -1,8 +1,8 @@
 ---
 id: 663855865f5d53510f9cd9a5
-title: Task 38
+title: Task 40
 challengeType: 22
-dashedName: task-38
+dashedName: task-40
 ---
 
 <!-- (Audio) Bob: Sarah, I'm hearing a lot about AI in programming these days, but I don't know how to use it. Any ideas? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/663856f8cf403151ac9d9e8a.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/663856f8cf403151ac9d9e8a.md
@@ -1,8 +1,8 @@
 ---
 id: 663856f8cf403151ac9d9e8a
-title: Task 39
+title: Task 41
 challengeType: 19
-dashedName: task-39
+dashedName: task-41
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/663897f00196a953f16499c6.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/663897f00196a953f16499c6.md
@@ -1,8 +1,8 @@
 ---
 id: 663897f00196a953f16499c6
-title: Task 40
+title: Task 42
 challengeType: 19
-dashedName: task-40
+dashedName: task-42
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/6638994f7dbcb3548e458202.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/6638994f7dbcb3548e458202.md
@@ -1,8 +1,8 @@
 ---
 id: 6638994f7dbcb3548e458202
-title: Task 41
+title: Task 43
 challengeType: 19
-dashedName: task-41
+dashedName: task-43
 ---
 
 <!-- (Audio) Bob: Sarah, I'm hearing a lot about AI in programming these days, but I don't know how to use it. Any ideas? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/66389a37bc8a4b5539eab451.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/66389a37bc8a4b5539eab451.md
@@ -1,8 +1,8 @@
 ---
 id: 66389a37bc8a4b5539eab451
-title: Task 42
+title: Task 44
 challengeType: 19
-dashedName: task-42
+dashedName: task-44
 ---
 
 <!-- (Audio) Bob: Sarah, I'm hearing a lot about AI in programming these days, but I don't know how to use it. Any ideas? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/66389c04cffc4f55e6e0f798.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/66389c04cffc4f55e6e0f798.md
@@ -1,8 +1,8 @@
 ---
 id: 66389c04cffc4f55e6e0f798
-title: Task 43
+title: Task 45
 challengeType: 22
-dashedName: task-43
+dashedName: task-45
 ---
 
 <!-- (Audio) Sarah: AI in programming involves using smart computers to help write code or find errors. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/66389e09cec2fa569567b15a.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/66389e09cec2fa569567b15a.md
@@ -1,8 +1,8 @@
 ---
 id: 66389e09cec2fa569567b15a
-title: Task 44
+title: Task 46
 challengeType: 19
-dashedName: task-44
+dashedName: task-46
 ---
 
 <!-- (Audio) Sarah: AI in programming involves using smart computers to help write code or find errors. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/66389ee34417c057109ed5f6.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/66389ee34417c057109ed5f6.md
@@ -1,8 +1,8 @@
 ---
 id: 66389ee34417c057109ed5f6
-title: Task 45
+title: Task 47
 challengeType: 22
-dashedName: task-45
+dashedName: task-47
 ---
 
 <!-- (Audio) Sarah: It's one of those trends that automates certain tasks in development. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/6638a163d5757f57e5270598.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/6638a163d5757f57e5270598.md
@@ -1,8 +1,8 @@
 ---
 id: 6638a163d5757f57e5270598
-title: Task 46
+title: Task 48
 challengeType: 19
-dashedName: task-46
+dashedName: task-48
 ---
 
 <!-- (Audio) Sarah: It's one of those trends that automates certain tasks in development. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/6638a290bc4a5458dd6ebf07.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/6638a290bc4a5458dd6ebf07.md
@@ -1,8 +1,8 @@
 ---
 id: 6638a290bc4a5458dd6ebf07
-title: Task 47
+title: Task 49
 challengeType: 22
-dashedName: task-47
+dashedName: task-49
 ---
 
 <!-- (Audio) Sarah: I was actually thinking of using AI in tasks like code analysis and bug detection. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/6638a5aaf619a15a1c5cfe6f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/6638a5aaf619a15a1c5cfe6f.md
@@ -1,8 +1,8 @@
 ---
 id: 6638a5aaf619a15a1c5cfe6f
-title: Task 48
+title: Task 50
 challengeType: 22
-dashedName: task-48
+dashedName: task-50
 ---
 
 <!-- (Audio) Sarah: I was actually thinking of using AI in tasks like code analysis and bug detection. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/6638a7713695f25abd3f3c02.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/6638a7713695f25abd3f3c02.md
@@ -1,8 +1,8 @@
 ---
 id: 6638a7713695f25abd3f3c02
-title: Task 49
+title: Task 51
 challengeType: 22
-dashedName: task-49
+dashedName: task-51
 ---
 
 <!-- (Audio) Sarah: It can improve code quality and reduce the time spent on debugging. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/6638a9a5dee1ac5b6a9db7d9.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/6638a9a5dee1ac5b6a9db7d9.md
@@ -1,8 +1,8 @@
 ---
 id: 6638a9a5dee1ac5b6a9db7d9
-title: Task 50
+title: Task 52
 challengeType: 19
-dashedName: task-50
+dashedName: task-52
 ---
 
 <!-- (Audio) Sarah: I was actually thinking of using AI in tasks like code analysis and bug detection. It can improve code quality and reduce the time spent on debugging. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/6638aa72831d185bdac55c12.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/6638aa72831d185bdac55c12.md
@@ -1,8 +1,8 @@
 ---
 id: 6638aa72831d185bdac55c12
-title: Task 51
+title: Task 53
 challengeType: 22
-dashedName: task-51
+dashedName: task-53
 ---
 
 <!-- (Audio) Bob: Great idea. I think we should give it a go and test it out. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/6638abe5e8d43a5c7ed9d320.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/6638abe5e8d43a5c7ed9d320.md
@@ -1,8 +1,8 @@
 ---
 id: 6638abe5e8d43a5c7ed9d320
-title: Task 52
+title: Task 54
 challengeType: 19
-dashedName: task-52
+dashedName: task-54
 ---
 
 <!-- (Audio) Sarah: I was actually thinking of using AI in tasks like code analysis and bug detection. It can improve code quality and reduce the time spent on debugging. Bob: Great idea. I think we should give it a go and test it out. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/6859214362dab4169311ce7c.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/6859214362dab4169311ce7c.md
@@ -1,0 +1,84 @@
+---
+id: 6859214362dab4169311ce7c
+title: Task 23
+challengeType: 22
+dashedName: task-23
+---
+
+<!-- REVIEW -->
+
+# --description--
+
+This is a review of the entire dialogue you just studied.
+
+# --instructions--
+
+Place the following phrases in the correct spot:
+
+`low-code development`, `extensive coding`, `check out`, `convenient`, `software`, and `projects`.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`Brian: Hey Sarah, I read about BLANK on the internet and I got curious. Do you know what it's all about?`
+
+`Sarah: Low-code development is about making BLANK with less code. It's one of those trends that simplifies the development process.`
+
+`Brian: That sounds BLANK, but can we use it on our projects?`
+
+`Sarah: We can consider low-code tools to speed up development and reduce the need for BLANK. It's particularly useful when you have many tasks and a limited coding team.`
+
+`Brian: I see. Maybe we could try it on some of our more demanding BLANK.`
+
+`Sarah: I think so. Why don't we BLANK some of these tools to see if they can help us?`
+
+`Brian: I'm on it.`
+
+## --blanks--
+
+`low-code development`
+
+### --feedback--
+
+Making software using simple tools that don't need much coding.
+
+---
+
+`software`
+
+### --feedback--
+
+Programs or apps that run on a computer or device.
+
+---
+
+`convenient`
+
+### --feedback--
+
+Easy and helpful to use.
+
+---
+
+`extensive coding`
+
+### --feedback--
+
+Writing a lot of code to build something.
+
+---
+
+`projects`
+
+### --feedback--
+
+Work or tasks you plan and build, often with goals and steps.
+
+---
+
+`check out`
+
+### --feedback--
+
+To look at something or try it to learn more.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/685921b21282d316f55adc7f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/685921b21282d316f55adc7f.md
@@ -1,0 +1,88 @@
+---
+id: 685921b21282d316f55adc7f
+title: Task 39
+challengeType: 22
+dashedName: task-39
+---
+
+<!-- REVIEW -->
+
+# --description--
+
+This is a review of the entire dialogue you just studied.
+
+# --instructions--
+
+Place the following phrases in the correct spot:
+
+`cloud computing`, `servers`, `serverless computing`, `workloads`, `app`, `server management`, and `handle`.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`Tom: Lisa, do you know what this BLANK trend is all about?`
+
+`Lisa: Serverless computing is an interesting concept, Tom. It's when we run code without managing BLANK, like having computer helpers. It's one of those trends that's making BLANK even more convenient.`
+
+`Tom: That sounds cool. Do you think we can use it for our upcoming project?`
+
+`Lisa: Well, for our project, we can consider using serverless computing to build parts of our BLANK that need to scale easily. It's especially useful when we need to handle variable BLANK and want to save on BLANK tasks.`
+
+`Tom: Got it. So we should explore serverless computing for the parts of our project that need to BLANK changing workloads. Good to know.`
+
+## --blanks--
+
+`serverless computing`
+
+### --feedback--
+
+Running apps without managing the servers yourself.
+
+---
+
+`servers`
+
+### --feedback--
+
+Powerful computers that store data and run programs for other devices.
+
+---
+
+`cloud computing`
+
+### --feedback--
+
+Using the internet to store data and run programs instead of using your own computer.
+
+---
+
+`app`
+
+### --feedback--
+
+A program designed to do a specific job, like messaging or shopping.
+
+---
+
+`workloads`
+
+### --feedback--
+
+The amount of work a computer system needs to do.
+
+---
+
+`server management`
+
+### --feedback--
+
+Taking care of servers, like updating and fixing them.
+
+---
+
+`handle`
+
+### --feedback--
+
+To take care of or deal with something.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/685921ea5a8eb9174d88d209.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-tech-trends-and-updates/685921ea5a8eb9174d88d209.md
@@ -1,0 +1,80 @@
+---
+id: 685921ea5a8eb9174d88d209
+title: Task 55
+challengeType: 22
+dashedName: task-55
+---
+
+<!-- REVIEW -->
+
+# --description--
+
+This is a review of the entire dialogue you just studied.
+
+# --instructions--
+
+Place the following phrases in the correct spot:
+
+`AI`, `bug detection`, `errors`, `automate`, `debugging`, and `improve`.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`Bob: Sarah, I'm hearing a lot about BLANK in programming these days, but I don't know how to use it. Any ideas?`
+
+`Sarah: AI in programming involves using smart computers to help write code or find BLANK. It's one of those trends that BLANK certain tasks in development.`
+
+`Bob: That's fascinating.`
+
+`Sarah: It is, right? I was actually thinking of using AI in tasks like code analysis and BLANK. It can BLANK code quality and reduce the time spent on BLANK.`
+
+`Bob: Great idea. I think we should give it a go and test it out.`
+
+## --blanks--
+
+`AI`
+
+### --feedback--
+
+An acronym for `Artificial Intelligence` - when computers do things that usually need human thinking.
+
+---
+
+`errors`
+
+### --feedback--
+
+Problems or mistakes in a program that stop it from working right.
+
+---
+
+`automate`
+
+### --feedback--
+
+To make something happen by itself using a program, without people doing it.
+
+---
+
+`bug detection`
+
+### --feedback--
+
+Finding mistakes or problems in code.
+
+---
+
+`improve`
+
+### --feedback--
+
+To make something better.
+
+---
+
+`debugging`
+
+### --feedback--
+
+Fixing the problems or mistakes in your code.


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

Related to https://github.com/freeCodeCamp/freeCodeCamp/issues/55293

The EC team found that "summary tasks" were ineffective and confusing for learners, as noted in the related issue. In the B1 curriculum, we replaced them with "review tasks."

This PR is part of a series to apply the same changes to the A2 curriculum. To keep reviews easier, I'm splitting the updates into multiple PRs. This one covers Block 15.
