### PR TITLE
feat(curriculum): add review tasks to block 7 of the A2 curriculum

### DIFF
--- a/curriculum/challenges/_meta/learn-how-to-ask-and-share-about-educational-and-professional-background/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-ask-and-share-about-educational-and-professional-background/meta.json
@@ -86,60 +86,68 @@
       "title": "Task 19"
     },
     {
+      "id": "685d7943f9aed415ef9ebabe",
+      "title": "Task 20"
+    },
+    {
       "id": "657b46c9be150f577f5a1086",
       "title": "Dialogue 2: Another Job Interview"
     },
     {
       "id": "657b153ac677705c7059530d",
-      "title": "Task 20"
-    },
-    {
-      "id": "657b15dbcafe4d5f39a5de82",
       "title": "Task 21"
     },
     {
-      "id": "657b160d6a8662610fe6a523",
+      "id": "657b15dbcafe4d5f39a5de82",
       "title": "Task 22"
     },
     {
-      "id": "657b163c9da40e62b904be1f",
+      "id": "657b160d6a8662610fe6a523",
       "title": "Task 23"
     },
     {
-      "id": "657b18e71067d6680b9ac5d3",
+      "id": "657b163c9da40e62b904be1f",
       "title": "Task 24"
     },
     {
-      "id": "657b1a03df3ec46eca276046",
+      "id": "657b18e71067d6680b9ac5d3",
       "title": "Task 25"
     },
     {
-      "id": "657b1985ae17886b05b382b1",
+      "id": "657b1a03df3ec46eca276046",
       "title": "Task 26"
     },
     {
-      "id": "657b19bf7b32af6caf763ef7",
+      "id": "657b1985ae17886b05b382b1",
       "title": "Task 27"
     },
     {
-      "id": "657b1a9581015573806e1e20",
+      "id": "657b19bf7b32af6caf763ef7",
       "title": "Task 28"
     },
     {
-      "id": "657b1a27dc6daf6ffd52ff1f",
+      "id": "657b1a9581015573806e1e20",
       "title": "Task 29"
     },
     {
-      "id": "657b1cc072206e7ac3db88b8",
+      "id": "657b1a27dc6daf6ffd52ff1f",
       "title": "Task 30"
     },
     {
-      "id": "657b1a637e4dc571f8f4d3d7",
+      "id": "657b1cc072206e7ac3db88b8",
       "title": "Task 31"
     },
     {
-      "id": "657b1d080265ba7c4f96bf79",
+      "id": "657b1a637e4dc571f8f4d3d7",
       "title": "Task 32"
+    },
+    {
+      "id": "657b1d080265ba7c4f96bf79",
+      "title": "Task 33"
+    },
+    {
+      "id": "685d7a22363c58163423c6c2",
+      "title": "Task 34"
     },
     {
       "id": "657b1d4ec0e2587e8bcc95f7",
@@ -147,131 +155,135 @@
     },
     {
       "id": "657b1da0b27fef8117827ce5",
-      "title": "Task 33"
-    },
-    {
-      "id": "65f22f7d84784d8bd129c9a4",
-      "title": "Task 34"
-    },
-    {
-      "id": "65f230854698ec8c68b67fa4",
       "title": "Task 35"
     },
     {
-      "id": "65f3146b4f4fb2c1f95c7335",
+      "id": "65f22f7d84784d8bd129c9a4",
       "title": "Task 36"
     },
     {
-      "id": "657b1e2fad2ffe84ab420a56",
+      "id": "65f230854698ec8c68b67fa4",
       "title": "Task 37"
     },
     {
-      "id": "657b1dfec76149836ea5c7d0",
+      "id": "65f3146b4f4fb2c1f95c7335",
       "title": "Task 38"
     },
     {
-      "id": "65f310fc37e701bfa451be47",
+      "id": "657b1e2fad2ffe84ab420a56",
       "title": "Task 39"
     },
     {
-      "id": "65f31898ad2ed9c3b1a4c9b3",
+      "id": "657b1dfec76149836ea5c7d0",
       "title": "Task 40"
     },
     {
-      "id": "65f3212e767d81dbcfbeb0cc",
+      "id": "65f310fc37e701bfa451be47",
       "title": "Task 41"
     },
     {
-      "id": "65f3234e85f828dd1f45d384",
+      "id": "65f31898ad2ed9c3b1a4c9b3",
       "title": "Task 42"
     },
     {
-      "id": "657b1e66159fec86336a737b",
+      "id": "65f3212e767d81dbcfbeb0cc",
       "title": "Task 43"
     },
     {
-      "id": "65f3641948909aecf182befe",
+      "id": "65f3234e85f828dd1f45d384",
       "title": "Task 44"
     },
     {
-      "id": "65f365351cf89fedddcc281e",
+      "id": "657b1e66159fec86336a737b",
       "title": "Task 45"
     },
     {
-      "id": "65f365bc3c1491ee60db85a8",
+      "id": "65f3641948909aecf182befe",
       "title": "Task 46"
     },
     {
-      "id": "657b1e9a62603587747f7f45",
+      "id": "65f365351cf89fedddcc281e",
       "title": "Task 47"
     },
     {
-      "id": "657b1f0585d48f8ac0b19654",
+      "id": "65f365bc3c1491ee60db85a8",
       "title": "Task 48"
     },
     {
-      "id": "657b1f598f63008c8bdb20b8",
+      "id": "657b1e9a62603587747f7f45",
       "title": "Task 49"
     },
     {
-      "id": "657b1f981cd42e8dc3b282d9",
+      "id": "657b1f0585d48f8ac0b19654",
       "title": "Task 50"
     },
     {
-      "id": "657b1fe950c0df90346e5d12",
+      "id": "657b1f598f63008c8bdb20b8",
       "title": "Task 51"
     },
     {
-      "id": "657b201372864e91d4f5bb53",
+      "id": "657b1f981cd42e8dc3b282d9",
       "title": "Task 52"
     },
     {
-      "id": "657b20338e0802931673c1e1",
+      "id": "657b1fe950c0df90346e5d12",
       "title": "Task 53"
     },
     {
-      "id": "65f39df8d18f4814c75d3fba",
+      "id": "657b201372864e91d4f5bb53",
       "title": "Task 54"
     },
     {
-      "id": "657b20985d315095e5c3851d",
+      "id": "657b20338e0802931673c1e1",
       "title": "Task 55"
     },
     {
-      "id": "65f39f5bc6d49d15d7ae3d73",
+      "id": "65f39df8d18f4814c75d3fba",
       "title": "Task 56"
     },
     {
-      "id": "65f3a19e8b77c4170ed0704d",
+      "id": "657b20985d315095e5c3851d",
       "title": "Task 57"
     },
     {
-      "id": "657b21e28a01039cb27b4f13",
+      "id": "65f39f5bc6d49d15d7ae3d73",
       "title": "Task 58"
     },
     {
-      "id": "657b221b2ab0ac9e18a173ef",
+      "id": "65f3a19e8b77c4170ed0704d",
       "title": "Task 59"
     },
     {
-      "id": "657b223e41ce6b9f9a01d214",
+      "id": "657b21e28a01039cb27b4f13",
       "title": "Task 60"
     },
     {
-      "id": "65f3a5111de04c216a38d998",
+      "id": "657b221b2ab0ac9e18a173ef",
       "title": "Task 61"
     },
     {
-      "id": "65f3a5733a199c21ca589173",
+      "id": "657b223e41ce6b9f9a01d214",
       "title": "Task 62"
     },
     {
-      "id": "65f3a66869afaa22af33a9a3",
+      "id": "65f3a5111de04c216a38d998",
       "title": "Task 63"
     },
     {
-      "id": "65f3a7087f990a233ebb16ba",
+      "id": "65f3a5733a199c21ca589173",
       "title": "Task 64"
+    },
+    {
+      "id": "65f3a66869afaa22af33a9a3",
+      "title": "Task 65"
+    },
+    {
+      "id": "65f3a7087f990a233ebb16ba",
+      "title": "Task 66"
+    },
+    {
+      "id": "685d7a6785617d165f78aa02",
+      "title": "Task 67"
     },
     {
       "id": "657b227f7ad32ea17e2cdf28",
@@ -279,59 +291,63 @@
     },
     {
       "id": "657b2310b8cd52a4f15c1818",
-      "title": "Task 65"
-    },
-    {
-      "id": "657b2340be1593a6517fe77b",
-      "title": "Task 66"
-    },
-    {
-      "id": "657b236aa1eb9fa7b209aa03",
-      "title": "Task 67"
-    },
-    {
-      "id": "657b23a413d28da927e087ca",
       "title": "Task 68"
     },
     {
-      "id": "657b23bc0e32f9aa9c62eb82",
+      "id": "657b2340be1593a6517fe77b",
       "title": "Task 69"
     },
     {
-      "id": "657b23f03b449aac2c517089",
+      "id": "657b236aa1eb9fa7b209aa03",
       "title": "Task 70"
     },
     {
-      "id": "657b24774d8cdab052ffe2a6",
+      "id": "657b23a413d28da927e087ca",
       "title": "Task 71"
     },
     {
-      "id": "657b242d06512dadaea55056",
+      "id": "657b23bc0e32f9aa9c62eb82",
       "title": "Task 72"
     },
     {
-      "id": "657b24542024c8af092cd6c4",
+      "id": "657b23f03b449aac2c517089",
       "title": "Task 73"
     },
     {
-      "id": "657b24a500800cb1c6945da9",
+      "id": "657b24774d8cdab052ffe2a6",
       "title": "Task 74"
     },
     {
-      "id": "657b2be1b19500c63fc1a467",
+      "id": "657b242d06512dadaea55056",
       "title": "Task 75"
     },
     {
-      "id": "657b2c040bb5f6c77fa5df80",
+      "id": "657b24542024c8af092cd6c4",
       "title": "Task 76"
     },
     {
-      "id": "657b2d618b8851cc5baf9490",
+      "id": "657b24a500800cb1c6945da9",
       "title": "Task 77"
     },
     {
-      "id": "657b2d9cb974dace59024964",
+      "id": "657b2be1b19500c63fc1a467",
       "title": "Task 78"
+    },
+    {
+      "id": "657b2c040bb5f6c77fa5df80",
+      "title": "Task 79"
+    },
+    {
+      "id": "657b2d618b8851cc5baf9490",
+      "title": "Task 80"
+    },
+    {
+      "id": "657b2d9cb974dace59024964",
+      "title": "Task 81"
+    },
+    {
+      "id": "685d7a9fa94aca168aedbe10",
+      "title": "Task 82"
     },
     {
       "id": "657b2dd7745fdcd03e5160f4",
@@ -339,59 +355,63 @@
     },
     {
       "id": "657b2e0666d4a9d1b851f90e",
-      "title": "Task 79"
-    },
-    {
-      "id": "657b2ec6c054efd71e503a27",
-      "title": "Task 80"
-    },
-    {
-      "id": "657b2eeb31e435d89ecce6f3",
-      "title": "Task 81"
-    },
-    {
-      "id": "657b2f0b3bcfe7d9f4151854",
-      "title": "Task 82"
-    },
-    {
-      "id": "657b2f3bf7a2cbdb58d959d5",
       "title": "Task 83"
     },
     {
-      "id": "657b2f6cb66826dcbac08094",
+      "id": "657b2ec6c054efd71e503a27",
       "title": "Task 84"
     },
     {
-      "id": "657b2fa89ddc20de629ca21f",
+      "id": "657b2eeb31e435d89ecce6f3",
       "title": "Task 85"
     },
     {
-      "id": "657b2fc9c0f96bdfddfce4d9",
+      "id": "657b2f0b3bcfe7d9f4151854",
       "title": "Task 86"
     },
     {
-      "id": "657b2fea728c2be14a8a98c4",
+      "id": "657b2f3bf7a2cbdb58d959d5",
       "title": "Task 87"
     },
     {
-      "id": "657b3026ff79fbe2dda6cb39",
+      "id": "657b2f6cb66826dcbac08094",
       "title": "Task 88"
     },
     {
-      "id": "657b306fe94f29e4b4aa9105",
+      "id": "657b2fa89ddc20de629ca21f",
       "title": "Task 89"
     },
     {
-      "id": "657b30ac03b523e6640deaf1",
+      "id": "657b2fc9c0f96bdfddfce4d9",
       "title": "Task 90"
     },
     {
-      "id": "657b30e1b9f035e7e656fd01",
+      "id": "657b2fea728c2be14a8a98c4",
       "title": "Task 91"
     },
     {
-      "id": "657b315533e4edeba65111b8",
+      "id": "657b3026ff79fbe2dda6cb39",
       "title": "Task 92"
+    },
+    {
+      "id": "657b306fe94f29e4b4aa9105",
+      "title": "Task 93"
+    },
+    {
+      "id": "657b30ac03b523e6640deaf1",
+      "title": "Task 94"
+    },
+    {
+      "id": "657b30e1b9f035e7e656fd01",
+      "title": "Task 95"
+    },
+    {
+      "id": "657b315533e4edeba65111b8",
+      "title": "Task 96"
+    },
+    {
+      "id": "685d7ae2d6435316f643723e",
+      "title": "Task 97"
     }
   ],
   "helpCategory": "English",

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b153ac677705c7059530d.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b153ac677705c7059530d.md
@@ -1,8 +1,8 @@
 ---
 id: 657b153ac677705c7059530d
