### PR TITLE
feat(curriculum): add review tasks to block 24 of the A2 curriculum

### DIFF
--- a/curriculum/challenges/_meta/learn-how-to-express-agreement-or-disagreement/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-express-agreement-or-disagreement/meta.json
@@ -46,52 +46,60 @@
       "title": "Task 9"
     },
     {
+      "id": "685c0ef9a6cecf06d8d8c463",
+      "title": "Task 10"
+    },
+    {
       "id": "66177150856cd6d0ca504c9f",
       "title": "Dialogue 2: What to Prioritize Next"
     },
     {
       "id": "661771a11af289d1ec5c72f9",
-      "title": "Task 10"
-    },
-    {
-      "id": "661772551b64ddd40c834b1e",
       "title": "Task 11"
     },
     {
-      "id": "661772f42e1412d5bfe4c655",
+      "id": "661772551b64ddd40c834b1e",
       "title": "Task 12"
     },
     {
-      "id": "6617962704224fe969a76811",
+      "id": "661772f42e1412d5bfe4c655",
       "title": "Task 13"
     },
     {
-      "id": "661796e4635cd3eb1c8c78a4",
+      "id": "6617962704224fe969a76811",
       "title": "Task 14"
     },
     {
-      "id": "661797b505f2d3ed4b170d74",
+      "id": "661796e4635cd3eb1c8c78a4",
       "title": "Task 15"
     },
     {
-      "id": "66179829f664e3ee9b42ce5f",
+      "id": "661797b505f2d3ed4b170d74",
       "title": "Task 16"
     },
     {
-      "id": "6617994636fa13f16060b12b",
+      "id": "66179829f664e3ee9b42ce5f",
       "title": "Task 17"
     },
     {
-      "id": "6617aea9ccdd68f7088368d1",
+      "id": "6617994636fa13f16060b12b",
       "title": "Task 18"
     },
     {
-      "id": "6617af3ab73475f87b53a59d",
+      "id": "6617aea9ccdd68f7088368d1",
       "title": "Task 19"
     },
     {
-      "id": "6617afa03e1a7bf99f123c52",
+      "id": "6617af3ab73475f87b53a59d",
       "title": "Task 20"
+    },
+    {
+      "id": "6617afa03e1a7bf99f123c52",
+      "title": "Task 21"
+    },
+    {
+      "id": "685c0f39010fd807142e568b",
+      "title": "Task 22"
     },
     {
       "id": "6617b04b6e9139fb30d059d9",
@@ -99,59 +107,63 @@
     },
     {
       "id": "6617b087df2220fcc00514ec",
-      "title": "Task 21"
-    },
-    {
-      "id": "6617b1efe920c2ffea40b54d",
-      "title": "Task 22"
-    },
-    {
-      "id": "6617b23534265c00d6b800fd",
       "title": "Task 23"
     },
     {
-      "id": "6617b2b0388c600232500e28",
+      "id": "6617b1efe920c2ffea40b54d",
       "title": "Task 24"
     },
     {
-      "id": "6617b34260704803d74a6e07",
+      "id": "6617b23534265c00d6b800fd",
       "title": "Task 25"
     },
     {
-      "id": "6617b3d0e2de65050f11351c",
+      "id": "6617b2b0388c600232500e28",
       "title": "Task 26"
     },
     {
-      "id": "6617b41fe23fc0066e715317",
+      "id": "6617b34260704803d74a6e07",
       "title": "Task 27"
     },
     {
-      "id": "6617b494880f74079c400fa2",
+      "id": "6617b3d0e2de65050f11351c",
       "title": "Task 28"
     },
     {
-      "id": "6617b500a7049808f3a2a593",
+      "id": "6617b41fe23fc0066e715317",
       "title": "Task 29"
     },
     {
-      "id": "6617b53e5eda8e09c6c67d28",
+      "id": "6617b494880f74079c400fa2",
       "title": "Task 30"
     },
     {
-      "id": "6617b674eb480b0c8d3d6031",
+      "id": "6617b500a7049808f3a2a593",
       "title": "Task 31"
     },
     {
-      "id": "6617b81046e7b11287a7bef8",
+      "id": "6617b53e5eda8e09c6c67d28",
       "title": "Task 32"
     },
     {
-      "id": "6617b9b4bb38f916a2c01f8e",
+      "id": "6617b674eb480b0c8d3d6031",
       "title": "Task 33"
     },
     {
-      "id": "6617bae50ecd231987654d2e",
+      "id": "6617b81046e7b11287a7bef8",
       "title": "Task 34"
+    },
+    {
+      "id": "6617b9b4bb38f916a2c01f8e",
+      "title": "Task 35"
+    },
+    {
+      "id": "6617bae50ecd231987654d2e",
+      "title": "Task 36"
+    },
+    {
+      "id": "685c0f71b4a0a007615071f2",
+      "title": "Task 37"
     }
   ],
   "helpCategory": "English",

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/661771a11af289d1ec5c72f9.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/661771a11af289d1ec5c72f9.md
@@ -1,8 +1,8 @@
 ---
 id: 661771a11af289d1ec5c72f9
