### PR TITLE
fix: clarify CSS file linking by adding example in HTML linking challenge

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-blog-post-card/66eaddd04a9e533fba689001.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-blog-post-card/66eaddd04a9e533fba689001.md
@@ -39,6 +39,10 @@ In this lab, you'll practice how to style backgrounds and borders by creating a 
 
 **Note:** Be sure to link your stylesheet in your HTML and apply your CSS.
 
+<link rel="stylesheet" href="styles.css">
+
+
+
 # --hints--
 
 You should have a `div` with a class of `blog-post-card`.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x ] My pull request targets the `main` branch of freeCodeCamp.
- [x ] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the #61472 below with the issue number.-->

Closes #61472

<!-- Feel free to add any additional description of changes below this line -->


This pull request adds the missing <link rel="stylesheet" href="styles.css"> line in the "Link HTML and CSS Files" challenge. It clarifies the step where users are expected to connect their HTML file to a CSS file but may be confused due to the lack of explicit instruction. This enhances clarity for learners, especially beginners, and aligns the lesson content with its intended goal.