-title: Task 20
+title: Task 21
 challengeType: 19
-dashedName: task-20
+dashedName: task-21
 ---
 
 <!-- (Audio) Anna: Hello! Thanks for coming in today. Could you tell me about your previous roles and responsibilities? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b15dbcafe4d5f39a5de82.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b15dbcafe4d5f39a5de82.md
@@ -1,8 +1,8 @@
 ---
 id: 657b15dbcafe4d5f39a5de82
-title: Task 21
+title: Task 22
 challengeType: 19
-dashedName: task-21
+dashedName: task-22
 ---
 
 <!-- (Audio) Anna: Hello! Thanks for coming in today. Could you tell me about your previous roles and responsibilities? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b160d6a8662610fe6a523.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b160d6a8662610fe6a523.md
@@ -1,8 +1,8 @@
 ---
 id: 657b160d6a8662610fe6a523
-title: Task 22
+title: Task 23
 challengeType: 22
-dashedName: task-22
+dashedName: task-23
 ---
 
 <!-- (Audio) Second Candidate: Hello! Certainly. I worked at Mock Corporation for five years. I was part of a team of software engineers, and we were responsible for developing and maintaining various applications. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b163c9da40e62b904be1f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b163c9da40e62b904be1f.md
@@ -1,8 +1,8 @@
 ---
 id: 657b163c9da40e62b904be1f
