### PR TITLE
feat(curriculum): add confirm string ending challenge

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -3125,6 +3125,12 @@
           "In this lab, you will practice truncating a string at a certain length."
         ]
       },
+      "lab-string-ending-checker": {
+        "title": "Implement a String Ending Checker Function",
+        "intro": [
+          "In this lab, you will implement a function that checks if a given string ends with a specified target string."
+        ]
+      },
       "review-javascript-functions": {
         "title": "JavaScript Functions Review",
         "intro": [

--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -3126,7 +3126,7 @@
         ]
       },
       "lab-string-ending-checker": {
-        "title": "Implement a String Ending Checker Function",
+        "title": "Build a Confirm the Ending Tool",
         "intro": [
           "In this lab, you will implement a function that checks if a given string ends with a specified target string."
         ]

--- a/client/src/pages/learn/full-stack-developer/lab-string-ending-checker/index.md
+++ b/client/src/pages/learn/full-stack-developer/lab-string-ending-checker/index.md
@@ -1,0 +1,9 @@
+---
+title: Introduction to the Implement a String Ending Checker Function
+block: lab-string-ending-checker
+superBlock: full-stack-developer
+---
+
+## Introduction to the Implement a String Ending Checker Function
+
+In this lab, you will implement a function that checks if a given string ends with a specified target string.

--- a/client/src/pages/learn/full-stack-developer/lab-string-ending-checker/index.md
+++ b/client/src/pages/learn/full-stack-developer/lab-string-ending-checker/index.md
@@ -1,9 +1,9 @@
 ---
-title: Introduction to the Implement a String Ending Checker Function
+title: Introduction to the Build a Confirm the Ending Tool
 block: lab-string-ending-checker
 superBlock: full-stack-developer
 ---
 
-## Introduction to the Implement a String Ending Checker Function
+## Introduction to the Build a Confirm the Ending Tool
 
 In this lab, you will implement a function that checks if a given string ends with a specified target string.

--- a/curriculum/challenges/_meta/lab-string-ending-checker/meta.json
+++ b/curriculum/challenges/_meta/lab-string-ending-checker/meta.json
@@ -1,0 +1,11 @@
+{
+  "name": "Implement a String Ending Checker Function",
+  "isUpcomingChange": false,
+  "dashedName": "lab-string-ending-checker",
+  "superBlock": "full-stack-developer",
+  "helpCategory": "JavaScript",
+  "challengeOrder": [{ "id": "6878d00d701b922699f96f06", "title": "Implement a String Ending Checker Function" }],
+  "blockType": "lab",
+  "blockLayout": "link",
+  "usesMultifileEditor": true
+}

--- a/curriculum/challenges/_meta/lab-string-ending-checker/meta.json
+++ b/curriculum/challenges/_meta/lab-string-ending-checker/meta.json
@@ -4,7 +4,7 @@
   "dashedName": "lab-string-ending-checker",
   "superBlock": "full-stack-developer",
   "helpCategory": "JavaScript",
-  "challengeOrder": [{ "id": "6878d00d701b922699f96f06", "title": "Implement a String Ending Checker Function" }],
+  "challengeOrder": [{ "id": "acda2fb1324d9b0fa741e6b5", "title": "Implement a String Ending Checker Function" }],
   "blockType": "lab",
   "blockLayout": "link",
   "usesMultifileEditor": true

--- a/curriculum/challenges/_meta/lab-string-ending-checker/meta.json
+++ b/curriculum/challenges/_meta/lab-string-ending-checker/meta.json
@@ -1,10 +1,10 @@
 {
-  "name": "Implement a String Ending Checker Function",
+  "name": "Build a Confirm the Ending Tool",
   "isUpcomingChange": false,
   "dashedName": "lab-string-ending-checker",
   "superBlock": "full-stack-developer",
   "helpCategory": "JavaScript",
-  "challengeOrder": [{ "id": "acda2fb1324d9b0fa741e6b5", "title": "Implement a String Ending Checker Function" }],
+  "challengeOrder": [{ "id": "acda2fb1324d9b0fa741e6b5", "title": "Build a Confirm the Ending Tool" }],
   "blockType": "lab",
   "blockLayout": "link",
   "usesMultifileEditor": true

--- a/curriculum/challenges/english/25-front-end-development/lab-string-ending-checker/acda2fb1324d9b0fa741e6b5.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-string-ending-checker/acda2fb1324d9b0fa741e6b5.md
@@ -15,6 +15,7 @@ In this lab, you will implement a function that checks if a string ends with the
 
 1. You should create a function named `confirmEnding` that takes two parameters: the string to check and the string to check against.
 2. The function should return `true` if the first string ends with the second string, and `false` otherwise.
+3. You should not use the `.endsWith()` method; instead, use one of the JavaScript substring methods to achieve this.
 
 # --hints--
 
@@ -98,6 +99,13 @@ assert.isFalse(
 
 ```js
 assert.isTrue(confirmEnding('Abstraction', 'action'));
+```
+
+Your code should not use the built-in method `.endsWith()` to solve the lab.
+
+```js
+assert.notMatch(__helpers.removeJSComments(code), /\.endsWith\(.*?\)\s*?;?/);
+assert.notMatch(__helpers.removeJSComments(code), /\['endsWith'\]/);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/lab-string-ending-checker/acda2fb1324d9b0fa741e6b5.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-string-ending-checker/acda2fb1324d9b0fa741e6b5.md
@@ -1,0 +1,119 @@
+---
+id: acda2fb1324d9b0fa741e6b5
+title: Implement a String Ending Checker Function
+challengeType: 26
+dashedName: implement-a-string-ending-checker-function
+---
+
+# --description--
+
+In this lab, you will implement a function that checks if a string ends with the given target string.
+
+**Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab.
+
+**User Stories:**
+
+1. You should create a function named `confirmEnding` that takes two parameters: the string to check and the string to check against.
+2. The function should return `true` if the first string ends with the second string, and `false` otherwise.
+
+# --hints--
+
+You should create a function named `confirmEnding`.
+
+```js
+assert.isFunction(confirmEnding);
+```
+
+`confirmEnding` should take 2 parameters.
+
+```js
+assert.lengthOf(confirmEnding, 2);
+```
+
+`confirmEnding("Bastian", "n")` should return `true`.
+
+```js
+assert.isTrue(confirmEnding('Bastian', 'n'));
+```
+
+`confirmEnding("Congratulation", "on")` should return `true`.
+
+```js
+assert.isTrue(confirmEnding('Congratulation', 'on'));
+```
+
+`confirmEnding("Connor", "n")` should return `false`.
+
+```js
+assert.isFalse(confirmEnding('Connor', 'n'));
+```
+
+`confirmEnding("Walking on water and developing software from a specification are easy if both are frozen", "specification")` should return `false`.
+
+```js
+assert.isFalse(
+  confirmEnding(
+    'Walking on water and developing software from a specification are easy if both are frozen',
+    'specification'
+  )
+);
+```
+
+`confirmEnding("He has to give me a new name", "name")` should return `true`.
+
+```js
+assert.isTrue(confirmEnding('He has to give me a new name', 'name'));
+```
+
+`confirmEnding("Open sesame", "same")` should return `true`.
+
+```js
+assert.isTrue(confirmEnding('Open sesame', 'same'));
+```
+
+`confirmEnding("Open sesame", "sage")` should return `false`.
+
+```js
+assert.isFalse(confirmEnding('Open sesame', 'sage'));
+```
+
+`confirmEnding("Open sesame", "game")` should return `false`.
+
+```js
+assert.isFalse(confirmEnding('Open sesame', 'game'));
+```
+
+`confirmEnding("If you want to save our world, you must hurry. We dont know how much longer we can withstand the nothing", "mountain")` should return `false`.
+
+```js
+assert.isFalse(
+  confirmEnding(
+    'If you want to save our world, you must hurry. We dont know how much longer we can withstand the nothing',
+    'mountain'
+  )
+);
+```
+
+`confirmEnding("Abstraction", "action")` should return `true`.
+
+```js
+assert.isTrue(confirmEnding('Abstraction', 'action'));
+```
+
+# --seed--
+
+## --seed-contents--
+
+```js
+
+```
+
+# --solutions--
+
+```js
+function confirmEnding(str, target) {
+  return str.substring(str.length - target.length) === target;
+}
+
+confirmEnding('Bastian', 'n');
+```

--- a/curriculum/challenges/english/25-front-end-development/lab-string-ending-checker/acda2fb1324d9b0fa741e6b5.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-string-ending-checker/acda2fb1324d9b0fa741e6b5.md
@@ -1,6 +1,6 @@
 ---
 id: acda2fb1324d9b0fa741e6b5
-title: Implement a String Ending Checker Function
+title: Build a Confirm the Ending Tool
 challengeType: 26
 dashedName: implement-a-string-ending-checker-function
 ---

--- a/curriculum/superblock-structure/full-stack.json
+++ b/curriculum/superblock-structure/full-stack.json
@@ -637,6 +637,9 @@
               "dashedName": "lab-truncate-string"
             },
             {
+              "dashedName": "lab-string-ending-checker"
+            },
+            {
               "dashedName": "review-javascript-functions"
             },
             {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes https://github.com/freeCodeCamp/CurriculumExpansion/issues/880

Labs are open ended so I have removed the requirement of not using `endsWith()` as mentioned in the original lab. If this needs to be restored, let me know.

<!-- Feel free to add any additional description of changes below this line -->
