### PR TITLE
chore(curriculum): update test assertions in workshop-magazine to use chai methods steps 58-63

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148d0b863d10d50544ace0e.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148d0b863d10d50544ace0e.md
@@ -14,13 +14,13 @@ The other text has been shifted out of place. Move it into position by giving th
 Your `.first-paragraph::first-letter` selector should have a `float` property set to `left`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.first-paragraph::first-letter')?.float === 'left');
+assert.equal(new __helpers.CSSHelp(document).getStyle('.first-paragraph::first-letter')?.float, 'left');
 ```
 
 Your `.first-paragraph::first-letter` selector should have a `margin-right` property set to `1rem`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.first-paragraph::first-letter')?.marginRight === '1rem');
+assert.equal(new __helpers.CSSHelp(document).getStyle('.first-paragraph::first-letter')?.marginRight, '1rem');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148d1bdf39c5b5186f5974b.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148d1bdf39c5b5186f5974b.md
@@ -14,13 +14,13 @@ Create an `hr` selector, and give it a `margin` property set to `1.5rem 0`.
 You should have an `hr` selector.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('hr'));
+assert.exists(new __helpers.CSSHelp(document).getStyle('hr'));
 ```
 
 Your `hr` selector should have a `margin` property set to `1.5rem 0`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('hr')?.margin === '1.5rem 0px');
+assert.equal(new __helpers.CSSHelp(document).getStyle('hr')?.margin, '1.5rem 0px');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148d2444d01ab541e64a1e4.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148d2444d01ab541e64a1e4.md
@@ -14,25 +14,25 @@ Create a `.quote` selector. Give it a `color` property set to `#00beef`, a `font
 You should have a `.quote` selector.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.quote'));
+assert.exists(new __helpers.CSSHelp(document).getStyle('.quote'));
 ```
 
 Your `.quote` selector should have a `color` property set to `#00beef`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.quote')?.color === 'rgb(0, 190, 239)');
+assert.equal(new __helpers.CSSHelp(document).getStyle('.quote')?.color, 'rgb(0, 190, 239)');
 ```
 
 Your `.quote` selector should have a `font-size` property set to `2.4rem`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.quote')?.fontSize === '2.4rem');
+assert.equal(new __helpers.CSSHelp(document).getStyle('.quote')?.fontSize, '2.4rem');
 ```
 
 Your `.quote` selector should have a `text-align` property set to `center`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.quote')?.textAlign === 'center');
+assert.equal(new __helpers.CSSHelp(document).getStyle('.quote')?.textAlign, 'center');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148d33e31fccf558696c745.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148d33e31fccf558696c745.md
@@ -15,7 +15,7 @@ Your `.quote` selector should have a `font-family` property set to `Raleway` wit
 
 ```js
 const fontFamily = new __helpers.CSSHelp(document).getStyle('.quote')?.fontFamily;
-assert(fontFamily === 'Raleway, sans-serif' || fontFamily === `"Raleway", sans-serif`);
+assert.oneOf(fontFamily, ['Raleway, sans-serif', `"Raleway", sans-serif`]);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148d3fff5186b57123d97e2.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148d3fff5186b57123d97e2.md
@@ -18,25 +18,25 @@ Also, create a `.quote::after` selector and set the `content` property to `"` wi
 You should have a `.quote::before` selector.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.quote::before'));
+assert.exists(new __helpers.CSSHelp(document).getStyle('.quote::before'));
 ```
 
 Your `.quote::before` selector should have a `content` property set to `'" '`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.quote::before')?.content?.match(/\"\\"\s\"/));
+assert.match(new __helpers.CSSHelp(document).getStyle('.quote::before')?.content, /\"\\"\s\"/);
 ```
 
 You should have a `.quote::after` selector.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.quote::after'));
+assert.exists(new __helpers.CSSHelp(document).getStyle('.quote::after'));
 ```
 
 Your `.quote::after` selector should have a `content` property set to `' "'`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.quote::after')?.content?.match(/\"\s\\""/));
+assert.match(new __helpers.CSSHelp(document).getStyle('.quote::after')?.content, /\"\s\\""/);
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org/).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the main branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

Changes Made:
This pull request updates the test assertions for steps 58–59 and 61–63 in the workshop-magazine challenges.

I replaced the generic `assert()` statements with the appropriate Chai assertion methods:
- `assert.equal()` for comparing values
- `assert.exists()` to check for presence
- `assert.oneOf()` where multiple values are valid
- `assert.match()` for regular expression matching

These changes follow the instructions in issue #61319 and help improve the consistency and clarity of the test code.

Closes #61319 

