### PR TITLE
fix(curriculum): add missing backticks and fix wording in reusable navbar step 7

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6745d799beeb822076a4da9d.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6745d799beeb822076a4da9d.md
@@ -7,7 +7,7 @@ dashedName: step-7
 
 # --description--
 
-Inside the third list item, create a `button` with an `aria-expanded` attribute set to `false`. Also, set the text of the `button` to `Apps`.
+Inside the third list item, create a `button` element with an `aria-expanded` attribute set to `false`. Also, set the text of the `button` to `Apps`.
 
 The `aria-expanded` attribute will communicate to screen reader users that the button triggers an expandable submenu.
 
@@ -19,7 +19,7 @@ You should create a `button` element inside the second list item.
 assert.exists(document.querySelector('li button'));
 ```
 
-Your `button` should have an `aria-expanded` attribute set to `false`.
+Your `button` element should have an `aria-expanded` attribute set to `false`.
 
 ```js
 assert.equal(document.querySelector('button')?.getAttribute('aria-expanded'), 'false');

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6745d799beeb822076a4da9d.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-mega-navbar/6745d799beeb822076a4da9d.md
@@ -7,25 +7,25 @@ dashedName: step-7
 
 # --description--
 
-Inside the third list item, create a button with an `aria-expanded` attribute set to `false`. Also, set the text of the `button` to `Apps`.
+Inside the third list item, create a `button` with an `aria-expanded` attribute set to `false`. Also, set the text of the `button` to `Apps`.
 
 The `aria-expanded` attribute will communicate to screen reader users that the button triggers an expandable submenu.
 
 # --hints--
 
-You should create a `button` tag inside the second list item.
+You should create a `button` element inside the second list item.
 
 ```js
 assert.exists(document.querySelector('li button'));
 ```
 
-Your button should have an `aria-expanded` attribute set to `false`.
+Your `button` should have an `aria-expanded` attribute set to `false`.
 
 ```js
 assert.equal(document.querySelector('button')?.getAttribute('aria-expanded'), 'false');
 ```
 
-Your `button` tag should have the text `Apps`.
+Your `button` element should have the text `Apps`.
 
 ```js
 assert.equal(document.querySelector('li button')?.textContent, 'Apps');


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #61038

<!-- Feel free to add any additional description of changes below this line -->

This PR addresses issue [#61038](https://github.com/freeCodeCamp/freeCodeCamp/issues/61038).

- Adds missing backticks around the word `button` when referring to the HTML element.
- Updates hint to say "button element" instead of "button tag", as per freeCodeCamp style.
- Applies the change to both the step and the hint section.

