### PR TITLE
feat(curriculum): add review tasks to block 18 of the A2 curriculum

### DIFF
--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-for-clarification-on-code-understanding/65f43c96b08a08ac434de6cb.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-for-clarification-on-code-understanding/65f43c96b08a08ac434de6cb.md
@@ -5,165 +5,66 @@ challengeType: 22
 dashedName: task-15
 ---
 
-<!-- (Audio) The whole dialogue -->
+<!-- REVIEW -->
 
 # --description--
 
-This task summarizes the conversation between Brian and Sarah.
+This is a review of the entire dialogue you just studied.
+
+# --instructions--
+
+Place the following phrases in the correct spot:
+
+`going through`, `uncertain about`, `figure out`, `clarification on`, and `as expected`.
 
 # --fillInTheBlank--
 
 ## --sentence--
 
-`Brian was BLANK through the new code changes when he realized he needed clarification. Sarah offered to BLANK him BLANK the code to BLANK out what was causing the issue.`
+`Brian: Hey Sarah, I was BLANK the new code changes you made in this module, and I might need some BLANK a specific part.`
+
+`Sarah: Of course Brian, I can explain what I was trying to achieve there. What part of the code are you BLANK?`
+
+`Brian: In the function you added, it could be that I'm missing something, but it may not be working BLANK. I should probably understand the logic better.`
+
+`Sarah: I understand Brian, let's go through it together. I can walk you through the code, and we should be able to BLANK what's going wrong.`
 
 ## --blanks--
 
-`going`
+`going through`
 
 ### --feedback--
 
-Brian was reviewing or examining the code changes.
+Reading or checking something carefully, step by step.
 
 ---
 
-`walk`
+`clarification on`
 
 ### --feedback--
 
-Sarah proposed to guide Brian through the code.
+More explanation to help you understand something better.
 
 ---
 
-`through`
+`uncertain about`
 
 ### --feedback--
 
-It means a thorough review or walkthrough of the code.
+Not sure or not confident about something.
 
 ---
 
-`figure`
+`as expected`
 
 ### --feedback--
 
-Their goal was to understand and resolve the code problem.
+Happened the way you thought it would.
 
-# --scene--
+---
 
-```json
-{
-  "setup": {
-    "background": "company2-center.png",
-    "characters": [
-      {
-        "character": "Brian",
-        "position": { "x": -25, "y": 0, "z": 1 }
-      },
-      {
-        "character": "Sarah",
-        "position": { "x": 125, "y": 0, "z": 1 }
-      }
-    ],
-    "audio": {
-      "filename": "6.3-1.mp3",
-      "startTime": 1
-    },
-    "alwaysShowDialogue": true
-  },
-  "commands": [
-    {
-      "character": "Brian",
-      "position": { "x": 25, "y": 0, "z": 1 },
-      "startTime": 0
-    },
-    {
-      "character": "Sarah",
-      "position": { "x": 70, "y": 0, "z": 1 },
-      "startTime": 0.5
-    },
-    {
-      "character": "Brian",
-      "startTime": 1.52,
-      "finishTime": 5.24,
-      "dialogue": {
-        "text": "Hey Sarah, I was going through the new code changes you made in this module,",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Brian",
-      "startTime": 5.52,
-      "finishTime": 8.14,
-      "dialogue": {
-        "text": "and I might need some clarification on a specific part.",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Sarah",
-      "startTime": 8.66,
-      "finishTime": 11.5,
-      "dialogue": {
-        "text": "Of course Brian, I can explain what I was trying to achieve there.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Sarah",
-      "startTime": 11.78,
-      "finishTime": 13.46,
-      "dialogue": {
-        "text": "What part of the code are you uncertain about?",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Brian",
-      "startTime": 13.76,
-      "finishTime": 16.4,
-      "dialogue": {
-        "text": "In the function you added, it could be that I'm missing something,",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Brian",
-      "startTime": 16.58,
-      "finishTime": 21.02,
-      "dialogue": {
-        "text": "but it may not be working as expected. I should probably understand the logic better.",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Sarah",
-      "startTime": 22.24,
-      "finishTime": 24.22,
-      "dialogue": {
-        "text": "I understand Brian, let's go through it together.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Sarah",
-      "startTime": 24.58,
-      "finishTime": 27.96,
-      "dialogue": {
-        "text": "I can walk you through the code, and we should be able to figure out what's going wrong.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Sarah",
-      "position": { "x": 125, "y": 0, "z": 1 },
-      "startTime": 28.46
-    },
-    {
-      "character": "Brian",
-      "position": { "x": -25, "y": 0, "z": 1 },
-      "startTime": 28.96
-    }
-  ]
-}
-```
+`figure out`
+
+### --feedback--
+
+To understand or solve something after thinking about it.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-for-clarification-on-code-understanding/65f5703b434254615ec3b886.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-for-clarification-on-code-understanding/65f5703b434254615ec3b886.md
@@ -5,165 +5,74 @@ challengeType: 22
 dashedName: task-27
 ---
 
