### PR TITLE
fix(curriculum): correct grammar in semantic HTML lesson

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lecture-importance-of-semantic-html/6729963b1ab11638753cf082.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-importance-of-semantic-html/6729963b1ab11638753cf082.md
@@ -29,7 +29,7 @@ In the example, the words `incorrect`, `spelling`, and `issues` are misspelled. 
 
 In HTML4, the `u` element was used for styling purposes. But in HTML5, the `u` element should only be used to indicate that text has non-textual annotation applied.
 
-If you want to style a piece of text with a underline, then you should use CSS instead of HTML.
+If you want to style a piece of text with an underline, you should use CSS instead of HTML.
 
 The strikethrough element, or `s` element for short, should be used to represent when text is no longer accurate or relevant. Here is an example of using the `s` element to show the cancellation of an activity:
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #60991

<!-- Feel free to add any additional description of changes below this line -->
### Description
This pull request fixes a grammatical error in the curriculum lesson on semantic HTML. The following sentence:

> "If you want to style a piece of text with a underline, then you should use CSS instead of HTML."

has been corrected to:

> "If you want to style a piece of text with an underline, you should use CSS instead of HTML."