### PR TITLE
feat: ab test for independent lowerjaw under editor

### DIFF
--- a/client/src/templates/Challenges/classic/desktop-layout.tsx
+++ b/client/src/templates/Challenges/classic/desktop-layout.tsx
@@ -19,6 +19,7 @@ import {
 } from '../redux/selectors';
 import PreviewPortal from '../components/preview-portal';
 import Notes from '../components/notes';
+import IndependentLowerJaw from '../components/independent-lower-jaw';
 import ActionRow from './action-row';
 
 type Pane = { flex: number };
@@ -322,6 +323,7 @@ const DesktopLayout = (props: DesktopLayoutProps): JSX.Element => {
               )}
             </ReflexContainer>
           )}
+          {showIndependentLowerJaw && <IndependentLowerJaw />}
         </ReflexElement>
         {displayNotes && <ReflexSplitter propagate={true} {...resizeProps} />}
         {displayNotes && (

--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -311,7 +311,9 @@ function ShowClassic({
 
   // Independent lower jaw is only enabled for the urriculum outline workshop
   const showIndependentLowerJaw =
-    blockName === 'workshop-curriculum-outline' && isIndependentLowerJawEnabled;
+    blockName === 'workshop-curriculum-outline' &&
+    isIndependentLowerJawEnabled &&
+    !isMobile;
 
   useEffect(() => {
     if (isPreFetchEnabled && envData.clientLocale === 'espanol') {

--- a/client/src/templates/Challenges/components/independent-lower-jaw.css
+++ b/client/src/templates/Challenges/components/independent-lower-jaw.css
@@ -17,7 +17,7 @@
 }
 
 .independent-lower-jaw .btn-cta {
-  padding: 4px 10px;
+  padding: 6px 12px;
 }
 
 .independent-lower-jaw .buttons-row-container {
@@ -79,7 +79,7 @@
 .independent-lower-jaw .tooltip:hover .tooltiptext {
   visibility: visible;
   opacity: 1;
-  transition: opacity 0.5s ease 0.5s;
+  transition: opacity 0.5s ease 1s;
 }
 
 .tooltiptext::after {

--- a/client/src/templates/Challenges/components/side-panel.tsx
+++ b/client/src/templates/Challenges/components/side-panel.tsx
@@ -8,7 +8,6 @@ import { Test } from '../../../redux/prop-types';
 import { challengeTestsSelector } from '../redux/selectors';
 import { openModal } from '../redux/actions';
 import TestSuite from './test-suite';
-import IndependentLowerJaw from './independent-lower-jaw';
 
 import './side-panel.css';
 
@@ -49,41 +48,38 @@ export function SidePanel({
   showIndependentLowerJaw
 }: SidePanelProps): JSX.Element {
   return (
-    <>
-      <div
-        className='instructions-panel'
-        ref={instructionsPanelRef}
-        tabIndex={-1}
-      >
-        {challengeTitle}
-        {hasDemo && (
-          <p>
-            <Trans i18nKey='learn.example-app'>
-              <span
-                className='example-app-link'
-                onClick={() => openModal('projectPreview')}
-                role='button'
-                tabIndex={0}
-                onKeyDown={e => {
-                  if (e.key === 'Enter' || e.key === ' ') {
-                    openModal('projectPreview');
-                  }
-                }}
-              ></span>
-            </Trans>
-          </p>
-        )}{' '}
-        {challengeDescription}
-        {!showIndependentLowerJaw && (
-          <>
-            <Spacer size='m' />
-            {toolPanel}
-            <TestSuite tests={tests} />
-          </>
-        )}
-      </div>
-      {showIndependentLowerJaw && <IndependentLowerJaw />}
-    </>
+    <div
+      className='instructions-panel'
+      ref={instructionsPanelRef}
+      tabIndex={-1}
+    >
+      {challengeTitle}
+      {hasDemo && (
+        <p>
+          <Trans i18nKey='learn.example-app'>
+            <span
+              className='example-app-link'
+              onClick={() => openModal('projectPreview')}
+              role='button'
+              tabIndex={0}
+              onKeyDown={e => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  openModal('projectPreview');
+                }
+              }}
+            ></span>
+          </Trans>
+        </p>
+      )}{' '}
+      {challengeDescription}
+      {!showIndependentLowerJaw && (
+        <>
+          <Spacer size='m' />
+          {toolPanel}
+          <TestSuite tests={tests} />
+        </>
+      )}
+    </div>
   );
 }
 


### PR DESCRIPTION
This pr moves the independent lower jaw to the editor pane.

<img width="1477" alt="Screenshot 2025-07-09 at 6 10 26 PM" src="https://github.com/user-attachments/assets/72f797f9-f3d7-46ea-9c79-4f40260f8ca7" />


Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

