### PR TITLE
chore(curriculum): replace find_case_body helper

### DIFF
--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-interfaces-by-building-an-equation-solver/667944fed1f6b61da3406bd8.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-interfaces-by-building-an-equation-solver/667944fed1f6b61da3406bd8.md
@@ -38,7 +38,7 @@ You should create a new `case` with the pattern `0`.
 You should assign a list containing `'No real roots'` to `result_list` inside the `case` body.
 
 ```js
-({ test: () => assert(runPython(`_Node(_code).find_function("solver").find_matches()[0].find_match_cases()[0].find_case_body().is_equivalent("result_list = ['No real roots']")`)) })
+({ test: () => assert(runPython(`_Node(_code).find_function("solver").find_matches()[0].find_match_cases()[0].find_body().is_equivalent("result_list = ['No real roots']")`)) })
 ```
 
 # --seed--

--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-interfaces-by-building-an-equation-solver/66799278873fd2570217bffa.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-interfaces-by-building-an-equation-solver/66799278873fd2570217bffa.md
@@ -23,7 +23,7 @@ You should not modify your existing `case` block.
 ({ test: () => runPython(`
 case = _Node(_code).find_function("solver").find_matches()[0].find_match_cases()[0]
 assert case.find_case_pattern().is_equivalent("0")
-assert case.find_case_body().is_equivalent("result_list = ['No real roots']")
+assert case.find_body().is_equivalent("result_list = ['No real roots']")
 `) })
 ```
 
@@ -36,7 +36,7 @@ You should create a new `case` with the pattern `1` after the existing `case` bl
 You should assign a list containing `f'x = {results[0]:+}'` to `result_list` inside your new `case` body.
 
 ```js
-({ test: () => assert(runPython(`_Node(_code).find_function("solver").find_matches()[0].find_match_cases()[1].find_case_body().is_equivalent("result_list = [f'x = {results[0]:+}']")`)) })
+({ test: () => assert(runPython(`_Node(_code).find_function("solver").find_matches()[0].find_match_cases()[1].find_body().is_equivalent("result_list = [f'x = {results[0]:+}']")`)) })
 ```
 
 # --seed--

--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-interfaces-by-building-an-equation-solver/6679934707d5fe577f898efd.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-interfaces-by-building-an-equation-solver/6679934707d5fe577f898efd.md
@@ -23,10 +23,10 @@ You should not modify your existing `case` blocks.
 ({ test: () => runPython(`
 case0 = _Node(_code).find_function("solver").find_matches()[0].find_match_cases()[0]
 assert case0.find_case_pattern().is_equivalent("0")
-assert case0.find_case_body().is_equivalent("result_list = ['No real roots']")
+assert case0.find_body().is_equivalent("result_list = ['No real roots']")
 case1 = _Node(_code).find_function("solver").find_matches()[0].find_match_cases()[1]
 assert case1.find_case_pattern().is_equivalent("1")
-assert case1.find_case_body().is_equivalent("result_list = [f'x = {results[0]:+}']")
+assert case1.find_body().is_equivalent("result_list = [f'x = {results[0]:+}']")
 `) })
 ```
 
@@ -39,7 +39,7 @@ You should create a new `case` with the pattern `2` after the existing `case` bl
 You should assign a list containing two strings with the format `x1 = <root1>` and `x2 = <root2>` to `result_list` inside your new `case` body. Display both positive and negative signs for the results.
 
 ```js
-({ test: () => assert(runPython(`_Node(_code).find_function("solver").find_matches()[0].find_match_cases()[2].find_case_body().is_equivalent("result_list = [f'x1 = {results[0]:+}', f'x2 = {results[1]:+}']")`)) })
+({ test: () => assert(runPython(`_Node(_code).find_function("solver").find_matches()[0].find_match_cases()[2].find_body().is_equivalent("result_list = [f'x1 = {results[0]:+}', f'x2 = {results[1]:+}']")`)) })
 ```
 
 # --seed--

--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-interfaces-by-building-an-equation-solver/66799c1a0204668cef35555d.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-interfaces-by-building-an-equation-solver/66799c1a0204668cef35555d.md
@@ -16,13 +16,13 @@ Within the curly braces of the f-strings contained inside `result_list`, write t
 You should modify the string contained in `result_list` in your `case 1` block into `f'x = {results[0]:+.3f}'`.
 
 ```js
-({ test: () => assert(runPython(`_Node(_code).find_function("solver").find_matches()[0].find_match_cases()[1].find_case_body().is_equivalent("result_list = [f'x = {results[0]:+.3f}']")`)) })
+({ test: () => assert(runPython(`_Node(_code).find_function("solver").find_matches()[0].find_match_cases()[1].find_body().is_equivalent("result_list = [f'x = {results[0]:+.3f}']")`)) })
 ```
 
 You should modify the strings contained in `result_list` in your `case 2` block so that the results are displayed with `3` decimal digits.
 
 ```js
-({ test: () => assert(runPython(`_Node(_code).find_function("solver").find_matches()[0].find_match_cases()[2].find_case_body().is_equivalent("result_list = [f'x1 = {results[0]:+.3f}', f'x2 = {results[1]:+.3f}']")`)) })
+({ test: () => assert(runPython(`_Node(_code).find_function("solver").find_matches()[0].find_match_cases()[2].find_body().is_equivalent("result_list = [f'x1 = {results[0]:+.3f}', f'x2 = {results[1]:+.3f}']")`)) })
 ```
 
 # --seed--

