### PR TITLE
feat(curriculum): add review tasks to block 21 of the A2 curriculum

### DIFF
--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-analyze-code-documentation/660686845b5e788def3527ca.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-analyze-code-documentation/660686845b5e788def3527ca.md
@@ -5,41 +5,55 @@ challengeType: 22
 dashedName: task-9
 ---
 
-<!-- (Audio) The whole dialogue -->
+<!-- REVIEW -->
 
 # --description--
 
-Listen to the audio and complete the sentence.
+This is a review of the entire dialogue you just studied.
+
+# --instructions--
+
+Place the following phrases in the correct spot:
+
+`API`, `identified`, `by checking`, `analyze`, `routes`, and `examples for`.
 
 # --fillInTheBlank--
 
 ## --sentence--
 
-`Sophie is working with a new API and is unsure how to BLANK its documentation effectively. Brian suggests she should BLANK by checking the BLANK and BLANK in the documentation for a clear idea of what the API offers. He then advises that once she's BLANK the endpoints, she should BLANK the BLANK and BLANK for each. This helps in understanding the API's use in projects. Sophie thanks Brian and says she'll give it a BLANK.`
+`Sophie: I'm working with a new BLANK and I'm not sure how to BLANK its documentation effectively. What's the right approach in your opinion?`
+
+`Brian: You should begin BLANK the endpoints and the BLANK provided in the documentation. This can give you a clear idea of what the API offers.`
+
+`Sophie: Okay, and what should I do next?`
+
+`Brian: Once you've BLANK the endpoints, read the descriptions and BLANK each one. This can help you understand how to use the API in your project.`
+
+`Sophie: Thanks, I'll give it a shot.`
 
 ## --blanks--
+
+`API`
+
+### --feedback--
+
+A set of tools that lets programs talk to each other.
+
+---
 
 `analyze`
 
 ### --feedback--
 
-It means to examine in detail. Sophie wants to understand how to look at the API documentation closely.
+To study something carefully to understand it better.
 
 ---
 
-`begin`
+`by checking`
 
 ### --feedback--
 
-It means to start. Brian advises starting with the endpoints and routes.
-
----
-
-`endpoints`
-
-### --feedback--
-
-They are specific locations where API requests are made. Brian mentions these as starting points.
+Looking at something to find out more or confirm it.
 
 ---
 
@@ -47,7 +61,7 @@ They are specific locations where API requests are made. Brian mentions these as
 
 ### --feedback--
 
-They are paths defined in the API for handling requests. They are key parts of the documentation.
+Paths that show how data moves in a web app or API.
 
 ---
 
@@ -55,155 +69,12 @@ They are paths defined in the API for handling requests. They are key parts of t
 
 ### --feedback--
 
-It means recognized or discovered. Sophie needs to recognize the endpoints first.
+Found or recognized something.
 
 ---
 
-`read`
+`examples for`
 
 ### --feedback--
 
