### PR TITLE
fix(curriculum): update CheckPoint to Checkpoint for consistent class naming

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64cb262dd91ecc62998736af.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-intermediate-oop-by-building-a-platformer-game/64cb262dd91ecc62998736af.md
@@ -9,14 +9,14 @@ dashedName: step-93
 
 The last portion of the project is to add the logic for the checkpoints. When a player collides with a checkpoint, the checkpoint screen should appear.
 
-Start by creating a new `class` called `CheckPoint`.
+Start by creating a new `class` called `Checkpoint`.
 
 # --hints--
 
-You should have a `class` called `CheckPoint`.
+You should have a `class` called `Checkpoint`.
 
 ```js
-assert.match(code, /\s*class\s*CheckPoint\s*{\s*}\s*;?/);
+assert.match(code, /\s*class\s*Checkpoint\s*{\s*}\s*;?/);
 ```
 
 # --seed--


### PR DESCRIPTION
### Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #61322 

### Description

This pull request addresses an inconsistency in class naming within the platformer game challenge. The `CheckPoint` class name has been corrected to `Checkpoint` to match standard naming conventions and maintain consistency with related variable names throughout the lesson.

### Changes include:
- Updated class name reference in the description block
- Updated hint test regex to look for `class Checkpoint` instead of `CheckPoint`

