### PR TITLE
feat(curriculum): add review tasks to block 26 of the A2 curriculum

### DIFF
--- a/curriculum/challenges/_meta/learn-how-to-request-and-receive-guidance/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-request-and-receive-guidance/meta.json
@@ -126,108 +126,116 @@
       "title": "Task 29"
     },
     {
+      "id": "685d18feaafc2a0720d0ca31",
+      "title": "Task 30"
+    },
+    {
       "id": "6625ceb55c430866094b40b9",
       "title": "Dialogue 2: Learning a New Technology"
     },
     {
       "id": "6625cee408515366fddbf402",
-      "title": "Task 30"
-    },
-    {
-      "id": "6625cf67c35a69684aafd265",
       "title": "Task 31"
     },
     {
-      "id": "6625cff7d0c95169e5b8fc7d",
+      "id": "6625cf67c35a69684aafd265",
       "title": "Task 32"
     },
     {
-      "id": "6625d0e9ef6f966c3e2d6164",
+      "id": "6625cff7d0c95169e5b8fc7d",
       "title": "Task 33"
     },
     {
-      "id": "6625d3af386a1a72d220e20d",
+      "id": "6625d0e9ef6f966c3e2d6164",
       "title": "Task 34"
     },
     {
-      "id": "6625d42589aa8173e84c6cac",
+      "id": "6625d3af386a1a72d220e20d",
       "title": "Task 35"
     },
     {
-      "id": "6625d472aa9f8074dca7199f",
+      "id": "6625d42589aa8173e84c6cac",
       "title": "Task 36"
     },
     {
-      "id": "6625d4b5b043f075a2e9425d",
+      "id": "6625d472aa9f8074dca7199f",
       "title": "Task 37"
     },
     {
-      "id": "6625d54c1eb70c774106c380",
+      "id": "6625d4b5b043f075a2e9425d",
       "title": "Task 38"
     },
     {
-      "id": "6625d5ad00fc51785d7fb311",
+      "id": "6625d54c1eb70c774106c380",
       "title": "Task 39"
     },
     {
-      "id": "6625d612ad11c279939fb91c",
+      "id": "6625d5ad00fc51785d7fb311",
       "title": "Task 40"
     },
     {
-      "id": "6625d6554783147a7dbce128",
+      "id": "6625d612ad11c279939fb91c",
       "title": "Task 41"
     },
     {
-      "id": "6625d6b086abb87b8c962955",
+      "id": "6625d6554783147a7dbce128",
       "title": "Task 42"
     },
     {
-      "id": "6625d757c9a1667d13c358db",
+      "id": "6625d6b086abb87b8c962955",
       "title": "Task 43"
     },
     {
-      "id": "6625d7e129384c7ec26b2cc3",
+      "id": "6625d757c9a1667d13c358db",
       "title": "Task 44"
     },
     {
-      "id": "6625d81940f2c57f66bbd17e",
+      "id": "6625d7e129384c7ec26b2cc3",
       "title": "Task 45"
     },
     {
-      "id": "6625d84e92201f802eac3973",
+      "id": "6625d81940f2c57f66bbd17e",
       "title": "Task 46"
     },
     {
-      "id": "6625d8bc46b89481625b068b",
+      "id": "6625d84e92201f802eac3973",
       "title": "Task 47"
     },
     {
-      "id": "6625d910fb77f9826de00b73",
+      "id": "6625d8bc46b89481625b068b",
       "title": "Task 48"
     },
     {
-      "id": "6625d9508854008334d44831",
+      "id": "6625d910fb77f9826de00b73",
       "title": "Task 49"
     },
     {
-      "id": "6625d987196d2383e359d41f",
+      "id": "6625d9508854008334d44831",
       "title": "Task 50"
     },
     {
-      "id": "6625da09ef6e5b8547626587",
+      "id": "6625d987196d2383e359d41f",
       "title": "Task 51"
     },
     {
-      "id": "6625da582aba58863d900bcf",
+      "id": "6625da09ef6e5b8547626587",
       "title": "Task 52"
     },
     {
-      "id": "6625dc1d103a638a7fd5308b",
+      "id": "6625da582aba58863d900bcf",
       "title": "Task 53"
     },
     {
-      "id": "6625dc81861c0d8b754a4829",
+      "id": "6625dc1d103a638a7fd5308b",
       "title": "Task 54"
+    },
+    {
+      "id": "6625dc81861c0d8b754a4829",
+      "title": "Task 55"
+    },
+    {
+      "id": "685d1933c0d8ab075f5da3ce",
+      "title": "Task 56"
     },
     {
       "id": "6625ddee54d1db9090a4800f",
@@ -235,39 +243,39 @@
     },
     {
       "id": "6625de24962337919e462c20",
-      "title": "Task 55"
-    },
-    {
-      "id": "6625deaf1ab4a69314d3125e",
-      "title": "Task 56"
-    },
-    {
-      "id": "6625dee8ccb83a93da674fca",
       "title": "Task 57"
     },
     {
-      "id": "6625df2bb732da94b03089d1",
+      "id": "6625deaf1ab4a69314d3125e",
       "title": "Task 58"
     },
     {
-      "id": "6625df8d71b44495cde83d48",
+      "id": "6625dee8ccb83a93da674fca",
       "title": "Task 59"
     },
     {
-      "id": "6625dfe17a5dd696cf89cb01",
+      "id": "6625df2bb732da94b03089d1",
       "title": "Task 60"
     },
     {
-      "id": "6625e02aa797a497b69d2c55",
+      "id": "6625df8d71b44495cde83d48",
       "title": "Task 61"
     },
     {
-      "id": "6625e08130068e98c6c166c6",
+      "id": "6625dfe17a5dd696cf89cb01",
       "title": "Task 62"
     },
     {
-      "id": "6625e0c2e7f616999352aa7b",
+      "id": "6625e02aa797a497b69d2c55",
       "title": "Task 63"
+    },
+    {
+      "id": "6625e08130068e98c6c166c6",
+      "title": "Task 64"
+    },
+    {
+      "id": "6625e0c2e7f616999352aa7b",
+      "title": "Task 65"
     }
   ],
   "helpCategory": "English",

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625cee408515366fddbf402.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625cee408515366fddbf402.md
@@ -1,8 +1,8 @@
 ---
 id: 6625cee408515366fddbf402
