### PR TITLE
fix(curriculum): capitalize CSS abbreviation in Flexbox quiz question

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/quiz-css-flexbox/66ed8fe7f45ce3ece4053eb2.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-css-flexbox/66ed8fe7f45ce3ece4053eb2.md
@@ -39,7 +39,7 @@ A one-dimensional model for layout.
 
 #### --text--
 
-What css property is set to enable the flexbox layout for the `div` element?
+What CSS property is set to enable the flexbox layout for the `div` element?
 
 #### --distractors--
 


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

Closes #61214

<!-- Feel free to add any additional description of changes below this line -->

Fixed the issue where "css" was written in lowercase in the second question of the Flexbox Quiz.  
Changed "css" to uppercase "CSS" for consistency throughout the quiz, as CSS is an abbreviation and should be capitalized.

### Before
![Screenshot from 2025-07-05 17-33-47](https://github.com/user-attachments/assets/98bb4562-ed79-49c1-a64e-caf32b3aa68a)
### After
![Screenshot from 2025-07-05 17-33-40](https://github.com/user-attachments/assets/b5c4d834-9a92-4ffa-85c8-172125cdb39e)
