### PR TITLE
fix(curriculum): handle whitespace for step 12 of workshop-cat-photo-app 

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-photo-app/671b6e873249bb35c9debfcf.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-photo-app/671b6e873249bb35c9debfcf.md
@@ -26,7 +26,7 @@ assert.strictEqual(document.querySelector('a')?.innerText?.replace(/\s+/g, ' ').
 You should have `See more <a href="https://freecatphotoapp.com">cat photos</a> in our gallery` in your code.
 
 ```js
-assert.match(code, /See more <a href="https:\/\/freecatphotoapp\.com">cat photos<\/a> in our gallery/)
+assert.match(code, /See more\s*<a href="https:\/\/freecatphotoapp\.com">cat photos<\/a>\s*in our gallery/)
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-photo-app/671b6e873249bb35c9debfcf.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-photo-app/671b6e873249bb35c9debfcf.md
@@ -26,7 +26,7 @@ assert.strictEqual(document.querySelector('a')?.innerText?.replace(/\s+/g, ' ').
 You should have `See more <a href="https://freecatphotoapp.com">cat photos</a> in our gallery` in your code.
 
 ```js
-assert.match(code, /See more\s*<a href="https:\/\/freecatphotoapp\.com">cat photos<\/a>\s*in our gallery/)
+assert.match(code, /See more\s+<a href="https:\/\/freecatphotoapp\.com">cat photos<\/a>\s+in our gallery/)
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-photo-app/671b6e873249bb35c9debfcf.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-photo-app/671b6e873249bb35c9debfcf.md
@@ -26,7 +26,7 @@ assert.strictEqual(document.querySelector('a')?.innerText?.replace(/\s+/g, ' ').
 You should have `See more <a href="https://freecatphotoapp.com">cat photos</a> in our gallery` in your code.
 
 ```js
-assert.match(code, /See more\s+<a href="https:\/\/freecatphotoapp\.com">cat photos<\/a>\s+in our gallery/)
+assert.match(code, /See more\s+<a href="https:\/\/freecatphotoapp\.com">cat photos<\/a>\s+in our gallery/);
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

[ X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org/).
[ X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
[ X] My pull request targets the main branch of freeCodeCamp.
[X ] I have tested these changes either locally on my machine, or Gitpod.

Related to
https://github.com/freeCodeCamp/freeCodeCamp/issues/60690

Allows user to position anchor tag on different lines than preceding and subsequent text.

Tested on local instance of freeCodeCamp

Before:
<img width="828" height="565" alt="2025-07-14 cat-photo-app-step-12-before" src="https://github.com/user-attachments/assets/08d4732d-79f7-4728-9c32-1571a3a24c1e" />

After:
<img width="815" height="569" alt="2025-07-14 cat-photo-app-step-12-after" src="https://github.com/user-attachments/assets/8f292605-478f-40ee-9234-b7b0e1411499" />