-title: Task 23
+title: Task 24
 challengeType: 22
-dashedName: task-23
+dashedName: task-24
 ---
 
 <!-- (Audio) Anna: That's great to hear. Were the members of the team involved in any specific achievements or projects? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b18e71067d6680b9ac5d3.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b18e71067d6680b9ac5d3.md
@@ -1,8 +1,8 @@
 ---
 id: 657b18e71067d6680b9ac5d3
-title: Task 24
+title: Task 25
 challengeType: 19
-dashedName: task-24
+dashedName: task-25
 ---
 
 <!-- (Audio) Second Candidate: Yes, our team was involved in a project to redesign the company's website. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b1985ae17886b05b382b1.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b1985ae17886b05b382b1.md
@@ -1,8 +1,8 @@
 ---
 id: 657b1985ae17886b05b382b1
-title: Task 26
+title: Task 27
 challengeType: 19
-dashedName: task-26
+dashedName: task-27
 ---
 
 <!-- (Audio) Second Candidate: We were responsible for implementing new features and ensuring that the website had fast performance. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b19bf7b32af6caf763ef7.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b19bf7b32af6caf763ef7.md
@@ -1,8 +1,8 @@
 ---
 id: 657b19bf7b32af6caf763ef7
-title: Task 27
+title: Task 28
 challengeType: 19
-dashedName: task-27
+dashedName: task-28
 ---
 
 <!-- (Audio) Second Candidate: It was a collaborative effort, and we were able to deliver the project on time. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b1a03df3ec46eca276046.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b1a03df3ec46eca276046.md
@@ -1,8 +1,8 @@
 ---
 id: 657b1a03df3ec46eca276046
-title: Task 25
+title: Task 26
 challengeType: 22
-dashedName: task-25
+dashedName: task-26
 ---
 
 <!-- (Audio) Second Candidate: Yes, our team was involved in a project to redesign the company's website. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b1a27dc6daf6ffd52ff1f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b1a27dc6daf6ffd52ff1f.md
@@ -1,8 +1,8 @@
 ---
 id: 657b1a27dc6daf6ffd52ff1f
-title: Task 29
+title: Task 30
 challengeType: 19
-dashedName: task-29
+dashedName: task-30
 ---
 
 <!-- (Audio) Anna: Excellent! Can you share details about your educational background? Were you trained in a specific field?

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b1a637e4dc571f8f4d3d7.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b1a637e4dc571f8f4d3d7.md
@@ -1,8 +1,8 @@
 ---
 id: 657b1a637e4dc571f8f4d3d7
-title: Task 31
+title: Task 32
 challengeType: 19
-dashedName: task-31
+dashedName: task-32
 ---
 
 <!-- (Audio) Anna: Impressive. We appreciate candidates with strong educational backgrounds and practical experience. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b1a9581015573806e1e20.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b1a9581015573806e1e20.md
@@ -1,8 +1,8 @@
 ---
 id: 657b1a9581015573806e1e20
-title: Task 28
+title: Task 29
 challengeType: 22
-dashedName: task-28
+dashedName: task-29
 ---
 
 <!-- (Audio) Second Candidate: We were responsible for implementing new features and ensuring the website's performance. It was a collaborative effort, and we were able to deliver the project on time. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b1cc072206e7ac3db88b8.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b1cc072206e7ac3db88b8.md
@@ -1,8 +1,8 @@
 ---
 id: 657b1cc072206e7ac3db88b8
-title: Task 30
+title: Task 31
 challengeType: 22
-dashedName: task-30
+dashedName: task-31
 ---
 
 <!-- (Audio) Second Candidate: I have a master's degree in computer science. My studies were intensive, and I was introduced to many different methodologies. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b1d080265ba7c4f96bf79.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b1d080265ba7c4f96bf79.md
@@ -1,8 +1,8 @@
 ---
 id: 657b1d080265ba7c4f96bf79
-title: Task 32
+title: Task 33
 challengeType: 22
-dashedName: task-32
+dashedName: task-33
 ---
 
 <!-- (Audio) Anna: Impressive! We appreciate candidates with strong educational backgrounds and practical experience. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b1da0b27fef8117827ce5.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b1da0b27fef8117827ce5.md
@@ -1,8 +1,8 @@
 ---
 id: 657b1da0b27fef8117827ce5
-title: Task 33
+title: Task 35
 challengeType: 19
-dashedName: task-33
+dashedName: task-35
 ---
 
 <!-- (Audio) Brian: Hey, how's it going? I noticed you're relatively new here. What's your background in tech? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b1dfec76149836ea5c7d0.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b1dfec76149836ea5c7d0.md
@@ -1,8 +1,8 @@
 ---
 id: 657b1dfec76149836ea5c7d0
-title: Task 38
+title: Task 40
 challengeType: 22
-dashedName: task-38
+dashedName: task-40
 ---
 
 <!-- (Audio) Sophie: It wasn't exactly tech-related, but I learned a lot about problem-solving and critical thinking. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b1e2fad2ffe84ab420a56.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b1e2fad2ffe84ab420a56.md
@@ -1,8 +1,8 @@
 ---
 id: 657b1e2fad2ffe84ab420a56
-title: Task 37
+title: Task 39
 challengeType: 19
-dashedName: task-37
+dashedName: task-39
 ---
 
 <!-- (Audio) Sophie: I didn't study computer science at university, but I majored in electrical engineering. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b1e66159fec86336a737b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b1e66159fec86336a737b.md
@@ -1,8 +1,8 @@
 ---
 id: 657b1e66159fec86336a737b
-title: Task 43
+title: Task 45
 challengeType: 19
-dashedName: task-43
+dashedName: task-45
 ---
 
 <!-- (Audio) Sophie: No, not really. I played around with coding, but most of my projects involved circuit designs and electrical systems. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b1e9a62603587747f7f45.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b1e9a62603587747f7f45.md
@@ -1,8 +1,8 @@
 ---
 id: 657b1e9a62603587747f7f45
-title: Task 47
+title: Task 49
 challengeType: 19
-dashedName: task-47
+dashedName: task-49
 ---
 
 <!-- (Audio) Brian: I see. Did you enjoy your time there, even if it wasn't entirely tech-focused? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b1f0585d48f8ac0b19654.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b1f0585d48f8ac0b19654.md
