### PR TITLE
fix: update assert methods in workshop-magazine challenges (#61331)

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148d0b863d10d50544ace0e.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148d0b863d10d50544ace0e.md
@@ -14,13 +14,14 @@ The other text has been shifted out of place. Move it into position by giving th
 Your `.first-paragraph::first-letter` selector should have a `float` property set to `left`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.first-paragraph::first-letter')?.float === 'left');
+assert.equal(new __helpers.CSSHelp(document).getStyle('.first-paragraph::first-letter')?.float, 'left');
 ```
 
 Your `.first-paragraph::first-letter` selector should have a `margin-right` property set to `1rem`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.first-paragraph::first-letter')?.marginRight === '1rem');
+assert.equal(new __helpers.CSSHelp(document).getStyle('.first-paragraph::first-letter')?.marginRight, '1rem');
+
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148d1bdf39c5b5186f5974b.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148d1bdf39c5b5186f5974b.md
@@ -14,13 +14,14 @@ Create an `hr` selector, and give it a `margin` property set to `1.5rem 0`.
 You should have an `hr` selector.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('hr'));
+assert.exists(new __helpers.CSSHelp(document).getStyle('hr'));
+
 ```
 
 Your `hr` selector should have a `margin` property set to `1.5rem 0`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('hr')?.margin === '1.5rem 0px');
+assert.equal(new __helpers.CSSHelp(document).getStyle('hr')?.margin, '1.5rem 0px');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148d2444d01ab541e64a1e4.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148d2444d01ab541e64a1e4.md
@@ -14,30 +14,39 @@ Create a `.quote` selector. Give it a `color` property set to `#00beef`, a `font
 You should have a `.quote` selector.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.quote'));
+assert.exists(new __helpers.CSSHelp(document).getStyle('.quote'));
+
 ```
 
 Your `.quote` selector should have a `color` property set to `#00beef`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.quote')?.color === 'rgb(0, 190, 239)');
+assert.equal(new __helpers.CSSHelp(document).getStyle('.quote')?.color, 'rgb(0, 190, 239)');
+
 ```
 
 Your `.quote` selector should have a `font-size` property set to `2.4rem`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.quote')?.fontSize === '2.4rem');
+assert.equal(new __helpers.CSSHelp(document).getStyle('.quote')?.fontSize, '2.4rem');
 ```
 
 Your `.quote` selector should have a `text-align` property set to `center`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.quote')?.textAlign === 'center');