-title: Task 30
+title: Task 31
 challengeType: 22
-dashedName: task-30
+dashedName: task-31
 ---
 
 <!-- (Audio) Tom: Ugh! I'm really trying to understand how to use this library, but I'm a bit lost. Mind if I ask you for some guidance? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625cf67c35a69684aafd265.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625cf67c35a69684aafd265.md
@@ -1,8 +1,8 @@
 ---
 id: 6625cf67c35a69684aafd265
-title: Task 31
+title: Task 32
 challengeType: 19
-dashedName: task-31
+dashedName: task-32
 ---
 
 <!-- (Audio) Tom: Ugh! I'm really trying to understand how to use this library, but I'm a bit lost. Mind if I ask you for some guidance? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625cff7d0c95169e5b8fc7d.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625cff7d0c95169e5b8fc7d.md
@@ -1,8 +1,8 @@
 ---
 id: 6625cff7d0c95169e5b8fc7d
-title: Task 32
+title: Task 33
 challengeType: 19
-dashedName: task-32
+dashedName: task-33
 ---
 
 <!-- (Audio) Sarah: Of course! I'm here to help. What are you having trouble with? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625d0e9ef6f966c3e2d6164.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625d0e9ef6f966c3e2d6164.md
@@ -1,8 +1,8 @@
 ---
 id: 6625d0e9ef6f966c3e2d6164
-title: Task 33
+title: Task 34
 challengeType: 22
