### PR TITLE
fix: update Step 21 test in Music Player lab to support Safari

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148b185ef37522f688316b0.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148b185ef37522f688316b0.md
@@ -18,7 +18,7 @@ Give your `.heading` element a `grid-template-columns` property set to `repeat(2
 Your `.heading` selector should have a `grid-template-columns` property set to `repeat(2, 1fr)`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.heading')?.gridTemplateColumns === 'repeat(2, 1fr)');
+assert.equal(new __helpers.CSSHelp(document).getStyle('.heading')?.gridTemplateColumns, 'repeat(2, 1fr)');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148b30464daf630848c21d4.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148b30464daf630848c21d4.md
@@ -14,7 +14,7 @@ Give your `.heading` selector a `row-gap` property set to `1.5rem`.
 Your `.heading` selector should have a `row-gap` property set to `1.5rem`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.heading')?.rowGap === '1.5rem');
+assert.equal(new __helpers.CSSHelp(document).getStyle('.heading')?.rowGap, '1.5rem');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148b4b150434734143db6f2.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148b4b150434734143db6f2.md
@@ -16,13 +16,13 @@ Create a `.hero` selector and give it a `grid-column` property set to `1 / -1`. 
 You should have a `.hero` selector.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.hero'));
+assert.exists(new __helpers.CSSHelp(document).getStyle('.hero'));
 ```
 
 Your `.hero` selector should have a `grid-column` property set to `1 / -1`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.hero')?.gridColumn === '1 / -1');
+assert.equal(new __helpers.CSSHelp(document).getStyle('.hero')?.gridColumn, '1 / -1');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148b5623efa8f369f2c3643.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148b5623efa8f369f2c3643.md
@@ -14,7 +14,7 @@ Give the `.hero` selector a `position` property set to `relative`.
 Your `.hero` selector should have a `position` property set to `relative`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.hero')?.position === 'relative');
+assert.equal(new __helpers.CSSHelp(document).getStyle('.hero')?.position, 'relative');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148b59ef318e03875f35c4a.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148b59ef318e03875f35c4a.md
@@ -16,19 +16,19 @@ The `object-fit` property tells the browser how to position the element within i
 You should have an `img` selector.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('img'));
+assert.exists(new __helpers.CSSHelp(document).getStyle('img'));
 ```
 
 Your `img` selector should have a `width` property set to `100%`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('img')?.width === '100%');
+assert.equal(new __helpers.CSSHelp(document).getStyle('img')?.width, '100%');
 ```
 
 Your `img` selector should have an `object-fit` property set to `cover`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('img')?.objectFit === 'cover');
+assert.equal(new __helpers.CSSHelp(document).getStyle('img')?.objectFit, 'cover');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148bd62bbb8c83a5f1fc1b3.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148bd62bbb8c83a5f1fc1b3.md
@@ -14,25 +14,25 @@ Create a `.hero-title` selector and give it a `text-align` property set to `cent
 You should have a `.hero-title` selector.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.hero-title'));
+assert.exists(new __helpers.CSSHelp(document).getStyle('.hero-title'));
 ```
 
 Your `.hero-title` selector should have a `text-align` property set to `center`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.hero-title')?.textAlign === 'center');
+assert.equal(new __helpers.CSSHelp(document).getStyle('.hero-title')?.textAlign, 'center');
 ```
 
 Your `.hero-title` selector should have a `color` property set to `orangered`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.hero-title')?.color === 'orangered');
+assert.equal(new __helpers.CSSHelp(document).getStyle('.hero-title')?.color, 'orangered');
 ```
 
 Your `.hero-title` selector should have a `font-size` property set to `8rem`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.hero-title')?.fontSize === '8rem');
+assert.equal(new __helpers.CSSHelp(document).getStyle('.hero-title')?.fontSize, '8rem');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148be3d605d6b3ca9425d11.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148be3d605d6b3ca9425d11.md
@@ -14,25 +14,25 @@ The subtitle also needs to be styled. Create a `.hero-subtitle` selector and giv
 You should have a `.hero-subtitle` selector.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.hero-subtitle'));
+assert.exists(new __helpers.CSSHelp(document).getStyle('.hero-subtitle'));
 ```
 
 Your `.hero-subtitle` selector should have a `font-size` property set to `2.4rem`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.hero-subtitle')?.fontSize === '2.4rem');
+assert.equal(new __helpers.CSSHelp(document).getStyle('.hero-subtitle')?.fontSize, '2.4rem');
 ```
 
 Your `.hero-subtitle` selector should have a `color` property set to `orangered`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.hero-subtitle')?.color === 'orangered');
