### PR TITLE
feat(curriculum): add review tasks to block 22 of the A2 curriculum

### DIFF
--- a/curriculum/challenges/_meta/learn-how-to-share-progress-and-accomplishments/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-share-progress-and-accomplishments/meta.json
@@ -62,64 +62,68 @@
       "title": "Task 13"
     },
     {
+      "id": "685a68802f25930d4837e1ac",
+      "title": "Task 14"
+    },
+    {
       "id": "66122a393fd32d2a4876ca95",
       "title": "Dialogue 2: A Manager and a Direct Report in a Performance Review"
     },
     {
       "id": "66122a6093ba082abb2cd136",
-      "title": "Task 14"
-    },
-    {
-      "id": "66122ab30afc8e2b1f42b78a",
       "title": "Task 15"
     },
     {
-      "id": "66122b7d6f1f182bb1fe0338",
+      "id": "66122ab30afc8e2b1f42b78a",
       "title": "Task 16"
     },
     {
-      "id": "661253cc9fb5ee2d01a0d6a8",
+      "id": "66122b7d6f1f182bb1fe0338",
       "title": "Task 17"
     },
     {
-      "id": "661254cf9474ed2da90fec1b",
+      "id": "661253cc9fb5ee2d01a0d6a8",
       "title": "Task 18"
     },
     {
-      "id": "66125530a1a9e92e0e08d594",
+      "id": "661254cf9474ed2da90fec1b",
       "title": "Task 19"
     },
     {
-      "id": "661255c3b6ea612e984a62b8",
+      "id": "66125530a1a9e92e0e08d594",
       "title": "Task 20"
     },
     {
-      "id": "66125666f8437c2f3616045e",
+      "id": "661255c3b6ea612e984a62b8",
       "title": "Task 21"
     },
     {
-      "id": "661256fe823f142fb9858beb",
+      "id": "66125666f8437c2f3616045e",
       "title": "Task 22"
     },
     {
-      "id": "66126744e24b0a31255718a7",
+      "id": "661256fe823f142fb9858beb",
       "title": "Task 23"
     },
     {
-      "id": "661267c5ac355931ab1f933d",
+      "id": "66126744e24b0a31255718a7",
       "title": "Task 24"
     },
     {
-      "id": "6612693507cbd43269ae64e0",
+      "id": "661267c5ac355931ab1f933d",
       "title": "Task 25"
     },
     {
-      "id": "661269c4ccdd4132db7517b8",
+      "id": "6612693507cbd43269ae64e0",
       "title": "Task 26"
     },
     {
-      "id": "66126a21821998335a86a34b",
+      "id": "661269c4ccdd4132db7517b8",
       "title": "Task 27"
+    },
+    {
+      "id": "66126a21821998335a86a34b",
+      "title": "Task 28"
     },
     {
       "id": "66127192c932be37ed0217e7",
@@ -127,55 +131,59 @@
     },
     {
       "id": "661271c2b16aff3870604148",
-      "title": "Task 28"
-    },
-    {
-      "id": "6612727ec0a11b390b8e92cb",
       "title": "Task 29"
     },
     {
-      "id": "6612752978bcc239ae7b60da",
+      "id": "6612727ec0a11b390b8e92cb",
       "title": "Task 30"
     },
     {
-      "id": "6612757ffdc16b3a22b08427",
+      "id": "6612752978bcc239ae7b60da",
       "title": "Task 31"
     },
     {
-      "id": "6612762a058bb43b960e91ca",
+      "id": "6612757ffdc16b3a22b08427",
       "title": "Task 32"
     },
     {
-      "id": "66127678c88f183c0312d8e8",
+      "id": "6612762a058bb43b960e91ca",
       "title": "Task 33"
     },
     {
-      "id": "66127755a52efa3c9a73065b",
+      "id": "66127678c88f183c0312d8e8",
       "title": "Task 34"
     },
     {
-      "id": "661277970c67233d02f138de",
+      "id": "66127755a52efa3c9a73065b",
       "title": "Task 35"
     },
     {
-      "id": "661278160653ee3d9040ed68",
+      "id": "661277970c67233d02f138de",
       "title": "Task 36"
     },
     {
-      "id": "66127850c4415c3df1b4e99a",
+      "id": "661278160653ee3d9040ed68",
       "title": "Task 37"
     },
     {
-      "id": "6612792bc77de13e8f2af3ad",
+      "id": "66127850c4415c3df1b4e99a",
       "title": "Task 38"
     },
     {
-      "id": "6612797faf03663ef83f4459",
+      "id": "6612792bc77de13e8f2af3ad",
       "title": "Task 39"
     },
     {
-      "id": "661279c8d3bf0f3f6f23f21f",
+      "id": "6612797faf03663ef83f4459",
       "title": "Task 40"
+    },
+    {
+      "id": "661279c8d3bf0f3f6f23f21f",
+      "title": "Task 41"
+    },
+    {
+      "id": "685a6b1bbaea710fbdf98bc4",
+      "title": "Task 42"
     }
   ],
   "helpCategory": "English",

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/66122a6093ba082abb2cd136.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/66122a6093ba082abb2cd136.md
@@ -1,8 +1,8 @@
 ---
 id: 66122a6093ba082abb2cd136