-<!-- (Audio) The whole dialogue -->
+<!-- REVIEW -->
 
 # --description--
 
-This challenge summarizes the entire dialogue between Tom and Sarah. 
+This is a review of the entire dialogue you just studied.
+
+# --instructions--
+
+Place the following phrases in the correct spot:
+
+`dealing with`, `related to`, `work together`, `take a look`, `step by step`, and `figure it out`.
 
 # --fillInTheBlank--
 
 ## --sentence--
 
-`Tom discusses a BLANK bug with Sarah and expresses his difficulty in resolving it. Sarah offers to BLANK and suggests going through the code step by step. They agree to work BLANK to BLANK the coding problem.`
+`Tom: Hey, Sarah. I'm BLANK a persistent bug in this section of the code. I can't BLANK and I may need your expertise.`
+
+`Sarah: Sure, Tom. I can BLANK at it. Let's start by identifying the issue. Where does it seem to be happening?`
+
+`Tom: Well, I believe it may be BLANK data processing. I've tried a few things, but it could be something more complicated.`
+
+`Sarah: I see. I should probably debug it BLANK. With your input, we can BLANK to solve this problem.`
 
 ## --blanks--
 
-`persistent`
+`dealing with`
 
 ### --feedback--
 
-This word refers to the ongoing nature of the bug Tom is facing.
+Trying to fix or handle a problem or situation.
 
 ---
 
-`help`
+`figure it out`
 
 ### --feedback--
 
-Sarah offers her assistance to Tom in resolving the issue.
+To find the answer or solution to something.
 
 ---
 
-`together`
+`take a look`
 
 ### --feedback--
 
-It emphasizes their teamwork and collaborative effort.
+To quickly check or examine something.
 
 ---
 
-`solve`
+`related to`
 
 ### --feedback--
 
-It means to find a solution or fix the issue.
+Connected or linked to something else.
 
-# --scene--
+---
 
-```json
-{
-  "setup": {
-    "background": "company2-center.png",
-    "characters": [
-      {
-        "character": "Tom",
-        "position": { "x": -25, "y": 0, "z": 1 }
-      },
-      {
-        "character": "Sarah",
-        "position": { "x": 125, "y": 0, "z": 1 }
-      }
-    ],
-    "audio": {
-      "filename": "6.3-2.mp3",
-      "startTime": 1
-    },
-    "alwaysShowDialogue": true
-  },
-  "commands": [
-    {
-      "character": "Tom",
-      "position": { "x": 25, "y": 0, "z": 1 },
-      "startTime": 0
-    },
-    {
-      "character": "Sarah",
-      "position": { "x": 70, "y": 0, "z": 1 },
-      "startTime": 0.5
-    },
-    {
-      "character": "Tom",
-      "startTime": 1,
-      "finishTime": 4.36,
-      "dialogue": {
-        "text": "Hey, Sarah. I'm dealing with a persistent bug in this section of the code.",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Tom",
-      "startTime": 4.74,
-      "finishTime": 7.3,
-      "dialogue": {
-        "text": "I can't figure it out and I may need your expertise.",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Sarah",
-      "startTime": 8.16,
-      "finishTime": 11.46,
-      "dialogue": {
-        "text": "Sure, Tom. I can take a look at it. Let's start by identifying the issue.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Sarah",
-      "startTime": 11.9,
-      "finishTime": 13.06,
-      "dialogue": {
-        "text": "Where does it seem to be happening?",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Tom",
-      "startTime": 13.74,
-      "finishTime": 16.7,
-      "dialogue": {
-        "text": "Well, I believe it may be related to data processing.",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Tom",
-      "startTime": 17.18,
-      "finishTime": 20.2,
-      "dialogue": {
-        "text": "I've tried a few things, but it could be something more complicated.",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Sarah",
-      "startTime": 20.9,
-      "finishTime": 23.78,
-      "dialogue": {
-        "text": "I see. I should probably debug it step by step.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Sarah",
-      "startTime": 24.1,
-      "finishTime": 26.52,
-      "dialogue": {
-        "text": "With your input, we can work together to solve this problem.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Sarah",
-      "position": { "x": 125, "y": 0, "z": 1 },
-      "startTime": 27.02
-    },
-    {
-      "character": "Tom",
-      "position": { "x": -25, "y": 0, "z": 1 },
-      "startTime": 27.52
-    }
-  ]
-}
-```
+`step by step`
+
+### --feedback--
+
+Doing something slowly, one part at a time.
+
+---
+
+`work together`
+
+### --feedback--
+
+To help each other and do something as a team.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-for-clarification-on-code-understanding/65f6fc00be7facffe0898c6d.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-for-clarification-on-code-understanding/65f6fc00be7facffe0898c6d.md
@@ -5,173 +5,74 @@ challengeType: 22
 dashedName: task-43
 ---
 
-<!-- (Audio) The whole dialogue -->
+<!-- REVIEW -->
 
 # --description--
 