-title: Task 10
+title: Task 11
 challengeType: 19
-dashedName: task-10
+dashedName: task-11
 ---
 
 <!-- (Audio) Brian: Hey Sarah, we need to prioritize the new features for the next release. I think we should focus on the mobile app version. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/661772551b64ddd40c834b1e.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/661772551b64ddd40c834b1e.md
@@ -1,8 +1,8 @@
 ---
 id: 661772551b64ddd40c834b1e
-title: Task 11
+title: Task 12
 challengeType: 19
-dashedName: task-11
+dashedName: task-12
 ---
 
 <!-- (Audio) Sarah: I'm not sure I agree with that, Brian. The web app needs attention. It has more users. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/661772f42e1412d5bfe4c655.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/661772f42e1412d5bfe4c655.md
@@ -1,8 +1,8 @@
 ---
 id: 661772f42e1412d5bfe4c655
-title: Task 12
+title: Task 13
 challengeType: 22
-dashedName: task-12
+dashedName: task-13
 ---
 
 <!-- (Audio) Sarah: I'm not sure I agree with that, Brian. The web app needs attention. It has more users. Prioritizing the web app makes more sense given its larger user base. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617962704224fe969a76811.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617962704224fe969a76811.md
@@ -1,8 +1,8 @@
 ---
 id: 6617962704224fe969a76811
-title: Task 13
+title: Task 14
 challengeType: 19
-dashedName: task-13
+dashedName: task-14
 ---
 
 <!-- (Audio) Sarah: I'm not sure I agree with that, Brian. The web app needs attention. It has more users. Prioritizing the web app makes more sense given its larger user base. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/661796e4635cd3eb1c8c78a4.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/661796e4635cd3eb1c8c78a4.md
@@ -1,8 +1,8 @@
 ---
 id: 661796e4635cd3eb1c8c78a4
-title: Task 14
+title: Task 15
 challengeType: 22
-dashedName: task-14
+dashedName: task-15
 ---
 
 <!-- (Audio) Brian: Well, here's what I think we could do. Why don't we allocate resources to both platforms equally? We could give equal priority to both the web app and the mobile app. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/661797b505f2d3ed4b170d74.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/661797b505f2d3ed4b170d74.md
@@ -1,8 +1,8 @@
 ---
 id: 661797b505f2d3ed4b170d74
-title: Task 15
+title: Task 16
 challengeType: 19
-dashedName: task-15
+dashedName: task-16
 ---
 
 <!-- (Audio) Brian: Well, here's what I think we could do. Why don't we allocate resources to both platforms equally? We could give equal priority to both the web app and the mobile app. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/66179829f664e3ee9b42ce5f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/66179829f664e3ee9b42ce5f.md
@@ -1,8 +1,8 @@
 ---
 id: 66179829f664e3ee9b42ce5f
-title: Task 16
+title: Task 17
 challengeType: 19
-dashedName: task-16
+dashedName: task-17
 ---
 
 <!-- (Audio) Sarah: I'm not sure I agree with that, Brian. The web app needs attention. It has more users. Prioritizing the web app makes more sense given its larger user base. Brian: Well, here's what I think we could do. Why don't we allocate resources to both platforms equally? We could give equal priority to both the web app and the mobile app. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617994636fa13f16060b12b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617994636fa13f16060b12b.md
@@ -1,8 +1,8 @@
 ---
 id: 6617994636fa13f16060b12b
-title: Task 17
+title: Task 18
 challengeType: 22
-dashedName: task-17
+dashedName: task-18
 ---
 
 <!-- (Audio) Sarah: I still think we should dedicate more time to the web app, but I see where you're coming from, Brian. I think we can try giving equal priority for a while. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617aea9ccdd68f7088368d1.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617aea9ccdd68f7088368d1.md
