### PR TITLE
fix(curriculum): replace 'spreadsheet' with 'stylesheet' in a CSS lecture

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-fonts/672bd834cedccefd5939a913.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-fonts/672bd834cedccefd5939a913.md
@@ -1,14 +1,13 @@
 ---
 id: 672bd834cedccefd5939a913
 title: What Is the @font-face At-Rule, and How Does It Work?
-challengeType: 11
-videoId: hpD2-pwEQjc
+challengeType: 19
 dashedName: what-is-the-font-face-at-rule
 ---
 
 # --description--
 
-Watch the video or read the transcript and answer the questions below.
+Read the transcript and answer the questions below.
 
 # --transcript--
 
@@ -24,7 +23,7 @@ With `@font-face`, you can define a custom font by specifying the font file, for
 }
 ```
 
-Within the curly brackets, you will need to include descriptors to customize your font face. Let's see some of the most commonly used ones. The font-family descriptor specifies the name that you will use throughout the spreadsheet to refer to that font. For example, let's say that you define this `@font-face rule`. It has the `font-family` descriptor defined and its value is `MyCustomFont`:
+Within the curly brackets, you will need to include descriptors to customize your font face. Let's see some of the most commonly used ones. The font-family descriptor specifies the name that you will use throughout the stylesheet to refer to that font. For example, let's say that you define this `@font-face rule`. It has the `font-family` descriptor defined and its value is `MyCustomFont`:
 
 ```css
 @font-face {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #61229 

<!-- Feel free to add any additional description of changes below this line -->
As per discussion in the comments of the issue I have made changes to https://github.com/freeCodeCamp/freeCodeCamp/blob/main/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-fonts/672bd834cedccefd5939a913.md
file of the codebase . In this I changed the metadata, description and transcript inside the file to fix the wrong use of 'spreadsheet'.