### PR TITLE
feat(curriculum): add review tasks to block 23 of the A2 curriculum

### DIFF
--- a/curriculum/challenges/_meta/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/meta.json
@@ -62,48 +62,56 @@
       "title": "Task 13"
     },
     {
+      "id": "685a77009fc96d13f956ea7b",
+      "title": "Task 14"
+    },
+    {
       "id": "6614abad2657585c6229fb4a",
       "title": "Dialogue 2: Discussing Strategies for the Release of a Product at a Conference Call"
     },
     {
       "id": "6614ac949f89655d25e9d43c",
-      "title": "Task 14"
-    },
-    {
-      "id": "6614ad58c102e15df06c96d5",
       "title": "Task 15"
     },
     {
-      "id": "6614ae3e02cc465ebee68851",
+      "id": "6614ad58c102e15df06c96d5",
       "title": "Task 16"
     },
     {
-      "id": "6614b1f8ee220c5f79df89b8",
+      "id": "6614ae3e02cc465ebee68851",
       "title": "Task 17"
     },
     {
-      "id": "6614b2714761f45fe3b17294",
+      "id": "6614b1f8ee220c5f79df89b8",
       "title": "Task 18"
     },
     {
-      "id": "6614b326f956cf605cd03775",
+      "id": "6614b2714761f45fe3b17294",
       "title": "Task 19"
     },
     {
-      "id": "6614b3e52a6aca60bc3417fb",
+      "id": "6614b326f956cf605cd03775",
       "title": "Task 20"
     },
     {
-      "id": "6614b4a8ff3874612a8df77c",
+      "id": "6614b3e52a6aca60bc3417fb",
       "title": "Task 21"
     },
     {
-      "id": "6614b53003e92d6182e98978",
+      "id": "6614b4a8ff3874612a8df77c",
       "title": "Task 22"
     },
     {
-      "id": "6614b572f81cb561d4ac39da",
+      "id": "6614b53003e92d6182e98978",
       "title": "Task 23"
+    },
+    {
+      "id": "6614b572f81cb561d4ac39da",
+      "title": "Task 24"
+    },
+    {
+      "id": "685a7852682d74152ccb5769",
+      "title": "Task 25"
     },
     {
       "id": "6614bde62b7db56b9448285e",
@@ -111,35 +119,39 @@
     },
     {
       "id": "6614be2a21b4426bfcd25919",
-      "title": "Task 24"
-    },
-    {
-      "id": "6614be98fc11336c52aa3093",
-      "title": "Task 25"
-    },
-    {
-      "id": "6614befe8e1dc16ca27b7b65",
       "title": "Task 26"
     },
     {
-      "id": "6614c03efeb2cb6d2227d0b4",
+      "id": "6614be98fc11336c52aa3093",
       "title": "Task 27"
     },
     {
-      "id": "6614c0ec11b55c6d849fbe3a",
+      "id": "6614befe8e1dc16ca27b7b65",
       "title": "Task 28"
     },
     {
-      "id": "6614c12f91d2286dcd1f0fe4",
+      "id": "6614c03efeb2cb6d2227d0b4",
       "title": "Task 29"
     },
     {
-      "id": "6614c1d0e9e1976e3b524435",
+      "id": "6614c0ec11b55c6d849fbe3a",
       "title": "Task 30"
     },
     {
-      "id": "6614c2262f754e6e85d2ff1a",
+      "id": "6614c12f91d2286dcd1f0fe4",
       "title": "Task 31"
+    },
+    {
+      "id": "6614c1d0e9e1976e3b524435",
+      "title": "Task 32"
+    },
+    {
+      "id": "6614c2262f754e6e85d2ff1a",
+      "title": "Task 33"
+    },
+    {
+      "id": "685a7945a1a632162f0931e4",
+      "title": "Task 34"
     }
   ],
   "helpCategory": "English",

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6614ac949f89655d25e9d43c.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6614ac949f89655d25e9d43c.md
@@ -1,8 +1,8 @@
 ---
 id: 6614ac949f89655d25e9d43c
-title: Task 14
+title: Task 15
 challengeType: 22
-dashedName: task-14
+dashedName: task-15
 ---
 
 <!-- (Audio) Brian: Hi, team! Thanks for joining the call. Let's discuss our strategy for the upcoming product launch. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6614ad58c102e15df06c96d5.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6614ad58c102e15df06c96d5.md
@@ -1,8 +1,8 @@
 ---
 id: 6614ad58c102e15df06c96d5
-title: Task 15
+title: Task 16
 challengeType: 22
-dashedName: task-15
+dashedName: task-16
 ---
 
 <!-- (Audio) Sophie: I think we're going to focus on social media marketing. It's cost-effective, and it will reach a broader audience. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6614ae3e02cc465ebee68851.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6614ae3e02cc465ebee68851.md
