### PR TITLE
feat(curriculum): add review tasks to block 25 of the A2 curriculum

### DIFF
--- a/curriculum/challenges/_meta/learn-how-to-offer-technical-support-and-guidance/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-offer-technical-support-and-guidance/meta.json
@@ -134,72 +134,80 @@
       "title": "Task 31"
     },
     {
+      "id": "685c1c9a73dda60c3c752724",
+      "title": "Task 32"
+    },
+    {
       "id": "662229a912046b51dd81b35a",
       "title": "Dialogue 2: Tom's Onboarding with Maria"
     },
     {
       "id": "662229d4a4690852e430a704",
-      "title": "Task 32"
-    },
-    {
-      "id": "66222a1ac43cd953b431e464",
       "title": "Task 33"
     },
     {
-      "id": "66222b2a53c6be5671cd5b38",
+      "id": "66222a1ac43cd953b431e464",
       "title": "Task 34"
     },
     {
-      "id": "66222b6f66670e574eedea0d",
+      "id": "66222b2a53c6be5671cd5b38",
       "title": "Task 35"
     },
     {
-      "id": "66222be67d3aa258bc576aee",
+      "id": "66222b6f66670e574eedea0d",
       "title": "Task 36"
     },
     {
-      "id": "66222c85f656035a4b1325f6",
+      "id": "66222be67d3aa258bc576aee",
       "title": "Task 37"
     },
     {
-      "id": "66222e95ac25115f2dc5f171",
+      "id": "66222c85f656035a4b1325f6",
       "title": "Task 38"
     },
     {
-      "id": "66222ef6f67cf4605103f73a",
+      "id": "66222e95ac25115f2dc5f171",
       "title": "Task 39"
     },
     {
-      "id": "66222fe05f1727629efcbeb9",
+      "id": "66222ef6f67cf4605103f73a",
       "title": "Task 40"
     },
     {
-      "id": "662230f3b1103a655e612d6c",
+      "id": "66222fe05f1727629efcbeb9",
       "title": "Task 41"
     },
     {
-      "id": "662231495ea4e36644b0a1f3",
+      "id": "662230f3b1103a655e612d6c",
       "title": "Task 42"
     },
     {
-      "id": "662232980acab86a1f32aed0",
+      "id": "662231495ea4e36644b0a1f3",
       "title": "Task 43"
     },
     {
-      "id": "662234053814b36dc0ab9ae5",
+      "id": "662232980acab86a1f32aed0",
       "title": "Task 44"
     },
     {
-      "id": "6622346c798d906ee4d31846",
+      "id": "662234053814b36dc0ab9ae5",
       "title": "Task 45"
     },
     {
-      "id": "662236f6f07f7775b35ca43d",
+      "id": "6622346c798d906ee4d31846",
       "title": "Task 46"
     },
     {
-      "id": "6622372ee4a646767edcbfde",
+      "id": "662236f6f07f7775b35ca43d",
       "title": "Task 47"
+    },
+    {
+      "id": "6622372ee4a646767edcbfde",
+      "title": "Task 48"
+    },
+    {
+      "id": "685c1cc4859ee60c606005f2",
+      "title": "Task 49"
     },
     {
       "id": "6623472f50e39ddeccb047c6",
@@ -207,79 +215,83 @@
     },
     {
       "id": "662347b1bb7b3cdfcccffa57",
-      "title": "Task 48"
-    },
-    {
-      "id": "66234815e0a0b2e1967556c1",
-      "title": "Task 49"
-    },
-    {
-      "id": "66234877415f31e2b8717a91",
       "title": "Task 50"
     },
     {
-      "id": "66234939088c72e4a35b3608",
+      "id": "66234815e0a0b2e1967556c1",
       "title": "Task 51"
     },
     {
-      "id": "662349f0cadfcce6b20889bd",
+      "id": "66234877415f31e2b8717a91",
       "title": "Task 52"
     },
     {
-      "id": "66234a5dc9c4d8e7dcc629d7",
+      "id": "66234939088c72e4a35b3608",
       "title": "Task 53"
     },
     {
-      "id": "66234ab7decaffe8ecb8327d",
+      "id": "662349f0cadfcce6b20889bd",
       "title": "Task 54"
     },
     {
-      "id": "66234b28ae877fea2d15571e",
+      "id": "66234a5dc9c4d8e7dcc629d7",
       "title": "Task 55"
     },
     {
-      "id": "66234b711dab68eafd8bf850",
+      "id": "66234ab7decaffe8ecb8327d",
       "title": "Task 56"
     },
     {
-      "id": "66234f32cadc5ff3e109d696",
+      "id": "66234b28ae877fea2d15571e",
       "title": "Task 57"
     },
     {
-      "id": "66234fc78749f6f521af89f3",
+      "id": "66234b711dab68eafd8bf850",
       "title": "Task 58"
     },
     {
-      "id": "662350dc387cd3f81989ba51",
+      "id": "66234f32cadc5ff3e109d696",
       "title": "Task 59"
     },
     {
-      "id": "66235136fd7a23f8f802b279",
+      "id": "66234fc78749f6f521af89f3",
       "title": "Task 60"
     },
     {
-      "id": "662351c28974b0faad8607be",
+      "id": "662350dc387cd3f81989ba51",
       "title": "Task 61"
     },
     {
-      "id": "66235f35bef6ef183f7a06ff",
+      "id": "66235136fd7a23f8f802b279",
       "title": "Task 62"
     },
     {
-      "id": "66235ffab373a11abea1a42c",
+      "id": "662351c28974b0faad8607be",
       "title": "Task 63"
     },
     {
-      "id": "662360667ceb071bd3061489",
+      "id": "66235f35bef6ef183f7a06ff",
       "title": "Task 64"
     },
     {
-      "id": "66236122aafa541e002b61e5",
+      "id": "66235ffab373a11abea1a42c",
       "title": "Task 65"
     },
     {
-      "id": "6623619449c2dc1f62f15ff2",
+      "id": "662360667ceb071bd3061489",
       "title": "Task 66"
+    },
+    {
+      "id": "66236122aafa541e002b61e5",
+      "title": "Task 67"
+    },
+    {
+      "id": "6623619449c2dc1f62f15ff2",
+      "title": "Task 68"
+    },
+    {
+      "id": "685c1d15f44d290cc99635e2",
+      "title": "Task 69"
     }
   ],
   "helpCategory": "English",

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/662229d4a4690852e430a704.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/662229d4a4690852e430a704.md
@@ -1,8 +1,8 @@
 ---
 id: 662229d4a4690852e430a704