-title: Task 14
+title: Task 15
 challengeType: 22
-dashedName: task-14
+dashedName: task-15
 ---
 
 <!-- (Audio) Maria: Hi there, Brian. It's time for our performance review. How's everything going? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/66122ab30afc8e2b1f42b78a.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/66122ab30afc8e2b1f42b78a.md
@@ -1,8 +1,8 @@
 ---
 id: 66122ab30afc8e2b1f42b78a
-title: Task 15
+title: Task 16
 challengeType: 22
-dashedName: task-15
+dashedName: task-16
 ---
 
 <!-- (Audio) Brian: Things are going well. Last week, I worked on improving our project's documentation. I updated the user manual and added some FAQs based on customer feedback. I also attended the customer support training session. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/66122b7d6f1f182bb1fe0338.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/66122b7d6f1f182bb1fe0338.md
@@ -1,8 +1,8 @@
 ---
 id: 66122b7d6f1f182bb1fe0338
-title: Task 16
+title: Task 17
 challengeType: 19
-dashedName: task-16
+dashedName: task-17
 ---
 
 <!-- (Audio) Brian: Things are going well. Last week, I worked on improving our project's documentation. I updated the user manual and added some FAQs based on customer feedback. I also attended the customer support training session. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/661253cc9fb5ee2d01a0d6a8.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/661253cc9fb5ee2d01a0d6a8.md
@@ -1,8 +1,8 @@
 ---
 id: 661253cc9fb5ee2d01a0d6a8
-title: Task 17
+title: Task 18
 challengeType: 22
-dashedName: task-17
+dashedName: task-18
 ---
 
 <!-- (Audio) Brian: It helped me to understand the issues our customers are facing, and I learned some strategies for better addressing their concerns. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/661254cf9474ed2da90fec1b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/661254cf9474ed2da90fec1b.md
@@ -1,8 +1,8 @@
 ---
 id: 661254cf9474ed2da90fec1b
-title: Task 18
+title: Task 19
 challengeType: 19
-dashedName: task-18
+dashedName: task-19
 ---
 
 <!-- (Audio) Brian: Things are going well. Last week, I worked on improving our project's documentation. I updated the user manual and added some FAQs based on customer feedback. I also attended the customer support training session. It helped me understand the issues our customers are facing, and I learned some strategies for better addressing their concerns. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/66125530a1a9e92e0e08d594.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/66125530a1a9e92e0e08d594.md
@@ -1,8 +1,8 @@
 ---
 id: 66125530a1a9e92e0e08d594
-title: Task 19
+title: Task 20
 challengeType: 22
-dashedName: task-19
+dashedName: task-20
 ---
 
 <!-- (Audio) Maria: Excellent. Learning more about our customers is essential. I appreciate your dedication. Can you tell me about your long-term goals? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/661255c3b6ea612e984a62b8.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/661255c3b6ea612e984a62b8.md
