### PR TITLE
fix(curriculum): correct terminology from 'function' to 'component' i…

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-fetching-and-memoization-in-react/67d2f4ddb4a4306fdf5bbaee.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-fetching-and-memoization-in-react/67d2f4ddb4a4306fdf5bbaee.md
@@ -36,7 +36,7 @@ The memoization process happens this way:
 
 To improve developer experience with memoization, React provides three tools – `React.memo` (or `memo`), `useMemo` and `useCallback`. 
 
-As you might guess, both `useMemo` and `useCallback` are hooks, but `React.memo` is a component wrapper, a higher-order function (HOC).
+As you might guess, both `useMemo` and `useCallback` are hooks, but `React.memo` is a component wrapper, a higher-order component (HOC).
 
 In the next lecture, we will take a look at how the `useCallback` hook and `React.memo` work.
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.


Closes #60992
- Changed 'higher-order function (HOC)' to 'higher-order component (HOC)'
