### PR TITLE
feat(client): enable daily challenges + add e2e tests

### DIFF
--- a/client/src/components/daily-coding-challenge/calendar-day.tsx
+++ b/client/src/components/daily-coding-challenge/calendar-day.tsx
@@ -29,6 +29,7 @@ function DailyCodingChallengeCalendarDay({
       <button
         disabled
         className='calendar-day not-available'
+        data-playwright-test-label='calendar-day'
         aria-label={`${date && formatDisplayDate(date)}, (${t('aria.not-available')})`}
       >
         <span className='calendar-day-number' aria-hidden='true'>
@@ -42,6 +43,7 @@ function DailyCodingChallengeCalendarDay({
     <Link
       to={`/learn/daily-coding-challenge?date=${date}`}
       className='calendar-day available'
+      data-playwright-test-label='calendar-day'
       aria-label={`${date && formatDisplayDate(date)}`}
     >
       <span className='calendar-day-number' aria-hidden='true'>
@@ -49,11 +51,17 @@ function DailyCodingChallengeCalendarDay({
       </span>
 
       {isCompleted ? (
-        <span className='completed'>
+        <span
+          className='completed'
+          data-playwright-test-label='calendar-day-completed'
+        >
           <GreenPass />
         </span>
       ) : (
-        <span className='not-completed'>
+        <span
+          className='not-completed'
+          data-playwright-test-label='calendar-day-not-completed'
+        >
           <GreenNotCompleted />
         </span>
       )}

--- a/e2e/daily-coding-challenge.spec.ts
+++ b/e2e/daily-coding-challenge.spec.ts
@@ -203,12 +203,8 @@ test.describe('Daily Coding Challenges', () => {
       '# Python seed code'
     );
 
-    // Should stay on Python UI after reload
-    const reloadApiPromise = page.waitForResponse(dateRouteRe);
+    await page.goto(`/learn/daily-coding-challenge?date=${todayUsCentral}`);
 
-    await page.reload();
-    // Wait for the API call to complete so we know page it loaded
-    await reloadApiPromise;
     await expect(page.getByRole('button', { name: /main.py/i })).toBeVisible();
   });
 });

--- a/e2e/daily-coding-challenge.spec.ts
+++ b/e2e/daily-coding-challenge.spec.ts
@@ -1,8 +1,7 @@
 import { test, expect } from '@playwright/test';
 import {
   getTodayUsCentral,
-  formatDate,
-  formatDisplayDate
+  formatDate
 } from '../client/src/components/daily-coding-challenge/helpers';
 
 const dateRouteRe = /.*\/daily-coding-challenge\/date\/.*/;
@@ -12,8 +11,6 @@ const todayUsCentral = getTodayUsCentral();
 const [year, month, day] = todayUsCentral.split('-').map(Number);
 
 const todayMidnight = `${todayUsCentral}T00:00:00.000Z`;
-
-const displayDate = formatDisplayDate(todayUsCentral);
 
 const mockApiChallenge = {
   id: 'test-challenge-id',
@@ -142,10 +139,6 @@ test.describe('Daily Coding Challenges', () => {
 
     // Description
     await expect(page.getByText('Test description')).toBeVisible();
-
-    // Breadcrumbs
-    await expect(page.getByText('Daily coding challenge')).toBeVisible();
-    await expect(page.getByText(displayDate)).toBeVisible();
 
     // Language buttons
     await expect(

--- a/e2e/daily-coding-challenge.spec.ts
+++ b/e2e/daily-coding-challenge.spec.ts
@@ -81,6 +81,7 @@ test.describe('Daily Coding Challenges', () => {
     await page.route(dateRouteRe, async route => {
       await route.fulfill({
         status: 404,
+        headers: { 'Content-Type': 'application/json' },
         json: { type: 'error', message: 'Challenge not found.' }
       });
     });
@@ -95,6 +96,7 @@ test.describe('Daily Coding Challenges', () => {
     await page.route(dateRouteRe, async route => {
       await route.fulfill({
         status: 500,
+        headers: { 'Content-Type': 'application/json' },
         json: { type: 'error', message: 'Internal server error.' }
       });
     });
@@ -110,8 +112,9 @@ test.describe('Daily Coding Challenges', () => {
   }) => {
     await page.route(dateRouteRe, async route => {
       await route.fulfill({
-        json: { invalid: 'data structure' },
-        status: 200
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+        json: { invalid: 'data structure' }
       });
     });
 
@@ -126,8 +129,9 @@ test.describe('Daily Coding Challenges', () => {
   }) => {
     await page.route(dateRouteRe, async route => {
       await route.fulfill({
-        json: mockApiChallenge,
-        status: 200
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+        json: mockApiChallenge
       });
     });
 
@@ -153,8 +157,9 @@ test.describe('Daily Coding Challenges', () => {
   }) => {
     await page.route(dateRouteRe, async route => {
       await route.fulfill({
-        json: mockApiChallenge,
-        status: 200
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+        json: mockApiChallenge
       });
     });
 
@@ -213,8 +218,9 @@ test.describe('Daily Coding Challenge Archive', () => {
   test('should load and display the calendar', async ({ page }) => {
     await page.route(allRouteRe, async route => {
       await route.fulfill({
-        json: mockApiAllChallenges,
-        status: 200
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+        json: mockApiAllChallenges
       });
     });
 

--- a/e2e/daily-coding-challenge.spec.ts
+++ b/e2e/daily-coding-challenge.spec.ts
@@ -124,29 +124,6 @@ test.describe('Daily Coding Challenges', () => {
     ).toBeVisible();
   });
 
-  // test('', async ({
-  //   page
-  // }) => {
-  //   await page.route(dateRouteRe, async route => {
-  //     await route.fulfill({
-  //       status: 200,
-  //       headers: { 'Content-Type': 'application/json' },
-  //       json: mockApiChallenge
-  //     });
-  //   });
-
-  //   await page.goto(`/learn/daily-coding-challenge?date=${todayUsCentral}`);
-
-  //   // Breadcrumbs
-  //   // await expect(
-  //   //   page.getByRole('link', { name: /daily coding challenge/i })
-  //   // ).toBeVisible();
-  //   // await expect(
-  //   //   page.getByRole('link', { name: new RegExp(displayDate, 'i') })
-  //   // ).toBeVisible();
-
-  // });
-
   test('should load and display a daily coding challenge with a valid date, and should be able to switch between JavaScript and Python', async ({
     page
   }) => {
@@ -167,11 +144,12 @@ test.describe('Daily Coding Challenges', () => {
     await expect(page.getByText('Test description')).toBeVisible();
 
     // Breadcrumbs
+    const breadcrumb = page.getByTestId('breadcrumb-desktop');
     await expect(
-      page.getByRole('link', { name: /daily coding challenge/i })
+      breadcrumb.getByRole('link', { name: /daily coding challenge/i })
     ).toBeVisible();
     await expect(
-      page.getByRole('link', { name: new RegExp(displayDate, 'i') })
+      breadcrumb.getByRole('link', { name: new RegExp(displayDate, 'i') })
     ).toBeVisible();
 
     // Language buttons

--- a/e2e/daily-coding-challenge.spec.ts
+++ b/e2e/daily-coding-challenge.spec.ts
@@ -134,10 +134,8 @@ test.describe('Daily Coding Challenges', () => {
 
     await page.goto(`/learn/daily-coding-challenge?date=${todayUsCentral}`);
 
-    // Title
     await expect(page.getByText('Test title')).toBeVisible();
 
-    // Description
     await expect(page.getByText('Test description')).toBeVisible();
 
     // Language buttons
@@ -148,19 +146,14 @@ test.describe('Daily Coding Challenges', () => {
 
     // Should show JS UI by default
 
-    // script.js button
     await expect(
       page.getByRole('button', { name: /script.js/i })
     ).toBeVisible();
-    // No main.py button
     await expect(
       page.getByRole('button', { name: /main.py/i })
     ).not.toBeVisible();
-    // Console Button
     await expect(page.getByRole('button', { name: /console/i })).toBeVisible();
-    // No Preview button
     await expect(page.getByTestId('preview-pane-button')).not.toBeVisible();
-    // Should have JS seed code
     await expect(page.locator("div[role='code'].monaco-editor")).toContainText(
       '// JavaScript seed code'
     );
@@ -168,17 +161,12 @@ test.describe('Daily Coding Challenges', () => {
     // Show show Python UI after changing language
     await page.getByRole('button', { name: /python/i }).click();
 
-    // main.py button
     await expect(page.getByRole('button', { name: /main.py/i })).toBeVisible();
-    // No script.js button
     await expect(
       page.getByRole('button', { name: /script.js/i })
     ).not.toBeVisible();
-    // Console Button
     await expect(page.getByRole('button', { name: /console/i })).toBeVisible();
-    // Preview button
     await expect(page.getByTestId('preview-pane-button')).toBeVisible();
-    // Should have Python seed code
     await expect(page.locator("div[role='code'].monaco-editor")).toContainText(
       '# Python seed code'
     );
@@ -203,7 +191,6 @@ test.describe('Daily Coding Challenge Archive', () => {
 
     await expect(page.getByText('Daily Coding Challenges')).toBeVisible();
 
-    // Navigation buttons
     await expect(
       page.getByRole('button', { name: /previous month/i })
     ).toBeVisible();
@@ -211,19 +198,15 @@ test.describe('Daily Coding Challenge Archive', () => {
       page.getByRole('button', { name: /next month/i })
     ).toBeVisible();
 
-    // Go to today button
     await expect(
       page.getByRole('link', { name: /go to today/i })
     ).toBeVisible();
 
-    // Calendar should render a day for each day in the month
     const totalCalendarDays = await page.getByTestId('calendar-day').count();
     expect(totalCalendarDays).toBe(mockDaysInMonth);
 
-    // Completed days
     await expect(page.getByTestId('calendar-day-completed')).toHaveCount(1);
 
-    // Not completed days
     await expect(page.getByTestId('calendar-day-not-completed')).toHaveCount(1);
   });
 });

--- a/e2e/daily-coding-challenge.spec.ts
+++ b/e2e/daily-coding-challenge.spec.ts
@@ -144,13 +144,8 @@ test.describe('Daily Coding Challenges', () => {
     await expect(page.getByText('Test description')).toBeVisible();
 
     // Breadcrumbs
-    const breadcrumb = page.getByTestId('breadcrumb-desktop');
-    await expect(
-      breadcrumb.getByRole('link', { name: /daily coding challenge/i })
-    ).toBeVisible();
-    await expect(
-      breadcrumb.getByRole('link', { name: new RegExp(displayDate, 'i') })
-    ).toBeVisible();
+    await expect(page.getByText('Daily coding challenge')).toBeVisible();
+    await expect(page.getByText(displayDate)).toBeVisible();
 
     // Language buttons
     await expect(

--- a/e2e/daily-coding-challenge.spec.ts
+++ b/e2e/daily-coding-challenge.spec.ts
@@ -1,0 +1,252 @@
+import { test, expect } from '@playwright/test';
+import {
+  getTodayUsCentral,
+  formatDate,
+  formatDisplayDate
+} from '../client/src/components/daily-coding-challenge/helpers';
+
+const dateRouteRe = /.*\/daily-coding-challenge\/date\/.*/;
+const allRouteRe = /.*\/daily-coding-challenge\/all/;
+
+const todayUsCentral = getTodayUsCentral();
+const [year, month, day] = todayUsCentral.split('-').map(Number);
+
+const todayMidnight = `${todayUsCentral}T00:00:00.000Z`;
+
+const displayDate = formatDisplayDate(todayUsCentral);
+
+const mockApiChallenge = {
+  id: 'test-challenge-id',
+  challengeNumber: 1,
+  title: 'Test title',
+  date: todayMidnight,
+  description: 'Test description',
+  javascript: {
+    tests: [
+      {
+        text: 'Test text',
+        testString: 'assert.strictEqual(true, true);'
+      }
+    ],
+    challengeFiles: [
+      {
+        fileKey: 'scriptjs',
+        contents: '// JavaScript seed code'
+      }
+    ]
+  },
+  python: {
+    tests: [
+      {
+        text: 'Test text',
+        testString: '({test: () => { runPython(`assert True == True`)}})'
+      }
+    ],
+    challengeFiles: [
+      {
+        fileKey: 'mainpy',
+        contents: '# Python seed code'
+      }
+    ]
+  }
+};
+
+const mockApiAllChallenges = [
+  // today
+  {
+    // real ID from certified user so it shows completed in calendar
+    id: '6814d8e1516e86b171929de4',
+    date: todayMidnight
+  },
+  // yesterday, or tomorrow if today is the first
+  {
+    id: 'other-id',
+    date: `${formatDate({ year, month, day: day === 1 ? day + 1 : day - 1 })}T00:00:00.000Z`
+  }
+];
+
+const mockDaysInMonth = new Date(year, month, 0).getDate();
+
+test.describe('Daily Coding Challenges', () => {
+  test('should show not found page for invalid date', async ({ page }) => {
+    await page.goto('/learn/daily-coding-challenge?date=invalid-date');
+    await expect(
+      page.getByText(/daily coding challenge not found\./i)
+    ).toBeVisible();
+  });
+
+  test('should show not found page for date without challenge', async ({
+    page
+  }) => {
+    await page.route(dateRouteRe, async route => {
+      await route.fulfill({
+        status: 404,
+        json: { type: 'error', message: 'Challenge not found.' }
+      });
+    });
+
+    await page.goto('/learn/daily-coding-challenge?date=2025-01-01');
+    await expect(
+      page.getByText(/daily coding challenge not found\./i)
+    ).toBeVisible();
+  });
+
+  test('should show not found page for API error', async ({ page }) => {
+    await page.route(dateRouteRe, async route => {
+      await route.fulfill({
+        status: 500,
+        json: { type: 'error', message: 'Internal server error.' }
+      });
+    });
+
+    await page.goto('/learn/daily-coding-challenge?date=2025-01-01');
+    await expect(
+      page.getByText(/daily coding challenge not found\./i)
+    ).toBeVisible();
+  });
+
+  test('should show not found page for invalid challenge data', async ({
+    page
+  }) => {
+    await page.route(dateRouteRe, async route => {
+      await route.fulfill({
+        json: { invalid: 'data structure' },
+        status: 200
+      });
+    });
+
+    await page.goto('/learn/daily-coding-challenge?date=2025-06-27');
+    await expect(
+      page.getByText(/daily coding challenge not found\./i)
+    ).toBeVisible();
+  });
+
+  test('should load and display a daily coding challenge with a valid date', async ({
+    page
+  }) => {
+    await page.route(dateRouteRe, async route => {
+      await route.fulfill({
+        json: mockApiChallenge,
+        status: 200
+      });
+    });
+
+    await page.goto(`/learn/daily-coding-challenge?date=${todayUsCentral}`);
+
+    // Title
+    await expect(page.getByText('Test title')).toBeVisible();
+
+    // Description
+    await expect(page.getByText('Test description')).toBeVisible();
+
+    // Breadcrumbs
+    await expect(
+      page.getByRole('link', { name: /daily coding challenge/i })
+    ).toBeVisible();
+    await expect(
+      page.getByRole('link', { name: new RegExp(displayDate, 'i') })
+    ).toBeVisible();
+  });
+
+  test('should be able to switch between JavaScript and Python', async ({
+    page
+  }) => {
+    await page.route(dateRouteRe, async route => {
+      await route.fulfill({
+        json: mockApiChallenge,
+        status: 200
+      });
+    });
+
+    await page.goto(`/learn/daily-coding-challenge?date=${todayUsCentral}`);
+
+    // Language buttons
+    await expect(
+      page.getByRole('button', { name: /javascript/i })
+    ).toBeVisible();
+    await expect(page.getByRole('button', { name: /python/i })).toBeVisible();
+
+    // Should show JS UI by default
+
+    // script.js button
+    await expect(
+      page.getByRole('button', { name: /script.js/i })
+    ).toBeVisible();
+    // No main.py button
+    await expect(
+      page.getByRole('button', { name: /main.py/i })
+    ).not.toBeVisible();
+    // Console Button
+    await expect(page.getByRole('button', { name: /console/i })).toBeVisible();
+    // No Preview button
+    await expect(page.getByTestId('preview-pane-button')).not.toBeVisible();
+    // Should have JS seed code
+    await expect(page.locator("div[role='code'].monaco-editor")).toContainText(
+      '// JavaScript seed code'
+    );
+
+    // Show show Python UI after changing language
+    await page.getByRole('button', { name: /python/i }).click();
+
+    // main.py button
+    await expect(page.getByRole('button', { name: /main.py/i })).toBeVisible();
+    // No script.js button
+    await expect(
+      page.getByRole('button', { name: /script.js/i })
+    ).not.toBeVisible();
+    // Console Button
+    await expect(page.getByRole('button', { name: /console/i })).toBeVisible();
+    // Preview button
+    await expect(page.getByTestId('preview-pane-button')).toBeVisible();
+    // Should have Python seed code
+    await expect(page.locator("div[role='code'].monaco-editor")).toContainText(
+      '# Python seed code'
+    );
+
+    // Should stay on Python UI after reload
+    const reloadApiPromise = page.waitForResponse(dateRouteRe);
+
+    await page.reload();
+    // Wait for the API call to complete so we know page it loaded
+    await reloadApiPromise;
+    await expect(page.getByRole('button', { name: /main.py/i })).toBeVisible();
+  });
+});
+
+test.describe('Daily Coding Challenge Archive', () => {
+  test('should load and display the calendar', async ({ page }) => {
+    await page.route(allRouteRe, async route => {
+      await route.fulfill({
+        json: mockApiAllChallenges,
+        status: 200
+      });
+    });
+
+    await page.goto('/learn/daily-coding-challenge/archive');
+
+    await expect(page.getByText('Daily Coding Challenges')).toBeVisible();
+
+    // Navigation buttons
+    await expect(
+      page.getByRole('button', { name: /previous month/i })
+    ).toBeVisible();
+    await expect(
+      page.getByRole('button', { name: /next month/i })
+    ).toBeVisible();
+
+    // Go to today button
+    await expect(
+      page.getByRole('link', { name: /go to today/i })
+    ).toBeVisible();
+
+    // Calendar should render a day for each day in the month
+    const totalCalendarDays = await page.getByTestId('calendar-day').count();
+    expect(totalCalendarDays).toBe(mockDaysInMonth);
+
+    // Completed days
+    await expect(page.getByTestId('calendar-day-completed')).toHaveCount(1);
+
+    // Not completed days
+    await expect(page.getByTestId('calendar-day-not-completed')).toHaveCount(1);
+  });
+});

--- a/e2e/daily-coding-challenge.spec.ts
+++ b/e2e/daily-coding-challenge.spec.ts
@@ -1,8 +1,8 @@
 import { test, expect } from '@playwright/test';
 import {
   getTodayUsCentral,
-  formatDate
-  // formatDisplayDate
+  formatDate,
+  formatDisplayDate
 } from '../client/src/components/daily-coding-challenge/helpers';
 
 const dateRouteRe = /.*\/daily-coding-challenge\/date\/.*/;
@@ -13,7 +13,7 @@ const [year, month, day] = todayUsCentral.split('-').map(Number);
 
 const todayMidnight = `${todayUsCentral}T00:00:00.000Z`;
 
-// const displayDate = formatDisplayDate(todayUsCentral);
+const displayDate = formatDisplayDate(todayUsCentral);
 
 const mockApiChallenge = {
   id: 'test-challenge-id',
@@ -167,12 +167,12 @@ test.describe('Daily Coding Challenges', () => {
     await expect(page.getByText('Test description')).toBeVisible();
 
     // Breadcrumbs
-    // await expect(
-    //   page.getByRole('link', { name: /daily coding challenge/i })
-    // ).toBeVisible();
-    // await expect(
-    //   page.getByRole('link', { name: new RegExp(displayDate, 'i') })
-    // ).toBeVisible();
+    await expect(
+      page.getByRole('link', { name: /daily coding challenge/i })
+    ).toBeVisible();
+    await expect(
+      page.getByRole('link', { name: new RegExp(displayDate, 'i') })
+    ).toBeVisible();
 
     // Language buttons
     await expect(

--- a/e2e/daily-coding-challenge.spec.ts
+++ b/e2e/daily-coding-challenge.spec.ts
@@ -1,8 +1,8 @@
 import { test, expect } from '@playwright/test';
 import {
   getTodayUsCentral,
-  formatDate,
-  formatDisplayDate
+  formatDate
+  // formatDisplayDate
 } from '../client/src/components/daily-coding-challenge/helpers';
 
 const dateRouteRe = /.*\/daily-coding-challenge\/date\/.*/;
@@ -13,7 +13,7 @@ const [year, month, day] = todayUsCentral.split('-').map(Number);
 
 const todayMidnight = `${todayUsCentral}T00:00:00.000Z`;
 
-const displayDate = formatDisplayDate(todayUsCentral);
+// const displayDate = formatDisplayDate(todayUsCentral);
 
 const mockApiChallenge = {
   id: 'test-challenge-id',
@@ -124,7 +124,30 @@ test.describe('Daily Coding Challenges', () => {
     ).toBeVisible();
   });
 
-  test('should load and display a daily coding challenge with a valid date', async ({
+  // test('', async ({
+  //   page
+  // }) => {
+  //   await page.route(dateRouteRe, async route => {
+  //     await route.fulfill({
+  //       status: 200,
+  //       headers: { 'Content-Type': 'application/json' },
+  //       json: mockApiChallenge
+  //     });
+  //   });
+
+  //   await page.goto(`/learn/daily-coding-challenge?date=${todayUsCentral}`);
+
+  //   // Breadcrumbs
+  //   // await expect(
+  //   //   page.getByRole('link', { name: /daily coding challenge/i })
+  //   // ).toBeVisible();
+  //   // await expect(
+  //   //   page.getByRole('link', { name: new RegExp(displayDate, 'i') })
+  //   // ).toBeVisible();
+
+  // });
+
+  test('should load and display a daily coding challenge with a valid date, and should be able to switch between JavaScript and Python', async ({
     page
   }) => {
     await page.route(dateRouteRe, async route => {
@@ -144,26 +167,12 @@ test.describe('Daily Coding Challenges', () => {
     await expect(page.getByText('Test description')).toBeVisible();
 
     // Breadcrumbs
-    await expect(
-      page.getByRole('link', { name: /daily coding challenge/i })
-    ).toBeVisible();
-    await expect(
-      page.getByRole('link', { name: new RegExp(displayDate, 'i') })
-    ).toBeVisible();
-  });
-
-  test('should be able to switch between JavaScript and Python', async ({
-    page
-  }) => {
-    await page.route(dateRouteRe, async route => {
-      await route.fulfill({
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-        json: mockApiChallenge
-      });
-    });
-
-    await page.goto(`/learn/daily-coding-challenge?date=${todayUsCentral}`);
+    // await expect(
+    //   page.getByRole('link', { name: /daily coding challenge/i })
+    // ).toBeVisible();
+    // await expect(
+    //   page.getByRole('link', { name: new RegExp(displayDate, 'i') })
+    // ).toBeVisible();
 
     // Language buttons
     await expect(

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -13,8 +13,6 @@ dotenvConfig({ path: envPath });
  */
 export default defineConfig({
   testDir: 'e2e',
-  /* Run only daily coding challenge tests for debugging */
-  testMatch: '**/daily-coding-challenge.spec.ts',
   /* Run tests in files in parallel */
   fullyParallel: false,
   /* Fail the build on CI if you accidentally left test.only in the source code. */

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -13,6 +13,8 @@ dotenvConfig({ path: envPath });
  */
 export default defineConfig({
   testDir: 'e2e',
+  /* Run only daily coding challenge tests for debugging */
+  testMatch: '**/daily-coding-challenge.spec.ts',
   /* Run tests in files in parallel */
   fullyParallel: false,
   /* Fail the build on CI if you accidentally left test.only in the source code. */

--- a/sample.env
+++ b/sample.env
@@ -54,7 +54,7 @@ CURRICULUM_LOCALE=english
 
 # Show or hide WIP in progress challenges
 SHOW_UPCOMING_CHANGES=false
-SHOW_DAILY_CODING_CHALLENGES=false
+SHOW_DAILY_CODING_CHALLENGES=true
 
 # ---------------------
 # New API

--- a/tools/scripts/seed/user-data.js
+++ b/tools/scripts/seed/user-data.js
@@ -12281,6 +12281,13 @@ module.exports.fullyCertifiedUser = {
       id: '672d456f4ac35950b300e93f'
     }
   ],
+  completedDailyCodingChallenges: [
+    {
+      id: '6814d8e1516e86b171929de4',
+      completedDate: 1729240849345,
+      languages: ['javascript']
+    }
+  ],
   completedExams: [
     {
       id: '647e22d18acb466c97ccbef8',


### PR DESCRIPTION
I just set `SHOW_DAILY_CODING_CHALLENGES=true` in the `sample.env` - which should let the tests pass, and then we can set it manually in our VM's to show it on staging and prod.

I'm not sure if that's the way to go, or if I should remove the variable entirely right now and default them to shown. I guess the reason maybe not to is if we want to revert it quickly or something.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