@@ -1,8 +1,8 @@
 ---
 id: 661255c3b6ea612e984a62b8
-title: Task 20
+title: Task 21
 challengeType: 19
-dashedName: task-20
+dashedName: task-21
 ---
 
 <!-- (Audio) Maria: Excellent. Learning more about our customers is essential. I appreciate your dedication. Can you tell me about your long-term goals? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/66125666f8437c2f3616045e.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/66125666f8437c2f3616045e.md
@@ -1,8 +1,8 @@
 ---
 id: 66125666f8437c2f3616045e
-title: Task 21
+title: Task 22
 challengeType: 22
-dashedName: task-21
+dashedName: task-22
 ---
 
 <!-- (Audio) Brian: Of course. By the end of the quarter, I plan to have the documentation I'm working on fully updated, and I intend to improve our customer support process based on the training I received. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/661256fe823f142fb9858beb.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/661256fe823f142fb9858beb.md
@@ -1,8 +1,8 @@
 ---
 id: 661256fe823f142fb9858beb
-title: Task 22
+title: Task 23
 challengeType: 19
-dashedName: task-22
+dashedName: task-23
 ---
 
 <!-- (Audio) Brian: Of course. By the end of the quarter, I plan to have the documentation I'm working on fully updated, and I intend to improve our customer support process based on the training I received. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/66126744e24b0a31255718a7.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/66126744e24b0a31255718a7.md
@@ -1,8 +1,8 @@
 ---
 id: 66126744e24b0a31255718a7
-title: Task 23
+title: Task 24
 challengeType: 19
-dashedName: task-23
+dashedName: task-24
 ---
 
 <!-- (Audio) Brian: Of course. By the end of the quarter, I plan to have the documentation I'm working on fully updated, and I intend to improve our customer support process based on the training I received. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/661267c5ac355931ab1f933d.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/661267c5ac355931ab1f933d.md
@@ -1,8 +1,8 @@
 ---
 id: 661267c5ac355931ab1f933d
-title: Task 24
+title: Task 25
 challengeType: 22
-dashedName: task-24
+dashedName: task-25
 ---
 
 <!-- (Audio) Maria: It sounds like you're on the right track. Keep up the good work, and don't hesitate to reach out if you need any support. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/6612693507cbd43269ae64e0.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/6612693507cbd43269ae64e0.md
@@ -1,8 +1,8 @@
 ---
 id: 6612693507cbd43269ae64e0
-title: Task 25
+title: Task 26
 challengeType: 19
-dashedName: task-25
+dashedName: task-26
 ---
 
 <!-- (Audio) Maria: It sounds like you're on the right track. Keep up the good work, and don't hesitate to reach out if you need any support.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/661269c4ccdd4132db7517b8.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/661269c4ccdd4132db7517b8.md
@@ -1,8 +1,8 @@
 ---
 id: 661269c4ccdd4132db7517b8
-title: Task 26
+title: Task 27
 challengeType: 22
-dashedName: task-26
+dashedName: task-27
 ---
 
 <!-- (Audio) Brian: Thanks, Maria. I appreciate your guidance. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/66126a21821998335a86a34b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/66126a21821998335a86a34b.md
@@ -1,232 +1,98 @@
 ---
 id: 66126a21821998335a86a34b
-title: Task 27
+title: Task 28
 challengeType: 22
-dashedName: task-27
+dashedName: task-28
 ---
 
-<!-- (Audio) The whole dialogue -->
+<!-- REVIEW -->
 
 # --description--
 
-Listen to the audio and complete the sentence.
+This is a review of the entire dialogue you just studied.
+
+# --instructions--
+
+Place the following phrases in the correct spot:
+
+`training session`, `on the right track`, `plan to`, `time for`, `reach out`, `updated`, `long-term goals`, and `based on`.
 
 # --fillInTheBlank--
 
 ## --sentence--
 
