### PR TITLE
fix(curriculum): make book inventory demo responsive for mobile

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-book-inventory-app/66a207974c806a19d6607073.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-book-inventory-app/66a207974c806a19d6607073.md
@@ -45,10 +45,10 @@ You should have only one `h1` element.
 assert.equal(document.querySelectorAll('h1')?.length, 1);
 ```
 
-You should have a `table` element after your `h1` element.
+You should have a `table` element.
 
 ```js
-assert.equal(document.querySelector('table')?.previousElementSibling?.tagName, 'H1')
+assert.equal(document.querySelectorAll('table')?.length, 1);
 ```
 
 Your `table` element should have five columns.

--- a/curriculum/challenges/english/25-front-end-development/lab-book-inventory-app/66a207974c806a19d6607073.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-book-inventory-app/66a207974c806a19d6607073.md
@@ -529,85 +529,87 @@ assert.include(new __helpers.CSSHelp(document).getStyleAny(selectors)?.getPropVa
 <body>
   <main>
     <h1>Book Inventory</h1>
-    <table>
-      <thead>
-        <tr>
-          <th>Title</th>
-          <th>Author</th>
-          <th>Category</th>
-          <th>Status</th>
-          <th>Rate</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr class="read">
-          <td>The Three Musketeers</td>
-          <td>Alexandre Dumas</td>
-          <td>Historical Novel</td>
-          <td><span class="status">Read</span></td>
-          <td>
-            <span class="rate three">
-              <span></span><span></span><span></span>
-            </span>
-          </td>
-        </tr>
-        <tr class="to-read">
-          <td>The Plague</td>
-          <td>Albert Camus</td>
-          <td>Philosophical Novel</td>
-          <td><span class="status">To Read</span></td>
-          <td>
-            <span class="rate">
-              <span></span><span></span><span></span>
-            </span>
-          </td>
-        </tr>
-        <tr class="read">
-          <td>The Metamorphosis</td>
-          <td>Franz Kafka</td>
-          <td>Novella</td>
-          <td><span class="status">Read</span></td>
-          <td>
-            <span class="rate one">
-              <span></span><span></span><span></span>
-            </span>
-          </td>
-        </tr>
-        <tr class="read">
-          <td>Dead Souls</td>
-          <td>Nikolai Gogol</td>
-          <td>Picaresque</td>
-          <td><span class="status">Read</span></td>
-          <td>
-            <span class="rate two">
-              <span></span><span></span><span></span>
-            </span>
-          </td>
-        </tr>
-        <tr class="in-progress">
-          <td>Lord of the Flies</td>
-          <td>William Golding</td>
-          <td>Allegorical Novel</td>
-          <td><span class="status">In Progress</span></td>
-          <td>
-            <span class="rate">
-              <span></span><span></span><span></span>
-            </span>
-          </td>
-        </tr>
-        <tr class="read">
-          <td>Do Androids Dream of Electric Sheep?</td>
-          <td>Philip K. Dick</td>
-          <td>Science Fiction</td>
-          <td><span class="status">Read</span></td>
-          <td>
-            <span class="rate two">
-              <span></span><span></span><span></span>
-            </span>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+    <div class="table-container">
+      <table>
+        <thead>
+          <tr>
+            <th>Title</th>
+            <th>Author</th>
+            <th>Category</th>
+            <th>Status</th>
+            <th>Rate</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr class="read">
+            <td>The Three Musketeers</td>
+            <td>Alexandre Dumas</td>
+            <td>Historical Novel</td>
+            <td><span class="status">Read</span></td>
+            <td>
+              <span class="rate three">
+                <span></span><span></span><span></span>
+              </span>
+            </td>
+          </tr>
+          <tr class="to-read">
+            <td>The Plague</td>
+            <td>Albert Camus</td>
+            <td>Philosophical Novel</td>
+            <td><span class="status">To Read</span></td>
+            <td>
+              <span class="rate">
+                <span></span><span></span><span></span>
+              </span>
+            </td>
+          </tr>
+          <tr class="read">
+            <td>The Metamorphosis</td>
+            <td>Franz Kafka</td>
+            <td>Novella</td>
+            <td><span class="status">Read</span></td>
+            <td>
+              <span class="rate one">
+                <span></span><span></span><span></span>
+              </span>
+            </td>
+          </tr>
+          <tr class="read">
+            <td>Dead Souls</td>
+            <td>Nikolai Gogol</td>
+            <td>Picaresque</td>
+            <td><span class="status">Read</span></td>
+            <td>
+              <span class="rate two">
+                <span></span><span></span><span></span>
+              </span>
+            </td>
+          </tr>
+          <tr class="in-progress">
+            <td>Lord of the Flies</td>
+            <td>William Golding</td>
+            <td>Allegorical Novel</td>
+            <td><span class="status">In Progress</span></td>
+            <td>
+              <span class="rate">
+                <span></span><span></span><span></span>
+              </span>
+            </td>
+          </tr>
+          <tr class="read">
+            <td>Do Androids Dream of Electric Sheep?</td>
+            <td>Philip K. Dick</td>
+            <td>Science Fiction</td>
+            <td><span class="status">Read</span></td>
+            <td>
+              <span class="rate two">
+                <span></span><span></span><span></span>
+              </span>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
   </main>
 </body>
 
@@ -618,6 +620,10 @@ assert.include(new __helpers.CSSHelp(document).getStyleAny(selectors)?.getPropVa
 * {
     box-sizing: border-box;
     font-family: Arial, sans-serif;
+}
+
+.table-container {
+  overflow-x: auto;
 }
 
 table {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

I noticed that the table in the Book Inventory demo isn't responsive on mobile. It expands beyond the view width and makes the page scroll horizontally. This PR fixes that issue.

Note that I'm only changing the demo project and not adding responsiveness as a requirement because the lab is above the CSS Responsive Design module.

Link to the lab: https://www.freecodecamp.org/learn/full-stack-developer/lab-book-inventory-app/build-a-book-inventory-app

## Screenshots

<details>
<summary>Before</summary>

https://github.com/user-attachments/assets/bae5a001-d192-45c3-b28f-681a05c7e8af

</details>

<details>
<summary>After</summary>

 https://github.com/user-attachments/assets/c00b2a63-80c9-4228-8b7e-217ed6bd582e

</details>

<!-- Feel free to add any additional description of changes below this line -->
