### PR TITLE
feat(curriculum): add review tasks to block 27 of the A2 curriculum

### DIFF
--- a/curriculum/challenges/_meta/learn-how-to-provide-explanations-when-helping-others/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-provide-explanations-when-helping-others/meta.json
@@ -82,48 +82,56 @@
       "title": "Task 18"
     },
     {
+      "id": "685d2a40955f7a0d9f5c81f4",
+      "title": "Task 19"
+    },
+    {
       "id": "662637442baaf548015d56d9",
       "title": "Dialogue 2: An Online Meeting for Software Training"
     },
     {
       "id": "662637b4ae77ed48d6d5ba8d",
-      "title": "Task 19"
-    },
-    {
-      "id": "66263800f12d8d4a6edffdcd",
       "title": "Task 20"
     },
     {
-      "id": "66263852d4e9534b53c82e2e",
+      "id": "66263800f12d8d4a6edffdcd",
       "title": "Task 21"
     },
     {
-      "id": "66263891f8b3f74c36cd90b4",
+      "id": "66263852d4e9534b53c82e2e",
       "title": "Task 22"
     },
     {
-      "id": "662638ca74be054d04c448fa",
+      "id": "66263891f8b3f74c36cd90b4",
       "title": "Task 23"
     },
     {
-      "id": "662639212dc5664e08ec05f6",
+      "id": "662638ca74be054d04c448fa",
       "title": "Task 24"
     },
     {
-      "id": "6626396c2fd2604f117731b2",
+      "id": "662639212dc5664e08ec05f6",
       "title": "Task 25"
     },
     {
-      "id": "66263a41ce552c514cb6fc3e",
+      "id": "6626396c2fd2604f117731b2",
       "title": "Task 26"
     },
     {
-      "id": "66263aace1c84e52a2974049",
+      "id": "66263a41ce552c514cb6fc3e",
       "title": "Task 27"
     },
     {
-      "id": "66263b5ca3878d54811f9ac2",
+      "id": "66263aace1c84e52a2974049",
       "title": "Task 28"
+    },
+    {
+      "id": "66263b5ca3878d54811f9ac2",
+      "title": "Task 29"
+    },
+    {
+      "id": "685d2a6c1db06d0dd721af8b",
+      "title": "Task 30"
     },
     {
       "id": "66263d28fe1eae5a2601d0d6",
@@ -131,55 +139,59 @@
     },
     {
       "id": "66263d47baac2d5ad278e68c",
-      "title": "Task 29"
-    },
-    {
-      "id": "66264a9e3e030663acc4109a",
-      "title": "Task 30"
-    },
-    {
-      "id": "66264bc673d62766a8ab48bc",
       "title": "Task 31"
     },
     {
-      "id": "66265cebc033f66a2a4451e9",
+      "id": "66264a9e3e030663acc4109a",
       "title": "Task 32"
     },
     {
-      "id": "66265d447926ae6b9e9af13e",
+      "id": "66264bc673d62766a8ab48bc",
       "title": "Task 33"
     },
     {
-      "id": "66265dd49cbab56d038d0d2e",
+      "id": "66265cebc033f66a2a4451e9",
       "title": "Task 34"
     },
     {
-      "id": "66265e0ac3bdc26ddf3525f5",
+      "id": "66265d447926ae6b9e9af13e",
       "title": "Task 35"
     },
     {
-      "id": "66265e4a43ec6d6e9ba7cc79",
+      "id": "66265dd49cbab56d038d0d2e",
       "title": "Task 36"
     },
     {
-      "id": "66265ec39f8cf36fe615bd11",
+      "id": "66265e0ac3bdc26ddf3525f5",
       "title": "Task 37"
     },
     {
-      "id": "66265f07ee69a670cc620d1e",
+      "id": "66265e4a43ec6d6e9ba7cc79",
       "title": "Task 38"
     },
     {
-      "id": "66265f3bb6ec0c7186e0c621",
+      "id": "66265ec39f8cf36fe615bd11",
       "title": "Task 39"
     },
     {
-      "id": "6626676b898b1d721834736a",
+      "id": "66265f07ee69a670cc620d1e",
       "title": "Task 40"
     },
     {
-      "id": "662668a5aa1437017755151d",
+      "id": "66265f3bb6ec0c7186e0c621",
       "title": "Task 41"
+    },
+    {
+      "id": "6626676b898b1d721834736a",
+      "title": "Task 42"
+    },
+    {
+      "id": "662668a5aa1437017755151d",
+      "title": "Task 43"
+    },
+    {
+      "id": "685d2a933f6ee10e354d4737",
+      "title": "Task 44"
     }
   ],
   "helpCategory": "English",

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-provide-explanations-when-helping-others/662637b4ae77ed48d6d5ba8d.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-provide-explanations-when-helping-others/662637b4ae77ed48d6d5ba8d.md
@@ -1,8 +1,8 @@
 ---
 id: 662637b4ae77ed48d6d5ba8d
