### PR TITLE
fix(curriculum): improve test for profile card step 4

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef2d357676e50e469165a.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef2d357676e50e469165a.md
@@ -24,10 +24,8 @@ Your `App` component should return an empty string.
 ```js
 // This isn't a perfect test, since various return values are converted into
 // empty strings, but it has to be a valid React component.
-async() => {
-  const testElem = await __helpers.prepTestComponent(window.index.App);
-  assert.equal(testElem.textContent, '');
-}
+const code = __helpers.removeJSComments(window.index.App.toString());
+assert.match(code, /return\s*\(\s*""\s*\)/);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef2d357676e50e469165a.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-reusable-profile-card-component/674ef2d357676e50e469165a.md
@@ -22,8 +22,6 @@ assert.isFunction(window.index.App);
 Your `App` component should return an empty string.
 
 ```js
-// This isn't a perfect test, since various return values are converted into
-// empty strings, but it has to be a valid React component.
 const code = __helpers.removeJSComments(window.index.App.toString());
 assert.match(code, /return\s*\(\s*""\s*\)/);
 ```


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #60931 

<!-- Feel free to add any additional description of changes below this line -->

This PR resolves the issue by replacing the weak test for Step 4 with a stricter regex-based assertion.
