### PR TITLE
feat(curriculum): add review tasks to block 8 of the A2 curriculum

### DIFF
--- a/curriculum/challenges/_meta/learn-how-to-talk-about-hobbies-and-interests/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-talk-about-hobbies-and-interests/meta.json
@@ -170,96 +170,104 @@
       "title": "Task 39"
     },
     {
+      "id": "685e4c36bc03dc064d265e2e",
+      "title": "Task 40"
+    },
+    {
       "id": "657ef0061e99a3ddd0e1245f",
       "title": "Dialogue 3: The Collector"
     },
     {
       "id": "657eda6e48e0d7c92f0af163",
-      "title": "Task 40"
-    },
-    {
-      "id": "657edbc3e12e35cfc1d80358",
       "title": "Task 41"
     },
     {
-      "id": "657edc5136791ed04ffab234",
+      "id": "657edbc3e12e35cfc1d80358",
       "title": "Task 42"
     },
     {
-      "id": "657ee0a0c52d0ed1164a85d8",
+      "id": "657edc5136791ed04ffab234",
       "title": "Task 43"
     },
     {
-      "id": "657ee214b9ad1ad2b6f8325c",
+      "id": "657ee0a0c52d0ed1164a85d8",
       "title": "Task 44"
     },
     {
-      "id": "657ee25acee11cd3122e0876",
+      "id": "657ee214b9ad1ad2b6f8325c",
       "title": "Task 45"
     },
     {
-      "id": "657ee2f44346f3d4017cc990",
+      "id": "657ee25acee11cd3122e0876",
       "title": "Task 46"
     },
     {
-      "id": "657ee3954d64e5d465500620",
+      "id": "657ee2f44346f3d4017cc990",
       "title": "Task 47"
     },
     {
-      "id": "657ee4171371e9d4d1402e91",
+      "id": "657ee3954d64e5d465500620",
       "title": "Task 48"
     },
     {
-      "id": "657ee47c1af836d5289254d9",
+      "id": "657ee4171371e9d4d1402e91",
       "title": "Task 49"
     },
     {
-      "id": "657ee51ce8dac8d5a227f758",
+      "id": "657ee47c1af836d5289254d9",
       "title": "Task 50"
     },
     {
-      "id": "657ee5ddb47b1dd62f87d784",
+      "id": "657ee51ce8dac8d5a227f758",
       "title": "Task 51"
     },
     {
-      "id": "657ee66dd1216ad6c61f1168",
+      "id": "657ee5ddb47b1dd62f87d784",
       "title": "Task 52"
     },
     {
-      "id": "657ee781258676d764a5282f",
+      "id": "657ee66dd1216ad6c61f1168",
       "title": "Task 53"
     },
     {
-      "id": "657ee8a9a195b8d8756ca5e1",
+      "id": "657ee781258676d764a5282f",
       "title": "Task 54"
     },
     {
-      "id": "657ee957cb4719d9031a0be4",
+      "id": "657ee8a9a195b8d8756ca5e1",
       "title": "Task 55"
     },
     {
-      "id": "657ee9b69c2e26d964f67ee4",
+      "id": "657ee957cb4719d9031a0be4",
       "title": "Task 56"
     },
     {
-      "id": "657eeb163e1993d9e342d661",
+      "id": "657ee9b69c2e26d964f67ee4",
       "title": "Task 57"
     },
     {
-      "id": "657eebaa042b5cda6ec2dac9",
+      "id": "657eeb163e1993d9e342d661",
       "title": "Task 58"
     },
     {
-      "id": "657eec0a21bc7adada04453e",
+      "id": "657eebaa042b5cda6ec2dac9",
       "title": "Task 59"
     },
     {
-      "id": "657eecb3b368badb3cc7fe4c",
+      "id": "657eec0a21bc7adada04453e",
       "title": "Task 60"
     },
     {
-      "id": "657eed5ed318e4dbbce6903a",
+      "id": "657eecb3b368badb3cc7fe4c",
       "title": "Task 61"
+    },
+    {
+      "id": "657eed5ed318e4dbbce6903a",
+      "title": "Task 62"
+    },
+    {
+      "id": "685e4d6e2088a407609f9377",
+      "title": "Task 63"
     },
     {
       "id": "657ef4e5a4a1e1e126eba6dd",
@@ -267,111 +275,115 @@
     },
     {
       "id": "657ef58855ff45e1e4ca70ee",
-      "title": "Task 62"
-    },
-    {
-      "id": "657fb48f31654ae4cb52d395",
-      "title": "Task 63"
-    },
-    {
-      "id": "657fb5034da144e55cbee9d7",
       "title": "Task 64"
     },
     {
-      "id": "657ef61be0a682e2591776f6",
+      "id": "657fb48f31654ae4cb52d395",
       "title": "Task 65"
     },
     {
-      "id": "657fb8cfbd0e4ae797fc6077",
+      "id": "657fb5034da144e55cbee9d7",
       "title": "Task 66"
     },
     {
-      "id": "657fb665a39478e642f5a139",
+      "id": "657ef61be0a682e2591776f6",
       "title": "Task 67"
     },
     {
-      "id": "657fbad88163d8e96189f823",
+      "id": "657fb8cfbd0e4ae797fc6077",
       "title": "Task 68"
     },
     {
-      "id": "657fbb3a1a63d0e9c307fd83",
+      "id": "657fb665a39478e642f5a139",
       "title": "Task 69"
     },
     {
-      "id": "657fba163fec41e8e00c5817",
+      "id": "657fbad88163d8e96189f823",
       "title": "Task 70"
     },
     {
-      "id": "657fbc14d41a20ea5f286378",
+      "id": "657fbb3a1a63d0e9c307fd83",
       "title": "Task 71"
     },
     {
-      "id": "657fbc85c25a16eac8356182",
+      "id": "657fba163fec41e8e00c5817",
       "title": "Task 72"
     },
     {
-      "id": "657fbcecfc4d42eb28700349",
+      "id": "657fbc14d41a20ea5f286378",
       "title": "Task 73"
     },
     {
-      "id": "657fbd591461eaeba07ffff1",
+      "id": "657fbc85c25a16eac8356182",
       "title": "Task 74"
     },
     {
-      "id": "657fbde9a43e35ec1ebafe56",
+      "id": "657fbcecfc4d42eb28700349",
       "title": "Task 75"
     },
     {
-      "id": "657fb92c6f888fe8013f1a28",
+      "id": "657fbd591461eaeba07ffff1",
       "title": "Task 76"
     },
     {
-      "id": "657fb980a9b567e860b77f2c",
+      "id": "657fbde9a43e35ec1ebafe56",
       "title": "Task 77"
     },
     {
-      "id": "657fff0bfb6a28f1d70fa9ef",
+      "id": "657fb92c6f888fe8013f1a28",
       "title": "Task 78"
     },
     {
-      "id": "657fb5afeeba2de5d01dda0e",
+      "id": "657fb980a9b567e860b77f2c",
       "title": "Task 79"
     },
     {
-      "id": "657fff7dabba2ff23993b08c",
+      "id": "657fff0bfb6a28f1d70fa9ef",
       "title": "Task 80"
     },
     {
-      "id": "6580001adc7fd4f2b244f3a5",
+      "id": "657fb5afeeba2de5d01dda0e",
       "title": "Task 81"
     },
     {
-      "id": "65800082405352f30c6dbc7a",
+      "id": "657fff7dabba2ff23993b08c",
       "title": "Task 82"
     },
     {
-      "id": "65800148406738f397561d77",
+      "id": "6580001adc7fd4f2b244f3a5",
       "title": "Task 83"
     },
     {
-      "id": "658001a018bbcbf3fd84f832",
+      "id": "65800082405352f30c6dbc7a",
       "title": "Task 84"
     },
     {
-      "id": "6580026241ae0ef46b181e49",
+      "id": "65800148406738f397561d77",
       "title": "Task 85"
     },
     {
-      "id": "658002d23e245ff4ca8542d5",
+      "id": "658001a018bbcbf3fd84f832",
       "title": "Task 86"
     },
     {
-      "id": "658003870281a9f5541085af",
+      "id": "6580026241ae0ef46b181e49",
       "title": "Task 87"
     },
     {
-      "id": "658003d8ff9da6f5c08971a1",
+      "id": "658002d23e245ff4ca8542d5",
       "title": "Task 88"
+    },
+    {
+      "id": "658003870281a9f5541085af",
+      "title": "Task 89"
+    },
+    {
+      "id": "658003d8ff9da6f5c08971a1",
+      "title": "Task 90"
+    },
+    {
+      "id": "685e4e97f6ed62087370555f",
+      "title": "Task 91"
     },
     {
       "id": "658030876ac4f605145aeae1",
@@ -379,71 +391,75 @@
     },
     {
       "id": "658009d86dc9caf988e2ea64",
-      "title": "Task 89"
-    },
-    {
-      "id": "65800a95389cc0fa4c197587",
-      "title": "Task 90"
-    },
-    {
-      "id": "65800b1c13005dfa9df75d73",
-      "title": "Task 91"
-    },
-    {
-      "id": "65800b96989013fb24aa1b70",
       "title": "Task 92"
     },
     {
-      "id": "65800c12978ba7fb82007446",
+      "id": "65800a95389cc0fa4c197587",
       "title": "Task 93"
     },
     {
-      "id": "65800cf36faba0fbfa1027b6",
+      "id": "65800b1c13005dfa9df75d73",
       "title": "Task 94"
     },
     {
-      "id": "65800d61890343fc5cce0ec8",
+      "id": "65800b96989013fb24aa1b70",
       "title": "Task 95"
     },
     {
-      "id": "65800df7fc5d49fcd7209248",
+      "id": "65800c12978ba7fb82007446",
       "title": "Task 96"
     },
     {
-      "id": "65800e60dad5fefd4ed91589",
+      "id": "65800cf36faba0fbfa1027b6",
       "title": "Task 97"
     },
     {
-      "id": "65800f4d194382fdebb81e1f",
+      "id": "65800d61890343fc5cce0ec8",
       "title": "Task 98"
     },
     {
-      "id": "658010478daa16fe79d8113a",
+      "id": "65800df7fc5d49fcd7209248",
       "title": "Task 99"
     },
     {
-      "id": "65801182280f63ff10ca4d4f",
+      "id": "65800e60dad5fefd4ed91589",
       "title": "Task 100"
     },
     {
-      "id": "658011ef9ec114ff80ce5e42",
+      "id": "65800f4d194382fdebb81e1f",
       "title": "Task 101"
     },
     {
-      "id": "658013bd3b1a06001a59e006",
+      "id": "658010478daa16fe79d8113a",
       "title": "Task 102"
     },
     {
-      "id": "65802ee9706eb103aea442f8",
+      "id": "65801182280f63ff10ca4d4f",
       "title": "Task 103"
     },
     {
-      "id": "65802f717cef8c042af950b8",
+      "id": "658011ef9ec114ff80ce5e42",
       "title": "Task 104"
     },
     {
-      "id": "65802fe92ef0f404ba0437f7",
+      "id": "658013bd3b1a06001a59e006",
       "title": "Task 105"
+    },
+    {
+      "id": "65802ee9706eb103aea442f8",
+      "title": "Task 106"
+    },
+    {
+      "id": "65802f717cef8c042af950b8",
+      "title": "Task 107"
+    },
+    {
+      "id": "65802fe92ef0f404ba0437f7",
+      "title": "Task 108"
+    },
+    {
+      "id": "685e4f5c185bf709446741b5",
+      "title": "Task 109"
     }
   ],
   "helpCategory": "English",

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657da1d38bf3e693eb579be9.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657da1d38bf3e693eb579be9.md
@@ -5,53 +5,57 @@ challengeType: 22
 dashedName: task-25
 ---
 
