### PR TITLE
Fix step21 runtime test clean

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-superhero-application-form/680900675ae3d54ee19590d3.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-superhero-application-form/680900675ae3d54ee19590d3.md
@@ -4,6 +4,7 @@ title: Step 21
 challengeType: 0
 dashedName: step-21
 ---
+
 # --description--
 
 Did you notice that you can submit the form without filling in the inputs?
@@ -244,8 +245,7 @@ export const SuperheroForm = () => {
 --fcc-editable-region--
         <button
           className='submit-btn'
-          type='submit'
-        
+          type='submit' 
         >
           Join the League
         </button>

--- a/curriculum/challenges/english/25-front-end-development/workshop-superhero-application-form/680900675ae3d54ee19590d3.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-superhero-application-form/680900675ae3d54ee19590d3.md
@@ -4,7 +4,6 @@ title: Step 21
 challengeType: 0
 dashedName: step-21
 ---
-
 # --description--
 
 Did you notice that you can submit the form without filling in the inputs?
@@ -20,19 +19,46 @@ With that, you superhero application form is complete.
 You should not modify the existing content of the button.
 
 ```js
-assert.match(code, /<\s*button\s+className\s*=\s*('|")\s*submit-btn\s*\1\s*type\s*=\s*('|")\s*submit\s*\2/)
+assert.match(code, /<\s*button\s+className\s*=\s*('|")\s*submit-btn\s*\1\s*type\s*=\s*('|")\s*submit\s*\2/);
 ```
 
 Your `button` element should have a `disabled` property.
 
 ```js
-assert.match(code, /<\s*button\s+className\s*=\s*('|")\s*submit-btn\s*\1\s*type\s*=\s*('|")\s*submit\s*\2\s*disabled/)
+assert.match(code, /<\s*button[^>]*disabled/);
 ```
 
 You should disable the `button` if any of `heroName`, `realName`, and `powerSource` is false, or if the length of `powers` is `0`.
 
 ```js
-assert.match(code, /disabled\s*=\s*\{\s*(?:!heroName\s*\|\|\s*!realName\s*\|\|\s*!powerSource\s*\|\|\s*powers\.length\s*===\s*0|!heroName\s*\|\|\s*!realName\s*\|\|\s*powers\.length\s*===\s*0\s*\|\|\s*!powerSource|!heroName\s*\|\|\s*!powerSource\s*\|\|\s*!realName\s*\|\|\s*powers\.length\s*===\s*0|!heroName\s*\|\|\s*!powerSource\s*\|\|\s*powers\.length\s*===\s*0\s*\|\|\s*!realName|!heroName\s*\|\|\s*powers\.length\s*===\s*0\s*\|\|\s*!realName\s*\|\|\s*!powerSource|!heroName\s*\|\|\s*powers\.length\s*===\s*0\s*\|\|\s*!powerSource\s*\|\|\s*!realName|!realName\s*\|\|\s*!heroName\s*\|\|\s*!powerSource\s*\|\|\s*powers\.length\s*===\s*0|!realName\s*\|\|\s*!heroName\s*\|\|\s*powers\.length\s*===\s*0\s*\|\|\s*!powerSource|!realName\s*\|\|\s*!powerSource\s*\|\|\s*!heroName\s*\|\|\s*powers\.length\s*===\s*0|!realName\s*\|\|\s*!powerSource\s*\|\|\s*powers\.length\s*===\s*0\s*\|\|\s*!heroName|!realName\s*\|\|\s*powers\.length\s*===\s*0\s*\|\|\s*!heroName\s*\|\|\s*!powerSource|!realName\s*\|\|\s*powers\.length\s*===\s*0\s*\|\|\s*!powerSource\s*\|\|\s*!heroName|!powerSource\s*\|\|\s*!heroName\s*\|\|\s*!realName\s*\|\|\s*powers\.length\s*===\s*0|!powerSource\s*\|\|\s*!heroName\s*\|\|\s*powers\.length\s*===\s*0\s*\|\|\s*!realName|!powerSource\s*\|\|\s*!realName\s*\|\|\s*!heroName\s*\|\|\s*powers\.length\s*===\s*0|!powerSource\s*\|\|\s*!realName\s*\|\|\s*powers\.length\s*===\s*0\s*\|\|\s*!heroName|!powerSource\s*\|\|\s*powers\.length\s*===\s*0\s*\|\|\s*!heroName\s*\|\|\s*!realName|!powerSource\s*\|\|\s*powers\.length\s*===\s*0\s*\|\|\s*!realName\s*\|\|\s*!heroName|powers\.length\s*===\s*0\s*\|\|\s*!heroName\s*\|\|\s*!realName\s*\|\|\s*!powerSource|powers\.length\s*===\s*0\s*\|\|\s*!heroName\s*\|\|\s*!powerSource\s*\|\|\s*!realName|powers\.length\s*===\s*0\s*\|\|\s*!realName\s*\|\|\s*!heroName\s*\|\|\s*!powerSource|powers\.length\s*===\s*0\s*\|\|\s*!realName\s*\|\|\s*!powerSource\s*\|\|\s*!heroName|powers\.length\s*===\s*0\s*\|\|\s*!powerSource\s*\|\|\s*!heroName\s*\|\|\s*!realName|powers\.length\s*===\s*0\s*\|\|\s*!powerSource\s*\|\|\s*!realName\s*\|\|\s*!heroName)\s*\}/)
+export default function test({ getByRole, act, setProps }) {
+  const button = getByRole('button', { name: /join the league/i });
+
+  function setState(hero, real, source, powers) {
+    act(() => {
+      setProps({
+        heroName: hero,
+        realName: real,
+        powerSource: source,
+        powers: powers
+      });
+    });
+  }
+
+  // All invalid combinations: button should be disabled
+  setState('', 'Test', 'Test', ['Power']);
+  assert.isTrue(button.disabled);
+  setState('Hero', '', 'Test', ['Power']);
+  assert.isTrue(button.disabled);
+  setState('Hero', 'Real', '', ['Power']);
+  assert.isTrue(button.disabled);
+  setState('Hero', 'Real', 'Test', []);
+  assert.isTrue(button.disabled);
+
+  // All fields valid: button should be enabled
+  setState('Hero', 'Real', 'Test', ['Power']);
+  assert.isFalse(button.disabled);
+}
 ```
 
 # --seed--
@@ -219,7 +245,7 @@ export const SuperheroForm = () => {
         <button
           className='submit-btn'
           type='submit'
-          
+        
         >
           Join the League
         </button>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #60953

Replaced the long regex-based test for the disabled `button` in Step 21 with a runtime test using `getByRole`, `act`, and `setProps`.  
This makes the test simpler, more maintainable, and avoids overly complex regex patterns.