### PR TITLE
fix(curriculum): correct typos in semantic HTML content

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lecture-importance-of-semantic-html/672995ffdfd2f337f5f215f8.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-importance-of-semantic-html/672995ffdfd2f337f5f215f8.md
@@ -46,7 +46,7 @@ Here is an example of using the subscript element to show the chemical represent
 
 The number two is wrapped inside `sub` tags to illustrate that the character should be a subscript.
 
-Common uses cases for the subscript element include chemical formulas, foot notes, and variable subscripts.
+Common use cases for the subscript element include chemical formulas, footnotes, and variable subscripts.
 
 # --questions--
 

--- a/curriculum/challenges/english/25-front-end-development/quiz-semantic-html/66ed903cf45ce3ece4053ebe.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-semantic-html/66ed903cf45ce3ece4053ebe.md
@@ -845,7 +845,7 @@ variable subscripts
 
 ---
 
-foot notes
+footnotes
 
 ---
 
@@ -897,7 +897,7 @@ ordinal numbers
 
 #### --answer--
 
-foot notes
+footnotes
 
 ### --question--
 

--- a/curriculum/challenges/english/25-front-end-development/review-semantic-html/671a83934b61f64cefe87a61.md
+++ b/curriculum/challenges/english/25-front-end-development/review-semantic-html/671a83934b61f64cefe87a61.md
@@ -125,7 +125,7 @@ The `lang` attribute inside the open `i` tag is used to specify the language of 
 </p>
 ```
 
-- **Subscript (`sub`) element**: used to represent subscript text. Common uses cases for the subscript element include chemical formulas, foot notes, and variable subscripts.
+- **Subscript (`sub`) element**: used to represent subscript text. Common use cases for the subscript element include chemical formulas, footnotes, and variable subscripts.
 
 ```html
 <p>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #60985

<!-- Feel free to add any additional description of changes below this line -->

This PR fixes minor typographical errors in the semantic HTML curriculum:

- Replaced **"uses cases"** with **"use cases"**
- Replaced **"foot notes"** with **"footnotes"**

Affected files:
- `lecture-importance-of-semantic-html/672995ffdfd2f337f5f215f8.md`
- `review-semantic-html/671a83934b61f64cefe87a61.md`
- `quiz-semantic-html/66ed903cf45ce3ece4053ebe.md`