-dashedName: task-33
+dashedName: task-34
 ---
 
 <!-- (Audio) Tom: Well, I'm trying to understand the basics, like how to set up the environment. Have you ever worked with this tech stack before? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625d3af386a1a72d220e20d.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625d3af386a1a72d220e20d.md
@@ -1,8 +1,8 @@
 ---
 id: 6625d3af386a1a72d220e20d
-title: Task 34
+title: Task 35
 challengeType: 19
-dashedName: task-34
+dashedName: task-35
 ---
 
 <!-- (Audio) Tom: Well, I'm trying to understand the basics, like how to set up the environment. Have you ever worked with this tech stack before? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625d42589aa8173e84c6cac.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625d42589aa8173e84c6cac.md
@@ -1,8 +1,8 @@
 ---
 id: 6625d42589aa8173e84c6cac
-title: Task 35
+title: Task 36
 challengeType: 19
-dashedName: task-35
+dashedName: task-36
 ---
 
 <!-- (Audio) Tom: Well, I'm trying to understand the basics, like how to set up the environment. Have you ever worked with this tech stack before? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625d472aa9f8074dca7199f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625d472aa9f8074dca7199f.md
@@ -1,8 +1,8 @@
 ---
 id: 6625d472aa9f8074dca7199f
-title: Task 36
+title: Task 37
 challengeType: 22
-dashedName: task-36
+dashedName: task-37
 ---
 
 <!-- (Audio) Sarah: Yes, I have. Setting up the environment can be a bit tricky initially. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625d4b5b043f075a2e9425d.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625d4b5b043f075a2e9425d.md
@@ -1,8 +1,8 @@
 ---
 id: 6625d4b5b043f075a2e9425d
-title: Task 37
+title: Task 38
 challengeType: 19
-dashedName: task-37
+dashedName: task-38
 ---
 
 <!-- (Audio) Sarah: Yes, I have. Setting up the environment can be a bit tricky initially. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625d54c1eb70c774106c380.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625d54c1eb70c774106c380.md
@@ -1,8 +1,8 @@
 ---
 id: 6625d54c1eb70c774106c380
-title: Task 38
+title: Task 39
 challengeType: 22
-dashedName: task-38
+dashedName: task-39
 ---
 
 <!-- (Audio) Sarah: Let's walk through the steps together. First, download the installer from the official website. It'll guide you through the setup process. If you have any issues during the installation, don't hesitate to reach out. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625d5ad00fc51785d7fb311.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625d5ad00fc51785d7fb311.md
@@ -1,8 +1,8 @@
 ---
 id: 6625d5ad00fc51785d7fb311
-title: Task 39
+title: Task 40
 challengeType: 19
-dashedName: task-39
+dashedName: task-40
 ---
 
 <!-- (Audio) Sarah: Let's walk through the steps together. First, download the installer from the official website. It'll guide you through the setup process. If you have any issues during the installation, don't hesitate to reach out. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625d612ad11c279939fb91c.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625d612ad11c279939fb91c.md
@@ -1,8 +1,8 @@
 ---
 id: 6625d612ad11c279939fb91c
-title: Task 40
+title: Task 41
 challengeType: 22
-dashedName: task-40
+dashedName: task-41
 ---
 
 <!-- (Audio) Sarah: We can troubleshoot together. By the way, have you ever tried looking at the official documentation for this library? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625d6554783147a7dbce128.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625d6554783147a7dbce128.md
@@ -1,8 +1,8 @@
 ---
 id: 6625d6554783147a7dbce128
-title: Task 41
+title: Task 42
 challengeType: 19
-dashedName: task-41
+dashedName: task-42
 ---
 
 <!-- (Audio) Sarah: We can troubleshoot together. By the way, have you ever tried looking at the official documentation for this library? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625d6b086abb87b8c962955.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625d6b086abb87b8c962955.md
