### PR TITLE
fix(api): duplicate reply on error in /daily-coding-challenge-completed

### DIFF
--- a/api/src/routes/protected/challenge.ts
+++ b/api/src/routes/protected/challenge.ts
@@ -291,6 +291,7 @@ export const challengeRoutes: FastifyPluginCallbackTypebox = (
             type: 'error',
             message: 'That does not appear to be a valid challenge submission.'
           });
+        } else {
           fastify.errorHandler(error, req, reply);
         }
       }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

The error handler should either deal with the error or pass it off the main handler, not both. 

<!-- Feel free to add any additional description of changes below this line -->
