### PR TITLE
test: separate test runner creation from test evaluation

### DIFF
--- a/curriculum/test/test-challenges.js
+++ b/curriculum/test/test-challenges.js
@@ -378,7 +378,7 @@ function populateTestsForLang({ lang, challenges, meta, superBlocks }) {
 
                 let testRunner;
                 it('Must create a test runner', async function () {
-                  this.timeout(10000);
+                  this.timeout(20000);
                   testRunner = await createTestRunner(
                     challenge,
                     challenge.challengeFiles,

--- a/curriculum/test/test-challenges.js
+++ b/curriculum/test/test-challenges.js
@@ -375,6 +375,17 @@ function populateTestsForLang({ lang, challenges, meta, superBlocks }) {
                 // The python tests are (currently) slow, so we give them more time.
                 const timePerTest =
                   challengeType === challengeTypes.python ? 10000 : 5000;
+
+                let testRunner;
+                it('Must create a test runner', async function () {
+                  this.timeout(10000);
+                  testRunner = await createTestRunner(
+                    challenge,
+                    challenge.challengeFiles,
+                    buildChallenge
+                  );
+                });
+
                 it('Test suite must fail on the initial contents', async function () {
                   // TODO: some tests take a surprisingly long time to setup the
                   // test runner, so this timeout is large while we investigate.
@@ -383,30 +394,16 @@ function populateTestsForLang({ lang, challenges, meta, superBlocks }) {
                   const oldConsoleError = console.error;
                   console.error = () => {};
                   let fails = false;
-                  let testRunner;
-                  try {
-                    testRunner = await createTestRunner(
-                      challenge,
-                      challenge.challengeFiles,
-                      buildChallenge
-                    );
-                  } catch (e) {
-                    console.error(
-                      `Error creating test runner for initial contents`
-                    );
-                    console.error(e);
-                    fails = true;
-                  }
-                  if (!fails) {
-                    for (const test of tests) {
-                      try {
-                        await testRunner(test);
-                      } catch {
-                        fails = true;
-                        break;
-                      }
+
+                  for (const test of tests) {
+                    try {
+                      await testRunner(test);
+                    } catch {
+                      fails = true;
+                      break;
                     }
                   }
+
                   console.error = oldConsoleError;
                   assert(
                     fails,

--- a/curriculum/test/test-challenges.js
+++ b/curriculum/test/test-challenges.js
@@ -377,7 +377,7 @@ function populateTestsForLang({ lang, challenges, meta, superBlocks }) {
                   challengeType === challengeTypes.python ? 10000 : 5000;
 
                 let testRunner;
-                it('Must create a test runner', async function () {
+                it('Must create a test runner for the initial conditions', async function () {
                   this.timeout(20000);
                   testRunner = await createTestRunner(
                     challenge,
@@ -486,16 +486,21 @@ seed goes here
 
                 describe('Check tests against solutions', function () {
                   solutions.forEach((solution, index) => {
-                    it(`Solution ${
-                      index + 1
-                    } must pass the tests`, async function () {
-                      this.timeout(timePerTest * tests.length + 2000);
-                      const testRunner = await createTestRunner(
+                    it('Must create a test runner for the solution', async function () {
+                      this.timeout(20000);
+                      testRunner = await createTestRunner(
                         challenge,
                         solution,
                         buildChallenge,
                         solutionFromNext
                       );
+                    });
+
+                    it(`Solution ${
+                      index + 1
+                    } must pass the tests`, async function () {
+                      this.timeout(timePerTest * tests.length + 2000);
+
                       for (const test of tests) {
                         await testRunner(test);
                       }


### PR DESCRIPTION
This should help debug the random test failures, since it's currently unclear which of the two is timing out.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