@@ -1,8 +1,8 @@
 ---
 id: 6614ae3e02cc465ebee68851
-title: Task 16
+title: Task 17
 challengeType: 19
-dashedName: task-16
+dashedName: task-17
 ---
 
 <!-- (Audio) Sophie: I think we're going to focus on social media marketing. It's cost-effective, and it will reach a broader audience. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6614b1f8ee220c5f79df89b8.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6614b1f8ee220c5f79df89b8.md
@@ -1,8 +1,8 @@
 ---
 id: 6614b1f8ee220c5f79df89b8
-title: Task 17
+title: Task 18
 challengeType: 19
-dashedName: task-17
+dashedName: task-18
 ---
 
 <!-- (Audio) Sophie: I think we're going to focus on social media marketing. It's cost-effective, and it will reach a broader audience. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6614b2714761f45fe3b17294.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6614b2714761f45fe3b17294.md
@@ -1,8 +1,8 @@
 ---
 id: 6614b2714761f45fe3b17294
-title: Task 18
+title: Task 19
 challengeType: 22
-dashedName: task-18
+dashedName: task-19
 ---
 
 <!-- (Audio) Brian: That sounds good. I suggest that we also invest in email marketing. It's more targeted, and it will allow us to engage with our subscribers directly. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6614b326f956cf605cd03775.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6614b326f956cf605cd03775.md
@@ -1,8 +1,8 @@
 ---
 id: 6614b326f956cf605cd03775
-title: Task 19
+title: Task 20
 challengeType: 19
-dashedName: task-19
+dashedName: task-20
 ---
 
 <!-- (Audio) Brian: That sounds good. I suggest that we also invest in email marketing. It's more targeted, and it will allow us to engage with our subscribers directly. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6614b3e52a6aca60bc3417fb.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6614b3e52a6aca60bc3417fb.md
@@ -1,8 +1,8 @@
 ---
 id: 6614b3e52a6aca60bc3417fb
-title: Task 20
+title: Task 21
 challengeType: 19
-dashedName: task-20
+dashedName: task-21
 ---
 
 <!-- (Audio) Sophie: I think we're going to focus on social media marketing. It's cost-effective, and it will reach a broader audience. Brian: That sounds good. I suggest that we also invest in email marketing. It's more targeted, and it will allow us to engage with our subscribers directly. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6614b4a8ff3874612a8df77c.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6614b4a8ff3874612a8df77c.md
@@ -1,8 +1,8 @@
 ---
 id: 6614b4a8ff3874612a8df77c
-title: Task 21
+title: Task 22
 challengeType: 22
-dashedName: task-21
+dashedName: task-22
 ---
 
 <!-- (Audio) Brian: Great! So, we are going to create a detailed marketing plan, combining social media and email marketing. It will help us achieve our goals. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6614b53003e92d6182e98978.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6614b53003e92d6182e98978.md
@@ -1,8 +1,8 @@
 ---
 id: 6614b53003e92d6182e98978
-title: Task 22
+title: Task 23
 challengeType: 19
-dashedName: task-22
+dashedName: task-23
 ---
 
 <!-- (Audio) Brian: Great! So, we are going to create a detailed marketing plan, combining social media and email marketing. It will help us achieve our goals. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6614b572f81cb561d4ac39da.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6614b572f81cb561d4ac39da.md
@@ -1,8 +1,8 @@
 ---
 id: 6614b572f81cb561d4ac39da
-title: Task 23
+title: Task 24
 challengeType: 19
-dashedName: task-23
+dashedName: task-24
 ---
 
 <!-- (Audio) Sophie: Perfect. We'll work on it and meet again next week for an update. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6614be2a21b4426bfcd25919.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6614be2a21b4426bfcd25919.md
@@ -1,8 +1,8 @@
 ---
 id: 6614be2a21b4426bfcd25919
-title: Task 24
+title: Task 26
 challengeType: 19
-dashedName: task-24
+dashedName: task-26
 ---
 
 <!-- (Audio) Sarah: Bob, I wanted to talk about our presentation for the conference next month. What's the plan? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6614be98fc11336c52aa3093.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6614be98fc11336c52aa3093.md
@@ -1,8 +1,8 @@
 ---
 id: 6614be98fc11336c52aa3093
-title: Task 25
+title: Task 27
 challengeType: 19
-dashedName: task-25
+dashedName: task-27
 ---
 
 <!-- (Audio) Bob: Well, I think we should use a slide deck for the presentation. It's the standard format, and it will make the information more accessible. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6614befe8e1dc16ca27b7b65.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6614befe8e1dc16ca27b7b65.md
