### PR TITLE
chore: update Step 22 of magazine workshop to use specific assert met…

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6143cd08fe927072ca3a371d.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6143cd08fe927072ca3a371d.md
@@ -14,37 +14,40 @@ Within your `.image-wrapper` element, give the second `img` element a `src` of `
 Your second `img` element should have a `src` set to `https://cdn.freecodecamp.org/testable-projects-fcc/images/calc.png`.
 
 ```js
-assert(document.querySelectorAll('.image-wrapper img')?.[1]?.getAttribute('src') === 'https://cdn.freecodecamp.org/testable-projects-fcc/images/calc.png');
+assert.equal(
+  document.querySelectorAll('.image-wrapper img')?.[1]?.getAttribute('src'),
+  'https://cdn.freecodecamp.org/testable-projects-fcc/images/calc.png'
+);
 ```
 
 Your second `img` element should have an `alt` set to `image of a calculator project`.
 
 ```js
-assert(document.querySelectorAll('.image-wrapper img')?.[1]?.getAttribute('alt') === 'image of a calculator project');
+assert.equal(document.querySelectorAll('.image-wrapper img')?.[1]?.getAttribute('alt') === 'image of a calculator project');
 ```
 
 Your second `img` element should have a `loading` attribute set to `lazy`.
 
 ```js
-assert(document.querySelectorAll('.image-wrapper img')?.[1]?.getAttribute('loading') === 'lazy');
+assert.equal(document.querySelectorAll('.image-wrapper img')?.[1]?.getAttribute('loading') === 'lazy');
 ```
 
 Your second `img` element should have a `class` set to `image-2`.
 
 ```js
-assert(document.querySelectorAll('.image-wrapper img')?.[1]?.classList?.contains('image-2'));
+assert.isTrue(document.querySelectorAll('.image-wrapper img')?.[1]?.classList?.contains('image-2'));
 ```
 
 Your second `img` element should have a `width` set to `400`.
 
 ```js
-assert(document.querySelectorAll('.image-wrapper img')?.[1]?.getAttribute('width') === '400');
+assert.equal(document.querySelectorAll('.image-wrapper img')?.[1]?.getAttribute('width') === '400');
 ```
 
 Your second `img` element should have a `height` set to `400`.
 
 ```js
-assert(document.querySelectorAll('.image-wrapper img')?.[1]?.getAttribute('height') === '400');
+assert.equal(document.querySelectorAll('.image-wrapper img')?.[1]?.getAttribute('height') === '400');
 ```
 
 # --seed--


### PR DESCRIPTION
### Description

This PR updates Step 22 of the Magazine Workshop curriculum challenge to use more specific Chai `assert` methods, as outlined in issue #61150.

### Changes Made

- Replaced general `assert(...)` with `assert.equal(...)` and `assert.isTrue(...)`
- Ensured all test lines end with semicolons for consistency

### Related Issue

Fixes #61150

---

Let me know if any further changes are needed. Happy to contribute! ✨
