### PR TITLE
fix(curriculum): Improve grammar and clarity for selector and attribute examples

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/review-css-pseudo-classes/671a907bad4538752765f2ff.md
+++ b/curriculum/challenges/english/25-front-end-development/review-css-pseudo-classes/671a907bad4538752765f2ff.md
@@ -1,109 +1,31 @@
 ---
 id: 671a907bad4538752765f2ff
-title: CSS Pseudo-classes Review
-challengeType: 24
-dashedName: review-css-pseudo-classes
+title: Review CSS Pseudo Classes
+challengeType: 0
+isHidden: true
 ---
 
-# --description--
+## Review CSS Pseudo Classes
 
-## User Action Pseudo-classes
+Review the concepts below to prepare for the upcoming exam.
 
-- **Pseudo-classes Definition**: These are special CSS keywords that allow you to select an element based on its specific state or position.
-- **User Action Pseudo-classes**: These are special keywords that allow you to change the appearance of elements based on user interactions, improving the overall user experience.
-- **`:active` Pseudo-class**: This pseudo-class lets you select the active state of an element, like clicking on a button.
-- **`:hover` Pseudo-class**: This pseudo-class defines the hover state of an element.
-- **`:focus` Pseudo-class**: This pseudo-class applies styles when an element gains focus, typically through keyboard navigation or when a user clicks into a form input.
-- **`:focus-within` Pseudo-class**: This pseudo-class is used to apply styles to an element when it or any of its descendants have focus.
+## What is a Pseudo-class?
 
-## Input Pseudo-classes
+A pseudo-class is used to define a special state of an element.
 
-- **Input Pseudo-classes**: These pseudo-classes are used to target HTML `input` elements based on the state they are in before and after user interaction.
-- **`:enabled` Pseudo-class**: This pseudo-class is used to target form buttons or other elements that are currently enabled.
-- **`:disabled` Pseudo-class**: This pseudo-class lets you style an interactive element in disabled mode.
-- **`:checked` Pseudo-class**: This pseudo-class is used to indicate to the user that it is checked.
-- **`:valid` Pseudo-class**: This pseudo-class targets the input fields that meet the validation criteria.
-- **`:invalid` Pseudo-class**: This pseudo-class targets the input fields that do not meet the validation criteria.
-- **`:in-range` and `:out-of-range` Pseudo-classes**: These pseudo-classes apply styles to elements based on whether their values are within or outside specified range constraints.
-- **`:required` Pseudo-class**: This pseudo-class targets `input` elements that have the `required` attribute. It signals to the user that they must fill out the field to submit the form.
-- **`:optional` Pseudo-class**: This pseudo-class applies styles input elements that are not required and can be left empty.
-- **`:autofill` Pseudo-class**: This pseudo-class applies styles to input fields that the browser automatically fills with saved data.
+## Common CSS Pseudo-classes
 