-title: Task 32
+title: Task 33
 challengeType: 22
-dashedName: task-32
+dashedName: task-33
 ---
 
 <!-- (Audio) Maria: Welcome to the team! We're thrilled to have you on board. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/66222a1ac43cd953b431e464.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/66222a1ac43cd953b431e464.md
@@ -1,8 +1,8 @@
 ---
 id: 66222a1ac43cd953b431e464
-title: Task 33
+title: Task 34
 challengeType: 22
-dashedName: task-33
+dashedName: task-34
 ---
 
 <!-- (Audio) Maria: If you have any questions during your onboarding, don't hesitate to ask. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/66222b2a53c6be5671cd5b38.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/66222b2a53c6be5671cd5b38.md
@@ -1,8 +1,8 @@
 ---
 id: 66222b2a53c6be5671cd5b38
-title: Task 34
+title: Task 35
 challengeType: 19
-dashedName: task-34
+dashedName: task-35
 ---
 
 <!-- (Audio) Maria: Welcome to the team! We're thrilled to have you on board. If you have any questions during your onboarding, don't hesitate to ask. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/66222b6f66670e574eedea0d.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/66222b6f66670e574eedea0d.md
@@ -1,8 +1,8 @@
 ---
 id: 66222b6f66670e574eedea0d
-title: Task 35
+title: Task 36
 challengeType: 22
-dashedName: task-35
+dashedName: task-36
 ---
 
 <!-- (Audio) Tom: Thanks, Maria. I appreciate that. I'm eager to get started. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/66222be67d3aa258bc576aee.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/66222be67d3aa258bc576aee.md
@@ -1,8 +1,8 @@
 ---
 id: 66222be67d3aa258bc576aee
-title: Task 36
+title: Task 37
 challengeType: 22
-dashedName: task-36
+dashedName: task-37
 ---
 
 <!-- (Audio) Maria: Great to hear that. Now, first things first. Install the development environment correctly, and you'll be all set to start coding. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/66222c85f656035a4b1325f6.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/66222c85f656035a4b1325f6.md