@@ -1,8 +1,8 @@
 ---
 id: 657b1f0585d48f8ac0b19654
-title: Task 48
+title: Task 50
 challengeType: 22
-dashedName: task-48
+dashedName: task-50
 ---
 
 <!-- (Audio) Brian: I see. Did you enjoy your time there, even if it wasn't entirely tech-focused?

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b1f598f63008c8bdb20b8.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b1f598f63008c8bdb20b8.md
@@ -1,8 +1,8 @@
 ---
 id: 657b1f598f63008c8bdb20b8
-title: Task 49
+title: Task 51
 challengeType: 19
-dashedName: task-49
+dashedName: task-51
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b1f981cd42e8dc3b282d9.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b1f981cd42e8dc3b282d9.md
@@ -1,8 +1,8 @@
 ---
 id: 657b1f981cd42e8dc3b282d9
-title: Task 50
+title: Task 52
 challengeType: 19
-dashedName: task-50
+dashedName: task-52
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b1fe950c0df90346e5d12.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b1fe950c0df90346e5d12.md
@@ -1,8 +1,8 @@
 ---
 id: 657b1fe950c0df90346e5d12
-title: Task 51
+title: Task 53
 challengeType: 22
-dashedName: task-51
+dashedName: task-53
 ---
 
 <!-- (Audio) Sophie: I did. It was challenging, but I met some fantastic people. We had a bunch of fun coding marathons, although I wasn't always a very strong programmer. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b201372864e91d4f5bb53.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b201372864e91d4f5bb53.md
@@ -1,8 +1,8 @@
 ---
 id: 657b201372864e91d4f5bb53
-title: Task 52
+title: Task 54
 challengeType: 22
-dashedName: task-52
+dashedName: task-54
 ---
 
 <!-- (Audio) Brian: I studied at a small college as well and majored in information technology. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b20338e0802931673c1e1.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b20338e0802931673c1e1.md
@@ -1,8 +1,8 @@
 ---
 id: 657b20338e0802931673c1e1
-title: Task 53
+title: Task 55
 challengeType: 22
-dashedName: task-53
+dashedName: task-55
 ---
 
 <!-- (Audio) Brian: It was more hands-on, and I loved every bit of it. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b20985d315095e5c3851d.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b20985d315095e5c3851d.md
@@ -1,8 +1,8 @@
 ---
 id: 657b20985d315095e5c3851d
-title: Task 55
+title: Task 57
 challengeType: 19
-dashedName: task-55
+dashedName: task-57
 ---
 
 <!-- (Audio) Brian: I got to build and maintain networks and manage a few small projects. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b21e28a01039cb27b4f13.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b21e28a01039cb27b4f13.md
@@ -1,8 +1,8 @@
 ---
 id: 657b21e28a01039cb27b4f13
-title: Task 58
+title: Task 60
 challengeType: 19
-dashedName: task-58
+dashedName: task-60
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b221b2ab0ac9e18a173ef.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b221b2ab0ac9e18a173ef.md
@@ -1,8 +1,8 @@
 ---
 id: 657b221b2ab0ac9e18a173ef
-title: Task 59
+title: Task 61
 challengeType: 22
-dashedName: task-59
+dashedName: task-61
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b223e41ce6b9f9a01d214.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b223e41ce6b9f9a01d214.md
@@ -1,8 +1,8 @@
 ---
 id: 657b223e41ce6b9f9a01d214
-title: Task 60
+title: Task 62
 challengeType: 22
-dashedName: task-60
+dashedName: task-62
 ---
 
 <!-- (Audio) Brian: They weren't exactly big projects. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b2310b8cd52a4f15c1818.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b2310b8cd52a4f15c1818.md
@@ -1,8 +1,8 @@
 ---
 id: 657b2310b8cd52a4f15c1818
-title: Task 65
+title: Task 68
 challengeType: 19
-dashedName: task-65
+dashedName: task-68
 ---
 
 <!-- (Audio) Tom: Hey, Alice. How was it for you to get into tech?

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b2340be1593a6517fe77b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b2340be1593a6517fe77b.md
@@ -1,8 +1,8 @@
 ---
 id: 657b2340be1593a6517fe77b
-title: Task 66
+title: Task 69
 challengeType: 22
-dashedName: task-66
+dashedName: task-69
 ---
 
 <!-- (Audio) Alice: I didn't study tech at a traditional university. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b236aa1eb9fa7b209aa03.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b236aa1eb9fa7b209aa03.md
@@ -1,8 +1,8 @@
 ---
 id: 657b236aa1eb9fa7b209aa03
-title: Task 67
+title: Task 70
 challengeType: 19
-dashedName: task-67
+dashedName: task-70
 ---
 
 <!-- (Audio) Alice: I'm mostly self-taught, and I took a lot of online courses. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b23a413d28da927e087ca.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b23a413d28da927e087ca.md
@@ -1,8 +1,8 @@
 ---
 id: 657b23a413d28da927e087ca
-title: Task 68
+title: Task 71
 challengeType: 22
-dashedName: task-68
+dashedName: task-71
 ---
 
 <!-- (Audio) Alice: I'm mostly self-taught, and I took a lot of online courses. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b23bc0e32f9aa9c62eb82.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b23bc0e32f9aa9c62eb82.md
@@ -1,8 +1,8 @@
 ---
 id: 657b23bc0e32f9aa9c62eb82
-title: Task 69
+title: Task 72
 challengeType: 19
-dashedName: task-69
+dashedName: task-72
 ---
 
 <!-- (Audio) Alice: I'm mostly self-taught, and I took a lot of online courses. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b23f03b449aac2c517089.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b23f03b449aac2c517089.md
@@ -1,8 +1,8 @@
 ---
 id: 657b23f03b449aac2c517089
-title: Task 70
+title: Task 73
 challengeType: 22
-dashedName: task-70
+dashedName: task-73
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b242d06512dadaea55056.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b242d06512dadaea55056.md
@@ -1,8 +1,8 @@
 ---
 id: 657b242d06512dadaea55056
-title: Task 72
+title: Task 75
 challengeType: 19
-dashedName: task-72
+dashedName: task-75
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b24542024c8af092cd6c4.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b24542024c8af092cd6c4.md
@@ -1,8 +1,8 @@
 ---
 id: 657b24542024c8af092cd6c4
-title: Task 73
+title: Task 76
 challengeType: 22
-dashedName: task-73
+dashedName: task-76
 ---
 
 <!-- (Audio) Tom: So, you didn't attend a regular college or anything like that? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b24774d8cdab052ffe2a6.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b24774d8cdab052ffe2a6.md
@@ -1,8 +1,8 @@
 ---
 id: 657b24774d8cdab052ffe2a6
-title: Task 71
+title: Task 74
 challengeType: 22
-dashedName: task-71
+dashedName: task-74
 ---
 
 <!-- (Audio) Alice: I didn't study tech at a traditional university. I'm mostly self-taught, and I took a lot of online courses. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b24a500800cb1c6945da9.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b24a500800cb1c6945da9.md