-<!-- (Audio) The whole dialog. -->
+<!-- REVIEW -->
 
----
 # --description--
 
-In this task is a summary of the dialogue. You will apply what you have learned from the previous challenges in this lesson. You need to listen to the dialogue and fill in the blanks with the appropriate words. 
+This is a review of the entire dialogue you just studied.
 
-Notice that the text below is not a literal transcript of the dialogue. So, you need to understand the dialogue and find where the right words fit. 
+# -- instructions--
 
+Write the following words or phrases in the correct spot:
+
+`newbie`, `decade`, `into`, `basics`, `passionate about`, and `as a hobby`.
 
 # --fillInTheBlank--
 
 ## --sentence--
 
-`Maria BLANK a camera on Bob's desk and decided to ask him if BLANK is a hobby for him. He says he BLANK BLANK in love with photography for about a BLANK. He also mentions that it was originally a BLANK, but that it BLANK BLANK a very important part of his life. She asks about his favorite kinds of picture. Bob mentions he prefers BLANK and BLANK. When Maria asks for tips for beginners, Bob recommends not taking things so BLANK, BLANK with the basics, learning about your BLANK, and trying to have fun.`
+`Maria: Hey, I noticed that you have a camera on your desk. Are you BLANK photography?`
+
+`Bob: Absolutely! I've been BLANK photography for many years. Capturing moments and scenes is like magic to me.`
+
+`Maria: That's awesome! How long have you been into photography?`
+
+`Bob: For nearly a BLANK now. It started BLANK, but it's become a significant part of my life.`
+
+`Maria: Wow, that's quite a while! What kind of photography do you enjoy the most?`
+
+`Bob: I like landscapes and nature. It's incredible to capture the beauty of our world in pictures.`
+
+`Maria: That sounds amazing. I like photos a lot. Any tips for a BLANK?`
+
+`Bob: Absolutely! I've taken things way too seriously in the past. So, I always recommend starting with the BLANK, learning about your camera, and trying to have fun.`
+
+`Maria: Cool! Thanks for the tips.`
+
+`Bob: No problem!`
 
 ## --blanks--
 
