### PR TITLE
fix(curriculum): make semicolon optional for test 8 of lab-password-generator

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-password-generator/66f53dc2c5bd6a11d6c3282f.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-password-generator/66f53dc2c5bd6a11d6c3282f.md
@@ -82,7 +82,7 @@ const length2 = 10;
 const password3 = generatePassword(length2);
 assert.lengthOf(password3, length2);
 assert.equal(password3.length, generatePassword(length2).length);
-assert.match(__helpers.removeJSComments(code), /(let|const|var)\s+password\s*=\s*generatePassword\(\d+\)\;/);
+assert.match(__helpers.removeJSComments(code), /(let|const|var)\s+password\s*=\s*generatePassword\(\d+\)\;?/);
 ```
 
 You should log a single string combining `Generated password:` and the `password` separated by a single space using `+` or a template literal.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #61457

<!-- Feel free to add any additional description of changes below this line -->