@@ -1,8 +1,8 @@
 ---
 id: 6625d6b086abb87b8c962955
-title: Task 42
+title: Task 43
 challengeType: 22
-dashedName: task-42
+dashedName: task-43
 ---
 
 <!-- (Audio) Sarah: By the way, have you ever tried looking at the official documentation for this library? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625d757c9a1667d13c358db.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625d757c9a1667d13c358db.md
@@ -1,8 +1,8 @@
 ---
 id: 6625d757c9a1667d13c358db
-title: Task 43
+title: Task 44
 challengeType: 19
-dashedName: task-43
+dashedName: task-44
 ---
 
 <!-- (Audio) Sarah: By the way, have you ever tried looking at the official documentation for this library? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625d7e129384c7ec26b2cc3.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625d7e129384c7ec26b2cc3.md
@@ -1,8 +1,8 @@
 ---
 id: 6625d7e129384c7ec26b2cc3
-title: Task 44
+title: Task 45
 challengeType: 22
-dashedName: task-44
+dashedName: task-45
 ---
 
 <!-- (Audio) Tom: I looked at it, but it seemed a bit overwhelming. Do you have any tips on how to approach it? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625d81940f2c57f66bbd17e.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625d81940f2c57f66bbd17e.md
@@ -1,8 +1,8 @@
 ---
 id: 6625d81940f2c57f66bbd17e
-title: Task 45
+title: Task 46
 challengeType: 19
-dashedName: task-45
+dashedName: task-46
 ---
 
 <!-- (Audio) Tom: I looked at it, but it seemed a bit overwhelming. Do you have any tips on how to approach it? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625d84e92201f802eac3973.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625d84e92201f802eac3973.md
@@ -1,8 +1,8 @@
 ---
 id: 6625d84e92201f802eac3973
-title: Task 46
+title: Task 47
 challengeType: 22
-dashedName: task-46
+dashedName: task-47
 ---
 
 <!-- (Audio) Sarah: When the documentation is extensive, start with the introductory sections. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625d8bc46b89481625b068b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625d8bc46b89481625b068b.md
@@ -1,8 +1,8 @@
 ---
 id: 6625d8bc46b89481625b068b
-title: Task 47
+title: Task 48
 challengeType: 19
-dashedName: task-47
+dashedName: task-48
 ---
 
 <!-- (Audio) Sarah: When the documentation is extensive, start with the introductory sections. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625d910fb77f9826de00b73.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625d910fb77f9826de00b73.md
@@ -1,8 +1,8 @@
 ---
 id: 6625d910fb77f9826de00b73
-title: Task 48
+title: Task 49
 challengeType: 19
-dashedName: task-48
+dashedName: task-49
 ---
 
 <!-- (Audio) Sarah: When the documentation is extensive, start with the introductory sections. If you focus on understanding the core concepts first, it becomes more manageable. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625d9508854008334d44831.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625d9508854008334d44831.md
@@ -1,8 +1,8 @@
 ---
 id: 6625d9508854008334d44831
-title: Task 49
+title: Task 50
 challengeType: 22
-dashedName: task-49
+dashedName: task-50
 ---
 
 <!-- (Audio) Also, have you ever joined online tech forums or communities? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625d987196d2383e359d41f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625d987196d2383e359d41f.md
@@ -1,8 +1,8 @@
 ---
 id: 6625d987196d2383e359d41f
-title: Task 50
+title: Task 51
 challengeType: 19
-dashedName: task-50
+dashedName: task-51
 ---
 
 <!-- (Audio) Sarah: Also, have you ever joined online tech forums or communities? Tom: Not yet. Are they helpful? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625da09ef6e5b8547626587.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625da09ef6e5b8547626587.md
@@ -1,8 +1,8 @@
 ---
 id: 6625da09ef6e5b8547626587
-title: Task 51
+title: Task 52
 challengeType: 22
