### PR TITLE
fix(curriculum): address misleading info about join() default separator

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/review-javascript-arrays/6723c66f623701a3cdf72130.md
+++ b/curriculum/challenges/english/25-front-end-development/review-javascript-arrays/6723c66f623701a3cdf72130.md
@@ -197,7 +197,7 @@ const desserts = ["cake", "cookies", "pie"];
 console.log(desserts.reverse()); // ["pie", "cookies", "cake"]
 ```
 
-- **`join()` Method**: This method concatenates all the elements of an array into a single string, with each element separated by a specified separator. If no separator is provided, or an empty string (`""`) is used, the elements will be joined without any separator.
+- **`join()` Method**: This method concatenates all the elements of an array into a single string, with each element separated by a specified separator.  If no separator is provided, the default separator (`,`) is used; if an empty string (`""`) is provided, the elements will be joined without any separator.
 
 ```js
 const reversedArray = ["o", "l", "l", "e", "h"];


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
The description of the join() method is misleading. It currently states:

“If no separator is provided, or an empty string (`""`) is used, the elements will be joined without any separator.”

Expected behavior: the elements are separated by commas (the default separator) or by a specified separator string—in other words, if no separator is provided, the default separator (`,`) is used.