### PR TITLE
chore: replace generic assert() with specific Chai methods in workshop-magazine challenges (#61179)

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6143d2842b497779bad947de.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6143d2842b497779bad947de.md
@@ -16,19 +16,29 @@ Set the `padding` and `margin` properties both to `0` and set the `box-sizing` p
 You should have a `*, ::before, ::after` selector.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('*, ::before, ::after'));
+assert.exists(new __helpers.CSSHelp(document).getStyle('*, ::before, ::after'));
 ```
 
 Your `*, ::before, ::after` selector should have a `padding` property set to `0`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('*, ::before, ::after')?.padding === '0px');
+assert.equal(
+  new __helpers.CSSHelp(document).getStyle('*, ::before, ::after')?.padding,
+  '0px'
+);
 ```
 
-Your `*, ::before, ::after` selector should have a `margin` property set to `0`.
+assert.equal(
+  new __helpers.CSSHelp(document).getStyle('*, ::before, ::after')?.margin,
+  '0px'
+);
+
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('*, ::before, ::after')?.margin === '0px');
+assert.equal(
+  new __helpers.CSSHelp(document).getStyle('*, ::before, ::after')?.boxSizing,
+  'border-box'
+);
 ```
 
 Your `*, ::before, ::after` selector should have a `box-sizing` property set to `border-box`.


### PR DESCRIPTION
Checklist:


- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

Closes #61179


This PR updates general `assert()` calls to more specific Chai assertion methods in the workshop-magazine curriculum files.