@@ -1,8 +1,8 @@
 ---
 id: 66222c85f656035a4b1325f6
-title: Task 37
+title: Task 38
 challengeType: 22
-dashedName: task-37
+dashedName: task-38
 ---
 
 <!-- (Audio) Maria: Great to hear that. Now, first things first. Install the development environment correctly, and you'll be all set to start coding. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/66222e95ac25115f2dc5f171.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/66222e95ac25115f2dc5f171.md
@@ -1,8 +1,8 @@
 ---
 id: 66222e95ac25115f2dc5f171
-title: Task 38
+title: Task 39
 challengeType: 19
-dashedName: task-38
+dashedName: task-39
 ---
 
 <!-- (Audio) Maria: Great to hear that. Now, first things first. Install the development environment correctly, and you'll be all set to start coding. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/66222ef6f67cf4605103f73a.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/66222ef6f67cf4605103f73a.md
@@ -1,8 +1,8 @@
 ---
 id: 66222ef6f67cf4605103f73a
-title: Task 39
+title: Task 40
 challengeType: 22
-dashedName: task-39
+dashedName: task-40
 ---
 
 <!-- (Audio) Tom: How can I do this? If I follow the installation guide step by step, everything should work smoothly, right? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/66222fe05f1727629efcbeb9.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/66222fe05f1727629efcbeb9.md
@@ -1,8 +1,8 @@
 ---
 id: 66222fe05f1727629efcbeb9
-title: Task 40
+title: Task 41
 challengeType: 19
-dashedName: task-40
+dashedName: task-41
 ---
 
 <!-- (Audio) Tom: How can I do this? If I follow the installation guide step by step, everything should work smoothly, right? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/662230f3b1103a655e612d6c.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/662230f3b1103a655e612d6c.md
@@ -1,8 +1,8 @@
 ---
 id: 662230f3b1103a655e612d6c
-title: Task 41
+title: Task 42
 challengeType: 22
-dashedName: task-41
+dashedName: task-42
 ---
 
 <!-- (Audio) Maria: Exactly. It's crucial for a seamless setup. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/662231495ea4e36644b0a1f3.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/662231495ea4e36644b0a1f3.md
@@ -1,8 +1,8 @@
 ---
 id: 662231495ea4e36644b0a1f3
-title: Task 42
+title: Task 43
 challengeType: 22
-dashedName: task-42
+dashedName: task-43
 ---
 
 <!-- (Audio) Maria: In case you see any unfamiliar terms or concepts, always check the documentation. The documentation is a valuable resource. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/662232980acab86a1f32aed0.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/662232980acab86a1f32aed0.md
@@ -1,8 +1,8 @@
 ---
 id: 662232980acab86a1f32aed0
-title: Task 43
+title: Task 44
 challengeType: 19
-dashedName: task-43
+dashedName: task-44
 ---
 
 <!-- (Audio) Maria: Exactly. It's crucial for a seamless setup. In case you see any unfamiliar terms or concepts, always check the documentation. The documentation is a valuable resource. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/662234053814b36dc0ab9ae5.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/662234053814b36dc0ab9ae5.md
@@ -1,8 +1,8 @@
 ---
 id: 662234053814b36dc0ab9ae5
-title: Task 44
+title: Task 45
 challengeType: 22
-dashedName: task-44
+dashedName: task-45
 ---
 
 <!-- (Audio) Tom: Thanks, Maria. I'll keep that in mind. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/6622346c798d906ee4d31846.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/6622346c798d906ee4d31846.md
@@ -1,8 +1,8 @@
 ---
 id: 6622346c798d906ee4d31846
-title: Task 45
+title: Task 46
 challengeType: 22
-dashedName: task-45
+dashedName: task-46
 ---
 
 <!-- (Audio) Maria: One last thing. We're a collaborative team and supporting each other is key to our success. So don't hesitate to ask for help from the team if you need it. Welcome again. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/662236f6f07f7775b35ca43d.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/662236f6f07f7775b35ca43d.md
@@ -1,8 +1,8 @@
 ---
 id: 662236f6f07f7775b35ca43d
-title: Task 46
+title: Task 47
 challengeType: 19
