### PR TITLE
fix(curriculum): improve .middle style tests for display and flex-direction

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-page-of-playing-cards/66be24cb4144f955b6bcc550.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-page-of-playing-cards/66be24cb4144f955b6bcc550.md
@@ -142,11 +142,17 @@ You should have a `.right` selector that sets its elements' `align-self` to `fle
 assert.equal(new __helpers.CSSHelp(document).getStyle('.right')?.alignSelf, 'flex-end');
 ```
 
-You should have a `.middle` selector that sets its elements' `flex-direction` to `column`.
+
+You should have a `.middle` selector that sets its elements' `display` to `flex` and `flex-direction` to `column`.
 
 ```js
-assert.equal(new __helpers.CSSHelp(document).getStyle('.middle')?.flexDirection, 'column');
+const middleStyles = new __helpers.CSSHelp(document).getStyle('.middle');
+
+assert.strictEqual(middleStyles?.display, 'flex', 'Expected display to be flex');
+assert.strictEqual(middleStyles?.flexDirection, 'column', 'Expected flexDirection to be column');
+
 ```
+
 
 # --seed--
 

--- a/curriculum/challenges/english/25-front-end-development/lab-page-of-playing-cards/66be24cb4144f955b6bcc550.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-page-of-playing-cards/66be24cb4144f955b6bcc550.md
@@ -142,7 +142,6 @@ You should have a `.right` selector that sets its elements' `align-self` to `fle
 assert.equal(new __helpers.CSSHelp(document).getStyle('.right')?.alignSelf, 'flex-end');
 ```
 
-
 You should have a `.middle` selector that sets its elements' `display` to `flex` and `flex-direction` to `column`.
 
 ```js
@@ -152,6 +151,7 @@ assert.strictEqual(middleStyles?.display, 'flex', 'Expected display to be flex')
 assert.strictEqual(middleStyles?.flexDirection, 'column', 'Expected flexDirection to be column');
 
 ```
+
 
 
 # --seed--


### PR DESCRIPTION
Checklist:



- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine or on Gitpod.


Closes: #61104

Description:
This PR updates the test for the .middle selector to ensure that it is correctly styled as a flex container with a vertical layout.
What This PR Does:
-Adds an assertion to check that .middle has display: flex
-Adds an assertion to confirm that flex-direction: column is applied
-Improves test reliability by explicitly validating both required flexbox properties