@@ -1,8 +1,8 @@
 ---
 id: 657b24a500800cb1c6945da9
-title: Task 74
+title: Task 77
 challengeType: 22
-dashedName: task-74
+dashedName: task-77
 ---
 
 <!-- (Audio) Alice: No, not at all. I was at a different job, but I got really interested in programming and tech, so I started learning in my free time. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b2be1b19500c63fc1a467.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b2be1b19500c63fc1a467.md
@@ -1,8 +1,8 @@
 ---
 id: 657b2be1b19500c63fc1a467
-title: Task 75
+title: Task 78
 challengeType: 22
-dashedName: task-75
+dashedName: task-78
 ---
 
 <!-- (Audio) Tom: Did you work on any projects during your self-study? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b2c040bb5f6c77fa5df80.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b2c040bb5f6c77fa5df80.md
@@ -1,8 +1,8 @@
 ---
 id: 657b2c040bb5f6c77fa5df80
-title: Task 76
+title: Task 79
 challengeType: 22
-dashedName: task-76
+dashedName: task-79
 ---
 
 <!-- (Audio) Alice: Absolutely. It was challenging, but I loved it. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b2d618b8851cc5baf9490.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b2d618b8851cc5baf9490.md
@@ -1,8 +1,8 @@
 ---
 id: 657b2d618b8851cc5baf9490
-title: Task 77
+title: Task 80
 challengeType: 22
-dashedName: task-77
+dashedName: task-80
 ---
 
 <!-- (Audio) Alice: Yes, I did. I built a few small web applications just to practice. It was a great way to apply what I learned. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b2d9cb974dace59024964.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b2d9cb974dace59024964.md
@@ -1,8 +1,8 @@
 ---
 id: 657b2d9cb974dace59024964
-title: Task 78
+title: Task 81
 challengeType: 19
-dashedName: task-78
+dashedName: task-81
 ---
 
 <!-- (Audio) Tom: I admire your dedication! It is amazing how far you got studying by yourself. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b2e0666d4a9d1b851f90e.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b2e0666d4a9d1b851f90e.md
@@ -1,8 +1,8 @@
 ---
 id: 657b2e0666d4a9d1b851f90e
-title: Task 79
+title: Task 83
 challengeType: 19
-dashedName: task-79
+dashedName: task-83
 ---
 
 <!-- (Audio) Tom: Hey, I've been curious about your background. How did you end up as a Tech recruiter? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b2ec6c054efd71e503a27.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b2ec6c054efd71e503a27.md
@@ -1,8 +1,8 @@
 ---
 id: 657b2ec6c054efd71e503a27
-title: Task 80
+title: Task 84
 challengeType: 19
-dashedName: task-80
+dashedName: task-84
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b2eeb31e435d89ecce6f3.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b2eeb31e435d89ecce6f3.md
@@ -1,8 +1,8 @@
 ---
 id: 657b2eeb31e435d89ecce6f3
-title: Task 81
+title: Task 85
 challengeType: 22
-dashedName: task-81
+dashedName: task-85
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b2f0b3bcfe7d9f4151854.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b2f0b3bcfe7d9f4151854.md
@@ -1,8 +1,8 @@
 ---
 id: 657b2f0b3bcfe7d9f4151854
-title: Task 82
+title: Task 86
 challengeType: 19
-dashedName: task-82
+dashedName: task-86
 ---
 
 <!-- (Audio) Anna: I actually studied psychology in college. My plan was to become a therapist or counselor. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b2f3bf7a2cbdb58d959d5.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b2f3bf7a2cbdb58d959d5.md
@@ -1,8 +1,8 @@
 ---
 id: 657b2f3bf7a2cbdb58d959d5
-title: Task 83
+title: Task 87
 challengeType: 19
-dashedName: task-83
+dashedName: task-87
 ---
 
 <!-- (Audio) Anna: During my last year, I took a course in organizational psychology. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b2f6cb66826dcbac08094.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b2f6cb66826dcbac08094.md
@@ -1,8 +1,8 @@
 ---
 id: 657b2f6cb66826dcbac08094
-title: Task 84
+title: Task 88
 challengeType: 19
-dashedName: task-84
+dashedName: task-88
 ---
 
 <!-- (Audio) Anna: During my last year, I took a course in organizational psychology. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b2fa89ddc20de629ca21f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b2fa89ddc20de629ca21f.md
@@ -1,8 +1,8 @@
 ---
 id: 657b2fa89ddc20de629ca21f
-title: Task 85
+title: Task 89
 challengeType: 22
-dashedName: task-85
+dashedName: task-89
 ---
 
 <!-- (Audio) Anna: I actually studied psychology in college. My plan was to become a therapist or counselor. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b2fc9c0f96bdfddfce4d9.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b2fc9c0f96bdfddfce4d9.md
@@ -1,8 +1,8 @@
 ---
 id: 657b2fc9c0f96bdfddfce4d9
-title: Task 86
+title: Task 90
 challengeType: 22
-dashedName: task-86
+dashedName: task-90
 ---
 
 <!-- (Audio) Anna: I took a course in organizational psychology, and it piqued my interest in the workplace and employee dynamics. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b2fea728c2be14a8a98c4.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b2fea728c2be14a8a98c4.md
@@ -1,8 +1,8 @@
 ---
 id: 657b2fea728c2be14a8a98c4
-title: Task 87
+title: Task 91
 challengeType: 19
-dashedName: task-87
+dashedName: task-91
 ---
 
 <!-- (Audio) Anna: I took a course in organizational psychology, and it piqued my interest in the workplace and employee dynamics. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b3026ff79fbe2dda6cb39.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b3026ff79fbe2dda6cb39.md
@@ -1,8 +1,8 @@
 ---
 id: 657b3026ff79fbe2dda6cb39
-title: Task 88
+title: Task 92
 challengeType: 19
-dashedName: task-88
+dashedName: task-92
 ---
 
 <!-- (Audio) Tom: That's a cool twist. Did you immediately start working as a tech recruiter after college? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b306fe94f29e4b4aa9105.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b306fe94f29e4b4aa9105.md
@@ -1,8 +1,8 @@
 ---
 id: 657b306fe94f29e4b4aa9105
-title: Task 89
+title: Task 93
 challengeType: 19
-dashedName: task-89
+dashedName: task-93
 ---
 
 <!-- (Audio) Anna: Not right away. I worked in a general HR role at a non-tech company first, focusing on training and development. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b30ac03b523e6640deaf1.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b30ac03b523e6640deaf1.md
@@ -1,8 +1,8 @@
 ---
 id: 657b30ac03b523e6640deaf1
-title: Task 90
+title: Task 94
 challengeType: 22
-dashedName: task-90
+dashedName: task-94
 ---
 
 <!-- (Audio) Tom: That's a cool twist. Did you immediately start working as a tech recruiter after college?

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b30e1b9f035e7e656fd01.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b30e1b9f035e7e656fd01.md
@@ -1,8 +1,8 @@
 ---
 id: 657b30e1b9f035e7e656fd01
-title: Task 91
+title: Task 95
 challengeType: 19
