### PR TITLE
fix(curriculum): correct flex-direction assertion and check for display flex

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-page-of-playing-cards/66be24cb4144f955b6bcc550.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-page-of-playing-cards/66be24cb4144f955b6bcc550.md
@@ -145,7 +145,12 @@ assert.equal(new __helpers.CSSHelp(document).getStyle('.right')?.alignSelf, 'fle
 You should have a `.middle` selector that sets its elements' `flex-direction` to `column`.
 
 ```js
-assert.equal(new __helpers.CSSHelp(document).getStyle('.middle')?.flexDirection, 'column');
+const middleStyles = new __helpers.CSSHelp(document).getStyle('.middle');
+
+assert.equal(
+  middleStyles?.display === 'flex' && middleStyles?.flexDirection === 'column',
+  true
+);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/lab-page-of-playing-cards/66be24cb4144f955b6bcc550.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-page-of-playing-cards/66be24cb4144f955b6bcc550.md
@@ -142,15 +142,14 @@ You should have a `.right` selector that sets its elements' `align-self` to `fle
 assert.equal(new __helpers.CSSHelp(document).getStyle('.right')?.alignSelf, 'flex-end');
 ```
 
-You should have a `.middle` selector that sets its elements' `flex-direction` to `column`.
+You should have a `.middle` selector that sets its elements' `display` to `flex` and `flex-direction` to `column`.
 
 ```js
 const middleStyles = new __helpers.CSSHelp(document).getStyle('.middle');
 
-assert.equal(
-  middleStyles?.display === 'flex' && middleStyles?.flexDirection === 'column',
-  true
-);
+assert.equal(middleStyles?.display, 'flex');
+assert.equal(middleStyles?.flexDirection, 'column');
+
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:


- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or Gitpod.

Closes: #61104

Description:
Previously, the test only checked for `flex-direction: column` without confirming that the element was a flex container, which could lead to a false positive since `flex-direction` has no effect unless `display` is set to `flex`.

This fix improves the accuracy and reliability of the test by ensuring proper CSS context.

Changes:
- Assigned styles to a variable to avoid multiple calls to `.getStyle()`
- Combined the conditions for `display` and `flex-direction` in a single assertion
