### PR TITLE
feat(curriculum): add review tasks to block 9 of the A2 curriculum

### DIFF
--- a/curriculum/challenges/_meta/learn-how-to-discuss-roles-and-responsibilies/meta.json
+++ b/curriculum/challenges/_meta/learn-how-to-discuss-roles-and-responsibilies/meta.json
@@ -138,104 +138,112 @@
       "title": "Task 32"
     },
     {
+      "id": "685e5aca93db0b0d9d7dc088",
+      "title": "Task 33"
+    },
+    {
       "id": "65d5cebba7a44042a1815053",
       "title": "Dialogue 2: Talking about Anna"
     },
     {
       "id": "65d5d17a45be4e4d56be704a",
-      "title": "Task 33"
-    },
-    {
-      "id": "65d5d1bdbd0a7f4e3edb6c8e",
       "title": "Task 34"
     },
     {
-      "id": "65d5fb1e575bfe649f5cea4b",
+      "id": "65d5d1bdbd0a7f4e3edb6c8e",
       "title": "Task 35"
     },
     {
-      "id": "65d5feaac55f2d673480abe1",
+      "id": "65d5fb1e575bfe649f5cea4b",
       "title": "Task 36"
     },
     {
-      "id": "65d60150d4ac7c73895342cc",
+      "id": "65d5feaac55f2d673480abe1",
       "title": "Task 37"
     },
     {
-      "id": "65d60402f5661e79dfddab63",
+      "id": "65d60150d4ac7c73895342cc",
       "title": "Task 38"
     },
     {
-      "id": "65d60609e931277ebddf1dd8",
+      "id": "65d60402f5661e79dfddab63",
       "title": "Task 39"
     },
     {
-      "id": "65d6099b91bfe381c68a12f8",
+      "id": "65d60609e931277ebddf1dd8",
       "title": "Task 40"
     },
     {
-      "id": "65d6b7cfc3544c15a83b2008",
+      "id": "65d6099b91bfe381c68a12f8",
       "title": "Task 41"
     },
     {
-      "id": "65d6bc21bbb3fb20d47cd7ed",
+      "id": "65d6b7cfc3544c15a83b2008",
       "title": "Task 42"
     },
     {
-      "id": "65d6bd19de6bad235879c032",
+      "id": "65d6bc21bbb3fb20d47cd7ed",
       "title": "Task 43"
     },
     {
-      "id": "65d6bfc0ef75202990f3c838",
+      "id": "65d6bd19de6bad235879c032",
       "title": "Task 44"
     },
     {
-      "id": "65d6c0b53262202bf8813f73",
+      "id": "65d6bfc0ef75202990f3c838",
       "title": "Task 45"
     },
     {
-      "id": "65d6c19c1a1dc52e536a8e21",
+      "id": "65d6c0b53262202bf8813f73",
       "title": "Task 46"
     },
     {
-      "id": "65d6c390f03b85333445b5e4",
+      "id": "65d6c19c1a1dc52e536a8e21",
       "title": "Task 47"
     },
     {
-      "id": "65d6c7f99ec5d13d543dccf4",
+      "id": "65d6c390f03b85333445b5e4",
       "title": "Task 48"
     },
     {
-      "id": "65d6c8c2c21ad83f837b4bb9",
+      "id": "65d6c7f99ec5d13d543dccf4",
       "title": "Task 49"
     },
     {
-      "id": "65d6ca37133db041a059b352",
+      "id": "65d6c8c2c21ad83f837b4bb9",
       "title": "Task 50"
     },
     {
-      "id": "65d6cb8800b1274686877c25",
+      "id": "65d6ca37133db041a059b352",
       "title": "Task 51"
     },
     {
-      "id": "65d6cc2551fe584833cd6cda",
+      "id": "65d6cb8800b1274686877c25",
       "title": "Task 52"
     },
     {
-      "id": "65d6cd757478424b84d7f445",
+      "id": "65d6cc2551fe584833cd6cda",
       "title": "Task 53"
     },
     {
-      "id": "65d6dadcc5e50f5d3d3c8e95",
+      "id": "65d6cd757478424b84d7f445",
       "title": "Task 54"
     },
     {
-      "id": "65d6dc5686b49d61612472e0",
+      "id": "65d6dadcc5e50f5d3d3c8e95",
       "title": "Task 55"
     },
     {
-      "id": "65d6dd0d7fc3c563482b8ad6",
+      "id": "65d6dc5686b49d61612472e0",
       "title": "Task 56"
+    },
+    {
+      "id": "65d6dd0d7fc3c563482b8ad6",
+      "title": "Task 57"
+    },
+    {
+      "id": "685e5b186e34570dd3d2ff19",
+      "title": "Task 58"
     },
     {
       "id": "65d6e2c17bb85b727ddf51d6",
@@ -243,87 +251,91 @@
     },
     {
       "id": "65d7480fba8a2b88f5499094",
-      "title": "Task 57"
-    },
-    {
-      "id": "65d74ca5293a7b9397dec0e6",
-      "title": "Task 58"
-    },
-    {
-      "id": "65d750f42fb8c69d48edb565",
       "title": "Task 59"
     },
     {
-      "id": "65d75185d536899fd3c01977",
+      "id": "65d74ca5293a7b9397dec0e6",
       "title": "Task 60"
     },
     {
-      "id": "65d752c6240228a36a5a3ac3",
+      "id": "65d750f42fb8c69d48edb565",
       "title": "Task 61"
     },
     {
-      "id": "65d862dca01bd8e8a6f7561b",
+      "id": "65d75185d536899fd3c01977",
       "title": "Task 62"
     },
     {
-      "id": "65d863be0ea26dea821fb459",
+      "id": "65d752c6240228a36a5a3ac3",
       "title": "Task 63"
     },
     {
-      "id": "65d86638218150ecf514c478",
+      "id": "65d862dca01bd8e8a6f7561b",
       "title": "Task 64"
     },
     {
-      "id": "65d867969a26ebf43e31297d",
+      "id": "65d863be0ea26dea821fb459",
       "title": "Task 65"
     },
     {
-      "id": "65d868a1bdc45bf6ec63b5bb",
+      "id": "65d86638218150ecf514c478",
       "title": "Task 66"
     },
     {
-      "id": "65d869b6f586e1f9a02aa19b",
+      "id": "65d867969a26ebf43e31297d",
       "title": "Task 67"
     },
     {
-      "id": "65d86af6cdfed1fcab11abbe",
+      "id": "65d868a1bdc45bf6ec63b5bb",
       "title": "Task 68"
     },
     {
-      "id": "65d86c1b4c4fd6fef305999b",
+      "id": "65d869b6f586e1f9a02aa19b",
       "title": "Task 69"
     },
     {
-      "id": "65d86d187f5ec600eb58fb9e",
+      "id": "65d86af6cdfed1fcab11abbe",
       "title": "Task 70"
     },
     {
-      "id": "65d86e08994c4a0436d92766",
+      "id": "65d86c1b4c4fd6fef305999b",
       "title": "Task 71"
     },
     {
-      "id": "65d86f2835110e0770f5333f",
+      "id": "65d86d187f5ec600eb58fb9e",
       "title": "Task 72"
     },
     {
-      "id": "65d87217064c730ef7bc63fe",
+      "id": "65d86e08994c4a0436d92766",
       "title": "Task 73"
     },
     {
-      "id": "65d74e055819ee970713e509",
+      "id": "65d86f2835110e0770f5333f",
       "title": "Task 74"
     },
     {
-      "id": "65d74fe1b1db8c9b43fb93fd",
+      "id": "65d87217064c730ef7bc63fe",
       "title": "Task 75"
     },
     {
-      "id": "65d8713fd64b650c269676cd",
+      "id": "65d74e055819ee970713e509",
       "title": "Task 76"
     },
     {
-      "id": "65d881130285e11fd1a6f790",
+      "id": "65d74fe1b1db8c9b43fb93fd",
       "title": "Task 77"
+    },
+    {
+      "id": "65d8713fd64b650c269676cd",
+      "title": "Task 78"
+    },
+    {
+      "id": "65d881130285e11fd1a6f790",
+      "title": "Task 79"
+    },
+    {
+      "id": "685e5b48d4770d0dfbac7497",
+      "title": "Task 80"
     },
     {
       "id": "65d88b76573df039d43f29bc",
@@ -331,43 +343,47 @@
     },
     {
       "id": "65d892ad7262d64a5db56906",
-      "title": "Task 78"
-    },
-    {
-      "id": "65d890f37666763b1c08e284",
-      "title": "Task 79"
-    },
-    {
-      "id": "65d8938e6254064bd4cd63fa",
-      "title": "Task 80"
-    },
-    {
-      "id": "65d8947a2588474f90595bcf",
       "title": "Task 81"
     },
     {
-      "id": "65d89562dff69551e7683df3",
+      "id": "65d890f37666763b1c08e284",
       "title": "Task 82"
     },
     {
-      "id": "65d897caddd4d657e3862b36",
+      "id": "65d8938e6254064bd4cd63fa",
       "title": "Task 83"
     },
     {
-      "id": "65d950cef8533a636d6bd51e",
+      "id": "65d8947a2588474f90595bcf",
       "title": "Task 84"
     },
     {
-      "id": "65d957af14072272d091fc45",
+      "id": "65d89562dff69551e7683df3",
       "title": "Task 85"
     },
     {
-      "id": "65d959d3478ceb77dc1b28a3",
+      "id": "65d897caddd4d657e3862b36",
       "title": "Task 86"
     },
     {
-      "id": "65d95c504f0bce7e8f6a30ea",
+      "id": "65d950cef8533a636d6bd51e",
       "title": "Task 87"
+    },
+    {
+      "id": "65d957af14072272d091fc45",
+      "title": "Task 88"
+    },
+    {
+      "id": "65d959d3478ceb77dc1b28a3",
+      "title": "Task 89"
+    },
+    {
+      "id": "65d95c504f0bce7e8f6a30ea",
+      "title": "Task 90"
+    },
+    {
+      "id": "685e5b7c1213d90e23edb44a",
+      "title": "Task 91"
     },
     {
       "id": "65d9633ff2cc710bd3e18c03",
@@ -375,79 +391,83 @@
     },
     {
       "id": "65d9646cf07b7b0e74fbfe6f",
-      "title": "Task 88"
-    },
-    {
-      "id": "65d9664a976fb114cf9f1928",
-      "title": "Task 89"
-    },
-    {
-      "id": "65d967ec3ad9fb162e3b6d67",
-      "title": "Task 90"
-    },
-    {
-      "id": "65d96b62de43441ee5d01b88",
-      "title": "Task 91"
-    },
-    {
-      "id": "65daa3bcb0ef255d206f91b8",
       "title": "Task 92"
     },
     {
-      "id": "65daa68d2bec806393956a94",
+      "id": "65d9664a976fb114cf9f1928",
       "title": "Task 93"
     },
     {
-      "id": "65daa8143ae77767ad914ba4",
+      "id": "65d967ec3ad9fb162e3b6d67",
       "title": "Task 94"
     },
     {
-      "id": "65daa8cce1b9206995e4aec3",
+      "id": "65d96b62de43441ee5d01b88",
       "title": "Task 95"
     },
     {
-      "id": "65daa9fa35b2dd6c6e29636d",
+      "id": "65daa3bcb0ef255d206f91b8",
       "title": "Task 96"
     },
     {
-      "id": "65daab9b713d3e6e6272c8bf",
+      "id": "65daa68d2bec806393956a94",
       "title": "Task 97"
     },
     {
-      "id": "65dab0c26091a87db218685a",
+      "id": "65daa8143ae77767ad914ba4",
       "title": "Task 98"
     },
     {
-      "id": "65dab1186529467ee5e463a7",
+      "id": "65daa8cce1b9206995e4aec3",
       "title": "Task 99"
     },
     {
-      "id": "65dab20c41a21a817084ecdb",
+      "id": "65daa9fa35b2dd6c6e29636d",
       "title": "Task 100"
     },
     {
-      "id": "65dab50a398b0f851f7a1c9b",
+      "id": "65daab9b713d3e6e6272c8bf",
       "title": "Task 101"
     },
     {
-      "id": "65dab742fb5c1c8d81bb063b",
+      "id": "65dab0c26091a87db218685a",
       "title": "Task 102"
     },
     {
-      "id": "65dabddd6b64319c42b36aa2",
+      "id": "65dab1186529467ee5e463a7",
       "title": "Task 103"
     },
     {
-      "id": "65dabf5eb13aae9ff91c40a2",
+      "id": "65dab20c41a21a817084ecdb",
       "title": "Task 104"
     },
     {
-      "id": "65dacf1ea93489b07bbe48d8",
+      "id": "65dab50a398b0f851f7a1c9b",
       "title": "Task 105"
     },
     {
-      "id": "65dad153fd675cb51e8423b0",
+      "id": "65dab742fb5c1c8d81bb063b",
       "title": "Task 106"
+    },
+    {
+      "id": "65dabddd6b64319c42b36aa2",
+      "title": "Task 107"
+    },
+    {
+      "id": "65dabf5eb13aae9ff91c40a2",
+      "title": "Task 108"
+    },
+    {
+      "id": "65dacf1ea93489b07bbe48d8",
+      "title": "Task 109"
+    },
+    {
+      "id": "65dad153fd675cb51e8423b0",
+      "title": "Task 110"
+    },
+    {
+      "id": "685e60aec4c643115ef37313",
+      "title": "Task 111"
     }
   ],
   "helpCategory": "English",

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d5d17a45be4e4d56be704a.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d5d17a45be4e4d56be704a.md
@@ -1,8 +1,8 @@
 ---
 id: 65d5d17a45be4e4d56be704a
