### PR TITLE
chore(curriculum): update magazine workshop steps 22–23 to use specific assert methods

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6143cd08fe927072ca3a371d.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6143cd08fe927072ca3a371d.md
@@ -15,8 +15,8 @@ Your second `img` element should have a `src` set to `https://cdn.freecodecamp.o
 
 ```js
 assert.equal(
- document.querySelectorAll('.image-wrapper img')?.[1]?.getAttribute('src'),
- 'https://cdn.freecodecamp.org/testable-projects-fcc/images/calc.png'
+  document.querySelectorAll('.image-wrapper img')?.[1]?.getAttribute('src'),
+  'https://cdn.freecodecamp.org/testable-projects-fcc/images/calc.png'
 );
 ```
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6143cd08fe927072ca3a371d.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6143cd08fe927072ca3a371d.md
@@ -16,7 +16,7 @@ Your second `img` element should have a `src` set to `https://cdn.freecodecamp.o
 ```js
 assert.equal(
  document.querySelectorAll('.image-wrapper img')?.[1]?.getAttribute('src'),
-  'https://cdn.freecodecamp.org/testable-projects-fcc/images/calc.png'
+ 'https://cdn.freecodecamp.org/testable-projects-fcc/images/calc.png'
 );
 ```
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6143cd08fe927072ca3a371d.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6143cd08fe927072ca3a371d.md
@@ -14,37 +14,53 @@ Within your `.image-wrapper` element, give the second `img` element a `src` of `
 Your second `img` element should have a `src` set to `https://cdn.freecodecamp.org/testable-projects-fcc/images/calc.png`.
 
 ```js
-assert(document.querySelectorAll('.image-wrapper img')?.[1]?.getAttribute('src') === 'https://cdn.freecodecamp.org/testable-projects-fcc/images/calc.png');
+assert.equal(
+  document.querySelectorAll('.image-wrapper img')?.[1]?.getAttribute('src'),'https://cdn.freecodecamp.org/testable-projects-fcc/images/calc.png');
 ```
 
 Your second `img` element should have an `alt` set to `image of a calculator project`.
 
 ```js
-assert(document.querySelectorAll('.image-wrapper img')?.[1]?.getAttribute('alt') === 'image of a calculator project');
+assert.equal(
+  document.querySelectorAll('.image-wrapper img')?.[1]?.getAttribute('alt'),
+  'image of a calculator project'
+);
 ```
 
 Your second `img` element should have a `loading` attribute set to `lazy`.
 
 ```js
-assert(document.querySelectorAll('.image-wrapper img')?.[1]?.getAttribute('loading') === 'lazy');
+assert.equal(
+  document.querySelectorAll('.image-wrapper img')?.[1]?.getAttribute('loading'),
+  'lazy'
+);
 ```
 
 Your second `img` element should have a `class` set to `image-2`.
 
 ```js
-assert(document.querySelectorAll('.image-wrapper img')?.[1]?.classList?.contains('image-2'));
+assert.isTrue(
+  document.querySelectorAll('.image-wrapper img')?.[1]?.classList?.contains('image-2')
+);
 ```
 
 Your second `img` element should have a `width` set to `400`.
 
 ```js
-assert(document.querySelectorAll('.image-wrapper img')?.[1]?.getAttribute('width') === '400');
+assert.equal(
+  document.querySelectorAll('.image-wrapper img')?.[1]?.getAttribute('width'),
+  '400'
+);
 ```
 
 Your second `img` element should have a `height` set to `400`.
 
 ```js
-assert(document.querySelectorAll('.image-wrapper img')?.[1]?.getAttribute('height') === '400');
+ assert.equal(
+  document.querySelectorAll('.image-wrapper img')?.[1]?.getAttribute('height'),
+  '400'
+);
+
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6143cd08fe927072ca3a371d.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6143cd08fe927072ca3a371d.md
@@ -15,7 +15,9 @@ Your second `img` element should have a `src` set to `https://cdn.freecodecamp.o
 
 ```js
 assert.equal(
-  document.querySelectorAll('.image-wrapper img')?.[1]?.getAttribute('src'),'https://cdn.freecodecamp.org/testable-projects-fcc/images/calc.png');
+ document.querySelectorAll('.image-wrapper img')?.[1]?.getAttribute('src'),
+  'https://cdn.freecodecamp.org/testable-projects-fcc/images/calc.png'
+);
 ```
 
 Your second `img` element should have an `alt` set to `image of a calculator project`.
@@ -60,7 +62,6 @@ Your second `img` element should have a `height` set to `400`.
   document.querySelectorAll('.image-wrapper img')?.[1]?.getAttribute('height'),
   '400'
 );