-`noticed`
+`into`
 
 ### --feedback--
 
-This is the verb used to say something caught your attention. Use it in the past form.
+To really like or be interested in something.
 
 ---
 
-`photography`
+`passionate about`
 
 ### --feedback--
 
-The habit of taking pictures.
-
----
-
-`has`
-
-### --feedback--
-
-Auxiliary verb for the Present Perfect. 3rd person singular (`he`/`she`/`it`)
-
----
-
-`been`
-
-### --feedback--
-
-The verb to `be`, in the form it is used in the Present Perfect.
+To have strong feelings or love for something you enjoy doing.
 
 ---
 
@@ -59,277 +63,28 @@ The verb to `be`, in the form it is used in the Present Perfect.
 
 ### --feedback--
 
-The same as ten years.
+A period of 10 years.
 
 ---
 
-`hobby`
+`as a hobby`
 
 ### --feedback--
 
-Something you do just to entertain yourself.
+Something you do for fun in your free time.
 
 ---
 
-`has`
+`newbie`
 
 ### --feedback--
 
-Auxiliary verb for the Present Perfect. 3rd person singular (`he`/`she`/`it`)
+A person who is new to something and still learning.
 
 ---
 
-`become`
+`basics`
 
 ### --feedback--
 
-The verb to talk about transformation, starting to be something different. Use its Present Perfect form.
-
----
-
-`landscapes`
-
-### --feedback--
-
-Natural scenery, in the plural.
-
----
-
-`nature`
-
-### --feedback--
-
-The natural world.
-
----
-
-`seriously`
-
-### --feedback--
-
-Not having fun, but assuming as a responsibility. Adverb - use `-ly` in the end.
-
----
-
-`starting`
-
-### --feedback--
-
-Verb similar to `begin`. Use the `-ing` form.
-
----
-
-`camera`
-
-### --feedback--
-
-The device you use for taking pictures.
-
-# --scene--
-
-```json
-{
-  "setup": {
-    "background": "company2-center.png",
-    "characters": [
-      {
-        "character": "Maria",
-        "position": { "x": -25, "y": 0, "z": 1 }
-      },
-      {
-        "character": "Bob",
-        "position": { "x": 125, "y": 0, "z": 1 }
-      }
-    ],
-    "audio": {
-      "filename": "3.2-1.mp3",
-      "startTime": 1
-    },
-    "alwaysShowDialogue": true
-  },
-  "commands": [
-    {
-      "character": "Maria",
-      "position": { "x": 25, "y": 0, "z": 1 },
-      "startTime": 0
-    },
-    {
-      "character": "Bob",
-      "position": { "x": 70, "y": 0, "z": 1 },
-      "startTime": 0.5
-    },
-    {
-      "character": "Maria",
-      "startTime": 1,
-      "finishTime": 3.5,
-      "dialogue": {
-        "text": "Hey, I noticed that you have a camera on your desk.",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Maria",
-      "startTime": 3.6,
-      "finishTime": 4.6,
-      "dialogue": {
-        "text": "Are you into photography?",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Bob",
-      "startTime": 5.3,
-      "finishTime": 9.2,
-      "dialogue": {
-        "text": "Absolutely! I've been passionate about photography for many years.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Bob",
-      "startTime": 9.4,
-      "finishTime": 12.2,
-      "dialogue": {
-        "text": "Capturing moments and scenes is like magic to me.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Maria",
-      "startTime": 13,
-      "finishTime": 15.2,
-      "dialogue": {
-        "text": "That's awesome! How long have you been into photography?",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Bob",
-      "startTime": 15.6,
-      "finishTime": 18.3,
-      "dialogue": {
-        "text": "For nearly a decade now. It started as a hobby,",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Bob",
-      "startTime": 18.5,
-      "finishTime": 21.1,
-      "dialogue": {
-        "text": "but it's become a significant part of my life.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Maria",
-      "startTime": 21.3,
-      "finishTime": 22.6,
-      "dialogue": {
-        "text": "Wow, that's quite a while!",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Maria",
-      "startTime": 23,
-      "finishTime": 25.2,
-      "dialogue": {
-        "text": "What kind of photography do you enjoy the most?",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Bob",
-      "startTime": 25.5,
-      "finishTime": 27.2,
-      "dialogue": {
-        "text": "I like landscapes and nature.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Bob",
-      "startTime": 27.6,
-      "finishTime": 30.8,
-      "dialogue": {
-        "text": "It's incredible to capture the beauty of our world in pictures.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Maria",
-      "startTime": 31,
-      "finishTime": 33.8,
-      "dialogue": {
-        "text": "That sounds amazing. I like photos a lot.",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Maria",
-      "startTime": 34.1,
-      "finishTime": 35,
-      "dialogue": {
-        "text": "Any tips for a newbie?",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Bob",
-      "startTime": 35.5,
-      "finishTime": 38.7,
-      "dialogue": {
-        "text": "Absolutely! I've taken things way too seriously in the past.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Bob",
-      "startTime": 39.3,
-      "finishTime": 41.6,
-      "dialogue": {
-        "text": "So, I always recommend starting with the basics,",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Bob",
-      "startTime": 41.8,
-      "finishTime": 44.6,
-      "dialogue": {
-        "text": "learning about your camera, and trying to have fun.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Maria",
-      "startTime": 44.8,
-      "finishTime": 46,
-      "dialogue": {
-        "text": "Cool! Thanks for the tips.",
-        "align": "left"
-      }
-    },
-    {
-      "character": "Bob",
-      "startTime": 46.4,
-      "finishTime": 47,
-      "dialogue": {
-        "text": "No problem!",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Bob",
-      "position": { "x": 125, "y": 0, "z": 1 },
-      "startTime": 47.5
-    },
-    {
-      "character": "Maria",
-      "position": { "x": -25, "y": 0, "z": 1 },
-      "startTime": 48
-    }
-  ]
-}
-```
+The simple and most important parts of something.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657da1d38bf3e693eb579be9.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657da1d38bf3e693eb579be9.md
@@ -15,7 +15,7 @@ This is a review of the entire dialogue you just studied.
 
 Write the following words or phrases in the correct spot:
 
-`newbie`, `decade`, `into`, `basics`, `passionate about`, and `as a hobby`.
+`newbie`, `decade`, `I've been into`, `basics`, `passionate about`, and `as a hobby`.
 
 # --fillInTheBlank--
 
@@ -23,7 +23,7 @@ Write the following words or phrases in the correct spot:
 
 `Maria: Hey, I noticed that you have a camera on your desk. Are you BLANK photography?`
 
-`Bob: Absolutely! I've been BLANK photography for many years. Capturing moments and scenes is like magic to me.`
+`Bob: Absolutely! BLANK photography for many years. Capturing moments and scenes is like magic to me.`
 
 `Maria: That's awesome! How long have you been into photography?`
 
@@ -43,11 +43,11 @@ Write the following words or phrases in the correct spot:
 
 ## --blanks--
 
-`into`
+`I've been into`
 
 ### --feedback--
 