-title: Task 33
+title: Task 34
 challengeType: 22
-dashedName: task-33
+dashedName: task-34
 ---
 
 <!-- (Audio) Tom: Hey, have you ever worked with Anna from HR? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d5d1bdbd0a7f4e3edb6c8e.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d5d1bdbd0a7f4e3edb6c8e.md
@@ -1,8 +1,8 @@
 ---
 id: 65d5d1bdbd0a7f4e3edb6c8e
-title: Task 34
+title: Task 35
 challengeType: 19
-dashedName: task-34
+dashedName: task-35
 ---
 
 <!-- (Audio) Tom: Hey, have you ever worked with Anna from HR? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d5fb1e575bfe649f5cea4b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d5fb1e575bfe649f5cea4b.md
@@ -1,8 +1,8 @@
 ---
 id: 65d5fb1e575bfe649f5cea4b
-title: Task 35
+title: Task 36
 challengeType: 19
-dashedName: task-35
+dashedName: task-36
 ---
 
 <!-- (Audio) Alice: I've seen her a couple of times. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d5feaac55f2d673480abe1.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d5feaac55f2d673480abe1.md
@@ -1,8 +1,8 @@
 ---
 id: 65d5feaac55f2d673480abe1
-title: Task 36
+title: Task 37
 challengeType: 22
