### PR TITLE
Fix asserts magazine 58 63

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148d0b863d10d50544ace0e.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148d0b863d10d50544ace0e.md
@@ -4,7 +4,6 @@ title: Step 58
 challengeType: 0
 dashedName: step-58
 ---
-
 # --description--
 
 The other text has been shifted out of place. Move it into position by giving the `.first-paragraph::first-letter` selector a `float` property set to `left` and a `margin-right` property set to `1rem`.
@@ -14,13 +13,13 @@ The other text has been shifted out of place. Move it into position by giving th
 Your `.first-paragraph::first-letter` selector should have a `float` property set to `left`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.first-paragraph::first-letter')?.float === 'left');
+assert.equal(new __helpers.CSSHelp(document).getStyle('.first-paragraph::first-letter')?.float , 'left');
 ```
 
 Your `.first-paragraph::first-letter` selector should have a `margin-right` property set to `1rem`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.first-paragraph::first-letter')?.marginRight === '1rem');
+assert.equal(new __helpers.CSSHelp(document).getStyle('.first-paragraph::first-letter')?.marginRight ,'1rem');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148d0b863d10d50544ace0e.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148d0b863d10d50544ace0e.md
@@ -4,6 +4,7 @@ title: Step 58
 challengeType: 0
 dashedName: step-58
 ---
+
 # --description--
 
 The other text has been shifted out of place. Move it into position by giving the `.first-paragraph::first-letter` selector a `float` property set to `left` and a `margin-right` property set to `1rem`.

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148d1bdf39c5b5186f5974b.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148d1bdf39c5b5186f5974b.md
@@ -4,7 +4,6 @@ title: Step 59
 challengeType: 0
 dashedName: step-59
 ---
-
 # --description--
 
 Create an `hr` selector, and give it a `margin` property set to `1.5rem 0`.
@@ -14,13 +13,13 @@ Create an `hr` selector, and give it a `margin` property set to `1.5rem 0`.
 You should have an `hr` selector.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('hr'));
+assert.exists(new __helpers.CSSHelp(document).getStyle('hr'));
 ```
 
 Your `hr` selector should have a `margin` property set to `1.5rem 0`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('hr')?.margin === '1.5rem 0px');
+assert.equal(new __helpers.CSSHelp(document).getStyle('hr')?.margin , '1.5rem 0px');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148d1bdf39c5b5186f5974b.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148d1bdf39c5b5186f5974b.md
@@ -3,7 +3,9 @@ id: 6148d1bdf39c5b5186f5974b
 title: Step 59
 challengeType: 0
 dashedName: step-59
+
 ---
+
 # --description--
 
 Create an `hr` selector, and give it a `margin` property set to `1.5rem 0`.

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148d2444d01ab541e64a1e4.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148d2444d01ab541e64a1e4.md
@@ -4,7 +4,6 @@ title: Step 61
 challengeType: 0
 dashedName: step-61
 ---
-
 # --description--
 
 Create a `.quote` selector. Give it a `color` property set to `#00beef`, a `font-size` property set to `2.4rem`, and a `text-align` property set to `center`.
@@ -14,25 +13,25 @@ Create a `.quote` selector. Give it a `color` property set to `#00beef`, a `font
 You should have a `.quote` selector.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.quote'));
+assert.exists(new __helpers.CSSHelp(document).getStyle('.quote'));
 ```
 
 Your `.quote` selector should have a `color` property set to `#00beef`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.quote')?.color === 'rgb(0, 190, 239)');
+assert.equal(new __helpers.CSSHelp(document).getStyle('.quote')?.color , 'rgb(0, 190, 239)');
 ```
 
 Your `.quote` selector should have a `font-size` property set to `2.4rem`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.quote')?.fontSize === '2.4rem');
+assert.equal(new __helpers.CSSHelp(document).getStyle('.quote')?.fontSize , '2.4rem');
 ```
 
 Your `.quote` selector should have a `text-align` property set to `center`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.quote')?.textAlign === 'center');
