### PR TITLE
fix(curriculum): remove redundant backticks around MCQ options

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-arrays/6732aebaa8abb9086a9bb17a.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-arrays/6732aebaa8abb9086a9bb17a.md
@@ -91,7 +91,7 @@ What happens if you try to access an array element at an index that doesn't exis
 
 ## --answers--
 
-`It throws an error.`
+It throws an error.
 
 ### --feedback--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #61392 


<!-- Feel free to add any additional description of changes below this line -->
This PR removes unnecessary backticks surrounding an MCQ option in the curriculum challenge.
These backticks made the option appear as inline code, which isn't semantically correct and may confuse learners.

