### PR TITLE
fix(curriculum): Fixed misleading hint in step 1 of [Profile Card Component] workshop

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef11f75254548672d998c.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef11f75254548672d998c.md
@@ -33,7 +33,7 @@ assert.match(functionDefinition, /\{[^{]*title[^{]*\}/);
 assert.match(functionDefinition, /\{[^{]*bio[^{]*\}/);
 ```
 
-Your `Card` component should return an empty string.
+Your `Card` component should return a pair of parentheses with an empty string inside.
 
 ```js
 const functionRegex = __helpers.functionRegex("Card", null, { capture: true });


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #61061

<!-- Feel free to add any additional description of changes below this line -->

This pull request updates the wording of hint in step 1 of profile card component workshop.