-dashedName: task-36
+dashedName: task-37
 ---
 
 <!-- (Audio) Tom: Well, I noticed that she's always in the office super early and leaves pretty late. Do you know why? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d60150d4ac7c73895342cc.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d60150d4ac7c73895342cc.md
@@ -1,8 +1,8 @@
 ---
 id: 65d60150d4ac7c73895342cc
-title: Task 37
+title: Task 38
 challengeType: 19
-dashedName: task-37
+dashedName: task-38
 ---
 
 <!-- (Audio) Tom: Well, I noticed that she's always in the office super early and leaves pretty late. Do you know why? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d60402f5661e79dfddab63.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d60402f5661e79dfddab63.md
@@ -1,8 +1,8 @@
 ---
 id: 65d60402f5661e79dfddab63
-title: Task 38
+title: Task 39
 challengeType: 22
-dashedName: task-38
+dashedName: task-39
 ---
 
 <!-- (Audio) Alice: Yeah, she's very committed. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d60609e931277ebddf1dd8.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d60609e931277ebddf1dd8.md
@@ -1,8 +1,8 @@
 ---
 id: 65d60609e931277ebddf1dd8
-title: Task 39
+title: Task 40
 challengeType: 22
-dashedName: task-39
+dashedName: task-40
 ---
 
 <!-- (Audio) Alice: She seems to take her work very seriously. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d6099b91bfe381c68a12f8.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d6099b91bfe381c68a12f8.md
@@ -1,8 +1,8 @@
 ---
 id: 65d6099b91bfe381c68a12f8
-title: Task 40
+title: Task 41
 challengeType: 22
-dashedName: task-40
+dashedName: task-41
 ---
 
 <!-- (Audio) Alice: She seems to take her work very seriously. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d6b7cfc3544c15a83b2008.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d6b7cfc3544c15a83b2008.md
@@ -1,8 +1,8 @@
 ---
 id: 65d6b7cfc3544c15a83b2008
-title: Task 41
+title: Task 42
 challengeType: 19
-dashedName: task-41
+dashedName: task-42
 ---
 
 <!-- (Audio) Alice: Yeah, she's very committed. She seems to take her work very seriously. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d6bc21bbb3fb20d47cd7ed.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d6bc21bbb3fb20d47cd7ed.md
@@ -1,8 +1,8 @@
 ---
 id: 65d6bc21bbb3fb20d47cd7ed
-title: Task 42
+title: Task 43
 challengeType: 22
-dashedName: task-42
+dashedName: task-43
 ---
 
 <!-- (Audio) Tom: I don't really know her, to be honest. What's her role?

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d6bd19de6bad235879c032.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d6bd19de6bad235879c032.md
@@ -1,8 +1,8 @@
 ---
 id: 65d6bd19de6bad235879c032
-title: Task 43
+title: Task 44
 challengeType: 22
-dashedName: task-43
+dashedName: task-44
 ---
 
 <!-- (Audio) Alice: Anna is the head of HR, and she has to make sure our company runs smoothly when it comes to HR. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d6bfc0ef75202990f3c838.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d6bfc0ef75202990f3c838.md
@@ -1,8 +1,8 @@
 ---
 id: 65d6bfc0ef75202990f3c838
-title: Task 44
+title: Task 45
 challengeType: 22
-dashedName: task-44
+dashedName: task-45
 ---
 
 <!-- (Audio) Alice: Anna is the head of HR, and she has to make sure our company runs smoothly when it comes to HR. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d6c0b53262202bf8813f73.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d6c0b53262202bf8813f73.md
@@ -1,8 +1,8 @@
 ---
 id: 65d6c0b53262202bf8813f73
-title: Task 45
+title: Task 46
 challengeType: 22
-dashedName: task-45
+dashedName: task-46
 ---
 
 <!-- (Audio) Alice: Anna is the head of HR, and she has to make sure our company runs smoothly when it comes to HR. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d6c19c1a1dc52e536a8e21.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d6c19c1a1dc52e536a8e21.md
@@ -1,8 +1,8 @@
 ---
 id: 65d6c19c1a1dc52e536a8e21
-title: Task 46
+title: Task 47
 challengeType: 19
-dashedName: task-46
+dashedName: task-47
 ---
 
 <!-- (Audio) Tom: What's her role?

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d6c390f03b85333445b5e4.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d6c390f03b85333445b5e4.md
@@ -1,8 +1,8 @@
 ---
 id: 65d6c390f03b85333445b5e4
-title: Task 47
+title: Task 48
 challengeType: 22
-dashedName: task-47
+dashedName: task-48
 ---
 
 <!-- (Audio) Alice: She doesn't have to interview for hiring people, though. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d6c7f99ec5d13d543dccf4.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d6c7f99ec5d13d543dccf4.md
@@ -1,8 +1,8 @@
 ---
 id: 65d6c7f99ec5d13d543dccf4
-title: Task 48
+title: Task 49
 challengeType: 22
-dashedName: task-48
+dashedName: task-49
 ---
 
 <!-- (Audio) Alice: She doesn't have to interview for hiring people, though. The rest of the HR team does the interviews. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d6c8c2c21ad83f837b4bb9.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d6c8c2c21ad83f837b4bb9.md
@@ -1,8 +1,8 @@
 ---
 id: 65d6c8c2c21ad83f837b4bb9
-title: Task 49
+title: Task 50
 challengeType: 19
