### PR TITLE
fix(curriculum): allow for optional semicolon in block-style return

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef11f75254548672d998c.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef11f75254548672d998c.md
@@ -39,7 +39,7 @@ Your `Card` component should return an empty string.
 const functionRegex = __helpers.functionRegex("Card", null, { capture: true });
 const match = code.match(functionRegex);
 const functionDefinition = match[0];
-assert.match(functionDefinition, /\s*{\s*return\s*\(\s*(''|""|``)\s*\)\s*}|\s*=>\s*\(\s*(''|""|``)\s*\)/);
+assert.match(functionDefinition, /\s*(?:{\s*return|\=>)\s*\(\s*(?:''|""|``)\s*\)\s*;?\s*}?/);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef11f75254548672d998c.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef11f75254548672d998c.md
@@ -39,7 +39,7 @@ Your `Card` component should return an empty string.
 const functionRegex = __helpers.functionRegex("Card", null, { capture: true });
 const match = code.match(functionRegex);
 const functionDefinition = match[0];
-assert.match(functionDefinition, /\s*(?:{\s*return|\=>)\s*\(\s*(?:''|""|``)\s*\)\s*;?\s*}?/);
+assert.match(functionDefinition, /\s*{\s*return\s*\(\s*(''|""|``)\s*\)\s*;?\s*}|\s*=>\s*\(\s*(''|""|``)\s*\)/);
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #61050 

<!-- Feel free to add any additional description of changes below this line -->

;? will optionally match a semicolon after the return expression. I've also improved the regex to avoid repeating (''|""|``). The improved regex is flexible to support all scenarios, i.e.

```
=> ('');
=> ('')
{ return (''); }
{ return ('') }
```

I've tested my changes locally, as you can see in the attached screenshots
![fcc4](https://github.com/user-attachments/assets/f9fbe571-de8d-429d-a99a-93270545757c)
![fcc3](https://github.com/user-attachments/assets/0ed3f4da-f024-4de4-928a-56c118fcfef5)
![fcc2](https://github.com/user-attachments/assets/cd4bab24-0060-4965-b35d-a3b00168683d)
![pcc1](https://github.com/user-attachments/assets/bdf24897-c13e-44d9-9d7f-da11f7d66eec)

