### PR TITLE
chore(deps): update curriculum-helpers to v6

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-reusable-profile-card-component/674ef2d357676e50e469165a.md
+++ b/curriculum/challenges/english/blocks/workshop-reusable-profile-card-component/674ef2d357676e50e469165a.md
@@ -22,15 +22,13 @@ assert.isFunction(window.index.App);
 Your `App` component should return a pair of parentheses with an empty string inside.
 
 ```js
-async () => {
-  const functionRegex = __helpers.functionRegex("App", null, { capture: true });
-  const match = code.match(functionRegex);
-  const functionDefinition = match[0];
-  assert.match(
-    functionDefinition,
-    /\s*{\s*return\s*\(\s*(''|""|``)\s*\)\s*;?\s*}|\s*=>\s*\(\s*(''|""|``)\s*\)/
-  );
-}
+const functionRegex = __helpers.functionRegex("App", null, { capture: true });
+const match = code.match(functionRegex);
+const functionDefinition = match[0];
+assert.match(
+  functionDefinition,
+  /\s*{\s*return\s*\(\s*(''|""|``)\s*\)\s*;?\s*}|\s*=>\s*\(\s*(''|""|``)\s*\)/
+);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-reusable-profile-card-component/68720c179cd34be6793bfdf6.md
+++ b/curriculum/challenges/english/blocks/workshop-reusable-profile-card-component/68720c179cd34be6793bfdf6.md
@@ -16,11 +16,9 @@ Remove the three `<Card />` components inside `<div className="flex-container">`
 You should remove the three `<Card />` components from your code.
 
 ```js
-async () => {
-  const testElem = await __helpers.prepTestComponent(window.index.App);
-  const cards = testElem.querySelectorAll(".card");
-  assert.lengthOf(cards, 0);
-};
+const testElem = await __helpers.prepTestComponent(window.index.App);
+const cards = testElem.querySelectorAll(".card");
+assert.lengthOf(cards, 0);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-reusable-profile-card-component/68779156bd3704b727ba5f38.md
+++ b/curriculum/challenges/english/blocks/workshop-reusable-profile-card-component/68779156bd3704b727ba5f38.md
@@ -55,15 +55,13 @@ assert.match(code, /profiles\.map\s*\(/);
 You should pass `name`, `title`, and `bio` props from the `profile` object.
 
 ```js
-async () => {
-  const testElem = await __helpers.prepTestComponent(window.index.App);
-  const cards = testElem.querySelectorAll(".card");
-  assert.lengthOf(cards, 1);
+const testElem = await __helpers.prepTestComponent(window.index.App);
+const cards = testElem.querySelectorAll(".card");
+assert.lengthOf(cards, 1);
 
-  assert.equal(cards[0]?.querySelector("h2").textContent, "Mark");
-  assert.equal(cards[0]?.querySelector(".card-title").textContent, "Frontend developer");
-  assert.equal(cards[0]?.querySelector("p:last-of-type").textContent, "I like to work with different frontend technologies and play video games.");
-};
+assert.equal(cards[0]?.querySelector("h2").textContent, "Mark");
+assert.equal(cards[0]?.querySelector(".card-title").textContent, "Frontend developer");
+assert.equal(cards[0]?.querySelector("p:last-of-type").textContent, "I like to work with different frontend technologies and play video games.");
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-reusable-profile-card-component/68779c7183f88b0811570275.md
+++ b/curriculum/challenges/english/blocks/workshop-reusable-profile-card-component/68779c7183f88b0811570275.md
@@ -30,11 +30,9 @@ With that, your reusable profile card component project is complete!
 You should render exactly three `Card` components.
 
 ```js
-async () => {
-  const testElem = await __helpers.prepTestComponent(window.index.App);
-  const cards = testElem.querySelectorAll('.card');
-  assert.lengthOf(cards, 3);
-};
+const testElem = await __helpers.prepTestComponent(window.index.App);
+const cards = testElem.querySelectorAll('.card');
+assert.lengthOf(cards, 3);
 ```
 
 # --seed--

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -977,8 +977,8 @@ importers:
   tools/client-plugins/browser-scripts:
     dependencies:
       '@freecodecamp/curriculum-helpers':
-        specifier: ^5.4.1
-        version: 5.4.1(debug@4.3.4)(typescript@5.8.2)
+        specifier: ^6.0.1
+        version: 6.0.1(debug@4.3.4)(typescript@5.8.2)
       xterm:
         specifier: ^5.2.1
         version: 5.3.0
@@ -2924,8 +2924,8 @@ packages:
       '@fortawesome/fontawesome-svg-core': ~1 || ~6 || ~7
       react: ^16.3 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  '@freecodecamp/curriculum-helpers@5.4.1':
-    resolution: {integrity: sha512-Lcy9sTrcbFbRY6HmaCKARDbulAAgJs7Tre5QRjmNyU0Bd1NLaf+9YLvcs84mCzHy+JP3itmIkxDAT9IHD4BArQ==}
+  '@freecodecamp/curriculum-helpers@6.0.1':
+    resolution: {integrity: sha512-mbqbN1Q2la4ovDHCPqbltRBGenOANO/nhxiC4Kz3CWIhjFVNZL5bvicKKSJnQqDWfl8+1ss32AIc2jTPKtZRtw==}
     engines: {pnpm: '>= 10'}
 
   '@freecodecamp/loop-protect@3.0.0':
@@ -11330,6 +11330,7 @@ packages:
   puppeteer@24.10.0:
     resolution: {integrity: sha512-Oua9VkGpj0S2psYu5e6mCer6W9AU9POEQh22wRgSXnLXASGH+MwLUVWgLCLeP9QPHHcJ7tySUlg4Sa9OJmaLpw==}
     engines: {node: '>=18'}
+    deprecated: < 24.10.2 is no longer supported
     hasBin: true
 
   pyodide@0.23.3:
@@ -16958,7 +16959,7 @@ snapshots:
       prop-types: 15.8.1
       react: 17.0.2
 
-  '@freecodecamp/curriculum-helpers@5.4.1(debug@4.3.4)(typescript@5.8.2)':
+  '@freecodecamp/curriculum-helpers@6.0.1(debug@4.3.4)(typescript@5.8.2)':
     dependencies:
       '@sinonjs/fake-timers': 14.0.0
       '@types/jquery': 3.5.32

--- a/tools/client-plugins/browser-scripts/package.json
+++ b/tools/client-plugins/browser-scripts/package.json
@@ -41,7 +41,7 @@
     "webpack-cli": "4.10.0"
   },
   "dependencies": {
-    "@freecodecamp/curriculum-helpers": "^5.4.1",
+    "@freecodecamp/curriculum-helpers": "^6.0.1",
     "xterm": "^5.2.1"
   }
 }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

The most important change is how challenge tests like

```
async () => { ... }
```

are handled. In earlier versions these functions would be called and awaited. Now they're not.

Also, 5.4.1 has a bug on firefox because of how it handled the possibility that a test might be wrapped in `async () =>` but 6.0.1 no-longer tries to handle it and so fixes the bug. As a result this closes https://github.com/freeCodeCamp/freeCodeCamp/issues/62425

<!-- Feel free to add any additional description of changes below this line -->