-dashedName: task-49
+dashedName: task-50
 ---
 
 <!-- (Audio) Alice: She doesn't have to interview for hiring people, though. The rest of the HR team does the interviews. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d6ca37133db041a059b352.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d6ca37133db041a059b352.md
@@ -1,8 +1,8 @@
 ---
 id: 65d6ca37133db041a059b352
-title: Task 50
+title: Task 51
 challengeType: 19
-dashedName: task-50
+dashedName: task-51
 ---
 
 <!-- (Audio) Alice: She's been with us for about eight years now. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d6cb8800b1274686877c25.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d6cb8800b1274686877c25.md
@@ -1,8 +1,8 @@
 ---
 id: 65d6cb8800b1274686877c25
-title: Task 51
+title: Task 52
 challengeType: 22
-dashedName: task-51
+dashedName: task-52
 ---
 
 <!-- (Audio) Tom: Wow, that's a long time. Is she a strict person? Alice: She's very easygoing, actually. She's serious when it comes to work but also has a good sense of humor. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d6cc2551fe584833cd6cda.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d6cc2551fe584833cd6cda.md
@@ -1,8 +1,8 @@
 ---
 id: 65d6cc2551fe584833cd6cda
-title: Task 52
+title: Task 53
 challengeType: 19
-dashedName: task-52
+dashedName: task-53
 ---
 
 <!-- (Audio) Tom: Wow, that's a long time. Is she a strict person? Alice: She's very easygoing, actually. She's serious when it comes to work but also has a good sense of humor. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d6cd757478424b84d7f445.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d6cd757478424b84d7f445.md
@@ -1,8 +1,8 @@
 ---
 id: 65d6cd757478424b84d7f445
-title: Task 53
+title: Task 54
 challengeType: 22
-dashedName: task-53
+dashedName: task-54
 ---
 
 <!-- (Audio) Alice: She's fair and supportive, always willing to help and answer questions. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d6dadcc5e50f5d3d3c8e95.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d6dadcc5e50f5d3d3c8e95.md
@@ -1,8 +1,8 @@
 ---
 id: 65d6dadcc5e50f5d3d3c8e95
-title: Task 54
+title: Task 55
 challengeType: 19
-dashedName: task-54
+dashedName: task-55
 ---
 
 <!-- (Audio) Alice: She's fair and supportive, always willing to help and answer questions. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d6dc5686b49d61612472e0.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d6dc5686b49d61612472e0.md
@@ -1,8 +1,8 @@
 ---
 id: 65d6dc5686b49d61612472e0
-title: Task 55
+title: Task 56
 challengeType: 22
-dashedName: task-55
+dashedName: task-56
 ---
 
 <!-- (Audio) Tom: She sounds like a great person. I should have a chat with her sometime. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d6dd0d7fc3c563482b8ad6.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d6dd0d7fc3c563482b8ad6.md
@@ -1,8 +1,8 @@
 ---
 id: 65d6dd0d7fc3c563482b8ad6
-title: Task 56
+title: Task 57
 challengeType: 19
-dashedName: task-56
+dashedName: task-57
 ---
 
 <!-- (Audio) Tom: She sounds like a great person. I should have a chat with her sometime. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d7480fba8a2b88f5499094.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d7480fba8a2b88f5499094.md
@@ -1,8 +1,8 @@
 ---
 id: 65d7480fba8a2b88f5499094
-title: Task 57
+title: Task 59
 challengeType: 22
-dashedName: task-57
+dashedName: task-59
 ---
 
 <!-- (Audio) Tom: I got this message saying I must talk with Jeff from the Security department. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d74ca5293a7b9397dec0e6.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d74ca5293a7b9397dec0e6.md
@@ -1,8 +1,8 @@
 ---
 id: 65d74ca5293a7b9397dec0e6
-title: Task 58
+title: Task 60
 challengeType: 19
-dashedName: task-58
+dashedName: task-60
 ---
 
 <!-- (Audio) Tom: I got this message saying I must talk with Jeff from the Security department. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d74e055819ee970713e509.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d74e055819ee970713e509.md
@@ -1,8 +1,8 @@
 ---
 id: 65d74e055819ee970713e509
-title: Task 74
+title: Task 76
 challengeType: 22
-dashedName: task-74
+dashedName: task-76
 ---
 
 <!-- (Audio) Maria: You mustn't share your access codes or passwords with anyone. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d74fe1b1db8c9b43fb93fd.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d74fe1b1db8c9b43fb93fd.md
@@ -1,8 +1,8 @@
 ---
 id: 65d74fe1b1db8c9b43fb93fd
-title: Task 75
+title: Task 77
 challengeType: 19
-dashedName: task-75
+dashedName: task-77
 ---
 
 <!-- (Audio) Maria: You mustn't share your access codes or passwords with anyone. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d750f42fb8c69d48edb565.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d750f42fb8c69d48edb565.md
@@ -1,8 +1,8 @@
 ---
 id: 65d750f42fb8c69d48edb565
-title: Task 59
+title: Task 61
 challengeType: 22
-dashedName: task-59
+dashedName: task-61
 ---
 
 <!-- (Audio) Maria: Yeah, I've seen him around. He's responsible for security operations in our company. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d75185d536899fd3c01977.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d75185d536899fd3c01977.md
@@ -1,8 +1,8 @@
 ---
 id: 65d75185d536899fd3c01977
-title: Task 60
+title: Task 62
 challengeType: 19
-dashedName: task-60
+dashedName: task-62
 ---
 
 <!-- (Audio) Maria: Yeah, I've seen him around. He's responsible for security operations in our company. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d752c6240228a36a5a3ac3.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d752c6240228a36a5a3ac3.md
@@ -1,8 +1,8 @@
 ---
 id: 65d752c6240228a36a5a3ac3
-title: Task 61
+title: Task 63
 challengeType: 22
-dashedName: task-61
+dashedName: task-63
 ---
 
 <!-- (Audio) Maria: He's been with us for some time, nearly 10 years. He's tall and has curly hair. He always has this vigilant look, probably a result of his job. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d862dca01bd8e8a6f7561b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d862dca01bd8e8a6f7561b.md
@@ -1,8 +1,8 @@
 ---
 id: 65d862dca01bd8e8a6f7561b
-title: Task 62
+title: Task 64
 challengeType: 22
-dashedName: task-62
+dashedName: task-64
 ---
 
 <!-- (Audio) Tom: He sounds like a dedicated professional. I've always wondered what the folks in security do around here. What are his responsibilities? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d863be0ea26dea821fb459.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d863be0ea26dea821fb459.md
@@ -1,8 +1,8 @@
 ---
 id: 65d863be0ea26dea821fb459
-title: Task 63
+title: Task 65
 challengeType: 19
-dashedName: task-63
+dashedName: task-65
 ---
 
 <!-- (Audio) Tom: He sounds like a dedicated professional. I've always wondered what the folks in security do around here. What are his responsibilities? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d86638218150ecf514c478.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d86638218150ecf514c478.md
