### PR TITLE
fix(curriculum): allow optional semicolon in Card component return statement

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef11f75254548672d998c.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef11f75254548672d998c.md
@@ -39,7 +39,7 @@ Your `Card` component should return an empty string.
 const functionRegex = __helpers.functionRegex("Card", null, { capture: true });
 const match = code.match(functionRegex);
 const functionDefinition = match[0];
-assert.match(functionDefinition, /\s*{\s*return\s*\(\s*(''|""|``)\s*\)\s*}|\s*=>\s*\(\s*(''|""|``)\s*\)/);
+assert.match(functionDefinition, /\s*{\s*return\s*\(\s*(''|""|``)\s*\)\s*;?\s*}|\s*=>\s*\(\s*(''|""|``)\s*\)/);
 ```
 
 # --seed--


### PR DESCRIPTION


Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #61050

<!-- Feel free to add any additional description of changes below this line -->

This PR updates the regex in the test for step 1 of the Profile Card workshop challenge to allow for the presence or absence of a semicolon after the return statement.