-dashedName: task-51
+dashedName: task-52
 ---
 
 <!-- (Audio) Sarah: Absolutely! Joining forums or communities provides a platform where you can ask questions and learn from others'  experiences. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625da582aba58863d900bcf.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625da582aba58863d900bcf.md
@@ -1,8 +1,8 @@
 ---
 id: 6625da582aba58863d900bcf
-title: Task 52
+title: Task 53
 challengeType: 22
-dashedName: task-52
+dashedName: task-53
 ---
 
 <!-- (Audio) Sarah: Absolutely! Joining forums or communities provides a platform where you can ask questions and learn from others' experiences. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625dc1d103a638a7fd5308b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625dc1d103a638a7fd5308b.md
@@ -1,8 +1,8 @@
 ---
 id: 6625dc1d103a638a7fd5308b
-title: Task 53
+title: Task 54
 challengeType: 19
-dashedName: task-53
+dashedName: task-54
 ---
 
 <!-- (Audio) Sarah: Absolutely! Joining forums or communities provides a platform where you can ask questions and learn from others' experiences. If you encounter any roadblocks, it's a great resource. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625dc81861c0d8b754a4829.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625dc81861c0d8b754a4829.md
@@ -1,8 +1,8 @@
 ---
 id: 6625dc81861c0d8b754a4829
-title: Task 54
+title: Task 55
 challengeType: 19
-dashedName: task-54
+dashedName: task-55
 ---
 
 <!-- (Audio) Tom: Awesome. I'll give it a try. Thanks for the suggestion, Sarah. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625de24962337919e462c20.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625de24962337919e462c20.md
@@ -1,8 +1,8 @@
 ---
 id: 6625de24962337919e462c20
-title: Task 55
+title: Task 57
 challengeType: 22
-dashedName: task-55
+dashedName: task-57
 ---
 
 <!-- (Audio) Maria: Hey, Tom. I noticed that you were struggling with the version control system. Need a hand? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625deaf1ab4a69314d3125e.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625deaf1ab4a69314d3125e.md
@@ -1,8 +1,8 @@
 ---
 id: 6625deaf1ab4a69314d3125e
-title: Task 56
+title: Task 58
 challengeType: 19
-dashedName: task-56
+dashedName: task-58
 ---
 
 <!-- (Audio) Maria: Hey, Tom. I noticed that you were struggling with the version control system. Need a hand? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625dee8ccb83a93da674fca.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625dee8ccb83a93da674fca.md
@@ -1,8 +1,8 @@
 ---
 id: 6625dee8ccb83a93da674fca
-title: Task 57
+title: Task 59
 challengeType: 22
-dashedName: task-57
+dashedName: task-59
 ---
 
 <!-- (Audio) Tom: Oh, thanks, Maria. I'm having a hard time understanding how to merge branches. Have you ever had to deal with this? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625df2bb732da94b03089d1.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625df2bb732da94b03089d1.md
@@ -1,8 +1,8 @@
 ---
 id: 6625df2bb732da94b03089d1
-title: Task 58
+title: Task 60
 challengeType: 22
-dashedName: task-58
+dashedName: task-60
 ---
 
 <!-- (Audio) Tom: Oh, thanks, Maria. I'm having a hard time understanding how to merge branches. Have you ever had to deal with this? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625df8d71b44495cde83d48.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625df8d71b44495cde83d48.md
@@ -1,8 +1,8 @@
 ---
 id: 6625df8d71b44495cde83d48
-title: Task 59
+title: Task 61
 challengeType: 19
-dashedName: task-59
+dashedName: task-61
 ---
 
 <!-- (Audio) Tom: Oh, thanks, Maria. I'm having a hard time understanding how to merge branches. Have you ever had to deal with this? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625dfe17a5dd696cf89cb01.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625dfe17a5dd696cf89cb01.md
@@ -1,8 +1,8 @@
 ---
 id: 6625dfe17a5dd696cf89cb01