+assert.equal(new __helpers.CSSHelp(document).getStyle('.quote')?.textAlign, 'center');
 ```
 
 # --seed--
 
 ## --seed-contents--
+<style>
+  .quote {
+    color: #00beef;
+    font-size: 2.4rem;
+    text-align: center;
+  }
+</style>
 
 ```html
 <!DOCTYPE html>

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148d2444d01ab541e64a1e4.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148d2444d01ab541e64a1e4.md
@@ -40,13 +40,7 @@ assert.equal(new __helpers.CSSHelp(document).getStyle('.quote')?.textAlign, 'cen
 # --seed--
 
 ## --seed-contents--
-<style>
-  .quote {
-    color: #00beef;
-    font-size: 2.4rem;
-    text-align: center;
-  }
-</style>
+
 
 ```html
 <!DOCTYPE html>

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148d33e31fccf558696c745.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148d33e31fccf558696c745.md
@@ -15,12 +15,19 @@ Your `.quote` selector should have a `font-family` property set to `Raleway` wit
 
 ```js
 const fontFamily = new __helpers.CSSHelp(document).getStyle('.quote')?.fontFamily;
-assert(fontFamily === 'Raleway, sans-serif' || fontFamily === `"Raleway", sans-serif`);
+assert.oneOf(fontFamily, ['Raleway, sans-serif', '"Raleway", sans-serif']);
+
 ```
 
 # --seed--
 
 ## --seed-contents--
+<style>
+  .quote {
+    font-family: "Raleway", sans-serif;
+  }
+</style>
+
 
 ```html
 <!DOCTYPE html>

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148d33e31fccf558696c745.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148d33e31fccf558696c745.md
@@ -22,11 +22,6 @@ assert.oneOf(fontFamily, ['Raleway, sans-serif', '"Raleway", sans-serif']);
 # --seed--
 
 ## --seed-contents--
-<style>
-  .quote {
-    font-family: "Raleway", sans-serif;
-  }
-</style>
 
 
 ```html

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148d33e31fccf558696c745.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148d33e31fccf558696c745.md
@@ -22,8 +22,6 @@ assert.oneOf(fontFamily, ['Raleway, sans-serif', '"Raleway", sans-serif']);
 # --seed--
 
 ## --seed-contents--
-
-
 ```html
 <!DOCTYPE html>
 <html lang="en">

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148d3fff5186b57123d97e2.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148d3fff5186b57123d97e2.md
@@ -42,7 +42,7 @@ Your `.quote::after` selector should have a `content` property set to `' "'`.
 
 ```js
 assert.match(
-  new __helpers.CSSHelp(document).getStyle('.quote::after')?.content ?? '',
+  new __helpers.CSSHelp(document).getStyle('.quote::after')?.content,
   /\"\s\\""/
 );
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148d3fff5186b57123d97e2.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148d3fff5186b57123d97e2.md
@@ -18,30 +18,50 @@ Also, create a `.quote::after` selector and set the `content` property to `"` wi
 You should have a `.quote::before` selector.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.quote::before'));
+assert.exists(new __helpers.CSSHelp(document).getStyle('.quote::before'));
+
 ```
 
 Your `.quote::before` selector should have a `content` property set to `'" '`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.quote::before')?.content?.match(/\"\\"\s\"/));
+assert.match(
+  new __helpers.CSSHelp(document).getStyle('.quote::before')?.content ?? '',
+  /\"\\"\s\"/
+);
 ```
 
 You should have a `.quote::after` selector.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.quote::after'));
+assert.exists(new __helpers.CSSHelp(document).getStyle('.quote::after'));
+
 ```
 
 Your `.quote::after` selector should have a `content` property set to `' "'`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.quote::after')?.content?.match(/\"\s\\""/));
+assert.match(
+  new __helpers.CSSHelp(document).getStyle('.quote::after')?.content ?? '',
+  /\"\s\\""/
+);
+
 ```
 
 # --seed--
 
 ## --seed-contents--
+
+<style>
+  .quote::before {
+    content: '" ';
+  }
+  .quote::after {
+    content: ' "';
+  }
+</style>
+
+
 
 ```html
 <!DOCTYPE html>

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148d3fff5186b57123d97e2.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148d3fff5186b57123d97e2.md
@@ -53,8 +53,6 @@ assert.match(
 ## --seed-contents--
 
 
-
-
 ```html
 <!DOCTYPE html>
 <html lang="en">

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148d3fff5186b57123d97e2.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148d3fff5186b57123d97e2.md
@@ -52,14 +52,6 @@ assert.match(
 
 ## --seed-contents--
 
-<style>
-  .quote::before {
-    content: '" ';
-  }
-  .quote::after {
-    content: ' "';
-  }
-</style>
 
 
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148d3fff5186b57123d97e2.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148d3fff5186b57123d97e2.md
@@ -26,7 +26,7 @@ Your `.quote::before` selector should have a `content` property set to `'" '`.
 
 ```js
 assert.match(
-  new __helpers.CSSHelp(document).getStyle('.quote::before')?.content ?? '',
+  new __helpers.CSSHelp(document).getStyle('.quote::before')?.content,
   /\"\\"\s\"/
 );
 ```

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148e246146b646cf4255f0c.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148e246146b646cf4255f0c.md
@@ -14,13 +14,13 @@ Create a `.list-title, .list-subtitle` selector and set the `color` property to 
 You should have a `.list-title, .list-subtitle` selector.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.list-title, .list-subtitle'))
+assert.exists(new __helpers.CSSHelp(document).getStyle('.list-title, .list-subtitle'));
 ```
 
 Your `.list-title, .list-subtitle` selector should have a `color` property set to `#00beef`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.list-title, .list-subtitle')?.color === 'rgb(0, 190, 239)');
+assert.equal(new __helpers.CSSHelp(document).getStyle('.list-title, .list-subtitle')?.color, 'rgb(0, 190, 239)');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148e2dcdd60306dd77d41cc.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148e2dcdd60306dd77d41cc.md
@@ -16,13 +16,13 @@ The images are wrapped with an `aside` element using the `image-wrapper` class, 
 You should have an `.image-wrapper` selector.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.image-wrapper'));
+assert.exists(new __helpers.CSSHelp(document).getStyle('.image-wrapper'));
 ```
 
 Your `.image-wrapper` selector should have a `display` property set to `grid`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.image-wrapper')?.display === 'grid');
+assert.equal(new __helpers.CSSHelp(document).getStyle('.image-wrapper')?.display, 'grid');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148e4d6861a486f60681f36.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148e4d6861a486f60681f36.md
@@ -16,13 +16,13 @@ Give the `.image-wrapper` selector a `grid-template-columns` property set to `2f
 Your `.image-wrapper` selector should have a `grid-template-columns` property set to `2fr 1fr`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.image-wrapper')?.gridTemplateColumns === '2fr 1fr');
+assert.equal(new __helpers.CSSHelp(document).getStyle('.image-wrapper')?.gridTemplateColumns, '2fr 1fr');
 ```
 
 Your `.image-wrapper` selector should have a `grid-template-rows` property set to `repeat(3, min-content)`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.image-wrapper')?.gridTemplateRows === 'repeat(3, min-content)');
+assert.equal(new __helpers.CSSHelp(document).getStyle('.image-wrapper')?.gridTemplateRows, 'repeat(3, min-content)');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148e5a204d99e70343a63e4.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148e5a204d99e70343a63e4.md
@@ -16,7 +16,7 @@ Give the `.image-wrapper` selector a `gap` property set to `2rem`.
 Your `.image-wrapper` element should have a `gap` property set to `2rem`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.image-wrapper')?.gap === '2rem');
+assert.equal(new __helpers.CSSHelp(document).getStyle('.image-wrapper')?.gap, '2rem');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148e62a6f768f71c4f04828.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148e62a6f768f71c4f04828.md
@@ -16,7 +16,7 @@ Give the `.image-wrapper` selector a `place-items` property set to `center`.
 Your `.image-wrapper` selector should have a `place-items` property set to `center`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.image-wrapper')?.placeItems === 'center');
+assert.equal(new __helpers.CSSHelp(document).getStyle('.image-wrapper')?.placeItems, 'center');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148e789329dc9736ce59b85.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148e789329dc9736ce59b85.md
@@ -14,13 +14,13 @@ Create an `.image-1, .image-3` rule and give it a `grid-column` property set to 
 You should have an `.image-1, .image-3` selector.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.image-1, .image-3'));
+assert.exists(new __helpers.CSSHelp(document).getStyle('.image-1, .image-3'));
 ```
 
 Your `.image-1, .image-3` selector should have a `grid-column` property set to `1 / -1`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.image-1, .image-3')?.gridColumn === '1 / -1');
+assert.equal(new __helpers.CSSHelp(document).getStyle('.image-1, .image-3')?.gridColumn, '1 / -1');
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ x] My pull request targets the `main` branch of freeCodeCamp.
- [x ] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #61331 

<!-- Feel free to add any additional description of changes below this line -->

Summary
This pull request updates the test assertions for the workshop-magazine curriculum steps 70 through 75, in accordance with the requirements outlined in [issue #61331](https://github.com/freeCodeCamp/freeCodeCamp/issues/61331). The changes involve replacing generic assert(...) statements with more explicit Chai assertion methods such as assert.exists(...) and assert.equal(...). These updates improve the clarity, reliability, and maintainability of the test code.

Changes Made
Replaced assert(...) with assert.exists(...)
Assertions that previously relied on the truthy evaluation of assert(...) have been replaced with assert.exists(...) to explicitly confirm the existence of styles. These changes were made in:
Step 70 (6148e246146b646cf4255f0c.md) — verifying styles for .list-title, .list-subtitle)
Step 71 (6148e2dcdd60306dd77d41cc.md) — verifying styles for .image-wrapper)
Step 75 (6148e789329dc9736ce59b85.md) — verifying styles for .image-1, .image-3)

Replaced equality checks with assert.equal(...)
Assertions that used === inside assert(...) were replaced with assert.equal(...) for better readability and accuracy. These changes were made in:

Step 70 (6148e246146b646cf4255f0c.md) — color property check)
Step 71 (6148e2dcdd60306dd77d41cc.md) — display property check)
Step 72 (6148e4d6861a486f60681f36.md) — grid-template-columns and grid-template-rows checks)
Step 73 (6148e5a204d99e70343a63e4.md) — gap property check)
Step 74 (6148e62a6f768f71c4f04828.md) — place-items property check)
Step 75 (6148e789329dc9736ce59b85.md) — grid-column property check)

Additional Improvements:
Added missing semicolons on modified lines where applicable.
Ensured the test intent and structure remained unchanged while improving assertion accuracy.

Why These Changes Matter:
1. Updates test files to follow current Chai assert standards (assert.exists, assert.equal), improving clarity and intent.
2. Provides better, more accurate feedback for learners when tests fail.

3. Ensures consistency and maintainability in the curriculum as outlined in [issue #61331](https://github.com/freeCodeCamp/freeCodeCamp/issues/61331).