### PR TITLE
fix: GB request hanging

### DIFF
--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useGrowthBook } from '@growthbook/growthbook-react';
 import SEO from '../components/seo';
-import { Loader } from '../components/helpers';
 import LandingTopB from '../components/landing/components/landing-top-b';
 import LandingTop from '../components/landing/components/landing-top';
 import Testimonials from '../components/landing/components/testimonials';
@@ -27,27 +25,13 @@ const Landing = ({ showLandingPageRedesign }: LandingProps) => (
 
 function IndexPage(): JSX.Element {
   const { t } = useTranslation();
-  const growthbook = useGrowthBook();
-  if (growthbook && growthbook.ready) {
-    const showLandingPageRedesign = growthbook.getFeatureValue(
-      'landing-top-skill-focused',
-      false
-    );
-    growthbook.getFeatureValue('landing-aa-test', false);
-    return (
-      <>
-        <SEO title={t('metaTags:title')} />
-        <Landing showLandingPageRedesign={showLandingPageRedesign} />
-      </>
-    );
-  } else {
-    return (
-      <>
-        <SEO title={t('metaTags:title')} />
-        <Loader fullScreen={true} />
-      </>
-    );
-  }
+
+  return (
+    <>
+      <SEO title={t('metaTags:title')} />
+      <Landing showLandingPageRedesign={true} />
+    </>
+  );
 }
 
 IndexPage.displayName = 'IndexPage';


### PR DESCRIPTION
Our GB server went down, so the request to get GB info was hanging, causing the landing page to get stuck with the loader showing.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