-To really like or be interested in something.
+You've really liked or been interested in something.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657eda6e48e0d7c92f0af163.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657eda6e48e0d7c92f0af163.md
@@ -1,8 +1,8 @@
 ---
 id: 657eda6e48e0d7c92f0af163
-title: Task 40
+title: Task 41
 challengeType: 22
-dashedName: task-40
+dashedName: task-41
 ---
 
 <!-- (Audio) James: Hey, I noticed you have a huge collection of action figures on that shelf behind you. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657edbc3e12e35cfc1d80358.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657edbc3e12e35cfc1d80358.md
@@ -1,8 +1,8 @@
 ---
 id: 657edbc3e12e35cfc1d80358
-title: Task 41
+title: Task 42
 challengeType: 19
-dashedName: task-41
+dashedName: task-42
 ---
 
 <!-- (Audio) James: Hey, I noticed you have a huge collection of action figures on that shelf behind you. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657edc5136791ed04ffab234.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657edc5136791ed04ffab234.md
@@ -1,8 +1,8 @@
 ---
 id: 657edc5136791ed04ffab234
-title: Task 42
+title: Task 43
 challengeType: 19
-dashedName: task-42
+dashedName: task-43
 ---
 
 <!-- (Audio) James: Hey, I noticed you have a huge collection of action figures on that shelf behind you. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657ee0a0c52d0ed1164a85d8.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657ee0a0c52d0ed1164a85d8.md
@@ -1,8 +1,8 @@
 ---
 id: 657ee0a0c52d0ed1164a85d8
-title: Task 43
+title: Task 44
 challengeType: 22
-dashedName: task-43
+dashedName: task-44
 ---
 
 <!-- (Audio) James: Hey, I noticed you have a huge collection of action figures on that shelf behind you. Are you a collector? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657ee214b9ad1ad2b6f8325c.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657ee214b9ad1ad2b6f8325c.md
@@ -1,8 +1,8 @@
 ---
 id: 657ee214b9ad1ad2b6f8325c
-title: Task 44
+title: Task 45
 challengeType: 19
-dashedName: task-44
+dashedName: task-45
 ---
 
 <!-- (Audio) James: Hey, I noticed you have a huge collection of action figures on that shelf behind you. Are you a collector? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657ee25acee11cd3122e0876.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657ee25acee11cd3122e0876.md
@@ -1,8 +1,8 @@
 ---
 id: 657ee25acee11cd3122e0876
-title: Task 45
+title: Task 46
 challengeType: 19
-dashedName: task-45
+dashedName: task-46
 ---
 
 <!-- (Audio) James: Hey, I noticed you have a huge collection of action figures on that shelf behind you. Are you a collector? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657ee2f44346f3d4017cc990.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657ee2f44346f3d4017cc990.md
@@ -1,8 +1,8 @@
 ---
 id: 657ee2f44346f3d4017cc990
-title: Task 46
+title: Task 47
 challengeType: 19
-dashedName: task-46
+dashedName: task-47
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657ee3954d64e5d465500620.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657ee3954d64e5d465500620.md
@@ -1,8 +1,8 @@
 ---
 id: 657ee3954d64e5d465500620
-title: Task 47
+title: Task 48
 challengeType: 19
-dashedName: task-47
+dashedName: task-48
 ---
 
 <!-- (Audio) James: Hey, I noticed you have a huge collection of action figures on that shelf behind you. Are you a collector? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657ee4171371e9d4d1402e91.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657ee4171371e9d4d1402e91.md
@@ -1,8 +1,8 @@
 ---
 id: 657ee4171371e9d4d1402e91
-title: Task 48
+title: Task 49
 challengeType: 22
-dashedName: task-48
+dashedName: task-49
 ---
 
 <!-- (Audio) Sarah: You bet! I love action figures. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657ee47c1af836d5289254d9.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657ee47c1af836d5289254d9.md
@@ -1,8 +1,8 @@
 ---
 id: 657ee47c1af836d5289254d9
-title: Task 49
+title: Task 50
 challengeType: 19
-dashedName: task-49
+dashedName: task-50
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657ee51ce8dac8d5a227f758.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657ee51ce8dac8d5a227f758.md
@@ -1,8 +1,8 @@
 ---
 id: 657ee51ce8dac8d5a227f758
-title: Task 50
+title: Task 51
 challengeType: 19
-dashedName: task-50
+dashedName: task-51
 ---
 
 <!-- (Audio) James: That's awesome! What kind of figures are you most interested in? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657ee5ddb47b1dd62f87d784.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657ee5ddb47b1dd62f87d784.md
@@ -1,8 +1,8 @@
 ---
 id: 657ee5ddb47b1dd62f87d784
-title: Task 51
+title: Task 52
 challengeType: 19
-dashedName: task-51
+dashedName: task-52
 ---
 
 <!-- (Audio) Sarah: I like sci-fi and fantasy, mostly. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657ee66dd1216ad6c61f1168.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657ee66dd1216ad6c61f1168.md
@@ -1,8 +1,8 @@
 ---
 id: 657ee66dd1216ad6c61f1168
-title: Task 52
+title: Task 53
 challengeType: 22
-dashedName: task-52
+dashedName: task-53
 ---
 
 <!-- (Audio) James: What kind of figures are you most interested in? Sarah: I like sci-fi and fantasy, mostly. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657ee781258676d764a5282f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657ee781258676d764a5282f.md
@@ -1,8 +1,8 @@
 ---
 id: 657ee781258676d764a5282f
-title: Task 53
+title: Task 54
 challengeType: 19
-dashedName: task-53
+dashedName: task-54
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657ee8a9a195b8d8756ca5e1.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657ee8a9a195b8d8756ca5e1.md
@@ -1,8 +1,8 @@
 ---
 id: 657ee8a9a195b8d8756ca5e1
-title: Task 54
+title: Task 55
 challengeType: 22
-dashedName: task-54
+dashedName: task-55
 ---
 
 <!-- (Audio) Sarah: I've been a collector since I was 8 or 9 years old. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657ee957cb4719d9031a0be4.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657ee957cb4719d9031a0be4.md
@@ -1,8 +1,8 @@
 ---
 id: 657ee957cb4719d9031a0be4
-title: Task 55
+title: Task 56
 challengeType: 22
-dashedName: task-55
+dashedName: task-56
 ---
 
 <!-- (Audio) Sarah: It all started when I got my first action figure at a comic convention. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657ee9b69c2e26d964f67ee4.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657ee9b69c2e26d964f67ee4.md
@@ -1,8 +1,8 @@
 ---
 id: 657ee9b69c2e26d964f67ee4
-title: Task 56
+title: Task 57
 challengeType: 19
-dashedName: task-56
+dashedName: task-57
 ---
 
 <!-- (Audio) Sarah: I go to at least one convention every year. It's the best moment of the year to me! -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657eeb163e1993d9e342d661.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657eeb163e1993d9e342d661.md
@@ -1,8 +1,8 @@
 ---
 id: 657eeb163e1993d9e342d661