@@ -1,8 +1,8 @@
 ---
 id: 65d86638218150ecf514c478
-title: Task 64
+title: Task 66
 challengeType: 22
-dashedName: task-64
+dashedName: task-66
 ---
 
 <!-- (Audio) Maria: He makes sure the company's data and facilities are secure, monitors access controls, and conducts investigations when needed. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d867969a26ebf43e31297d.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d867969a26ebf43e31297d.md
@@ -1,8 +1,8 @@
 ---
 id: 65d867969a26ebf43e31297d
-title: Task 65
+title: Task 67
 challengeType: 22
-dashedName: task-65
+dashedName: task-67
 ---
 
 <!-- (Audio) Maria: He makes sure the company's data and facilities are secure, monitors access controls, and conducts investigations when needed. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d868a1bdc45bf6ec63b5bb.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d868a1bdc45bf6ec63b5bb.md
@@ -1,8 +1,8 @@
 ---
 id: 65d868a1bdc45bf6ec63b5bb
-title: Task 66
+title: Task 68
 challengeType: 22
-dashedName: task-66
+dashedName: task-68
 ---
 
 <!-- (Audio) Maria: He makes sure the company's data and facilities are secure, monitors access controls, and conducts investigations when needed. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d869b6f586e1f9a02aa19b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d869b6f586e1f9a02aa19b.md
@@ -1,8 +1,8 @@
 ---
 id: 65d869b6f586e1f9a02aa19b
-title: Task 67
+title: Task 69
 challengeType: 19
-dashedName: task-67
+dashedName: task-69
 ---
 
 <!-- (Audio) Maria: He makes sure the company's data and facilities are secure, monitors access controls, and conducts investigations when needed. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d86af6cdfed1fcab11abbe.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d86af6cdfed1fcab11abbe.md
@@ -1,8 +1,8 @@
 ---
 id: 65d86af6cdfed1fcab11abbe
-title: Task 68
+title: Task 70
 challengeType: 22
-dashedName: task-68
+dashedName: task-70
 ---
 
 <!-- (Audio) Maria: He also ensures that everyone follows security procedures. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d86c1b4c4fd6fef305999b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d86c1b4c4fd6fef305999b.md
@@ -1,8 +1,8 @@
 ---
 id: 65d86c1b4c4fd6fef305999b
-title: Task 69
+title: Task 71
 challengeType: 19
-dashedName: task-69
+dashedName: task-71
 ---
 
 <!-- (Audio) Maria: He also ensures that everyone follows security procedures. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d86d187f5ec600eb58fb9e.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d86d187f5ec600eb58fb9e.md
@@ -1,8 +1,8 @@
 ---
 id: 65d86d187f5ec600eb58fb9e
-title: Task 70
+title: Task 72
 challengeType: 22
-dashedName: task-70
+dashedName: task-72
 ---
 
 <!-- (Audio) Tom: Ah, speaking of procedures, is there anything he told you that we need to do when it comes to office security? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d86e08994c4a0436d92766.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d86e08994c4a0436d92766.md
@@ -1,8 +1,8 @@
 ---
 id: 65d86e08994c4a0436d92766
-title: Task 71
+title: Task 73
 challengeType: 19
-dashedName: task-71
+dashedName: task-73
 ---
 
 <!-- (Audio) Tom: Ah, speaking of procedures, is there anything he's told you that we need to do when it comes to office security? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d86f2835110e0770f5333f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d86f2835110e0770f5333f.md
@@ -1,8 +1,8 @@
 ---
 id: 65d86f2835110e0770f5333f
-title: Task 72
+title: Task 74
 challengeType: 22
-dashedName: task-72
+dashedName: task-74
 ---
 
 <!-- (Audio) Maria: Yes, there is one thing he emphasizes: you mustn't share your access codes or passwords with anyone. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d8713fd64b650c269676cd.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d8713fd64b650c269676cd.md
@@ -1,8 +1,8 @@
 ---
 id: 65d8713fd64b650c269676cd
-title: Task 76
+title: Task 78
 challengeType: 22
-dashedName: task-76
+dashedName: task-78
 ---
 
 <!-- (Audio) Maria: Security is a big deal for him.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d87217064c730ef7bc63fe.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d87217064c730ef7bc63fe.md
@@ -1,8 +1,8 @@
 ---
 id: 65d87217064c730ef7bc63fe
-title: Task 73
+title: Task 75
 challengeType: 19
-dashedName: task-73
+dashedName: task-75
 ---
 
 <!-- (Audio) Maria: Yes, there is one thing he emphasizes: you mustn't share your access codes or passwords with anyone. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d881130285e11fd1a6f790.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d881130285e11fd1a6f790.md
@@ -1,8 +1,8 @@
 ---
 id: 65d881130285e11fd1a6f790
-title: Task 77
+title: Task 79
 challengeType: 22
-dashedName: task-77
+dashedName: task-79
 ---
 
 <!-- (Audio) Maria: No problem. If you ever need any security tips, you really must talk to Jeff. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d890f37666763b1c08e284.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d890f37666763b1c08e284.md
@@ -1,8 +1,8 @@
 ---
 id: 65d890f37666763b1c08e284
-title: Task 79
+title: Task 82
 challengeType: 22
-dashedName: task-79
+dashedName: task-82
 ---
 
 <!-- (Audio) Bob: Of course, I'd be happy to. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d892ad7262d64a5db56906.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d892ad7262d64a5db56906.md
@@ -1,8 +1,8 @@
 ---
 id: 65d892ad7262d64a5db56906
-title: Task 78
+title: Task 81
 challengeType: 19
-dashedName: task-78
+dashedName: task-81
 ---
 
 <!-- (Audio) Sophie: Bob, could you tell me about your job and your responsibilities in the office?

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d8938e6254064bd4cd63fa.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d8938e6254064bd4cd63fa.md
@@ -1,8 +1,8 @@
 ---
 id: 65d8938e6254064bd4cd63fa
-title: Task 80
+title: Task 83
 challengeType: 22
-dashedName: task-80
+dashedName: task-83
 ---
 
 <!-- (Audio) Bob: In my role, I have to meet project deadlines and collaborate with the development team. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d8947a2588474f90595bcf.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d8947a2588474f90595bcf.md
@@ -1,8 +1,8 @@
 ---
 id: 65d8947a2588474f90595bcf
-title: Task 81
+title: Task 84
 challengeType: 19
-dashedName: task-81
+dashedName: task-84
 ---
 
 <!-- (Audio) Bob: In my role, I have to meet project deadlines and collaborate with the development team. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d89562dff69551e7683df3.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d89562dff69551e7683df3.md
@@ -1,8 +1,8 @@
 ---
 id: 65d89562dff69551e7683df3
-title: Task 82
+title: Task 85
 challengeType: 22
-dashedName: task-82
+dashedName: task-85
 ---
 
 <!-- (Audio) Bob: I also can't disclose sensitive information to anyone outside of the company. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d897caddd4d657e3862b36.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d897caddd4d657e3862b36.md