-title: Task 19
+title: Task 20
 challengeType: 22
-dashedName: task-19
+dashedName: task-20
 ---
 
 <!-- (Audio) David: Hi Maria, I'm having trouble navigating through the new software. Any tips? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-provide-explanations-when-helping-others/66263800f12d8d4a6edffdcd.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-provide-explanations-when-helping-others/66263800f12d8d4a6edffdcd.md
@@ -1,8 +1,8 @@
 ---
 id: 66263800f12d8d4a6edffdcd
-title: Task 20
+title: Task 21
 challengeType: 19
-dashedName: task-20
+dashedName: task-21
 ---
 
 <!-- (Audio) David: Hi Maria, I'm having trouble navigating through the new software. Any tips? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-provide-explanations-when-helping-others/66263852d4e9534b53c82e2e.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-provide-explanations-when-helping-others/66263852d4e9534b53c82e2e.md
@@ -1,8 +1,8 @@
 ---
 id: 66263852d4e9534b53c82e2e
-title: Task 21
+title: Task 22
 challengeType: 22
-dashedName: task-21
+dashedName: task-22
 ---
 
 <!-- (Audio) Maria: Of course! Have you tried watching the tutorial videos? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-provide-explanations-when-helping-others/66263891f8b3f74c36cd90b4.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-provide-explanations-when-helping-others/66263891f8b3f74c36cd90b4.md
@@ -1,8 +1,8 @@
 ---
 id: 66263891f8b3f74c36cd90b4
-title: Task 22
+title: Task 23
 challengeType: 19
-dashedName: task-22
+dashedName: task-23
 ---
 
 <!-- (Audio) Maria: Of course! Have you tried watching the tutorial videos? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-provide-explanations-when-helping-others/662638ca74be054d04c448fa.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-provide-explanations-when-helping-others/662638ca74be054d04c448fa.md
@@ -1,8 +1,8 @@
 ---
 id: 662638ca74be054d04c448fa
-title: Task 23
+title: Task 24
 challengeType: 19
-dashedName: task-23
+dashedName: task-24
 ---
 
 <!-- (Audio) Maria: Of course! Have you tried watching the tutorial videos? David: I did, but I'm still a bit confused. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-provide-explanations-when-helping-others/662639212dc5664e08ec05f6.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-provide-explanations-when-helping-others/662639212dc5664e08ec05f6.md
@@ -1,8 +1,8 @@
 ---
 id: 662639212dc5664e08ec05f6
-title: Task 24
+title: Task 25
 challengeType: 19
-dashedName: task-24
+dashedName: task-25
 ---
 
 <!-- (Audio) David: I did, but I'm still a bit confused. Maria: No worries. You might want to click on the `Help` menu. There are step-by-step guides there. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-provide-explanations-when-helping-others/6626396c2fd2604f117731b2.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-provide-explanations-when-helping-others/6626396c2fd2604f117731b2.md
@@ -1,8 +1,8 @@
 ---
 id: 6626396c2fd2604f117731b2
-title: Task 25
+title: Task 26
 challengeType: 19
-dashedName: task-25
+dashedName: task-26
 ---
 
 <!-- (Audio) Maria: No worries. You might want to click on the Help menu. There are step-by-step guides there. David: Okay, I'll check that out. Anything else I should do? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-provide-explanations-when-helping-others/66263a41ce552c514cb6fc3e.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-provide-explanations-when-helping-others/66263a41ce552c514cb6fc3e.md
@@ -1,8 +1,8 @@
 ---
 id: 66263a41ce552c514cb6fc3e
-title: Task 26
+title: Task 27
 challengeType: 19
-dashedName: task-26
+dashedName: task-27
 ---
 
 <!-- (Audio) Maria: If you're still having issues, you can always reach out to our support team. They're great at helping with specific problems. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-provide-explanations-when-helping-others/66263aace1c84e52a2974049.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-provide-explanations-when-helping-others/66263aace1c84e52a2974049.md
@@ -1,8 +1,8 @@
 ---
 id: 66263aace1c84e52a2974049
-title: Task 27
+title: Task 28
 challengeType: 19