@@ -1,8 +1,8 @@
 ---
 id: 6617aea9ccdd68f7088368d1
-title: Task 18
+title: Task 19
 challengeType: 19
-dashedName: task-18
+dashedName: task-19
 ---
 
 <!-- (Audio) Sarah: I still think we should dedicate more time to the web app, but I see where you're coming from, Brian. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617af3ab73475f87b53a59d.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617af3ab73475f87b53a59d.md
@@ -1,8 +1,8 @@
 ---
 id: 6617af3ab73475f87b53a59d
-title: Task 19
+title: Task 20
 challengeType: 19
-dashedName: task-19
+dashedName: task-20
 ---
 
 <!-- (Audio) Sarah: I still think we should dedicate more time to the web app, but I see where you're coming from, Brian. I think we can try giving equal priority for a while. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617afa03e1a7bf99f123c52.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617afa03e1a7bf99f123c52.md
@@ -1,8 +1,8 @@
 ---
 id: 6617afa03e1a7bf99f123c52
-title: Task 20
+title: Task 21
 challengeType: 22
-dashedName: task-20
+dashedName: task-21
 ---
 
 <!-- (Audio) Brian: Good! Thanks for your support. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617b087df2220fcc00514ec.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617b087df2220fcc00514ec.md
@@ -1,8 +1,8 @@
 ---
 id: 6617b087df2220fcc00514ec
-title: Task 21
+title: Task 23
 challengeType: 22
-dashedName: task-21
+dashedName: task-23
 ---
 
 <!-- (Audio) Sarah: We need to decide on the approach for the next phase of the project. I believe an Agile methodology is the way to go. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617b1efe920c2ffea40b54d.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617b1efe920c2ffea40b54d.md
@@ -1,8 +1,8 @@
 ---
 id: 6617b1efe920c2ffea40b54d
-title: Task 22
+title: Task 24
 challengeType: 19
-dashedName: task-22
+dashedName: task-24
 ---
 
 <!-- (Audio) Sarah: We need to decide on the approach for the next phase of the project. I believe an agile methodology is the way to go. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617b23534265c00d6b800fd.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617b23534265c00d6b800fd.md
@@ -1,8 +1,8 @@
 ---
 id: 6617b23534265c00d6b800fd
-title: Task 23
+title: Task 25
 challengeType: 22
-dashedName: task-23
+dashedName: task-25
 ---
 
 <!-- (Audio) Bob: I'm sorry, but I beg to differ. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617b2b0388c600232500e28.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617b2b0388c600232500e28.md
@@ -1,8 +1,8 @@
 ---
 id: 6617b2b0388c600232500e28
-title: Task 24
+title: Task 26
 challengeType: 19
-dashedName: task-24
+dashedName: task-26
 ---
 
 <!-- (Audio) Bob: While Agile may allow us to adapt to changes more efficiently, I still think Waterfall would be a better option. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617b34260704803d74a6e07.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617b34260704803d74a6e07.md
@@ -1,8 +1,8 @@
 ---
 id: 6617b34260704803d74a6e07
-title: Task 25
+title: Task 27
 challengeType: 22
-dashedName: task-25
+dashedName: task-27
 ---
 
 <!-- (Audio) Bob: It offers a more structured approach that will suit this project better. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617b3d0e2de65050f11351c.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617b3d0e2de65050f11351c.md
@@ -1,8 +1,8 @@
 ---
 id: 6617b3d0e2de65050f11351c
-title: Task 26
+title: Task 28
 challengeType: 19
-dashedName: task-26
+dashedName: task-28
 ---
 
 <!-- (Audio) Bob: I'm sorry, but I beg to differ. While Agile may allow us to adapt to changes more efficiently, I still think Waterfall would be a better option. It offers a more structured approach that will suit this project better. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617b41fe23fc0066e715317.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617b41fe23fc0066e715317.md
@@ -1,8 +1,8 @@
 ---
 id: 6617b41fe23fc0066e715317
-title: Task 27
+title: Task 29
 challengeType: 19
-dashedName: task-27
+dashedName: task-29
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617b494880f74079c400fa2.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617b494880f74079c400fa2.md
@@ -1,8 +1,8 @@
 ---
 id: 6617b494880f74079c400fa2