-`In their performance review, Brian reports his progress on the project's BLANK, discusses his BLANK to enhance customer support, and outlines his BLANK goals. Maria responds with encouragement and BLANK to provide support.`
+`Maria: Hi there, Brian. It's BLANK our performance review. How's everything going?`
+
+`Brian: Things are going well. Last week, I worked on improving our project's documentation. I updated the user manual and added some FAQs BLANK customer feedback. I also attended the customer support BLANK. It helped me to understand the issues our customers are facing, and I learned some strategies for better addressing their concerns.`
+
+`Maria: Excellent. Learning more about our customers is essential. I appreciate your dedication. Can you tell me about your BLANK?`
+
+`Brian: Of course. By the end of the quarter, I BLANK have the documentation I'm working on fully BLANK, and I intend to improve our customer support process based on the training I received.`
+
+`Maria: It sounds like you're BLANK. Keep up the good work, and don't hesitate to BLANK if you need any support.`
+
+`Brian: Thanks, Maria. I appreciate your guidance.`
 
 ## --blanks--
 
-`documentation`
+`time for`
 
 ### --feedback--
 
-It refers to the project materials Brian has been updating.
+The right moment to do something.
 
 ---
 
-`intention`
+`based on`
 
 ### --feedback--
 
-It highlights Brian's plan to improve the customer support process.
+Using information or facts to decide something.
 
 ---
 
-`long-term`
+`training session`
 
 ### --feedback--
 
-It describes the type of goals Brian is setting for the future.
+A meeting or class to help someone learn a new skill.
 
 ---
 
-`offers`
+`long-term goals`
 
 ### --feedback--
 
-It refers to Maria's willingness to provide assistance and support.
+Things you want to achieve in the future, not right away.
 
-# --scene--
+---
 
-```json
-{
-  "setup": {
-    "background": "interview-room3.png",
-    "characters": [
-      {
-        "character": "Maria",
-        "position": { "x": -25, "y": 0, "z": 1 }
-      },
-      {
-        "character": "Brian",
-        "position": { "x": 125, "y": 0, "z": 1 }
-      }
-    ],
-    "audio": {
-      "filename": "8.1-2.mp3",
-      "startTime": 1
-    },
-    "alwaysShowDialogue": true
-  },
-  "commands": [
-    {
-      "character": "Maria",
-      "position": { "x": 25, "y": 0, "z": 1 },
-      "startTime": 0
-    },
-    {
-      "character": "Brian",
-      "position": { "x": 70, "y": 0, "z": 1 },
-      "startTime": 0.5
-    },
-    {
-      "character": "Maria",
-      "startTime": 1,
-      "finishTime": 3.58,
-      "dialogue": {
-        "text": "Hi there, Brian. It's time for our performance review.",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Maria",
-      "startTime": 3.82,
-      "finishTime": 4.64,
-      "dialogue": {
-        "text": "How's everything going?",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Brian",
-      "startTime": 4.94,
-      "finishTime": 5.8,
-      "dialogue": {
-        "text": "Things are going well.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Brian",
-      "startTime": 5.98,
-      "finishTime": 8.74,
-      "dialogue": {
-        "text": "Last week, I worked on improving our project's documentation.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Brian",
-      "startTime": 9.22,
-      "finishTime": 13.76,
-      "dialogue": {
-        "text": "I updated the user manual and added some FAQs based on customer feedback.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Brian",
-      "startTime": 14.36,
-      "finishTime": 17.28,
-      "dialogue": {
-        "text": "I also attended the customer support training session.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Brian",
-      "startTime": 17.48,
-      "finishTime": 20.36,
-      "dialogue": {
-        "text": "It helped me to understand the issues our customers are facing,",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Brian",
-      "startTime": 20.36,
-      "finishTime": 23.5,
-      "dialogue": {
-        "text": "and I learned some strategies for better addressing their concerns.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Maria",
-      "startTime": 24.38,
-      "finishTime": 26.98,
-      "dialogue": {
-        "text": "Excellent. Learning more about our customers is essential.",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Maria",
-      "startTime": 27.44,
-      "finishTime": 30.72,
-      "dialogue": {
-        "text": "I appreciate your dedication. Can you tell me about your long-term goals?",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Brian",
-      "startTime": 30.72,
-      "finishTime": 35.62,
-      "dialogue": {
-        "text": "Of course. By the end of the quarter, I plan to have the documentation I'm working on fully updated,",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Brian",
-      "startTime": 35.82,
-      "finishTime": 40,
-      "dialogue": {
-        "text": "and I intend to improve our customer support process based on the training I received.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Maria",
-      "startTime": 40.58,
-      "finishTime": 41.82,
-      "dialogue": {
-        "text": "It sounds like you're on the right track.",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Maria",
-      "startTime": 42.18,
-      "finishTime": 45.24,
-      "dialogue": {
-        "text": "Keep up the good work, and don't hesitate to reach out if you need any support.",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Brian",
-      "startTime": 45.7,
-      "finishTime": 47.64,
-      "dialogue": {
-        "text": "Thanks, Maria. I appreciate your guidance.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Brian",
-      "position": { "x": 125, "y": 0, "z": 1 },
-      "startTime": 48.14
-    },
-    {
-      "character": "Maria",
-      "position": { "x": -25, "y": 0, "z": 1 },
-      "startTime": 48.64
-    }
-  ]
-}
-```
+`plan to`
+
+### --feedback--
+
+To decide or want to do something in the future.
+
+---
+
+`updated`
+
+### --feedback--
+
+Changed or made more current.
+
+---
+
+`on the right track`
+
+### --feedback--
+
+Doing things the correct way to reach a goal.
+
+---
+
+`reach out`
+
+### --feedback--
+
+To contact someone, usually for help or to share something.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/661271c2b16aff3870604148.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/661271c2b16aff3870604148.md
@@ -1,8 +1,8 @@
 ---
 id: 661271c2b16aff3870604148