-dashedName: task-91
+dashedName: task-95
 ---
 
 <!-- (Audio) Anna: I saw that tech companies appreciate innovation and care for the employees' well-being. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b315533e4edeba65111b8.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b315533e4edeba65111b8.md
@@ -1,8 +1,8 @@
 ---
 id: 657b315533e4edeba65111b8
-title: Task 92
+title: Task 96
 challengeType: 19
-dashedName: task-92
+dashedName: task-96
 ---
 
 <!-- (Audio) Anna: This has a direct relation to what made me become a psychologist. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/65f22f7d84784d8bd129c9a4.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/65f22f7d84784d8bd129c9a4.md
@@ -1,8 +1,8 @@
 ---
 id: 65f22f7d84784d8bd129c9a4
-title: Task 34
+title: Task 36
 challengeType: 22
-dashedName: task-34
+dashedName: task-36
 ---
 
 <!-- (Audio) Brian: Hey, how's it going? I noticed you're relatively new here. What's your background in tech? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/65f230854698ec8c68b67fa4.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/65f230854698ec8c68b67fa4.md
@@ -1,8 +1,8 @@
 ---
 id: 65f230854698ec8c68b67fa4
-title: Task 35
+title: Task 37
 challengeType: 22
-dashedName: task-35
+dashedName: task-37
 ---
 
 <!-- (Audio) Sophie: Hey! Yeah, I joined the team a few months ago. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/65f310fc37e701bfa451be47.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/65f310fc37e701bfa451be47.md
@@ -1,8 +1,8 @@
 ---
 id: 65f310fc37e701bfa451be47
-title: Task 39
+title: Task 41
 challengeType: 22
-dashedName: task-39
+dashedName: task-41
 ---
 
 <!-- (Audio) Sophie: Hey! Yeah, I joined the team a few months ago. I didn't study computer science at Tech University, but I majored in electrical engineering It wasn't exactly tech-related, but I learned a lot about problem-solving and critical thinking. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/65f3146b4f4fb2c1f95c7335.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/65f3146b4f4fb2c1f95c7335.md
@@ -1,8 +1,8 @@
 ---
 id: 65f3146b4f4fb2c1f95c7335
-title: Task 36
+title: Task 38
 challengeType: 19
-dashedName: task-36
+dashedName: task-38
 ---
 
 <!-- (Audio) Brian: Hey, how's it going? I noticed you're relatively new here. What's your background in tech?

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/65f31898ad2ed9c3b1a4c9b3.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/65f31898ad2ed9c3b1a4c9b3.md
@@ -1,8 +1,8 @@
 ---
 id: 65f31898ad2ed9c3b1a4c9b3
-title: Task 40
+title: Task 42
 challengeType: 22
-dashedName: task-40
+dashedName: task-42
 ---
 
 <!-- (Audio) Sophie: I didn't study computer science at university, but I majored in electrical engineering. It wasn't exactly tech-related, but I learned a lot about problem-solving and critical thinking. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/65f3212e767d81dbcfbeb0cc.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/65f3212e767d81dbcfbeb0cc.md
@@ -1,8 +1,8 @@
 ---
 id: 65f3212e767d81dbcfbeb0cc
-title: Task 41
+title: Task 43
 challengeType: 22
-dashedName: task-41
+dashedName: task-43
 ---
 
 <!-- (Audio) Brian: That's interesting! So, you didn't work on many programming projects during your studies, did you? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/65f3234e85f828dd1f45d384.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/65f3234e85f828dd1f45d384.md
@@ -1,8 +1,8 @@
 ---
 id: 65f3234e85f828dd1f45d384
-title: Task 42
+title: Task 44
 challengeType: 19
-dashedName: task-42
+dashedName: task-44
 ---
 
 <!-- (Audio) Brian: That's interesting! So, you didn't work on many programming projects during your studies, did you? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/65f3641948909aecf182befe.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/65f3641948909aecf182befe.md
@@ -1,8 +1,8 @@
 ---
 id: 65f3641948909aecf182befe
-title: Task 44
+title: Task 46
 challengeType: 22
-dashedName: task-44
+dashedName: task-46
 ---
 
 <!-- (Audio) Sophie: No, not really. I played around with coding, but most of my projects involved circuit designs and electrical systems. It was a bit different. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/65f365351cf89fedddcc281e.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/65f365351cf89fedddcc281e.md
@@ -1,8 +1,8 @@
 ---
 id: 65f365351cf89fedddcc281e
-title: Task 45
+title: Task 47
 challengeType: 22
-dashedName: task-45
+dashedName: task-47
 ---
 
 <!-- (Audio) Sophie: No, not really. I played around with coding, but most of my projects involved circuit designs and electrical systems. It was a bit different. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/65f365bc3c1491ee60db85a8.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/65f365bc3c1491ee60db85a8.md
@@ -1,8 +1,8 @@
 ---
 id: 65f365bc3c1491ee60db85a8
-title: Task 46
+title: Task 48
 challengeType: 19
-dashedName: task-46
+dashedName: task-48
 ---
 
 <!-- (Audio) Brian: That's interesting! So, you didn't work on many programming projects during your studies, did you?

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/65f39df8d18f4814c75d3fba.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/65f39df8d18f4814c75d3fba.md
@@ -1,8 +1,8 @@
 ---
 id: 65f39df8d18f4814c75d3fba
-title: Task 54
+title: Task 56
 challengeType: 22
-dashedName: task-54
+dashedName: task-56
 ---
 
 <!-- (Audio) Brian: We didn't have to wear too many hats, but I got to build and maintain networks and manage a few small projects. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/65f39f5bc6d49d15d7ae3d73.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/65f39f5bc6d49d15d7ae3d73.md
@@ -1,8 +1,8 @@
 ---
 id: 65f39f5bc6d49d15d7ae3d73
-title: Task 56
+title: Task 58
 challengeType: 22
-dashedName: task-56
+dashedName: task-58
 ---
 
 <!-- (Audio) Brian: Well, we all have different journeys. I studied at a small college as well and majored in information technology. It was more hands-on, and I loved every bit of it. We didn't have to wear too many hats, but I got to build and maintain networks and manage a few small projects. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/65f3a19e8b77c4170ed0704d.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/65f3a19e8b77c4170ed0704d.md
@@ -1,8 +1,8 @@
 ---
 id: 65f3a19e8b77c4170ed0704d
-title: Task 57
+title: Task 59
 challengeType: 19
-dashedName: task-57
+dashedName: task-59
 ---
 
 <!-- (Audio) Sophie: That sounds cool. Did you ever work on any big projects during your studies? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/65f3a5111de04c216a38d998.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/65f3a5111de04c216a38d998.md
@@ -1,8 +1,8 @@
 ---
 id: 65f3a5111de04c216a38d998
-title: Task 61
+title: Task 63
 challengeType: 22
-dashedName: task-61
+dashedName: task-63
 ---
 
 <!-- (Audio) Brian: They weren't exactly big projects. Most of them were smaller scale. But it was a great learning experience. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/65f3a5733a199c21ca589173.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/65f3a5733a199c21ca589173.md