-dashedName: task-46
+dashedName: task-47
 ---
 
 <!-- (Audio) Maria: One last thing. We're a collaborative team and supporting each other is key to our success. So don't hesitate to ask for help from the team if you need it. Welcome again. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/6622372ee4a646767edcbfde.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/6622372ee4a646767edcbfde.md
@@ -1,8 +1,8 @@
 ---
 id: 6622372ee4a646767edcbfde
-title: Task 47
+title: Task 48
 challengeType: 22
-dashedName: task-47
+dashedName: task-48
 ---
 
 <!-- (Audio) Tom: Thank you. I'm looking forward to contributing to the team. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/662347b1bb7b3cdfcccffa57.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/662347b1bb7b3cdfcccffa57.md
@@ -1,8 +1,8 @@
 ---
 id: 662347b1bb7b3cdfcccffa57
-title: Task 48
+title: Task 50
 challengeType: 22
-dashedName: task-48
+dashedName: task-50
 ---
 
 <!-- (Audio) Brian: Sophie, I heard you're working on fixing that bug in the user authentication module. Need any help? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/66234815e0a0b2e1967556c1.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/66234815e0a0b2e1967556c1.md
@@ -1,8 +1,8 @@
 ---
 id: 66234815e0a0b2e1967556c1
-title: Task 49
+title: Task 51
 challengeType: 19
-dashedName: task-49
+dashedName: task-51
 ---
 
 <!-- (Audio) Brian: Sophie, I heard you're working on fixing that bug in the user authentication module. Need any help? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/66234877415f31e2b8717a91.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/66234877415f31e2b8717a91.md
@@ -1,8 +1,8 @@
 ---
 id: 66234877415f31e2b8717a91
-title: Task 50
+title: Task 52
 challengeType: 22
-dashedName: task-50
+dashedName: task-52
 ---
 
 <!-- (Audio) Sophie: Yeah, I'm a bit stuck. If I change the logic in this function, it might solve the issue, but I'm not sure. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/66234939088c72e4a35b3608.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/66234939088c72e4a35b3608.md
@@ -1,8 +1,8 @@
 ---
 id: 66234939088c72e4a35b3608
-title: Task 51
+title: Task 53
 challengeType: 19
-dashedName: task-51
+dashedName: task-53
 ---
 
 <!-- (Audio) Sophie: Yeah, I'm a bit stuck. If I change the logic in this function, it might solve the issue, but I'm not sure. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/662349f0cadfcce6b20889bd.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/662349f0cadfcce6b20889bd.md
@@ -1,8 +1,8 @@
 ---
 id: 662349f0cadfcce6b20889bd
-title: Task 52
+title: Task 54
 challengeType: 22
-dashedName: task-52
+dashedName: task-54
 ---
 
 <!-- (Audio) Brian: No problem, Sophie. Let's check it together. If you modify the logic, consider the impact it might have on other parts of the system. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/66234a5dc9c4d8e7dcc629d7.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/66234a5dc9c4d8e7dcc629d7.md
@@ -1,8 +1,8 @@
 ---
 id: 66234a5dc9c4d8e7dcc629d7
-title: Task 53
+title: Task 55
 challengeType: 19
-dashedName: task-53
+dashedName: task-55
 ---
 
 <!-- (Audio) Brian: No problem, Sophie. Let's check it together. If you modify the logic, consider the impact it might have on other parts of the system. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/66234ab7decaffe8ecb8327d.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/66234ab7decaffe8ecb8327d.md
@@ -1,8 +1,8 @@
 ---
 id: 66234ab7decaffe8ecb8327d
-title: Task 54
+title: Task 56
 challengeType: 22
-dashedName: task-54
+dashedName: task-56
 ---
 
 <!-- (Audio) Sophie: Ok, so if I make changes here, do you think it could affect other functionalities? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/66234b28ae877fea2d15571e.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/66234b28ae877fea2d15571e.md
@@ -1,8 +1,8 @@
 ---
 id: 66234b28ae877fea2d15571e
-title: Task 55
+title: Task 57
 challengeType: 19
-dashedName: task-55
+dashedName: task-57
 ---
 
 <!-- (Audio) Sophie: Ok, so if I make changes here, do you think it could affect other functionalities? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/66234b711dab68eafd8bf850.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/66234b711dab68eafd8bf850.md
@@ -1,8 +1,8 @@
 ---
 id: 66234b711dab68eafd8bf850
