### PR TITLE
fix(client): fix typo in useState variable name in progress-inner.tsx

### DIFF
--- a/client/src/components/Progress/progress-inner.tsx
+++ b/client/src/components/Progress/progress-inner.tsx
@@ -39,7 +39,7 @@ function ProgressInner({
   meta
 }: ProgressInnerProps): JSX.Element {
   const [shownPercent, setShownPercent] = useState(0);
-  const [lastShopwnPercent, setLastShownPercent] = useState(0);
+  const [lastShownPercent, setLastShownPercent] = useState(0);
   const progressInnerWrap = useRef<HTMLDivElement>(null);
   const isProgressInViewport = useIsInViewport(progressInnerWrap);
 
@@ -66,7 +66,7 @@ function ProgressInner({
     }, intervalLength);
   };
   useEffect(() => {
-    if (lastShopwnPercent !== completedPercent && isProgressInViewport) {
+    if (lastShownPercent !== completedPercent && isProgressInViewport) {
       setLastShownPercent(completedPercent);
       animateProgressInner(completedPercent);
     }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #61428

<!-- Feel free to add any additional description of changes below this line -->
This change fixes a typo in the `useState` variable name in `progress-inner.tsx`. From `lastShopwnPercent` to `lastShownPercent` on line 42 and also on line 69