### PR TITLE
chore(magazine-tests): refactor assert statements

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6143d003ad9e9d76766293ec.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6143d003ad9e9d76766293ec.md
@@ -27,9 +27,9 @@ Your `.image-quote` children should be in the correct order.
 
 ```js
 const children = document.querySelector('.image-quote')?.children;
-assert.equal(children?.[0]?.localName , 'hr');
-assert.equal(children?.[1]?.localName ,'p');
-assert.equal(children?.[2]?.localName ,'hr');
+assert.equal(children?.[0]?.localName, 'hr');
+assert.equal(children?.[1]?.localName, 'p');
+assert.equal(children?.[2]?.localName, 'hr');
 ```
 
 Your new `p` element should have a `class` set to `quote`.
@@ -41,7 +41,7 @@ assert.isTrue(document.querySelector('.image-quote p')?.classList.contains('quot
 Your new `p` element should have the text `The millions of people who are learning to code through freeCodeCamp will have an even better resource to help them learn these fundamentals.`.
 
 ```js
-assert.equal(document.querySelector('.image-quote p')?.innerText ,'The millions of people who are learning to code through freeCodeCamp will have an even better resource to help them learn these fundamentals.');
+assert.equal(document.querySelector('.image-quote p')?.innerText, 'The millions of people who are learning to code through freeCodeCamp will have an even better resource to help them learn these fundamentals.');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6143d003ad9e9d76766293ec.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6143d003ad9e9d76766293ec.md
@@ -14,34 +14,34 @@ Within your `.image-quote` element, nest an `hr` element, a `p` element and a se
 You should add two `hr` elements to your `.image-quote` element.
 
 ```js
-assert(document.querySelectorAll('.image-quote hr')?.length === 2);
+assert.lengthOf(document.querySelectorAll('.image-quote hr'), 2);
 ```
 
 You should add a `p` element to your `.image-quote` element.
 
 ```js
-assert(document.querySelectorAll('.image-quote p')?.length === 1);
+assert.lengthOf(document.querySelectorAll('.image-quote p'), 1);
 ```
 
 Your `.image-quote` children should be in the correct order.
 
 ```js
 const children = document.querySelector('.image-quote')?.children;
-assert(children?.[0]?.localName === 'hr');
-assert(children?.[1]?.localName === 'p');
-assert(children?.[2]?.localName === 'hr');
+assert.equal(children?.[0]?.localName , 'hr');
+assert.equal(children?.[1]?.localName ,'p');
+assert.equal(children?.[2]?.localName ,'hr');
 ```
 
 Your new `p` element should have a `class` set to `quote`.
 
 ```js
-assert(document.querySelector('.image-quote p')?.classList.contains('quote'));
+assert.isTrue(document.querySelector('.image-quote p')?.classList.contains('quote'));
 ```
 
 Your new `p` element should have the text `The millions of people who are learning to code through freeCodeCamp will have an even better resource to help them learn these fundamentals.`.
 
 ```js
-assert(document.querySelector('.image-quote p')?.innerText === 'The millions of people who are learning to code through freeCodeCamp will have an even better resource to help them learn these fundamentals.');
+assert.equal(document.querySelector('.image-quote p')?.innerText ,'The millions of people who are learning to code through freeCodeCamp will have an even better resource to help them learn these fundamentals.');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6143d2842b497779bad947de.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6143d2842b497779bad947de.md
@@ -16,25 +16,25 @@ Set the `padding` and `margin` properties both to `0` and set the `box-sizing` p
 You should have a `*, ::before, ::after` selector.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('*, ::before, ::after'));
+assert.exists(new __helpers.CSSHelp(document).getStyle('*, ::before, ::after'));
 ```
 
 Your `*, ::before, ::after` selector should have a `padding` property set to `0`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('*, ::before, ::after')?.padding === '0px');
+assert.equal(new __helpers.CSSHelp(document).getStyle('*, ::before, ::after')?.padding ,'0px');
 ```
 
 Your `*, ::before, ::after` selector should have a `margin` property set to `0`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('*, ::before, ::after')?.margin === '0px');
+assert.equal(new __helpers.CSSHelp(document).getStyle('*, ::before, ::after')?.margin , '0px');
 ```
 
 Your `*, ::before, ::after` selector should have a `box-sizing` property set to `border-box`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('*, ::before, ::after')?.boxSizing === 'border-box');
+assert.equal(new __helpers.CSSHelp(document).getStyle('*, ::before, ::after')?.boxSizing ,'border-box');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6143d2842b497779bad947de.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6143d2842b497779bad947de.md
@@ -22,13 +22,13 @@ assert.exists(new __helpers.CSSHelp(document).getStyle('*, ::before, ::after'));
 Your `*, ::before, ::after` selector should have a `padding` property set to `0`.
 
 ```js
-assert.equal(new __helpers.CSSHelp(document).getStyle('*, ::before, ::after')?.padding ,'0px');
+assert.equal(new __helpers.CSSHelp(document).getStyle('*, ::before, ::after')?.padding, '0px');
 ```
 
 Your `*, ::before, ::after` selector should have a `margin` property set to `0`.
 
 ```js
-assert.equal(new __helpers.CSSHelp(document).getStyle('*, ::before, ::after')?.margin , '0px');
+assert.equal(new __helpers.CSSHelp(document).getStyle('*, ::before, ::after')?.margin, '0px');
 ```
 
 Your `*, ::before, ::after` selector should have a `box-sizing` property set to `border-box`.

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6143d2842b497779bad947de.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6143d2842b497779bad947de.md
@@ -34,7 +34,7 @@ assert.equal(new __helpers.CSSHelp(document).getStyle('*, ::before, ::after')?.m
 Your `*, ::before, ::after` selector should have a `box-sizing` property set to `border-box`.
 
 ```js
-assert.equal(new __helpers.CSSHelp(document).getStyle('*, ::before, ::after')?.boxSizing ,'border-box');
+assert.equal(new __helpers.CSSHelp(document).getStyle('*, ::before, ::after')?.boxSizing, 'border-box');
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

Closes #61179  
Parent issue: #61205

### Description

This PR updates several generic `assert()` statements to specific Chai assert methods in the **Workshop Magazine** curriculum files. These updates improve readability and error messages in tests, and follow the recommendations from the Chai documentation.

#### 🔁 Changes made:
- Replaced `assert(a === b)` with `assert.equal(a, b)`
- Replaced `assert(a.length === n)` with `assert.lengthOf(a, n)`
- Replaced `assert(expression)` (for boolean) with `assert.isTrue(expression)`
- Replaced `assert(expression)` (for existence) with `assert.exists(expression)`
- Added missing semicolons where appropriate

Let me know if any adjustments are needed — happy to make updates!
