### PR TITLE
fix(curriculum): add period to options in Troubleshoot on GitHub

### DIFF
--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65b2b54bf7897c3954e20971.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/65b2b54bf7897c3954e20971.md
@@ -19,7 +19,7 @@ What did Tom discover while debugging?
 
 ## --answers--
 
-A complex software bug that needed elaborate fixing
+A complex software bug that needed elaborate fixing.
 
 ### --feedback--
 
@@ -27,7 +27,7 @@ Tom actually found the issue to be simpler.
 
 ---
 
-That he needed assistance from another developer
+That he needed assistance from another developer.
 
 ### --feedback--
 
@@ -43,7 +43,7 @@ Tom doesn't mention the need for a complete change.
 
 ---
 
-A simple configuration error in the code
+A simple configuration error in the code.
 
 ## --video-solution--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

A period is missing from three of the options.