### PR TITLE
fix: capitalize CSS in flexbox quiz question for consistency

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/quiz-css-flexbox/66ed8fe7f45ce3ece4053eb2.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-css-flexbox/66ed8fe7f45ce3ece4053eb2.md
@@ -39,7 +39,7 @@ A one-dimensional model for layout.
 
 #### --text--
 
-What css property is set to enable the flexbox layout for the `div` element?
+What CSS property is set to enable the flexbox layout for the `div` element?
 
 #### --distractors--
 


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub environment.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #61214

<!-- Feel free to add any additional description of changes below this line -->

### 🛠️ Changes Made
- Updated the quiz question in `66ed8fe7f45ce3ece4053eb2.md` (line 42) in the **Flexbox section** of the curriculum.
- Changed:
  > *"What css property is set to enable the flexbox layout for the `div` element?"*

  to:

  > *"What CSS property is used to enable the Flexbox layout for a `div` element?"*

- Fixes grammar, capitalizes “CSS”, and improves clarity.