-dashedName: task-27
+dashedName: task-28
 ---
 
 <!-- (Audio) Maria: If you're still having issues, you can always reach out to our support team. They're great at helping with specific problems. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-provide-explanations-when-helping-others/66263b5ca3878d54811f9ac2.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-provide-explanations-when-helping-others/66263b5ca3878d54811f9ac2.md
@@ -1,8 +1,8 @@
 ---
 id: 66263b5ca3878d54811f9ac2
-title: Task 28
+title: Task 29
 challengeType: 19
-dashedName: task-28
+dashedName: task-29
 ---
 
 <!-- (Audio) David: Thanks! I'll give that a go. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-provide-explanations-when-helping-others/66263d47baac2d5ad278e68c.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-provide-explanations-when-helping-others/66263d47baac2d5ad278e68c.md
@@ -1,8 +1,8 @@
 ---
 id: 66263d47baac2d5ad278e68c
-title: Task 29
+title: Task 31
 challengeType: 22
-dashedName: task-29
+dashedName: task-31
 ---
 
 <!-- (Audio) Sophie: Hey, I'm a bit stuck trying to integrate this framework into our project. Any advice? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-provide-explanations-when-helping-others/66264a9e3e030663acc4109a.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-provide-explanations-when-helping-others/66264a9e3e030663acc4109a.md
@@ -1,8 +1,8 @@
 ---
 id: 66264a9e3e030663acc4109a
-title: Task 30
+title: Task 32
 challengeType: 19
-dashedName: task-30
+dashedName: task-32
 ---
 
 <!-- (Audio) Sophie: Hey, I'm a bit stuck trying to integrate this framework into our project. Any advice? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-provide-explanations-when-helping-others/66264bc673d62766a8ab48bc.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-provide-explanations-when-helping-others/66264bc673d62766a8ab48bc.md
@@ -1,8 +1,8 @@
 ---
 id: 66264bc673d62766a8ab48bc
-title: Task 31
+title: Task 33
 challengeType: 19
-dashedName: task-31
+dashedName: task-33
 ---
 
 <!-- (Audio) Brian: Which framework are you working with? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-provide-explanations-when-helping-others/66265cebc033f66a2a4451e9.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-provide-explanations-when-helping-others/66265cebc033f66a2a4451e9.md
@@ -1,8 +1,8 @@
 ---
 id: 66265cebc033f66a2a4451e9
-title: Task 32
+title: Task 34
 challengeType: 22
-dashedName: task-32
+dashedName: task-34
 ---
 
 <!-- (Audio) Sophie: It's a new one I found for handling user authentication, but the documentation is a bit confusing. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-provide-explanations-when-helping-others/66265d447926ae6b9e9af13e.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-provide-explanations-when-helping-others/66265d447926ae6b9e9af13e.md
@@ -1,8 +1,8 @@
 ---
 id: 66265d447926ae6b9e9af13e
-title: Task 33
+title: Task 35
 challengeType: 19
-dashedName: task-33
+dashedName: task-35
 ---
 
 <!-- (Audio) Sophie: It's a new one I found for handling user authentication, but the documentation is a bit confusing. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-provide-explanations-when-helping-others/66265dd49cbab56d038d0d2e.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-provide-explanations-when-helping-others/66265dd49cbab56d038d0d2e.md
@@ -1,8 +1,8 @@
 ---
 id: 66265dd49cbab56d038d0d2e
-title: Task 34
+title: Task 36
 challengeType: 22
-dashedName: task-34
+dashedName: task-36
 ---
 
 <!-- (Audio) Brian: I get that. Make sure you've included the framework library in our project dependencies. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-provide-explanations-when-helping-others/66265e0ac3bdc26ddf3525f5.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-provide-explanations-when-helping-others/66265e0ac3bdc26ddf3525f5.md
@@ -1,8 +1,8 @@
 ---
 id: 66265e0ac3bdc26ddf3525f5
-title: Task 35
+title: Task 37
 challengeType: 19
-dashedName: task-35
+dashedName: task-37
 ---
 
 <!-- (Audio) Brian: I get that. Make sure you've included the framework library in our project dependencies. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-provide-explanations-when-helping-others/66265e4a43ec6d6e9ba7cc79.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-provide-explanations-when-helping-others/66265e4a43ec6d6e9ba7cc79.md
@@ -1,8 +1,8 @@
 ---
 id: 66265e4a43ec6d6e9ba7cc79
-title: Task 36
+title: Task 38
 challengeType: 22
