### PR TITLE
feat(learn): add Bluesky link to socials schema

### DIFF
--- a/api/src/routes/protected/settings.test.ts
+++ b/api/src/routes/protected/settings.test.ts
@@ -759,7 +759,8 @@ Happy coding!
           website: 'https://www.freecodecamp.org/',
           twitter: 'https://twitter.com/ossia',
           linkedin: 'https://www.linkedin.com/in/quincylarson',
-          githubProfile: 'https://github.com/QuincyLarson'
+          githubProfile: 'https://github.com/QuincyLarson',
+          bluesky: 'https://bsky.app/profile/testuser.bsky.social'
         });
 
         expect(response.body).toEqual({
@@ -774,7 +775,8 @@ Happy coding!
           website: 'https://www.freecodecamp.org/',
           twitter: '',
           linkedin: '',
-          githubProfile: ''
+          githubProfile: '',
+          bluesky: ''
         });
 
         expect(response.body).toEqual({
@@ -789,7 +791,8 @@ Happy coding!
           website: 'invalid',
           twitter: '',
           linkedin: '',
-          githubProfile: ''
+          githubProfile: '',
+          bluesky: ''
         });
 
         expect(response.body).toEqual(updateErrorResponse);
@@ -801,7 +804,8 @@ Happy coding!
           website: '',
           twitter: '',
           linkedin: '',
-          githubProfile: 'https://x.com/should-be-github'
+          githubProfile: 'https://x.com/should-be-github',
+          bluesky: ''
         });
 
         expect(response.body).toEqual(updateErrorResponse);

--- a/api/src/routes/protected/settings.test.ts
+++ b/api/src/routes/protected/settings.test.ts
@@ -759,8 +759,8 @@ Happy coding!
           website: 'https://www.freecodecamp.org/',
           twitter: 'https://twitter.com/ossia',
           linkedin: 'https://www.linkedin.com/in/quincylarson',
