### PR TITLE
fix(curriculum): update wording in HTML Accessibility quiz

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/quiz-html-accessibility/66ed9026f45ce3ece4053ebb.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-html-accessibility/66ed9026f45ce3ece4053ebb.md
@@ -932,23 +932,23 @@ Which of the following is the correct way to indicate whether an element is in t
 
 #### --text--
 
-Which of the following is an example of a window role?
+Which of the following is a role used for popups?
 
 #### --distractors--
 
-hidden
+`hidden`
 
 ---
 
-send
+`send`
 
 ---
 
-notify
+`notify`
 
 #### --answer--
 
-dialog
+`dialog`
 
 ### --question--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #61036 

<!-- Feel free to add any additional description of changes below this line -->

Description:

1. Changed the wording of set 2 - question 17 [HTML Accessibility Quiz] from "Which of the following is an example of a window role? " to "Which of the following is a role used for popups?"
2. Wrapped the distractors and answer in backticks.
