### PR TITLE
chore(deps): update curriculum-helpers to 5.3.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -945,8 +945,8 @@ importers:
   tools/client-plugins/browser-scripts:
     dependencies:
       '@freecodecamp/curriculum-helpers':
-        specifier: ^5.0.0
-        version: 5.0.0(typescript@5.8.2)
+        specifier: ^5.1.0
+        version: 5.1.0(typescript@5.8.2)
       react:
         specifier: '16'
         version: 16.14.0
@@ -2748,8 +2748,8 @@ packages:
       '@fortawesome/fontawesome-svg-core': ~1 || ~6
       react: '>=16.3'
 
-  '@freecodecamp/curriculum-helpers@5.0.0':
-    resolution: {integrity: sha512-HS/qFbnOQ3Lgn+dQMrmF8iagK7T+TNpgmbTbBIqIo32/yamKFAqWvmeT3aPucLEuWrC+Abp0w6SwYCrx7DcBXg==}
+  '@freecodecamp/curriculum-helpers@5.1.0':
+    resolution: {integrity: sha512-cw6qwWxX44XHAY3Ek0NV79u6xZQWbojbW49E7HoDP4qAVyeUjzkHOxv8EXF5rBzN1emDiYSl0v3/4nTr8vVs2A==}
     engines: {pnpm: '>= 10'}
 
   '@freecodecamp/loop-protect@3.0.0':
@@ -16887,7 +16887,7 @@ snapshots:
       prop-types: 15.8.1
       react: 17.0.2
 
-  '@freecodecamp/curriculum-helpers@5.0.0(typescript@5.8.2)':
+  '@freecodecamp/curriculum-helpers@5.1.0(typescript@5.8.2)':
     dependencies:
       '@sinonjs/fake-timers': 14.0.0
       '@types/jquery': 3.5.32

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -945,8 +945,8 @@ importers:
   tools/client-plugins/browser-scripts:
     dependencies:
       '@freecodecamp/curriculum-helpers':
-        specifier: ^5.1.0
-        version: 5.1.0(typescript@5.8.2)
+        specifier: ^5.2.0
+        version: 5.2.0(typescript@5.8.2)
       react:
         specifier: '16'
         version: 16.14.0
@@ -2748,8 +2748,8 @@ packages:
       '@fortawesome/fontawesome-svg-core': ~1 || ~6
       react: '>=16.3'
 
-  '@freecodecamp/curriculum-helpers@5.1.0':
-    resolution: {integrity: sha512-cw6qwWxX44XHAY3Ek0NV79u6xZQWbojbW49E7HoDP4qAVyeUjzkHOxv8EXF5rBzN1emDiYSl0v3/4nTr8vVs2A==}
+  '@freecodecamp/curriculum-helpers@5.2.0':
+    resolution: {integrity: sha512-JOFtwx/Qm0BkYXPHJGsIKkwaEaI7zZYw5a2IF9iVzIhy+1RLf9cwQzAb1Rv6qMTxWI72ovakZufRE3CV6Rh0kw==}
     engines: {pnpm: '>= 10'}
 
   '@freecodecamp/loop-protect@3.0.0':
@@ -16887,7 +16887,7 @@ snapshots:
       prop-types: 15.8.1
       react: 17.0.2
 
-  '@freecodecamp/curriculum-helpers@5.1.0(typescript@5.8.2)':
+  '@freecodecamp/curriculum-helpers@5.2.0(typescript@5.8.2)':
     dependencies:
       '@sinonjs/fake-timers': 14.0.0
       '@types/jquery': 3.5.32

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -945,8 +945,8 @@ importers:
   tools/client-plugins/browser-scripts:
     dependencies:
       '@freecodecamp/curriculum-helpers':
-        specifier: ^5.2.0
-        version: 5.2.0(typescript@5.8.2)
+        specifier: ^5.3.0
+        version: 5.3.0(typescript@5.8.2)
       react:
         specifier: '16'
         version: 16.14.0
@@ -2748,8 +2748,8 @@ packages:
       '@fortawesome/fontawesome-svg-core': ~1 || ~6
       react: '>=16.3'
 
-  '@freecodecamp/curriculum-helpers@5.2.0':
-    resolution: {integrity: sha512-JOFtwx/Qm0BkYXPHJGsIKkwaEaI7zZYw5a2IF9iVzIhy+1RLf9cwQzAb1Rv6qMTxWI72ovakZufRE3CV6Rh0kw==}
+  '@freecodecamp/curriculum-helpers@5.3.0':
+    resolution: {integrity: sha512-ya+NlEA4G/I64yfDwwFh6JR9qxmLOtM0512bnupdVP08MQh8A71r0a9YhbGxpxIOym08WcEd0nVHjYk652EMmA==}
     engines: {pnpm: '>= 10'}
 
   '@freecodecamp/loop-protect@3.0.0':
@@ -16887,7 +16887,7 @@ snapshots:
       prop-types: 15.8.1
       react: 17.0.2
 
-  '@freecodecamp/curriculum-helpers@5.2.0(typescript@5.8.2)':
+  '@freecodecamp/curriculum-helpers@5.3.0(typescript@5.8.2)':
     dependencies:
       '@sinonjs/fake-timers': 14.0.0
       '@types/jquery': 3.5.32

--- a/tools/client-plugins/browser-scripts/package.json
+++ b/tools/client-plugins/browser-scripts/package.json
@@ -43,7 +43,7 @@
     "webpack-cli": "4.10.0"
   },
   "dependencies": {
-    "@freecodecamp/curriculum-helpers": "^5.1.0",
+    "@freecodecamp/curriculum-helpers": "^5.2.0",
     "react": "16",
     "react-dom": "16",
     "xterm": "^5.2.1"

--- a/tools/client-plugins/browser-scripts/package.json
+++ b/tools/client-plugins/browser-scripts/package.json
@@ -43,7 +43,7 @@
     "webpack-cli": "4.10.0"
   },
   "dependencies": {
-    "@freecodecamp/curriculum-helpers": "^5.0.0",
+    "@freecodecamp/curriculum-helpers": "^5.1.0",
     "react": "16",
     "react-dom": "16",
     "xterm": "^5.2.1"

--- a/tools/client-plugins/browser-scripts/package.json
+++ b/tools/client-plugins/browser-scripts/package.json
@@ -43,7 +43,7 @@
     "webpack-cli": "4.10.0"
   },
   "dependencies": {
-    "@freecodecamp/curriculum-helpers": "^5.2.0",
+    "@freecodecamp/curriculum-helpers": "^5.3.0",
     "react": "16",
     "react-dom": "16",
     "xterm": "^5.2.1"


### PR DESCRIPTION
This supports top-level await in tests as well as continuing to support async function tests. The plan is to remove async function tests and then stop supporting them.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->