-title: Task 28
+title: Task 29
 challengeType: 19
-dashedName: task-28
+dashedName: task-29
 ---
 
 <!-- (Audio) Brian: Hey, Sarah! It's been a while since we hung out like this. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/6612727ec0a11b390b8e92cb.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/6612727ec0a11b390b8e92cb.md
@@ -1,8 +1,8 @@
 ---
 id: 6612727ec0a11b390b8e92cb
-title: Task 29
+title: Task 30
 challengeType: 19
-dashedName: task-29
+dashedName: task-30
 ---
 
 <!-- (Audio) Sarah: Hey! Work has kept me busy this week. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/6612752978bcc239ae7b60da.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/6612752978bcc239ae7b60da.md
@@ -1,8 +1,8 @@
 ---
 id: 6612752978bcc239ae7b60da
-title: Task 30
+title: Task 31
 challengeType: 22
-dashedName: task-30
+dashedName: task-31
 ---
 
 <!-- (Audio) Sarah: Hey! Work has kept me busy this week. I worked on the new app interface, designed some cool icons, and presented the layout to the team yesterday. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/6612757ffdc16b3a22b08427.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/6612757ffdc16b3a22b08427.md
@@ -1,8 +1,8 @@
 ---
 id: 6612757ffdc16b3a22b08427
-title: Task 31
+title: Task 32
 challengeType: 22
-dashedName: task-31
+dashedName: task-32
 ---
 
 <!-- (Audio) Brian: That sounds awesome! I tested the app for bugs. We found a few, but the good news is we fixed them all. It seems pretty solid now. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/6612762a058bb43b960e91ca.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/6612762a058bb43b960e91ca.md
@@ -1,8 +1,8 @@
 ---
 id: 6612762a058bb43b960e91ca
-title: Task 32
+title: Task 33
 challengeType: 19
-dashedName: task-32
+dashedName: task-33
 ---
 
 <!-- (Audio) Brian: That sounds awesome! I tested the app for bugs. We found a few, but the good news is we fixed them all. It seems pretty solid now. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/66127678c88f183c0312d8e8.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/66127678c88f183c0312d8e8.md
