### PR TITLE
fix(curriculum): clarify selector-specific styling in Moon Orbit lab 

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-moon-orbit/66a37f37ef5823a313de8c26.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-moon-orbit/66a37f37ef5823a313de8c26.md
@@ -40,9 +40,9 @@ Fulfill the user stories below and get all the tests to pass to complete the lab
 
 13. You should further adjust the horizontal positioning of the `.moon` element by moving the element to the left by half of its width.
 
-14. The .earth selector should have a background-color and a border-radius of 50%.
-The .moon selector should have a background-color and a border-radius of 50%.
-Apply these styles in separate CSS rules for each selector. 
+14. The `.earth` selector should have a background color and a `border-radius` of `50%`.
+
+15. The `.moon` selector should have a background color and a `border-radius` of `50%`.
 
 15. You should define a `@keyframes orbit` animation that rotates the `.orbit` element 360 degrees around its center. You should apply this animation to the `.orbit` element with a duration of `5` seconds, a linear timing function, and infinite iterations.
 

--- a/curriculum/challenges/english/25-front-end-development/lab-moon-orbit/66a37f37ef5823a313de8c26.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-moon-orbit/66a37f37ef5823a313de8c26.md
@@ -188,25 +188,25 @@ The `.moon` element should be adjusted horizontally by translating it to `-50%` 
 assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.moon')?.transform, 'translateX(-50%)');
 ```
 
-Your `.earth` element should have a background color.
+The `.earth` selector should have a background color. Apply this style in a separate CSS rule for the `.earth` selector.
 
 ```js
 assert.isNotEmpty(new __helpers.CSSHelp(document).getStyle('.earth')?.backgroundColor);
 ```
 
-Your `.earth` element should have `border-radius` of `50%` to make it look like a circle.
+The `.earth` selector should have `border-radius` of `50%` to make it look like a circle. Apply this style in a separate CSS rule for the `.earth` selector.
 
 ```js
 assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.earth')?.borderRadius, '50%');
 ```
 
-Your `.moon` element should have a background color.
+The `.moon` selector should have a background color. Apply this style in a separate CSS rule for the `.moon` selector.
 
 ```js
 assert.isNotEmpty(new __helpers.CSSHelp(document).getStyle('.moon')?.backgroundColor);
 ```
 
-Your `.moon` element should have `border-radius` of `50%` to make it look like a circle.
+The `.moon` selector should have `border-radius` of `50%` to make it look like a circle. Apply this style in a separate CSS rule for the `.moon` selector.
 
 ```js
 assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.moon')?.borderRadius, '50%');

--- a/curriculum/challenges/english/25-front-end-development/lab-moon-orbit/66a37f37ef5823a313de8c26.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-moon-orbit/66a37f37ef5823a313de8c26.md
@@ -40,7 +40,8 @@ Fulfill the user stories below and get all the tests to pass to complete the lab
 
 13. You should further adjust the horizontal positioning of the `.moon` element by moving the element to the left by half of its width.
 
-14. Your `.earth` and `.moon` elements should have a background color and a `border-radius` of `50%` to make them look like planets.
+14. Your `.earth` and `.moon` elements should each have a `background-color` and a `border-radius` of `50%` to make them look like planets.  
+Apply these styles in **separate CSS rules** for each selector.  
 
 15. You should define a `@keyframes orbit` animation that rotates the `.orbit` element 360 degrees around its center. You should apply this animation to the `.orbit` element with a duration of `5` seconds, a linear timing function, and infinite iterations.
 

--- a/curriculum/challenges/english/25-front-end-development/lab-moon-orbit/66a37f37ef5823a313de8c26.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-moon-orbit/66a37f37ef5823a313de8c26.md
@@ -40,8 +40,9 @@ Fulfill the user stories below and get all the tests to pass to complete the lab
 
 13. You should further adjust the horizontal positioning of the `.moon` element by moving the element to the left by half of its width.
 
-14. Your `.earth` and `.moon` elements should each have a `background-color` and a `border-radius` of `50%` to make them look like planets.  
-Apply these styles in **separate CSS rules** for each selector.  
+14. The .earth selector should have a background-color and a border-radius of 50%.
+The .moon selector should have a background-color and a border-radius of 50%.
+Apply these styles in separate CSS rules for each selector. 
 
 15. You should define a `@keyframes orbit` animation that rotates the `.orbit` element 360 degrees around its center. You should apply this animation to the `.orbit` element with a duration of `5` seconds, a linear timing function, and infinite iterations.
 

--- a/curriculum/challenges/english/25-front-end-development/lab-moon-orbit/66a37f37ef5823a313de8c26.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-moon-orbit/66a37f37ef5823a313de8c26.md
@@ -44,7 +44,7 @@ Fulfill the user stories below and get all the tests to pass to complete the lab
 
 15. The `.moon` selector should have a background color and a `border-radius` of `50%`.
 
