### PR TITLE
feat(api): allow HOME_LOCATION origin in development

### DIFF
--- a/api/src/plugins/auth0.test.ts
+++ b/api/src/plugins/auth0.test.ts
@@ -107,7 +107,7 @@ describe('auth0 plugin', () => {
       });
 
       expect(res.headers.location).toMatch(
-        `${HOME_LOCATION}/learn?${formatMessage({ type: 'danger', content: 'flash.generic-error' })}`
+        `${HOME_LOCATION}/?${formatMessage({ type: 'danger', content: 'flash.generic-error' })}`
       );
       expect(res.statusCode).toBe(302);
     });
@@ -119,7 +119,7 @@ describe('auth0 plugin', () => {
       });
 
       expect(res.headers.location).toMatch(
-        `${HOME_LOCATION}/learn?${formatMessage({ type: 'danger', content: 'flash.generic-error' })}`
+        `${HOME_LOCATION}/?${formatMessage({ type: 'danger', content: 'flash.generic-error' })}`
       );
       expect(res.statusCode).toBe(302);
     });

--- a/api/src/routes/public/signout.test.ts
+++ b/api/src/routes/public/signout.test.ts
@@ -31,11 +31,9 @@ describe('GET /signout', () => {
   it('should redirect to / on the client by default', async () => {
     const res = await superRequest('/signout', { method: 'GET' });
 
-    // This happens because localhost:8000 is not an allowed origin and so
-    // normalizeParams rejects it and sets the returnTo to /learn. TODO:
-    // separate the validation and normalization logic.
+    // TODO: separate the validation and normalization logic.
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    expect(res.headers.location).toBe(`${HOME_LOCATION}/learn`);
+    expect(res.headers.location).toBe(`${HOME_LOCATION}/`);
     expect(res.status).toBe(302);
   });
 });

--- a/api/src/utils/allowed-origins.ts
+++ b/api/src/utils/allowed-origins.ts
@@ -1,4 +1,6 @@
-export const allowedOrigins = [
+import { HOME_LOCATION, FREECODECAMP_NODE_ENV } from './env';
+
+const ALLOWED_ORIGINS = [
   'https://www.freecodecamp.dev',
   'https://www.freecodecamp.org',
   // pretty sure the rest of these can go?
@@ -7,3 +9,8 @@ export const allowedOrigins = [
   'https://chinese.freecodecamp.dev',
   'https://chinese.freecodecamp.org'
 ];
+
+export const allowedOrigins =
+  FREECODECAMP_NODE_ENV === 'development'
+    ? [...ALLOWED_ORIGINS, HOME_LOCATION]
+    : ALLOWED_ORIGINS;

--- a/api/src/utils/redirection.test.ts
+++ b/api/src/utils/redirection.test.ts
@@ -182,13 +182,13 @@ describe('redirection', () => {
       expect(result).toEqual(expectedReturn);
     });
 
-    it('should use HOME_LOCATION with missing referer', () => {
+    it('should returnTo the origin if the referer is missing', () => {
       const req = {
         headers: {}
       };
 
       const expectedReturn = {
-        returnTo: `${HOME_LOCATION}/learn`,
+        returnTo: `${HOME_LOCATION}/`,
         origin: HOME_LOCATION,
         pathPrefix: ''
       };
@@ -197,7 +197,7 @@ describe('redirection', () => {
       expect(result).toEqual(expectedReturn);
     });
 
-    it('should use HOME_LOCATION with invalid referrer', () => {
+    it('should returnTo the origin if the referrer is invalid', () => {
       const req = {
         headers: {
           referer: 'invalid-url'
@@ -205,7 +205,7 @@ describe('redirection', () => {
       };
 
       const expectedReturn = {
-        returnTo: `${HOME_LOCATION}/learn`,
+        returnTo: `${HOME_LOCATION}/`,
         origin: HOME_LOCATION,
         pathPrefix: ''
       };

--- a/e2e/signout-modal.spec.ts
+++ b/e2e/signout-modal.spec.ts
@@ -31,7 +31,7 @@ test.describe('Signout Modal component', () => {
     ).toBeVisible();
   });
 
-  test('signs out and redirects to /learn after user confirms they want to sign out', async ({
+  test('signs out and redirects to / after user confirms they want to sign out', async ({
     page
   }) => {
     await page.getByRole('button', { name: translations.buttons.menu }).click();
@@ -50,7 +50,7 @@ test.describe('Signout Modal component', () => {
     await expect(
       page.getByRole('dialog', { name: translations.signout.heading })
     ).not.toBeVisible();
-    await expect(page).toHaveURL(allowTrailingSlash('/learn'));
+    await expect(page).toHaveURL(allowTrailingSlash(''));
   });
 
   test('closes modal after user cancels signing out', async ({ page }) => {


### PR DESCRIPTION
Otherwise we get spurious "Received request from disallowed origin: ..." warnings.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
