### PR TITLE
fix: update 'ecommerce' to 'e-commerce' for consistency (#61207)

### DIFF
--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b135e9029fb4f8141e40c.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-ask-and-share-about-educational-and-professional-background/657b135e9029fb4f8141e40c.md
@@ -99,7 +99,7 @@ This term refers to the process of completing a purchase.
       "startTime": 4.28,
       "finishTime": 9.84,
       "dialogue": {
-        "text": "Yes. In one of my team's projects, we were involved in the development of an ecommerce platform.",
+        "text": "Yes. In one of my team's projects, we were involved in the development of an e-commerce platform.",
         "align": "center"
       }
     },


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

This PR updates a sentence in the A2 English for Developers challenge to use the correct and consistent spelling of **"e-commerce"** instead of **"ecommerce"**.

It improves consistency across the curriculum content.
