### PR TITLE
fix: remove duplicate title from HTML lecture (#61477)

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lecture-understanding-html-attributes/66f6db08d55022680a3cfbc9.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-understanding-html-attributes/66f6db08d55022680a3cfbc9.md
@@ -7,8 +7,6 @@ dashedName: what-is-html
 
 # --description--
 
-What Role Does HTML Play on the Web?
-
 HTML, which stands for Hypertext Markup Language, is a markup language for creating web pages. When you visit a website and see content like paragraphs, headings, links, images, and videos; that's HTML. HTML represents the content and structure of a webpage through the use of elements. Here's an example of a paragraph element:
 
 ```html


### PR DESCRIPTION
### Summary

This PR removes a duplicate title from the file:
`freeCodeCamp/curriculum/challenges/english/25-front-end-development/lecture-understanding-html-attributes/66f6db08d55022680a3cfbc9.md`

The title `What Role Does HTML Play on the Web?` already exists in the frontmatter, so it was removed from the body content to avoid redundancy.

### Related Issue

Closes #61477

### Checklist

- [x] I have read the contribution guidelines
- [x] I followed the instructions provided in the issue description