@@ -1,8 +1,8 @@
 ---
 id: 6614befe8e1dc16ca27b7b65
-title: Task 26
+title: Task 28
 challengeType: 22
-dashedName: task-26
+dashedName: task-28
 ---
 
 <!-- (Audio) Bob: Well, I think we should use a slide deck for the presentation. It's the standard format, and it will make the information more accessible. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6614c03efeb2cb6d2227d0b4.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6614c03efeb2cb6d2227d0b4.md
@@ -1,8 +1,8 @@
 ---
 id: 6614c03efeb2cb6d2227d0b4
-title: Task 27
+title: Task 29
 challengeType: 22
-dashedName: task-27
+dashedName: task-29
 ---
 
 <!-- (Audio) Sarah: True, but I was thinking we could try something different. Let's use an interactive demo instead of slides. It will engage the audience more effectively. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6614c0ec11b55c6d849fbe3a.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6614c0ec11b55c6d849fbe3a.md
@@ -1,8 +1,8 @@
 ---
 id: 6614c0ec11b55c6d849fbe3a
-title: Task 28
+title: Task 30
 challengeType: 19
-dashedName: task-28
+dashedName: task-30
 ---
 
 <!-- (Audio) Bob: Well, I think we should use a slide deck for the presentation. It's the standard format, and it will make the information more accessible. Sarah: True, but I was thinking we could try something different. Let's use an interactive demo instead of slides. It will engage the audience more effectively. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6614c12f91d2286dcd1f0fe4.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6614c12f91d2286dcd1f0fe4.md
@@ -1,8 +1,8 @@
 ---
 id: 6614c12f91d2286dcd1f0fe4
-title: Task 29
+title: Task 31
 challengeType: 19
-dashedName: task-29
+dashedName: task-31
 ---
 
 <!-- (Audio) Bob: Oh, I see what you mean. That's a great idea. It will certainly grab the audience's attention better. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6614c1d0e9e1976e3b524435.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6614c1d0e9e1976e3b524435.md
@@ -1,8 +1,8 @@
 ---
 id: 6614c1d0e9e1976e3b524435
-title: Task 30
+title: Task 32
 challengeType: 19
-dashedName: task-30
+dashedName: task-32
 ---
 
 <!-- (Audio) Bob: Well, I think we should use a slide deck for the presentation. It's the standard format, and it will make the information more accessible. Sarah: True, but I was thinking we could try something different. Let's use an interactive demo instead of slides. It will engage the audience more effectively. Bob: Oh, I see what you mean. That's a great idea. It will certainly grab the audience's attention better. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6614c2262f754e6e85d2ff1a.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/6614c2262f754e6e85d2ff1a.md
@@ -1,8 +1,8 @@
 ---
 id: 6614c2262f754e6e85d2ff1a
-title: Task 31
+title: Task 33
 challengeType: 19
-dashedName: task-31
+dashedName: task-33
 ---
 
 <!-- (Audio) Sarah: Awesome. We'll work on the interactive demo and make sure it's ready in time. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/685a77009fc96d13f956ea7b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/685a77009fc96d13f956ea7b.md
