### PR TITLE
fix(curriculum): check for display: flex before flex-direction in .mi…

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-page-of-playing-cards/66be24cb4144f955b6bcc550.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-page-of-playing-cards/66be24cb4144f955b6bcc550.md
@@ -145,7 +145,9 @@ assert.equal(new __helpers.CSSHelp(document).getStyle('.right')?.alignSelf, 'fle
 You should have a `.middle` selector that sets its elements' `flex-direction` to `column`.
 
 ```js
-assert.equal(new __helpers.CSSHelp(document).getStyle('.middle')?.flexDirection, 'column');
+const style = new __helpers.CSSHelp(document).getStyle('.middle');
+assert.equal(style?.display, 'flex');
+assert.equal(style?.flexDirection, 'column');
 ```
 
 # --seed--


### PR DESCRIPTION
…ddle assertion (fixes #61104

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ x] My pull request targets the `main` branch of freeCodeCamp.
- [ x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #61104

<!-- Feel free to add any additional description of changes below this line -->

**Description:**
This PR updates the assertion for the `.middle` selector in the Playing Cards Lab to ensure that the element is a flex container (`display: flex`) before checking for `flex-direction: column`, as required by the user stories.