@@ -1,8 +1,8 @@
 ---
 id: 65d897caddd4d657e3862b36
-title: Task 83
+title: Task 86
 challengeType: 19
-dashedName: task-83
+dashedName: task-86
 ---
 
 <!-- (Audio) Bob: I also can't disclose sensitive information to anyone outside the company. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d950cef8533a636d6bd51e.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d950cef8533a636d6bd51e.md
@@ -1,8 +1,8 @@
 ---
 id: 65d950cef8533a636d6bd51e
-title: Task 84
+title: Task 87
 challengeType: 22
-dashedName: task-84
+dashedName: task-87
 ---
 
 <!-- (Audio) Sophie: What about daily tasks? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d957af14072272d091fc45.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d957af14072272d091fc45.md
@@ -1,8 +1,8 @@
 ---
 id: 65d957af14072272d091fc45
-title: Task 85
+title: Task 88
 challengeType: 22
-dashedName: task-85
+dashedName: task-88
 ---
 
 <!-- (Audio) Bob: Well, I have to attend team meetings and provide progress reports, but I don't have to work overtime unless it's an urgent situation. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d959d3478ceb77dc1b28a3.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d959d3478ceb77dc1b28a3.md
@@ -1,8 +1,8 @@
 ---
 id: 65d959d3478ceb77dc1b28a3
-title: Task 86
+title: Task 89
 challengeType: 22
-dashedName: task-86
+dashedName: task-89
 ---
 
 <!-- (Audio) Bob: Well, I have to attend team meetings and provide progress reports, but I don't have to work overtime unless it's an urgent situation. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d95c504f0bce7e8f6a30ea.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d95c504f0bce7e8f6a30ea.md
@@ -1,8 +1,8 @@
 ---
 id: 65d95c504f0bce7e8f6a30ea
-title: Task 87
+title: Task 90
 challengeType: 19
-dashedName: task-87
+dashedName: task-90
 ---
 
 <!-- (Audio) Bob: Well, I have to attend team meetings and provide progress reports, but I don't have to work extra hours unless it's an urgent situation. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d9646cf07b7b0e74fbfe6f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d9646cf07b7b0e74fbfe6f.md
@@ -1,8 +1,8 @@
 ---
 id: 65d9646cf07b7b0e74fbfe6f
-title: Task 88
+title: Task 92
 challengeType: 22
-dashedName: task-88
+dashedName: task-92
 ---
 
 <!-- (Audio) Brian: Sophie, how do you manage your work-life balance and your responsibilities outside of the office? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d9664a976fb114cf9f1928.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d9664a976fb114cf9f1928.md
@@ -1,8 +1,8 @@
 ---
 id: 65d9664a976fb114cf9f1928
-title: Task 89
+title: Task 93
 challengeType: 19
-dashedName: task-89
+dashedName: task-93
 ---
 
 <!-- (Audio) Brian: Sophie, how do you manage your work-life balance and your responsibilities outside of the office? -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d967ec3ad9fb162e3b6d67.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d967ec3ad9fb162e3b6d67.md
@@ -1,8 +1,8 @@
 ---
 id: 65d967ec3ad9fb162e3b6d67
-title: Task 90
+title: Task 94
 challengeType: 22
-dashedName: task-90
+dashedName: task-94
 ---
 
 <!-- (Audio) Sophie: It's not always easy, but I've found ways to make it work. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d96b62de43441ee5d01b88.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65d96b62de43441ee5d01b88.md
@@ -1,8 +1,8 @@
 ---
 id: 65d96b62de43441ee5d01b88
-title: Task 91
+title: Task 95
 challengeType: 19
-dashedName: task-91
+dashedName: task-95
 ---
 
 <!-- (Audio) Sophie: It's not always easy, but I've found ways to make it work. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65daa3bcb0ef255d206f91b8.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65daa3bcb0ef255d206f91b8.md
@@ -1,8 +1,8 @@
 ---
 id: 65daa3bcb0ef255d206f91b8
-title: Task 92
+title: Task 96
 challengeType: 22
-dashedName: task-92
+dashedName: task-96
 ---
 
 <!-- (Audio) Brian: Tell me about your responsibilities beyond work. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65daa68d2bec806393956a94.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65daa68d2bec806393956a94.md
@@ -1,8 +1,8 @@
 ---
 id: 65daa68d2bec806393956a94
-title: Task 93
+title: Task 97
 challengeType: 22
-dashedName: task-93
+dashedName: task-97
 ---
 
 <!-- (Audio) Sophie: Well, I have to make time for my family – that's really important to me. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65daa8143ae77767ad914ba4.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65daa8143ae77767ad914ba4.md
@@ -1,8 +1,8 @@
 ---
 id: 65daa8143ae77767ad914ba4
-title: Task 94
+title: Task 98
 challengeType: 22
-dashedName: task-94
+dashedName: task-98
 ---
 
 <!-- (Audio) Sophie: I also don't want to neglect my health, so two months ago I started jogging regularly. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65daa8cce1b9206995e4aec3.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65daa8cce1b9206995e4aec3.md
@@ -1,8 +1,8 @@
 ---
 id: 65daa8cce1b9206995e4aec3
-title: Task 95
+title: Task 99
 challengeType: 22
-dashedName: task-95
+dashedName: task-99
 ---
 
 <!-- (Audio) Sophie: I also don't want to neglect my health, so two months ago I started jogging regularly. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65daa9fa35b2dd6c6e29636d.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65daa9fa35b2dd6c6e29636d.md
@@ -1,8 +1,8 @@
 ---
 id: 65daa9fa35b2dd6c6e29636d
-title: Task 96
+title: Task 100
 challengeType: 19
-dashedName: task-96
+dashedName: task-100
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65daab9b713d3e6e6272c8bf.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65daab9b713d3e6e6272c8bf.md
@@ -1,8 +1,8 @@
 ---
 id: 65daab9b713d3e6e6272c8bf
-title: Task 97
+title: Task 101
 challengeType: 22
-dashedName: task-97
+dashedName: task-101
 ---
 
 <!-- (Audio) Sophie: I also don't want to neglect my health, so two months ago I started jogging regularly. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65dab0c26091a87db218685a.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65dab0c26091a87db218685a.md
@@ -1,8 +1,8 @@
 ---
 id: 65dab0c26091a87db218685a
-title: Task 98
+title: Task 102
 challengeType: 22
-dashedName: task-98
+dashedName: task-102
 ---
 
 <!-- (Audio) Sophie: It helps me relax and stay fit. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65dab1186529467ee5e463a7.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65dab1186529467ee5e463a7.md
@@ -1,8 +1,8 @@
 ---
 id: 65dab1186529467ee5e463a7
-title: Task 99
+title: Task 103
 challengeType: 19
