### PR TITLE
fix(curriculum): Add test and user story to enforce correct RPG Creature API endpoint usage

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/build-an-rpg-creature-search-app-project/build-an-rpg-creature-search-app.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/build-an-rpg-creature-search-app-project/build-an-rpg-creature-search-app.md
@@ -36,7 +36,6 @@ In this project, you'll build an app that will search for creatures from an RPG 
 1. When the `#search-input` element contains the value `2` and the `#search-button` element is clicked, two elements should be added within the `#types` element that contain text values `WATER` and `ROCK`, respectively. The `#types` element content should be cleared between searches.
 1. When the `#search-input` element contains an invalid creature name, and the `#search-button` element is clicked, an alert should appear with the text `"Creature not found"`.
 1. When the `#search-input` element contains a valid creature ID and the `#search-button` element is clicked, the UI should be filled with the correct data.
-1. Your app must fetch creature data using the endpoint `https://rpg-creature-api.freecodecamp.rocks/api/creature/{name-or-id}` (where `{name-or-id}` is the user input).
 
 Fulfill the user stories and pass all the tests below to complete this project. Give it your own personal style. Happy Coding!
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/build-an-rpg-creature-search-app-project/build-an-rpg-creature-search-app.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/build-an-rpg-creature-search-app-project/build-an-rpg-creature-search-app.md
@@ -36,6 +36,7 @@ In this project, you'll build an app that will search for creatures from an RPG 
 1. When the `#search-input` element contains the value `2` and the `#search-button` element is clicked, two elements should be added within the `#types` element that contain text values `WATER` and `ROCK`, respectively. The `#types` element content should be cleared between searches.
 1. When the `#search-input` element contains an invalid creature name, and the `#search-button` element is clicked, an alert should appear with the text `"Creature not found"`.
 1. When the `#search-input` element contains a valid creature ID and the `#search-button` element is clicked, the UI should be filled with the correct data.
+1. Your app must fetch creature data using the endpoint `https://rpg-creature-api.freecodecamp.rocks/api/creature/{name-or-id}` (where `{name-or-id}` is the user input).
 
 Fulfill the user stories and pass all the tests below to complete this project. Give it your own personal style. Happy Coding!
 
@@ -379,6 +380,38 @@ async () => {
   } catch (err) {
     throw new Error(err);
   }
+};
+```
+
+When the search button is clicked, the app should send a fetch request to the correct endpoint for the creature name or ID.
+
+```js
+async () => {
+  const spy = __helpers.spyOn(window, 'fetch');
+  const searchInput = document.getElementById('search-input');
+  const searchButton = document.getElementById('search-button');
+
+  searchInput.value = 'Pyrolynx';
+  searchInput.dispatchEvent(new Event('change'));
+  searchButton.click();
+  await new Promise((resolve) => setTimeout(resolve, 500));
+
+  searchInput.value = '2';
+  searchInput.dispatchEvent(new Event('change'));
+  searchButton.click();
+  await new Promise((resolve) => setTimeout(resolve, 500));
+
+  // Test with random valid ID
+  const randomValidCreatureId = String(Math.floor(Math.random() * 20) + 1);
+  searchInput.value = randomValidCreatureId;
+  searchInput.dispatchEvent(new Event('change'));
+  searchButton.click();
+  await new Promise((resolve) => setTimeout(resolve, 500));
+
+  const calls = spy.calls.map((call) => call[0]);
+  assert.isTrue(calls.some((url) => url.toLowerCase() === 'https://rpg-creature-api.freecodecamp.rocks/api/creature/pyrolynx'));
+  assert.isTrue(calls.some((url) => url.toLowerCase() === 'https://rpg-creature-api.freecodecamp.rocks/api/creature/2'));
+  assert.isTrue(calls.some((url) => url.toLowerCase() === `https://rpg-creature-api.freecodecamp.rocks/api/creature/${randomValidCreatureId}`.toLowerCase()));
 };
 ```
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/build-an-rpg-creature-search-app-project/build-an-rpg-creature-search-app.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/build-an-rpg-creature-search-app-project/build-an-rpg-creature-search-app.md
@@ -409,9 +409,9 @@ async () => {
   await new Promise((resolve) => setTimeout(resolve, 500));
 
   const calls = spy.calls.map((call) => call[0]);
-  assert.isTrue(calls.some((url) => url.toLowerCase() === 'https://rpg-creature-api.freecodecamp.rocks/api/creature/pyrolynx'));
-  assert.isTrue(calls.some((url) => url.toLowerCase() === 'https://rpg-creature-api.freecodecamp.rocks/api/creature/2'));
-  assert.isTrue(calls.some((url) => url.toLowerCase() === `https://rpg-creature-api.freecodecamp.rocks/api/creature/${randomValidCreatureId}`.toLowerCase()));
+  assert.strictEqual(calls[0].toLowerCase(), 'https://rpg-creature-api.freecodecamp.rocks/api/creature/pyrolynx');
+  assert.strictEqual(calls[1], 'https://rpg-creature-api.freecodecamp.rocks/api/creature/2');
+  assert.strictEqual(calls[2], `https://rpg-creature-api.freecodecamp.rocks/api/creature/${randomValidCreatureId}`);
 };
 ```
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #61041

<!-- Feel free to add any additional description of changes below this line -->
Let me know if you'd like another test to ensure the user doesn't fetch data from `https://rpg-creature-api.freecodecamp.rocks/api/creatures`

```js
assert.isFalse(calls.some((url) => url.toLowerCase() === 'https://rpg-creature-api.freecodecamp.rocks/api/creatures'));
```