-title: Task 60
+title: Task 62
 challengeType: 19
-dashedName: task-60
+dashedName: task-62
 ---
 
 <!-- (Audio) Maria: All the time. Merging can be tricky. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625e02aa797a497b69d2c55.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625e02aa797a497b69d2c55.md
@@ -1,8 +1,8 @@
 ---
 id: 6625e02aa797a497b69d2c55
-title: Task 61
+title: Task 63
 challengeType: 22
-dashedName: task-61
+dashedName: task-63
 ---
 
 <!-- (Audio) Maria: All the time. Merging can be tricky. Let's sit down after the meeting, and I'll walk you through it step by step. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625e08130068e98c6c166c6.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625e08130068e98c6c166c6.md
@@ -1,8 +1,8 @@
 ---
 id: 6625e08130068e98c6c166c6
-title: Task 62
+title: Task 64
 challengeType: 19
-dashedName: task-62
+dashedName: task-64
 ---
 
 <!-- (Audio) Maria: All the time. Merging can be tricky. Let's sit down after the meeting, and I'll walk you through it step by step. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625e0c2e7f616999352aa7b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/6625e0c2e7f616999352aa7b.md
@@ -1,158 +1,76 @@
 ---
 id: 6625e0c2e7f616999352aa7b
-title: Task 63
+title: Task 65
 challengeType: 22
-dashedName: task-63
+dashedName: task-65
 ---
 
-<!-- (Audio) The whole dialogue -->
+<!-- REVIEW -->
 
 # --description--
 
-This task summarizes the dialogue between Maria and Tom, focusing on the key words related to their interaction about version control and merging branches.
+This is a review of the entire dialogue you just studied.
+
+# --instructions--
+
+Write the following words or phrases in the correct spot:
+
+`struggling with`, `sit down`, `a hard time`, `a hand`, `walk you through`, and `deal with`.
 
 # --fillInTheBlank--
 
 ## --sentence--
 
-`Tom was BLANK with the version control system, and Maria offered to BLANK him a BLANK. She frequently BLANK with merging branches and suggested sitting down to BLANK Tom BLANK the process.`
+`Maria: Hey Tom, I noticed that you were BLANK the version control system. Need BLANK?`
+
+`Tom: Oh, thanks Maria. I'm having BLANK understanding how to merge branches. Have you ever had to BLANK this?`
+
+`Maria: All the time. Merging can be tricky. Let's BLANK after the meeting and I'll BLANK it step by step.`
 
 ## --blanks--
 
-`struggling`
+`struggling with`
 
 ### --feedback--
 
-It refers to Tom having difficulty with the version control system.
+Having a lot of difficulty with something.
 
 ---
 
-`give`
+`a hand`
 
 ### --feedback--
 
-Maria offers assistance to Tom.
+In this context it means help or support.
 
 ---
 
-`hand`
+`a hard time`
 
 ### --feedback--
 
-It refers to help or assistance.
+Finding something difficult to do or understand.
 
 ---
 
-`deals`
+`deal with`
 
 ### --feedback--
 
-Maria is experienced with handling such tasks.
+To handle or manage a problem or situation.
 
 ---
 
-`guide`
+`sit down`
 
 ### --feedback--
 
-Maria proposes to help Tom understand the process.
+To take time to focus on something, usually with someone's help.
 
 ---
 
-`through`
+`walk you through`
 
 ### --feedback--
 
