### PR TITLE
fix(curriculum): correct heading levels and formatting for custom mar…

### DIFF
--- a/curriculum/challenges/english/16-the-odin-project/top-basic-function-projects/top-basic-functions-exercise-a.md
+++ b/curriculum/challenges/english/16-the-odin-project/top-basic-function-projects/top-basic-functions-exercise-a.md
@@ -48,7 +48,7 @@ assert.strictEqual(addOrSubtract(10), 7);
 
 ```
 
-## --solutions--
+# --solutions--
 
 ```js
 function addOrSubtract(num) {

--- a/curriculum/challenges/english/16-the-odin-project/top-basic-function-projects/top-basic-functions-exercise-b.md
+++ b/curriculum/challenges/english/16-the-odin-project/top-basic-function-projects/top-basic-functions-exercise-b.md
@@ -38,7 +38,7 @@ assert.strictEqual(multiply(10, 10), 100);
 
 ```
 
-## --solutions--
+# --solutions--
 
 ```js 
 function multiply(a, b) {

--- a/curriculum/challenges/english/16-the-odin-project/top-basic-function-projects/top-basic-functions-exercise-c.md
+++ b/curriculum/challenges/english/16-the-odin-project/top-basic-function-projects/top-basic-functions-exercise-c.md
@@ -38,7 +38,7 @@ assert.strictEqual(capitalize('sem'), 'Sem');
 
 ```
 
-## --solutions--
+# --solutions--
 
 ```js
 function capitalize(str) {

--- a/curriculum/challenges/english/16-the-odin-project/top-basic-function-projects/top-basic-functions-exercise-d.md
+++ b/curriculum/challenges/english/16-the-odin-project/top-basic-function-projects/top-basic-functions-exercise-d.md
@@ -38,7 +38,7 @@ assert.strictEqual(lastLetter('Sem'), 'm');
 
 ```
 
-## --solutions--
+# --solutions--
 
 ```js
 function lastLetter(str) {

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bd968e52c34220164de8d.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bd968e52c34220164de8d.md
@@ -45,7 +45,7 @@ She did nothing about it
 
 Sarah stated that she already tried a few things, which means she did take some action.
 
-### --video-solution--
+## --video-solution--
 
 2
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/6622346c798d906ee4d31846.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-offer-technical-support-and-guidance/6622346c798d906ee4d31846.md
@@ -51,7 +51,7 @@ It is about team members helping and encouraging one another.
 
 `key`
 
-### --feedback---
+## --feedback--
 
 It refers to something that is very important in achieving a specific goal or outcome.
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657da1d38bf3e693eb579be9.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/657da1d38bf3e693eb579be9.md
@@ -11,7 +11,7 @@ dashedName: task-25
 
 This is a review of the entire dialogue you just studied.
 
-# -- instructions--
+# --instructions--
 
 Write the following words or phrases in the correct spot:
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/685e4c36bc03dc064d265e2e.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/685e4c36bc03dc064d265e2e.md
@@ -11,7 +11,7 @@ dashedName: task-40
 
 This is a review of the entire dialogue you just studied.
 
-# -- instructions--
+# --instructions--
 
 Write the following words or phrases in the correct spot:
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/685e4d6e2088a407609f9377.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/685e4d6e2088a407609f9377.md
@@ -11,7 +11,7 @@ dashedName: task-63
 
 This is a review of the entire dialogue you just studied.
 
-# -- instructions--
+# --instructions--
 
 Write the following words or phrases in the correct spot:
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/685e4e97f6ed62087370555f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/685e4e97f6ed62087370555f.md
@@ -11,7 +11,7 @@ dashedName: task-91
 
 This is a review of the entire dialogue you just studied.
 
-# -- instructions--
+# --instructions--
 
 Write the following words or phrases in the correct spot:
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/685e4f5c185bf709446741b5.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-talk-about-hobbies-and-interests/685e4f5c185bf709446741b5.md
@@ -11,7 +11,7 @@ dashedName: task-109
 
 This is a review of the entire dialogue you just studied.
 
-# -- instructions--
+# --instructions--
 
 Write the following words or phrases in the correct spot:
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672830d9aa2e0c2ff2fad7f8.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672830d9aa2e0c2ff2fad7f8.md
@@ -33,7 +33,7 @@ This word is used to indicate a starting point in time for an action that contin
 
 These two words together refer to a version of software that has been improved or fixed.
 
-## --explanation--
+# --explanation--
 
 In the `Present Perfect Continuous` tense, `since` is used to indicate when an action began and continues up to the present. For example:
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/6728378c94eaf541fce8f334.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/6728378c94eaf541fce8f334.md
@@ -33,7 +33,7 @@ This word refers to comments or opinions about a product or service, often used 
 
 This term refers to errors in software that need to be resolved. It's plural form.
 
-## --explanation--
+# --explanation--
 
 `Feedback` refers to responses or evaluations from users regarding a product's performance. For example:
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/67289e1748ed4b9623086332.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/67289e1748ed4b9623086332.md
@@ -33,7 +33,7 @@ These two words together mean to concentrate attention or effort on a particular
 
 This noun refers to the process of assessing or judging the quality, value, or performance of something.
 
-## --explanation--
+# --explanation--
 
 The phrase `focus on` indicates directing attention or effort towards a specific area or task. For example:
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/6728bf5cd59713a140c558be.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/6728bf5cd59713a140c558be.md
@@ -25,7 +25,7 @@ Listen to the audio and complete the sentence below.
 
 This preposition indicates the duration of time over which an action has been occurring. The first letter is capitalized.
 
-## --explanation--
+# --explanation--
 
 In the `Present Perfect Continuous` tense, `for` is used to specify the duration of time that an action has been happening. For example:
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/6728c369d38d3ea6634c1649.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/6728c369d38d3ea6634c1649.md
@@ -33,7 +33,7 @@ This word in the plural form refers to different situations or contexts that may
 
 This adverb means in a way that is reliable and uniform over time.
 
-## --explanation--
+# --explanation--
 
 `Scenarios` refers to different situations or possible events that could occur. For example:
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672a192e685fba081cfbeb2d.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672a192e685fba081cfbeb2d.md
@@ -25,7 +25,7 @@ Listen to the audio and complete the sentence below.
 
 These two words together refer to the technology that allows a computer or device to understand and interpret human speech.
 
-## --explanation--
+# --explanation--
 
 `Voice recognition` is a technology that enables machines to recognize and respond to human speech. It's commonly used in devices like smartphones, smart speakers, and virtual assistants, allowing users to control these devices through voice commands. For example:
 

--- a/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672a1e2fbec6a61bf477ea49.md
+++ b/curriculum/challenges/english/24-b1-english-for-developers/learn-present-perfect-while-talking-about-accessibility/672a1e2fbec6a61bf477ea49.md
@@ -41,7 +41,7 @@ These two words together refer to any unwanted sounds in the environment, such a
 
 It refers to how correct or precise something is. In this case, it means how well the system can understand speech without errors or confusion.
 
-## --explanation--
+# --explanation--
 
 `Accent` refers to variations in pronunciation based on someone's region or cultural background. For example:
   

--- a/curriculum/challenges/english/25-front-end-development/lab-customer-complaint-form/67279fe50237291f80eed8b8.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-customer-complaint-form/67279fe50237291f80eed8b8.md
@@ -587,7 +587,7 @@ textarea {
 
 ```
 
-## --solutions--
+# --solutions--
 
 ```html
 <!DOCTYPE html>

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-regular-expressions/6733c5ba834ded4bb067e67c.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-regular-expressions/6733c5ba834ded4bb067e67c.md
@@ -276,7 +276,7 @@ false
 false
 ```
 
-## --feedback--
+### --feedback--
 
 The `i` flag makes the regex case-insensitive, so `freeCodeCamp` matches regardless of case, as long as the letters are the same.
 


### PR DESCRIPTION
…kers

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #61184

<!-- Feel free to add any additional description of changes below this line -->
This PR fixes invalid heading levels and formatting for custom section markers in the curriculum Markdown files, as required by the validator introduced in [#61148](https://github.com/freeCodeCamp/freeCodeCamp/pull/61148).

### ✅ Changes made:

- Changed ## --solutions-- to # --solutions--
- Changed ### --video-solution-- to ## --video-solution--
- Corrected ### --feedback--- to ### --feedback-- (removed extra dash)
- Updated ## --feedback-- to ### --feedback-- in lecture 6733c5ba834ded4bb067e67c.md
- Fixed spacing in # -- instructions-- to # --instructions--
- Changed ## --explanation-- to # --explanation--

These changes are necessary to pass the new curriculum validator and ensure consistent formatting across the curriculum.

Let me know if anything needs adjustment — happy to update!