### PR TITLE
fix: make paragraph closing tag case-insensitive in step 3

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-cat-photo-app/5dc17d3bf86c76b9248c6eb4.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-cat-photo-app/5dc17d3bf86c76b9248c6eb4.md
@@ -22,7 +22,7 @@ assert.exists(document.querySelector('p'));
 Your `p` element should have a closing tag. Closing tags have a `/` just after the `<` character.
 
 ```js
-assert.match(code, /<\/p\>/);
+assert.match(code, /<\/p\>/i);
 ```
 
 Your `p` element's text should be `Everyone loves cute cats online!` You have either omitted the text or have a typo.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ ] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

### Summary

Updated the test in Step 3 of the Cat Photo App workshop to make the paragraph closing tag check case-insensitive. This allows users to pass the test even if they use `</P>` or mixed case like `</p>`.

### Reason

HTML is case-insensitive for tag names, so this change improves user experience and makes the validation more forgiving while still correct.