-It means to look at and comprehend text. Brian suggests reading the details for each endpoint.
-
----
-
-`descriptions`
-
-### --feedback--
-
-They give details about something. Sophie should read the details about each endpoint.
-
----
-
-`examples`
-
-### --feedback--
-
-They are specific instances showing how something works. They are important for understanding the API.
-
----
-
-`shot`
-
-### --feedback--
-
-It means to try or attempt. Sophie decides to try out Brian's suggestions.
-
-# --scene--
-
-```json
-{
-  "setup": {
-    "background": "company2-breakroom.png",
-    "characters": [
-      {
-        "character": "Sophie",
-        "position": { "x": -25, "y": 0, "z": 1 }
-      },
-      {
-        "character": "Brian",
-        "position": { "x": 125, "y": 0, "z": 1 }
-      }
-    ],
-    "audio": {
-      "filename": "7.3-1.mp3",
-      "startTime": 1
-    },
-    "alwaysShowDialogue": true
-  },
-  "commands": [
-    {
-      "character": "Sophie",
-      "position": { "x": 25, "y": 0, "z": 1 },
-      "startTime": 0
-    },
-    {
-      "character": "Brian",
-      "position": { "x": 70, "y": 0, "z": 1 },
-      "startTime": 0.5
-    },
-    {
-      "character": "Sophie",
-      "startTime": 1,
-      "finishTime": 5.38,
-      "dialogue": {
-        "text": "I'm working with a new API and I'm not sure how to analyze its documentation effectively.",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Sophie",
-      "startTime": 5.84,
-      "finishTime": 7.48,
-      "dialogue": {
-        "text": "What's the right approach in your opinion?",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Brian",
-      "startTime": 8.16,
-      "finishTime": 12.08,
-      "dialogue": {
-        "text": "You should begin by checking the endpoints and the routes provided in the documentation.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Brian",
-      "startTime": 12.42,
-      "finishTime": 15.26,
-      "dialogue": {
-        "text": "This can give you a clear idea of what the API offers.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Sophie",
-      "startTime": 15.96,
-      "finishTime": 17.36,
-      "dialogue": {
-        "text": "Okay, and what should I do next?",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Brian",
-      "startTime": 17.84,
-      "finishTime": 22.04,
-      "dialogue": {
-        "text": "Once you've identified the endpoints, read the descriptions and examples for each one.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Brian",
-      "startTime": 22.38,
-      "finishTime": 25.5,
-      "dialogue": {
-        "text": "This can help you understand how to use the API in your project.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Sophie",
-      "startTime": 26.06,
-      "finishTime": 27.28,
-      "dialogue": {
-        "text": "Thanks, I'll give it a shot.",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Brian",
-      "position": { "x": 125, "y": 0, "z": 1 },
-      "startTime": 27.78
-    },
-    {
-      "character": "Sophie",
-      "position": { "x": -25, "y": 0, "z": 1 },
-      "startTime": 28.28
-    }
-  ]
-}
-```
+Sample cases that show how to use or do something.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-analyze-code-documentation/6606906b3f31fc953f1ee3b6.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-analyze-code-documentation/6606906b3f31fc953f1ee3b6.md
@@ -5,17 +5,31 @@ challengeType: 22
 dashedName: task-17
 ---
 
-<!-- (Audio) The whole dialogue -->
+<!-- REVIEW -->
 
 # --description--
 
-Listen to the audio and complete the sentence.
+This is a review of the entire dialogue you just studied.
+
+# --instructions--
+
+Place the following phrases in the correct spot:
+
+`effectively`, `return type`, `usage examples`, `examine`, `signature`, and `library`.
 
 # --fillInTheBlank--
 
 ## --sentence--
 
-`Sophie finds a BLANK with BLANK functions and wants to know how to BLANK its documentation. Brian advises her that when BLANK with functions, it's important to check the function's BLANK. This BLANK what the function does, its parameters, and return BLANK. Understanding this makes BLANK, and then, the next step is to BLANK the documentation for more details, like BLANK examples. Sophie agrees and says she'll follow BLANK steps for BLANK function.`
+`Sophie: This BLANK has so many functions. How can I BLANK analyze the documentation for them?`
+
+`Brian: When dealing with functions, start by looking at the function's BLANK. It can provide information about the function's name, parameters, and BLANK.`
+
+`Sophie: That makes sense. What's the next step? What should I do then?`
+
+`Brian: Next, you should BLANK the function's description in the documentation. It can explain what the function does and provide BLANK.`
+
+`Sophie: Thanks. I'll make sure to follow these steps for each function.`
 
 ## --blanks--
 
@@ -23,31 +37,15 @@ Listen to the audio and complete the sentence.
 
 ### --feedback--
 
-It refers to a collection of pre-written code or functions in programming.
+A collection of ready-made code you can use in your program.
 
 ---
 
-`many`
+`effectively`
 
 ### --feedback--
 
-This word indicates a large number of something, here referring to functions.
-
----
-
-`analyze`
-
-### --feedback--
-
-It means to examine something carefully.
-
----
-
-`dealing`
-
-### --feedback--
-
-It refers to how you manage or work with something.
+In a way that works well or gets good results.
 
 ---
 
@@ -55,31 +53,15 @@ It refers to how you manage or work with something.
 
 ### --feedback--
 
-It includes details of a function, like its name and parameters.
+The name, parameters, and return type of a function.
 
 ---
 
-`provides`
+`return type`
 
 ### --feedback--
 
-It means to give or supply, here referring to the information given by the signature.
-
----
-
-`type`
-
-### --feedback--
-
-In this context, it refers to the kind of result or output a function gives.
-
----
-
-`sense`
-
-### --feedback--
-
-It means something is clear or understandable.
+The kind of value a function gives back after it runs.
 
 ---
 
@@ -87,138 +69,12 @@ It means something is clear or understandable.
 
 ### --feedback--
 
-This word means to look at something carefully.
+To look at something carefully to understand it.
 
 ---
 
-`usage`
+`usage examples`
 
 ### --feedback--
 