-          githubProfile: 'https://github.com/QuincyLarson',
-          bluesky: 'https://bsky.app/profile/testuser.bsky.social'
+          githubProfile: 'https://bsky.app/profile/quincy.bsky.social',
+          bluesky: ''
         });
 
         expect(response.body).toEqual({

--- a/api/src/routes/protected/settings.test.ts
+++ b/api/src/routes/protected/settings.test.ts
@@ -759,8 +759,8 @@ Happy coding!
           website: 'https://www.freecodecamp.org/',
           twitter: 'https://twitter.com/ossia',
           linkedin: 'https://www.linkedin.com/in/quincylarson',
-          githubProfile: 'https://bsky.app/profile/quincy.bsky.social',
-          bluesky: ''
+          githubProfile: 'https://github.com/QuincyLarson',
+          bluesky: 'https://bsky.app/profile/quincy.bsky.social'
         });
 
         expect(response.body).toEqual({

--- a/api/src/schemas/settings/update-my-socials.ts
+++ b/api/src/schemas/settings/update-my-socials.ts
@@ -10,7 +10,8 @@ export const updateMySocials = {
     website: urlOrEmptyString,
     twitter: urlOrEmptyString,
     githubProfile: urlOrEmptyString,
-    linkedin: urlOrEmptyString
+    linkedin: urlOrEmptyString,
+    bluesky: urlOrEmptyString // Optional Bluesky profile link
   }),
   response: {
     200: Type.Object({

--- a/api/src/schemas/settings/update-my-socials.ts
+++ b/api/src/schemas/settings/update-my-socials.ts
@@ -11,7 +11,7 @@ export const updateMySocials = {
     twitter: urlOrEmptyString,
     githubProfile: urlOrEmptyString,
     linkedin: urlOrEmptyString,
-    bluesky: urlOrEmptyString // Optional Bluesky profile link
+    bluesky: urlOrEmptyString
   }),
   response: {
     200: Type.Object({

--- a/client/src/components/profile/components/bio.tsx
+++ b/client/src/components/profile/components/bio.tsx
@@ -29,6 +29,7 @@ const Bio = ({ user, setIsEditing, isSessionUser }: BioProps) => {
     linkedin,
     twitter,
     website,
+    bluesky,
     isDonating,
     yearsTopContributor,
     picture,
@@ -87,6 +88,7 @@ const Bio = ({ user, setIsEditing, isSessionUser }: BioProps) => {
           twitter={twitter}
           username={username}
           website={website}
+          bluesky={bluesky}
         />
       </section>
     </FullWidthRow>

--- a/client/src/components/profile/components/internet.tsx
+++ b/client/src/components/profile/components/internet.tsx
@@ -21,9 +21,11 @@ import SectionHeader from '../../settings/section-header';
 import { User } from '../../../redux/prop-types';
 import { updateMySocials } from '../../../redux/settings/actions';
 
+// Added Bluesky to supported social links
 export interface Socials {
   githubProfile: string;
   linkedin: string;
+  bluesky: string; // new field
   twitter: string;
   website: string;
 }
@@ -50,6 +52,7 @@ const mapDispatchToProps: {
   updateMySocials
 };
 
+// Destructure user prop to get initial value for Bluesky
 const InternetSettings = ({
   user,
   t,
@@ -60,12 +63,15 @@ const InternetSettings = ({
     githubProfile = '',
     linkedin = '',
     twitter = '',
+    bluesky = '', // new field
     website = ''
   } = user;
 
+// Added Bluesky to the form state
   const [formValues, setFormValues] = useState<Socials>({
     githubProfile,
     linkedin,
+    bluesky, // new field
     twitter,
     website
   });
@@ -99,7 +105,8 @@ const InternetSettings = ({
     };
 
   const isFormPristine = () => {
-    const originalValues = { githubProfile, linkedin, twitter, website };
+    // Added Bluesky to original values for comparison
+    const originalValues = { githubProfile, linkedin, bluesky, twitter, website };
 
     return (Object.keys(originalValues) as Array<keyof Socials>).every(
       key => originalValues[key] === formValues[key]
@@ -127,6 +134,10 @@ const InternetSettings = ({
 
   const { state: linkedinValidation, message: linkedinValidationMessage } =
     getValidationStateFor(formValues.linkedin);
+
+// Validate the Bluesky input
+  const { state: blueskyValidation, message: blueskyValidationMessage } =
+    getValidationStateFor(formValues.bluesky);
 
   const { state: twitterValidation, message: twitterValidationMessage } =
     getValidationStateFor(formValues.twitter);
@@ -188,6 +199,28 @@ const InternetSettings = ({
               />
               <Info message={linkedinValidationMessage} />
             </FormGroup>
+            {/* Bluesky social link field */}
+          <FormGroup
+            controlId='internet-bluesky'
+            validationState={blueskyValidation}
+          >
+            <ControlLabel htmlFor='internet-bluesky-input'>
+              Bluesky
+            </ControlLabel>
+            <FormControl
+              onChange={createHandleChange('bluesky')}
+              placeholder='https://bsky.app/profile/your-handle.bsky.social'
+              type='url'
+              value={formValues.bluesky}
+              id='internet-bluesky-input'
+            />
+            <Check
+              url={formValues.bluesky}
+              validation={blueskyValidation}
+              dataPlaywrightTestLabel='internet-bluesky-check'
+            />
+            <Info message={blueskyValidationMessage} />
+          </FormGroup>
             <FormGroup
               controlId='internet-twitter'
               validationState={twitterValidation}

--- a/client/src/components/profile/components/internet.tsx
+++ b/client/src/components/profile/components/internet.tsx
@@ -21,11 +21,10 @@ import SectionHeader from '../../settings/section-header';
 import { User } from '../../../redux/prop-types';
 import { updateMySocials } from '../../../redux/settings/actions';
 
-// Added Bluesky to supported social links
 export interface Socials {
   githubProfile: string;
   linkedin: string;
-  bluesky: string; // new field
+  bluesky: string;
   twitter: string;
   website: string;
 }
@@ -52,7 +51,6 @@ const mapDispatchToProps: {
   updateMySocials
 };
 
-// Destructure user prop to get initial value for Bluesky
 const InternetSettings = ({
   user,
   t,
@@ -63,15 +61,14 @@ const InternetSettings = ({
     githubProfile = '',
     linkedin = '',
     twitter = '',
-    bluesky = '', // new field
+    bluesky = '',
     website = ''
   } = user;
 
-// Added Bluesky to the form state
   const [formValues, setFormValues] = useState<Socials>({
     githubProfile,
     linkedin,
-    bluesky, // new field
+    bluesky,
     twitter,
     website
   });
@@ -105,8 +102,13 @@ const InternetSettings = ({
     };
 
   const isFormPristine = () => {
-    // Added Bluesky to original values for comparison
-    const originalValues = { githubProfile, linkedin, bluesky, twitter, website };
+    const originalValues = {
+      githubProfile,
+      linkedin,
+      bluesky,
+      twitter,
+      website
+    };
 
     return (Object.keys(originalValues) as Array<keyof Socials>).every(
       key => originalValues[key] === formValues[key]
@@ -121,7 +123,6 @@ const InternetSettings = ({
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!isFormPristine() && isFormValid()) {
-      // Only submit the form if is has changed, and if it is valid
       updateMySocials({ ...formValues });
     }
     setIsEditing(false);
@@ -135,7 +136,7 @@ const InternetSettings = ({
   const { state: linkedinValidation, message: linkedinValidationMessage } =
     getValidationStateFor(formValues.linkedin);
 
-// Validate the Bluesky input
+  // Validate the Bluesky input
   const { state: blueskyValidation, message: blueskyValidationMessage } =
     getValidationStateFor(formValues.bluesky);
 
@@ -199,28 +200,27 @@ const InternetSettings = ({
               />
               <Info message={linkedinValidationMessage} />
             </FormGroup>
-            {/* Bluesky social link field */}
-          <FormGroup
-            controlId='internet-bluesky'
-            validationState={blueskyValidation}
-          >
-            <ControlLabel htmlFor='internet-bluesky-input'>
-              Bluesky
-            </ControlLabel>
-            <FormControl
-              onChange={createHandleChange('bluesky')}
-              placeholder='https://bsky.app/profile/your-handle.bsky.social'
-              type='url'
-              value={formValues.bluesky}
-              id='internet-bluesky-input'
-            />
-            <Check
-              url={formValues.bluesky}
-              validation={blueskyValidation}
-              dataPlaywrightTestLabel='internet-bluesky-check'
-            />
-            <Info message={blueskyValidationMessage} />
-          </FormGroup>
+            <FormGroup
+              controlId='internet-bluesky'
+              validationState={blueskyValidation}
+            >
+              <ControlLabel htmlFor='internet-bluesky-input'>
+                Bluesky
+              </ControlLabel>
+              <FormControl
+                onChange={createHandleChange('bluesky')}
+                placeholder='https://bsky.app/profile/your-handle.bsky.social'
+                type='url'
+                value={formValues.bluesky}
+                id='internet-bluesky-input'
+              />
+              <Check
+                url={formValues.bluesky}
+                validation={blueskyValidation}
+                dataPlaywrightTestLabel='internet-bluesky-check'
+              />
+              <Info message={blueskyValidationMessage} />
+            </FormGroup>
             <FormGroup
               controlId='internet-twitter'
               validationState={twitterValidation}

--- a/client/src/components/profile/components/social-icons.tsx
+++ b/client/src/components/profile/components/social-icons.tsx
@@ -1,7 +1,8 @@
 import {
   faLinkedin,
   faGithub,
-  faXTwitter
+  faXTwitter,
+  faBluesky, // Add Bluesky brand icon
 } from '@fortawesome/free-brands-svg-icons';
 import { faLink } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -16,6 +17,7 @@ interface SocialIconsProps {
   githubProfile: string;
   linkedin: string;
   show?: boolean;
+  bluesky: string; // Add Bluesky field to props
   twitter: string;
   username: string;
   website: string;
@@ -82,9 +84,25 @@ function TwitterIcon({ href, username }: IconProps): JSX.Element {
   );
 }
 
+// Bluesky social icon component
+function BlueskyIcon({ href, username }: IconProps): JSX.Element {
+  const { t } = useTranslation();
+  return (
+    <a
+      aria-label={t('aria.bluesky', { username })} // 📣 Add i18n support (optional)
+      href={href}
+      rel='noopener noreferrer'
+      target='_blank'
+    >
+      <FontAwesomeIcon icon={faBluesky} size='2x' />
+    </a>
+  );
+}
+
 function SocialIcons(props: SocialIconsProps): JSX.Element | null {
-  const { githubProfile, linkedin, twitter, username, website } = props;
-  const show = linkedin || githubProfile || website || twitter;
+  // Destructure Bluesky from props
+  const { githubProfile, linkedin, bluesky, twitter, username, website } = props;
+  const show = linkedin || githubProfile || website || twitter || bluesky;
   if (!show) {
     return null;
   }
@@ -96,6 +114,7 @@ function SocialIcons(props: SocialIconsProps): JSX.Element | null {
         {githubProfile ? (
           <GitHubIcon href={githubProfile} username={username} />
         ) : null}
+        {bluesky ? <BlueskyIcon href={bluesky} username={username} /> : null} // New Bluesky icon
         {website ? <WebsiteIcon href={website} username={username} /> : null}
         {twitter ? <TwitterIcon href={twitter} username={username} /> : null}
       </Col>

--- a/client/src/components/profile/components/social-icons.tsx
+++ b/client/src/components/profile/components/social-icons.tsx
@@ -84,7 +84,6 @@ function TwitterIcon({ href, username }: IconProps): JSX.Element {
   );
 }
 
-// Bluesky social icon component
 function BlueskyIcon({ href, username }: IconProps): JSX.Element {
   const { t } = useTranslation();
   return (
@@ -100,7 +99,6 @@ function BlueskyIcon({ href, username }: IconProps): JSX.Element {
 }
 
 function SocialIcons(props: SocialIconsProps): JSX.Element | null {
-  // Destructure Bluesky from props
   const { githubProfile, linkedin, bluesky, twitter, username, website } =
     props;
   const show = linkedin || githubProfile || website || twitter || bluesky;

--- a/client/src/components/profile/components/social-icons.tsx
+++ b/client/src/components/profile/components/social-icons.tsx
@@ -2,7 +2,7 @@ import {
   faLinkedin,
   faGithub,
   faXTwitter,
-  faBluesky, // Add Bluesky brand icon
+  faBluesky
 } from '@fortawesome/free-brands-svg-icons';
 import { faLink } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -17,7 +17,7 @@ interface SocialIconsProps {
   githubProfile: string;
   linkedin: string;
   show?: boolean;
-  bluesky: string; // Add Bluesky field to props
+  bluesky: string;
   twitter: string;
   username: string;
   website: string;
@@ -89,7 +89,7 @@ function BlueskyIcon({ href, username }: IconProps): JSX.Element {
   const { t } = useTranslation();
   return (
     <a
-      aria-label={t('aria.bluesky', { username })} // 📣 Add i18n support (optional)
+      aria-label={t('aria.bluesky', { username })}
       href={href}
       rel='noopener noreferrer'
       target='_blank'
@@ -101,7 +101,8 @@ function BlueskyIcon({ href, username }: IconProps): JSX.Element {
 
 function SocialIcons(props: SocialIconsProps): JSX.Element | null {
   // Destructure Bluesky from props
-  const { githubProfile, linkedin, bluesky, twitter, username, website } = props;
+  const { githubProfile, linkedin, bluesky, twitter, username, website } =
+    props;
   const show = linkedin || githubProfile || website || twitter || bluesky;
   if (!show) {
     return null;
@@ -114,7 +115,7 @@ function SocialIcons(props: SocialIconsProps): JSX.Element | null {
         {githubProfile ? (
           <GitHubIcon href={githubProfile} username={username} />
         ) : null}
-        {bluesky ? <BlueskyIcon href={bluesky} username={username} /> : null} // New Bluesky icon
+        {bluesky ? <BlueskyIcon href={bluesky} username={username} /> : null}
         {website ? <WebsiteIcon href={website} username={username} /> : null}
         {twitter ? <TwitterIcon href={twitter} username={username} /> : null}
       </Col>

--- a/client/src/redux/prop-types.ts
+++ b/client/src/redux/prop-types.ts
@@ -301,6 +301,7 @@ export type User = {
   calendar: Record<string, number>;
   about: string;
   acceptedPrivacyTerms: boolean;
+  bluesky: string; // Bluesky profile URL
   completedChallenges: CompletedChallenge[];
   completedSurveys: SurveyResults[];
   currentChallengeId: string;

--- a/e2e/internet-presence-settings.spec.ts
+++ b/e2e/internet-presence-settings.spec.ts
@@ -7,6 +7,7 @@ const settingsPageElement = {
   githubCheckmark: 'internet-github-check',
   linkedinCheckmark: 'internet-linkedin-check',
   twitterCheckmark: 'internet-twitter-check',
+  blueskyCheckmark: 'internet-bluesky-check',
   personalWebsiteCheckmark: 'internet-website-check',
   flashMessageAlert: 'flash-message',
   internetPresenceForm: 'internet-presence'
@@ -62,6 +63,12 @@ test.describe('Your Internet Presence', () => {
       url: 'https://twitter.com/certified-user',
       label: 'Twitter',
       checkTestId: settingsPageElement.twitterCheckmark
+    },
+    {
+      name: 'bluesky',
+      url: 'https://bsky.app/profile/certified-user.bsky.social',
+      label: 'Bluesky',
+      checkTestId: settingsPageElement.blueskyCheckmark
     },
     {
       name: 'website',


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #61176

<!-- Feel free to add any additional description of changes below this line -->

This pull request adds support for a new `bluesky` field in the `update-my-socials` API endpoint.  
- The field is validated as a URI or empty string.  
- It's included in the Swagger UI schema.  
- Successfully tested locally via Swagger interface with a valid Bluesky profile link.