--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-interfaces-by-building-an-equation-solver/667a7ce2a9925416e7b4781b.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-interfaces-by-building-an-equation-solver/667a7ce2a9925416e7b4781b.md
@@ -38,7 +38,7 @@ You should modify your first `case` to use the pattern `[]`.
 You should not modify your first `case` body.
 
 ```js
-({ test: () => assert(runPython(`_Node(_code).find_function("solver").find_matches()[0].find_match_cases()[0].find_case_body().is_equivalent("result_list = ['No real roots']")`)) })
+({ test: () => assert(runPython(`_Node(_code).find_function("solver").find_matches()[0].find_match_cases()[0].find_body().is_equivalent("result_list = ['No real roots']")`)) })
 ```
 
 You should modify your second `case` to use the pattern `[x]`.
@@ -50,7 +50,7 @@ You should modify your second `case` to use the pattern `[x]`.
 You should modify the f-string contained inside `result_list` to use `x` in place of `result[0]`.
 
 ```js
-({ test: () => assert(runPython(`_Node(_code).find_function("solver").find_matches()[0].find_match_cases()[1].find_case_body().is_equivalent("result_list = [f'x = {x:+.3f}']")`)) })
+({ test: () => assert(runPython(`_Node(_code).find_function("solver").find_matches()[0].find_match_cases()[1].find_body().is_equivalent("result_list = [f'x = {x:+.3f}']")`)) })
 ```
 
 You should modify your third `case` to use a list containing `x1` and `x2` as the pattern.
@@ -62,7 +62,7 @@ You should modify your third `case` to use a list containing `x1` and `x2` as th
 You should modify the f-strings contained inside `result_list` to use the bound variables from your pattern.
 
 ```js
-({ test: () => assert(runPython(`_Node(_code).find_function("solver").find_matches()[0].find_match_cases()[2].find_case_body().is_equivalent("result_list = [f'x1 = {x1:+.3f}', f'x2 = {x2:+.3f}']")`)) })
+({ test: () => assert(runPython(`_Node(_code).find_function("solver").find_matches()[0].find_match_cases()[2].find_body().is_equivalent("result_list = [f'x1 = {x1:+.3f}', f'x2 = {x2:+.3f}']")`)) })
 ```
 
 # --seed--

--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-interfaces-by-building-an-equation-solver/667a860c3b61f61b7a18930c.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-interfaces-by-building-an-equation-solver/667a860c3b61f61b7a18930c.md
@@ -30,7 +30,7 @@ You should create a new `case` with the pattern `{'slope': slope, 'intercept': i
 You should assign a list containing two f-strings having the form `slope = <slope>` and `y-intercept = <intercept>` to `details_list` inside the `case` body. Remember to format the numerical values to display `3` decimal digits.
 
 ```js
-({ test: () => assert(runPython(`_Node(_code).find_function("solver").find_matches()[1].find_match_cases()[0].find_case_body().is_equivalent("details_list = [f'slope = {slope:.3f}', f'y-intercept = {intercept:.3f}']")`)) })
+({ test: () => assert(runPython(`_Node(_code).find_function("solver").find_matches()[1].find_match_cases()[0].find_body().is_equivalent("details_list = [f'slope = {slope:.3f}', f'y-intercept = {intercept:.3f}']")`)) })
 ```
 
 # --seed--

--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-interfaces-by-building-an-equation-solver/667a8d7a735cf221729570ff.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-interfaces-by-building-an-equation-solver/667a8d7a735cf221729570ff.md
@@ -27,7 +27,7 @@ You should not modify your existing `case` block.
 ({ test: () => runPython(`
 case = _Node(_code).find_function("solver").find_matches()[1].find_match_cases()[0]
 assert case.find_case_pattern().is_equivalent("{'slope': slope, 'intercept': intercept}")
-assert case.find_case_body().is_equivalent("details_list = [f'slope = {slope:.3f}', f'y-intercept = {intercept:.3f}']")
+assert case.find_body().is_equivalent("details_list = [f'slope = {slope:.3f}', f'y-intercept = {intercept:.3f}']")
 `) })
 ```
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
I realized that a dedicated helper to find the body of a `case` statement was not necessary as `find_body` does the job for any node that has a body. Replacing these as I'm planning to remove `find_case_body` from the available helpers.