@@ -1,8 +1,8 @@
 ---
 id: 66127678c88f183c0312d8e8
-title: Task 33
+title: Task 34
 challengeType: 19
-dashedName: task-33
+dashedName: task-34
 ---
 
 <!-- (Audio) Brian: It seems pretty solid now. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/66127755a52efa3c9a73065b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/66127755a52efa3c9a73065b.md
@@ -1,8 +1,8 @@
 ---
 id: 66127755a52efa3c9a73065b
-title: Task 34
+title: Task 35
 challengeType: 22
-dashedName: task-34
+dashedName: task-35
 ---
 
 <!-- (Audio) Sarah: Nice work! I also attended a UX design workshop last month. I learned some great techniques for user research. I've applied them to our project, and it helped improve the user experience. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/661277970c67233d02f138de.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/661277970c67233d02f138de.md
@@ -1,8 +1,8 @@
 ---
 id: 661277970c67233d02f138de
-title: Task 35
+title: Task 36
 challengeType: 22
-dashedName: task-35
+dashedName: task-36
 ---
 
 <!-- (Audio) Sarah: Nice work! I also attended a UX design workshop last month. I learned some great techniques for user research. I've applied them to our project, and it helped improve the user experience. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/661278160653ee3d9040ed68.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/661278160653ee3d9040ed68.md
@@ -1,8 +1,8 @@
 ---
 id: 661278160653ee3d9040ed68
-title: Task 36
+title: Task 37
 challengeType: 19
-dashedName: task-36
+dashedName: task-37
 ---
 
 <!-- (Audio) Sarah: Nice work! I also attended a UX design workshop last month. I learned some great techniques for user research. I've applied them to our project, and it helped improve the user experience. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/66127850c4415c3df1b4e99a.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/66127850c4415c3df1b4e99a.md
@@ -1,8 +1,8 @@
 ---
 id: 66127850c4415c3df1b4e99a
-title: Task 37
+title: Task 38
 challengeType: 22
-dashedName: task-37
+dashedName: task-38
 ---
 
 <!-- (Audio) Brian: That's impressive. I met with the client yesterday, and they loved our progress. They gave us the green light to move on to the next phase. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/6612792bc77de13e8f2af3ad.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/6612792bc77de13e8f2af3ad.md
@@ -1,8 +1,8 @@
 ---
 id: 6612792bc77de13e8f2af3ad
-title: Task 38
+title: Task 39
 challengeType: 19
-dashedName: task-38
+dashedName: task-39
 ---
 
 <!-- (Audio) Brian: That's impressive. I met with the client yesterday, and they loved our progress. They gave us the green light to move on to the next phase. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/6612797faf03663ef83f4459.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/6612797faf03663ef83f4459.md
@@ -1,8 +1,8 @@
 ---
 id: 6612797faf03663ef83f4459
-title: Task 39
+title: Task 40
 challengeType: 22
-dashedName: task-39
+dashedName: task-40
 ---
 
 <!-- (Audio) Sarah: Way to go! It looks like we're making great progress. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/661279c8d3bf0f3f6f23f21f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/661279c8d3bf0f3f6f23f21f.md
@@ -1,8 +1,8 @@
 ---
 id: 661279c8d3bf0f3f6f23f21f
-title: Task 40
+title: Task 41
 challengeType: 19
-dashedName: task-40
+dashedName: task-41
 ---
 
 <!-- (Audio) The whole dialogue -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/685a68802f25930d4837e1ac.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/685a68802f25930d4837e1ac.md