-These examples show how something can be used.
-
----
-
-`these`
-
-### --feedback--
-
-It refers to specific things mentioned earlier, in this case, the steps for analyzing functions.
-
----
-
-`each`
-
-### --feedback--
-
-It is used to refer to individual items or cases, here meaning every single function.
-
-# --scene--
-
-```json
-{
-  "setup": {
-    "background": "company2-center.png",
-    "characters": [
-      {
-        "character": "Sophie",
-        "position": { "x": -25, "y": 0, "z": 1 }
-      },
-      {
-        "character": "Brian",
-        "position": { "x": 125, "y": 0, "z": 1 }
-      }
-    ],
-    "audio": {
-      "filename": "7.3-2.mp3",
-      "startTime": 1
-    },
-    "alwaysShowDialogue": true
-  },
-  "commands": [
-    {
-      "character": "Sophie",
-      "position": { "x": 25, "y": 0, "z": 1 },
-      "startTime": 0
-    },
-    {
-      "character": "Brian",
-      "position": { "x": 70, "y": 0, "z": 1 },
-      "startTime": 0.5
-    },
-    {
-      "character": "Sophie",
-      "startTime": 1,
-      "finishTime": 6.4,
-      "dialogue": {
-        "text": "This library has so many functions. How can I effectively analyze the documentation for them?",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Brian",
-      "startTime": 7.02,
-      "finishTime": 10.16,
-      "dialogue": {
-        "text": "When dealing with functions, start by looking at the function's signature.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Brian",
-      "startTime": 10.46,
-      "finishTime": 14.68,
-      "dialogue": {
-        "text": "It can provide information about the function's name, parameters, and return type.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Sophie",
-      "startTime": 15.34,
-      "finishTime": 18.1,
-      "dialogue": {
-        "text": "That makes sense. What's the next step? What should I do then?",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Brian",
-      "startTime": 18.7,
-      "finishTime": 22.04,
-      "dialogue": {
-        "text": "Next, you should examine the function's description in the documentation.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Brian",
-      "startTime": 22.34,
-      "finishTime": 25.94,
-      "dialogue": {
-        "text": "It can explain what the function does and provide usage examples.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Sophie",
-      "startTime": 26.72,
-      "finishTime": 29.2,
-      "dialogue": {
-        "text": "Thanks. I'll make sure to follow these steps for each function.",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Brian",
-      "position": { "x": 125, "y": 0, "z": 1 },
-      "startTime": 29.7
-    },
-    {
-      "character": "Sophie",
-      "position": { "x": -25, "y": 0, "z": 1 },
-      "startTime": 30.2
-    }
-  ]
-}
-```
+Sample code that shows how to use a function or tool.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-analyze-code-documentation/6606989c34f0be9d141130b1.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-analyze-code-documentation/6606989c34f0be9d141130b1.md
@@ -5,25 +5,39 @@ challengeType: 22
 dashedName: task-25
 ---
 
-<!-- (Audio) The whole dialogue -->
+<!-- REVIEW -->
 
 # --description--
 
-Listen to the audio and complete the sentence.
+This is a review of the entire dialogue you just studied.
+
+# --instructions--
+
+Place the following phrases in the correct spot:
+
+`confusing`, `class`, `structure`, `properties`, `interact with`, and `associated with`.
 
 # --fillInTheBlank--
 
 ## --sentence--
 
-`Sophie feels overwhelmed by a BLANK class and its BLANK documentation. Brian suggests BLANK with the class's BLANK and BLANK, then reading the BLANK and BLANK BLANK with the class, understanding how to BLANK with the class and what to BLANK with it. Sophie decides to BLANK down and approach the documentation BLANK.`
+`Sophie: Ugh, this BLANK I'm working with is really complex. The documentation looks BLANK. What should I do?`
+
+`Brian: When you're dealing with classes, begin by checking the class's name and BLANK. This will give you an idea of its purpose and its BLANK.`
+
+`Sophie: Okay, what else?`
+
+`Brian: After that, you should read the methods and functions BLANK the class. These can explain how to BLANK the class and what you can achieve using it.`
+
+`Sophie: I'll try to calm down and read the documentation more carefully. Thanks for the tips.`
 
 ## --blanks--
 
-`complex`
+`class`
 
 ### --feedback--
 
-It refers to the complicated nature of the class Sophie is working with.
+A blueprint in code used to create objects with the same properties and actions.
 
 ---
 