-title: Task 56
+title: Task 58
 challengeType: 22
-dashedName: task-56
+dashedName: task-58
 ---
 
 <!-- (Audio) Brian: Hmm, maybe. If you encounter any unexpected behavior after your changes, try to isolate the issue. It will help us get to the root cause. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/66234f32cadc5ff3e109d696.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/66234f32cadc5ff3e109d696.md
@@ -1,8 +1,8 @@
 ---
 id: 66234f32cadc5ff3e109d696
-title: Task 57
+title: Task 59
 challengeType: 19
-dashedName: task-57
+dashedName: task-59
 ---
 
 <!-- (Audio) Brian: Hmm, maybe. If you encounter any unexpected behavior after your changes, try to isolate the issue. It will help us get to the root cause. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/66234fc78749f6f521af89f3.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/66234fc78749f6f521af89f3.md
@@ -1,8 +1,8 @@
 ---
 id: 66234fc78749f6f521af89f3
-title: Task 58
+title: Task 60
 challengeType: 22
-dashedName: task-58
+dashedName: task-60
 ---
 
 <!-- (Audio) Sophie: I see. So, if I notice anything unusual, I should try to find the source of the problem, right? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/662350dc387cd3f81989ba51.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/662350dc387cd3f81989ba51.md
@@ -1,8 +1,8 @@
 ---
 id: 662350dc387cd3f81989ba51
-title: Task 59
+title: Task 61
 challengeType: 19
-dashedName: task-59
+dashedName: task-61
 ---
 
 <!-- (Audio) Sophie: I see. So, if I notice anything unusual, I should try to find the source of the problem, right? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/66235136fd7a23f8f802b279.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/66235136fd7a23f8f802b279.md
@@ -1,8 +1,8 @@
 ---
 id: 66235136fd7a23f8f802b279
-title: Task 60
+title: Task 62
 challengeType: 22
-dashedName: task-60
+dashedName: task-62
 ---
 
 <!-- (Audio) Brian: Right. When you start testing, write test cases for the modified function. It'll ensure that your changes don't break anything else. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/662351c28974b0faad8607be.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/662351c28974b0faad8607be.md
@@ -1,8 +1,8 @@
 ---
 id: 662351c28974b0faad8607be
-title: Task 61
+title: Task 63
 challengeType: 19
-dashedName: task-61
+dashedName: task-63
 ---
 
 <!-- (Audio) Brian: Right. When you start testing, write test cases for the modified function. It'll ensure that your changes don't break anything else. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/66235f35bef6ef183f7a06ff.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/66235f35bef6ef183f7a06ff.md
@@ -1,8 +1,8 @@
 ---
 id: 66235f35bef6ef183f7a06ff
-title: Task 62
+title: Task 64
 challengeType: 22
-dashedName: task-62
+dashedName: task-64
 ---
 
 <!-- (Audio) Sophie: Will it help ensure the overall system's stability? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/66235ffab373a11abea1a42c.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/66235ffab373a11abea1a42c.md
@@ -1,8 +1,8 @@
 ---
 id: 66235ffab373a11abea1a42c
-title: Task 63
+title: Task 65
 challengeType: 19
-dashedName: task-63
+dashedName: task-65
 ---
 
 <!-- (Audio) Sophie: Will it help ensure the overall system's stability? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/662360667ceb071bd3061489.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/662360667ceb071bd3061489.md
@@ -1,8 +1,8 @@
 ---
 id: 662360667ceb071bd3061489
-title: Task 64
+title: Task 66
 challengeType: 22
-dashedName: task-64
+dashedName: task-66
 ---
 
 <!-- (Audio) Brian: Absolutely. Testing is a safety net. And don't forget: if you're still unsure about anything, don't hesitate to ask for a second opinion. I'm here to help. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/66236122aafa541e002b61e5.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/66236122aafa541e002b61e5.md
@@ -1,8 +1,8 @@
 ---
 id: 66236122aafa541e002b61e5
-title: Task 65
+title: Task 67
 challengeType: 19
-dashedName: task-65
+dashedName: task-67
 ---
 
 <!-- (Audio) Brian: Absolutely. Testing is a safety net. And don't forget: if you're still unsure about anything, don't hesitate to ask for a second opinion. I'm here to help. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/6623619449c2dc1f62f15ff2.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/6623619449c2dc1f62f15ff2.md