@@ -1,0 +1,100 @@
+---
+id: 685a68802f25930d4837e1ac
+title: Task 14
+challengeType: 22
+dashedName: task-14
+---
+
+<!-- REVIEW -->
+
+# --description--
+
+This is a review of the entire dialogue you just studied.
+
+# --instructions--
+
+Place the following phrases in the correct spot:
+
+`worked on`, `keep up`, `to discuss`, `project update meeting`, `for catching`, `as necessary`, `achieved`, and `this week`.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`Bob: Hi everyone. Let's start our weekly BLANK. Sarah, would you like to begin?`
+
+`Sarah: Sure. This week I BLANK the user interface design. I designed a new layout for the app and I created some mockups to show how it will look.`
+
+`Bob: That's great, Sarah. I've also been pretty busy BLANK. I tested the new feature we added last week. It seems to be working well. And I found a few minor issues that we need to fix.`
+
+`Sarah: Thanks BLANK those. As for me, I also finished the market research report. I presented it to the team yesterday. We've gathered valuable data that will help us make informed decisions.`
+
+`Bob: Excellent work, team. I organized a meeting with the client BLANK their feedback. They liked our progress so far and expressed satisfaction with our work.`
+
+`Sarah: That's wonderful to hear. It sounds like we have BLANK a lot this week.`
+
+`Bob: Yes, it's been a productive week. Let's BLANK the good work. Don't forget to report any issues and communicate with the team BLANK. Our collaboration is key to our success.`
+
+## --blanks--
+
+`project update meeting`
+
+### --feedback--
+
+A meeting where team members share progress and next steps on a project.
+
+---
+
+`worked on`
+
+### --feedback--
+
+Someone has done or helped with tasks or activities.
+
+---
+
+`this week`
+
+### --feedback--
+
+The current week, from Monday to Sunday.
+
+---
+
+`for catching`
+
+### --feedback--
+
+Noticing a mistake or problem.
+
+---
+
+`to discuss`
+
+### --feedback--
+
+To talk about something in detail.
+
+---
+
+`achieved`
+
+### --feedback--
+
+Finished something successfully.
+
+---
+
+`keep up`
+
+### --feedback--
+
+To continue doing something well or at the same speed.
+
+---
+
+`as necessary`
+
+### --feedback--
+
+Only when needed or required.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/685a6b1bbaea710fbdf98bc4.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-share-progress-and-accomplishments/685a6b1bbaea710fbdf98bc4.md
@@ -1,0 +1,82 @@
+---
+id: 685a6b1bbaea710fbdf98bc4
+title: Task 42
+challengeType: 22
+dashedName: task-42
+---
+
+<!-- REVIEW -->
+
+# --description--
+
+This is a review of the entire dialogue you just studied.
+
+# --instructions--
+
+Place the following phrases in the correct spot:
+
+`last month`, `a while since`, `next phase`, `good news`, `yesterday`, and `green light`.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`Brian: Hey, Sarah, it's been BLANK we hung out like this.`
+
+`Sarah: Hey, work has kept me busy this week. I worked on the new app interface, designed some cool icons, and presented the layout to the team BLANK.`
+
+`Brian: That sounds awesome. I tested the app for bugs. We found a few, but the BLANK is we fixed them all. It seems pretty solid now.`
+
+`Sarah: Nice work. I also attended a UX design workshop BLANK. I learned some great techniques for user research. I've applied them to our project and it helped improve the user experience.`
+
+`Brian: That's impressive. I met with the client yesterday and they loved our progress. They gave us the BLANK to move on to the BLANK.`
+
+`Sarah: Way to go. It looks like we're making great progress.`
+
+## --blanks--
+
+`a while since`
+
+### --feedback--
+
+A way to say it has been some time since something happened.
+
+---
+
+`yesterday`
+
+### --feedback--
+
+The day before today.
+
+---
+
+`good news`
+
+### --feedback--
+
+Positive or happy information.
+
+---
+
+`last month`
+
+### --feedback--
+
+The month before the current one.
+
+---
+
+`green light`
+
+### --feedback--
+
+Permission to start something.
+
+---
+
+`next phase`
+
+### --feedback--
+
+The following part or step in a plan or project.


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

Related to https://github.com/freeCodeCamp/freeCodeCamp/issues/55293

The EC team found that "summary tasks" were ineffective and confusing for learners, as noted in the related issue. In the B1 curriculum, we replaced them with "review tasks."

This PR is part of a series to apply the same changes to the A2 curriculum. To keep reviews easier, I'm splitting the updates into multiple PRs. This one covers Block 22.