-title: Task 57
+title: Task 58
 challengeType: 19
-dashedName: task-57
+dashedName: task-58
 ---
 
 <!-- (Audio) James: I didn't know you were interested in this. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657eebaa042b5cda6ec2dac9.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657eebaa042b5cda6ec2dac9.md
@@ -1,8 +1,8 @@
 ---
 id: 657eebaa042b5cda6ec2dac9
-title: Task 58
+title: Task 59
 challengeType: 22
-dashedName: task-58
+dashedName: task-59
 ---
 
 <!-- (Audio) Sarah: Are you kidding? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657eec0a21bc7adada04453e.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657eec0a21bc7adada04453e.md
@@ -1,8 +1,8 @@
 ---
 id: 657eec0a21bc7adada04453e
-title: Task 59
+title: Task 60
 challengeType: 19
-dashedName: task-59
+dashedName: task-60
 ---
 
 <!-- (Audio)

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657eecb3b368badb3cc7fe4c.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657eecb3b368badb3cc7fe4c.md
@@ -1,8 +1,8 @@
 ---
 id: 657eecb3b368badb3cc7fe4c
-title: Task 60
+title: Task 61
 challengeType: 22
-dashedName: task-60
+dashedName: task-61
 ---
 
 <!-- (Audio) Sarah: I go to at least one convention every year. It's the best moment of the year for me. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657eed5ed318e4dbbce6903a.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657eed5ed318e4dbbce6903a.md
@@ -1,8 +1,8 @@
 ---
 id: 657eed5ed318e4dbbce6903a
-title: Task 61
+title: Task 62
 challengeType: 19
-dashedName: task-61
+dashedName: task-62
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657ef58855ff45e1e4ca70ee.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657ef58855ff45e1e4ca70ee.md
@@ -1,8 +1,8 @@
 ---
 id: 657ef58855ff45e1e4ca70ee
-title: Task 62
+title: Task 64
 challengeType: 22
-dashedName: task-62
+dashedName: task-64
 ---
 
 <!-- (Audio) Sarah: Hey, Tom! Have I told you I'm a huge sci-fi fan? I'm even part of an amazing fandom. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657ef61be0a682e2591776f6.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657ef61be0a682e2591776f6.md
@@ -1,8 +1,8 @@
 ---
 id: 657ef61be0a682e2591776f6
-title: Task 65
+title: Task 67
 challengeType: 19
-dashedName: task-65
+dashedName: task-67
 ---
 
 <!-- (Audio) Tom: That's cool, Sarah! I've heard there are massive communities of people into sci-fi. What kind of events do you have? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657fb48f31654ae4cb52d395.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657fb48f31654ae4cb52d395.md
@@ -1,8 +1,8 @@
 ---
 id: 657fb48f31654ae4cb52d395
-title: Task 63
+title: Task 65
 challengeType: 22
-dashedName: task-63
+dashedName: task-65
 ---
 
 <!-- (Audio) Sarah: Hey, Tom! Have I told you I'm a huge sci-fi fan? I'm even part of an amazing fandom. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657fb5034da144e55cbee9d7.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657fb5034da144e55cbee9d7.md
@@ -1,8 +1,8 @@
 ---
 id: 657fb5034da144e55cbee9d7
-title: Task 64
+title: Task 66
 challengeType: 19
-dashedName: task-64
+dashedName: task-66
 ---
 
 <!-- (Audio) Sarah: Hey, Tom! Have I told you I'm a huge sci-fi fan? I'm even part of an amazing fandom. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657fb5afeeba2de5d01dda0e.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657fb5afeeba2de5d01dda0e.md
@@ -1,8 +1,8 @@
 ---
 id: 657fb5afeeba2de5d01dda0e
-title: Task 79
+title: Task 81
 challengeType: 19
-dashedName: task-79
+dashedName: task-81
 ---
 
 <!-- (Audio) Tom: Thanks for the invite, Sarah. I appreciate it, but I'm not really into sci-fi. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657fb665a39478e642f5a139.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657fb665a39478e642f5a139.md
@@ -1,8 +1,8 @@
 ---
 id: 657fb665a39478e642f5a139
-title: Task 67
+title: Task 69
 challengeType: 19
-dashedName: task-67
+dashedName: task-69
 ---
 
 <!-- (Audio) Sarah: Well, we have movie marathons, conventions, and even play together some movie-related video games. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657fb8cfbd0e4ae797fc6077.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657fb8cfbd0e4ae797fc6077.md
@@ -1,8 +1,8 @@
 ---
 id: 657fb8cfbd0e4ae797fc6077
-title: Task 66
+title: Task 68
 challengeType: 22
-dashedName: task-66
+dashedName: task-68
 ---
 
 <!-- (Audio) Tom: That's cool, Sarah! I've heard there are massive communities of people who are into sci-fi. What kind of events do you have? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657fb92c6f888fe8013f1a28.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657fb92c6f888fe8013f1a28.md
@@ -1,8 +1,8 @@
 ---
 id: 657fb92c6f888fe8013f1a28
-title: Task 76
+title: Task 78
 challengeType: 19
-dashedName: task-76
+dashedName: task-78
 ---
 
 <!-- (Audio) Sarah: There's a big convention next month. Would you like to come? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657fb980a9b567e860b77f2c.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657fb980a9b567e860b77f2c.md
@@ -1,8 +1,8 @@
 ---
 id: 657fb980a9b567e860b77f2c
-title: Task 77
+title: Task 79
 challengeType: 22
-dashedName: task-77
+dashedName: task-79
 ---
 
 <!-- (Audio) Sarah: There's a big convention next month. Would you like to come? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657fba163fec41e8e00c5817.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657fba163fec41e8e00c5817.md
@@ -1,8 +1,8 @@
 ---
 id: 657fba163fec41e8e00c5817
-title: Task 70
+title: Task 72
 challengeType: 19
-dashedName: task-70
+dashedName: task-72
 ---
 
 <!-- (Audio) Sarah: Well, we have movie marathons, conventions, and even play together some movie-related video games. There's a big convention next month. Would you like to come? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657fbad88163d8e96189f823.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657fbad88163d8e96189f823.md
@@ -1,8 +1,8 @@
 ---
 id: 657fbad88163d8e96189f823
-title: Task 68
+title: Task 70
 challengeType: 22
-dashedName: task-68
+dashedName: task-70
 ---
 
 <!-- (Audio) Sarah: Well, we have movie marathons, conventions, and even play some movie-related video games together. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657fbb3a1a63d0e9c307fd83.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657fbb3a1a63d0e9c307fd83.md
@@ -1,8 +1,8 @@
 ---
 id: 657fbb3a1a63d0e9c307fd83
-title: Task 69
+title: Task 71
 challengeType: 19
-dashedName: task-69
+dashedName: task-71
 ---
 
 <!-- (Audio) Sarah: Well, we have movie marathons, conventions, and we even play some movie-related video games together. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657fbc14d41a20ea5f286378.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657fbc14d41a20ea5f286378.md