-dashedName: task-99
+dashedName: task-103
 ---
 
 <!-- (Audio) Brian: Tell me about your responsibilities beyond work.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65dab20c41a21a817084ecdb.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65dab20c41a21a817084ecdb.md
@@ -1,8 +1,8 @@
 ---
 id: 65dab20c41a21a817084ecdb
-title: Task 100
+title: Task 104
 challengeType: 22
-dashedName: task-100
+dashedName: task-104
 ---
 
 <!-- (Audio) Brian: It sounds like you're doing great dealing with work and life responsibilities at the same time. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65dab50a398b0f851f7a1c9b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65dab50a398b0f851f7a1c9b.md
@@ -1,8 +1,8 @@
 ---
 id: 65dab50a398b0f851f7a1c9b
-title: Task 101
+title: Task 105
 challengeType: 19
-dashedName: task-101
+dashedName: task-105
 ---
 
 <!-- (Audio) Brian: It sounds like you're doing great dealing with work and life responsibilities at the same time. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65dab742fb5c1c8d81bb063b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65dab742fb5c1c8d81bb063b.md
@@ -1,8 +1,8 @@
 ---
 id: 65dab742fb5c1c8d81bb063b
-title: Task 102
+title: Task 106
 challengeType: 22
-dashedName: task-102
+dashedName: task-106
 ---
 
 <!-- (Audio) Sophie: Thank you. It's all about finding the right balance for you and your well-being. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65dabddd6b64319c42b36aa2.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65dabddd6b64319c42b36aa2.md
@@ -1,8 +1,8 @@
 ---
 id: 65dabddd6b64319c42b36aa2
-title: Task 103
+title: Task 107
 challengeType: 19
-dashedName: task-103
+dashedName: task-107
 ---
 
 <!-- (Audio) Sophie: Thank you. It's all about finding the right balance for you and your well-being. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65dabf5eb13aae9ff91c40a2.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65dabf5eb13aae9ff91c40a2.md
@@ -1,8 +1,8 @@
 ---
 id: 65dabf5eb13aae9ff91c40a2
-title: Task 104
+title: Task 108
 challengeType: 22
-dashedName: task-104
+dashedName: task-108
 ---
 
 <!-- (Audio) Sophie: And you don't have to search for expensive solutions for that. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65dacf1ea93489b07bbe48d8.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65dacf1ea93489b07bbe48d8.md
@@ -1,8 +1,8 @@
 ---
 id: 65dacf1ea93489b07bbe48d8
-title: Task 105
+title: Task 109
 challengeType: 22
-dashedName: task-105
+dashedName: task-109
 ---
 
 <!-- (Audio) Sophie: Sometimes, it's the simple and free things that bring us the result we're looking for. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65dad153fd675cb51e8423b0.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/65dad153fd675cb51e8423b0.md
@@ -1,8 +1,8 @@
 ---
 id: 65dad153fd675cb51e8423b0
-title: Task 106
+title: Task 110
 challengeType: 19