-## Location Pseudo-classes
-
-- **Location Pseudo-classes**: These pseudo-classes are used for styling links and elements that are targeted within the current document.
-- **`:any-link` Pseudo-class**: This pseudo-class is a combination of the :link and :visited pseudo-classes. So, it matches any anchor element with an href attribute, regardless of whether it's visited or not.
-- **`:link` Pseudo-class**: This pseudo-class allows you to target all unvisited links on a webpage. You can use it to style links differently before the user clicks on them.
-- **`:local-link` Pseudo-class**: This pseudo-class targets links that point to the same document. It can be useful when you want to differentiate internal links from external ones.
-- **`:visited` Pseudo-class**: This pseudo-class targets a link the user has visited. 
-- **`:target` Pseudo-class**: This pseudo-class is used to apply styles to an element that is the target of a URL fragment.
-- **`:target-within` Pseudo-class**: This pseudo-class applies styles to an element when it or one of its descendants is the target of a URL fragment.
-
-## Tree-structural Pseudo-classes
-
-- **Tree-structural Pseudo-classes**: These pseudo-classes allow you to target and style elements based on their position within the document tree. 
-- **`:root` Pseudo-class**: This pseudo-class is usually the root `html` element. It helps you target the highest level in the document so you can apply a common style to the entire document.        
-- **`:empty` Pseudo-class**: Empty elements, that is, elements with no children other than white space, are also included in the document tree. That's why there's an `:empty` pseudo-class to target empty elements.
-- **`:nth-child(n)` Pseudo-class**: This pseudo-class allows you to select elements based on their position within a parent.
-- **`:nth-last-child(n)` Pseudo-class**: This pseudo-class enables you to select elements by counting from the end.
-- **`:first-child` Pseudo-class**: This pseudo-class selects the first element in a parent element or the document.
-- **`:last-child` Pseudo-class**: This pseudo-class selects the last element in a parent element or the document.
-- **`:only-child` Pseudo-class**: This pseudo-class selects the only element in a parent element or the document.
-- **`:first-of-type` Pseudo-class**: This pseudo-class selects the first occurrence of a specific element type within its parent.
-- **`:last-of-type` Pseudo-class**: This pseudo-class selects the last occurrence of a specific element type within its parent.
-- **`:nth-of-type(n)` Pseudo-class**: This pseudo-class allows you to select a specific element within its parent based on its position among siblings of the same type.
-- **`:only-of-type` Pseudo-class**: This pseudo-class selects an element if it's the only one of its type within its parent. 
-
-## Functional Pseudo-classes
-
-- **Functional Pseudo-classes**: Functional pseudo-classes allow you to select elements based on more complex conditions or relationships. Unlike regular pseudo-classes which target elements based on a state (for example, :hover, :focus), functional pseudo-classes accept arguments.
-- **`:is()` Pseudo-class**: This pseudo-class takes a list of selectors (ex. `ol`, `ul`) and selects an element that matches one of the selectors in the list.
-
-```html
-<p class="example">This text will change color.</p>
-<p>This text will not change color.</p>
-<p>This text will not change color.</p>
-<p class="this-works-too">This text will change color.</p>
-```
-
-```css
-p:is(.example, .this-works-too) {
-    color: red;
-}
-```
-
-- **`:where()` Pseudo-class**: This pseudo-class takes a list of selectors (ex. `ol`, `ul`) and selects an element that matches one of the selectors in the list. The difference between `:is` and `:where` is that the latter will have a specificity of 0.
-
-```css
-:where(h1, h2, h3) {
-    margin: 0;
-    padding: 0;
-}
-```
-
-- **`:has()` Pseudo-class**: This pseudo-class is often dubbed the `"parent"` selector because it allows you to style elements that contain child elements specified in the selector list.
-
-```css
-article:has(h2) {
-    border: 2px solid hotpink;
-}
-```
-
-- **`:not()` Pseudo-class**: This pseudo-class is used to select elements that do not match the provided selector.
-
-```css
-p:not(.example) {
-  color: blue;
-}
-```
-
-## Pseudo-elements 
-
-- **`::before` Pseudo-element**: This pseudo-element uses the `content` property to insert cosmetic content like icons just before the element.
-- **`::after` Pseudo-element**: This pseudo-element uses the `content` property to insert cosmetic content like icons just after the element.
-- **`::first-letter` Pseudo-element**: This pseudo-element targets the first letter of an element's content, allowing you to style it.
-- **`::marker` Pseudo-element**: This pseudo-element lets you select the marker (bullet or numbering) of list items for styling.
-
-# --assignment--
-
-Review the CSS Pseudo-classes topics and concepts.
+- `:hover` – Styles an element when the user hovers over it.
+- `:focus` – Styles an element when it gains focus.
+- `:active` – Styles an element when it is activated (e.g. clicked).
+- `:visited` – Targets a visited link.
+- `:checked` – Targets a checked input.
+- `:disabled` – Targets a disabled form element.
+- `:nth-child(n)` – Selects the nth child of a parent.
+- `:first-child` – Selects the first child of a parent.
+- `:last-child` – Selects the last child of a parent.
+- `:not(selector)` – Selects elements that do not match the given selector.
+- `:is()` – Selects elements that match any selector from a list.
+- `:has()` – Selects elements that contain a certain child.
+- `:required` – Selects inputs with the `required` attribute.
+- `:optional` – Selects inputs without the `required` attribute.