@@ -1,8 +1,8 @@
 ---
 id: 657fbc14d41a20ea5f286378
-title: Task 71
+title: Task 73
 challengeType: 22
-dashedName: task-71
+dashedName: task-73
 ---
 
 <!-- (Audio) Sarah: Well, we have movie marathons, conventions, and we even play some movie-related video games together.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657fbc85c25a16eac8356182.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657fbc85c25a16eac8356182.md
@@ -1,8 +1,8 @@
 ---
 id: 657fbc85c25a16eac8356182
-title: Task 72
+title: Task 74
 challengeType: 19
-dashedName: task-72
+dashedName: task-74
 ---
 
 <!-- (Audio) Sarah: Well, we have movie marathons, conventions, and we even play some movie-related video games together. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657fbcecfc4d42eb28700349.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657fbcecfc4d42eb28700349.md
@@ -1,8 +1,8 @@
 ---
 id: 657fbcecfc4d42eb28700349
-title: Task 73
+title: Task 75
 challengeType: 19
-dashedName: task-73
+dashedName: task-75
 ---
 
 <!-- (Audio) Sarah: Well, we have movie marathons, conventions, and we even play some movie-related video games together. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657fbd591461eaeba07ffff1.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657fbd591461eaeba07ffff1.md
@@ -1,8 +1,8 @@
 ---
 id: 657fbd591461eaeba07ffff1
-title: Task 74
+title: Task 76
 challengeType: 19
-dashedName: task-74
+dashedName: task-76
 ---
 
 <!-- (Audio) Sarah: There's a big convention next month. Would you like to come? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657fbde9a43e35ec1ebafe56.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657fbde9a43e35ec1ebafe56.md
@@ -1,8 +1,8 @@
 ---
 id: 657fbde9a43e35ec1ebafe56
-title: Task 75
+title: Task 77
 challengeType: 19
-dashedName: task-75
+dashedName: task-77
 ---
 
 <!-- (Audio) Sarah: There's a big convention next month. Would you like to come? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657fff0bfb6a28f1d70fa9ef.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657fff0bfb6a28f1d70fa9ef.md
@@ -1,8 +1,8 @@
 ---
 id: 657fff0bfb6a28f1d70fa9ef
-title: Task 78
+title: Task 80
 challengeType: 22
-dashedName: task-78
+dashedName: task-80
 ---
 
 <!-- (Audio) Tom: Thanks for the invite, Sarah. I appreciate it, but I'm not really into sci-fi. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657fff7dabba2ff23993b08c.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657fff7dabba2ff23993b08c.md
@@ -1,8 +1,8 @@
 ---
 id: 657fff7dabba2ff23993b08c
-title: Task 80
+title: Task 82
 challengeType: 19
-dashedName: task-80
+dashedName: task-82
 ---
 
 <!-- (Audio) Tom: Thanks for the invite, Sarah. I appreciate it, but I'm not really into sci-fi. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/6580001adc7fd4f2b244f3a5.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/6580001adc7fd4f2b244f3a5.md
@@ -1,8 +1,8 @@
 ---
 id: 6580001adc7fd4f2b244f3a5
-title: Task 81
+title: Task 83
 challengeType: 22
-dashedName: task-81
+dashedName: task-83
 ---
 
 <!-- (Audio) Tom: Thanks for the invite, Sarah. I appreciate it, but I'm not really into sci-fi. I hope you have a blast at the convention, though! -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/65800082405352f30c6dbc7a.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/65800082405352f30c6dbc7a.md
@@ -1,8 +1,8 @@
 ---
 id: 65800082405352f30c6dbc7a
-title: Task 82
+title: Task 84
 challengeType: 19
-dashedName: task-82
+dashedName: task-84
 ---
 
 <!-- (Audio) Tom: Thanks for the invite, Sarah. I appreciate it, but I'm not really into sci-fi. I hope you have a blast at the convention, though! -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/65800148406738f397561d77.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/65800148406738f397561d77.md
@@ -1,8 +1,8 @@
 ---
 id: 65800148406738f397561d77
-title: Task 83
+title: Task 85
 challengeType: 22
-dashedName: task-83
+dashedName: task-85
 ---
 
 <!-- (Audio) Tom: I hope you have a blast at the convention, though! -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/658001a018bbcbf3fd84f832.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/658001a018bbcbf3fd84f832.md
@@ -1,8 +1,8 @@
 ---
 id: 658001a018bbcbf3fd84f832
-title: Task 84
+title: Task 86
 challengeType: 19
-dashedName: task-84
+dashedName: task-86
 ---
 
 <!-- (Audio) Tom: Thanks for the invite, Sarah. I appreciate it, but I'm not really into sci-fi. I hope you have a blast at the convention, though! -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/6580026241ae0ef46b181e49.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/6580026241ae0ef46b181e49.md
@@ -1,8 +1,8 @@
 ---
 id: 6580026241ae0ef46b181e49
-title: Task 85
+title: Task 87
 challengeType: 22
-dashedName: task-85
+dashedName: task-87
 ---
 
 <!-- (Audio) Sarah: No problem, Tom. Maybe next time you'll join us! -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/658002d23e245ff4ca8542d5.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/658002d23e245ff4ca8542d5.md
@@ -1,8 +1,8 @@
 ---
 id: 658002d23e245ff4ca8542d5
-title: Task 86
+title: Task 88
 challengeType: 19
-dashedName: task-86
+dashedName: task-88
 ---
 
 <!-- (Audio) Sarah: No problem, Tom. Maybe next time you'll join us! -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/658003870281a9f5541085af.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/658003870281a9f5541085af.md
@@ -1,8 +1,8 @@
 ---
 id: 658003870281a9f5541085af
-title: Task 87
+title: Task 89
 challengeType: 22
-dashedName: task-87
+dashedName: task-89
 ---
 
 <!-- (Audio) Tom: Thanks! Have fun. I hope the convention is a success! -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/658003d8ff9da6f5c08971a1.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/658003d8ff9da6f5c08971a1.md
@@ -1,8 +1,8 @@
 ---
 id: 658003d8ff9da6f5c08971a1
-title: Task 88
+title: Task 90
 challengeType: 19
-dashedName: task-88
+dashedName: task-90
 ---
 
 <!-- (Audio) Tom: Thanks! Have fun. I hope the convention is a success!

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/658009d86dc9caf988e2ea64.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/658009d86dc9caf988e2ea64.md
@@ -1,8 +1,8 @@
 ---
 id: 658009d86dc9caf988e2ea64
-title: Task 89
+title: Task 92
 challengeType: 19
-dashedName: task-89
+dashedName: task-92
 ---
 
 <!-- (Audio) Brian: Hey, Sophie. I heard you're into extreme sports. Is that true? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/65800a95389cc0fa4c197587.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/65800a95389cc0fa4c197587.md
@@ -1,8 +1,8 @@
 ---
 id: 65800a95389cc0fa4c197587
-title: Task 90
+title: Task 93
 challengeType: 22