-This task will help you summarize the dialogue using keywords from it. 
+This is a review of the entire dialogue you just studied.
+
+# --instructions--
+
+Place the following phrases in the correct spot:
+
+`symptoms of`, `may occur`, `start by`, `clearer picture`, `investigate`, and `a second pair of eyes`.
 
 # --fillInTheBlank--
 
 ## --sentence--
 
-`Sophie has BLANK an issue in the code and needs Brian's BLANK to figure it out. They plan to BLANK the symptoms and investigate what's happening, especially with BLANK data sets. By the end, they expect to have a BLANK understanding of the problem.`
+`Sophie: Brian, I've encountered an issue in the code, and I can't quite pinpoint what's causing it. I may need BLANK to help me out.`
+
+`Brian: No problem, Sophie. I can definitely work on that with you. Let's BLANK understanding the BLANK the issue.`
+
+`Sophie: I've noticed that the issue BLANK when we handle large data sets. It could be a performance bottleneck, but I should confirm it.`
+
+`Brian: Understood. We can BLANK this together, and by the end of it, we should have a BLANK of what's happening.`
 
 ## --blanks--
 
-`encountered`
+`a second pair of eyes`
 
 ### --feedback--
 
-Sophie uses this word to describe finding a problem in the code.
+Another person who checks your work to help find mistakes.
 
 ---
 
-`help`
+`start by`
 
 ### --feedback--
 
-Sophie is seeking assistance from Brian.
+Begin with something as the first step.
 
 ---
 
-`understand`
+`symptoms of`
 
 ### --feedback--
 
-Brian suggests starting by understanding the issue's symptoms.
+Signs that show something might be wrong.
 
 ---
 
-`large`
+`may occur`
 
 ### --feedback--
 
-Sophie mentions the problem may occur with a lot of data sets.
+This means something might happen.
 
 ---
 
-`clearer`
+`investigate`
 
 ### --feedback--
 
-Brian believes that through investigation, they will gain a better understanding.
+To look carefully at something to understand what is happening.
 
-# --scene--
+---
 
-```json
-{
-  "setup": {
-    "background": "company2-breakroom.png",
-    "characters": [
-      {
-        "character": "Sophie",
-        "position": { "x": -25, "y": 0, "z": 1 }
-      },
-      {
-        "character": "Brian",
-        "position": { "x": 125, "y": 0, "z": 1 }
-      }
-    ],
-    "audio": {
-      "filename": "6.3-3.mp3",
-      "startTime": 1
-    },
-    "alwaysShowDialogue": true
-  },
-  "commands": [
-    {
-      "character": "Sophie",
-      "position": { "x": 25, "y": 0, "z": 1 },
-      "startTime": 0
-    },
-    {
-      "character": "Brian",
-      "position": { "x": 70, "y": 0, "z": 1 },
-      "startTime": 0.5
-    },
-    {
-      "character": "Sophie",
-      "startTime": 1,
-      "finishTime": 5.92,
-      "dialogue": {
-        "text": "Brian, I've encountered an issue in the code, and I can't quite pinpoint what's causing it.",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Sophie",
-      "startTime": 6.22,
-      "finishTime": 8.6,
-      "dialogue": {
-        "text": "I may need a second pair of eyes to help me out.",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Brian",
-      "startTime": 8.98,
-      "finishTime": 11.76,
-      "dialogue": {
-        "text": "No problem, Sophie. I can definitely work on that with you.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Brian",
-      "startTime": 11.86,
-      "finishTime": 14.26,
-      "dialogue": {
-        "text": "Let's start by understanding the symptoms of the issue.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Sophie",
-      "startTime": 15.08,
-      "finishTime": 18.44,
-      "dialogue": {
-        "text": "I've noticed that the issue may occur when we handle large data sets.",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Sophie",
-      "startTime": 18.92,
-      "finishTime": 21.54,
-      "dialogue": {
-        "text": "It could be a performance bottleneck, but I should confirm it.",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Brian",
-      "startTime": 21.94,
-      "finishTime": 25.22,
-      "dialogue": {
-        "text": "Understood. We can investigate this together, and by the end of it,",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Brian",
-      "startTime": 25.34,
-      "finishTime": 27.28,
-      "dialogue": {
-        "text": "we should have a clearer picture of what's happening.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Brian",
-      "position": { "x": 125, "y": 0, "z": 1 },
-      "startTime": 27.78
-    },
-    {
-      "character": "Sophie",
-      "position": { "x": -25, "y": 0, "z": 1 },
-      "startTime": 28.28
-    }
-  ]
-}
-```
+`clearer picture`
+
+### --feedback--
+
+A better understanding of a situation.


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

Related to https://github.com/freeCodeCamp/freeCodeCamp/issues/55293

The EC team found that "summary tasks" were ineffective and confusing for learners, as noted in the related issue. In the B1 curriculum, we replaced them with "review tasks."

This PR is part of a series to apply the same changes to the A2 curriculum. To keep reviews easier, I'm splitting the updates into multiple PRs. This one covers Block 18.
