### PR TITLE
fix(client): duplicate challengeFile declaration in editor

### DIFF
--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -1317,9 +1317,6 @@ const Editor = (props: EditorProps): JSX.Element => {
     return challengeIsComplete();
   };
 
-  const challengeFile = props.challengeFiles?.find(
-    challengeFile => challengeFile.fileKey === props.fileKey
-  );
   const showFileName = challengeFile && props.challengeFiles!.length > 1;
   return (
     <Suspense fallback={<Loader loaderDelay={600} />}>


### PR DESCRIPTION
[This PR](https://github.com/freeCodeCamp/freeCodeCamp/pull/59186) added a second declaration of `challengeFile` in the main editor file. The tests passed there presumably because they ran before the first one was added.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
