### PR TITLE
chore(curriculum): update asserts in magazine workshop steps 26-30

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6144d66a5358db0c80628757.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6144d66a5358db0c80628757.md
@@ -22,7 +22,7 @@ assert.exists(new __helpers.CSSHelp(document).getStyle('html'));
 Your `html` selector should have a `font-size` property set to `62.5%`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('html')?.fontSize === '62.5%'); assert.equal(new __helpers.CSSHelp(document).getStyle('html')?.fontSize, '62.5%');
+assert.equal(new __helpers.CSSHelp(document).getStyle('html')?.fontSize, '62.5%');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6144d66a5358db0c80628757.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6144d66a5358db0c80628757.md
@@ -16,13 +16,13 @@ This will make it easier for you to work with `rem` units later, as `2rem` would
 You should create an `html` selector.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('html'));
+assert.exists(new __helpers.CSSHelp(document).getStyle('html'));
 ```
 
 Your `html` selector should have a `font-size` property set to `62.5%`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('html')?.fontSize === '62.5%');
+assert(new __helpers.CSSHelp(document).getStyle('html')?.fontSize === '62.5%'); assert.equal(new __helpers.CSSHelp(document).getStyle('html')?.fontSize, '62.5%');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6144d7dbdd3e580da730ff45.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6144d7dbdd3e580da730ff45.md
@@ -14,26 +14,26 @@ Create a `body` selector. Set the `font-family` property to `Baskervville`, with
 You should have a `body` selector.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('body'));
+assert.exists(new __helpers.CSSHelp(document).getStyle('body'));
 ```
 
 Your `body` selector should have a `font-family` property set to `Baskervville`, with a fallback of `serif`.
 
 ```js
 const fontFamily = new __helpers.CSSHelp(document).getStyle('body')?.fontFamily;
-assert(fontFamily === 'Baskervville, serif' || fontFamily === `"Baskervville", serif`);
+assert.oneOf(fontFamily, ['Baskervville, serif', `"Baskervville", serif`]);
 ```
 
 Your `body` selector should have a `color` property set to `linen`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('body')?.color === 'linen');
+assert.equal(new __helpers.CSSHelp(document).getStyle('body')?.color, 'linen');
 ```
 
 Your `body` selector should have a `background-color` property set to `rgb(20, 30, 40)`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('body')?.backgroundColor === 'rgb(20, 30, 40)');
+assert.equal(new __helpers.CSSHelp(document).getStyle('body')?.backgroundColor, 'rgb(20, 30, 40)');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6144de308591ec10e27d5383.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6144de308591ec10e27d5383.md
@@ -14,14 +14,14 @@ Create an `h1` selector, and set the `font-family` property to `Anton` with the 
 You should have an `h1` selector.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('h1'));
+assert.exists(new __helpers.CSSHelp(document).getStyle('h1'));
 ```
 
 Your `h1` selector should have a `font-family` property set to `Anton` with the fallback of `sans-serif`.
 
 ```js
 const fontFamily = new __helpers.CSSHelp(document).getStyle('h1')?.fontFamily;
-assert(fontFamily === 'Anton, sans-serif' || fontFamily === `"Anton", sans-serif`);
+assert.oneOf(fontFamily, ['Anton, sans-serif', `"Anton", sans-serif`]);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6144e1ba93e435127a7f516d.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6144e1ba93e435127a7f516d.md
@@ -14,14 +14,14 @@ Create an `h2, h3, h4, h5, h6` selector. Give it a `font-family` property set to
 You should have an `h2, h3, h4, h5, h6` selector.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('h2, h3, h4, h5, h6'));
+assert.exists(new __helpers.CSSHelp(document).getStyle('h2, h3, h4, h5, h6'));
 ```
 
 Your `h2, h3, h4, h5, h6` selector should have a `font-family` property set to `Raleway` with a fallback of `sans-serif`.
 
 ```js
 const fontFamily = new __helpers.CSSHelp(document).getStyle('h2, h3, h4, h5, h6')?.fontFamily;
-assert(fontFamily === 'Raleway, sans-serif' || fontFamily === `"Raleway", sans-serif`);
+assert.oneOf(fontFamily, ['Raleway, sans-serif', `"Raleway", sans-serif`]);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6144ee46a9d6e614c598cc05.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6144ee46a9d6e614c598cc05.md
@@ -14,19 +14,19 @@ Create an `a` selector, and give it a `text-decoration` property set to `none` a
 You should have an `a` selector.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('a'));
+assert.exists(new __helpers.CSSHelp(document).getStyle('a'));
 ```
 
 Your `a` selector should have a `text-decoration` property set to `none`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('a')?.textDecoration === 'none');
+assert.equal(new __helpers.CSSHelp(document).getStyle('a')?.textDecoration, 'none');
 ```
 
 Your `a` selector should have a `color` property set to `linen`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('a')?.color === 'linen');
+assert.equal(new __helpers.CSSHelp(document).getStyle('a')?.color, 'linen');
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #61180

<!-- Feel free to add any additional description of changes below this line -->
What does this PR do?

This PR updates generic `assert()` statements to use specific Chai assert methods (`assert.equal()`, `assert.exists()`, and `assert.oneOf()`) as described in issue #61180.  
This makes tests clearer and more specific.

Files affected:

`curriculum/challenges/english/25-front-end-development/workshop-magazine/6144d66a5358db0c80628757.md`
`curriculum/challenges/english/25-front-end-development/workshop-magazine/6144d7dbdd3e580da730ff45.md`
`curriculum/challenges/english/25-front-end-development/workshop-magazine/6144ee46a9d6e614c598cc05.md`
`curriculum/challenges/english/25-front-end-development/workshop-magazine/6144e1ba93e435127a7f516d.md`
`curriculum/challenges/english/25-front-end-development/workshop-magazine/6144de308591ec10e27d5383.md`