+assert.equal(new __helpers.CSSHelp(document).getStyle('.quote')?.textAlign , 'center');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148d2444d01ab541e64a1e4.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148d2444d01ab541e64a1e4.md
@@ -3,7 +3,10 @@ id: 6148d2444d01ab541e64a1e4
 title: Step 61
 challengeType: 0
 dashedName: step-61
+
+
 ---
+
 # --description--
 
 Create a `.quote` selector. Give it a `color` property set to `#00beef`, a `font-size` property set to `2.4rem`, and a `text-align` property set to `center`.

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148d33e31fccf558696c745.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148d33e31fccf558696c745.md
@@ -14,7 +14,7 @@ Your `.quote` selector should have a `font-family` property set to `Raleway` wit
 
 ```js
 const fontFamily = new __helpers.CSSHelp(document).getStyle('.quote')?.fontFamily;
-assert.oneof(fontFamily ,[ 'Raleway, sans-serif' ,`"Raleway", sans-serif`]);
+assert.oneOf(fontFamily ,[ 'Raleway, sans-serif' ,`"Raleway", sans-serif`]);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148d33e31fccf558696c745.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148d33e31fccf558696c745.md
@@ -4,6 +4,7 @@ title: Step 62
 challengeType: 0
 dashedName: step-62
 ---
+
 # --description--
 
 To make the quote text stand out more, give the `.quote` selector a `font-family` property set to `Raleway` with a fallback of `sans-serif`.

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148d33e31fccf558696c745.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148d33e31fccf558696c745.md
@@ -4,7 +4,6 @@ title: Step 62
 challengeType: 0
 dashedName: step-62
 ---
-
 # --description--
 
 To make the quote text stand out more, give the `.quote` selector a `font-family` property set to `Raleway` with a fallback of `sans-serif`.
@@ -15,7 +14,7 @@ Your `.quote` selector should have a `font-family` property set to `Raleway` wit
 
 ```js
 const fontFamily = new __helpers.CSSHelp(document).getStyle('.quote')?.fontFamily;
-assert(fontFamily === 'Raleway, sans-serif' || fontFamily === `"Raleway", sans-serif`);
+assert.oneof(fontFamily ,[ 'Raleway, sans-serif' ,`"Raleway", sans-serif`]);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148d3fff5186b57123d97e2.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148d3fff5186b57123d97e2.md
@@ -4,6 +4,7 @@ title: Step 63
 challengeType: 0
 dashedName: step-63
 ---
+
 # --description--
 
 A quote is not really a quote without proper quotation marks. You can add these with CSS pseudo selectors.

--- a/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148d3fff5186b57123d97e2.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-magazine/6148d3fff5186b57123d97e2.md
@@ -4,7 +4,6 @@ title: Step 63
 challengeType: 0
 dashedName: step-63
 ---
-
 # --description--
 
 A quote is not really a quote without proper quotation marks. You can add these with CSS pseudo selectors.
@@ -18,25 +17,25 @@ Also, create a `.quote::after` selector and set the `content` property to `"` wi
 You should have a `.quote::before` selector.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.quote::before'));
+assert.exists(new __helpers.CSSHelp(document).getStyle('.quote::before'));
 ```
 
 Your `.quote::before` selector should have a `content` property set to `'" '`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.quote::before')?.content?.match(/\"\\"\s\"/));
+assert.match(new __helpers.CSSHelp(document).getStyle('.quote::before')?.content? , /\"\\"\s\"/);
 ```
 
 You should have a `.quote::after` selector.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.quote::after'));
+assert.exists(new __helpers.CSSHelp(document).getStyle('.quote::after'));
 ```
 
 Your `.quote::after` selector should have a `content` property set to `' "'`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.quote::after')?.content?.match(/\"\s\\""/));
+assert.match(new __helpers.CSSHelp(document).getStyle('.quote::after')?.content? , /\"\s\\""/);
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #61319


This PR updates generic assert() calls to specific Chai assert methods for steps 58–63 in the Workshop Magazine curriculum section:

- assert() → assert.exists()
- assert(a === b) → assert.equal(a, b)
- assert(a || b) → assert.oneOf()
- assert(str.match(...)) → assert.match()

Also added semicolons at the end of modified lines where needed.

