### PR TITLE
fix: Allowing authors to be considered seperately

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-library-manager/67116d7584d0b469b14579c3.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-library-manager/67116d7584d0b469b14579c3.md
@@ -59,19 +59,29 @@ Your `getBooksByAuthor` function should return the correct number of books for a
 ```js
 const arvidKahlBooks = getBooksByAuthor(library, 'Arvid Kahl');
 const robertAndSharonBook = getBooksByAuthor(library, 'Robert Kiyosaki and Sharon Lechter');
+const robert = getBooksByAuthor(library,'Robert Kiyosaki');
+const sharon = getBooksByAuthor(library,'Sharon Lechter');
 const pbdAndGDBooks = getBooksByAuthor(library, 'Patrick Bet-David and Greg Dinkin');
 const pbdBook = getBooksByAuthor(library, 'Patrick Bet-David');
+const gregDinkin = getBooksByAuthor(library, 'Greg Dinkin');
 const johnGordon = getBooksByAuthor(library, 'Jon Gordon');
 const jamesClearBook = getBooksByAuthor(library, 'James Clear');
 const JDAndSDBook = getBooksByAuthor(library, 'Jeff DeGraff and Staney DeGraff');
+const jeffDeGraff = getBooksByAuthor(library, 'Jeff DeGraff');
+const staneyDeGraff = getBooksByAuthor(library, 'Staney DeGraff');
 
 assert.lengthOf(arvidKahlBooks, 2);
 assert.lengthOf(robertAndSharonBook, 1);
+assert.lengthOf(robert, 1);
+assert.lengthOf(sharon, 1);
 assert.lengthOf(pbdAndGDBooks, 1);
-assert.lengthOf(pbdBook, 1);
+assert.lengthOf(pbdBook, 2);
+assert.lengthOf(gregDinkin, 1);
 assert.lengthOf(johnGordon, 1);
 assert.lengthOf(jamesClearBook, 1);
 assert.lengthOf(JDAndSDBook, 1);
+assert.lengthOf(jeffDeGraff, 1);
+assert.lengthOf(staneyDeGraff, 1);
 
 const _differentLibrary = [
   {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #61230 

<!-- Feel free to add any additional description of changes below this line -->
I made changes to the test cases in file-
curriculum/challenges/english/25-front-end-development/workshop-library-manager/67116d7584d0b469b14579c3.md
so that authors that are mentioned like "A and B" can also be considered separately rather than as one. This means the code that is getting accepted will also be changed.