@@ -1,8 +1,8 @@
 ---
 id: 65f3a5733a199c21ca589173
-title: Task 62
+title: Task 64
 challengeType: 19
-dashedName: task-62
+dashedName: task-64
 ---
 
 <!-- (Audio) Sophie: That sounds cool. Did you ever work on any big projects during your studies? 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/65f3a66869afaa22af33a9a3.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/65f3a66869afaa22af33a9a3.md
@@ -1,8 +1,8 @@
 ---
 id: 65f3a66869afaa22af33a9a3
-title: Task 63
+title: Task 65
 challengeType: 22
-dashedName: task-63
+dashedName: task-65
 ---
 
 <!-- (Audio) Brian: It's fascinating to me how we all take different paths but end up in the same tech world, right? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/65f3a7087f990a233ebb16ba.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/65f3a7087f990a233ebb16ba.md
@@ -1,8 +1,8 @@
 ---
 id: 65f3a7087f990a233ebb16ba
-title: Task 64
+title: Task 66
 challengeType: 22
-dashedName: task-64
+dashedName: task-66
 ---
 
 <!-- (Audio) Brian: It's fascinating to me how we all take different paths but end up in the same tech world, right?

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/685d7943f9aed415ef9ebabe.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/685d7943f9aed415ef9ebabe.md
@@ -1,0 +1,92 @@
+---
+id: 685d7943f9aed415ef9ebabe
+title: Task 20
+challengeType: 22
+dashedName: task-20
+---
+
+<!-- REVIEW -->
+
+# --description--
+
+This is a review of the entire dialogue you just studied.
+
+# --instructions--
+
+Write the following words or phrases in the correct spot:
+
+`educational background`, `programmer at`, `previous job`, `responsible for`, `part of`, `specific projects`, and `degree in`.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`Anna: Good afternoon! Thanks for coming in for this interview. Can you tell me about your BLANK experiences?`
+
+`Candidate: Good afternoon! Sure, I was a BLANK Acme Tech. I was there for three years. I was responsible for developing web applications and maintaining the company's database. I was also BLANK the software update team.`
+
+`Anna: That's excellent. Were there any BLANK you'd like to mention?`
+
+`Candidate: Yes, in one of my team's projects, we were involved in the development of an e-commerce platform. We were BLANK the checkout process, and it was a successful implementation.`
+
+`Anna: Great! Can you tell me about your qualifications? Were you educated in computer science?`
+
+`Candidate: Yes. I have a bachelor's BLANK computer science from California State University. During my studies, I was introduced to various programming languages and software development principles.`
+
+`Anna: Wonderful! We value candidates with a strong BLANK. Thank you for sharing your experiences with us.`
+
+## --blanks--
+
+`previous job`
+
+### --feedback--
+
+The work you did before your current position.
+
+---
+
+`programmer at`
+
+### --feedback--
+
+A person who wrote code while working at a certain company or place.
+
+---
+
+`part of`
+
+### --feedback--
+
+Involved in a group or activity.
+
+---
+
+`specific projects`
+
+### --feedback--
+
+Clearly defined pieces of work with goals and results.
+
+---
+
+`responsible for`
+
+### --feedback--
+
+In charge of or having the duty to do something.
+
+---
+
+`degree in`
+
+### --feedback--
+
+An official qualification in a subject, like computer science or math.
+
+---
+
+`educational background`
+
+### --feedback--
+
+The schools you went to and what you studied.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/685d7a22363c58163423c6c2.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/685d7a22363c58163423c6c2.md
@@ -1,0 +1,84 @@
+---
+id: 685d7a22363c58163423c6c2
+title: Task 34
+challengeType: 22
+dashedName: task-34
+---
+
+<!-- REVIEW -->
+
+# --description--
+
+This is a review of the entire dialogue you just studied.
+
+# --instructions--
+
+Write the following words or phrases in the correct spot:
+
+`practical experience`, `roles`, `achievements`, `worked at`, `collaborative effort`, and `computer science`.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`Anna: Hello! Thanks for coming in today. Could you tell me about your previous BLANK and responsibilities?`
+
+`Second Candidate: Hello! Certainly. I BLANK Mock Corporation for five years. I was part of a team of software engineers, and we were responsible for developing and maintaining various applications. Our primary focus was creating user-friendly software.`
+
+`Anna: That's great to hear. Were the members of the team involved in any specific BLANK or projects?`
+
+`Second Candidate: Yes, our team was involved in a project to redesign the company's website. We were responsible for implementing new features and ensuring the website had fast performance. It was a BLANK, and we were able to deliver the project on time.`
+
+`Anna: Excellent! Can you share details about your educational background? Were you trained in a specific field?`
+
+`Second Candidate: Yes. I have a master's degree in BLANK. My studies were intensive, and I was introduced to many different methodologies.`
+
+`Anna: Impressive! We appreciate candidates with strong educational backgrounds and BLANK. Thanks a lot for coming to the interview.`
+
+## --blanks--
+
+`roles`
+
+### --feedback--
+
+The jobs or responsibilities someone has in a team or company.
+
+---
+
+`worked at`
+
+### --feedback--
+
+Had a job in a company or organization in the past.
+
+---
+
+`achievements`
+
+### --feedback--
+
+Things you have done successfully, especially after hard work.
+
+---
+
+`collaborative effort`
+
+### --feedback--
+
+Work done together by a group of people to reach a goal.
+
+---
+
+`computer science`
+
+### --feedback--
+
+The study of how computers work and how to write programs.
+
+---
+
+`practical experience`
+
+### --feedback--
+
+Real-world practice doing something, not just learning from books.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/685d7a6785617d165f78aa02.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/685d7a6785617d165f78aa02.md
@@ -1,0 +1,98 @@
+---
+id: 685d7a6785617d165f78aa02
+title: Task 67
+challengeType: 22
+dashedName: task-67
+---
+
+<!-- REVIEW -->
+
+# --description--
+
+This is a review of the entire dialogue you just studied.
+
+# --instructions--
+
+Write the following words or phrases in the correct spot:
+
+`majored in`, `marathons`, `studies`, `learning experience`, `hands-on`, `played around`, and `background`.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`Brian: Hey, how's it going? I noticed you're relatively new here. What's your BLANK in tech?`
+
+`Sophie: Hey! Yeah, I joined the team a few months ago. I didn't study computer science at university, but I BLANK electrical engineering. It wasn't exactly tech-related, but I learned a lot about problem-solving and critical thinking.`
+
+`Brian: That's interesting! So, you didn't work on many programming projects during your studies, did you?`
+
+`Sophie: No, not really. I BLANK with coding, but most of my projects involved circuit designs and electrical systems. It was a bit different.`
+
+`Brian: I see. Did you enjoy your time there, even if it wasn't entirely tech-focused?`
+
+`Sophie: I did. It was challenging, but I met some fantastic people. We had a bunch of fun coding BLANK, although I wasn't always a very strong programmer.`
+
+`Brian: Well, we all have different journeys. I studied at a small college as well and majored in information technology. It was more BLANK, and I loved every bit of it. We didn't have to wear too many hats, but I got to build and maintain networks and manage a few small projects.`
+
+`Sophie: That sounds cool. Did you ever work on any big projects during your BLANK?`
+
+`Brian: They weren't exactly big projects. Most of them were smaller scale. But it was a great BLANK. It's fascinating to me how we all take different paths but end up in the same tech world, right?`
+
+`Sophie: Absolutely! Let's grab a coffee sometime and chat more!`
+
+## --blanks--
+
+`background`
+
+### --feedback--
+
+The experience, skills, or education someone has.
+
+---
+
+`majored in`
+
+### --feedback--
+
+Studied a main subject in college or university.
+
+---
+
+`played around`
+
+### --feedback--
+
+Tried something out in a fun or casual way.
+
+---
+
+`marathons`
+
+### --feedback--
+
+Long events, often coding competitions, where people work on projects for hours.
+
+---
+
+`hands-on`
+
+### --feedback--
+
+Learning by doing something yourself, not just reading about it.
+
+---
+
+`studies`
+
+### --feedback--
+
+Learning at school, university, or through courses.
+
+---
+
+`learning experience`
+
+### --feedback--
+
+Something that teaches you a lesson through doing or trying.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/685d7a6785617d165f78aa02.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/685d7a6785617d165f78aa02.md
@@ -15,7 +15,7 @@ This is a review of the entire dialogue you just studied.
 
 Write the following words or phrases in the correct spot:
 
