### PR TITLE
chore(curriculum): update workshop-magazine tests to use specific assertions

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6143b9e1f5035c6e5f2a8231.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6143b9e1f5035c6e5f2a8231.md
@@ -29,9 +29,13 @@ assert(document.querySelectorAll('.lists li')?.length === 6);
 Each of your new `li` elements should have an `h4` and `p` element.
 
 ```js
-const lis = [...document.querySelectorAll('.lists li')];
-assert(lis?.every(li => li?.children?.[0]?.localName === 'h4' && li?.children?.[1]?.localName === 'p'));
-```
+const lis = document.querySelectorAll('.lists li');
+assert.isNotEmpty(lis);
+lis.forEach(li => {
+  assert.equal(li?.children?.[0]?.localName, 'h4');
+  assert.equal(li?.children?.[1]?.localName, 'p');
+});
+ ```
 
 Your first `h4` should have the text `V1 - 2014`.
 
@@ -108,8 +112,9 @@ assert(document.querySelectorAll('.lists li p')?.[5]?.innerText === 'We launched
 Your six `h4` elements should each have the class `list-subtitle`.
 
 ```js
-const h4s = [...document.querySelectorAll('.lists li h4')];
-assert(h4s?.every(h4 => h4?.classList?.contains('list-subtitle')));
+const h4s = document.querySelectorAll('.lists li h4');
+assert.isNotEmpty(h4s);
+h4s.forEach(h4 => { assert.isTrue(h4?.classList?.contains('list-subtitle')) });
 ```
 
 # --seed--


### PR DESCRIPTION
## What does this PR do?

This PR updates the test cases in the `workshop-magazine` challenge to use more specific assertions, as suggested in issue #61002. It replaces general `assert(...)` calls with clearer and more informative assertions such as `assert.equal`, `assert.isNotEmpty`, and `assert.isTrue`.

## What does this PR do?

This PR updates the test cases in the `workshop-magazine` challenge to use more specific assertions, as suggested in issue #61002. It replaces general `assert(...)` calls with clearer and more informative assertions such as `assert.equal`, `assert.isNotEmpty`, and `assert.isTrue`.

## Changes

- Replaced:
  ```js
  const lis = [...document.querySelectorAll('.lists li')];
  assert(lis?.every(li => li?.children?.[0]?.localName === 'h4' && li?.children?.[1]?.localName === 'p'));
```  
- With:
```js
  const lis = document.querySelectorAll('.lists li');
  assert.isNotEmpty(lis);
  lis.forEach(li => {
    assert.equal(li?.children?.[0]?.localName, 'h4');
    assert.equal(li?.children?.[1]?.localName, 'p');
  });
```

- Replaced:

```js
  const h4s = [...document.querySelectorAll('.lists li h4')];
  assert(h4s?.every(h4 => h4?.classList?.contains('list-subtitle')));
```
With:

```js
  const h4s = document.querySelectorAll('.lists li h4');
  assert.isNotEmpty(h4s);
  h4s.forEach(h4 => {
    assert.isTrue(h4?.classList?.contains('list-subtitle'));
  });
```
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


Closes #61002

<!-- Feel free to add any additional description of changes below this line -->
