### PR TITLE
fix(curriculum): remove redundant question from HTML attributes lecture

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lecture-understanding-html-attributes/66f6db08d55022680a3cfbc9.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-understanding-html-attributes/66f6db08d55022680a3cfbc9.md
@@ -7,7 +7,6 @@ dashedName: what-is-html
 
 # --description--
 
-What Role Does HTML Play on the Web?
 
 HTML, which stands for Hypertext Markup Language, is a markup language for creating web pages. When you visit a website and see content like paragraphs, headings, links, images, and videos; that's HTML. HTML represents the content and structure of a webpage through the use of elements. Here's an example of a paragraph element:
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #61477 

<!-- Feel free to add any additional description of changes below this line -->

## Description

This PR fixes a duplicate title issue in the HTML attributes lecture challenge. The file `curriculum/challenges/english/25-front-end-development/lecture-understanding-html-attributes/66f6db08d55022680a3cfbc9.md` contained a duplicate title "What Role Does HTML Play on the Web?" on line 10, which was redundant since the title is already properly defined in the frontmatter.

## Changes Made

- Removed the duplicate title line from the description section
- Ensured proper spacing with exactly one empty line after the `# --description--` heading
- The title is now only present once in the frontmatter where it belongs

## Testing

- Verified that the file structure remains correct
- Confirmed that the content flows properly without the duplicate title
- Checked that the spacing follows the established format