-title: Task 28
+title: Task 30
 challengeType: 19
-dashedName: task-28
+dashedName: task-30
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617b500a7049808f3a2a593.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617b500a7049808f3a2a593.md
@@ -1,8 +1,8 @@
 ---
 id: 6617b500a7049808f3a2a593
-title: Task 29
+title: Task 31
 challengeType: 22
-dashedName: task-29
+dashedName: task-31
 ---
 
 <!-- (Audio) Sarah: I see what you mean. I strongly feel that Agile aligns with our team's strengths, though. I think we'll have a greater chance of success with it. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617b53e5eda8e09c6c67d28.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617b53e5eda8e09c6c67d28.md
@@ -1,8 +1,8 @@
 ---
 id: 6617b53e5eda8e09c6c67d28
-title: Task 30
+title: Task 32
 challengeType: 22
-dashedName: task-30
+dashedName: task-32
 ---
 
 <!-- (Audio) Sarah: I see what you mean. I strongly feel that Agile aligns with our team's strengths, though. I think we'll have a greater chance of success with it. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617b674eb480b0c8d3d6031.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617b674eb480b0c8d3d6031.md
@@ -1,8 +1,8 @@
 ---
 id: 6617b674eb480b0c8d3d6031
-title: Task 31
+title: Task 33
 challengeType: 19
-dashedName: task-31
+dashedName: task-33
 ---
 
 <!-- (Audio) Sarah: I see what you mean. I strongly feel that Agile aligns with our team's strengths, though. I think we'll have a greater chance of success with it. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617b81046e7b11287a7bef8.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617b81046e7b11287a7bef8.md
@@ -1,8 +1,8 @@
 ---
 id: 6617b81046e7b11287a7bef8
-title: Task 32
+title: Task 34
 challengeType: 19
-dashedName: task-32
+dashedName: task-34
 ---
 
 <!-- (Audio) Sarah: I see what you mean. I strongly feel that Agile aligns with our team's strengths, though. I think we'll have a greater chance of success with it. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617b9b4bb38f916a2c01f8e.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617b9b4bb38f916a2c01f8e.md
@@ -1,8 +1,8 @@
 ---
 id: 6617b9b4bb38f916a2c01f8e
-title: Task 33
+title: Task 35
 challengeType: 22
-dashedName: task-33
+dashedName: task-35
 ---
 
 <!-- (Audio) Bob: Well, I think everyone is more used to Agile, right? OK, I give in. We can proceed with the Agile approach. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617bae50ecd231987654d2e.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/6617bae50ecd231987654d2e.md
@@ -1,8 +1,8 @@
 ---
 id: 6617bae50ecd231987654d2e
-title: Task 34
+title: Task 36
 challengeType: 19
-dashedName: task-34
+dashedName: task-36
 ---
 
 <!-- (Audio) Bob: Well, I think everyone is more used to Agile, right? OK, I give in. We can proceed with the Agile approach. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/685c0ef9a6cecf06d8d8c463.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/685c0ef9a6cecf06d8d8c463.md
