### PR TITLE
fix(curriculum): update test in Music Player lab to be reliable across browsers

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-music-player/6748567229cc8fe3f706de02.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-music-player/6748567229cc8fe3f706de02.md
@@ -23,9 +23,16 @@ assert.isFunction(pauseSong);
 Your `pauseSong` function should set the `songCurrentTime` of the `userData` object to the `currentTime` of the `audio` variable.
 
 ```js
-userData.songCurrentTime = 99;
-pauseSong()
-assert.strictEqual(userData.songCurrentTime, audio.currentTime);
+Object.defineProperty(audio, 'currentTime', {
+  value: 10,
+  writable: true,
+  configurable: true
+});
+
+userData.songCurrentTime = 0;
+pauseSong();
+assert.strictEqual(userData.songCurrentTime, 10);
+delete audio.currentTime;
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-music-player/6748567229cc8fe3f706de02.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-music-player/6748567229cc8fe3f706de02.md
@@ -23,10 +23,9 @@ assert.isFunction(pauseSong);
 Yor `pauseSong` function should set the `songCurrentTime` of the `userData` object to the `currentTime` of the `audio` variable.
 
 ```js
-userData.songCurrentTime = 0;
-audio.currentTime = 10;
+userData.songCurrentTime = 99;
 pauseSong()
-assert.equal(userData.songCurrentTime, 10);
+assert.strictEqual(userData.songCurrentTime, audio.currentTime);
 ```
 
 # --seed--


### PR DESCRIPTION
This PR fixes an unreliable test for the `pauseSong` function in "Build a Music Lab" workshop.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

### The Problem

The original test failed because assigning `audio.currentTime = 10` is not an instant change, it's a request sent to the browser's audio player, which takes some time to process. Safari handles media elements differently from other browsers, and the test code did not wait. 

The previous test code was:

```js
userData.songCurrentTime = 0;
audio.currentTime = 10;
pauseSong()
assert.equal(userData.songCurrentTime, 10);
```

### The Solution

My fix was to stop relying on the browser's timer during the test. I used `Object.defineProperty()` to temporarily set `audio.currentTime` to a solid, predictable number. This way, the test focuses only on whether the camper's code works, not on random browser behavior.

The new test code is:

```js
Object.defineProperty(audio, 'currentTime', {
  value: 10,
  writable: true,
  configurable: true
});

userData.songCurrentTime = 0;
pauseSong();
assert.strictEqual(userData.songCurrentTime, 10);
delete audio.currentTime;
```

### Safari browser

<img width="1512" height="943" alt="Screenshot 2025-07-11 at 01 10 13" src="https://github.com/user-attachments/assets/694959ef-3fb0-4fd5-a1d3-8212d90f70f1" />

Closes #60964