### PR TITLE
fix(curriculum): add missing transcript for React components video

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e879c78ee6c61db25b90.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e879c78ee6c61db25b90.md
@@ -113,7 +113,7 @@ function Greeting() {
 }
 ```
 
-In future lecture videos we will continue to learn more about how to work with components and jsx. But for now you've gained a solid introduction to building user interfaces with components setting a strong foundation for what's to come.
+In future lecture videos, we will continue to learn more about how to work with components and JSX. But for now, you've gained a solid introduction to building user interfaces with components, setting a strong foundation for what's to come.
 
 ```
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e879c78ee6c61db25b90.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e879c78ee6c61db25b90.md
@@ -115,7 +115,6 @@ function Greeting() {
 
 In future lecture videos, we will continue to learn more about how to work with components and JSX. But for now, you've gained a solid introduction to building user interfaces with components, setting a strong foundation for what's to come.
 
-
 # --questions--
 
 ## --text--

--- a/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e879c78ee6c61db25b90.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e879c78ee6c61db25b90.md
@@ -113,6 +113,10 @@ function Greeting() {
 }
 ```
 
+In future lecture videos we will continue to learn more about how to work with components and jsx. But for now you've gained a solid introduction to building user interfaces with components setting a strong foundation for what's to come.
+
+```
+
 
 # --questions--
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e879c78ee6c61db25b90.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-introduction-to-javascript-libraries-and-frameworks/6734e879c78ee6c61db25b90.md
@@ -115,8 +115,6 @@ function Greeting() {
 
 In future lecture videos, we will continue to learn more about how to work with components and JSX. But for now, you've gained a solid introduction to building user interfaces with components, setting a strong foundation for what's to come.
 
-```
-
 
 # --questions--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #61035

<!-- Feel free to add any additional description of changes below this line -->

This PR adds the missing transcript content from timestamp 4:07 to the end of the video on the page:
"What are components in React and how do they work"
(https://www.freecodecamp.org/learn/full-stack-developer/lecture-introduction-to-javascript-libraries-and-frameworks/what-are-components-in-react-and-how-do-they-work)