@@ -1,8 +1,8 @@
 ---
 id: 6623619449c2dc1f62f15ff2
-title: Task 66
+title: Task 68
 challengeType: 22
-dashedName: task-66
+dashedName: task-68
 ---
 
 <!-- (Audio) Sophie: I really appreciate it. I'll reach out to you if I need more help. Thanks, Brian. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/685c1c9a73dda60c3c752724.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/685c1c9a73dda60c3c752724.md
@@ -1,0 +1,114 @@
+---
+id: 685c1c9a73dda60c3c752724
+title: Task 32
+challengeType: 22
+dashedName: task-32
+---
+
+<!-- REVIEW -->
+
+# --description--
+
+This is a review of the entire dialogue you just studied.
+
+# --instructions--
+
+Write the following words or phrases in the correct spot:
+
+`complex parts`, `good practice`, `talk about`, `take a look`, `submit the code`, `to manage`, `code reviews`, `a good idea`, and `let's consider`.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`Sarah: Hi, Tom. Thanks for submitting your code for review. Let's BLANK together.`
+
+`Tom: Sure. I'm still trying to understand the code structure here.`
+
+`Sarah: No worries. That's what BLANK are for. First, I'd suggest that you format the code consistently. It'll be easier for everyone to read.`
+
+`Tom: Got it. So if I indent the blocks consistently, it improves code readability?`
+
+`Sarah: Exactly. Consistent indentation makes the code visually organized. It's a BLANK. It also helps maintainability. Now, let's BLANK error handling. If you encounter potential issues, it's BLANK to use conditional statements to handle them gracefully.`
+
+`Tom: So I should include conditional statements BLANK them?`
+
+`Sarah: Absolutely. It prevents unexpected crashes and provides a better user experience. To finish, BLANK the comments. If you include comments when they're necessary, it helps future developers understand the logic.`
+
+`Tom: I see. So by explaining the BLANK with comments, I'll help other people understand the code better. Is that right?`
+
+`Sarah: Precisely. It's a form of documentation within the code. Great job grasping these concepts.`
+
+`Tom: Thanks. And great tips, by the way. I'll make those suggested changes and BLANK again.`
+
+## --blanks--
+
+`take a look`
+
+### --feedback--
+
+To check or examine something briefly.
+
+---
+
+`code reviews`
+
+### --feedback--
+
+When someone checks your code to find mistakes or suggest improvements.
+
+---
+
+`good practice`
+
+### --feedback--
+
+A smart or correct way to do something.
+
+---
+
+`talk about`
+
+### --feedback--
+
+To discuss or speak about something.
+
+---
+
+`a good idea`
+
+### --feedback--
+
+Something helpful or smart to do.
+
+---
+
+`to manage`
+
+### --feedback--
+
+To handle or take care of something.
+
+---
+
+`let's consider`
+
+### --feedback--
+
+Used to suggest thinking carefully about something.
+
+---
+
+`complex parts`
+
+### --feedback--
+
+Sections that are difficult or have many steps.
+
+---
+
+`submit the code`
+
+### --feedback--
+
+To send your finished program to be reviewed or used.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/685c1cc4859ee60c606005f2.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/685c1cc4859ee60c606005f2.md
@@ -1,0 +1,102 @@
+---
+id: 685c1cc4859ee60c606005f2
+title: Task 49
+challengeType: 22
+dashedName: task-49
+---
+
+<!-- REVIEW -->
+
+# --description--
+
+This is a review of the entire dialogue you just studied.
+
+# --instructions--
+
+Write the following words or phrases in the correct spot:
+
+`on board`, `valuable resource`, `all set`, `hesitate`, `installation guide`, `get started`, `collaborative`, and `contributing`.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`Maria: Welcome to the team. We're thrilled to have you BLANK. If you have any questions during your onboarding, don't BLANK to ask.`
+
+`Tom: Thanks, Maria. I appreciate that. I'm eager to BLANK.`
+
+`Maria: Great to hear that. Now, first things first. Install the development environment correctly, and you'll be BLANK to start coding.`
+
+`Tom: How can I do this? If I follow the BLANK step by step, everything should work smoothly, right?`
+
+`Maria: Exactly. It's crucial for a seamless setup. In case you see any unfamiliar terms or concepts, always check the documentation. The documentation is a BLANK.`
+
+`Tom: Thanks, Maria. I'll keep that in mind.`
+
+`Maria: One last thing. We're a BLANK team, and supporting each other is key to our success. So don't hesitate to ask for help from the team if you need it. Welcome again.`
+
+`Tom: Thank you. I'm looking forward to BLANK to the team.`
+
+## --blanks--
+
+`on board`
+
+### --feedback--
+
+To be part of a team or project.
+
+---
+
+`hesitate`
+
+### --feedback--
+
+To stop or pause before doing something, often because you are unsure.
+
+---
+
+`get started`
+
+### --feedback--
+
+To begin doing something.
+
+---
+
+`all set`
+
+### --feedback--
+
+Fully ready to begin.
+
+---
+
+`installation guide`
+
+### --feedback--
+
+Instructions that show how to set up software or a tool.
+
+---
+
+`valuable resource`
+
+### --feedback--
+
+Something very helpful for learning or solving problems.
+
+---
+
+`collaborative`
+
+### --feedback--
+
+Working together with others as a team.
+
+---
+
+`contributing`
+
+### --feedback--
+
+Giving help or adding something useful to a group or project.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/685c1d15f44d290cc99635e2.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/685c1d15f44d290cc99635e2.md
@@ -1,0 +1,122 @@
+---
+id: 685c1d15f44d290cc99635e2
+title: Task 69
+challengeType: 22
+dashedName: task-69
+---
+
+<!-- REVIEW -->
+
+# --description--
+
+This is a review of the entire dialogue you just studied.
+
+# --instructions--
+
+Write the following words or phrases in the correct spot:
+
+`fixing`, `could affect`, `test cases`, `try to`, `reach out`, `consider`, `root cause`, `source of`, `ensure`, and `second opinion`.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`Brian: Sophie, I heard you're working on BLANK that bug in the user authentication module. Need any help?`
+
+`Sophie: Yeah, I'm a bit stuck. If I change the logic in this function, it might solve the issue, but I'm not sure.`
+
+`Brian: No problem, Sophie. Let's check it together. If you modify the logic, BLANK the impact it might have on other parts of the system.`
+
+`Sophie: Okay, so if I make changes here, do you think it BLANK other functionalities?`
+
+`Brian: Hmm, maybe. If you encounter any unexpected behavior after your changes, BLANK isolate the issue. It will help us get to the BLANK.`
+
+`Sophie: I see. So if I notice anything unusual, I should try to find the BLANK the problem, right?`
+
+`Brian: Right. When you start testing, write BLANK for the modified function. It'll ensure that your changes don't break anything else.`
+
+`Sophie: It'll help BLANK the overall system's stability?`
+
+`Brian: Absolutely. Testing is a safety net. And don't forget, if you're still unsure about anything, don't hesitate to ask for a BLANK. I'm here to help.`
+
+`Sophie: I really appreciate it. I'll BLANK to you if I need more help. Thanks, Brian.`
+
+## --blanks--
+
+`fixing`
+
+### --feedback--
+
+Making something work correctly again.
+
+---
+
+`consider`
+
+### --feedback--
+
+To think carefully about something before making a choice.
+
+---
+
+`could affect`
+
+### --feedback--
+
+Might change or influence something.
+
+---
+
+`try to`
+
+### --feedback--
+
+To make an effort to do something.
+
+---
+
+`root cause`
+
+### --feedback--
+
+The main reason why a problem is happening.
+
+---
+
+`source of`
+
+### --feedback--
+
+Where something comes from or begins.
+
+---
+
+`test cases`
+
+### --feedback--
+
+Examples used to check if the code works correctly.
+
+---
+
+`ensure`
+
+### --feedback--
+
+To make sure something is true or happens.
+
+---
+
+`second opinion`
+
+### --feedback--
+
+Asking another person for their thoughts or advice.
+
+---
+
+`reach out`
+
+### --feedback--
+
+To contact someone for help or information.


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

Related to https://github.com/freeCodeCamp/freeCodeCamp/issues/55293

The EC team found that "summary tasks" were ineffective and confusing for learners, as noted in the related issue. In the B1 curriculum, we replaced them with "review tasks."

This PR is part of a series to apply the same changes to the A2 curriculum. To keep reviews easier, I'm splitting the updates into multiple PRs. This one covers Block 25.