-15. You should define a `@keyframes orbit` animation that rotates the `.orbit` element 360 degrees around its center. You should apply this animation to the `.orbit` element with a duration of `5` seconds, a linear timing function, and infinite iterations.
+16. You should define a `@keyframes orbit` animation that rotates the `.orbit` element 360 degrees around its center. You should apply this animation to the `.orbit` element with a duration of `5` seconds, a linear timing function, and infinite iterations.
 
 **Note:** Be sure to link your stylesheet in your HTML and apply your CSS.
 

--- a/curriculum/challenges/english/25-front-end-development/lab-moon-orbit/66a37f37ef5823a313de8c26.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-moon-orbit/66a37f37ef5823a313de8c26.md
@@ -194,7 +194,7 @@ The `.earth` selector should have a background color.
 assert.isNotEmpty(new __helpers.CSSHelp(document).getStyle('.earth')?.backgroundColor);
 ```
 
-The `.earth` selector should have `border-radius` of `50%` to make it look like a circle. Apply this style in a separate CSS rule for the `.earth` selector.
+The `.earth` selector should have `border-radius` of `50%` to make it look like a circle.
 
 ```js
 assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.earth')?.borderRadius, '50%');

--- a/curriculum/challenges/english/25-front-end-development/lab-moon-orbit/66a37f37ef5823a313de8c26.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-moon-orbit/66a37f37ef5823a313de8c26.md
@@ -188,7 +188,7 @@ The `.moon` element should be adjusted horizontally by translating it to `-50%` 
 assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.moon')?.transform, 'translateX(-50%)');
 ```
 
-The `.earth` selector should have a background color. Apply this style in a separate CSS rule for the `.earth` selector.
+The `.earth` selector should have a background color.
 
 ```js
 assert.isNotEmpty(new __helpers.CSSHelp(document).getStyle('.earth')?.backgroundColor);

--- a/curriculum/challenges/english/25-front-end-development/lab-moon-orbit/66a37f37ef5823a313de8c26.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-moon-orbit/66a37f37ef5823a313de8c26.md
@@ -206,7 +206,7 @@ The `.moon` selector should have a background color.
 assert.isNotEmpty(new __helpers.CSSHelp(document).getStyle('.moon')?.backgroundColor);
 ```
 
-The `.moon` selector should have `border-radius` of `50%` to make it look like a circle.
+The `.moon` selector should have `border-radius` of `50%`.
 
 ```js
 assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.moon')?.borderRadius, '50%');

--- a/curriculum/challenges/english/25-front-end-development/lab-moon-orbit/66a37f37ef5823a313de8c26.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-moon-orbit/66a37f37ef5823a313de8c26.md
@@ -200,7 +200,7 @@ The `.earth` selector should have `border-radius` of `50%` to make it look like 
 assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.earth')?.borderRadius, '50%');
 ```
 
-The `.moon` selector should have a background color. Apply this style in a separate CSS rule for the `.moon` selector.
+The `.moon` selector should have a background color.
 
 ```js
 assert.isNotEmpty(new __helpers.CSSHelp(document).getStyle('.moon')?.backgroundColor);

--- a/curriculum/challenges/english/25-front-end-development/lab-moon-orbit/66a37f37ef5823a313de8c26.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-moon-orbit/66a37f37ef5823a313de8c26.md
@@ -206,7 +206,7 @@ The `.moon` selector should have a background color.
 assert.isNotEmpty(new __helpers.CSSHelp(document).getStyle('.moon')?.backgroundColor);
 ```
 
-The `.moon` selector should have `border-radius` of `50%` to make it look like a circle. Apply this style in a separate CSS rule for the `.moon` selector.
+The `.moon` selector should have `border-radius` of `50%` to make it look like a circle.
 
 ```js
 assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.moon')?.borderRadius, '50%');

--- a/curriculum/challenges/english/25-front-end-development/lab-moon-orbit/66a37f37ef5823a313de8c26.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-moon-orbit/66a37f37ef5823a313de8c26.md
@@ -194,7 +194,7 @@ The `.earth` selector should have a background color.
 assert.isNotEmpty(new __helpers.CSSHelp(document).getStyle('.earth')?.backgroundColor);
 ```
 
-The `.earth` selector should have `border-radius` of `50%` to make it look like a circle.
+The `.earth` selector should have `border-radius` of `50%`.
 
 ```js
 assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.earth')?.borderRadius, '50%');


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

Closes #61394

<!-- Feel free to add any additional description of changes below this line -->

This pull request clarifies that styles like `background-color` and `border-radius` in the Moon Orbit lab must be applied separately to `.earth` and `.moon` selectors, not grouped together. This aligns the instructions with the current test requirements and avoids confusion when using grouped selectors.
