### PR TITLE
fix(api): handle termination signals

### DIFF
--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -7,9 +7,9 @@ const start = async () => {
   const fastify = await build(buildOptions);
 
   const stop = async (signal: NodeJS.Signals) => {
-    console.log(`Received ${signal}, shutting down...`);
+    fastify.log.info(`Received ${signal}, shutting down.`);
     await fastify.close();
-    console.log('...shutdown complete');
+    fastify.log.info('Shutdown complete');
     process.exit(0);
   };
 

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -5,6 +5,17 @@ import { HOST, PORT } from './utils/env';
 
 const start = async () => {
   const fastify = await build(buildOptions);
+
+  const stop = async (signal: NodeJS.Signals) => {
+    console.log(`Received ${signal}, shutting down...`);
+    await fastify.close();
+    console.log('...shutdown complete');
+    process.exit(0);
+  };
+
+  process.on('SIGINT', signal => void stop(signal));
+  process.on('SIGTERM', signal => void stop(signal));
+
   try {
     const port = Number(PORT);
     fastify.log.info(`Starting server on port ${port}`);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

I belatedly realised the `server.onClose` hook was not firing. Now it does.

<!-- Feel free to add any additional description of changes below this line -->
