### PR TITLE
fix(curriculum): clarify React props question wording

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-in-react/6734e3ceee2da4b0301719b7.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-data-in-react/6734e3ceee2da4b0301719b7.md
@@ -166,7 +166,7 @@ Think about how attributes are added to JSX elements.
 
 ## --text--
 
-How would you access a prop named `userName` inside a functional child component?
+How would you access a prop named `userName` inside a functional child component, assuming the props are passed as a `props` object?
 
 ## --answers--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #61045

<!-- Feel free to add any additional description of changes below this line -->

# Pull Request: Clarify React Props Question Wording

## Description
This pull request improves the wording of a React props lecture question to address ambiguity. The updated question now specifies that the `props` object is named `props`, ensuring clarity for learners.

## Changes
- Reworded the question in the React props lecture.
- Improved phrasing to remove assumptions about variable naming or destructuring.

## Affected Pages
- [React Props Lecture](https://www.freecodecamp.org/learn/full-stack-developer/lecture-working-with-data-in-react/how-do-you-pass-props-from-a-parent-component-to-a-child-component-in-react)

## Reason for Change
The previous question wording assumed the `props` object was always named `props`, which led to confusion. The new phrasing ensures learners can answer accurately without prior assumptions.

## Checklist
- [x] Tested the changes locally.
- [x] Verified clarity and correctness of the revised question.
- [x] Ensured all references and links are accurate.

## Additional Context
Feedback and suggestions for further improvement are welcome. Thank you for reviewing!
