### PR TITLE
refactor(curriculum): replace $.ajax with fetch

### DIFF
--- a/curriculum/challenges/english/blocks/back-end-development-and-apis-projects/bd7158d8c443edefaeb5bdef.md
+++ b/curriculum/challenges/english/blocks/back-end-development-and-apis-projects/bd7158d8c443edefaeb5bdef.md
@@ -28,108 +28,96 @@ You should provide your own project, not the example URL.
 A request to `/api/:date?` with a valid date should return a JSON object with a `unix` key that is a Unix timestamp of the input date in milliseconds (as type Number)
 
 ```js
-  $.get(code + '/api/2016-12-25').then(
-    (data) => {
-      assert.equal(
-        data.unix,
-        1482624000000,
-        'Should be a valid unix timestamp'
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
+  const response = await fetch(code + '/api/2016-12-25');
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  assert.equal(
+    data.unix,
+    1482624000000,
+    'Should be a valid unix timestamp'
   );
 ```
 
 A request to `/api/:date?` with a valid date should return a JSON object with a `utc` key that is a string of the input date in the format: `Thu, 01 Jan 1970 00:00:00 GMT`
 
 ```js
-  $.get(code + '/api/2016-12-25').then(
-    (data) => {
-      assert.equal(
-        data.utc,
-        'Sun, 25 Dec 2016 00:00:00 GMT',
-        'Should be a valid UTC date string'
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
+  const response = await fetch(code + '/api/2016-12-25');
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  assert.equal(
+    data.utc,
+    'Sun, 25 Dec 2016 00:00:00 GMT',
+    'Should be a valid UTC date string'
   );
 ```
 
 A request to `/api/1451001600000` should return `{ unix: 1451001600000, utc: "Fri, 25 Dec 2015 00:00:00 GMT" }`
 
 ```js
-  $.get(code + '/api/1451001600000').then(
-    (data) => {
-      assert(
-        data.unix === 1451001600000 &&
-          data.utc === 'Fri, 25 Dec 2015 00:00:00 GMT'
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
+  const response = await fetch(code + '/api/1451001600000');
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  assert(
+    data.unix === 1451001600000 &&
+      data.utc === 'Fri, 25 Dec 2015 00:00:00 GMT'
   );
 ```
 
 Your project can handle dates that can be successfully parsed by `new Date(date_string)`
 
 ```js
-  $.get(code + '/api/05 October 2011, GMT').then(
-    (data) => {
-      assert(
-        data.unix === 1317772800000 &&
-          data.utc === 'Wed, 05 Oct 2011 00:00:00 GMT'
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
+  const response = await fetch(code + '/api/05 October 2011, GMT');
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  assert(
+    data.unix === 1317772800000 &&
+      data.utc === 'Wed, 05 Oct 2011 00:00:00 GMT'
   );
 ```
 
 If the input date string is invalid, the API returns an object having the structure `{ error : "Invalid Date" }`
 
 ```js
-  $.get(code + '/api/this-is-not-a-date').then(
-    (data) => {
-      assert.equal(data.error.toLowerCase(), 'invalid date');
-    },
-    (xhr) => {
-      assert(xhr.responseJSON.error.toLowerCase() === 'invalid date');
-    }
-  );
+  const response = await fetch(code + '/api/this-is-not-a-date');
+  if (response.ok) {
+    const data = await response.json();
+    assert.equal(data.error.toLowerCase(), 'invalid date');
+  } else {
+    const errorData = await response.json();
+    assert(errorData.error.toLowerCase() === 'invalid date');
+  }
 ```
 
 An empty date parameter should return the current time in a JSON object with a `unix` key
 
 ```js
-  $.get(code + '/api').then(
-    (data) => {
-      var now = Date.now();
-      assert.approximately(data.unix, now, 20000);
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+  const response = await fetch(code + '/api');
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  var now = Date.now();
+  assert.approximately(data.unix, now, 20000);
 ```
 
 An empty date parameter should return the current time in a JSON object with a `utc` key
 
 ```js
-  $.get(code + '/api').then(
-    (data) => {
-      var now = Date.now();
-      var serverTime = new Date(data.utc).getTime();
-      assert.approximately(serverTime, now, 20000);
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+  const response = await fetch(code + '/api');
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  var now = Date.now();
+  var serverTime = new Date(data.utc).getTime();
+  assert.approximately(serverTime, now, 20000);
 ```
 

--- a/curriculum/challenges/english/blocks/back-end-development-and-apis-projects/bd7158d8c443edefaeb5bdff.md
+++ b/curriculum/challenges/english/blocks/back-end-development-and-apis-projects/bd7158d8c443edefaeb5bdff.md
@@ -28,33 +28,33 @@ You should provide your own project, not the example URL.
 A request to `/api/whoami` should return a JSON object with your IP address in the `ipaddress` key.
 
 ```js
-  $.get(code + '/api/whoami').then(
-    (data) => assert(data.ipaddress && data.ipaddress.length > 0),
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+  const response = await fetch(code + '/api/whoami');
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  assert(data.ipaddress && data.ipaddress.length > 0);
 ```
 
 A request to `/api/whoami` should return a JSON object with your preferred language in the `language` key.
 
 ```js
-  $.get(code + '/api/whoami').then(
-    (data) => assert(data.language && data.language.length > 0),
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+  const response = await fetch(code + '/api/whoami');
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  assert(data.language && data.language.length > 0);
 ```
 
 A request to `/api/whoami` should return a JSON object with your software in the `software` key.
 
 ```js
-  $.get(code + '/api/whoami').then(
-    (data) => assert(data.software && data.software.length > 0),
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+  const response = await fetch(code + '/api/whoami');
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  assert(data.software && data.software.length > 0);
 ```
 

--- a/curriculum/challenges/english/blocks/basic-node-and-express/587d7fb0367417b2b2512bed.md
+++ b/curriculum/challenges/english/blocks/basic-node-and-express/587d7fb0367417b2b2512bed.md
@@ -36,13 +36,11 @@ Modify the `myApp.js` file to log "Hello World" to the console.
 `"Hello World"` should be in the console
 
 ```js
-  $.get(code + '/_api/hello-console').then(
-    (data) => {
-      assert.isTrue(data.passed, '"Hello World" is not in the server console');
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+  const response = await fetch(code + '/_api/hello-console');
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  assert.isTrue(data.passed, '"Hello World" is not in the server console');
 ```
 

--- a/curriculum/challenges/english/blocks/basic-node-and-express/587d7fb0367417b2b2512bee.md
+++ b/curriculum/challenges/english/blocks/basic-node-and-express/587d7fb0367417b2b2512bee.md
@@ -31,17 +31,15 @@ Use the `app.get()` method to serve the string "Hello Express" to GET requests m
 Your app should serve the string 'Hello Express'
 
 ```js
-  $.get(code).then(
-    (data) => {
-      assert.equal(
-        data,
-        'Hello Express',
-        'Your app does not serve the text "Hello Express"'
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
+  const response = await fetch(code);
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.text();
+  assert.equal(
+    data,
+    'Hello Express',
+    'Your app does not serve the text "Hello Express"'
   );
 ```
 

--- a/curriculum/challenges/english/blocks/basic-node-and-express/587d7fb0367417b2b2512bef.md
+++ b/curriculum/challenges/english/blocks/basic-node-and-express/587d7fb0367417b2b2512bef.md
@@ -25,17 +25,15 @@ Send the `/views/index.html` file as a response to GET requests to the `/` path.
 Your app should serve the file views/index.html
 
 ```js
-  $.get(code).then(
-    (data) => {
-      assert.match(
-        data,
-        /<h1>.*<\/h1>/,
-        'Your app does not serve the expected HTML'
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
+  const response = await fetch(code);
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.text();
+  assert.match(
+    data,
+    /<h1>.*<\/h1>/,
+    'Your app does not serve the expected HTML'
   );
 ```
 

--- a/curriculum/challenges/english/blocks/basic-node-and-express/587d7fb0367417b2b2512bf0.md
+++ b/curriculum/challenges/english/blocks/basic-node-and-express/587d7fb0367417b2b2512bf0.md
@@ -25,38 +25,35 @@ Now your app should be able to serve a CSS stylesheet. Note that the `/public/st
 Your app should serve asset files from the `/public` directory to the `/public` path
 
 ```js