@@ -1,0 +1,80 @@
+---
+id: 685c0ef9a6cecf06d8d8c463
+title: Task 10
+challengeType: 22
+dashedName: task-10
+---
+
+<!-- REVIEW -->
+
+# --description--
+
+This is a review of the entire dialogue you just studied.
+
+# --instructions--
+
+Write the following words or phrases in the correct spot:
+
+`I think`, `respectfully disagree`, `your feedback`, `take on`, `what you mean`, and `extra time`.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`Bob: I've received the new design and BLANK it looks great. What's your BLANK that?`
+
+`Sophie: I BLANK, Bob. I believe the color scheme needs some changes.`
+
+`Bob: Ah, I see BLANK. The color scheme doesn't match our brand's image.`
+
+`Sophie: Also, I think the font choice needs improvement.`
+
+`Bob: Thanks for BLANK. I'll share this feedback with Tom and give him some BLANK to work on these colors and fonts.`
+
+## --blanks--
+
+`I think`
+
+### --feedback--
+
+Used to share your opinion or idea.
+
+---
+
+`take on`
+
+### --feedback--
+
+Your opinion or point of view.
+
+---
+
+`respectfully disagree`
+
+### --feedback--
+
+A polite way to say you don't have the same opinion.
+
+---
+
+`what you mean`
+
+### --feedback--
+
+It means understanding someone's idea or point.
+
+---
+
+`your feedback`
+
+### --feedback--
+
+Comments or advice about how to improve something.
+
+---
+
+`extra time`
+
+### --feedback--
+
+More time than usual or more time added to a deadline.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/685c0f39010fd807142e568b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/685c0f39010fd807142e568b.md
@@ -1,0 +1,80 @@
+---
+id: 685c0f39010fd807142e568b
+title: Task 22
+challengeType: 22
+dashedName: task-22
+---
+
+<!-- REVIEW -->
+
+# --description--
+
+This is a review of the entire dialogue you just studied.
+
+# --instructions--
+
+Write the following words or phrases in the correct spot:
+
+`given`, `I still think`, `Why don't we`, `I see`, `we need to`, and `not sure`.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`Brian: Hey, Sarah, BLANK prioritize the new features for the next release. I think we should focus on the mobile app version.`
+
+`Sarah: I'm BLANK I agree with that, Brian. The web app needs attention. It has more users. Prioritizing the web app makes more sense BLANK its larger user base.`
+
+`Brian: Well, here's what I think we could do. BLANK allocate resources to both platforms equally? We could give equal priority to both the web app and the mobile app.`
+
+`Sarah: BLANK we should dedicate more time to the web app, but BLANK where you're coming from, Brian. I think we can try giving equal priority for a while.`
+
+`Brian: Good. Thanks for your support.`
+
+## --blanks--
+
+`we need to`
+
+### --feedback--
+
+Used to say that something is necessary to do.
+
+---
+
+`not sure`
+
+### --feedback--
+
+Not certain or not having a clear answer.
+
+---
+
+`given`
+
+### --feedback--
+
+Considering or based on a certain fact or situation.
+
+---
+
+`Why don't we`
+
+### --feedback--
+
+A polite way to make a suggestion. The first letter is capitalized.
+
+---
+
+`I still think`
+
+### --feedback--
+
+Used to repeat your opinion, even if others don't agree.
+
+---
+
+`I see`
+
+### --feedback--
+
+Used to show that you understand something.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/685c0f71b4a0a007615071f2.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-express-agreement-or-disagreement/685c0f71b4a0a007615071f2.md
@@ -1,0 +1,86 @@
+---
+id: 685c0f71b4a0a007615071f2
+title: Task 37
+challengeType: 22
+dashedName: task-37
+---
+
+<!-- REVIEW -->
+
+# --description--
+
+This is a review of the entire dialogue you just studied.
+
+# --instructions--
+
+Write the following words or phrases in the correct spot:
+
+`I give in`, `way to go`, `greater chance of`, `a better option`, `differ`, `strongly`, and `believe`.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`Sarah: We need to decide on the approach for the next phase of the project. I BLANK an Agile methodology is the BLANK.`
+
+`Bob: I'm sorry, but I beg to BLANK. While Agile may allow us to adapt to changes more efficiently, I still think Waterfall would be BLANK. It offers a more structured approach that will suit this project better.`
+
+`Sarah: I see what you mean. I BLANK feel that Agile aligns with our team's strengths, though. I think we'll have a BLANK success with it.`
+
+`Bob: Well, I think everyone is more used to Agile, right? Okay, BLANK. We can proceed with the Agile approach.`
+
+## --blanks--
+
+`believe`
+
+### --feedback--
+
+To think something is true or to have an opinion.
+
+---
+
+`way to go`
+
+### --feedback--
+
+The best method or the right choice to make.
+
+---
+
+`differ`
+
+### --feedback--
+
+To have a different opinion.
+
+---
+
+`a better option`
+
+### --feedback--
+
+A choice that is more helpful or useful than another.
+
+---
+
+`strongly`
+
+### --feedback--
+
+With a lot of feeling or certainty.
+
+---
+
+`greater chance of`
+
+### --feedback--
+
+More likely that something will happen.
+
+---
+
+`I give in`
+
+### --feedback--
+
+To stop arguing or disagreeing and accept the other person's idea.


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

Related to https://github.com/freeCodeCamp/freeCodeCamp/issues/55293

The EC team found that "summary tasks" were ineffective and confusing for learners, as noted in the related issue. In the B1 curriculum, we replaced them with "review tasks."

This PR is part of a series to apply the same changes to the A2 curriculum. To keep reviews easier, I'm splitting the updates into multiple PRs. This one covers Block 24.