-
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6143cdf48b634a747de42104.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6143cdf48b634a747de42104.md
@@ -15,8 +15,8 @@ Your third `img` element should have a `src` set to `https://cdn.freecodecamp.or
 
 ```js
 assert.equal(
-  document.querySelectorAll('.image-wrapper img')?.[1]?.getAttribute('src'),
-  'https://cdn.freecodecamp.org/testable-projects-fcc/images/calc.png'
+  document.querySelectorAll('.image-wrapper img')?.[2]?.getAttribute('src'),
+  'https://cdn.freecodecamp.org/testable-projects-fcc/images/survey-form-background.jpeg'
 );
 ```
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6143cdf48b634a747de42104.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6143cdf48b634a747de42104.md
@@ -15,8 +15,8 @@ Your third `img` element should have a `src` set to `https://cdn.freecodecamp.or
 
 ```js
 assert.equal(
-  document.querySelectorAll('.image-wrapper img')?.[2]?.getAttribute('src'),
-  'https://cdn.freecodecamp.org/testable-projects-fcc/images/survey-form-background.jpeg'
+  document.querySelectorAll('.image-wrapper img')?.[1]?.getAttribute('src'),
+  'https://cdn.freecodecamp.org/testable-projects-fcc/images/calc.png'
 );
 ```
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6143cdf48b634a747de42104.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6143cdf48b634a747de42104.md
@@ -14,37 +14,56 @@ Within your `.image-wrapper` element, give your third `img` element a `src` of `
 Your third `img` element should have a `src` set to `https://cdn.freecodecamp.org/testable-projects-fcc/images/survey-form-background.jpeg`.
 
 ```js
-assert(document.querySelectorAll('.image-wrapper img')?.[2]?.getAttribute('src') === 'https://cdn.freecodecamp.org/testable-projects-fcc/images/survey-form-background.jpeg');
+assert.equal(
+  document.querySelectorAll('.image-wrapper img')?.[2]?.getAttribute('src'),
+  'https://cdn.freecodecamp.org/testable-projects-fcc/images/survey-form-background.jpeg'
+);
 ```
 
 Your third `img` element should have an `alt` set to `four people working on code`.
 
 ```js
-assert(document.querySelectorAll('.image-wrapper img')?.[2]?.getAttribute('alt') === 'four people working on code');
+assert.equal(
+  document.querySelectorAll('.image-wrapper img')?.[2]?.getAttribute('alt'),
+  'four people working on code'
+);
+
 ```
 
 Your third `img` element should have a `loading` attribute set to `lazy`.
 
 ```js
-assert(document.querySelectorAll('.image-wrapper img')?.[2]?.getAttribute('loading') === 'lazy');
+assert.equal(
+  document.querySelectorAll('.image-wrapper img')?.[2]?.getAttribute('loading'),
+  'lazy'
+);
 ```
 
 Your third `img` element should have a `class` set to `image-3`.
 
 ```js
-assert(document.querySelectorAll('.image-wrapper img')?.[2]?.classList?.contains('image-3'));
+assert.isTrue(
+  document.querySelectorAll('.image-wrapper img')?.[2]?.classList?.contains('image-3')
+);
+
 ```
 
 Your third `img` element should have a `width` attribute set to `600`.
 
 ```js
-assert(document.querySelectorAll('.image-wrapper img')?.[2]?.getAttribute('width') === '600');
+assert.equal(
+  document.querySelectorAll('.image-wrapper img')?.[2]?.getAttribute('width'),
+  '600'
+);
 ```
 
 Your third `img` element should have a `height` attribute set to `400`.
 
 ```js
-assert(document.querySelectorAll('.image-wrapper img')?.[2]?.getAttribute('height') === '400');
+assert.equal(
+  document.querySelectorAll('.image-wrapper img')?.[2]?.getAttribute('height'),
+  '400'
+);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6143cdf48b634a747de42104.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6143cdf48b634a747de42104.md
@@ -27,7 +27,6 @@ assert.equal(
   document.querySelectorAll('.image-wrapper img')?.[2]?.getAttribute('alt'),
   'four people working on code'
 );
-
 ```
 
 Your third `img` element should have a `loading` attribute set to `lazy`.

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6143cdf48b634a747de42104.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6143cdf48b634a747de42104.md
@@ -44,7 +44,6 @@ Your third `img` element should have a `class` set to `image-3`.
 assert.isTrue(
   document.querySelectorAll('.image-wrapper img')?.[2]?.classList?.contains('image-3')
 );
-
 ```
 
 Your third `img` element should have a `width` attribute set to `600`.


### PR DESCRIPTION
Checklist:


- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or Gitpod.



Closes #61150

Description
This pull request updates test assertions in the curriculum to use more appropriate Chai assert methods. Specifically:
Replaces assert(a === b) with assert.equal(a, b)
Replaces assert(condition) with assert.isTrue(condition) where applicable

These changes improve the readability and accuracy of test assertions by using method-specific Chai functions.
