### PR TITLE
refactor: add demo data to the challenges that use them

### DIFF
--- a/client/gatsby-node.js
+++ b/client/gatsby-node.js
@@ -102,6 +102,20 @@ exports.createPages = async function createPages({
                 history
                 fileKey
               }
+              projectPreview {
+                challengeData {
+                  challengeType
+                  challengeFiles {
+                    name
+                    ext
+                    contents
+                    head
+                    tail
+                    history
+                    fileKey
+                  }
+                }
+              }
               solutions {
                 contents
                 ext

--- a/client/gatsby-node.js
+++ b/client/gatsby-node.js
@@ -102,7 +102,7 @@ exports.createPages = async function createPages({
                 history
                 fileKey
               }
-              projectPreview {
+              demo {
                 challengeData {
                   challengeType
                   challengeFiles {

--- a/client/gatsby-node.js
+++ b/client/gatsby-node.js
@@ -102,20 +102,6 @@ exports.createPages = async function createPages({
                 history
                 fileKey
               }
-              demo {
-                challengeData {
-                  challengeType
-                  challengeFiles {
-                    name
-                    ext
-                    contents
-                    head
-                    tail
-                    history
-                    fileKey
-                  }
-                }
-              }
               solutions {
                 contents
                 ext

--- a/client/src/client-only-routes/show-project-links.tsx
+++ b/client/src/client-only-routes/show-project-links.tsx
@@ -79,7 +79,7 @@ const ShowProjectLinks = (props: ShowProjectLinksProps): JSX.Element => {
         completedChallenge: completedProject,
         showCode: false
       });
-      openModal('projectPreview');
+      openModal('demo');
     };
 
     const showExamResults = () => {

--- a/client/src/components/SolutionViewer/solution-viewer.tsx
+++ b/client/src/components/SolutionViewer/solution-viewer.tsx
@@ -5,7 +5,7 @@ import { Panel } from '@freecodecamp/ui';
 import type { ChallengeFile } from '../../redux/prop-types';
 
 type Props = {
-  challengeFiles: Solution[] | null;
+  challengeFiles?: Solution[] | null;
   solution?: string;
 };
 type Solution = Pick<ChallengeFile, 'ext' | 'contents' | 'fileKey'>;

--- a/client/src/components/profile/components/time-line.tsx
+++ b/client/src/components/profile/components/time-line.tsx
@@ -82,7 +82,7 @@ function TimelineInner({
     setProjectTitle(
       idToNameMap.get(completedChallenge.id)?.challengeTitle ?? ''
     );
-    openModal('projectPreview');
+    openModal('demo');
   }
 
   function viewExamResults(completedChallenge: CompletedChallenge): void {

--- a/client/src/components/profile/components/time-line.tsx
+++ b/client/src/components/profile/components/time-line.tsx
@@ -12,10 +12,7 @@ import { getLangCode } from '../../../../../shared/config/i18n';
 import { getCertIds, getPathFromID } from '../../../../utils';
 import { regenerateMissingProperties } from '../../../../../shared/utils/polyvinyl';
 import CertificationIcon from '../../../assets/icons/certification';
-import type {
-  ChallengeData,
-  CompletedChallenge
-} from '../../../redux/prop-types';
+import type { CompletedChallenge } from '../../../redux/prop-types';
 import ProjectPreviewModal from '../../../templates/Challenges/components/project-preview-modal';
 import ExamResultsModal from '../../SolutionViewer/exam-results-modal';
 import { openModal } from '../../../templates/Challenges/redux/actions';
@@ -163,7 +160,7 @@ function TimelineInner({
     );
   }
 
-  const challengeData: ChallengeData | null = completedChallenge
+  const challengeData = completedChallenge
     ? {
         ...completedChallenge,
         // // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
@@ -174,7 +171,7 @@ function TimelineInner({
       }
     : null;
 
-  const id = challengeData?.id;
+  const id = completedChallenge?.id;
   const startIndex = (pageNo - 1) * ITEMS_PER_PAGE;
   const endIndex = pageNo * ITEMS_PER_PAGE;
 
@@ -211,8 +208,8 @@ function TimelineInner({
             </Modal.Header>
             <Modal.Body alignment='left'>
               <SolutionViewer
-                challengeFiles={challengeData.challengeFiles}
-                solution={challengeData.solution ?? ''}
+                challengeFiles={challengeData?.challengeFiles}
+                solution={challengeData?.solution ?? ''}
               />
             </Modal.Body>
             <Modal.Footer>

--- a/client/src/components/settings/certification.tsx
+++ b/client/src/components/settings/certification.tsx
@@ -257,7 +257,7 @@ function CertificationSettings(props: CertificationSettingsProps) {
     const showProjectPreview = () => {
       setProjectTitle(projectTitle);
       setChallengeData(challengeData);
-      openModal('projectPreview');
+      openModal('demo');
     };
 
     const showExamResults = () => {

--- a/client/src/redux/prop-types.ts
+++ b/client/src/redux/prop-types.ts
@@ -182,6 +182,9 @@ export type ChallengeNode = {
     challengeType: number;
     dashedName: string;
     demoType: 'onClick' | 'onLoad' | null;
+    demo: {
+      challengeData: ChallengeData | null;
+    } | null;
     description: string;
     challengeFiles: ChallengeFiles;
     explanation: string;
@@ -399,8 +402,9 @@ export interface CompletedChallenge {
   examResults?: GeneratedExamResults;
 }
 
-export interface ChallengeData extends CompletedChallenge {
+export interface ChallengeData {
   challengeFiles: ChallengeFile[] | null;
+  challengeType?: number;
 }
 
 export type ChallengeMeta = {

--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -116,7 +116,7 @@ interface ShowClassicProps extends Pick<PreviewProps, 'previewMounted'> {
   output: string;
   pageContext: {
     challengeMeta: ChallengeMeta;
-    projectPreview: {
+    demo: {
       challengeData: ChallengeData;
     } | null;
   };
@@ -215,7 +215,7 @@ function ShowClassic({
   pageContext: {
     challengeMeta,
     challengeMeta: { isFirstStep, nextChallengePath },
-    projectPreview
+    demo
   },
   createFiles,
   cancelTests,
@@ -379,7 +379,7 @@ function ShowClassic({
     // Typically, this kind of preview only appears on the first step of a
     // project and is shown (once) automatically. In contrast, labs are more
     // freeform, so the preview is shown on demand.
-    if (demoType === 'onLoad') openModal('projectPreview');
+    if (demoType === 'onLoad') openModal('demo');
     const challengePaths = getChallengePaths({
       currentCurriculumPaths: challengeMeta
     });
@@ -541,7 +541,7 @@ function ShowClassic({
         <VideoModal videoUrl={videoUrl} />
         <ResetModal challengeType={challengeType} challengeTitle={title} />
         <ProjectPreviewModal
-          challengeData={projectPreview?.challengeData}
+          challengeData={demo?.challengeData}
           closeText={t('buttons.start-coding')}
           previewTitle={
             demoType === 'onClick'

--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -118,7 +118,7 @@ interface ShowClassicProps extends Pick<PreviewProps, 'previewMounted'> {
     challengeMeta: ChallengeMeta;
     projectPreview: {
       challengeData: ChallengeData;
-    };
+    } | null;
   };
   updateChallengeMeta: (arg0: ChallengeMeta) => void;
   openModal: (modal: string) => void;
@@ -215,7 +215,7 @@ function ShowClassic({
   pageContext: {
     challengeMeta,
     challengeMeta: { isFirstStep, nextChallengePath },
-    projectPreview: { challengeData }
+    projectPreview
   },
   createFiles,
   cancelTests,
@@ -541,7 +541,7 @@ function ShowClassic({
         <VideoModal videoUrl={videoUrl} />
         <ResetModal challengeType={challengeType} challengeTitle={title} />
         <ProjectPreviewModal
-          challengeData={challengeData}
+          challengeData={projectPreview?.challengeData}
           closeText={t('buttons.start-coding')}
           previewTitle={
             demoType === 'onClick'

--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -16,7 +16,6 @@ import LearnLayout from '../../../components/layouts/learn';
 import { MAX_MOBILE_WIDTH } from '../../../../config/misc';
 
 import type {
-  ChallengeData,
   ChallengeFiles,
   ChallengeMeta,
   ChallengeNode,
@@ -116,9 +115,6 @@ interface ShowClassicProps extends Pick<PreviewProps, 'previewMounted'> {
   output: string;
   pageContext: {
     challengeMeta: ChallengeMeta;
-    demo: {
-      challengeData: ChallengeData;
-    } | null;
   };
   updateChallengeMeta: (arg0: ChallengeMeta) => void;
   openModal: (modal: string) => void;
@@ -194,6 +190,7 @@ function ShowClassic({
       challenge: {
         challengeFiles: seedChallengeFiles,
         block,
+        demo,
         demoType,
         title,
         description,
@@ -214,8 +211,7 @@ function ShowClassic({
   },
   pageContext: {
     challengeMeta,
-    challengeMeta: { isFirstStep, nextChallengePath },
-    demo
+    challengeMeta: { isFirstStep, nextChallengePath }
   },
   createFiles,
   cancelTests,
@@ -564,6 +560,20 @@ export const query = graphql`
     challengeNode(id: { eq: $id }) {
       challenge {
         block
+        demo {
+          challengeData {
+            challengeType
+            challengeFiles {
+              name
+              ext
+              contents
+              head
+              tail
+              history
+              fileKey
+            }
+          }
+        }
         demoType
         title
         description

--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -541,7 +541,7 @@ function ShowClassic({
         <VideoModal videoUrl={videoUrl} />
         <ResetModal challengeType={challengeType} challengeTitle={title} />
         <ProjectPreviewModal
-          challengeData={demo?.challengeData}
+          challengeData={demo ? demo.challengeData : null}
           closeText={t('buttons.start-coding')}
           previewTitle={
             demoType === 'onClick'

--- a/client/src/templates/Challenges/components/project-preview-modal.tsx
+++ b/client/src/templates/Challenges/components/project-preview-modal.tsx
@@ -15,14 +15,14 @@ import Preview from './preview';
 import './project-preview-modal.css';
 
 interface ProjectPreviewMountedPayload {
-  challengeData?: ChallengeData;
+  challengeData: ChallengeData | null;
 }
 
 interface Props {
   closeModal: (arg: string) => void;
   isOpen: boolean;
   projectPreviewMounted: (payload: ProjectPreviewMountedPayload) => void;
-  challengeData?: ChallengeData;
+  challengeData: ChallengeData | null;
   setEditorFocusability: (focusability: boolean) => void;
   previewTitle: string;
   closeText: string;

--- a/client/src/templates/Challenges/components/project-preview-modal.tsx
+++ b/client/src/templates/Challenges/components/project-preview-modal.tsx
@@ -15,14 +15,14 @@ import Preview from './preview';
 import './project-preview-modal.css';
 
 interface ProjectPreviewMountedPayload {
-  challengeData: ChallengeData | null;
+  challengeData?: ChallengeData;
 }
 
 interface Props {
   closeModal: (arg: string) => void;
   isOpen: boolean;
   projectPreviewMounted: (payload: ProjectPreviewMountedPayload) => void;
-  challengeData: ChallengeData | null;
+  challengeData?: ChallengeData;
   setEditorFocusability: (focusability: boolean) => void;
   previewTitle: string;
   closeText: string;

--- a/client/src/templates/Challenges/components/project-preview-modal.tsx
+++ b/client/src/templates/Challenges/components/project-preview-modal.tsx
@@ -54,7 +54,7 @@ function ProjectPreviewModal({
     <Modal
       size='large'
       onClose={() => {
-        closeModal('projectPreview');
+        closeModal('demo');
         setEditorFocusability(true);
       }}
       open={isOpen}
@@ -72,7 +72,7 @@ function ProjectPreviewModal({
           size='large'
           variant='primary'
           onClick={() => {
-            closeModal('projectPreview');
+            closeModal('demo');
             setEditorFocusability(true);
           }}
         >

--- a/client/src/templates/Challenges/components/side-panel.tsx
+++ b/client/src/templates/Challenges/components/side-panel.tsx
@@ -61,12 +61,12 @@ export function SidePanel({
             <Trans i18nKey='learn.example-app'>
               <span
                 className='example-app-link'
-                onClick={() => openModal('projectPreview')}
+                onClick={() => openModal('demo')}
                 role='button'
                 tabIndex={0}
                 onKeyDown={e => {
                   if (e.key === 'Enter' || e.key === ' ') {
-                    openModal('projectPreview');
+                    openModal('demo');
                   }
                 }}
               ></span>

--- a/client/src/templates/Challenges/redux/index.js
+++ b/client/src/templates/Challenges/redux/index.js
@@ -47,7 +47,7 @@ const initialState = {
     finishQuiz: false,
     examResults: false,
     survey: false,
-    projectPreview: false,
+    demo: false,
     shortcuts: false
   },
   portalWindow: null,

--- a/client/src/templates/Challenges/redux/selectors.js
+++ b/client/src/templates/Challenges/redux/selectors.js
@@ -44,8 +44,7 @@ export const isExamResultsModalOpenSelector = state =>
 export const isExitQuizModalOpenSelector = state => state[ns].modal.exitQuiz;
 export const isFinishQuizModalOpenSelector = state =>
   state[ns].modal.finishQuiz;
-export const isProjectPreviewModalOpenSelector = state =>
-  state[ns].modal.projectPreview;
+export const isProjectPreviewModalOpenSelector = state => state[ns].modal.demo;
 export const isShortcutsModalOpenSelector = state => state[ns].modal.shortcuts;
 export const isSubmittingSelector = state => state[ns].isSubmitting;
 export const isResettingSelector = state => state[ns].isResetting;

--- a/client/utils/gatsby/challenge-page-creator.js
+++ b/client/utils/gatsby/challenge-page-creator.js
@@ -100,7 +100,8 @@ exports.createChallengePages = function (
       template,
       challengeType,
       id,
-      isLastChallengeInBlock
+      isLastChallengeInBlock,
+      projectPreview
     } = node.challenge;
     // TODO: challengeType === 7 and isPrivate are the same, right? If so, we
     // should remove one of them.
@@ -127,45 +128,12 @@ exports.createChallengePages = function (
           prevChallengePath: idToPrevPathCurrentCurriculum[node.id],
           id
         },
-        projectPreview: getProjectPreviewConfig(
-          node.challenge,
-          allChallengeEdges
-        ),
+        projectPreview,
         id: node.id
       }
     });
   };
 };
-
-// TODO: figure out a cleaner way to get the last challenge in a block. Create
-// it during the curriculum build process and attach it to the first challenge?
-// That would remove the need to analyse allChallengeEdges.
-function getProjectPreviewConfig(challenge, allChallengeEdges) {
-  const { block } = challenge;
-
-  const challengesInBlock = allChallengeEdges
-    .filter(({ node: { challenge } }) => challenge.block === block)
-    .map(({ node: { challenge } }) => challenge);
-  const lastChallenge = challengesInBlock[challengesInBlock.length - 1];
-  const solutionFiles = lastChallenge.solutions[0] ?? [];
-  const lastChallengeFiles = lastChallenge.challengeFiles ?? [];
-
-  const findFileByKey = (key, files) =>
-    files.find(file => file.fileKey === key);
-
-  const projectPreviewChallengeFiles = lastChallengeFiles.map(file => ({
-    ...file,
-    contents:
-      findFileByKey(file.fileKey, solutionFiles)?.contents ?? file.contents
-  }));
-
-  return {
-    challengeData: {
-      challengeType: lastChallenge.challengeType,
-      challengeFiles: projectPreviewChallengeFiles
-    }
-  };
-}
 
 exports.createBlockIntroPages = function (createPage) {
   return function (edge) {

--- a/client/utils/gatsby/challenge-page-creator.js
+++ b/client/utils/gatsby/challenge-page-creator.js
@@ -100,8 +100,7 @@ exports.createChallengePages = function (
       template,
       challengeType,
       id,
-      isLastChallengeInBlock,
-      demo
+      isLastChallengeInBlock
     } = node.challenge;
     // TODO: challengeType === 7 and isPrivate are the same, right? If so, we
     // should remove one of them.
@@ -128,7 +127,6 @@ exports.createChallengePages = function (
           prevChallengePath: idToPrevPathCurrentCurriculum[node.id],
           id
         },
-        demo,
         id: node.id
       }
     });

--- a/client/utils/gatsby/challenge-page-creator.js
+++ b/client/utils/gatsby/challenge-page-creator.js
@@ -101,7 +101,7 @@ exports.createChallengePages = function (
       challengeType,
       id,
       isLastChallengeInBlock,
-      projectPreview
+      demo
     } = node.challenge;
     // TODO: challengeType === 7 and isPrivate are the same, right? If so, we
     // should remove one of them.
@@ -128,7 +128,7 @@ exports.createChallengePages = function (
           prevChallengePath: idToPrevPathCurrentCurriculum[node.id],
           id
         },
-        projectPreview,
+        demo,
         id: node.id
       }
     });

--- a/curriculum/get-challenges.js
+++ b/curriculum/get-challenges.js
@@ -69,7 +69,7 @@ function addProjectPreviewDataToChallenges(curriculum) {
           const preview = computeProjectPreviewForBlock(block.challenges);
           block.challenges.forEach(challenge => {
             // Add project preview data to each challenge
-            challenge.projectPreview = preview;
+            challenge.demo = preview;
           });
         }
       });

--- a/curriculum/get-challenges.js
+++ b/curriculum/get-challenges.js
@@ -34,7 +34,7 @@ const fullStackSuperBlockStructure = require('./superblock-structure/full-stack.
 assertSuperBlockStructure(fullStackSuperBlockStructure);
 
 // Function to compute project preview data for a block
-function computeProjectPreviewForBlock(challenges) {
+function computeDemoDataForBlock(challenges) {
   if (isEmpty(challenges)) return null;
 
   const lastChallenge = challenges[challenges.length - 1];
@@ -58,7 +58,7 @@ function computeProjectPreviewForBlock(challenges) {
   };
 }
 
-// Function to add project preview data to all challenges in the curriculum
+// Function to add project preview data to all challenges with deom in the curriculum
 function addProjectPreviewDataToChallenges(curriculum) {
   Object.keys(curriculum).forEach(superBlockName => {
     const superBlock = curriculum[superBlockName];
@@ -66,10 +66,10 @@ function addProjectPreviewDataToChallenges(curriculum) {
       Object.keys(superBlock.blocks).forEach(blockName => {
         const block = superBlock.blocks[blockName];
         if (!isEmpty(block.challenges)) {
-          const preview = computeProjectPreviewForBlock(block.challenges);
+          const demo = computeDemoDataForBlock(block.challenges);
           block.challenges.forEach(challenge => {
             // Add project preview data to each challenge
-            challenge.demo = preview;
+            if (challenge.demoType) challenge.demo = demo;
           });
         }
       });

--- a/curriculum/get-challenges.js
+++ b/curriculum/get-challenges.js
@@ -34,9 +34,12 @@ const fullStackSuperBlockStructure = require('./superblock-structure/full-stack.
 assertSuperBlockStructure(fullStackSuperBlockStructure);
 
 // Function to compute project preview data for a block
-function computeDemoDataForBlock(challenges) {
-  if (isEmpty(challenges)) return null;
+function computeDemoDataForBlock(unsortedChallenges) {
+  if (isEmpty(unsortedChallenges)) return null;
 
+  const challenges = unsortedChallenges.sort(
+    (a, b) => a.challengeOrder - b.challengeOrder
+  );
   const lastChallenge = challenges[challenges.length - 1];
   const solutionFiles = lastChallenge.solutions?.[0] ?? [];
   const lastChallengeFiles = lastChallenge.challengeFiles ?? [];
@@ -63,15 +66,19 @@ function addProjectPreviewDataToChallenges(curriculum) {
   Object.keys(curriculum).forEach(superBlockName => {
     const superBlock = curriculum[superBlockName];
     if (!isEmpty(superBlock.blocks)) {
-      Object.keys(superBlock.blocks).forEach(blockName => {
-        const block = superBlock.blocks[blockName];
-        if (!isEmpty(block.challenges)) {
-          const demo = computeDemoDataForBlock(block.challenges);
-          block.challenges.forEach(challenge => {
-            // Add project preview data to each challenge
-            if (challenge.demoType) challenge.demo = demo;
-          });
-        }
+      addProjectPreviewDataToBlock(superBlock.blocks);
+    }
+  });
+}
+
+function addProjectPreviewDataToBlock(blocks) {
+  Object.keys(blocks).forEach(blockName => {
+    const block = blocks[blockName];
+    if (!isEmpty(block.challenges)) {
+      const demo = computeDemoDataForBlock(block.challenges);
+      block.challenges.forEach(challenge => {
+        // Add project preview data to each challenge
+        if (challenge.demoType) challenge.demo = demo;
       });
     }
   });

--- a/curriculum/schema/challenge-schema.js
+++ b/curriculum/schema/challenge-schema.js
@@ -230,7 +230,7 @@ const schema = Joi.object()
       is: [challengeTypes.exam],
       then: Joi.array().items(prerequisitesJoi)
     }),
-    projectPreview: Joi.object().keys({
+    demo: Joi.object().keys({
       challengeData: Joi.object().keys({
         challengeType: challengeTypeJoi,
         challengeFiles: Joi.array().items(fileJoi)

--- a/curriculum/schema/challenge-schema.js
+++ b/curriculum/schema/challenge-schema.js
@@ -126,6 +126,8 @@ const quizJoi = Joi.object().keys({
     .required()
 });
 
+const challengeTypeJoi = Joi.number().min(0).max(30).required();
+
 const schema = Joi.object()
   .keys({
     block: Joi.string().regex(slugRE).required(),
@@ -159,7 +161,7 @@ const schema = Joi.object()
       otherwise: Joi.optional()
     }),
     certification: Joi.string().regex(slugWithSlashRE),
-    challengeType: Joi.number().min(0).max(30).required(),
+    challengeType: challengeTypeJoi,
     checksum: Joi.number(),
     // TODO: require this only for normal challenges, not certs
     dashedName: Joi.string().regex(slugRE),
@@ -227,6 +229,12 @@ const schema = Joi.object()
     prerequisites: Joi.when('challengeType', {
       is: [challengeTypes.exam],
       then: Joi.array().items(prerequisitesJoi)
+    }),
+    projectPreview: Joi.object().keys({
+      challengeData: Joi.object().keys({
+        challengeType: challengeTypeJoi,
+        challengeFiles: Joi.array().items(fileJoi)
+      })
     }),
     // video challenges only:
     videoId: Joi.when('challengeType', {

--- a/e2e/completed-project-preview.spec.ts
+++ b/e2e/completed-project-preview.spec.ts
@@ -31,8 +31,8 @@ async function expectPreviewToBeShown(page: Page) {
   });
   await expect(modalHeading).toBeVisible();
 
-  const projectPreview = page.frameLocator('#fcc-project-preview-frame');
-  await expect(projectPreview.getByText('Tribute page text')).toBeVisible();
+  const demo = page.frameLocator('#fcc-project-preview-frame');
+  await expect(demo.getByText('Tribute page text')).toBeVisible();
 }
 
 test.describe('Completed project preview', () => {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Instead of adding the `demo` (originally `projectPreview`) data to the page context of all challenge pages during the client build, now all challenges that can show demos get the data.

This should help with https://github.com/freeCodeCamp/freeCodeCamp/issues/61177

<!-- Feel free to add any additional description of changes below this line -->