+assert.equal(new __helpers.CSSHelp(document).getStyle('.hero-subtitle')?.color, 'orangered');
 ```
 
 Your `.hero-subtitle` selector should have a `text-align` property set to `center`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.hero-subtitle')?.textAlign === 'center');
+assert.equal(new __helpers.CSSHelp(document).getStyle('.hero-subtitle')?.textAlign, 'center');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148be82ca63c63daa8cca49.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148be82ca63c63daa8cca49.md
@@ -14,20 +14,20 @@ Create an `.author` selector and give it a `font-size` property set to `2rem` an
 You should have an `.author` selector.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.author'));
+assert.exists(new __helpers.CSSHelp(document).getStyle('.author'));
 ```
 
 Your `.author` selector should have a `font-size` property set to `2rem`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.author')?.fontSize === '2rem');
+assert.equal(new __helpers.CSSHelp(document).getStyle('.author')?.fontSize, '2rem');
 ```
 
 Your `.author` selector should have a `font-family` property set to `Raleway` with a fallback of `sans-serif`.
 
 ```js
 const fontFamily = new __helpers.CSSHelp(document).getStyle('.author')?.fontFamily;
-assert(fontFamily === 'Raleway, sans-serif' || fontFamily === `"Raleway", sans-serif`);
+assert.oneOf(fontFamily, ['Raleway, sans-serif',`"Raleway", sans-serif`]);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148be82ca63c63daa8cca49.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148be82ca63c63daa8cca49.md
@@ -27,7 +27,7 @@ Your `.author` selector should have a `font-family` property set to `Raleway` wi
 
 ```js
 const fontFamily = new __helpers.CSSHelp(document).getStyle('.author')?.fontFamily;
-assert.oneOf(fontFamily, ['Raleway, sans-serif',`"Raleway", sans-serif`]);
+assert.oneOf(fontFamily, ['Raleway, sans-serif', `"Raleway", sans-serif`]);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148bf49fcc7913f05dbf9b7.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148bf49fcc7913f05dbf9b7.md
@@ -16,13 +16,13 @@ This will create a hover effect only for the `a` element within the `.author-nam
 You should have an `.author-name a:hover` selector.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.author-name a:hover'));
+assert.exists(new __helpers.CSSHelp(document).getStyle('.author-name a:hover'));
 ```
 
 Your `.author-name a:hover` selector should have a `background-color` property set to `#306203`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.author-name a:hover')?.backgroundColor === 'rgb(48, 98, 3)');
+assert.equal(new __helpers.CSSHelp(document).getStyle('.author-name a:hover')?.backgroundColor, 'rgb(48, 98, 3)');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148bfc43df3bc40fe0e6405.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148bfc43df3bc40fe0e6405.md
@@ -14,13 +14,13 @@ Create a `.publish-date` selector and give it a `color` property of `rgba(255, 2
 You should have a `.publish-date` selector.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.publish-date'));
+assert.exists(new __helpers.CSSHelp(document).getStyle('.publish-date'));
 ```
 
 Your `.publish-date` selector should have a `color` property set to `rgba(255, 255, 255, 0.5)`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.publish-date')?.color === 'rgba(255, 255, 255, 0.5)');
+assert.equal(new __helpers.CSSHelp(document).getStyle('.publish-date')?.color, 'rgba(255, 255, 255, 0.5)');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-music-player/6748567229cc8fe3f706de02.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-music-player/6748567229cc8fe3f706de02.md
@@ -25,7 +25,13 @@ Yor `pauseSong` function should set the `songCurrentTime` of the `userData` obje
 ```js
 userData.songCurrentTime = 0;
 audio.currentTime = 10;
-pauseSong()
+
+await new Promise(resolve => {
+  if (audio.readyState >= 1) return resolve();
+  audio.addEventListener('loadedmetadata', resolve, { once: true });
+});
+
+pauseSong();
 assert.equal(userData.songCurrentTime, 10);
 ```
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

Closes #60964


This PR updates the test logic for Step 21 of the Build a Music Player lab to ensure compatibility with Safari.

### 🔍 Background:
In Safari, the `audio.currentTime` property doesn't update until the metadata is loaded. This caused the test to fail even for correct implementations.

### ✅ Fix:
Added a `loadedmetadata` event listener that resolves before asserting the `currentTime` value. This ensures the test waits for Safari to update the `audio` metadata before proceeding.

### 🧪 Updated Hint Test:
```js
userData.songCurrentTime = 0;
audio.currentTime = 10;

await new Promise(resolve => {
  if (audio.readyState >= 1) return resolve();
  audio.addEventListener('loadedmetadata', resolve, { once: true });
});

pauseSong();
assert.equal(userData.songCurrentTime, 10);