-dashedName: task-90
+dashedName: task-93
 ---
 
 <!-- (Audio) Sophie: Yeah, I love them. I've been into rock climbing and rafting for a while now. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/65800b1c13005dfa9df75d73.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/65800b1c13005dfa9df75d73.md
@@ -1,8 +1,8 @@
 ---
 id: 65800b1c13005dfa9df75d73
-title: Task 91
+title: Task 94
 challengeType: 19
-dashedName: task-91
+dashedName: task-94
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/65800b96989013fb24aa1b70.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/65800b96989013fb24aa1b70.md
@@ -1,8 +1,8 @@
 ---
 id: 65800b96989013fb24aa1b70
-title: Task 92
+title: Task 95
 challengeType: 19
-dashedName: task-92
+dashedName: task-95
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/65800c12978ba7fb82007446.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/65800c12978ba7fb82007446.md
@@ -1,8 +1,8 @@
 ---
 id: 65800c12978ba7fb82007446
-title: Task 93
+title: Task 96
 challengeType: 19
-dashedName: task-93
+dashedName: task-96
 ---
 
 <!-- (Audio) Brian: That's amazing! I've always wanted to try rafting but I've never had the opportunity. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/65800cf36faba0fbfa1027b6.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/65800cf36faba0fbfa1027b6.md
@@ -1,8 +1,8 @@
 ---
 id: 65800cf36faba0fbfa1027b6
-title: Task 94
+title: Task 97
 challengeType: 22
-dashedName: task-94
+dashedName: task-97
 ---
 
 <!-- (Audio) Sophie: Well, why don't you try it? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/65800d61890343fc5cce0ec8.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/65800d61890343fc5cce0ec8.md
@@ -1,8 +1,8 @@
 ---
 id: 65800d61890343fc5cce0ec8
-title: Task 95
+title: Task 98
 challengeType: 19
-dashedName: task-95
+dashedName: task-98
 ---
 
 <!-- (Audio) Sophie: Well, why don't you try it? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/65800df7fc5d49fcd7209248.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/65800df7fc5d49fcd7209248.md
@@ -1,8 +1,8 @@
 ---
 id: 65800df7fc5d49fcd7209248
-title: Task 96
+title: Task 99
 challengeType: 22
-dashedName: task-96
+dashedName: task-99
 ---
 
 <!-- (Audio) Sophie: Well, why don't you try it? I'm planning to go rafting this weekend. You're welcome to join. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/65800e60dad5fefd4ed91589.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/65800e60dad5fefd4ed91589.md
@@ -1,8 +1,8 @@
 ---
 id: 65800e60dad5fefd4ed91589
-title: Task 97
+title: Task 100
 challengeType: 22
-dashedName: task-97
+dashedName: task-100
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/65800f4d194382fdebb81e1f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/65800f4d194382fdebb81e1f.md
@@ -1,8 +1,8 @@
 ---
 id: 65800f4d194382fdebb81e1f
-title: Task 98
+title: Task 101
 challengeType: 22
-dashedName: task-98
+dashedName: task-101
 ---
 
 <!-- (Audio) Sophie: Well, why don't you try it? I'm planning to go rafting this weekend. You're welcome to join! -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/658010478daa16fe79d8113a.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/658010478daa16fe79d8113a.md
@@ -1,8 +1,8 @@
 ---
 id: 658010478daa16fe79d8113a
-title: Task 99
+title: Task 102
 challengeType: 19
-dashedName: task-99
+dashedName: task-102
 ---
 
 <!-- (Audio) Sophie: Well, why don't you try it? I'm planning to go rafting this weekend. You're welcome to join! -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/65801182280f63ff10ca4d4f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/65801182280f63ff10ca4d4f.md
@@ -1,8 +1,8 @@
 ---
 id: 65801182280f63ff10ca4d4f
-title: Task 100
+title: Task 103
 challengeType: 22
-dashedName: task-100
+dashedName: task-103
 ---
 
 <!-- (Audio) Brian: Really? That sounds great. I'd love to join you. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/658011ef9ec114ff80ce5e42.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/658011ef9ec114ff80ce5e42.md
@@ -1,8 +1,8 @@
 ---
 id: 658011ef9ec114ff80ce5e42
-title: Task 101
+title: Task 104
 challengeType: 19
-dashedName: task-101
+dashedName: task-104
 ---
 
 <!-- (Audio) Brian: Really? That sounds great. I'd love to join you. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/658013bd3b1a06001a59e006.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/658013bd3b1a06001a59e006.md
@@ -1,8 +1,8 @@
 ---
 id: 658013bd3b1a06001a59e006
-title: Task 102
+title: Task 105
 challengeType: 22
-dashedName: task-102
+dashedName: task-105
 ---
 
 <!-- (Audio) Brian: Really? That sounds great! I'd love to join you. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/65802ee9706eb103aea442f8.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/65802ee9706eb103aea442f8.md
@@ -1,8 +1,8 @@
 ---
 id: 65802ee9706eb103aea442f8
-title: Task 103
+title: Task 106
 challengeType: 19
-dashedName: task-103
+dashedName: task-106
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/65802f717cef8c042af950b8.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/65802f717cef8c042af950b8.md
@@ -1,8 +1,8 @@
 ---
 id: 65802f717cef8c042af950b8
-title: Task 104
+title: Task 107
 challengeType: 19
-dashedName: task-104
+dashedName: task-107
 ---
 
 <!-- (Audio) Sophie: Great! We'll have a lot of fun. I'll let you know all the details later. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/65802fe92ef0f404ba0437f7.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/65802fe92ef0f404ba0437f7.md
@@ -1,8 +1,8 @@
 ---
 id: 65802fe92ef0f404ba0437f7
-title: Task 105
+title: Task 108
 challengeType: 19
-dashedName: task-105
+dashedName: task-108
 ---
 
 <!-- (Audio) Brian: Thanks, Sophie. I'm looking forward to it! -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/685e4c36bc03dc064d265e2e.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/685e4c36bc03dc064d265e2e.md