@@ -31,23 +45,7 @@ It refers to the complicated nature of the class Sophie is working with.
 
 ### --feedback--
 
-This word describes how Sophie views the class's documentation.
-
----
-
-`starting`
-
-### --feedback--
-
-It indicates the beginning of the process Brian suggests.
-
----
-
-`name`
-
-### --feedback--
-
-It helps identify the class's purpose.
+Hard to understand or not clear.
 
 ---
 
@@ -55,188 +53,28 @@ It helps identify the class's purpose.
 
 ### --feedback--
 
-They are characteristics or attributes of the class.
+Values or data that belong to an object or class.
 
 ---
 
-`methods`
+`structure`
 
 ### --feedback--
 
-They are specific functions or procedures in the class.
+The way something is organized or built.
 
 ---
 
-`functions`
+`associated with`
 
 ### --feedback--
 
-It means the tasks or operations that the class can perform.
+Connected to or related to something.
 
 ---
 
-`associated`
+`interact with`
 
 ### --feedback--
 
-It means connected with the class.
-
----
-
-`interact`
-
-### --feedback--
-
-It refers to how one can use or work with the class.
-
----
-
-`achieve`
-
-### --feedback--
-
-It involves accomplishing something using the class.
-
----
-
-`calm`
-
-### --feedback--
-
-Part of Sophie's decision to relax and reduce stress.
-
----
-
-`carefully`
-
-### --feedback--
-
-It means to do something with attention to detail.
-
-# --scene--
-
-```json
-{
-  "setup": {
-    "background": "company2-center.png",
-    "characters": [
-      {
-        "character": "Sophie",
-        "position": { "x": -25, "y": 0, "z": 1 }
-      },
-      {
-        "character": "Brian",
-        "position": { "x": 125, "y": 0, "z": 1 }
-      }
-    ],
-    "audio": {
-      "filename": "7.3-3.mp3",
-      "startTime": 1
-    },
-    "alwaysShowDialogue": true
-  },
-  "commands": [
-    {
-      "character": "Sophie",
-      "position": { "x": 25, "y": 0, "z": 1 },
-      "startTime": 0
-    },
-    {
-      "character": "Brian",
-      "position": { "x": 70, "y": 0, "z": 1 },
-      "startTime": 0.5
-    },
-    {
-      "character": "Sophie",
-      "startTime": 1,
-      "finishTime": 4,
-      "dialogue": {
-        "text": "Ugh, this class I'm working with is really complex.",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Sophie",
-      "startTime": 4.42,
-      "finishTime": 6.96,
-      "dialogue": {
-        "text": "The documentation looks confusing. What should I do?",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Brian",
-      "startTime": 7.48,
-      "finishTime": 11.3,
-      "dialogue": {
-        "text": "When you're dealing with classes, begin by checking the class's name and properties.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Brian",
-      "startTime": 11.68,
-      "finishTime": 14.78,
-      "dialogue": {
-        "text": "This will give you an idea of its purpose and its structure.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Sophie",
-      "startTime": 15.54,
-      "finishTime": 16.42,
-      "dialogue": {
-        "text": "Okay, what else?",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Brian",
-      "startTime": 17.2,
-      "finishTime": 20.78,
-      "dialogue": {
-        "text": "After that, you should read the methods and functions associated with the class.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Brian",
-      "startTime": 21.16,
-      "finishTime": 25.46,
-      "dialogue": {
-        "text": "These can explain how to interact with the class and what you can achieve using it.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Sophie",
-      "startTime": 25.98,
-      "finishTime": 28.62,
-      "dialogue": {
-        "text": "I'll try to calm down and read the documentation more carefully.",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Sophie",
-      "startTime": 28.86,
-      "finishTime": 29.72,
-      "dialogue": {
-        "text": "Thanks for the tips.",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Brian",
-      "position": { "x": 125, "y": 0, "z": 1 },
-      "startTime": 30.22
-    },
-    {
-      "character": "Sophie",
-      "position": { "x": -25, "y": 0, "z": 1 },
-      "startTime": 30.72
-    }
-  ]
-}
-```
+To do something with or use something, like a program or object.


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

Related to https://github.com/freeCodeCamp/freeCodeCamp/issues/55293

The EC team found that "summary tasks" were ineffective and confusing for learners, as noted in the related issue. In the B1 curriculum, we replaced them with "review tasks."

This PR is part of a series to apply the same changes to the A2 curriculum. To keep reviews easier, I'm splitting the updates into multiple PRs. This one covers Block 21.
