### PR TITLE
fix(scripts): ignore upcoming blocks when building external curricula

### DIFF
--- a/tools/scripts/build/build-external-curricula-data-v2.ts
+++ b/tools/scripts/build/build-external-curricula-data-v2.ts
@@ -305,13 +305,17 @@ export function buildExtCurriculumDataV2(
             moduleType: module.moduleType,
             blocks: module.comingSoon
               ? []
-              : module.blocks.map(block => {
-                  const blockData = blocksWithData[block.dashedName];
-                  return {
-                    intro: superBlockIntros.blocks[block.dashedName].intro,
-                    meta: blockData.meta
-                  };
-                })
+              : module.blocks
+                  // Upcoming blocks aren't included in blocksWithData
+                  // and thus they have no metadata and need to be filtered out.
+                  .filter(block => blocksWithData[block.dashedName])
+                  .map(block => {
+                    const blockData = blocksWithData[block.dashedName];
+                    return {
+                      intro: superBlockIntros.blocks[block.dashedName].intro,
+                      meta: blockData.meta
+                    };
+                  })
           }))
     }));
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

The curriculum build script only adds data to blocks that have `isUpcomingChange: false`:

https://github.com/freeCodeCamp/freeCodeCamp/blob/4bed405425a267ce3c60435a99d9239818be4c0b/curriculum/get-challenges.js#L316-L320

The external curricula build script does take this to account (well, kind of) when processing the data, in that it ignores upcoming chapters and modules and won't try to add metadata for those. However, the script doesn't account for the scenario where a module is already released (`isUpcomingChange === false`) but some of its blocks are not (`isUpcomingChange === true`). Since the data of the blocks isn't available, an error is thrown when the script tries to access the blocks' data.

This PR updates the script to filter out upcoming blocks.

<!-- Feel free to add any additional description of changes below this line -->
