### PR TITLE
fix(curriculum): correct 'ecommerce' to 'e-commerce' for consistency

### DIFF
--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b135e9029fb4f8141e40c.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b135e9029fb4f8141e40c.md
@@ -99,7 +99,7 @@ This term refers to the process of completing a purchase.
       "startTime": 4.28,
       "finishTime": 9.84,
       "dialogue": {
-        "text": "Yes. In one of my team's projects, we were involved in the development of an ecommerce platform.",
+        "text": "Yes. In one of my team's projects, we were involved in the development of an e-commerce platform.",
         "align": "center"
       }
     },


### PR DESCRIPTION


Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #61207


<!-- Feel free to add any additional description of changes below this line -->

- Changed `"ecommerce"` to `"e-commerce"` in the `657b135e9029fb4f8141e40c.md` file.
- This aligns with usage across the curriculum content.
