### PR TITLE
Fix/assert methods magazine steps 22 23

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6143cd08fe927072ca3a371d.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6143cd08fe927072ca3a371d.md
@@ -14,38 +14,37 @@ Within your `.image-wrapper` element, give the second `img` element a `src` of `
 Your second `img` element should have a `src` set to `https://cdn.freecodecamp.org/testable-projects-fcc/images/calc.png`.
 
 ```js
-assert(document.querySelectorAll('.image-wrapper img')?.[1]?.getAttribute('src') === 'https://cdn.freecodecamp.org/testable-projects-fcc/images/calc.png');
+assert.equal(document.querySelectorAll('.image-wrapper img')?.[1]?.getAttribute('src'), 'https://cdn.freecodecamp.org/testable-projects-fcc/images/calc.png');
 ```
 
 Your second `img` element should have an `alt` set to `image of a calculator project`.
 
 ```js
-assert(document.querySelectorAll('.image-wrapper img')?.[1]?.getAttribute('alt') === 'image of a calculator project');
+assert.equal(document.querySelectorAll('.image-wrapper img')?.[1]?.getAttribute('alt'), 'image of a calculator project');
 ```
 
 Your second `img` element should have a `loading` attribute set to `lazy`.
 
 ```js
-assert(document.querySelectorAll('.image-wrapper img')?.[1]?.getAttribute('loading') === 'lazy');
+assert.equal(document.querySelectorAll('.image-wrapper img')?.[1]?.getAttribute('loading'), 'lazy');
 ```
 
 Your second `img` element should have a `class` set to `image-2`.
 
 ```js
-assert(document.querySelectorAll('.image-wrapper img')?.[1]?.classList?.contains('image-2'));
+assert.isTrue(document.querySelectorAll('.image-wrapper img')?.[1]?.classList?.contains('image-2'));
 ```
 
 Your second `img` element should have a `width` set to `400`.
 
 ```js
-assert(document.querySelectorAll('.image-wrapper img')?.[1]?.getAttribute('width') === '400');
+assert.equal(document.querySelectorAll('.image-wrapper img')?.[1]?.getAttribute('width'), '400');
 ```
 
 Your second `img` element should have a `height` set to `400`.
 
 ```js
-assert(document.querySelectorAll('.image-wrapper img')?.[1]?.getAttribute('height') === '400');
-```
+assert.equal( document.querySelectorAll('.image-wrapper img')?.[1]?.getAttribute('height'), '400');```
 
 # --seed--
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6143cdf48b634a747de42104.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6143cdf48b634a747de42104.md
@@ -14,37 +14,37 @@ Within your `.image-wrapper` element, give your third `img` element a `src` of `
 Your third `img` element should have a `src` set to `https://cdn.freecodecamp.org/testable-projects-fcc/images/survey-form-background.jpeg`.
 
 ```js
-assert(document.querySelectorAll('.image-wrapper img')?.[2]?.getAttribute('src') === 'https://cdn.freecodecamp.org/testable-projects-fcc/images/survey-form-background.jpeg');
+assert.equal(document.querySelectorAll('.image-wrapper img')?.[2]?.getAttribute('src'), 'https://cdn.freecodecamp.org/testable-projects-fcc/images/survey-form-background.jpeg');
 ```
 
 Your third `img` element should have an `alt` set to `four people working on code`.
 
 ```js
-assert(document.querySelectorAll('.image-wrapper img')?.[2]?.getAttribute('alt') === 'four people working on code');
+assert.equal(document.querySelectorAll('.image-wrapper img')?.[2]?.getAttribute('alt'), 'four people working on code');
 ```
 
 Your third `img` element should have a `loading` attribute set to `lazy`.
 
 ```js
-assert(document.querySelectorAll('.image-wrapper img')?.[2]?.getAttribute('loading') === 'lazy');
+assert.equal(document.querySelectorAll('.image-wrapper img')?.[2]?.getAttribute('loading'), 'lazy');
 ```
 
 Your third `img` element should have a `class` set to `image-3`.
 
 ```js
-assert(document.querySelectorAll('.image-wrapper img')?.[2]?.classList?.contains('image-3'));
+assert.isTrue(document.querySelectorAll('.image-wrapper img')?.[2]?.classList?.contains('image-3'));
 ```
 
 Your third `img` element should have a `width` attribute set to `600`.
 
 ```js
-assert(document.querySelectorAll('.image-wrapper img')?.[2]?.getAttribute('width') === '600');
+assert.equal(document.querySelectorAll('.image-wrapper img')?.[2]?.getAttribute('width'), '600');
 ```
 
 Your third `img` element should have a `height` attribute set to `400`.
 
 ```js
-assert(document.querySelectorAll('.image-wrapper img')?.[2]?.getAttribute('height') === '400');
+assert.equal(document.querySelectorAll('.image-wrapper img')?.[2]?.getAttribute('height'), '400');
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #61150

<!-- Feel free to add any additional description of changes below this line -->

## Description

This PR updates steps 22–23 of the Magazine Workshop project to use specific Chai assert methods as per the issue description.

### Summary of changes:
- Replaced general `assert(...)` using `===` with `assert.equal(...)`
- Replaced boolean expression asserts using `.contains(...)` with `assert.isTrue(...)`