### PR TITLE
test: remove unnecessary testString check

### DIFF
--- a/curriculum/test/test-challenges.js
+++ b/curriculum/test/test-challenges.js
@@ -1,5 +1,4 @@
 const path = require('path');
-const vm = require('vm');
 const { assert, AssertionError } = require('chai');
 const jsdom = require('jsdom');
 const liveServer = require('@compodoc/live-server');
@@ -358,14 +357,6 @@ function populateTestsForLang({ lang, challenges, meta, superBlocks }) {
                   it('Check tests. No tests.');
                   return;
                 }
-
-                describe('Check tests syntax', function () {
-                  tests.forEach(test => {
-                    it(`Check for: ${test.text}`, function () {
-                      assert.doesNotThrow(() => new vm.Script(test.testString));
-                    });
-                  });
-                });
 
                 if (challengeType === challengeTypes.backend) {
                   it('Check tests is not implemented.');


### PR DESCRIPTION
It doesn't matter if the testString would throw in isolation. It only matters if the test suite fails for initial conditions and passes for the solution.

My motivation for removing it is that the test runner now supports top-level await, but tests using that do not pass this check.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->
