### PR TITLE
fix(curriculum): fix typo in scene-assets.js

### DIFF
--- a/curriculum/schema/scene-assets.js
+++ b/curriculum/schema/scene-assets.js
@@ -13,7 +13,7 @@ const availableCharacters = [
   'James',
   'Jessica',
   'Jim',
-  'Jose',
+  'Josh',
   'Linda',
   'Lisa',
   'Maria',


### PR DESCRIPTION
This fixes a typo in curriculum/schema/scene-assets.js, which is causing one test for block 19 of the B1 English certification to fail.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or Gitpod.
