### PR TITLE
fix(curriculum): properly display draw message and prevent false positives in draw check test

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-tic-tac-toe/67e3a6b7f60b4085588189e6.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-tic-tac-toe/67e3a6b7f60b4085588189e6.md
@@ -473,14 +473,21 @@ export function Board() {
   const [squares, setSquares] = React.useState(Array(9).fill(null));
   const [isXNext, setIsXNext] = React.useState(true);
   const winner = calculateWinner(squares);
-  const isDraw = squares.every(square => square !== null) && !winner;
 
   function handleClick(index) {
     if (squares[index] || winner || isDraw) return;
     const nextSquares = squares.slice();
     nextSquares[index] = isXNext ? 'X' : 'O';
+
+    const winner = calculateWinner(nextSquares);
+    const isDraw = nextSquares.every(square => square !== null) && !winner;
+    
     setSquares(nextSquares);
-    setIsXNext(!isXNext);
+
+    if (!winner && !isDraw) {
+      setIsXNext(!isXNext);
+    }
+
   };
 
   function resetGame() {
@@ -496,7 +503,7 @@ export function Board() {
     <div className="board">
       <h1>Tic-Tac-Toe</h1>
       <div className="status">
-        {winner ? `Winner: ${winner}` : isDraw ? "It's a Draw!" : `Next Player: ${isXNext ? 'X' : 'O'}`}
+        {winner ? `Winner: ${winner}` : squares.every(sq => sq !== null) && !winner ? "It's a Draw!" : `Next Player: ${isXNext ? 'X' : 'O'}`}
       </div>
       <div className="board-row">
         {renderSquare(0)}


### PR DESCRIPTION
## Fix
Game didn’t show a draw message when the board was full.
The draw check happened too early, causing incorrect UI updates and false test passes.


Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #60732 
<!-- Feel free to add any additional description of changes below this line -->