@@ -1,0 +1,90 @@
+---
+id: 685e4c36bc03dc064d265e2e
+title: Task 40
+challengeType: 22
+dashedName: task-40
+---
+
+<!-- REVIEW -->
+
+# --description--
+
+This is a review of the entire dialogue you just studied.
+
+# -- instructions--
+
+Write the following words or phrases in the correct spot:
+
+`with time`, `since my childhood`, `what kind of`, `a great way to`, `get into`, and `one of these days`.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`Jake: Hey, is that bicycle outside the office yours? Do you enjoy cycling?`
+
+`Linda: I do! I've liked riding my bike BLANK. It's not just a hobby – it's a way of life for me.`
+
+`Jake: That's great! How long have you been into cycling?`
+
+`Linda: I've been a cyclist for more than 15 years. It's a love that hasn't disappeared BLANK.`
+
+`Jake: Wow! And BLANK cycling do you enjoy the most?`
+
+`Linda: I love road cycling and the feeling of the open road. It's BLANK stay fit and explore new places.`
+
+`Jake: That's fantastic. I want to BLANK cycling, too. I haven't been on a bike since I was a kid. I probably even forgot how to do it.`
+
+`Linda: People say we never forget. Say, do you still have a bike? Would you like to go cycling with me BLANK?`
+
+`Jake: Sure! I'd love to. Let's see what we can do next week.`
+
+`Linda: Ok, it's a bike date, then.`
+
+## --blanks--
+
+`since my childhood`
+
+### --feedback--
+
+From the time when you were a child until now.
+
+---
+
+`with time`
+
+### --feedback--
+
+As time passes or after some time.
+
+---
+
+`what kind of`
+
+### --feedback--
+
+Used to ask about the type or category of something.
+
+---
+
+`a great way to`
+
+### --feedback--
+
+A very good method or idea for doing something.
+
+---
+
+`get into`
+
+### --feedback--
+
+To start being interested in something or begin doing it.
+
+---
+
+`one of these days`
+
+### --feedback--
+
+Sometime in the future, but not sure when.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/685e4d6e2088a407609f9377.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/685e4d6e2088a407609f9377.md
@@ -51,7 +51,7 @@ A group of things gathered or stored together.
 
 ### --feedback--
 
-An informal way to say "of course."
+An informal way to say "of course." The first letter is capitalized.
 
 ---
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/685e4d6e2088a407609f9377.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/685e4d6e2088a407609f9377.md
@@ -1,0 +1,86 @@
+---
+id: 685e4d6e2088a407609f9377
+title: Task 63
+challengeType: 22
+dashedName: task-63
+---
+
+<!-- REVIEW -->
+
+# --description--
+
+This is a review of the entire dialogue you just studied.
+
+# -- instructions--
+
+Write the following words or phrases in the correct spot:
+
+`You bet`, `since`, `most interested in`, `the best moment`, `convention`, and `collection of`.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`James: Hey, I noticed you have a huge BLANK action figures on that shelf behind you. Are you a collector?`
+
+`Sarah: BLANK! I love action figures.`
+
+`James: That's awesome! What kind of figures are you BLANK?`
+
+`Sarah: I like sci-fi and fantasy, mostly. You can find everything here, from Star Wars to Lord of the Rings.`
+
+`James: That's cool. How long have you been into collecting?`
+
+`Sarah: I've been a collector BLANK I was 8 or 9 years old. It all started when I got my first action figure at a comic BLANK.`
+
+`James: I didn't know you were interested in this.`
+
+`Sarah: Are you kidding? I go to at least one convention every year. It's BLANK of the year for me!`
+
+## --blanks--
+
+`collection of`
+
+### --feedback--
+
+A group of things gathered or stored together.
+
+---
+
+`You bet`
+
+### --feedback--
+
+An informal way to say "of course."
+
+---
+
+`most interested in`
+
+### --feedback--
+
+What you like or care about the most.
+
+---
+
+`since`
+
+### --feedback--
+
+Used to show when something started.
+
+---
+
+`convention`
+
+### --feedback--
+
+A large meeting where people share ideas, often about a special topic.
+
+---
+
+`the best moment`
+
+### --feedback--
+
+The most exciting or important time in an experience.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/685e4e97f6ed62087370555f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/685e4e97f6ed62087370555f.md
@@ -1,0 +1,74 @@
+---
+id: 685e4e97f6ed62087370555f
+title: Task 91
+challengeType: 22
+dashedName: task-91
+---
+
+<!-- REVIEW -->
+
+# --description--
+
+This is a review of the entire dialogue you just studied.
+
+# -- instructions--
+
+Write the following words or phrases in the correct spot:
+
+`communities`, `have a blast`, `fandom`, `next time`, and `video games`.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`Sarah: Hey, Tom! Have I told you I'm a huge sci-fi fan? I'm even part of an amazing BLANK.`
+
+`Tom: That's cool, Sarah! I've heard there are massive BLANK of people who are into sci-fi. What kind of events do you have?`
+
+`Sarah: Well, we have movie marathons, conventions, and we even play some movie-related BLANK together. There's a big convention next month. Would you like to come?`
+
+`Tom: Thanks for the invite, Sarah. I appreciate it, but I'm not really into sci-fi. I hope you BLANK at the convention, though!`
+
+`Sarah: No problem, Tom. Maybe BLANK you'll join us!`
+
+`Tom: Thanks! Have fun. I hope the convention is a success!`
+
+## --blanks--
+
+`fandom`
+
+### --feedback--
+
+A group of people who really enjoy and follow the same show, game, or topic.
+
+---
+
+`communities`
+
+### --feedback--
+
+Groups of people with shared interests who talk and help each other.
+
+---
+
+`video games`
+
+### --feedback--
+
+Games played on a computer or console for fun.
+
+---
+
+`have a blast`
+
+### --feedback--
+
+To have a lot of fun.
+
+---
+
+`next time`
+
+### --feedback--
+
+When something happens again in the future.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/685e4f5c185bf709446741b5.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/685e4f5c185bf709446741b5.md
@@ -1,0 +1,76 @@
+---
+id: 685e4f5c185bf709446741b5
+title: Task 109
+challengeType: 22
+dashedName: task-109
+---
+
+<!-- REVIEW -->
+
+# --description--
+
+This is a review of the entire dialogue you just studied.
+
+# -- instructions--
+
+Write the following words or phrases in the correct spot:
+
+`welcome to join`, `for a while`, `details`, `extreme sports`, and `opportunity`.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`Brian: Hey, Sophie. I heard you're into BLANK. Is that true?`
+
+`Sophie: Yeah, I love them. I've been into rock climbing and rafting BLANK now.`
+
+`Brian: That's amazing! I've always wanted to try rafting but I've never had the BLANK.`
+
+`Sophie: Well, why don't you try it? I'm planning to go rafting this weekend. You're BLANK!`
+
+`Brian: Really? That sounds great! I'd love to join you.`
+
+`Sophie: Great! We'll have a lot of fun. I'll let you know all the BLANK later.`
+
+`Brian: Thanks, Sophie. I'm looking forward to it!`
+
+## --blanks--
+
+`extreme sports`
+
+### --feedback--
+
+Exciting and risky activities like skydiving or mountain biking.
+
+---
+
+`for a while`
+
+### --feedback--
+
+A short or medium amount of time.
+
+---
+
+`opportunity`
+
+### --feedback--
+
+A chance to do something.
+
+---
+
+`welcome to join`
+
+### --feedback--
+
+Invited or allowed to take part in something.
+
+---
+
+`details`
+
+### --feedback--
+
+Small pieces of information that give more about something.


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

Related to https://github.com/freeCodeCamp/freeCodeCamp/issues/55293

The EC team found that "summary tasks" were ineffective and confusing for learners, as noted in the related issue. In the B1 curriculum, we replaced them with "review tasks."

This PR is part of a series to apply the same changes to the A2 curriculum. To keep reviews easier, I'm splitting the updates into multiple PRs. This one covers Block 8.