-dashedName: task-36
+dashedName: task-38
 ---
 
 <!-- (Audio) Sophie: I did that, but now I'm not sure how to set it up to work with our existing login system. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-provide-explanations-when-helping-others/66265ec39f8cf36fe615bd11.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-provide-explanations-when-helping-others/66265ec39f8cf36fe615bd11.md
@@ -1,8 +1,8 @@
 ---
 id: 66265ec39f8cf36fe615bd11
-title: Task 37
+title: Task 39
 challengeType: 19
-dashedName: task-37
+dashedName: task-39
 ---
 
 <!-- (Audio) Sophie: I did that, but now I'm not sure how to set it up to work with our existing login system. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-provide-explanations-when-helping-others/66265f07ee69a670cc620d1e.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-provide-explanations-when-helping-others/66265f07ee69a670cc620d1e.md
@@ -1,8 +1,8 @@
 ---
 id: 66265f07ee69a670cc620d1e
-title: Task 38
+title: Task 40
 challengeType: 22
-dashedName: task-38
+dashedName: task-40
 ---
 
 <!-- (Audio) Brian: Okay, let's take it step by step. Check the framework documentation for initialization instructions. It usually involves configuring settings or initializing the library. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-provide-explanations-when-helping-others/66265f3bb6ec0c7186e0c621.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-provide-explanations-when-helping-others/66265f3bb6ec0c7186e0c621.md
@@ -1,8 +1,8 @@
 ---
 id: 66265f3bb6ec0c7186e0c621
-title: Task 39
+title: Task 41
 challengeType: 19
-dashedName: task-39
+dashedName: task-41
 ---
 
 <!-- (Audio) Brian: Okay, let's take it step by step. Check the framework documentation for initialization instructions. It usually involves configuring settings or initializing the library. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-provide-explanations-when-helping-others/6626676b898b1d721834736a.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-provide-explanations-when-helping-others/6626676b898b1d721834736a.md
@@ -1,8 +1,8 @@
 ---
 id: 6626676b898b1d721834736a
-title: Task 40
+title: Task 42
 challengeType: 19
-dashedName: task-40
+dashedName: task-42
 ---
 
 <!-- (Audio) Brian: Okay, let's take it step by step. Check the framework documentation for initialization instructions. It usually involves configuring settings or initializing the library. Sophie: I'll give that another look. Anything else? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-provide-explanations-when-helping-others/662668a5aa1437017755151d.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-provide-explanations-when-helping-others/662668a5aa1437017755151d.md
@@ -1,8 +1,8 @@
 ---
 id: 662668a5aa1437017755151d
-title: Task 41
+title: Task 43
 challengeType: 19
-dashedName: task-41
+dashedName: task-43
 ---
 
 <!-- (Audio) Brian: If you're still having trouble, check if there's a community forum or support channel for the framework. Other developers might have faced similar issues. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-provide-explanations-when-helping-others/685d2a40955f7a0d9f5c81f4.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-provide-explanations-when-helping-others/685d2a40955f7a0d9f5c81f4.md
