### PR TITLE
chore: replace generic assert statements with specific Chai methods in magazine workshop steps 49, 52-57

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148c004ffc8434252940dc3.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148c004ffc8434252940dc3.md
@@ -14,19 +14,19 @@ Create a `.social-icons` selector. Give it a `display` property set to `grid`, a
 You should have a `.social-icons` selector.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.social-icons'));
+assert.exists(new __helpers.CSSHelp(document).getStyle('.social-icons'));
 ```
 
 Your `.social-icons` selector should have a `display` property set to `grid`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.social-icons')?.display === 'grid');
+assert.equal(new __helpers.CSSHelp(document).getStyle('.social-icons')?.display, 'grid');
 ```
 
 Your `.social-icons` selector should have a `font-size` property set to `3rem`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.social-icons')?.fontSize === '3rem');
+assert.equal(new __helpers.CSSHelp(document).getStyle('.social-icons')?.fontSize, '3rem');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148c5036ddad94692a66230.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148c5036ddad94692a66230.md
@@ -16,7 +16,7 @@ You can override this with the `grid-auto-columns` property. Give the `.social-i
 Your `.social-icons` selector should have a `grid-auto-columns` property set to `1fr`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.social-icons')?.gridAutoColumns === '1fr');
+assert.equal(new __helpers.CSSHelp(document).getStyle('.social-icons')?.gridAutoColumns, '1fr');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148c58bace368497fb11bcf.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148c58bace368497fb11bcf.md
@@ -16,7 +16,7 @@ Give the `.social-icons` selector an `align-items` property set to `center`.
 Your `.social-icons` selector should have an `align-items` property set to `center`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.social-icons')?.alignItems === 'center');
+assert.equal(new __helpers.CSSHelp(document).getStyle('.social-icons')?.alignItems, 'center');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148c6aa9981d74af202125e.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148c6aa9981d74af202125e.md
@@ -14,13 +14,13 @@ Give the `.text` selector a `font-size` property set to `1.8rem` and a `letter-s
 Your `.text` selector should have a `font-size` property set to `1.8rem`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.text')?.fontSize === '1.8rem');
+assert.equal(new __helpers.CSSHelp(document).getStyle('.text')?.fontSize, '1.8rem');
 ```
 
 Your `.text` selector should have a `letter-spacing` property set to `0.6px`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.text')?.letterSpacing === '0.6px');
+assert.equal(new __helpers.CSSHelp(document).getStyle('.text')?.letterSpacing, '0.6px');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148c721e74ecd4c619ae51c.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148c721e74ecd4c619ae51c.md
@@ -16,7 +16,7 @@ Give your `.text` selector a `column-width` property set to `25rem`.
 Your `.text` selector should have a `column-width` property set to `25rem`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.text')?.columnWidth === '25rem');
+assert.equal(new __helpers.CSSHelp(document).getStyle('.text')?.columnWidth, '25rem');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148ceaf5d897d4d8b3554b3.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148ceaf5d897d4d8b3554b3.md
@@ -16,7 +16,7 @@ To make your project look like a printed magazine, give the `.text` selector a `
 Your `.text` selector should have a `text-align` property set to `justify`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.text')?.textAlign === 'justify');
+assert.equal(new __helpers.CSSHelp(document).getStyle('.text')?.textAlign, 'justify');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148cf094b3f2b4e8a032c63.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148cf094b3f2b4e8a032c63.md
@@ -16,19 +16,19 @@ Create a `.first-paragraph::first-letter` selector and set the `font-size` prope
 You should have a `.first-paragraph::first-letter` selector.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.first-paragraph::first-letter'));
+assert.exists(new __helpers.CSSHelp(document).getStyle('.first-paragraph::first-letter'));
 ```
 
 Your `.first-paragraph::first-letter` selector should have a `font-size` property set to `6rem`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.first-paragraph::first-letter')?.fontSize === '6rem');
+assert.equal(new __helpers.CSSHelp(document).getStyle('.first-paragraph::first-letter')?.fontSize, '6rem');
 ```
 
 Your `.first-paragraph::first-letter` selector should have a `color` property set to `orangered`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.first-paragraph::first-letter')?.color === 'orangered');
+assert.equal(new __helpers.CSSHelp(document).getStyle('.first-paragraph::first-letter')?.color, 'orangered');
 ```
 
 # --seed--


### PR DESCRIPTION
This pull request updates the test assertions in steps 49–57 of the magazine workshop curriculum:

-  Replaced `assert()` with `assert.exists()` for DOM existence checks  
-  Replaced `assert()` with `assert.equal()` for style equality comparisons  
-  Improved test specificity and output clarity using the proper Chai.js assertion methods  

These changes ensure alignment with the testing standards defined in [issue #61318](https://github.com/freeCodeCamp/freeCodeCamp/issues/61318).

Checklist:
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).  
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).  
- [x] My pull request targets the `main` branch of freeCodeCamp.  
- [x] I have tested these changes locally in Codespaces.

Closes #61318