-It indicates guiding someone from start to finish.
-
-# --scene--
-
-```json
-{
-  "setup": {
-    "background": "company1-boardroom.png",
-    "characters": [
-      {
-        "character": "Maria",
-        "position": { "x": -25, "y": 0, "z": 1 }
-      },
-      {
-        "character": "Tom",
-        "position": { "x": 125, "y": 0, "z": 1 }
-      }
-    ],
-    "audio": {
-      "filename": "9.2-3.mp3",
-      "startTime": 1
-    },
-    "alwaysShowDialogue": true
-  },
-  "commands": [
-    {
-      "character": "Maria",
-      "position": { "x": 25, "y": 0, "z": 1 },
-      "startTime": 0
-    },
-    {
-      "character": "Tom",
-      "position": { "x": 70, "y": 0, "z": 1 },
-      "startTime": 0.5
-    },
-    {
-      "character": "Maria",
-      "startTime": 1,
-      "finishTime": 5.26,
-      "dialogue": {
-        "text": "Hey, Tom. I noticed that you were struggling with the version control system. Need a hand?",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Tom",
-      "startTime": 5.58,
-      "finishTime": 9.32,
-      "dialogue": {
-        "text": "Oh, thanks Maria. I'm having a hard time understanding how to merge branches.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Tom",
-      "startTime": 9.82,
-      "finishTime": 11.18,
-      "dialogue": {
-        "text": "Have you ever had to deal with this?",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Maria",
-      "startTime": 11.7,
-      "finishTime": 13.7,
-      "dialogue": {
-        "text": "All the time. Merging can be tricky.",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Maria",
-      "startTime": 14.2,
-      "finishTime": 17.2,
-      "dialogue": {
-        "text": "Let's sit down after the meeting and I'll walk you through it step by step.",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Tom",
-      "position": { "x": 125, "y": 0, "z": 1 },
-      "startTime": 17.7
-    },
-    {
-      "character": "Maria",
-      "position": { "x": -25, "y": 0, "z": 1 },
-      "startTime": 18.2
-    }
-  ]
-}
-```
+To guide someone through something step by step.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/685d18feaafc2a0720d0ca31.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/685d18feaafc2a0720d0ca31.md
@@ -1,0 +1,110 @@
+---
+id: 685d18feaafc2a0720d0ca31
+title: Task 30
+challengeType: 22
+dashedName: task-30
+---
+
+<!-- REVIEW -->
+
+# --description--
+
+This is a review of the entire dialogue you just studied.
+
+# --instructions--
+
+Write the following words or phrases in the correct spot:
+
+`resources`, `dealt with`, `taking a look`, `break down`, `collaborated with`, `guidance`, `trying to`, and `stuck on`.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`Sophie: Hey, Brian. I'm working on this coding challenge, and I could use a fresh perspective. Mind BLANK?`
+
+`Brian: Of course. I'm happy to help. What seems to be the issue?`
+
+`Sophie: Well, I'm BLANK optimize this function, but I feel like I'm missing something. Have you ever tackled a similar optimization challenge?`
+
+`Brian: Absolutely. Optimization can be tricky. I'd suggest that you BLANK the function into smaller parts. It might make the optimization more manageable.`
+
+`Sophie: Good point. I'll try that. Also, have you ever BLANK time complexity issues in a similar context?`
+
+`Brian: Yes, I have. If you analyze the loops and conditional statements, it often shows areas for improvement.`
+
+`Sophie: Loops and conditionals... Thanks. By the way, when you see a logic challenge, how do you usually approach it?`
+
+`Brian: Well, I break it down step by step. If I get BLANK a specific part, I ask for help from colleagues. Have you ever BLANK someone to solve coding problems?`
+
+`Sophie: I haven't done that much, but it sounds like a great idea. I'll keep that in mind. Do you have any preferred resources for diving deep into optimization techniques?`
+
+`Brian: Definitely. There are some great articles and tutorials online. I can share a few links with you. Have you ever explored online BLANK for coding challenges?`
+
+`Sophie: Not extensively. I'd appreciate those links. Thanks for your BLANK. It's been really helpful.`
+
+`Brian: No problem. We're a team. Supporting each other is what makes us stronger.`
+
+## --blanks--
+
+`taking a look`
+
+### --feedback--
+
+Checking or reviewing something.
+
+---
+
+`trying to`
+
+### --feedback--
+
+Making an effort to do something, even if it's not easy.
+
+---
+
+`break down`
+
+### --feedback--
+
+To explain something step by step or in simpler parts.
+
+---
+
+`dealt with`
+
+### --feedback--
+
+Handled or managed a problem or situation.
+
+---
+
+`stuck on`
+
+### --feedback--
+
+Having trouble with something and not sure how to continue.
+
+---
+
+`collaborated with`
+
+### --feedback--
+
+Worked together with someone on a task or project.
+
+---
+
+`resources`
+
+### --feedback--
+
+Tools, materials, or information that help you learn or solve problems.
+
+---
+
+`guidance`
+
+### --feedback--
+
+Advice or help from someone more experienced.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/685d1933c0d8ab075f5da3ce.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-request-and-receive-guidance/685d1933c0d8ab075f5da3ce.md
@@ -1,0 +1,108 @@
+---
+id: 685d1933c0d8ab075f5da3ce
+title: Task 56
+challengeType: 22
+dashedName: task-56
+---
+
+<!-- REVIEW -->
+
+# --description--
+
+This is a review of the entire dialogue you just studied.
+
+# --instructions--
+
+Write the following words or phrases in the correct spot:
+
+`troubleshoot`, `any issues`, `a bit lost`, `learn from`, `approach`, `walk through`, `core concepts`, and `trouble with`.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`Tom: Ugh. I'm really trying to understand how to use this library but I'm BLANK. Mind if I ask you for some guidance?`
+
+`Sarah: Of course. I'm here to help. What are you having BLANK?`
+
+`Tom: Well, I'm trying to understand the basics, like how to set up the environment. Have you ever worked with this tech stack before?`
+
+`Sarah: Yes, I have. Setting up the environment can be a bit tricky initially. Let's BLANK the steps together. First, download the installer from the official website. It'll guide you through the setup process.`
+
+`Sarah: If you have BLANK during the installation, don't hesitate to reach out. We can BLANK together. By the way, have you ever tried looking at the official documentation for this library?`
+
+`Tom: I looked at it but it seemed a bit overwhelming. Do you have any tips for how to BLANK it?`
+
+`Sarah: When the documentation is extensive, start with the introductory sections. If you focus on understanding the BLANK first, it becomes more manageable. Also, have you ever joined online tech forums or communities?`
+
+`Tom: Not yet. Are they helpful?`
+
+`Sarah: Absolutely. Joining forums or communities provides a platform where you can ask questions and BLANK others' experiences. If you encounter any roadblocks, it's a great resource.`
+
+`Tom: Awesome. I'll give it a try. Thanks for the suggestions, Sarah.`
+
+`Sarah: Sure.`
+
+## --blanks--
+
+`a bit lost`
+
+### --feedback--
+
+Feeling confused or not sure what to do next.
+
+---
+
+`trouble with`
+
+### --feedback--
+
+Having difficulty understanding or doing something.
+
+---
+
+`walk through`
+
+### --feedback--
+
+To explain something step by step.
+
+---
+
+`any issues`
+
+### --feedback--
+
+Any problems or things that are not working.
+
+---
+
+`troubleshoot`
+
+### --feedback--
+
+To find and fix a problem.
+
+---
+
+`approach`
+
+### --feedback--
+
+To start dealing with a task or problem.
+
+---
+
+`core concepts`
+
+### --feedback--
+
+The most important and basic ideas you need to understand a topic.
+
+---
+
+`learn from`
+
+### --feedback--
+
+To get knowledge or skills by studying or experiencing something.


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

Related to https://github.com/freeCodeCamp/freeCodeCamp/issues/55293

The EC team found that "summary tasks" were ineffective and confusing for learners, as noted in the related issue. In the B1 curriculum, we replaced them with "review tasks."

This PR is part of a series to apply the same changes to the A2 curriculum. To keep reviews easier, I'm splitting the updates into multiple PRs. This one covers Block 26.