@@ -1,0 +1,76 @@
+---
+id: 685d2a40955f7a0d9f5c81f4
+title: Task 19
+challengeType: 22
+dashedName: task-19
+---
+
+<!--REVIEW -->
+
+# --description--
+
+This is a review of the entire dialogue you just studied.
+
+# --instructions--
+
+Write the following words or phrases in the correct spot:
+
+`Have you tried`, `causes issues`, `give that a shot`, `might want`, and `acting up`.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`Tom: Hey, Sarah. My computer is BLANK. I can't open any files.`
+
+`Sarah: Oh, that's frustrating. BLANK restarting it?`
+
+`Tom: Yes, I did, but it didn't work.`
+
+`Sarah: Okay, no worries. You BLANK to check if there's enough storage space on your hard drive. Sometimes that BLANK.`
+
+`Tom: How do I do that?`
+
+`Sarah: Just right click on the hard drive icon and select Properties. It'll show you the available space.`
+
+`Tom: Got it. Thanks. I'll BLANK.`
+
+## --blanks--
+
+`acting up`
+
+### --feedback--
+
+Not working correctly or behaving in a strange way.
+
+---
+
+`Have you tried`
+
+### --feedback--
+
+A way to suggest something that might help solve a problem. The first letter is capitalized.
+
+---
+
+`might want`
+
+### --feedback--
+
+A polite way to suggest doing something.
+
+---
+
+`causes issues`
+
+### --feedback--
+
+Creates problems or makes something not work properly.
+
+---
+
+`give that a shot`
+
+### --feedback--
+
+Try something to see if it works.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-provide-explanations-when-helping-others/685d2a6c1db06d0dd721af8b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-provide-explanations-when-helping-others/685d2a6c1db06d0dd721af8b.md
@@ -1,0 +1,84 @@
+---
+id: 685d2a6c1db06d0dd721af8b
+title: Task 30
+challengeType: 22
+dashedName: task-30
+---
+
+<!--REVIEW -->
+
+# --description--
+
+This is a review of the entire dialogue you just studied.
+
+# --instructions--
+
+Write the following words or phrases in the correct spot:
+
+`check that out`, `tutorial`, `guides`, `support team`, `navigating through`, and `problems`.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`David: Hi Maria, I'm having trouble BLANK the new software. Any tips?`
+
+`Maria: Of course. Have you tried watching the BLANK videos?`
+
+`David: I did, but I'm still a bit confused.`
+
+`Maria: No worries. You might want to click on the Help menu. There are step-by-step BLANK there.`
+
+`David: Okay, I'll BLANK. Anything else I should do?`
+
+`Maria: If you're still having issues, you can always reach out to our BLANK. They're great at helping with specific BLANK.`
+
+`David: Thanks. I'll give that a go.`
+
+## --blanks--
+
+`navigating through`
+
+### --feedback--
+
+Moving step by step through something, like an app or document.
+
+---
+
+`tutorial`
+
+### --feedback--
+
+A lesson that teaches you how to do something.
+
+---
+
+`guides`
+
+### --feedback--
+
+Instructions or information that help you learn or complete a task.
+
+---
+
+`check that out`
+
+### --feedback--
+
+Look at something to learn more about it or see if it helps.
+
+---
+
+`support team`
+
+### --feedback--
+
+A group of people who help solve problems and answer questions.
+
+---
+
+`problems`
+
+### --feedback--
+
+Things that are not working or need to be fixed.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-provide-explanations-when-helping-others/685d2a933f6ee10e354d4737.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-provide-explanations-when-helping-others/685d2a933f6ee10e354d4737.md
@@ -1,0 +1,96 @@
+---
+id: 685d2a933f6ee10e354d4737
+title: Task 44
+challengeType: 22
+dashedName: task-44
+---
+
+<!--REVIEW -->
+
+# --description--
+
+This is a review of the entire dialogue you just studied.
+
+# --instructions--
+
+Write the following words or phrases in the correct spot:
+
+`Make sure`, `advice`, `work with`, `stuck`, `another look`, `faced`, and `step by step`.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`Sophie: Hey, I'm a bit BLANK trying to integrate this framework into our project. Any BLANK?`
+
+`Brian: Which framework are you working with?`
+
+`Sophie: It's a new one I found for handling user authentication, but the documentation is a bit confusing.`
+
+`Brian: I get that. BLANK you've included the framework library in our project dependencies.`
+
+`Sophie: I did that, but now I'm not sure how to set it up to BLANK our existing login system.`
+
+`Brian: Okay, let's take it BLANK. Check the framework documentation for initialization instructions. It usually involves configuring settings or initializing the library.`
+
+`Sophie: I'll give that BLANK. Anything else?`
+
+`Brian: If you're still having trouble, check if there's a community forum or support channel for the framework. Other developers might have BLANK similar issues.`
+
+`Sophie: Good point. Thanks.`
+
+## --blanks--
+
+`stuck`
+
+### --feedback--
+
+Not able to move forward or solve something.
+
+---
+
+`advice`
+
+### --feedback--
+
+Helpful ideas or suggestions from someone.
+
+---
+
+`Make sure`
+
+### --feedback--
+
+Check or confirm that something is correct or done properly. The first letter is capitalized.
+
+---
+
+`work with`
+
+### --feedback--
+
+To do something together with someone else or use something to help.
+
+---
+
+`step by step`
+
+### --feedback--
+
+Doing things in order, one part at a time.
+
+---
+
+`another look`
+
+### --feedback--
+
+Checking something again to see if you missed anything.
+
+---
+
+`faced`
+
+### --feedback--
+
+Had to deal with a problem or situation.


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

Related to https://github.com/freeCodeCamp/freeCodeCamp/issues/55293

The EC team found that "summary tasks" were ineffective and confusing for learners, as noted in the related issue. In the B1 curriculum, we replaced them with "review tasks."

This PR is part of a series to apply the same changes to the A2 curriculum. To keep reviews easier, I'm splitting the updates into multiple PRs. This one covers Block 27.