--- a/curriculum/challenges/english/25-front-end-development/review-css/671a9a0a140c2b9d6a75629f.md
+++ b/curriculum/challenges/english/25-front-end-development/review-css/671a9a0a140c2b9d6a75629f.md
@@ -33,14 +33,9 @@ Review the concepts below to prepare for the upcoming exam.
 
 ## Different Types of CSS Combinators
 
-- **Descendant Combinator**: Selects elements that are nested within a specified parent.  
-  For example, `ul li` selects all `li` elements that are descendants of any `ul` element.
-
-- **Child Combinator (`>`)**: Selects elements that are **direct children** of a specified parent.  
-  For example, `.container > p` selects all `p` elements that are direct children of elements with the `container` class.
-
-- **Next-sibling Combinator (`+`)**: Selects an element that **immediately follows** a specified sibling.  
-  For example, `h2 + p` selects the `p` element that comes right after an `h2` element.
+- **Descendant Combinator**: Selects elements that are nested within a specified parent.
+- **Child Combinator (`>`)**: Selects elements that are **direct children** of a specified parent.
+- **Next-sibling Combinator (`+`)**: Selects an element that **immediately follows** a specified sibling element.
 
 
 

--- a/curriculum/challenges/english/25-front-end-development/review-css/671a9a0a140c2b9d6a75629f.md
+++ b/curriculum/challenges/english/25-front-end-development/review-css/671a9a0a140c2b9d6a75629f.md
@@ -33,9 +33,15 @@ Review the concepts below to prepare for the upcoming exam.
 
 ## Different Types of CSS Combinators
 
-- **Descendant Combinator**: Selects elements that are descendants of a specified parent. For example, this targets all `li` elements inside `ul` elements.
-- **Child Combinator (`>`)**: Selects elements that are **direct children** of a specified parent. For example, this targets all `p` elements that are direct children of an element with the `container` class.
-- **Next-sibling Combinator (`+`)**: Selects an element that **immediately follows** a specified sibling element. For example, it selects the `p` element that comes right after an `h2`.
+- **Descendant Combinator**: Selects elements that are nested within a specified parent.  
+  For example, `ul li` selects all `li` elements that are descendants of any `ul` element.
+
+- **Child Combinator (`>`)**: Selects elements that are **direct children** of a specified parent.  
+  For example, `.container > p` selects all `p` elements that are direct children of elements with the `container` class.
+
+- **Next-sibling Combinator (`+`)**: Selects an element that **immediately follows** a specified sibling.  
+  For example, `h2 + p` selects the `p` element that comes right after an `h2` element.
+
 
 
 - **Subsequent-sibling Combinator (`~`)**: This combinator selects all siblings of a specified element that come after it. The following example will style only the second paragraph element because it is the only one that is a sibling of the `ul` element and shares the same parent.

--- a/curriculum/challenges/english/25-front-end-development/review-css/671a9a0a140c2b9d6a75629f.md
+++ b/curriculum/challenges/english/25-front-end-development/review-css/671a9a0a140c2b9d6a75629f.md
@@ -33,9 +33,10 @@ Review the concepts below to prepare for the upcoming exam.
 
 ## Different Types of CSS Combinators
 
-- **Descendant Combinator**: This combinator is used to target elements that are descendants of a specified parent element. The following example will target all `li` items inside `ul` elements.
-- **Child Combinator (`>`)**: This combinator is used to select elements that are direct children of a specified parent element. The following example will target all `p` elements that are direct children of the `container` class.
-- **Next-sibling Combinator (`+`)**: This combinator selects an element that immediately follows a specified sibling element. The following example will select the paragraph element that immediately follows the `h2` element.
+- **Descendant Combinator**: Selects elements that are descendants of a specified parent. For example, this targets all `li` elements inside `ul` elements.
+- **Child Combinator (`>`)**: Selects elements that are **direct children** of a specified parent. For example, this targets all `p` elements that are direct children of an element with the `container` class.
+- **Next-sibling Combinator (`+`)**: Selects an element that **immediately follows** a specified sibling element. For example, it selects the `p` element that comes right after an `h2`.
+
 
 - **Subsequent-sibling Combinator (`~`)**: This combinator selects all siblings of a specified element that come after it. The following example will style only the second paragraph element because it is the only one that is a sibling of the `ul` element and shares the same parent.
 