@@ -1,0 +1,96 @@
+---
+id: 685a77009fc96d13f956ea7b
+title: Task 14
+challengeType: 22
+dashedName: task-14
+---
+
+<!-- REVIEW -->
+
+# --description--
+
+This is a review of the entire dialogue you just studied.
+
+# --instructions--
+
+Place the following phrases in the correct spot:
+
+`complex project`, `plans for`, `start assigning`, `comfortable with`, `on the same page`, `going to use`, `solid choice`, and `help us`.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`Sarah: Brian, it's time to discuss our BLANK the upcoming project. What do you think we should do?`
+
+`Brian: Well, we're BLANK a framework for the frontend, probably React. It's the technology we're most BLANK and it will make development faster.`
+
+`Sarah: Good point. I agree. I also think we are going to need a dedicated UX designer. It's a BLANK and a professional designer will BLANK create a great user interface.`
+
+`Brian: Absolutely. And as for the backend, I think we'll use Node.js. It's a BLANK and it will allow us to scale the application effectively.`
+
+`Sarah: Sure thing. I'm glad we're BLANK. Let's finalize these plans and BLANK tasks.`
+
+## --blanks--
+
+`plans for`
+
+### --feedback--
+
+Things you have decided to do in the future.
+
+---
+
+`going to use`
+
+### --feedback--
+
+Planning to work with or apply something.
+
+---
+
+`comfortable with`
+
+### --feedback--
+
+Feeling confident or okay using something.
+
+---
+
+`complex project`
+
+### --feedback--
+
+A project with many parts that may be difficult to manage.
+
+---
+
+`help us`
+
+### --feedback--
+
+Make something easier or better for the team.
+
+---
+
+`solid choice`
+
+### --feedback--
+
+A strong or good decision.
+
+---
+
+`on the same page`
+
+### --feedback--
+
+Everyone understands and agrees on what to do.
+
+---
+
+`start assigning`
+
+### --feedback--
+
+Begin giving tasks or responsibilities to people.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/685a7852682d74152ccb5769.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/685a7852682d74152ccb5769.md
@@ -1,0 +1,90 @@
+---
+id: 685a7852682d74152ccb5769
+title: Task 25
+challengeType: 22
+dashedName: task-25
+---
+
+<!-- REVIEW -->
+
+# --description--
+
+This is a review of the entire dialogue you just studied.
+
+# --instructions--
+
+Place the following phrases in the correct spot:
+
+`update`, `we are going`, `focus on`, `engage with`, `achieve our goals`, `suggest that`, and `product launch`.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`Brian: Hi team, thanks for joining the call. Let's discuss our strategy for the upcoming BLANK.`
+
+`Sophie: I think we're going to BLANK social media marketing. It's cost-effective and it will reach a broader audience.`
+
+`Brian: That sounds good. I BLANK we also invest in email marketing. It's more targeted and it will allow us to BLANK our subscribers directly.`
+
+`Sophie: I'm okay with that.`
+
+`Brian: Great. So BLANK to create a detailed marketing plan combining social media and email marketing. It will help us BLANK.`
+
+`Sophie: Perfect. We'll work on it and meet again next week for an BLANK.`
+
+## --blanks--
+
+`product launch`
+
+### --feedback--
+
+When a new product is released and made available to users.
+
+---
+
+`focus on`
+
+### --feedback--
+
+To give most of your attention to something.
+
+---
+
+`suggest that`
+
+### --feedback--
+
+To offer an idea or opinion.
+
+---
+
+`engage with`
+
+### --feedback--
+
+To connect or interact with someone or something.
+
+---
+
+`we are going`
+
+### --feedback--
+
+Talking about what will happen or what is planned.
+
+---
+
+`achieve our goals`
+
+### --feedback--
+
+To successfully do what you planned or wanted to do.
+
+---
+
+`update`
+
+### --feedback--
+
+New information or changes shared with others.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/685a7945a1a632162f0931e4.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-updates-and-plans-for-tasks-and-projects/685a7945a1a632162f0931e4.md
@@ -1,0 +1,88 @@
+---
+id: 685a7945a1a632162f0931e4
+title: Task 34
+challengeType: 22
+dashedName: task-34
+---
+
+<!-- REVIEW -->
+
+# --description--
+
+This is a review of the entire dialogue you just studied.
+
+# --instructions--
+
+Place the following phrases in the correct spot:
+
+`instead of`, `conference`, `presentation`, `could try`, `accessible`, `certainly`, and `in time`.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`Sarah: Hey Bob, I wanted to talk about our presentation for the BLANK next month. What's the plan?`
+
+`Bob: Well, I think we should use a slide deck for the BLANK. It's the standard format, and it will make the information more BLANK.`
+
+`Sarah: True, but I was thinking we BLANK something different. Let's use an interactive demo BLANK slides. It will engage the audience more effectively.`
+
+`Bob: Oh, I see what you mean. That's a great idea. It will BLANK grab the audience's attention better.`
+
+`Sarah: Awesome. We'll work on the interactive demo and make sure it's ready BLANK.`
+
+## --blanks--
+
+`conference`
+
+### --feedback--
+
+A large meeting where people talk and learn about a topic.
+
+---
+
+`presentation`
+
+### --feedback--
+
+A talk or display of information to an audience.
+
+---
+
+`accessible`
+
+### --feedback--
+
+Easy to reach, use, or understand.
+
+---
+
+`could try`
+
+### --feedback--
+
+A way to suggest testing or doing something new.
+
+---
+
+`instead of`
+
+### --feedback--
+
+Used when choosing one thing and not the other.
+
+---
+
+`certainly`
+
+### --feedback--
+
+A word that shows strong agreement or confidence, like "for sure."
+
+---
+
+`in time`
+
+### --feedback--
+
+Before a deadline or not too late.


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

Related to https://github.com/freeCodeCamp/freeCodeCamp/issues/55293

The EC team found that "summary tasks" were ineffective and confusing for learners, as noted in the related issue. In the B1 curriculum, we replaced them with "review tasks."

This PR is part of a series to apply the same changes to the A2 curriculum. To keep reviews easier, I'm splitting the updates into multiple PRs. This one covers Block 23.
