### PR TITLE
fix(ui): correct h1 size on review pages

### DIFF
--- a/client/src/templates/Challenges/components/challenge-title.css
+++ b/client/src/templates/Challenges/components/challenge-title.css
@@ -91,7 +91,7 @@
 }
 
 .challenge-title h1 {
-  font-size: 1.5rem;
+  font-size: 1.1rem;
   line-height: 1.42857143;
   margin: 0;
   display: inline;

--- a/client/src/templates/Challenges/components/challenge-title.css
+++ b/client/src/templates/Challenges/components/challenge-title.css
@@ -91,7 +91,7 @@
 }
 
 .challenge-title h1 {
-  font-size: inherit;
+  font-size: 1.5rem;
   line-height: 1.42857143;
   margin: 0;
   display: inline;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #57897

<!-- Feel free to add any additional description of changes below this line -->
## Fix: Correct `<h1>` Size on Review Pages

### Summary
## Summary  
This PR addresses the issue where `<h1>` elements on review pages were smaller or equal in visual hierarchy compared to `<h2>` elements. By explicitly defining the font size of `<h1>` elements as `1.1rem`, this update ensures consistency across challenge pages and maintains a proper typographic hierarchy.  

---

### Before and After Screenshots

#### Before:
![Before Screenshot](https://github.com/user-attachments/assets/234be197-405b-4289-b4b2-264dc8420f3b)

#### After:
![After Screenshot](https://github.com/user-attachments/assets/f6f62291-e51a-4619-9ff0-f92b74175e07)

---

### Changes Made 
1. Updated the CSS rule for `<h1>` elements to use `font-size: 1.1rem` instead of `font-size: inherit`.  
2. Ensured the same change was applied consistently across all review pages within the Full-Stack Developer curriculum. 

---

### Affected Pages
- `review-css-backgrounds-and-borders`
- All other review pages within the Full-Stack Developer curriculum exhibiting this issue.

---

### Testing
   - Manually inspected the affected pages.
   - Verified `<h1>` elements are slightly larger and consistent across pages.
   - Verified the changes did not impact unrelated pages.   

---

### Additional Context
The issue stemmed from the following CSS rule:
```css
.challenge-title h1 {
  font-size: inherit;
}