-  $.get(code + '/public/style.css').then(
-    (data) => {
-      assert.match(
-        data,
-        /body\s*\{[^\}]*\}/,
-        'Your app does not serve static assets'
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
+  const response = await fetch(code + '/public/style.css');
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.text();
+  assert.match(
+    data,
+    /body\s*\{[^\}]*\}/,
+    'Your app does not serve static assets'
   );
 ```
 
 Your app should not serve files from any other folders except from `/public` directory 
 
 ```js
-  $.get(code + '/server.js').then(
-    (data) => {
-       assert.equal(
-        data?.status + '',
-        404 + '',
-        'Your app must serve files only from "public" directory'
-      );
-    },
-    (xhr) => {
-      assert.equal(
-        xhr?.status + '',
-        404 + '',
-        'Your app must serve files only from "public" directory'
-      );
-    }
-  );
+  const response = await fetch(code + '/server.js');
+  if (response.ok) {
+    const data = await response.text();
+    assert.equal(
+      response.status + '',
+      404 + '',
+      'Your app must serve files only from "public" directory'
+    );
+  } else {
+    assert.equal(
+      response.status + '',
+      404 + '',
+      'Your app must serve files only from "public" directory'
+    );
+  }
 ```
 

--- a/curriculum/challenges/english/blocks/basic-node-and-express/587d7fb1367417b2b2512bf1.md
+++ b/curriculum/challenges/english/blocks/basic-node-and-express/587d7fb1367417b2b2512bf1.md
@@ -21,17 +21,15 @@ Serve the object `{"message": "Hello json"}` as a response, in JSON format, to G
 The endpoint `/json` should serve the JSON object `{"message": "Hello json"}`
 
 ```js
-  $.get(code + '/json').then(
-    (data) => {
-      assert.equal(
-        data.message,
-        'Hello json',
-        "The '/json' endpoint does not serve the right data"
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
+  const response = await fetch(code + '/json');
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  assert.equal(
+    data.message,
+    'Hello json',
+    "The '/json' endpoint does not serve the right data"
   );
 ```
 

--- a/curriculum/challenges/english/blocks/basic-node-and-express/587d7fb1367417b2b2512bf2.md
+++ b/curriculum/challenges/english/blocks/basic-node-and-express/587d7fb1367417b2b2512bf2.md
@@ -27,16 +27,14 @@ You will need to use the `dotenv` package. It loads environment variables from y
 The response of the endpoint `/json` should change according to the environment variable `MESSAGE_STYLE`
 
 ```js
-  $.get(code + '/_api/use-env-vars').then(
-    (data) => {
-      assert.isTrue(
-        data.passed,
-        'The response of "/json" does not change according to MESSAGE_STYLE'
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
+  const response = await fetch(code + '/_api/use-env-vars');
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  assert.isTrue(
+    data.passed,
+    'The response of "/json" does not change according to MESSAGE_STYLE'
   );
 ```
 

--- a/curriculum/challenges/english/blocks/basic-node-and-express/587d7fb1367417b2b2512bf3.md
+++ b/curriculum/challenges/english/blocks/basic-node-and-express/587d7fb1367417b2b2512bf3.md
@@ -32,16 +32,14 @@ Build a simple logger. For every request, it should log to the console a string 
 Root level logger middleware should be active
 
 ```js
-  $.get(code + '/_api/root-middleware-logger').then(
-    (data) => {
-      assert.isTrue(
-        data.passed,
-        'root-level logger is not working as expected'
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
+  const response = await fetch(code + '/_api/root-middleware-logger');
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  assert.isTrue(
+    data.passed,
+    'root-level logger is not working as expected'
   );
 ```
 

--- a/curriculum/challenges/english/blocks/basic-node-and-express/587d7fb1367417b2b2512bf4.md
+++ b/curriculum/challenges/english/blocks/basic-node-and-express/587d7fb1367417b2b2512bf4.md
@@ -34,35 +34,31 @@ In the route `app.get('/now', ...)` chain a middleware function and the final ha
 The /now endpoint should have mounted middleware
 
 ```js
-  $.get(code + '/_api/chain-middleware-time').then(
-    (data) => {
-      assert.equal(
-        data.stackLength,
-        2,
-        '"/now" route has no mounted middleware'
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
+  const response = await fetch(code + '/_api/chain-middleware-time');
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  assert.equal(
+    data.stackLength,
+    2,
+    '"/now" route has no mounted middleware'
   );
 ```
 
 The `/now` endpoint should return the current time.
 
 ```js
-  $.get(code + '/_api/chain-middleware-time').then(
-    (data) => {
-      var now = new Date();
-      assert.isAtMost(
-        Math.abs(new Date(data.time) - now),
-        20000,
-        'the returned time is not between +- 20 secs from now'
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
+  const response = await fetch(code + '/_api/chain-middleware-time');
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  var now = new Date();
+  assert.isAtMost(
+    Math.abs(new Date(data.time) - now),
+    20000,
+    'the returned time is not between +- 20 secs from now'
   );
 ```
 

--- a/curriculum/challenges/english/blocks/basic-node-and-express/587d7fb2367417b2b2512bf5.md
+++ b/curriculum/challenges/english/blocks/basic-node-and-express/587d7fb2367417b2b2512bf5.md
@@ -21,34 +21,30 @@ Build an echo server, mounted at the route `GET /:word/echo`. Respond with a JSO
 Test 1 : Your echo server should repeat words correctly
 
 ```js
-  $.get(code + '/eChOtEsT/echo').then(
-    (data) => {
-      assert.equal(
-        data.echo,
-        'eChOtEsT',
-        'Test 1: the echo server is not working as expected'
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
+  const response = await fetch(code + '/eChOtEsT/echo');
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  assert.equal(
+    data.echo,
+    'eChOtEsT',
+    'Test 1: the echo server is not working as expected'
   );
 ```
 
 Test 2 : Your echo server should repeat words correctly
 
 ```js
-  $.get(code + '/ech0-t3st/echo').then(
-    (data) => {
-      assert.equal(
-        data.echo,
-        'ech0-t3st',
-        'Test 2: the echo server is not working as expected'
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
+  const response = await fetch(code + '/ech0-t3st/echo');
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  assert.equal(
+    data.echo,
+    'ech0-t3st',
+    'Test 2: the echo server is not working as expected'
   );
 ```
 

--- a/curriculum/challenges/english/blocks/basic-node-and-express/587d7fb2367417b2b2512bf6.md
+++ b/curriculum/challenges/english/blocks/basic-node-and-express/587d7fb2367417b2b2512bf6.md
@@ -23,34 +23,30 @@ Build an API endpoint, mounted at `GET /name`. Respond with a JSON document, tak
 Test 1 : Your API endpoint should respond with `{ "name": "Mick Jagger" }` when the `/name` endpoint is called with `?first=Mick&last=Jagger`
 
 ```js
-  $.get(code + '/name?first=Mick&last=Jagger').then(
-    (data) => {
-      assert.equal(
-        data.name,
-        'Mick Jagger',
-        'Test 1: "GET /name" route does not behave as expected'
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
+  const response = await fetch(code + '/name?first=Mick&last=Jagger');
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  assert.equal(
+    data.name,
+    'Mick Jagger',
+    'Test 1: "GET /name" route does not behave as expected'
   );
 ```
 
 Test 2 : Your API endpoint should respond with `{ "name": "Keith Richards" }` when the `/name` endpoint is called with `?first=Keith&last=Richards`
 
 ```js
-  $.get(code + '/name?last=Richards&first=Keith').then(
-    (data) => {
-      assert.equal(
-        data.name,
-        'Keith Richards',
-        'Test 2: "GET /name" route does not behave as expected'
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
+  const response = await fetch(code + '/name?last=Richards&first=Keith');
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  assert.equal(
+    data.name,
+    'Keith Richards',
+    'Test 2: "GET /name" route does not behave as expected'
   );
 ```
 

--- a/curriculum/challenges/english/blocks/basic-node-and-express/587d7fb2367417b2b2512bf7.md
+++ b/curriculum/challenges/english/blocks/basic-node-and-express/587d7fb2367417b2b2512bf7.md
@@ -37,17 +37,15 @@ When using `extended=false`, values can be only strings or arrays. The object re
 The 'body-parser' middleware should be mounted
 
 ```js
-  $.get(code + '/_api/add-body-parser').then(
-    (data) => {
-      assert.isAbove(
-        data.mountedAt,
-        0,
-        '"body-parser" is not mounted correctly'
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
+  const response = await fetch(code + '/_api/add-body-parser');
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  assert.isAbove(
+    data.mountedAt,
+    0,
+    '"body-parser" is not mounted correctly'
   );
 ```
 

--- a/curriculum/challenges/english/blocks/basic-node-and-express/587d7fb2367417b2b2512bf8.md
+++ b/curriculum/challenges/english/blocks/basic-node-and-express/587d7fb2367417b2b2512bf8.md
@@ -31,37 +31,45 @@ There are also a couple of other methods which are used to negotiate a connectio
 Test 1 : Your API endpoint should respond with the correct name
 
 ```js
-  $.post(code + '/name', { first: 'Mick', last: 'Jagger' }).then(
-    (data) => {
-      assert.equal(
-        data.name,
-        'Mick Jagger',
-        'Test 1: "POST /name" route does not behave as expected'
-      );
+  const response = await fetch(code + '/name', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded'
     },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
+    body: new URLSearchParams({ first: 'Mick', last: 'Jagger' })
+  });
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  assert.equal(
+    data.name,
+    'Mick Jagger',
+    'Test 1: "POST /name" route does not behave as expected'
   );
 ```
 
 Test 2 : Your API endpoint should respond with the correct name
 
 ```js
-  $.post(code + '/name', {
-    first: 'Keith',
-    last: 'Richards'
-  }).then(
-    (data) => {
-      assert.equal(
-        data.name,
-        'Keith Richards',
-        'Test 2: "POST /name" route does not behave as expected'
-      );
+  const response = await fetch(code + '/name', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded'
     },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
+    body: new URLSearchParams({
+      first: 'Keith',
+      last: 'Richards'
+    })
+  });
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  assert.equal(
+    data.name,
+    'Keith Richards',
+    'Test 2: "POST /name" route does not behave as expected'
   );
 ```
 

--- a/curriculum/challenges/english/blocks/information-security-with-helmetjs/587d8247367417b2b2512c36.md
+++ b/curriculum/challenges/english/blocks/information-security-with-helmetjs/587d8247367417b2b2512c36.md
@@ -26,15 +26,13 @@ Helmet version `3.21.3` has already been installed, so require it as `helmet` in
 `helmet` version `3.21.3` should be in `package.json`
 
 ```js
-  $.get(code + '/_api/package.json').then(
-    (data) => {
-      const packJson = JSON.parse(data);
-      const helmet = packJson.dependencies.helmet;
-      assert(helmet === '3.21.3' || helmet === '^3.21.3');
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/package.json');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.text();
+const packJson = JSON.parse(data);
+const helmet = packJson.dependencies.helmet;
+assert(helmet === '3.21.3' || helmet === '^3.21.3');
 ```
 

--- a/curriculum/challenges/english/blocks/information-security-with-helmetjs/587d8247367417b2b2512c37.md
+++ b/curriculum/challenges/english/blocks/information-security-with-helmetjs/587d8247367417b2b2512c37.md
@@ -17,14 +17,12 @@ Hackers can exploit known vulnerabilities in Express/Node if they see that your 
 helmet.hidePoweredBy() middleware should be mounted correctly
 
 ```js
-  $.get(code + '/_api/app-info').then(
-    (data) => {
-      assert.include(data.appStack, 'hidePoweredBy');
-      assert.notEqual(data.headers['x-powered-by'], 'Express');
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/app-info');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.include(data.appStack, 'hidePoweredBy');
+assert.notEqual(data.headers['x-powered-by'], 'Express');
 ```
 

--- a/curriculum/challenges/english/blocks/information-security-with-helmetjs/587d8247367417b2b2512c38.md
+++ b/curriculum/challenges/english/blocks/information-security-with-helmetjs/587d8247367417b2b2512c38.md
@@ -23,31 +23,27 @@ Use `helmet.frameguard()` passing with the configuration object `{action: 'deny'
 helmet.frameguard() middleware should be mounted correctly
 
 ```js
-  $.get(code + '/_api/app-info').then(
-    (data) => {
-      assert.include(
-        data.appStack,
-        'frameguard',
-        'helmet.frameguard() middleware is not mounted correctly'
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/app-info');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.include(
+  data.appStack,
+  'frameguard',
+  'helmet.frameguard() middleware is not mounted correctly'
+);
 ```
 
 helmet.frameguard() 'action' should be set to 'DENY'
 
 ```js
-  $.get(code + '/_api/app-info').then(
-    (data) => {
-      assert.property(data.headers, 'x-frame-options');
-      assert.equal(data.headers['x-frame-options'], 'DENY');
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/app-info');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.property(data.headers, 'x-frame-options');
+assert.equal(data.headers['x-frame-options'], 'DENY');
 ```
 

--- a/curriculum/challenges/english/blocks/information-security-with-helmetjs/587d8247367417b2b2512c39.md
+++ b/curriculum/challenges/english/blocks/information-security-with-helmetjs/587d8247367417b2b2512c39.md
@@ -29,14 +29,12 @@ Use `helmet.xssFilter()` to sanitize input sent to your server.
 helmet.xssFilter() middleware should be mounted correctly
 
 ```js
-  $.get(code + '/_api/app-info').then(
-    (data) => {
-      assert.include(data.appStack, 'xXssProtection');
-      assert.property(data.headers, 'x-xss-protection');
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/app-info');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.include(data.appStack, 'xXssProtection');
+assert.property(data.headers, 'x-xss-protection');
 ```
 

--- a/curriculum/challenges/english/blocks/information-security-with-helmetjs/587d8248367417b2b2512c3a.md
+++ b/curriculum/challenges/english/blocks/information-security-with-helmetjs/587d8248367417b2b2512c3a.md
@@ -21,14 +21,12 @@ Use the `helmet.noSniff()` method on your server.
 helmet.noSniff() middleware should be mounted correctly
 
 ```js
-  $.get(code + '/_api/app-info').then(
-    (data) => {
-      assert.include(data.appStack, 'nosniff');
-      assert.equal(data.headers['x-content-type-options'], 'nosniff');
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/app-info');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.include(data.appStack, 'nosniff');
+assert.equal(data.headers['x-content-type-options'], 'nosniff');
 ```
 

--- a/curriculum/challenges/english/blocks/information-security-with-helmetjs/587d8248367417b2b2512c3b.md
+++ b/curriculum/challenges/english/blocks/information-security-with-helmetjs/587d8248367417b2b2512c3b.md
@@ -21,14 +21,12 @@ Use the `helmet.ieNoOpen()` method on your server.
 helmet.ieNoOpen() middleware should be mounted correctly
 
 ```js
-  $.get(code + '/_api/app-info').then(
-    (data) => {
-      assert.include(data.appStack, 'ienoopen');
-      assert.equal(data.headers['x-download-options'], 'noopen');
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/app-info');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.include(data.appStack, 'ienoopen');
+assert.equal(data.headers['x-download-options'], 'noopen');
 ```
 

--- a/curriculum/challenges/english/blocks/information-security-with-helmetjs/587d8248367417b2b2512c3c.md
+++ b/curriculum/challenges/english/blocks/information-security-with-helmetjs/587d8248367417b2b2512c3c.md
@@ -23,30 +23,26 @@ Note: Configuring HTTPS on a custom website requires the acquisition of a domain
 helmet.hsts() middleware should be mounted correctly
 
 ```js
-  $.get(code + '/_api/app-info').then(
-    (data) => {
-      assert.include(data.appStack, 'hsts');
-      assert.property(data.headers, 'strict-transport-security');
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/app-info');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.include(data.appStack, 'hsts');
+assert.property(data.headers, 'strict-transport-security');
 ```
 
 maxAge should be equal to 7776000 s (90 days)
 
 ```js
-  $.get(code + '/_api/app-info').then(
-    (data) => {
-      assert.match(
-        data.headers['strict-transport-security'],
-        /^max-age=7776000;?/
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/app-info');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.match(
+  data.headers['strict-transport-security'],
+  /^max-age=7776000;?/
+);
 ```
 

--- a/curriculum/challenges/english/blocks/information-security-with-helmetjs/587d8248367417b2b2512c3d.md
+++ b/curriculum/challenges/english/blocks/information-security-with-helmetjs/587d8248367417b2b2512c3d.md
@@ -21,14 +21,12 @@ Use the `helmet.dnsPrefetchControl()` method on your server.
 helmet.dnsPrefetchControl() middleware should be mounted correctly
 
 ```js
-  $.get(code + '/_api/app-info').then(
-    (data) => {
-      assert.include(data.appStack, 'dnsPrefetchControl');
-      assert.equal(data.headers['x-dns-prefetch-control'], 'off');
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/app-info');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.include(data.appStack, 'dnsPrefetchControl');
+assert.equal(data.headers['x-dns-prefetch-control'], 'off');
 ```
 

--- a/curriculum/challenges/english/blocks/information-security-with-helmetjs/587d8249367417b2b2512c3e.md
+++ b/curriculum/challenges/english/blocks/information-security-with-helmetjs/587d8249367417b2b2512c3e.md
@@ -21,17 +21,15 @@ Use the `helmet.noCache()` method on your server.
 helmet.noCache() middleware should be mounted correctly
 
 ```js
-  $.get(code + '/_api/app-info').then(
-    (data) => {
-      assert.include(data.appStack, 'nocache');
-      assert.equal(
-        data.headers['cache-control'],
-        'no-store, no-cache, must-revalidate, proxy-revalidate'
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/app-info');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.include(data.appStack, 'nocache');
+assert.equal(
+  data.headers['cache-control'],
+  'no-store, no-cache, must-revalidate, proxy-revalidate'
+);
 ```
 

--- a/curriculum/challenges/english/blocks/information-security-with-helmetjs/587d8249367417b2b2512c3f.md
+++ b/curriculum/challenges/english/blocks/information-security-with-helmetjs/587d8249367417b2b2512c3f.md
@@ -25,35 +25,31 @@ Hint: in the `'self'` keyword, the single quotes are part of the keyword itself,
 helmet.contentSecurityPolicy() middleware should be mounted correctly
 
 ```js
-  $.get(code + '/_api/app-info').then(
-    (data) => {
-      assert.include(data.appStack, 'csp');
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/app-info');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.include(data.appStack, 'csp');
 ```
 
 Your csp config is not correct. defaultSrc should be ["'self'"] and scriptSrc should be ["'self'", 'trusted-cdn.com']
 
 ```js
-  $.get(code + '/_api/app-info').then(
-    (data) => {
-      var cspHeader = Object.keys(data.headers).filter(function (k) {
-        return (
-          k === 'content-security-policy' ||
-          k === 'x-webkit-csp' ||
-          k === 'x-content-security-policy'
-        );
-      })[0];
-      assert.equal(
-        data.headers[cspHeader],
-        "default-src 'self'; script-src 'self' trusted-cdn.com"
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
+const response = await fetch(code + '/_api/app-info');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+var cspHeader = Object.keys(data.headers).filter(function (k) {
+  return (
+    k === 'content-security-policy' ||
+    k === 'x-webkit-csp' ||
+    k === 'x-content-security-policy'
   );
+})[0];
+assert.equal(
+  data.headers[cspHeader],
+  "default-src 'self'; script-src 'self' trusted-cdn.com"
+);
 ```

--- a/curriculum/challenges/english/blocks/information-security-with-helmetjs/58a25bcef9fc0f352b528e7c.md
+++ b/curriculum/challenges/english/blocks/information-security-with-helmetjs/58a25bcef9fc0f352b528e7c.md
@@ -27,35 +27,31 @@ Submit your page when you think you've got it right.
 BCrypt should be a dependency.
 
 ```js
-  $.get(code + '/_api/package.json').then(
-    (data) => {
-      var packJson = JSON.parse(data);
-      assert.property(
-        packJson.dependencies,
-        'bcrypt',
-        'Your project should list "bcrypt" as a dependency'
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.statusText);
-    }
-  );
+const response = await fetch(code + '/_api/package.json');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.text();
+var packJson = JSON.parse(data);
+assert.property(
+  packJson.dependencies,
+  'bcrypt',
+  'Your project should list "bcrypt" as a dependency'
+);
 ```
 
 BCrypt should be properly required.
 
 ```js
-  $.get(code + '/_api/server.js').then(
-    (data) => {
-      assert.match(
-        data,
-        /bcrypt.*=.*require.*('|")bcrypt('|")/gi,
-        'You should correctly require and instantiate socket.io as io.'
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.statusText);
-    }
-  );
+const response = await fetch(code + '/_api/server.js');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.text();
+assert.match(
+  data,
+  /bcrypt.*=.*require.*('|")bcrypt('|")/gi,
+  'You should correctly require and instantiate bcrypt as bcrypt.'
+);
 ```
 

--- a/curriculum/challenges/english/blocks/information-security-with-helmetjs/58a25bcff9fc0f352b528e7d.md
+++ b/curriculum/challenges/english/blocks/information-security-with-helmetjs/58a25bcff9fc0f352b528e7d.md
@@ -50,22 +50,20 @@ Submit your page when you think you've got it right.
 Async hash should be generated and correctly compared.
 
 ```js
-  $.get(code + '/_api/server.js').then(
-    (data) => {
-      assert.match(
-        data,
-        /START_ASYNC[^]*bcrypt.hash.*myPlaintextPassword( |),( |)saltRounds( |),( |).*err( |),( |)hash[^]*END_ASYNC/gi,
-        'You should call bcrypt.hash on myPlaintextPassword and saltRounds and handle err and hash as a result in the callback'
-      );
-      assert.match(
-        data,
-        /START_ASYNC[^]*bcrypt.hash[^]*bcrypt.compare.*myPlaintextPassword( |),( |)hash( |),( |).*err( |),( |)res[^]*}[^]*}[^]*END_ASYNC/gi,
-        'Nested within the hash function should be the compare function comparing myPlaintextPassword to hash'
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.statusText);
-    }
-  );
+const response = await fetch(code + '/_api/server.js');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.text();
+assert.match(
+  data,
+  /START_ASYNC[^]*bcrypt.hash.*myPlaintextPassword( |),( |)saltRounds( |),( |).*err( |),( |)hash[^]*END_ASYNC/gi,
+  'You should call bcrypt.hash on myPlaintextPassword and saltRounds and handle err and hash as a result in the callback'
+);
+assert.match(
+  data,
+  /START_ASYNC[^]*bcrypt.hash[^]*bcrypt.compare.*myPlaintextPassword( |),( |)hash( |),( |).*err( |),( |)res[^]*}[^]*}[^]*END_ASYNC/gi,
+  'Nested within the hash function should be the compare function comparing myPlaintextPassword to hash'
+);
 ```
 

--- a/curriculum/challenges/english/blocks/information-security-with-helmetjs/58a25bcff9fc0f352b528e7e.md
+++ b/curriculum/challenges/english/blocks/information-security-with-helmetjs/58a25bcff9fc0f352b528e7e.md
@@ -35,22 +35,20 @@ Submit your page when you think you've got it right.
 Sync hash should be generated and correctly compared.
 
 ```js
-  $.get(code + '/_api/server.js').then(
-    (data) => {
-      assert.match(
-        data,
-        /START_SYNC[^]*hash.*=.*bcrypt.hashSync.*myPlaintextPassword( |),( |)saltRounds[^]*END_SYNC/gi,
-        'You should call bcrypt.hashSync on myPlaintextPassword with saltRounds'
-      );
-      assert.match(
-        data,
-        /START_SYNC[^]*result.*=.*bcrypt.compareSync.*myPlaintextPassword( |),( |)hash[^]*END_SYNC/gi,
-        'You should call bcrypt.compareSync on myPlaintextPassword with the hash generated in the last line'
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.statusText);
-    }
-  );
+const response = await fetch(code + '/_api/server.js');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.text();
+assert.match(
+  data,
+  /START_SYNC[^]*hash.*=.*bcrypt.hashSync.*myPlaintextPassword( |),( |)saltRounds[^]*END_SYNC/gi,
+  'You should call bcrypt.hashSync on myPlaintextPassword with saltRounds'
+);
+assert.match(
+  data,
+  /START_SYNC[^]*result.*=.*bcrypt.compareSync.*myPlaintextPassword( |),( |)hash[^]*END_SYNC/gi,
+  'You should call bcrypt.compareSync on myPlaintextPassword with the hash generated in the last line'
+);
 ```
 

--- a/curriculum/challenges/english/blocks/mongodb-and-mongoose/587d7fb6367417b2b2512c06.md
+++ b/curriculum/challenges/english/blocks/mongodb-and-mongoose/587d7fb6367417b2b2512c06.md
@@ -32,32 +32,28 @@ mongoose.connect(<Your URI>, { useNewUrlParser: true, useUnifiedTopology: true }
 "mongoose version ^5.11.15" dependency should be in package.json
 
 ```js
-  $.get(code + '/_api/file/package.json').then(
-    (data) => {
-      var packJson = JSON.parse(data);
-      assert.property(packJson.dependencies, 'mongoose');
-      assert.match(
-        packJson.dependencies.mongoose,
-        /^\^5\.11\.15/,
-        'Wrong version of "mongoose". It should be ^5.11.15'
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
+  const response = await fetch(code + '/_api/file/package.json');
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.text();
+  var packJson = JSON.parse(data);
+  assert.property(packJson.dependencies, 'mongoose');
+  assert.match(
+    packJson.dependencies.mongoose,
+    /^\^5\.11\.15/,
+    'Wrong version of "mongoose". It should be ^5.11.15'
   );
 ```
 
 "mongoose" should be connected to a database
 
 ```js
-  $.get(code + '/_api/is-mongoose-ok').then(
-    (data) => {
-      assert.isTrue(data.isMongooseOk, 'mongoose is not connected');
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+  const response = await fetch(code + '/_api/is-mongoose-ok');
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  assert.isTrue(data.isMongooseOk, 'mongoose is not connected');
 ```
 

--- a/curriculum/challenges/english/blocks/mongodb-and-mongoose/587d7fb6367417b2b2512c07.md
+++ b/curriculum/challenges/english/blocks/mongodb-and-mongoose/587d7fb6367417b2b2512c07.md
@@ -46,9 +46,9 @@ Creating an instance from a mongoose schema should succeed
   const response = await fetch(code + '/_api/mongoose-model', {
     method: 'POST',
     headers: {
-      'Content-Type': 'application/x-www-form-urlencoded'
+      'Content-Type': 'application/json'
     },
-    body: new URLSearchParams({
+    body: JSON.stringify({
       name: 'Mike',
       age: 28,
       favoriteFoods: ['pizza', 'cheese']

--- a/curriculum/challenges/english/blocks/mongodb-and-mongoose/587d7fb6367417b2b2512c07.md
+++ b/curriculum/challenges/english/blocks/mongodb-and-mongoose/587d7fb6367417b2b2512c07.md
@@ -43,32 +43,36 @@ Now, create a model from the `personSchema` and assign it to the existing variab
 Creating an instance from a mongoose schema should succeed
 
 ```js
-  $.post(code + '/_api/mongoose-model', {
-    name: 'Mike',
-    age: 28,
-    favoriteFoods: ['pizza', 'cheese']
-  }).then(
-    (data) => {
-      assert.equal(data.name, 'Mike', '"model.name" is not what expected');
-      assert.equal(data.age, '28', '"model.age" is not what expected');
-      assert.isArray(
-        data.favoriteFoods,
-        '"model.favoriteFoods" is not an Array'
-      );
-      assert.include(
-        data.favoriteFoods,
-        'pizza',
-        '"model.favoriteFoods" does not include the expected items'
-      );
-      assert.include(
-        data.favoriteFoods,
-        'cheese',
-        '"model.favoriteFoods" does not include the expected items'
-      );
+  const response = await fetch(code + '/_api/mongoose-model', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded'
     },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
+    body: new URLSearchParams({
+      name: 'Mike',
+      age: 28,
+      favoriteFoods: ['pizza', 'cheese']
+    })
+  });
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  assert.equal(data.name, 'Mike', '"model.name" is not what expected');
+  assert.equal(data.age, '28', '"model.age" is not what expected');
+  assert.isArray(
+    data.favoriteFoods,
+    '"model.favoriteFoods" is not an Array'
+  );
+  assert.include(
+    data.favoriteFoods,
+    'pizza',
+    '"model.favoriteFoods" does not include the expected items'
+  );
+  assert.include(
+    data.favoriteFoods,
+    'cheese',
+    '"model.favoriteFoods" does not include the expected items'
   );
 ```
 

--- a/curriculum/challenges/english/blocks/mongodb-and-mongoose/587d7fb6367417b2b2512c09.md
+++ b/curriculum/challenges/english/blocks/mongodb-and-mongoose/587d7fb6367417b2b2512c09.md
@@ -28,19 +28,17 @@ person.save(function(err, data) {
 Creating and saving a db item should succeed
 
 ```js
-  $.get(code + '/_api/create-and-save-person').then(
-    (data) => {
-      assert.isString(data.name, '"item.name" should be a String');
-      assert.isNumber(data.age, '28', '"item.age" should be a Number');
-      assert.isArray(
-        data.favoriteFoods,
-        '"item.favoriteFoods" should be an Array'
-      );
-      assert.equal(data.__v, 0, 'The db item should be not previously edited');
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
+  const response = await fetch(code + '/_api/create-and-save-person');
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  assert.isString(data.name, '"item.name" should be a String');
+  assert.isNumber(data.age, '28', '"item.age" should be a Number');
+  assert.isArray(
+    data.favoriteFoods,
+    '"item.favoriteFoods" should be an Array'
   );
+  assert.equal(data.__v, 0, 'The db item should be not previously edited');
 ```
 

--- a/curriculum/challenges/english/blocks/mongodb-and-mongoose/587d7fb7367417b2b2512c0a.md
+++ b/curriculum/challenges/english/blocks/mongodb-and-mongoose/587d7fb7367417b2b2512c0a.md
@@ -21,38 +21,37 @@ Modify the `createManyPeople` function to create many people using `Model.create
 Creating many db items at once should succeed
 
 ```js
-  $.ajax({
-    url: code + '/_api/create-many-people',
-    type: 'POST',
-    contentType: 'application/json',
-    data: JSON.stringify([
+  const response = await fetch(code + '/_api/create-many-people', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify([
       { name: 'John', age: 24, favoriteFoods: ['pizza', 'salad'] },
       { name: 'Mary', age: 21, favoriteFoods: ['onions', 'chicken'] }
     ])
-  }).then(
-    (data) => {
-      assert.isArray(data, 'the response should be an array');
-      assert.equal(
-        data.length,
-        2,
-        'the response does not contain the expected number of items'
-      );
-      assert.equal(data[0].name, 'John', 'The first item is not correct');
-      assert.equal(
-        data[0].__v,
-        0,
-        'The first item should be not previously edited'
-      );
-      assert.equal(data[1].name, 'Mary', 'The second item is not correct');
-      assert.equal(
-        data[1].__v,
-        0,
-        'The second item should be not previously edited'
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
+  });
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  assert.isArray(data, 'the response should be an array');
+  assert.equal(
+    data.length,
+    2,
+    'the response does not contain the expected number of items'
+  );
+  assert.equal(data[0].name, 'John', 'The first item is not correct');
+  assert.equal(
+    data[0].__v,
+    0,
+    'The first item should be not previously edited'
+  );
+  assert.equal(data[1].name, 'Mary', 'The second item is not correct');
+  assert.equal(
+    data[1].__v,
+    0,
+    'The second item should be not previously edited'
   );
 ```
 

--- a/curriculum/challenges/english/blocks/mongodb-and-mongoose/587d7fb7367417b2b2512c0b.md
+++ b/curriculum/challenges/english/blocks/mongodb-and-mongoose/587d7fb7367417b2b2512c0b.md
@@ -24,9 +24,9 @@ Find all items corresponding to a criteria should succeed
   const response = await fetch(code + '/_api/find-all-by-name', {
     method: 'POST',
     headers: {
-      'Content-Type': 'application/x-www-form-urlencoded'
+      'Content-Type': 'application/json'
     },
-    body: new URLSearchParams({
+    body: JSON.stringify({
       name: 'r@nd0mN4m3',
       age: 24,
       favoriteFoods: ['pizza']

--- a/curriculum/challenges/english/blocks/mongodb-and-mongoose/587d7fb7367417b2b2512c0b.md
+++ b/curriculum/challenges/english/blocks/mongodb-and-mongoose/587d7fb7367417b2b2512c0b.md
@@ -21,23 +21,27 @@ Use the function argument `personName` as the search key.
 Find all items corresponding to a criteria should succeed
 
 ```js
-  $.post(code + '/_api/find-all-by-name', {
-    name: 'r@nd0mN4m3',
-    age: 24,
-    favoriteFoods: ['pizza']
-  }).then(
-    (data) => {
-      assert.isArray(data, 'the response should be an Array');
-      assert.equal(
-        data[0].name,
-        'r@nd0mN4m3',
-        'item.name is not what expected'
-      );
-      assert.equal(data[0].__v, 0, 'The item should be not previously edited');
+  const response = await fetch(code + '/_api/find-all-by-name', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded'
     },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
+    body: new URLSearchParams({
+      name: 'r@nd0mN4m3',
+      age: 24,
+      favoriteFoods: ['pizza']
+    })
+  });
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  assert.isArray(data, 'the response should be an Array');
+  assert.equal(
+    data[0].name,
+    'r@nd0mN4m3',
+    'item.name is not what expected'
   );
+  assert.equal(data[0].__v, 0, 'The item should be not previously edited');
 ```
 

--- a/curriculum/challenges/english/blocks/mongodb-and-mongoose/587d7fb7367417b2b2512c0c.md
+++ b/curriculum/challenges/english/blocks/mongodb-and-mongoose/587d7fb7367417b2b2512c0c.md
@@ -22,9 +22,9 @@ Find one item should succeed
   const response = await fetch(code + '/_api/find-one-by-food', {
     method: 'POST',
     headers: {
-      'Content-Type': 'application/x-www-form-urlencoded'
+      'Content-Type': 'application/json'
     },
-    body: new URLSearchParams({
+    body: JSON.stringify({
       name: 'Gary',
       age: 46,
       favoriteFoods: ['chicken salad']

--- a/curriculum/challenges/english/blocks/mongodb-and-mongoose/587d7fb7367417b2b2512c0c.md
+++ b/curriculum/challenges/english/blocks/mongodb-and-mongoose/587d7fb7367417b2b2512c0c.md
@@ -19,23 +19,27 @@ Modify the `findOneByFood` function to find just one person which has a certain 
 Find one item should succeed
 
 ```js
-  $.post(code + '/_api/find-one-by-food', {
-    name: 'Gary',
-    age: 46,
-    favoriteFoods: ['chicken salad']
-  }).then(
-    (data) => {
-      assert.equal(data.name, 'Gary', 'item.name is not what expected');
-      assert.deepEqual(
-        data.favoriteFoods,
-        ['chicken salad'],
-        'item.favoriteFoods is not what expected'
-      );
-      assert.equal(data.__v, 0, 'The item should be not previously edited');
+  const response = await fetch(code + '/_api/find-one-by-food', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded'
     },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
+    body: new URLSearchParams({
+      name: 'Gary',
+      age: 46,
+      favoriteFoods: ['chicken salad']
+    })
+  });
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  assert.equal(data.name, 'Gary', 'item.name is not what expected');
+  assert.deepEqual(
+    data.favoriteFoods,
+    ['chicken salad'],
+    'item.favoriteFoods is not what expected'
   );
+  assert.equal(data.__v, 0, 'The item should be not previously edited');
 ```
 

--- a/curriculum/challenges/english/blocks/mongodb-and-mongoose/587d7fb7367417b2b2512c0d.md
+++ b/curriculum/challenges/english/blocks/mongodb-and-mongoose/587d7fb7367417b2b2512c0d.md
@@ -19,20 +19,18 @@ Modify the `findPersonById` to find the only person having a given `_id`, using 
 Find an item by Id should succeed
 
 ```js
-  $.get(code + '/_api/find-by-id').then(
-    (data) => {
-      assert.equal(data.name, 'test', 'item.name is not what expected');
-      assert.equal(data.age, 0, 'item.age is not what expected');
-      assert.deepEqual(
-        data.favoriteFoods,
-        ['none'],
-        'item.favoriteFoods is not what expected'
-      );
-      assert.equal(data.__v, 0, 'The item should be not previously edited');
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
+  const response = await fetch(code + '/_api/find-by-id');
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  assert.equal(data.name, 'test', 'item.name is not what expected');
+  assert.equal(data.age, 0, 'item.age is not what expected');
+  assert.deepEqual(
+    data.favoriteFoods,
+    ['none'],
+    'item.favoriteFoods is not what expected'
   );
+  assert.equal(data.__v, 0, 'The item should be not previously edited');
 ```
 

--- a/curriculum/challenges/english/blocks/mongodb-and-mongoose/587d7fb8367417b2b2512c0e.md
+++ b/curriculum/challenges/english/blocks/mongodb-and-mongoose/587d7fb8367417b2b2512c0e.md
@@ -21,24 +21,28 @@ Modify the `findEditThenSave` function to find a person by `_id` (use any of the
 Find-edit-update an item should succeed
 
 ```js
-  $.post(code + '/_api/find-edit-save', {
-    name: 'Poldo',
-    age: 40,
-    favoriteFoods: ['spaghetti']
-  }).then(
-    (data) => {
-      assert.equal(data.name, 'Poldo', 'item.name is not what is expected');
-      assert.equal(data.age, 40, 'item.age is not what expected');
-      assert.deepEqual(
-        data.favoriteFoods,
-        ['spaghetti', 'hamburger'],
-        'item.favoriteFoods is not what expected'
-      );
-      assert.equal(data.__v, 1, 'The item should be previously edited');
+  const response = await fetch(code + '/_api/find-edit-save', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded'
     },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
+    body: new URLSearchParams({
+      name: 'Poldo',
+      age: 40,
+      favoriteFoods: ['spaghetti']
+    })
+  });
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  assert.equal(data.name, 'Poldo', 'item.name is not what is expected');
+  assert.equal(data.age, 40, 'item.age is not what expected');
+  assert.deepEqual(
+    data.favoriteFoods,
+    ['spaghetti', 'hamburger'],
+    'item.favoriteFoods is not what expected'
   );
+  assert.equal(data.__v, 1, 'The item should be previously edited');
 ```
 

--- a/curriculum/challenges/english/blocks/mongodb-and-mongoose/587d7fb8367417b2b2512c0e.md
+++ b/curriculum/challenges/english/blocks/mongodb-and-mongoose/587d7fb8367417b2b2512c0e.md
@@ -24,9 +24,9 @@ Find-edit-update an item should succeed
   const response = await fetch(code + '/_api/find-edit-save', {
     method: 'POST',
     headers: {
-      'Content-Type': 'application/x-www-form-urlencoded'
+      'Content-Type': 'application/json'
     },
-    body: new URLSearchParams({
+    body: JSON.stringify({
       name: 'Poldo',
       age: 40,
       favoriteFoods: ['spaghetti']

--- a/curriculum/challenges/english/blocks/mongodb-and-mongoose/587d7fb8367417b2b2512c0f.md
+++ b/curriculum/challenges/english/blocks/mongodb-and-mongoose/587d7fb8367417b2b2512c0f.md
@@ -24,9 +24,9 @@ findOneAndUpdate an item should succeed
   const response = await fetch(code + '/_api/find-one-update', {
     method: 'POST',
     headers: {
-      'Content-Type': 'application/x-www-form-urlencoded'
+      'Content-Type': 'application/json'
     },
-    body: new URLSearchParams({
+    body: JSON.stringify({
       name: 'Dorian Gray',
       age: 35,
       favoriteFoods: ['unknown']

--- a/curriculum/challenges/english/blocks/mongodb-and-mongoose/587d7fb8367417b2b2512c0f.md
+++ b/curriculum/challenges/english/blocks/mongodb-and-mongoose/587d7fb8367417b2b2512c0f.md
@@ -21,28 +21,32 @@ Modify the `findAndUpdate` function to find a person by `Name` and set the perso
 findOneAndUpdate an item should succeed
 
 ```js
-  $.post(code + '/_api/find-one-update', {
-    name: 'Dorian Gray',
-    age: 35,
-    favoriteFoods: ['unknown']
-  }).then(
-    (data) => {
-      assert.equal(data.name, 'Dorian Gray', 'item.name is not what expected');
-      assert.equal(data.age, 20, 'item.age is not what expected');
-      assert.deepEqual(
-        data.favoriteFoods,
-        ['unknown'],
-        'item.favoriteFoods is not what expected'
-      );
-      assert.equal(
-        data.__v,
-        0,
-        'findOneAndUpdate does not increment version by design!'
-      );
+  const response = await fetch(code + '/_api/find-one-update', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded'
     },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
+    body: new URLSearchParams({
+      name: 'Dorian Gray',
+      age: 35,
+      favoriteFoods: ['unknown']
+    })
+  });
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  assert.equal(data.name, 'Dorian Gray', 'item.name is not what expected');
+  assert.equal(data.age, 20, 'item.age is not what expected');
+  assert.deepEqual(
+    data.favoriteFoods,
+    ['unknown'],
+    'item.favoriteFoods is not what expected'
+  );
+  assert.equal(
+    data.__v,
+    0,
+    'findOneAndUpdate does not increment version by design!'
   );
 ```
 

--- a/curriculum/challenges/english/blocks/mongodb-and-mongoose/587d7fb8367417b2b2512c10.md
+++ b/curriculum/challenges/english/blocks/mongodb-and-mongoose/587d7fb8367417b2b2512c10.md
@@ -22,9 +22,9 @@ Deleting an item should succeed
   const response = await fetch(code + '/_api/remove-one-person', {
     method: 'POST',
     headers: {
-      'Content-Type': 'application/x-www-form-urlencoded'
+      'Content-Type': 'application/json'
     },
-    body: new URLSearchParams({
+    body: JSON.stringify({
       name: 'Jason Bourne',
       age: 36,
       favoriteFoods: ['apples']

--- a/curriculum/challenges/english/blocks/mongodb-and-mongoose/587d7fb8367417b2b2512c10.md
+++ b/curriculum/challenges/english/blocks/mongodb-and-mongoose/587d7fb8367417b2b2512c10.md
@@ -19,25 +19,29 @@ Modify the `removeById` function to delete one person by the person's `_id`. You
 Deleting an item should succeed
 
 ```js
-  $.post(code + '/_api/remove-one-person', {
-    name: 'Jason Bourne',
-    age: 36,
-    favoriteFoods: ['apples']
-  }).then(
-    (data) => {
-      assert.equal(data.name, 'Jason Bourne', 'item.name is not what expected');
-      assert.equal(data.age, 36, 'item.age is not what expected');
-      assert.deepEqual(
-        data.favoriteFoods,
-        ['apples'],
-        'item.favoriteFoods is not what expected'
-      );
-      assert.equal(data.__v, 0);
-      assert.equal(data.count, 0, 'the db items count is not what expected');
+  const response = await fetch(code + '/_api/remove-one-person', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded'
     },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
+    body: new URLSearchParams({
+      name: 'Jason Bourne',
+      age: 36,
+      favoriteFoods: ['apples']
+    })
+  });
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  assert.equal(data.name, 'Jason Bourne', 'item.name is not what expected');
+  assert.equal(data.age, 36, 'item.age is not what expected');
+  assert.deepEqual(
+    data.favoriteFoods,
+    ['apples'],
+    'item.favoriteFoods is not what expected'
   );
+  assert.equal(data.__v, 0);
+  assert.equal(data.count, 0, 'the db items count is not what expected');
 ```
 

--- a/curriculum/challenges/english/blocks/mongodb-and-mongoose/587d7fb8367417b2b2512c11.md
+++ b/curriculum/challenges/english/blocks/mongodb-and-mongoose/587d7fb8367417b2b2512c11.md
@@ -21,27 +21,26 @@ Modify the `removeManyPeople` function to delete all the people whose name is wi
 Deleting many items at once should succeed
 
 ```js
-  $.ajax({
-    url: code + '/_api/remove-many-people',
-    type: 'POST',
-    contentType: 'application/json',
-    data: JSON.stringify([
+  const response = await fetch(code + '/_api/remove-many-people', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify([
       { name: 'Mary', age: 16, favoriteFoods: ['lollipop'] },
       { name: 'Mary', age: 21, favoriteFoods: ['steak'] }
     ])
-  }).then(
-    (data) => {
-      assert.isTrue(!!data.ok, 'The mongo stats are not what expected');
-      assert.equal(
-        data.n,
-        2,
-        'The number of items affected is not what expected'
-      );
-      assert.equal(data.count, 0, 'the db items count is not what expected');
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
+  });
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  assert.isTrue(!!data.ok, 'The mongo stats are not what expected');
+  assert.equal(
+    data.n,
+    2,
+    'The number of items affected is not what expected'
   );
+  assert.equal(data.count, 0, 'the db items count is not what expected');
 ```
 

--- a/curriculum/challenges/english/blocks/mongodb-and-mongoose/587d7fb9367417b2b2512c12.md
+++ b/curriculum/challenges/english/blocks/mongodb-and-mongoose/587d7fb9367417b2b2512c12.md
@@ -19,48 +19,47 @@ Modify the `queryChain` function to find people who like the food specified by t
 Chaining query helpers should succeed
 
 ```js
-  $.ajax({
-    url: code + '/_api/query-tools',
-    type: 'POST',
-    contentType: 'application/json',
-    data: JSON.stringify([
+  const response = await fetch(code + '/_api/query-tools', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify([
       { name: 'Pablo', age: 26, favoriteFoods: ['burrito', 'hot-dog'] },
       { name: 'Bob', age: 23, favoriteFoods: ['pizza', 'nachos'] },
       { name: 'Ashley', age: 32, favoriteFoods: ['steak', 'burrito'] },
       { name: 'Mario', age: 51, favoriteFoods: ['burrito', 'prosciutto'] }
     ])
-  }).then(
-    (data) => {
-      assert.isArray(data, 'the response should be an Array');
-      assert.equal(
-        data.length,
-        2,
-        'the data array length is not what expected'
-      );
-      assert.notProperty(
-        data[0],
-        'age',
-        'The returned first item has too many properties'
-      );
-      assert.equal(
-        data[0].name,
-        'Ashley',
-        'The returned first item name is not what expected'
-      );
-      assert.notProperty(
-        data[1],
-        'age',
-        'The returned second item has too many properties'
-      );
-      assert.equal(
-        data[1].name,
-        'Mario',
-        'The returned second item name is not what expected'
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
+  });
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  assert.isArray(data, 'the response should be an Array');
+  assert.equal(
+    data.length,
+    2,
+    'the data array length is not what expected'
+  );
+  assert.notProperty(
+    data[0],
+    'age',
+    'The returned first item has too many properties'
+  );
+  assert.equal(
+    data[0].name,
+    'Ashley',
+    'The returned first item name is not what expected'
+  );
+  assert.notProperty(
+    data[1],
+    'age',
+    'The returned second item has too many properties'
+  );
+  assert.equal(
+    data[1].name,
+    'Mario',
+    'The returned second item name is not what expected'
   );
 ```
 

--- a/curriculum/challenges/english/blocks/quality-assurance-and-testing-with-chai/587d824a367417b2b2512c46.md
+++ b/curriculum/challenges/english/blocks/quality-assurance-and-testing-with-chai/587d824a367417b2b2512c46.md
@@ -22,39 +22,33 @@ Within `tests/1_unit-tests.js` under the test labeled `#1` in the `Basic Asserti
 All tests should pass.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=0').then(
-    (data) => {
-      assert.equal(data.state, 'passed');
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+  const response = await fetch(code + '/_api/get-tests?type=unit&n=0');
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  assert.equal(data.state, 'passed');
 ```
 
 You should choose the correct method for the first assertion - `isNull` vs. `isNotNull`.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=0').then(
-    (data) => {
-      assert.equal(data.assertions[0].method, 'isNull', 'Null is null');
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+  const response = await fetch(code + '/_api/get-tests?type=unit&n=0');
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  assert.equal(data.assertions[0].method, 'isNull', 'Null is null');
 ```
 
 You should choose the correct method for the second assertion - `isNull` vs. `isNotNull`.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=0').then(
-    (data) => {
-      assert.equal(data.assertions[1].method, 'isNotNull', '1 is not null');
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+  const response = await fetch(code + '/_api/get-tests?type=unit&n=0');
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  assert.equal(data.assertions[1].method, 'isNotNull', '1 is not null');
 ```
 

--- a/curriculum/challenges/english/blocks/quality-assurance-and-testing-with-chai/587d824b367417b2b2512c47.md
+++ b/curriculum/challenges/english/blocks/quality-assurance-and-testing-with-chai/587d824b367417b2b2512c47.md
@@ -19,64 +19,56 @@ Within `tests/1_unit-tests.js` under the test labeled `#2` in the `Basic Asserti
 All tests should pass.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=1').then(
-    (data) => {
-      assert.equal(data.state, 'passed');
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+  const response = await fetch(code + '/_api/get-tests?type=unit&n=1');
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  assert.equal(data.state, 'passed');
 ```
 
 You should choose the correct method for the first assertion - `isDefined` vs. `isUndefined`.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=1').then(
-    (data) => {
-      assert.equal(
-        data.assertions[0].method,
-        'isDefined',
-        'Null is not undefined'
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
+  const response = await fetch(code + '/_api/get-tests?type=unit&n=1');
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  assert.equal(
+    data.assertions[0].method,
+    'isDefined',
+    'Null is not undefined'
   );
 ```
 
 You should choose the correct method for the second assertion - `isDefined` vs. `isUndefined`.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=1').then(
-    (data) => {
-      assert.equal(
-        data.assertions[1].method,
-        'isUndefined',
-        'Undefined is undefined'
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
+  const response = await fetch(code + '/_api/get-tests?type=unit&n=1');
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  assert.equal(
+    data.assertions[1].method,
+    'isUndefined',
+    'Undefined is undefined'
   );
 ```
 
 You should choose the correct method for the third assertion - `isDefined` vs. `isUndefined`.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=1').then(
-    (data) => {
-      assert.equal(
-        data.assertions[2].method,
-        'isDefined',
-        'A string is not undefined'
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
+  const response = await fetch(code + '/_api/get-tests?type=unit&n=1');
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  assert.equal(
+    data.assertions[2].method,
+    'isDefined',
+    'A string is not undefined'
   );
 ```
 

--- a/curriculum/challenges/english/blocks/quality-assurance-and-testing-with-chai/587d824b367417b2b2512c48.md
+++ b/curriculum/challenges/english/blocks/quality-assurance-and-testing-with-chai/587d824b367417b2b2512c48.md
@@ -23,52 +23,44 @@ Within `tests/1_unit-tests.js` under the test labeled `#3` in the `Basic Asserti
 All tests should pass.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=2').then(
-    (data) => {
-      assert.equal(data.state, 'passed');
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+  const response = await fetch(code + '/_api/get-tests?type=unit&n=2');
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  assert.equal(data.state, 'passed');
 ```
 
 You should choose the correct method for the first assertion - `isOk` vs. `isNotOk`.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=2').then(
-    (data) => {
-      assert.equal(data.assertions[0].method, 'isNotOk', 'Null is falsy');
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+  const response = await fetch(code + '/_api/get-tests?type=unit&n=2');
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  assert.equal(data.assertions[0].method, 'isNotOk', 'Null is falsy');
 ```
 
 You should choose the correct method for the second assertion - `isOk` vs. `isNotOk`.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=2').then(
-    (data) => {
-      assert.equal(data.assertions[1].method, 'isOk', 'A string is truthy');
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+  const response = await fetch(code + '/_api/get-tests?type=unit&n=2');
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  assert.equal(data.assertions[1].method, 'isOk', 'A string is truthy');
 ```
 
 You should choose the correct method for the third assertion - `isOk` vs. `isNotOk`.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=2').then(
-    (data) => {
-      assert.equal(data.assertions[2].method, 'isOk', 'true is truthy');
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+  const response = await fetch(code + '/_api/get-tests?type=unit&n=2');
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  assert.equal(data.assertions[2].method, 'isOk', 'true is truthy');
 ```
 

--- a/curriculum/challenges/english/blocks/quality-assurance-and-testing-with-chai/587d824b367417b2b2512c49.md
+++ b/curriculum/challenges/english/blocks/quality-assurance-and-testing-with-chai/587d824b367417b2b2512c49.md
@@ -29,60 +29,52 @@ Within `tests/1_unit-tests.js` under the test labeled `#4` in the `Basic Asserti
 All tests should pass.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=3').then(
-    (data) => {
-      assert.equal(data.state, 'passed');
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+  const response = await fetch(code + '/_api/get-tests?type=unit&n=3');
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  assert.equal(data.state, 'passed');
 ```
 
 You should choose the correct method for the first assertion - `isTrue` vs. `isNotTrue`.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=3').then(
-    (data) => {
-      assert.equal(data.assertions[0].method, 'isTrue', 'True is true');
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+  const response = await fetch(code + '/_api/get-tests?type=unit&n=3');
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  assert.equal(data.assertions[0].method, 'isTrue', 'True is true');
 ```
 
 You should choose the correct method for the second assertion - `isTrue` vs. `isNotTrue`.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=3').then(
-    (data) => {
-      assert.equal(
-        data.assertions[1].method,
-        'isTrue',
-        'Double negation of a truthy value is true'
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
+  const response = await fetch(code + '/_api/get-tests?type=unit&n=3');
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  assert.equal(
+    data.assertions[1].method,
+    'isTrue',
+    'Double negation of a truthy value is true'
   );
 ```
 
 You should choose the correct method for the third assertion - `isTrue` vs. `isNotTrue`.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=3').then(
-    (data) => {
-      assert.equal(
-        data.assertions[2].method,
-        'isNotTrue',
-        'A truthy object is not true - neither is a false one'
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
+  const response = await fetch(code + '/_api/get-tests?type=unit&n=3');
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  assert.equal(
+    data.assertions[2].method,
+    'isNotTrue',
+    'A truthy object is not true - neither is a false one'
   );
 ```
 

--- a/curriculum/challenges/english/blocks/quality-assurance-and-testing-with-chai/587d824b367417b2b2512c4a.md
+++ b/curriculum/challenges/english/blocks/quality-assurance-and-testing-with-chai/587d824b367417b2b2512c4a.md
@@ -21,77 +21,67 @@ Within `tests/1_unit-tests.js` under the test labeled `#5` in the `Equality` sui
 All tests should pass.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=4').then(
-    (data) => {
-      assert.equal(data.state, 'passed');
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+  const response = await fetch(code + '/_api/get-tests?type=unit&n=4');
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  assert.equal(data.state, 'passed');
 ```
 
 You should choose the correct method for the first assertion - `equal` vs. `notEqual`.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=4').then(
-    (data) => {
-      assert.equal(
-        data.assertions[0].method,
-        'equal',
-        'Numbers are coerced into strings with == '
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
+  const response = await fetch(code + '/_api/get-tests?type=unit&n=4');
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  assert.equal(
+    data.assertions[0].method,
+    'equal',
+    'Numbers are coerced into strings with == '
   );
 ```
 
 You should choose the correct method for the second assertion - `equal` vs. `notEqual`.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=4').then(
-    (data) => {
-      assert.equal(
-        data.assertions[1].method,
-        'notEqual',
-        ' == compares object references'
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
+  const response = await fetch(code + '/_api/get-tests?type=unit&n=4');
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  assert.equal(
+    data.assertions[1].method,
+    'notEqual',
+    ' == compares object references'
   );
 ```
 
 You should choose the correct method for the third assertion - `equal` vs. `notEqual`.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=4').then(
-    (data) => {
-      assert.equal(
-        data.assertions[2].method,
-        'equal',
-        "6 * '2' is 12 ! It should be equal to '12'"
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
+  const response = await fetch(code + '/_api/get-tests?type=unit&n=4');
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  assert.equal(
+    data.assertions[2].method,
+    'equal',
+    "6 * '2' is 12 ! It should be equal to '12'"
   );
 ```
 
 You should choose the correct method for the fourth assertion - `equal` vs. `notEqual`.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=4').then(
-    (data) => {
-      assert.equal(data.assertions[3].method, 'notEqual', "6 + '2' is '62'...");
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+  const response = await fetch(code + '/_api/get-tests?type=unit&n=4');
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  assert.equal(data.assertions[3].method, 'notEqual', "6 + '2' is '62'...");
 ```
 

--- a/curriculum/challenges/english/blocks/quality-assurance-and-testing-with-chai/587d824b367417b2b2512c4b.md
+++ b/curriculum/challenges/english/blocks/quality-assurance-and-testing-with-chai/587d824b367417b2b2512c4b.md
@@ -21,77 +21,67 @@ Within `tests/1_unit-tests.js` under the test labeled `#6` in the `Equality` sui
 All tests should pass.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=5').then(
-    (data) => {
-      assert.equal(data.state, 'passed');
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+  const response = await fetch(code + '/_api/get-tests?type=unit&n=5');
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  assert.equal(data.state, 'passed');
 ```
 
 You should choose the correct method for the first assertion - `strictEqual` vs. `notStrictEqual`.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=5').then(
-    (data) => {
-      assert.equal(
-        data.assertions[0].method,
-        'notStrictEqual',
-        'with strictEqual the type must match'
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
+  const response = await fetch(code + '/_api/get-tests?type=unit&n=5');
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  assert.equal(
+    data.assertions[0].method,
+    'notStrictEqual',
+    'with strictEqual the type must match'
   );
 ```
 
 You should choose the correct method for the second assertion - `strictEqual` vs. `notStrictEqual`.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=5').then(
-    (data) => {
-      assert.equal(data.assertions[1].method, 'strictEqual', '3*2 = 6...');
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+  const response = await fetch(code + '/_api/get-tests?type=unit&n=5');
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  assert.equal(data.assertions[1].method, 'strictEqual', '3*2 = 6...');
 ```
 
 You should choose the correct method for the third assertion - `strictEqual` vs. `notStrictEqual`.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=5').then(
-    (data) => {
-      assert.equal(
-        data.assertions[2].method,
-        'strictEqual',
-        "6 * '2' is 12. Types match !"
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
+  const response = await fetch(code + '/_api/get-tests?type=unit&n=5');
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  assert.equal(
+    data.assertions[2].method,
+    'strictEqual',
+    "6 * '2' is 12. Types match !"
   );
 ```
 
 You should choose the correct method for the fourth assertion - `strictEqual` vs. `notStrictEqual`.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=5').then(
-    (data) => {
-      assert.equal(
-        data.assertions[3].method,
-        'notStrictEqual',
-        'Even if they have the same elements, the Arrays are notStrictEqual'
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
+  const response = await fetch(code + '/_api/get-tests?type=unit&n=5');
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  assert.equal(
+    data.assertions[3].method,
+    'notStrictEqual',
+    'Even if they have the same elements, the Arrays are notStrictEqual'
   );
 ```
 

--- a/curriculum/challenges/english/blocks/quality-assurance-and-testing-with-chai/587d824c367417b2b2512c4c.md
+++ b/curriculum/challenges/english/blocks/quality-assurance-and-testing-with-chai/587d824c367417b2b2512c4c.md
@@ -21,47 +21,47 @@ Within `tests/1_unit-tests.js` under the test labeled `#7` in the `Equality` sui
 All tests should pass.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=6').then(
-    (data) => {
-      assert.equal(data.state, 'passed');
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+(async () => {
+  const response = await fetch(code + '/_api/get-tests?type=unit&n=6');
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  assert.equal(data.state, 'passed');
+})();
 ```
 
 You should choose the correct method for the first assertion - `deepEqual` vs. `notDeepEqual`.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=6').then(
-    (data) => {
-      assert.equal(
-        data.assertions[0].method,
-        'deepEqual',
-        'The order of the keys does not matter'
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
+(async () => {
+  const response = await fetch(code + '/_api/get-tests?type=unit&n=6');
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  assert.equal(
+    data.assertions[0].method,
+    'deepEqual',
+    'The order of the keys does not matter'
   );
+})();
 ```
 
 You should choose the correct method for the second assertion - `deepEqual` vs. `notDeepEqual`.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=6').then(
-    (data) => {
-      assert.equal(
-        data.assertions[1].method,
-        'notDeepEqual',
-        'The position of elements within an array does matter'
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
+(async () => {
+  const response = await fetch(code + '/_api/get-tests?type=unit&n=6');
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const data = await response.json();
+  assert.equal(
+    data.assertions[1].method,
+    'notDeepEqual',
+    'The position of elements within an array does matter'
   );
+})();
 ```
 

--- a/curriculum/challenges/english/blocks/quality-assurance-and-testing-with-chai/587d824c367417b2b2512c4d.md
+++ b/curriculum/challenges/english/blocks/quality-assurance-and-testing-with-chai/587d824c367417b2b2512c4d.md
@@ -19,77 +19,67 @@ Within `tests/1_unit-tests.js` under the test labeled `#8` in the `Comparisons` 
 All tests should pass.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=7').then(
-    (data) => {
-      assert.equal(data.state, 'passed');
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=unit&n=7');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(data.state, 'passed');
 ```
 
 You should choose the correct method for the first assertion - `isAbove` vs. `isAtMost`.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=7').then(
-    (data) => {
-      assert.equal(
-        data.assertions[0].method,
-        'isAtMost',
-        '5 is at most (<=) 5'
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=unit&n=7');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(
+  data.assertions[0].method,
+  'isAtMost',
+  '5 is at most (<=) 5'
+);
 ```
 
 You should choose the correct method for the second assertion - `isAbove` vs. `isAtMost`.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=7').then(
-    (data) => {
-      assert.equal(data.assertions[1].method, 'isAbove', '1 is greater than 0');
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=unit&n=7');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(data.assertions[1].method, 'isAbove', '1 is greater than 0');
 ```
 
 You should choose the correct method for the third assertion - `isAbove` vs. `isAtMost`.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=7').then(
-    (data) => {
-      assert.equal(
-        data.assertions[2].method,
-        'isAbove',
-        'Math.PI = 3.14159265 is greater than 3'
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=unit&n=7');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(
+  data.assertions[2].method,
+  'isAbove',
+  'Math.PI = 3.14159265 is greater than 3'
+);
 ```
 
 You should choose the correct method for the fourth assertion - `isAbove` vs. `isAtMost`.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=7').then(
-    (data) => {
-      assert.equal(
-        data.assertions[3].method,
-        'isAtMost',
-        '1 - Math.random() is > 0 and <= 1. It is atMost 1 !'
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=unit&n=7');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(
+  data.assertions[3].method,
+  'isAtMost',
+  '1 - Math.random() is > 0 and <= 1. It is atMost 1 !'
+);
 ```
 

--- a/curriculum/challenges/english/blocks/quality-assurance-and-testing-with-chai/587d824c367417b2b2512c4e.md
+++ b/curriculum/challenges/english/blocks/quality-assurance-and-testing-with-chai/587d824c367417b2b2512c4e.md
@@ -19,77 +19,67 @@ Within `tests/1_unit-tests.js` under the test labelled `#9` in the `Comparisons`
 All tests should pass.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=8').then(
-    (data) => {
-      assert.equal(data.state, 'passed');
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=unit&n=8');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(data.state, 'passed');
 ```
 
 You should choose the correct method for the first assertion - `isBelow` vs. `isAtLeast`.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=8').then(
-    (data) => {
-      assert.equal(
-        data.assertions[0].method,
-        'isAtLeast',
-        '5 is at least (>=) 5'
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=unit&n=8');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(
+  data.assertions[0].method,
+  'isAtLeast',
+  '5 is at least (>=) 5'
+);
 ```
 
 You should choose the correct method for the second assertion - `isBelow` vs. `isAtLeast`.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=8').then(
-    (data) => {
-      assert.equal(
-        data.assertions[1].method,
-        'isAtLeast',
-        '2 * Math.random() is at least 0'
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=unit&n=8');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(
+  data.assertions[1].method,
+  'isAtLeast',
+  '2 * Math.random() is at least 0'
+);
 ```
 
 You should choose the correct method for the third assertion - `isBelow` vs. `isAtLeast`.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=8').then(
-    (data) => {
-      assert.equal(data.assertions[2].method, 'isBelow', '1 is smaller than 2');
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=unit&n=8');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(data.assertions[2].method, 'isBelow', '1 is smaller than 2');
 ```
 
 You should choose the correct method for the fourth assertion - `isBelow` vs. `isAtLeast`.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=8').then(
-    (data) => {
-      assert.equal(
-        data.assertions[3].method,
-        'isBelow',
-        '2/3 (0.6666) is smaller than 1'
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=unit&n=8');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(
+  data.assertions[3].method,
+  'isBelow',
+  '2/3 (0.6666) is smaller than 1'
+);
 ```
 

--- a/curriculum/challenges/english/blocks/quality-assurance-and-testing-with-chai/587d824c367417b2b2512c4f.md
+++ b/curriculum/challenges/english/blocks/quality-assurance-and-testing-with-chai/587d824c367417b2b2512c4f.md
@@ -27,49 +27,43 @@ Choose the minimum range (3rd parameter) to make the test always pass. It should
 All tests should pass.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=9').then(
-    (data) => {
-      assert.equal(data.state, 'passed');
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=unit&n=9');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(data.state, 'passed');
 ```
 
 You should choose the correct range for the first assertion - `approximately(actual, expected, range)`.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=9').then(
-    (data) => {
-      assert.equal(data.assertions[0].method, 'approximately');
-      assert.equal(
-        data.assertions[0].args[2],
-        0.5,
-        "weirdNumbers(0.5) is in the range (0.5, 1.5]. It's within 1 +/- 0.5"
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=unit&n=9');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(data.assertions[0].method, 'approximately');
+assert.equal(
+  data.assertions[0].args[2],
+  0.5,
+  "weirdNumbers(0.5) is in the range (0.5, 1.5]. It's within 1 +/- 0.5"
+);
 ```
 
 You should choose the correct range for the second assertion - `approximately(actual, expected, range)`.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=9').then(
-    (data) => {
-      assert.equal(data.assertions[1].method, 'approximately');
-      assert.equal(
-        data.assertions[1].args[2],
-        0.8,
-        "weirdNumbers(0.2) is in the range (0.2, 1.2]. It's within 1 +/- 0.8"
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=unit&n=9');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(data.assertions[1].method, 'approximately');
+assert.equal(
+  data.assertions[1].args[2],
+  0.8,
+  "weirdNumbers(0.2) is in the range (0.2, 1.2]. It's within 1 +/- 0.8"
+);
 ```
 

--- a/curriculum/challenges/english/blocks/quality-assurance-and-testing-with-chai/587d824d367417b2b2512c50.md
+++ b/curriculum/challenges/english/blocks/quality-assurance-and-testing-with-chai/587d824d367417b2b2512c50.md
@@ -19,47 +19,41 @@ Within `tests/1_unit-tests.js` under the test labeled `#11` in the `Arrays` suit
 All tests should pass.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=10').then(
-    (data) => {
-      assert.equal(data.state, 'passed');
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=unit&n=10');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(data.state, 'passed');
 ```
 
 You should choose the correct method for the first assertion - `isArray` vs. `isNotArray`.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=10').then(
-    (data) => {
-      assert.equal(
-        data.assertions[0].method,
-        'isArray',
-        'String.prototype.split() returns an Array'
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=unit&n=10');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(
+  data.assertions[0].method,
+  'isArray',
+  'String.prototype.split() returns an Array'
+);
 ```
 
 You should choose the correct method for the second assertion - `isArray` vs. `isNotArray`.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=10').then(
-    (data) => {
-      assert.equal(
-        data.assertions[1].method,
-        'isNotArray',
-        'Array.prototype.indexOf() returns a number'
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=unit&n=10');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(
+  data.assertions[1].method,
+  'isNotArray',
+  'Array.prototype.indexOf() returns a number'
+);
 ```
 

--- a/curriculum/challenges/english/blocks/quality-assurance-and-testing-with-chai/587d824d367417b2b2512c51.md
+++ b/curriculum/challenges/english/blocks/quality-assurance-and-testing-with-chai/587d824d367417b2b2512c51.md
@@ -19,47 +19,41 @@ Within `tests/1_unit-tests.js` under the test labeled `#12` in the `Arrays` suit
 All tests should pass.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=11').then(
-    (data) => {
-      assert.equal(data.state, 'passed');
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=unit&n=11');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(data.state, 'passed');
 ```
 
 You should choose the correct method for the first assertion - `include` vs. `notInclude`.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=11').then(
-    (data) => {
-      assert.equal(
-        data.assertions[0].method,
-        'notInclude',
-        "It's summer in july..."
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=unit&n=11');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(
+  data.assertions[0].method,
+  'notInclude',
+  "It's summer in july..."
+);
 ```
 
 You should choose the correct method for the second assertion - `include` vs. `notInclude`.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=11').then(
-    (data) => {
-      assert.equal(
-        data.assertions[1].method,
-        'include',
-        'JavaScript is a backend language !!'
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=unit&n=11');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(
+  data.assertions[1].method,
+  'include',
+  'JavaScript is a backend language !!'
+);
 ```
 

--- a/curriculum/challenges/english/blocks/quality-assurance-and-testing-with-chai/587d824d367417b2b2512c52.md
+++ b/curriculum/challenges/english/blocks/quality-assurance-and-testing-with-chai/587d824d367417b2b2512c52.md
@@ -21,60 +21,52 @@ Within `tests/1_unit-tests.js` under the test labeled `#13` in the `Strings` sui
 All tests should pass.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=12').then(
-    (data) => {
-      assert.equal(data.state, 'passed');
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=unit&n=12');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(data.state, 'passed');
 ```
 
 You should choose the correct method for the first assertion - `isString` vs. `isNotString`.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=12').then(
-    (data) => {
-      assert.equal(
-        data.assertions[0].method,
-        'isNotString',
-        'A float number is not a string'
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=unit&n=12');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(
+  data.assertions[0].method,
+  'isNotString',
+  'A float number is not a string'
+);
 ```
 
 You should choose the correct method for the second assertion - `isString` vs. `isNotString`.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=12').then(
-    (data) => {
-      assert.equal(
-        data.assertions[1].method,
-        'isString',
-        'environment vars are strings (or undefined)'
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=unit&n=12');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(
+  data.assertions[1].method,
+  'isString',
+  'environment vars are strings (or undefined)'
+);
 ```
 
 You should choose the correct method for the third assertion - `isString` vs. `isNotString`.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=12').then(
-    (data) => {
-      assert.equal(data.assertions[2].method, 'isString', 'A JSON is a string');
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=unit&n=12');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(data.assertions[2].method, 'isString', 'A JSON is a string');
 ```
 

--- a/curriculum/challenges/english/blocks/quality-assurance-and-testing-with-chai/587d824d367417b2b2512c53.md
+++ b/curriculum/challenges/english/blocks/quality-assurance-and-testing-with-chai/587d824d367417b2b2512c53.md
@@ -21,47 +21,41 @@ Within `tests/1_unit-tests.js` under the test labeled `#14` in the `Strings` sui
 All tests should pass.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=13').then(
-    (data) => {
-      assert.equal(data.state, 'passed');
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=unit&n=13');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(data.state, 'passed');
 ```
 
 You should choose the correct method for the first assertion - `include` vs. `notInclude`.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=13').then(
-    (data) => {
-      assert.equal(
-        data.assertions[0].method,
-        'include',
-        "'Arrow' contains 'row'..."
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=unit&n=13');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(
+  data.assertions[0].method,
+  'include',
+  "'Arrow' contains 'row'..."
+);
 ```
 
 You should choose the correct method for the second assertion - `include` vs. `notInclude`.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=13').then(
-    (data) => {
-      assert.equal(
-        data.assertions[1].method,
-        'notInclude',
-        "... a 'dart' doesn't contain a 'queue'"
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=unit&n=13');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(
+  data.assertions[1].method,
+  'notInclude',
+  "... a 'dart' doesn't contain a 'queue'"
+);
 ```
 

--- a/curriculum/challenges/english/blocks/quality-assurance-and-testing-with-chai/587d824d367417b2b2512c54.md
+++ b/curriculum/challenges/english/blocks/quality-assurance-and-testing-with-chai/587d824d367417b2b2512c54.md
@@ -21,47 +21,41 @@ Within `tests/1_unit-tests.js` under the test labeled `#15` in the `Strings` sui
 All tests should pass.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=14').then(
-    (data) => {
-      assert.equal(data.state, 'passed');
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=unit&n=14');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(data.state, 'passed');
 ```
 
 You should choose the correct method for the first assertion - `match` vs. `notMatch`.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=14').then(
-    (data) => {
-      assert.equal(
-        data.assertions[0].method,
-        'match',
-        "'# name:John Doe, age:35' matches the regex"
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=unit&n=14');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(
+  data.assertions[0].method,
+  'match',
+  "'# name:John Doe, age:35' matches the regex"
+);
 ```
 
 You should choose the correct method for the second assertion - `match` vs. `notMatch`.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=14').then(
-    (data) => {
-      assert.equal(
-        data.assertions[1].method,
-        'notMatch',
-        "'# name:Paul Smith III, age:twenty-four' does not match the regex (the age must be numeric)"
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=unit&n=14');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(
+  data.assertions[1].method,
+  'notMatch',
+  "'# name:Paul Smith III, age:twenty-four' does not match the regex (the age must be numeric)"
+);
 ```
 

--- a/curriculum/challenges/english/blocks/quality-assurance-and-testing-with-chai/587d824e367417b2b2512c55.md
+++ b/curriculum/challenges/english/blocks/quality-assurance-and-testing-with-chai/587d824e367417b2b2512c55.md
@@ -21,60 +21,52 @@ Within `tests/1_unit-tests.js` under the test labeled `#16` in the `Objects` sui
 All tests should pass.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=15').then(
-    (data) => {
-      assert.equal(data.state, 'passed');
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=unit&n=15');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(data.state, 'passed');
 ```
 
 You should choose the correct method for the first assertion - `property` vs. `notProperty`.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=15').then(
-    (data) => {
-      assert.equal(
-        data.assertions[0].method,
-        'notProperty',
-        'A car has not wings'
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=unit&n=15');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(
+  data.assertions[0].method,
+  'notProperty',
+  'A car has not wings'
+);
 ```
 
 You should choose the correct method for the second assertion - `property` vs. `notProperty`.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=15').then(
-    (data) => {
-      assert.equal(
-        data.assertions[1].method,
-        'property',
-        'planes have engines'
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=unit&n=15');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(
+  data.assertions[1].method,
+  'property',
+  'planes have engines'
+);
 ```
 
 You should choose the correct method for the third assertion - `property` vs. `notProperty`.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=15').then(
-    (data) => {
-      assert.equal(data.assertions[2].method, 'property', 'Cars have wheels');
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=unit&n=15');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(data.assertions[2].method, 'property', 'Cars have wheels');
 ```
 

--- a/curriculum/challenges/english/blocks/quality-assurance-and-testing-with-chai/587d824e367417b2b2512c56.md
+++ b/curriculum/challenges/english/blocks/quality-assurance-and-testing-with-chai/587d824e367417b2b2512c56.md
@@ -21,98 +21,86 @@ Within `tests/1_unit-tests.js` under the test labeled `#17` in the `Objects` sui
 All tests should pass.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=16').then(
-    (data) => {
-      assert.equal(data.state, 'passed');
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=unit&n=16');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(data.state, 'passed');
 ```
 
 You should choose the correct method for the first assertion - `typeOf` vs. `notTypeOf`.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=16').then(
-    (data) => {
-      assert.equal(
-        data.assertions[0].method,
-        'typeOf',
-        'myCar is typeOf Object'
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=unit&n=16');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(
+  data.assertions[0].method,
+  'typeOf',
+  'myCar is typeOf Object'
+);
 ```
 
 You should choose the correct method for the second assertion - `typeOf` vs. `notTypeOf`.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=16').then(
-    (data) => {
-      assert.equal(
-        data.assertions[1].method,
-        'typeOf',
-        'Car.model is a String'
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=unit&n=16');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(
+  data.assertions[1].method,
+  'typeOf',
+  'Car.model is a String'
+);
 ```
 
 You should choose the correct method for the third assertion - `typeOf` vs. `notTypeOf`.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=16').then(
-    (data) => {
-      assert.equal(
-        data.assertions[2].method,
-        'notTypeOf',
-        'Plane.wings is a Number (not a String)'
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=unit&n=16');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(
+  data.assertions[2].method,
+  'notTypeOf',
+  'Plane.wings is a Number (not a String)'
+);
 ```
 
 You should choose the correct method for the fourth assertion - `typeOf` vs. `notTypeOf`.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=16').then(
-    (data) => {
-      assert.equal(
-        data.assertions[3].method,
-        'typeOf',
-        'Plane.engines is an Array'
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=unit&n=16');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(
+  data.assertions[3].method,
+  'typeOf',
+  'Plane.engines is an Array'
+);
 ```
 
 You should choose the correct method for the fifth assertion - `typeOf` vs. `notTypeOf`.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=16').then(
-    (data) => {
-      assert.equal(
-        data.assertions[4].method,
-        'typeOf',
-        'Car.wheels is a Number'
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=unit&n=16');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(
+  data.assertions[4].method,
+  'typeOf',
+  'Car.wheels is a Number'
+);
 ```
 

--- a/curriculum/challenges/english/blocks/quality-assurance-and-testing-with-chai/587d824e367417b2b2512c57.md
+++ b/curriculum/challenges/english/blocks/quality-assurance-and-testing-with-chai/587d824e367417b2b2512c57.md
@@ -21,81 +21,71 @@ Within `tests/1_unit-tests.js` under the test labeled `#18` in the `Objects` sui
 All tests should pass.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=17').then(
-    (data) => {
-      assert.equal(data.state, 'passed');
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=unit&n=17');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(data.state, 'passed');
 ```
 
 You should choose the correct method for the first assertion - `instanceOf` vs. `notInstanceOf`.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=17').then(
-    (data) => {
-      assert.equal(
-        data.assertions[0].method,
-        'notInstanceOf',
-        'myCar is not an instance of Plane'
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=unit&n=17');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(
+  data.assertions[0].method,
+  'notInstanceOf',
+  'myCar is not an instance of Plane'
+);
 ```
 
 You should choose the correct method for the second assertion - `instanceOf` vs. `notInstanceOf`.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=17').then(
-    (data) => {
-      assert.equal(
-        data.assertions[1].method,
-        'instanceOf',
-        'airlinePlane is an instance of Plane'
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=unit&n=17');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(
+  data.assertions[1].method,
+  'instanceOf',
+  'airlinePlane is an instance of Plane'
+);
 ```
 
 You should choose the correct method for the third assertion - `instanceOf` vs. `notInstanceOf`.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=17').then(
-    (data) => {
-      assert.equal(
-        data.assertions[2].method,
-        'instanceOf',
-        'everything is an Object in JavaScript...'
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=unit&n=17');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(
+  data.assertions[2].method,
+  'instanceOf',
+  'everything is an Object in JavaScript...'
+);
 ```
 
 You should choose the correct method for the fourth assertion - `instanceOf` vs. `notInstanceOf`.
 
 ```js
-  $.get(code + '/_api/get-tests?type=unit&n=17').then(
-    (data) => {
-      assert.equal(
-        data.assertions[3].method,
-        'notInstanceOf',
-        'myCar.wheels is not an instance of String'
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=unit&n=17');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(
+  data.assertions[3].method,
+  'notInstanceOf',
+  'myCar.wheels is not an instance of String'
+);
 ```
 

--- a/curriculum/challenges/english/blocks/quality-assurance-and-testing-with-chai/587d824e367417b2b2512c58.md
+++ b/curriculum/challenges/english/blocks/quality-assurance-and-testing-with-chai/587d824e367417b2b2512c58.md
@@ -51,43 +51,37 @@ There should be no URL query. Without a name URL query, the endpoint responds wi
 All tests should pass
 
 ```js
-  $.get(code + '/_api/get-tests?type=functional&n=0').then(
-    (data) => {
-      assert.equal(data.state, 'passed');
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=functional&n=0');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(data.state, 'passed');
 ```
 
 You should test for `res.status` == 200
 
 ```js
-  $.get(code + '/_api/get-tests?type=functional&n=0').then(
-    (data) => {
-      assert.equal(data.assertions[0].method, 'equal');
-      assert.equal(data.assertions[0].args[0], 'res.status');
-      assert.equal(data.assertions[0].args[1], '200');
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=functional&n=0');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(data.assertions[0].method, 'equal');
+assert.equal(data.assertions[0].args[0], 'res.status');
+assert.equal(data.assertions[0].args[1], '200');
 ```
 
 You should test for `res.text` == `'hello Guest'`
 
 ```js
-  $.get(code + '/_api/get-tests?type=functional&n=0').then(
-    (data) => {
-      assert.equal(data.assertions[1].method, 'equal');
-      assert.equal(data.assertions[1].args[0], 'res.text');
-      assert.match(data.assertions[1].args[1], /('|")hello Guest\1/);
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=functional&n=0');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(data.assertions[1].method, 'equal');
+assert.equal(data.assertions[1].args[0], 'res.text');
+assert.match(data.assertions[1].args[1], /('|")hello Guest\1/);
 ```
 

--- a/curriculum/challenges/english/blocks/quality-assurance-and-testing-with-chai/587d824f367417b2b2512c59.md
+++ b/curriculum/challenges/english/blocks/quality-assurance-and-testing-with-chai/587d824f367417b2b2512c59.md
@@ -21,43 +21,37 @@ Send your name as a URL query by appending `?name=<your_name>` to the route. The
 All tests should pass
 
 ```js
-  $.get(code + '/_api/get-tests?type=functional&n=1').then(
-    (data) => {
-      assert.equal(data.state, 'passed');
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=functional&n=1');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(data.state, 'passed');
 ```
 
 You should test for `res.status` == 200
 
 ```js
-  $.get(code + '/_api/get-tests?type=functional&n=1').then(
-    (data) => {
-      assert.equal(data.assertions[0].method, 'equal');
-      assert.equal(data.assertions[0].args[0], 'res.status');
-      assert.equal(data.assertions[0].args[1], '200');
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=functional&n=1');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(data.assertions[0].method, 'equal');
+assert.equal(data.assertions[0].args[0], 'res.status');
+assert.equal(data.assertions[0].args[1], '200');
 ```
 
 You should test for `res.text` == `'hello <your_name>'`
 
 ```js
-  $.get(code + '/_api/get-tests?type=functional&n=1').then(
-    (data) => {
-      assert.equal(data.assertions[1].method, 'equal');
-      assert.equal(data.assertions[1].args[0], 'res.text');
-      assert.match(data.assertions[1].args[1], /hello [\w\d_-]/);
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=functional&n=1');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(data.assertions[1].method, 'equal');
+assert.equal(data.assertions[1].args[0], 'res.text');
+assert.match(data.assertions[1].args[1], /hello [\w\d_-]/);
 ```
 

--- a/curriculum/challenges/english/blocks/quality-assurance-and-testing-with-chai/587d824f367417b2b2512c5a.md
+++ b/curriculum/challenges/english/blocks/quality-assurance-and-testing-with-chai/587d824f367417b2b2512c5a.md
@@ -63,73 +63,63 @@ Follow the assertion order above - we rely on it. Also, be sure to remove `asser
 All tests should pass.
 
 ```js
-  $.get(code + '/_api/get-tests?type=functional&n=2').then(
-    (data) => {
-      assert.equal(data.state, 'passed');
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=functional&n=2');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(data.state, 'passed');
 ```
 
 You should test for `res.status` to be 200.
 
 ```js
-  $.get(code + '/_api/get-tests?type=functional&n=2').then(
-    (data) => {
-      assert.equal(data.assertions[0].method, 'equal');
-      assert.equal(data.assertions[0].args[0], 'res.status');
-      assert.equal(data.assertions[0].args[1], '200');
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=functional&n=2');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(data.assertions[0].method, 'equal');
+assert.equal(data.assertions[0].args[0], 'res.status');
+assert.equal(data.assertions[0].args[1], '200');
 ```
 
 You should test for `res.type` to be `'application/json'`.
 
 ```js
-  $.get(code + '/_api/get-tests?type=functional&n=2').then(
-    (data) => {
-      assert.equal(data.assertions[1].method, 'equal');
-      assert.equal(data.assertions[1].args[0], 'res.type');
-      assert.match(data.assertions[1].args[1], /('|")application\/json\1/);
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=functional&n=2');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(data.assertions[1].method, 'equal');
+assert.equal(data.assertions[1].args[0], 'res.type');
+assert.match(data.assertions[1].args[1], /('|")application\/json\1/);
 ```
 
 You should test for `res.body.name` to be `'Cristoforo'`.
 
 ```js
-  $.get(code + '/_api/get-tests?type=functional&n=2').then(
-    (data) => {
-      assert.equal(data.assertions[2].method, 'equal');
-      assert.equal(data.assertions[2].args[0], 'res.body.name');
-      assert.match(data.assertions[2].args[1], /('|")Cristoforo\1/);
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=functional&n=2');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(data.assertions[2].method, 'equal');
+assert.equal(data.assertions[2].args[0], 'res.body.name');
+assert.match(data.assertions[2].args[1], /('|")Cristoforo\1/);
 ```
 
 You should test for `res.body.surname` to be `'Colombo'`.
 
 ```js
-  $.get(code + '/_api/get-tests?type=functional&n=2').then(
-    (data) => {
-      assert.equal(data.assertions[3].method, 'equal');
-      assert.equal(data.assertions[3].args[0], 'res.body.surname');
-      assert.match(data.assertions[3].args[1], /('|")Colombo\1/);
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=functional&n=2');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(data.assertions[3].method, 'equal');
+assert.equal(data.assertions[3].args[0], 'res.body.surname');
+assert.match(data.assertions[3].args[1], /('|")Colombo\1/);
 ```
 

--- a/curriculum/challenges/english/blocks/quality-assurance-and-testing-with-chai/587d824f367417b2b2512c5b.md
+++ b/curriculum/challenges/english/blocks/quality-assurance-and-testing-with-chai/587d824f367417b2b2512c5b.md
@@ -40,73 +40,63 @@ Follow the assertion order above - we rely on it. Also, be sure to remove `asser
 All tests should pass
 
 ```js
-  $.get(code + '/_api/get-tests?type=functional&n=3').then(
-    (data) => {
-      assert.equal(data.state, 'passed');
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=functional&n=3');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(data.state, 'passed');
 ```
 
 You should test for `res.status` to be 200
 
 ```js
-  $.get(code + '/_api/get-tests?type=functional&n=3').then(
-    (data) => {
-      assert.equal(data.assertions[0].method, 'equal');
-      assert.equal(data.assertions[0].args[0], 'res.status');
-      assert.equal(data.assertions[0].args[1], '200');
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=functional&n=3');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(data.assertions[0].method, 'equal');
+assert.equal(data.assertions[0].args[0], 'res.status');
+assert.equal(data.assertions[0].args[1], '200');
 ```
 
 You should test for `res.type` to be `'application/json'`
 
 ```js
-  $.get(code + '/_api/get-tests?type=functional&n=3').then(
-    (data) => {
-      assert.equal(data.assertions[1].method, 'equal');
-      assert.equal(data.assertions[1].args[0], 'res.type');
-      assert.match(data.assertions[1].args[1], /('|")application\/json\1/);
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=functional&n=3');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(data.assertions[1].method, 'equal');
+assert.equal(data.assertions[1].args[0], 'res.type');
+assert.match(data.assertions[1].args[1], /('|")application\/json\1/);
 ```
 
 You should test for `res.body.name` to be `'Giovanni'`
 
 ```js
-  $.get(code + '/_api/get-tests?type=functional&n=3').then(
-    (data) => {
-      assert.equal(data.assertions[2].method, 'equal');
-      assert.equal(data.assertions[2].args[0], 'res.body.name');
-      assert.match(data.assertions[2].args[1], /('|")Giovanni\1/);
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=functional&n=3');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(data.assertions[2].method, 'equal');
+assert.equal(data.assertions[2].args[0], 'res.body.name');
+assert.match(data.assertions[2].args[1], /('|")Giovanni\1/);
 ```
 
 You should test for `res.body.surname` to be `'da Verrazzano'`
 
 ```js
-  $.get(code + '/_api/get-tests?type=functional&n=3').then(
-    (data) => {
-      assert.equal(data.assertions[3].method, 'equal');
-      assert.equal(data.assertions[3].args[0], 'res.body.surname');
-      assert.match(data.assertions[3].args[1], /('|")da Verrazzano\1/);
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=functional&n=3');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(data.assertions[3].method, 'equal');
+assert.equal(data.assertions[3].args[0], 'res.body.surname');
+assert.match(data.assertions[3].args[1], /('|")da Verrazzano\1/);
 ```
 

--- a/curriculum/challenges/english/blocks/quality-assurance-and-testing-with-chai/587d824f367417b2b2512c5c.md
+++ b/curriculum/challenges/english/blocks/quality-assurance-and-testing-with-chai/587d824f367417b2b2512c5c.md
@@ -50,13 +50,11 @@ suiteSetup(function(done) {
 All tests should pass.
 
 ```js
-  $.get(code + '/_api/get-tests?type=functional&n=4').then(
-    (data) => {
-      assert.equal(data.state, 'passed');
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=functional&n=4');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(data.state, 'passed');
 ```
 

--- a/curriculum/challenges/english/blocks/quality-assurance-and-testing-with-chai/587d8250367417b2b2512c5d.md
+++ b/curriculum/challenges/english/blocks/quality-assurance-and-testing-with-chai/587d8250367417b2b2512c5d.md
@@ -64,71 +64,61 @@ Do not forget to remove the `assert.fail()` call.
 All tests should pass.
 
 ```js
-  $.get(code + '/_api/get-tests?type=functional&n=5').then(
-    (data) => {
-      assert.equal(data.state, 'passed');
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=functional&n=5');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(data.state, 'passed');
 ```
 
 You should assert that the headless browser request succeeded.
 
 ```js
-  $.get(code + '/_api/get-tests?type=functional&n=5').then(
-    (data) => {
-      assert.equal(data.assertions[0].method, 'browser.success');
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=functional&n=5');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(data.assertions[0].method, 'browser.success');
 ```
 
 You should assert that the text inside the element `span#name` is `'Cristoforo'`.
 
 ```js
-  $.get(code + '/_api/get-tests?type=functional&n=5').then(
-    (data) => {
-      assert.equal(data.assertions[1].method, 'browser.text');
-      assert.match(data.assertions[1].args[0], /('|")span#name\1/);
-      assert.match(data.assertions[1].args[1], /('|")Cristoforo\1/);
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=functional&n=5');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(data.assertions[1].method, 'browser.text');
+assert.match(data.assertions[1].args[0], /('|")span#name\1/);
+assert.match(data.assertions[1].args[1], /('|")Cristoforo\1/);
 ```
 
 You should assert that the text inside the element `span#surname` is `'Colombo'`.
 
 ```js
-  $.get(code + '/_api/get-tests?type=functional&n=5').then(
-    (data) => {
-      assert.equal(data.assertions[2].method, 'browser.text');
-      assert.match(data.assertions[2].args[0], /('|")span#surname\1/);
-      assert.match(data.assertions[2].args[1], /('|")Colombo\1/);
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=functional&n=5');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(data.assertions[2].method, 'browser.text');
+assert.match(data.assertions[2].args[0], /('|")span#surname\1/);
+assert.match(data.assertions[2].args[1], /('|")Colombo\1/);
 ```
 
 You should assert that the element `span#dates` exist and its count is 1.
 
 ```js
-  $.get(code + '/_api/get-tests?type=functional&n=5').then(
-    (data) => {
-      assert.equal(data.assertions[3].method, 'browser.elements');
-      assert.match(data.assertions[3].args[0], /('|")span#dates\1/);
-      assert.equal(data.assertions[3].args[1], 1);
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=functional&n=5');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(data.assertions[3].method, 'browser.elements');
+assert.match(data.assertions[3].args[0], /('|")span#dates\1/);
+assert.equal(data.assertions[3].args[1], 1);
 ```
 

--- a/curriculum/challenges/english/blocks/quality-assurance-and-testing-with-chai/5f8884f4c46685731aabfc41.md
+++ b/curriculum/challenges/english/blocks/quality-assurance-and-testing-with-chai/5f8884f4c46685731aabfc41.md
@@ -31,71 +31,61 @@ Do not forget to remove the `assert.fail()` call.
 All tests should pass.
 
 ```js
-  $.get(code + '/_api/get-tests?type=functional&n=6').then(
-    (data) => {
-      assert.equal(data.state, 'passed');
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=functional&n=6');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(data.state, 'passed');
 ```
 
 You should assert that the headless browser request succeeded.
 
 ```js
-  $.get(code + '/_api/get-tests?type=functional&n=6').then(
-    (data) => {
-      assert.equal(data.assertions[0].method, 'browser.success');
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=functional&n=6');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(data.assertions[0].method, 'browser.success');
 ```
 
 You should assert that the text inside the element `span#name` is `'Amerigo'`.
 
 ```js
-  $.get(code + '/_api/get-tests?type=functional&n=6').then(
-    (data) => {
-      assert.equal(data.assertions[1].method, 'browser.text');
-      assert.match(data.assertions[1].args[0], /('|")span#name\1/);
-      assert.match(data.assertions[1].args[1], /('|")Amerigo\1/);
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=functional&n=6');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(data.assertions[1].method, 'browser.text');
+assert.match(data.assertions[1].args[0], /('|")span#name\1/);
+assert.match(data.assertions[1].args[1], /('|")Amerigo\1/);
 ```
 
 You should assert that the text inside the element `span#surname` is `'Vespucci'`.
 
 ```js
-  $.get(code + '/_api/get-tests?type=functional&n=6').then(
-    (data) => {
-      assert.equal(data.assertions[2].method, 'browser.text');
-      assert.match(data.assertions[2].args[0], /('|")span#surname\1/);
-      assert.match(data.assertions[2].args[1], /('|")Vespucci\1/);
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=functional&n=6');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(data.assertions[2].method, 'browser.text');
+assert.match(data.assertions[2].args[0], /('|")span#surname\1/);
+assert.match(data.assertions[2].args[1], /('|")Vespucci\1/);
 ```
 
 You should assert that the element `span#dates` exist and its count is 1.
 
 ```js
-  $.get(code + '/_api/get-tests?type=functional&n=6').then(
-    (data) => {
-      assert.equal(data.assertions[3].method, 'browser.elements');
-      assert.match(data.assertions[3].args[0], /('|")span#dates\1/);
-      assert.equal(data.assertions[3].args[1], 1);
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
+const response = await fetch(code + '/_api/get-tests?type=functional&n=6');
+if (!response.ok) {
+  throw Error(await response.text());
+}
+const data = await response.json();
+assert.equal(data.assertions[3].method, 'browser.elements');
+assert.match(data.assertions[3].args[0], /('|")span#dates\1/);
+assert.equal(data.assertions[3].args[1], 1);
 ```
 

--- a/curriculum/challenges/english/blocks/quality-assurance-projects/587d8249367417b2b2512c41.md
+++ b/curriculum/challenges/english/blocks/quality-assurance-projects/587d8249367417b2b2512c41.md
@@ -224,7 +224,7 @@ If the unit of measurement is invalid, returned will be `'invalid unit'`.
     if (!response.ok) {
       throw Error(await response.text());
     }
-    const data = await response.json();
+    const data = await response.text();
     assert(data.error === 'invalid unit' || data === 'invalid unit');
   } catch (xhr) {
     throw new Error(xhr.responseText || xhr.message);
@@ -241,7 +241,7 @@ If the number is invalid, returned will be `'invalid number'`.
     if (!response.ok) {
       throw Error(await response.text());
     }
-    const data = await response.json();
+    const data = await response.text();
     assert(data.error === 'invalid number' || data === 'invalid number');
   } catch (xhr) {
     throw new Error(xhr.responseText || xhr.message);
@@ -258,7 +258,7 @@ If both the unit and number are invalid, returned will be `'invalid number and u
     if (!response.ok) {
       throw Error(await response.text());
     }
-    const data = await response.json();
+    const data = await response.text();
     assert(
       data.error === 'invalid number and unit' ||
         data === 'invalid number and unit'

--- a/curriculum/challenges/english/blocks/quality-assurance-projects/587d8249367417b2b2512c41.md
+++ b/curriculum/challenges/english/blocks/quality-assurance-projects/587d8249367417b2b2512c41.md
@@ -72,16 +72,32 @@ You can convert `'gal'` to `'L'` and vice versa. (1 gal to 3.78541 L)
 
 ```js
   try {
-    const data1 = await $.get(code + '/api/convert?input=1gal');
+    const response1 = await fetch(code + '/api/convert?input=1gal');
+    if (!response1.ok) {
+      throw Error(await response1.text());
+    }
+    const data1 = await response1.json();
     assert.equal(data1.returnNum, 3.78541);
     assert.equal(data1.returnUnit, 'L');
-    const data2 = await $.get(code + '/api/convert?input=10gal');
+    const response2 = await fetch(code + '/api/convert?input=10gal');
+    if (!response2.ok) {
+      throw Error(await response2.text());
+    }
+    const data2 = await response2.json();
     assert.equal(data2.returnNum, 37.8541);
     assert.equal(data2.returnUnit, 'L');
-    const data3 = await $.get(code + '/api/convert?input=1l');
+    const response3 = await fetch(code + '/api/convert?input=1l');
+    if (!response3.ok) {
+      throw Error(await response3.text());
+    }
+    const data3 = await response3.json();
     assert.equal(data3.returnNum, 0.26417);
     assert.equal(data3.returnUnit, 'gal');
-    const data4 = await $.get(code + '/api/convert?input=10l');
+    const response4 = await fetch(code + '/api/convert?input=10l');
+    if (!response4.ok) {
+      throw Error(await response4.text());
+    }
+    const data4 = await response4.json();
     assert.equal(data4.returnNum, 2.64172);
     assert.equal(data4.returnUnit, 'gal');
   } catch (xhr) {
@@ -93,16 +109,32 @@ You can convert `'lbs'` to `'kg'` and vice versa. (1 lbs to 0.453592 kg)
 
 ```js
   try {
-    const data1 = await $.get(code + '/api/convert?input=1lbs');
+    const response1 = await fetch(code + '/api/convert?input=1lbs');
+    if (!response1.ok) {
+      throw Error(await response1.text());
+    }
+    const data1 = await response1.json();
     assert.equal(data1.returnNum, 0.45359);
     assert.equal(data1.returnUnit, 'kg');
-    const data2 = await $.get(code + '/api/convert?input=10lbs');
+    const response2 = await fetch(code + '/api/convert?input=10lbs');
+    if (!response2.ok) {
+      throw Error(await response2.text());
+    }
+    const data2 = await response2.json();
     assert.equal(data2.returnNum, 4.53592);
     assert.equal(data2.returnUnit, 'kg');
-    const data3 = await $.get(code + '/api/convert?input=1kg');
+    const response3 = await fetch(code + '/api/convert?input=1kg');
+    if (!response3.ok) {
+      throw Error(await response3.text());
+    }
+    const data3 = await response3.json();
     assert.equal(data3.returnNum, 2.20462);
     assert.equal(data3.returnUnit, 'lbs');
-    const data4 = await $.get(code + '/api/convert?input=10kg');
+    const response4 = await fetch(code + '/api/convert?input=10kg');
+    if (!response4.ok) {
+      throw Error(await response4.text());
+    }
+    const data4 = await response4.json();
     assert.equal(data4.returnNum, 22.04624);
     assert.equal(data4.returnUnit, 'lbs');
   } catch (xhr) {
@@ -114,16 +146,32 @@ You can convert `'mi'` to `'km'` and vice versa. (1 mi to 1.60934 km)
 
 ```js
   try {
-    const data1 = await $.get(code + '/api/convert?input=1mi');
+    const response1 = await fetch(code + '/api/convert?input=1mi');
+    if (!response1.ok) {
+      throw Error(await response1.text());
+    }
+    const data1 = await response1.json();
     assert.equal(data1.returnNum, 1.60934);
     assert.equal(data1.returnUnit, 'km');
-    const data2 = await $.get(code + '/api/convert?input=10mi');
+    const response2 = await fetch(code + '/api/convert?input=10mi');
+    if (!response2.ok) {
+      throw Error(await response2.text());
+    }
+    const data2 = await response2.json();
     assert.equal(data2.returnNum, 16.0934);
     assert.equal(data2.returnUnit, 'km');
-    const data3 = await $.get(code + '/api/convert?input=1km');
+    const response3 = await fetch(code + '/api/convert?input=1km');
+    if (!response3.ok) {
+      throw Error(await response3.text());
+    }
+    const data3 = await response3.json();
     assert.equal(data3.returnNum, 0.62137);
     assert.equal(data3.returnUnit, 'mi');
-    const data4 = await $.get(code + '/api/convert?input=10km');
+    const response4 = await fetch(code + '/api/convert?input=10km');
+    if (!response4.ok) {
+      throw Error(await response4.text());
+    }
+    const data4 = await response4.json();
     assert.equal(data4.returnNum, 6.21373);
     assert.equal(data4.returnUnit, 'mi');
   } catch (xhr) {
@@ -135,16 +183,32 @@ All incoming units should be accepted in both upper and lower case, but should b
 
 ```js
   try {
-    const data1 = await $.get(code + '/api/convert?input=1gal');
+    const response1 = await fetch(code + '/api/convert?input=1gal');
+    if (!response1.ok) {
+      throw Error(await response1.text());
+    }
+    const data1 = await response1.json();
     assert.equal(data1.initUnit, 'gal');
     assert.equal(data1.returnUnit, 'L');
-    const data2 = await $.get(code + '/api/convert?input=10L');
+    const response2 = await fetch(code + '/api/convert?input=10L');
+    if (!response2.ok) {
+      throw Error(await response2.text());
+    }
+    const data2 = await response2.json();
     assert.equal(data2.initUnit, 'L');
     assert.equal(data2.returnUnit, 'gal');
-    const data3 = await $.get(code + '/api/convert?input=1l');
+    const response3 = await fetch(code + '/api/convert?input=1l');
+    if (!response3.ok) {
+      throw Error(await response3.text());
+    }
+    const data3 = await response3.json();
     assert.equal(data3.initUnit, 'L');
     assert.equal(data3.returnUnit, 'gal');
-    const data4 = await $.get(code + '/api/convert?input=10KM');
+    const response4 = await fetch(code + '/api/convert?input=10KM');
+    if (!response4.ok) {
+      throw Error(await response4.text());
+    }
+    const data4 = await response4.json();
     assert.equal(data4.initUnit, 'km');
     assert.equal(data4.returnUnit, 'mi');
   } catch (xhr) {
@@ -156,7 +220,11 @@ If the unit of measurement is invalid, returned will be `'invalid unit'`.
 
 ```js
   try {
-    const data = await $.get(code + '/api/convert?input=1min');
+    const response = await fetch(code + '/api/convert?input=1min');
+    if (!response.ok) {
+      throw Error(await response.text());
+    }
+    const data = await response.json();
     assert(data.error === 'invalid unit' || data === 'invalid unit');
   } catch (xhr) {
     throw new Error(xhr.responseText || xhr.message);
@@ -167,9 +235,13 @@ If the number is invalid, returned will be `'invalid number'`.
 
 ```js
   try {
-    const data = await $.get(
+    const response = await fetch(
       code + '/api/convert?input=1//2gal'
     );
+    if (!response.ok) {
+      throw Error(await response.text());
+    }
+    const data = await response.json();
     assert(data.error === 'invalid number' || data === 'invalid number');
   } catch (xhr) {
     throw new Error(xhr.responseText || xhr.message);
@@ -180,9 +252,13 @@ If both the unit and number are invalid, returned will be `'invalid number and u
 
 ```js
   try {
-    const data = await $.get(
+    const response = await fetch(
       code + '/api/convert?input=1//2min'
     );
+    if (!response.ok) {
+      throw Error(await response.text());
+    }
+    const data = await response.json();
     assert(
       data.error === 'invalid number and unit' ||
         data === 'invalid number and unit'
@@ -196,23 +272,39 @@ You can use fractions, decimals or both in the parameter (ie. 5, 1/2, 2.5/6), bu
 
 ```js
   try {
-    const data1 = await $.get(code + '/api/convert?input=mi');
+    const response1 = await fetch(code + '/api/convert?input=mi');
+    if (!response1.ok) {
+      throw Error(await response1.text());
+    }
+    const data1 = await response1.json();
     assert.approximately(data1.initNum, 1, 0.001);
     assert.approximately(data1.returnNum, 1.60934, 0.001);
     assert.equal(data1.returnUnit, 'km');
-    const data2 = await $.get(code + '/api/convert?input=1/5mi');
+    const response2 = await fetch(code + '/api/convert?input=1/5mi');
+    if (!response2.ok) {
+      throw Error(await response2.text());
+    }
+    const data2 = await response2.json();
     assert.approximately(data2.initNum, 1 / 5, 0.1);
     assert.approximately(data2.returnNum, 0.32187, 0.001);
     assert.equal(data2.returnUnit, 'km');
-    const data3 = await $.get(
+    const response3 = await fetch(
       code + '/api/convert?input=1.5/7km'
     );
+    if (!response3.ok) {
+      throw Error(await response3.text());
+    }
+    const data3 = await response3.json();
     assert.approximately(data3.initNum, 1.5 / 7, 0.001);
     assert.approximately(data3.returnNum, 0.13315, 0.001);
     assert.equal(data3.returnUnit, 'mi');
-    const data4 = await $.get(
+    const response4 = await fetch(
       code + '/api/convert?input=3/2.7km'
     );
+    if (!response4.ok) {
+      throw Error(await response4.text());
+    }
+    const data4 = await response4.json();
     assert.approximately(data4.initNum, 3 / 2.7, 0.001);
     assert.approximately(data4.returnNum, 0.69041, 0.001);
     assert.equal(data4.returnUnit, 'mi');
@@ -225,7 +317,11 @@ Your return will consist of the `initNum`, `initUnit`, `returnNum`, `returnUnit`
 
 ```js
   try {
-    const data = await $.get(code + '/api/convert?input=2mi');
+    const response = await fetch(code + '/api/convert?input=2mi');
+    if (!response.ok) {
+      throw Error(await response.text());
+    }
+    const data = await response.json();
     assert.equal(data.initNum, 2);
     assert.equal(data.initUnit, 'mi');
     assert.approximately(data.returnNum, 3.21868, 0.001);
@@ -240,7 +336,11 @@ All 16 unit tests are complete and passing.
 
 ```js
   try {
-    const getTests = await $.get(code + '/_api/get-tests');
+    const response = await fetch(code + '/_api/get-tests');
+    if (!response.ok) {
+      throw Error(await response.text());
+    }
+    const getTests = await response.json();
     assert.isArray(getTests);
     const unitTests = getTests.filter(test => {
       return !!test.context.match(/Unit Tests/gi);
@@ -263,7 +363,11 @@ All 5 functional tests are complete and passing.
 
 ```js
   try {
-    const getTests = await $.get(code + '/_api/get-tests');
+    const response = await fetch(code + '/_api/get-tests');
+    if (!response.ok) {
+      throw Error(await response.text());
+    }
+    const getTests = await response.json();
     assert.isArray(getTests);
     const functTests = getTests.filter(test => {
       return !!test.context.match(/Functional Tests/gi);

--- a/curriculum/challenges/english/blocks/quality-assurance-projects/587d8249367417b2b2512c42.md
+++ b/curriculum/challenges/english/blocks/quality-assurance-projects/587d8249367417b2b2512c42.md
@@ -55,10 +55,15 @@ You can send a `POST` request to `/api/issues/{projectname}` with form data cont
       issue_text: 'Functional Test - Required Fields Only',
       created_by: 'fCC'
     };
-    const data = await $.post(
-      code + '/api/issues/fcc-project',
-      test_data
-    );
+    const response = await fetch(code + '/api/issues/fcc-project', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(test_data)
+    });
+    if (!response.ok) {
+      throw Error(await response.text());
+    }
+    const data = await response.json();
     assert.isObject(data);
     assert.nestedInclude(data, test_data);
   } catch (err) {
@@ -76,10 +81,15 @@ The `POST` request to `/api/issues/{projectname}` will return the created object
       created_by: 'fCC',
       assigned_to: 'Chai and Mocha'
     };
-    const data = await $.post(
-      code + '/api/issues/fcc-project',
-      test_data
-    );
+    const response = await fetch(code + '/api/issues/fcc-project', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(test_data)
+    });
+    if (!response.ok) {
+      throw Error(await response.text());
+    }
+    const data = await response.json();
     assert.isObject(data);
     assert.nestedInclude(data, test_data);
     assert.property(data, 'created_on');
@@ -103,9 +113,15 @@ If you send a `POST` request to `/api/issues/{projectname}` without the required
 ```js
   try {
     let test_data = { created_by: 'fCC' };
-    const data = await $.post(code + '/api/issues/fcc-project', {
-      created_by: 'fCC'
+    const response = await fetch(code + '/api/issues/fcc-project', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ created_by: 'fCC' })
     });
+    if (!response.ok) {
+      throw Error(await response.text());
+    }
+    const data = await response.json();
     assert.isObject(data);
     assert.property(data, 'error');
     assert.equal(data.error, 'required field(s) missing');
@@ -123,22 +139,41 @@ You can send a `GET` request to `/api/issues/{projectname}` for an array of all 
       code +
       '/api/issues/get_issues_test_' +
       Date.now().toString().substring(7);
-    const data1 = await $.post(
-      url,
-      Object.assign(test_data, { issue_title: 'Faux Issue 1' })
-    );
+    const response1 = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(Object.assign(test_data, { issue_title: 'Faux Issue 1' }))
+    });
+    if (!response1.ok) {
+      throw Error(await response1.text());
+    }
+    const data1 = await response1.json();
     assert.isObject(data1);
-    const data2 = await $.post(
-      url,
-      Object.assign(test_data, { issue_title: 'Faux Issue 2' })
-    );
+    const response2 = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(Object.assign(test_data, { issue_title: 'Faux Issue 2' }))
+    });
+    if (!response2.ok) {
+      throw Error(await response2.text());
+    }
+    const data2 = await response2.json();
     assert.isObject(data2);
-    const data3 = await $.post(
-      url,
-      Object.assign(test_data, { issue_title: 'Faux Issue 3' })
-    );
+    const response3 = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(Object.assign(test_data, { issue_title: 'Faux Issue 3' }))
+    });
+    if (!response3.ok) {
+      throw Error(await response3.text());
+    }
+    const data3 = await response3.json();
     assert.isObject(data3);
-    const getIssues = await $.get(url);
+    const getResponse = await fetch(url);
+    if (!getResponse.ok) {
+      throw Error(await getResponse.text());
+    }
+    const getIssues = await getResponse.json();
     assert.isArray(getIssues);
     assert.lengthOf(getIssues, 3);
     let re = new RegExp('Faux Issue \\d');
@@ -171,30 +206,62 @@ You can send a `GET` request to `/api/issues/{projectname}` and filter the reque
       code +
       '/api/issues/get_issues_test_' +
       Date.now().toString().substring(7);
-    const data1 = await $.post(
-      url,
-      Object.assign(test_data, { created_by: 'Alice', assigned_to: 'Bob' })
-    );
-    const data2 = await $.post(
-      url,
-      Object.assign(test_data, { created_by: 'Alice', assigned_to: 'Bob' })
-    );
-    const data3 = await $.post(
-      url,
-      Object.assign(test_data, { created_by: 'Alice', assigned_to: 'Eric' })
-    );
-    const data4 = await $.post(
-      url,
-      Object.assign(test_data, { created_by: 'Carol', assigned_to: 'Eric' })
-    );
-    const getSingle = await $.get(url + '?created_by=Alice');
+    const response1 = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(Object.assign(test_data, { created_by: 'Alice', assigned_to: 'Bob' }))
+    });
+    if (!response1.ok) {
+      throw Error(await response1.text());
+    }
+    const data1 = await response1.json();
+    const response2 = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(Object.assign(test_data, { created_by: 'Alice', assigned_to: 'Bob' }))
+    });
+    if (!response2.ok) {
+      throw Error(await response2.text());
+    }
+    const data2 = await response2.json();
+    const response3 = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(Object.assign(test_data, { created_by: 'Alice', assigned_to: 'Eric' }))
+    });
+    if (!response3.ok) {
+      throw Error(await response3.text());
+    }
+    const data3 = await response3.json();
+    const response4 = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(Object.assign(test_data, { created_by: 'Carol', assigned_to: 'Eric' }))
+    });
+    if (!response4.ok) {
+      throw Error(await response4.text());
+    }
+    const data4 = await response4.json();
+    const getSingleResponse = await fetch(url + '?created_by=Alice');
+    if (!getSingleResponse.ok) {
+      throw Error(await getSingleResponse.text());
+    }
+    const getSingle = await getSingleResponse.json();
     assert.isArray(getSingle);
     assert.lengthOf(getSingle, 3);
-    const getMultiple = await $.get(url + '?created_by=Alice&assigned_to=Bob');
+    const getMultipleResponse = await fetch(url + '?created_by=Alice&assigned_to=Bob');
+    if (!getMultipleResponse.ok) {
+      throw Error(await getMultipleResponse.text());
+    }
+    const getMultiple = await getMultipleResponse.json();
     assert.isArray(getMultiple);
     assert.lengthOf(getMultiple, 2);
     const copyId = getMultiple[0]._id;
-    const getById = await $.get(url + `?_id=${copyId}`);
+    const getByIdResponse = await fetch(url + `?_id=${copyId}`);
+    if (!getByIdResponse.ok) {
+      throw Error(await getByIdResponse.text());
+    }
+    const getById = await getByIdResponse.json();
     assert.isArray(getById);
     assert.lengthOf(getById, 1);
     assert.equal(getById[0]._id, copyId, 'should be able to query a document by _id')
@@ -213,18 +280,34 @@ You can send a `PUT` request to `/api/issues/{projectname}` with an `_id` and on
       created_by: 'fCC'
     };
     const url = code + '/api/issues/fcc-project';
-    const itemToUpdate = await $.post(url, initialData);
-    const updateSuccess = await $.ajax({
-      url: url,
-      type: 'PUT',
-      data: { _id: itemToUpdate._id, issue_text: 'New Issue Text' }
+    const createResponse = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(initialData)
     });
+    if (!createResponse.ok) {
+      throw Error(await createResponse.text());
+    }
+    const itemToUpdate = await createResponse.json();
+    const updateResponse = await fetch(url, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ _id: itemToUpdate._id, issue_text: 'New Issue Text' })
+    });
+    if (!updateResponse.ok) {
+      throw Error(await updateResponse.text());
+    }
+    const updateSuccess = await updateResponse.json();
     assert.isObject(updateSuccess);
     assert.deepEqual(updateSuccess, {
       result: 'successfully updated',
       _id: itemToUpdate._id
     });
-    const getUpdatedId = await $.get(url + '?_id=' + itemToUpdate._id);
+    const getUpdatedResponse = await fetch(url + '?_id=' + itemToUpdate._id);
+    if (!getUpdatedResponse.ok) {
+      throw Error(await getUpdatedResponse.text());
+    }
+    const getUpdatedId = await getUpdatedResponse.json();
     assert.isArray(getUpdatedId);
     assert.isObject(getUpdatedId[0]);
     assert.isAbove(
@@ -241,7 +324,11 @@ When the `PUT` request sent to `/api/issues/{projectname}` does not include an `
 ```js
   try {
     const url = code + '/api/issues/fcc-project';
-    const badUpdate = await $.ajax({ url: url, type: 'PUT' });
+    const response = await fetch(url, { method: 'PUT' });
+    if (!response.ok) {
+      throw Error(await response.text());
+    }
+    const badUpdate = await response.json();
     assert.isObject(badUpdate);
     assert.property(badUpdate, 'error');
     assert.equal(badUpdate.error, 'missing _id');
@@ -255,20 +342,28 @@ When the `PUT` request sent to `/api/issues/{projectname}` does not include upda
 ```js
   try {
     const url = code + '/api/issues/fcc-project';
-    const badUpdate = await $.ajax({
-      url: url,
-      type: 'PUT',
-      data: { _id: '5f665eb46e296f6b9b6a504d' }
+    const response1 = await fetch(url, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ _id: '5f665eb46e296f6b9b6a504d' })
     });
+    if (!response1.ok) {
+      throw Error(await response1.text());
+    }
+    const badUpdate = await response1.json();
     assert.deepEqual(badUpdate, {
       error: 'no update field(s) sent',
       _id: '5f665eb46e296f6b9b6a504d'
     });
-    const badIdUpdate = await $.ajax({
-      url: url,
-      type: 'PUT',
-      data: { _id: '5f665eb46e296f6b9b6a504d', issue_text: 'New Issue Text' }
+    const response2 = await fetch(url, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ _id: '5f665eb46e296f6b9b6a504d', issue_text: 'New Issue Text' })
     });
+    if (!response2.ok) {
+      throw Error(await response2.text());
+    }
+    const badIdUpdate = await response2.json();
     assert.deepEqual(badIdUpdate, {
       error: 'could not update',
       _id: '5f665eb46e296f6b9b6a504d'
@@ -288,26 +383,46 @@ You can send a `DELETE` request to `/api/issues/{projectname}` with an `_id` to 
       created_by: 'fCC'
     };
     const url = code + '/api/issues/fcc-project';
-    const itemToDelete = await $.post(url, initialData);
-    assert.isObject(itemToDelete);
-    const deleteSuccess = await $.ajax({
-      url: url,
-      type: 'DELETE',
-      data: { _id: itemToDelete._id }
+    const createResponse = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(initialData)
     });
+    if (!createResponse.ok) {
+      throw Error(await createResponse.text());
+    }
+    const itemToDelete = await createResponse.json();
+    assert.isObject(itemToDelete);
+    const deleteResponse = await fetch(url, {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ _id: itemToDelete._id })
+    });
+    if (!deleteResponse.ok) {
+      throw Error(await deleteResponse.text());
+    }
+    const deleteSuccess = await deleteResponse.json();
     assert.isObject(deleteSuccess);
     assert.deepEqual(deleteSuccess, {
       result: 'successfully deleted',
       _id: itemToDelete._id
     });
-    const noId = await $.ajax({ url: url, type: 'DELETE' });
+    const noIdResponse = await fetch(url, { method: 'DELETE' });
+    if (!noIdResponse.ok) {
+      throw Error(await noIdResponse.text());
+    }
+    const noId = await noIdResponse.json();
     assert.isObject(noId);
     assert.deepEqual(noId, { error: 'missing _id' });
-    const badIdDelete = await $.ajax({
-      url: url,
-      type: 'DELETE',
-      data: { _id: '5f665eb46e296f6b9b6a504d', issue_text: 'New Issue Text' }
+    const badIdDeleteResponse = await fetch(url, {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ _id: '5f665eb46e296f6b9b6a504d', issue_text: 'New Issue Text' })
     });
+    if (!badIdDeleteResponse.ok) {
+      throw Error(await badIdDeleteResponse.text());
+    }
+    const badIdDelete = await badIdDeleteResponse.json();
     assert.isObject(badIdDelete);
     assert.deepEqual(badIdDelete, {
       error: 'could not delete',
@@ -322,7 +437,11 @@ All 14 functional tests are complete and passing.
 
 ```js
   try {
-    const getTests = await $.get(code + '/_api/get-tests');
+    const response = await fetch(code + '/_api/get-tests');
+    if (!response.ok) {
+      throw Error(await response.text());
+    }
+    const getTests = await response.json();
     assert.isArray(getTests);
     assert.isAtLeast(getTests.length, 14, 'At least 14 tests passed');
     getTests.forEach((test) => {

--- a/curriculum/challenges/english/blocks/quality-assurance-projects/587d824a367417b2b2512c43.md
+++ b/curriculum/challenges/english/blocks/quality-assurance-projects/587d824a367417b2b2512c43.md
@@ -35,14 +35,28 @@ You can send a <b>POST</b> request to `/api/books` with `title` as part of the f
 
 ```js
   try {
-    let data1 = await $.post(code + '/api/books', {
-      title: 'Faux Book 1'
+    const response1 = await fetch(code + '/api/books', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'Faux Book 1' })
     });
+    if (!response1.ok) {
+      throw Error(await response1.text());
+    }
+    let data1 = await response1.json();
     assert.isObject(data1);
     assert.property(data1, 'title');
     assert.equal(data1.title, 'Faux Book 1');
     assert.property(data1, '_id');
-    let data2 = await $.post(code + '/api/books');
+    const response2 = await fetch(code + '/api/books', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({})
+    });
+    if (!response2.ok) {
+      throw Error(await response2.text());
+    }
+    let data2 = await response2.text();
     assert.isString(data2);
     assert.equal(data2, 'missing required field title');
   } catch (err) {
@@ -55,11 +69,36 @@ You can send a <b>GET</b> request to `/api/books` and receive a JSON response re
 ```js
   try {
     let url = code + '/api/books';
-    let a = $.post(url, { title: 'Faux Book A' });
-    let b = $.post(url, { title: 'Faux Book B' });
-    let c = $.post(url, { title: 'Faux Book C' });
+    let a = fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'Faux Book A' })
+    }).then(response => {
+      if (!response.ok) throw Error(response.text());
+      return response.json();
+    });
+    let b = fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'Faux Book B' })
+    }).then(response => {
+      if (!response.ok) throw Error(response.text());
+      return response.json();
+    });
+    let c = fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'Faux Book C' })
+    }).then(response => {
+      if (!response.ok) throw Error(response.text());
+      return response.json();
+    });
     await Promise.all([a, b, c]).then(async () => {
-      let data = await $.get(url);
+      const response = await fetch(url);
+      if (!response.ok) {
+        throw Error(await response.text());
+      }
+      let data = await response.json();
       assert.isArray(data);
       assert.isAtLeast(data.length, 3);
       data.forEach((book) => {
@@ -81,13 +120,29 @@ You can send a <b>GET</b> request to `/api/books/{_id}` to retrieve a single obj
 ```js
   try {
     let url = code + '/api/books';
-    let noBook = await $.get(url + '/5f665eb46e296f6b9b6a504d');
+    const noBookResponse = await fetch(url + '/5f665eb46e296f6b9b6a504d');
+    if (!noBookResponse.ok) {
+      throw Error(await noBookResponse.text());
+    }
+    let noBook = await noBookResponse.text();
     assert.isString(noBook);
     assert.equal(noBook, 'no book exists');
-    let sampleBook = await $.post(url, { title: 'Faux Book Alpha' });
+    const createResponse = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'Faux Book Alpha' })
+    });
+    if (!createResponse.ok) {
+      throw Error(await createResponse.text());
+    }
+    let sampleBook = await createResponse.json();
     assert.isObject(sampleBook);
     let bookId = sampleBook._id;
-    let bookQuery = await $.get(url + '/' + bookId);
+    const queryResponse = await fetch(url + '/' + bookId);
+    if (!queryResponse.ok) {
+      throw Error(await queryResponse.text());
+    }
+    let bookQuery = await queryResponse.json();
     assert.isObject(bookQuery);
     assert.property(bookQuery, 'title');
     assert.equal(bookQuery.title, 'Faux Book Alpha');
@@ -103,15 +158,35 @@ You can send a <b>POST</b> request containing `comment` as the form body data to
 ```js
   try {
     let url = code + '/api/books';
-    let commentTarget = await $.post(url, { title: 'Notable Book' });
+    const createResponse = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'Notable Book' })
+    });
+    if (!createResponse.ok) {
+      throw Error(await createResponse.text());
+    }
+    let commentTarget = await createResponse.json();
     assert.isObject(commentTarget);
     let bookId = commentTarget._id;
-    let bookCom1 = await $.post(url + '/' + bookId, {
-      comment: 'This book is fab!'
+    const comment1Response = await fetch(url + '/' + bookId, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ comment: 'This book is fab!' })
     });
-    let bookCom2 = await $.post(url + '/' + bookId, {
-      comment: 'I did not care for it'
+    if (!comment1Response.ok) {
+      throw Error(await comment1Response.text());
+    }
+    let bookCom1 = await comment1Response.json();
+    const comment2Response = await fetch(url + '/' + bookId, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ comment: 'I did not care for it' })
     });
+    if (!comment2Response.ok) {
+      throw Error(await comment2Response.text());
+    }
+    let bookCom2 = await comment2Response.json();
     assert.isObject(bookCom2);
     assert.property(bookCom2, '_id');
     assert.property(bookCom2, 'title');
@@ -121,12 +196,26 @@ You can send a <b>POST</b> request containing `comment` as the form body data to
       assert.isString(comment);
       assert.oneOf(comment, ['This book is fab!', 'I did not care for it']);
     });
-    let commentErr = await $.post(url + '/' + bookId);
+    const commentErrResponse = await fetch(url + '/' + bookId, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({})
+    });
+    if (!commentErrResponse.ok) {
+      throw Error(await commentErrResponse.text());
+    }
+    let commentErr = await commentErrResponse.text();
     assert.isString(commentErr);
     assert.equal(commentErr, 'missing required field comment');
-    let failingComment = await $.post(url + '/5f665eb46e296f6b9b6a504d', {
-      comment: 'Never Seen Comment'
+    const failingCommentResponse = await fetch(url + '/5f665eb46e296f6b9b6a504d', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ comment: 'Never Seen Comment' })
     });
+    if (!failingCommentResponse.ok) {
+      throw Error(await failingCommentResponse.text());
+    }
+    let failingComment = await failingCommentResponse.text();
     assert.isString(failingComment);
     assert.equal(failingComment, 'no book exists');
   } catch (err) {
@@ -139,16 +228,29 @@ You can send a <b>DELETE</b> request to `/api/books/{_id}` to delete a book from
 ```js
   try {
     let url = code + '/api/books';
-    let deleteTarget = await $.post(url, { title: 'Deletable Book' });
+    const createResponse = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'Deletable Book' })
+    });
+    if (!createResponse.ok) {
+      throw Error(await createResponse.text());
+    }
+    let deleteTarget = await createResponse.json();
     assert.isObject(deleteTarget);
     let bookId = deleteTarget._id;
-    let doDelete = await $.ajax({ url: url + '/' + bookId, type: 'DELETE' });
+    const deleteResponse = await fetch(url + '/' + bookId, { method: 'DELETE' });
+    if (!deleteResponse.ok) {
+      throw Error(await deleteResponse.text());
+    }
+    let doDelete = await deleteResponse.text();
     assert.isString(doDelete);
     assert.equal(doDelete, 'delete successful');
-    let failingDelete = await $.ajax({
-      url: url + '/5f665eb46e296f6b9b6a504d',
-      type: 'DELETE'
-    });
+    const failingDeleteResponse = await fetch(url + '/5f665eb46e296f6b9b6a504d', { method: 'DELETE' });
+    if (!failingDeleteResponse.ok) {
+      throw Error(await failingDeleteResponse.text());
+    }
+    let failingDelete = await failingDeleteResponse.text();
     assert.isString(failingDelete);
     assert.equal(failingDelete, 'no book exists');
   } catch (err) {
@@ -160,10 +262,11 @@ You can send a <b>DELETE</b> request to `/api/books` to delete all books in the 
 
 ```js
   try {
-    const deleteAll = await $.ajax({
-      url: code + '/api/books',
-      type: 'DELETE'
-    });
+    const response = await fetch(code + '/api/books', { method: 'DELETE' });
+    if (!response.ok) {
+      throw Error(await response.text());
+    }
+    const deleteAll = await response.text();
     assert.isString(deleteAll);
     assert.equal(deleteAll, 'complete delete successful');
   } catch (err) {
@@ -175,7 +278,11 @@ All 10 functional tests required are complete and passing.
 
 ```js
   try {
-    const getTests = await $.get(code + '/_api/get-tests');
+    const response = await fetch(code + '/_api/get-tests');
+    if (!response.ok) {
+      throw Error(await response.text());
+    }
+    const getTests = await response.json();
     assert.isArray(getTests);
     assert.isAtLeast(getTests.length, 10, 'At least 10 tests passed');
     getTests.forEach((test) => {

--- a/curriculum/challenges/english/blocks/quality-assurance-projects/5e601bf95ac9d0ecd8b94afd.md
+++ b/curriculum/challenges/english/blocks/quality-assurance-projects/5e601bf95ac9d0ecd8b94afd.md
@@ -319,7 +319,11 @@ All 12 unit tests are complete and passing.
 
 ```js
   try {
-    const getTests = await $.get(code + '/_api/get-tests');
+    const response = await fetch(code + '/_api/get-tests');
+    if (!response.ok) {
+      throw Error(await response.text());
+    }
+    const getTests = await response.json();
     assert.isArray(getTests);
     const unitTests = getTests.filter((test) => {
       return !!test.context.match(/Unit\s*Tests/gi);
@@ -342,7 +346,11 @@ All 14 functional tests are complete and passing.
 
 ```js
   try {
-    const getTests = await $.get(code + '/_api/get-tests');
+    const response = await fetch(code + '/_api/get-tests');
+    if (!response.ok) {
+      throw Error(await response.text());
+    }
+    const getTests = await response.json();
     assert.isArray(getTests);
     const functTests = getTests.filter((test) => {
       return !!test.context.match(/Functional\s*Tests/gi);

--- a/curriculum/challenges/english/blocks/quality-assurance-projects/5e601c0d5ac9d0ecd8b94afe.md
+++ b/curriculum/challenges/english/blocks/quality-assurance-projects/5e601c0d5ac9d0ecd8b94afe.md
@@ -259,7 +259,11 @@ All 24 unit tests are complete and passing.
 
 ```js
   try {
-    const getTests = await $.get(code + '/_api/get-tests');
+    const response = await fetch(code + '/_api/get-tests');
+    if (!response.ok) {
+      throw Error(await response.text());
+    }
+    const getTests = await response.json();
     assert.isArray(getTests);
     const unitTests = getTests.filter((test) => {
       return !!test.context.match(/Unit Tests/gi);
@@ -282,7 +286,11 @@ All 6 functional tests are complete and passing.
 
 ```js
   try {
-    const getTests = await $.get(code + '/_api/get-tests');
+    const response = await fetch(code + '/_api/get-tests');
+    if (!response.ok) {
+      throw Error(await response.text());
+    }
+    const getTests = await response.json();
     assert.isArray(getTests);
     const functTests = getTests.filter((test) => {
       return !!test.context.match(/Functional Tests/gi);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

The motivation for this is that the fetch proxy in https://github.com/freeCodeCamp/curriculum-helpers/pull/411 resolves https://github.com/freeCodeCamp/freeCodeCamp/issues/60874, but it's only a proxy for fetch.

I've not tested every challenge, but I have confirmed that all the updated projects work with fetch.

Also, https://www.freecodecamp.org/learn/quality-assurance/advanced-node-and-express/registration-of-new-users still uses .ajax and sends credentials.  As it stands it will not be fixed when https://github.com/freeCodeCamp/freeCodeCamp/issues/60874 gets resolved, since the proxied fetch will not be sending credentials. We should probably either "deprecate" this lesson (e.g. not link to it from the home page) or re-write it 

<!-- Feel free to add any additional description of changes below this line -->