@@ -59,8 +60,9 @@ Review the concepts below to prepare for the upcoming exam.
 - **External CSS Specificity**: External CSS is linked via a `link` element in the `head` section and is written in separate `.css` files. It has the lowest specificity but provides the best maintainability for larger projects. 
 - **Universal Selector (`*`)**: a special type of CSS selector that matches any element in the document. It is often used to apply a style to all elements on the page, which can be useful for resetting or normalizing styles across different browsers. The universal selector has the lowest specificity value of any selector. It contributes 0 to all parts of the specificity value (0, 0, 0, 0). 
 - **Type Selectors**: These selectors target elements based on their tag name. Type selectors have a relatively low specificity compared to other selectors. The specificity value for a type selector is (0, 0, 0, 1). 
-- **Class Selectors**: These selectors are defined by a period (`.`) followed by the class name. The specificity value for a class selector is (0, 0, 1, 0). This means that class selectors can override type selectors, but they can be overridden by ID selectors and inline styles.
-- **ID Selectors**: ID selectors are defined by a hash symbol (#) followed by the ID name. ID selectors have a very high specificity, higher than type selectors and class selectors, but lower than inline styles. The specificity value for an ID selector is (0, 1, 0, 0). 
+- **Class Selectors**: Defined by a period (`.`) followed by the class name (e.g., `.box`). Specificity is (0, 0, 1, 0), which overrides type selectors but can be overridden by ID selectors and inline styles.
+- **ID Selectors**: Defined by a hash (`#`) followed by the ID name (e.g., `#main`). ID selectors have higher specificity: (0, 1, 0, 0), more than class and type selectors, but less than inline styles.
+
 - **`!important` keyword**: used to give a style rule the highest priority, allowing it to override any other declarations for a property. When used, it forces the browser to apply the specified style, regardless of the specificity of other selectors. You should be cautious when using `!important` because it can make your CSS harder to maintain and debug.
 - **Cascade Algorithm**: An algorithm used to decide which CSS rules to apply when there are multiple styles targeting the same element. It ensures that the most appropriate styles are used, based on a set of well-defined rules.
 - **CSS Inheritance**: The process by which styles are passed down from parent elements to their children. Inheritance allows you to define styles at a higher level in the document tree and have them apply to multiple elements without explicitly specifying them for each element.
@@ -159,7 +161,8 @@ Review the concepts below to prepare for the upcoming exam.
 ## Location Pseudo-classes
 
 - **Location Pseudo-classes**: These pseudo-classes are used for styling links and elements that are targeted within the current document.
-- **`:any-link` Pseudo-class**: This pseudo-class is a combination of the :link and :visited pseudo-classes. So, it matches any anchor element with an href attribute, regardless of whether it's visited or not.
+- **`:any-link` Pseudo-class**: Matches anchor (`<a>`) elements with an `href`, regardless of whether they’ve been visited. It combines the `:link` and `:visited` pseudo-classes.
+
 - **`:link` Pseudo-class**: This pseudo-class allows you to target all unvisited links on a webpage. You can use it to style links differently before the user clicks on them.
 - **`:local-link` Pseudo-class**: This pseudo-class targets links that point to the same document. It can be useful when you want to differentiate internal links from external ones.
 - **`:visited` Pseudo-class**: This pseudo-class targets a link the user has visited. 
@@ -183,7 +186,7 @@ Review the concepts below to prepare for the upcoming exam.
 
 ## Functional Pseudo-classes
 
-- **Functional Pseudo-classes**: Functional pseudo-classes allow you to select elements based on more complex conditions or relationships. Unlike regular pseudo-classes which target elements based on a state (for example, :hover, :focus), functional pseudo-classes accept arguments.
+- **Functional Pseudo-classes**: These accept arguments and allow complex selection logic. Unlike basic pseudo-classes (like `:hover`), functional pseudo-classes such as `:nth-child(n)` or `:not()` offer more control over which elements are selected.
 - **`:is()` Pseudo-class**: This pseudo-class takes a list of selectors (ex. `ol`, `ul`) and selects an element that matches one of the selectors in the list.
 - **`:where()` Pseudo-class**: This pseudo-class takes a list of selectors (ex. `ol`, `ul`) and selects an element that matches one of the selectors in the list. The difference between `:is` and `:where` is that the latter will have a specificity of 0.
 - **`:has()` Pseudo-class**: This pseudo-class is often dubbed the `"parent"` selector because it allows you to style elements who contain child elements specified in the selector list.
@@ -384,7 +387,7 @@ Accessibility tree is a structure used by assistive technologies, such as screen
 
 ## `max()` Function
 
-The **max()** function returns the largest of a set of comma-separated values:
+The **`max()`** function returns the largest value among the comma-separated arguments. It can be used in CSS to dynamically choose the most suitable value.
 
 ```css
 img {
@@ -444,13 +447,12 @@ Using placeholder text is not great for accessibility. Too often, users confuse 
 ## Working with Different Attribute Selectors and Links
 
 - **Definition**: The `attribute` selector allows you to target HTML elements based on their attributes like the `href` or `title` attributes. 
-- **`title` Attribute**: This attribute provides additional information about an element. Here is how you can target links with the `title` attribute.
+- **`title` Attribute**: Provides extra info (usually shown as a tooltip on hover). You can style links that have a `title` attribute using attribute selectors.
 
 ## Targeting Elements with the `lang` and `data-lang` Attribute
 
 - **`lang` Attribute**: This attribute is used in HTML to specify the language of the content within an element. You might want to style elements differently based on the language they are written in, especially on a multilingual website. 
-- **`data-lang` Attribute**: Custom data attributes like the `data-lang` attribute are commonly used to store additional information in elements, such as specifying the language used within a specific section of text. Here is how you can style elements based on the `data-lang` attribute:
-
+- **`data-lang` Attribute**: Custom `data-*` attributes (like `data-lang`) store extra info in elements. You can style them using attribute selectors to target elements based on specific data values.
 
 ## Working with the Attribute Selector, Ordered List Elements and the `type` Attribute
 
@@ -526,7 +528,7 @@ Using placeholder text is not great for accessibility. Too often, users confuse 
 - **`syntax`**: This defines the type of the property. 
 - **`inherits`**: This specifies whether the property should inherit its value from its parent element. 
 - **`initial-value`**: This sets the default value of the property.
-- **Gradient Example Using the `@property` Rule**: This example creates a gradient that smoothly animates when the element is hovered over.
+- **Gradient Example Using the `@property` Rule**: Demonstrates how to animate a gradient using the `@property` rule when the user hovers over an element.
 - **Fallbacks**: When using the custom property, you can provide a fallback value using the `var()` function, just as you would with standard custom properties.
 
 ## CSS Grid Basics 
@@ -539,7 +541,7 @@ Using placeholder text is not great for accessibility. Too often, users confuse 
 - **Implicit Grid**: When items are placed outside of the grid, then rows and columns are automatically created for those outside elements.
 - **`minmax()` Function**: This function is used to set the minimum and maximum sizes for a track. 
 - **Line-based Placement**: All grids have lines. To specify where the item begins on a line, you can use the `grid-column-start` and `grid-row-start` properties. To specify where the item ends on the line, you can use the `grid-column-end` and `grid-row-end` properties. You can also choose to use the `grid-column` or `grid-row` shorthand properties instead.
-- **`grid-template-areas`**: The property is used to provide a name for the items you are going to position on the grid. 
+- **`grid-template-areas`**: Lets you assign names to grid areas, making layout definitions more readable and semantic.
 
 ## CSS Animation Basics 
 


### PR DESCRIPTION
Improved grammar and sentence clarity in the CSS selector and attribute examples.

Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes locally on my machine.

Closes #61441

<!-- Feel free to add any additional description of changes below this line -->

This PR updates the review section of the CSS module with clearer examples and more grammatically correct descriptions to help learners understand selector usage better.