-dashedName: task-106
+dashedName: task-110
 ---
 
 <!-- (Audio) Sophie: Sometimes, it's the simple and free things that bring us the result we're looking for. -->

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/685e5aca93db0b0d9d7dc088.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/685e5aca93db0b0d9d7dc088.md
@@ -1,0 +1,90 @@
+---
+id: 685e5aca93db0b0d9d7dc088
+title: Task 33
+challengeType: 22
+dashedName: task-33
+---
+
+<!-- REVIEW -->
+
+# --description--
+
+This is a review of the entire dialogue you just studied.
+
+# --instructions--
+
+Write the following words or phrases in the correct spot:
+
+`Word is`, `organized`, `in charge of`, `excellent at`, `hiring people`, `best interests`, and `in our company`.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`Bob: Hey, have you met Anna yet? She's now BLANK the HR department.`
+
+`Sophie: No, I haven't seen her yet. What can you tell me about her?`
+
+`Bob: She is a tall woman in her early 40s, with long blond hair and glasses. You'll recognize her right away. She's quite serious and BLANK, which makes her BLANK her job. She's been working with tech companies for about ten years.`
+
+`Sophie: Ten years? That's impressive! What does she do exactly?`
+
+`Bob: Well, she's responsible for BLANK and taking care of workers. She makes sure we follow the rules and that everyone is happy. BLANK that she's strict but fair, and she always looks out for the BLANK of the team.`
+
+`Sophie: Those are very positive things you've just said. I'm excited we have someone like her BLANK. I'd love to chat with her sometime and learn from her experiences.`
+
+## --blanks--
+
+`in charge of`
+
+### --feedback--
+
+Responsible for something or leading a team or task.
+
+---
+
+`organized`
+
+### --feedback--
+
+Good at planning and keeping things in order.
+
+---
+
+`excellent at`
+
+### --feedback--
+
+Very good at doing something.
+
+---
+
+`hiring people`
+
+### --feedback--
+
+Choosing and bringing new employees into a company.
+
+---
+
+`Word is`
+
+### --feedback--
+
+A phrase used to share something you've heard from others. The first letter is capitalized.
+
+---
+
+`best interests`
+
+### --feedback--
+
+What is most helpful or good for someone or a group.
+
+---
+
+`in our company`
+
+### --feedback--
+
+Part of the business or team where you work.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/685e5b186e34570dd3d2ff19.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/685e5b186e34570dd3d2ff19.md
@@ -1,0 +1,88 @@
+---
+id: 685e5b186e34570dd3d2ff19
+title: Task 58
+challengeType: 22
+dashedName: task-58
+---
+
+<!-- REVIEW -->
+
+# --description--
+
+This is a review of the entire dialogue you just studied.
+
+# --instructions--
+
+Write the following words or phrases in the correct spot:
+
+`from HR`, `runs smoothly`, `committed`, `willing to help`, `interviews`, and `easygoing`.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`Tom: Hey, have you ever worked with Anna BLANK?`
+
+`Alice: I've seen her a couple of times. Why do you ask?`
+
+`Tom: Well, I noticed that she's always in her office super early and leaves pretty late. Do you know why?`
+
+`Alice: Yeah, she's very BLANK. She seems to take her work very seriously.`
+
+`Tom: I don't really know much about her, to be honest. What's her role?`
+
+`Alice: Anna is the head of HR, and she has to make sure our company BLANK when it comes to HR. She doesn't have to interview for hiring people, though. The rest of the HR team does the BLANK. She's been with us for about eight years now.`
+
+`Tom: Wow, that's a long time! Is she a strict person?`
+
+`Alice: She's very BLANK, actually. She's serious when it comes to work but also has a good sense of humor. She's fair and supportive, always BLANK and answer questions.`
+
+`Tom: She sounds like a great person. I should have a chat with her sometime.`
+
+## --blanks--
+
+`from HR`
+
+### --feedback--
+
+A person that comes from the `Human Resources` team.
+
+---
+
+`committed`
+
+### --feedback--
+
+Loyal and serious about doing something well.
+
+---
+
+`runs smoothly`
+
+### --feedback--
+
+Happens without problems or delays.
+
+---
+
+`interviews`
+
+### --feedback--
+
+Meetings where someone is asked questions, usually for a job.
+
+---
+
+`easygoing`
+
+### --feedback--
+
+Relaxed and not easily upset.
+
+---
+
+`willing to help`
+
+### --feedback--
+
+Happy to give support or do something for someone.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/685e5b48d4770d0dfbac7497.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/685e5b48d4770d0dfbac7497.md
@@ -1,0 +1,86 @@
+---
+id: 685e5b48d4770d0dfbac7497
+title: Task 80
+challengeType: 22
+dashedName: task-80
+---
+
+<!-- REVIEW -->
+
+# --description--
+
+This is a review of the entire dialogue you just studied.
+
+# --instructions--
+
+Write the following words or phrases in the correct spot:
+
+`when needed`, `emphasizes`, `security operations`, `dedicated professional`, `security`, and `department`.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`Tom: I got this message saying I must talk to Jeff from the Security BLANK. Do you know him?`
+
+`Maria: Yeah, I've seen him around. He's responsible for BLANK in our company. He's been with us for some time, nearly ten years. He's tall and has curly hair. He always has this vigilant look, probably a result of his job.`
+
+`Tom: He sounds like a BLANK. I've always wondered what the folks in security do around here. What are his responsibilities?`
+
+`Maria: He makes sure the company's data and facilities are secure, monitors access controls, and conducts investigations BLANK. He also ensures that everyone follows security procedures.`
+
+`Tom: Ah, speaking of procedures, is there anything he's told you that we need to do when it comes to office BLANK?`
+
+`Maria: Yes, there is one thing he BLANK: you mustn't share your access cards or passwords with anyone. Security is a big deal for him.`
+
+`Tom: Understandable. Well, thanks.`
+
+`Maria: No problem. If you ever need any security tips, you really must talk to Jeff.`
+
+## --blanks--
+
+`department`
+
+### --feedback--
+
+A part of a company that does a specific type of work.
+
+---
+
+`security operations`
+
+### --feedback--
+
+The work of protecting systems, data, and people in a company.
+
+---
+
+`dedicated professional`
+
+### --feedback--
+
+Someone who works hard and takes their job seriously.
+
+---
+
+`when needed`
+
+### --feedback--
+
+Only at the time something is required.
+
+---
+
+`security`
+
+### --feedback--
+
+Protection from danger or keeping something safe.
+
+---
+
+`emphasizes`
+
+### --feedback--
+
+Shows that something is very important or gives it special attention.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/685e5b7c1213d90e23edb44a.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/685e5b7c1213d90e23edb44a.md
@@ -1,0 +1,78 @@
+---
+id: 685e5b7c1213d90e23edb44a
+title: Task 91
+challengeType: 22
+dashedName: task-91
+---
+
+<!-- REVIEW -->
+
+# --description--
+
+This is a review of the entire dialogue you just studied.
+
+# --instructions--
+
+Write the following words or phrases in the correct spot:
+
+`responsibilities`, `work overtime`, `deadlines`, `meetings`, and `collaborate with`.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`Sophie: Bob, could you tell me about your job and your BLANK in the office?`
+
+`Bob: Of course, I'd be happy to. In my role, I have to meet project BLANK and BLANK the development team. I also can't disclose sensitive information to anyone outside the company.`
+
+`Sophie: What about daily tasks?`
+
+`Bob: Well, I have to attend team BLANK and provide progress reports, but I don't have to BLANK unless it's an urgent situation.`
+
+## --blanks--
+
+`responsibilities`
+
+### --feedback--
+
+The tasks or duties you are expected to do.
+
+---
+
+`deadlines`
+
+### --feedback--
+
+The latest time or date when something must be finished.
+
+---
+
+`collaborate with`
+
+### --feedback--
+
+To work together with other people to reach a goal.
+
+---
+
+`sensitive information`
+
+### --feedback--
+
+Private or important data that must be kept safe.
+
+---
+
+`meetings`
+
+### --feedback--
+
+Gatherings where people talk about work or make decisions.
+
+---
+
+`work overtime`
+
+### --feedback--
+
+To work longer than the normal hours.

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/685e5b7c1213d90e23edb44a.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/685e5b7c1213d90e23edb44a.md
@@ -55,14 +55,6 @@ To work together with other people to reach a goal.
 
 ---
 
-`sensitive information`
-
-### --feedback--
-
-Private or important data that must be kept safe.
-
----
-
 `meetings`
 
 ### --feedback--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/685e60aec4c643115ef37313.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-discuss-roles-and-responsibilies/685e60aec4c643115ef37313.md
@@ -1,0 +1,82 @@
+---
+id: 685e60aec4c643115ef37313
+title: Task 111
+challengeType: 22
+dashedName: task-111
+---
+
+<!-- REVIEW -->
+
+# --description--
+
+This is a review of the entire dialogue you just studied.
+
+# --instructions--
+
+Write the following words or phrases in the correct spot:
+
+`regularly`, `work-life balance`, `expensive solutions`, `beyond work`, `right balance`, and `relax`.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`Brian: Sophie, how do you manage your BLANK and your responsibilities outside of the office?`
+
+`Sophie: It's not always easy, but I've found ways to make it work.`
+
+`Brian: Tell me about your responsibilities BLANK.`
+
+`Sophie: Well, I have to make time for my family – that's really important to me. I also don't want to neglect my health, so two months ago I started jogging BLANK. It helps me BLANK and stay fit.`
+
+`Brian: It sounds like you're doing great dealing with work and life responsibilities at the same time.`
+
+`Sophie: Thank you. It's all about finding the BLANK for you and your well-being. And you don't have to search for BLANK for that. Sometimes, it's the simple and free things that bring us the result we're looking for.`
+
+## --blanks--
+
+`work-life balance`
+
+### --feedback--
+
+Having enough time for both your job and your personal life.
+
+---
+
+`beyond work`
+
+### --feedback--
+
+Things that are not related to your job.
+
+---
+
+`regularly`
+
+### --feedback--
+
+Happening often or on a set schedule.
+
+---
+
+`relax`
+
+### --feedback--
+
+To rest and feel calm.
+
+---
+
+`right balance`
+
+### --feedback--
+
+A good mix between different things, like work and free time.
+
+---
+
+`expensive solutions`
+
+### --feedback--
+
+Fixes or options that cost a lot of money.


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

Related to https://github.com/freeCodeCamp/freeCodeCamp/issues/55293

The EC team found that "summary tasks" were ineffective and confusing for learners, as noted in the related issue. In the B1 curriculum, we replaced them with "review tasks."

This PR is part of a series to apply the same changes to the A2 curriculum. To keep reviews easier, I'm splitting the updates into multiple PRs. This one covers Block 9.