-`majored in`, `marathons`, `studies`, `learning experience`, `hands-on`, `played around`, and `background`.
+`majored in`, `coding marathons`, `studies`, `learning experience`, `hands-on`, `played around`, and `background`.
 
 # --fillInTheBlank--
 
@@ -31,7 +31,7 @@ Write the following words or phrases in the correct spot:
 
 `Brian: I see. Did you enjoy your time there, even if it wasn't entirely tech-focused?`
 
-`Sophie: I did. It was challenging, but I met some fantastic people. We had a bunch of fun coding BLANK, although I wasn't always a very strong programmer.`
+`Sophie: I did. It was challenging, but I met some fantastic people. We had a bunch of fun BLANK, although I wasn't always a very strong programmer.`
 
 `Brian: Well, we all have different journeys. I studied at a small college as well and majored in information technology. It was more BLANK, and I loved every bit of it. We didn't have to wear too many hats, but I got to build and maintain networks and manage a few small projects.`
 
@@ -67,7 +67,7 @@ Tried something out in a fun or casual way.
 
 ---
 
-`marathons`
+`coding marathons`
 
 ### --feedback--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/685d7a9fa94aca168aedbe10.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/685d7a9fa94aca168aedbe10.md
@@ -1,0 +1,88 @@
+---
+id: 685d7a9fa94aca168aedbe10
+title: Task 82
+challengeType: 22
+dashedName: task-82
+---
+
+<!-- REVIEW -->
+
+# --description--
+
+This is a review of the entire dialogue you just studied.
+
+# --instructions--
+
+Write the following words or phrases in the correct spot:
+
+`on your own`, `self-taught`, `online courses`, `to practice`, `interested in`, and `apply`.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`Tom: Hey, Alice. How did you get into tech?`
+
+`Alice: My background is a bit unconventional. I didn't study tech at a traditional university. I'm mostly BLANK, and I took a lot of BLANK.`
+
+`Tom: That's interesting! So, you didn't attend a regular college or anything like that?`
+
+`Alice: No, not at all. I was at a different job, but I got really BLANK programming and tech, so I started learning in my free time.`
+
+`Tom: That's impressive! Did you enjoy learning BLANK?`
+
+`Alice: Absolutely. It was challenging, but I loved it. The flexibility of online learning allowed me to balance my job and my studies.`
+
+`Tom: Did you work on any projects during your self-study?`
+
+`Alice: Yes, I did. I built a few small web applications, just BLANK. It was a great way to BLANK what I learned.`
+
+`Tom: I admire your dedication! It is amazing how far you got studying by yourself.`
+
+## --blanks--
+
+`self-taught`
+
+### --feedback--
+
+Learned something without a teacher, usually by studying alone.
+
+---
+
+`online courses`
+
+### --feedback--
+
+Lessons or classes you can take on the internet.
+
+---
+
+`interested in`
+
+### --feedback--
+
+Wanting to learn more about something or liking it.
+
+---
+
+`on your own`
+
+### --feedback--
+
+Doing something by yourself without help.
+
+---
+
+`to practice`
+
+### --feedback--
+
+To do something again and again to get better at it.
+
+---
+
+`apply`
+
+### --feedback--
+
+To use what you have learned in real situations.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/685d7ae2d6435316f643723e.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/685d7ae2d6435316f643723e.md
@@ -1,0 +1,84 @@
+---
+id: 685d7ae2d6435316f643723e
+title: Task 97
+challengeType: 22
+dashedName: task-97
+---
+
+<!-- REVIEW -->
+
+# --description--
+
+This is a review of the entire dialogue you just studied.
+
+# --instructions--
+
+Write the following words or phrases in the correct spot:
+
+`HR role`, `end up`, `after college`, `related to`, `interest in`, and `course in`.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`Tom: Hey, I've been curious about your background. How did you BLANK as a Tech recruiter?`
+
+`Anna: Hey! It's an interesting story. I actually studied psychology in college. My plan was to become a therapist or counselor. But during my last year, I took a BLANK organizational psychology, and it piqued my BLANK the workplace and employee dynamics.`
+
+`Tom: That's a cool twist. Did you immediately start working as a tech recruiter BLANK?`
+
+`Anna: Not right away. I worked in a general BLANK at a non-tech company first, focusing on training and development.`
+
+`Tom: What made you make the jump to tech?`
+
+`Anna: I saw that tech companies appreciate innovation and care for the employees' well-being. This is directly BLANK what made me want to become a psychologist. So basically, that's what brought me here.`
+
+`Tom: Awesome. It was great to get to know you better.`
+
+## --blanks--
+
+`end up`
+
+### --feedback--
+
+To finally be in a place or situation, often not planned.
+
+---
+
+`course in`
+
+### --feedback--
+
+A class where you learn about a subject, like math or programming.
+
+---
+
+`interest in`
+
+### --feedback--
+
+Wanting to know more about or be involved in something.
+
+---
+
+`after college`
+
+### --feedback--
+
+The time when you finish university or higher education.
+
+---
+
+`HR role`
+
+### --feedback--
+
+A job in `Human Resources`, working with hiring, training, or helping employees.
+
+---
+
+`related to`
+
+### --feedback--
+
+Connected with or having something to do with another thing.


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

Related to https://github.com/freeCodeCamp/freeCodeCamp/issues/55293

The EC team found that "summary tasks" were ineffective and confusing for learners, as noted in the related issue. In the B1 curriculum, we replaced them with "review tasks."

This PR is part of a series to apply the same changes to the A2 curriculum. To keep reviews easier, I'm splitting the updates into multiple PRs. This one covers Block 7.
