### PR TITLE
fix(api): return usernameDisplay

### DIFF
--- a/api/src/routes/protected/user.test.ts
+++ b/api/src/routes/protected/user.test.ts
@@ -140,6 +140,7 @@ const minimalUserData: Prisma.userCreateInput = {
   picture: 'https://www.freecodecamp.org/cat.png',
   sendQuincyEmail: true,
   username: 'testuser',
+  usernameDisplay: 'testuser',
   unsubscribeId: '1234567890'
 };
 
@@ -276,7 +277,8 @@ const publicUserData = {
   profileUI: testUserData.profileUI,
   savedChallenges: testUserData.savedChallenges,
   twitter: 'https://twitter.com/foobar',
-  username: testUserData.usernameDisplay, // It defaults to usernameDisplay
+  username: testUserData.username,
+  usernameDisplay: testUserData.usernameDisplay,
   website: testUserData.website,
   yearsTopContributor: testUserData.yearsTopContributor
 };

--- a/api/src/routes/protected/user.ts
+++ b/api/src/routes/protected/user.ts
@@ -683,7 +683,7 @@ export const userGetRoutes: FastifyPluginCallbackTypebox = (
               theme: theme ?? 'default',
               twitter: normalizeTwitter(twitter),
               username,
-              usernameDisplay,
+              usernameDisplay: usernameDisplay || username,
               userToken: encodedToken,
               completedSurveys: normalizeSurveys(completedSurveys),
               msUsername: msUsername?.msUsername

--- a/api/src/routes/protected/user.ts
+++ b/api/src/routes/protected/user.ts
@@ -682,7 +682,8 @@ export const userGetRoutes: FastifyPluginCallbackTypebox = (
               name: name ?? '',
               theme: theme ?? 'default',
               twitter: normalizeTwitter(twitter),
-              username: usernameDisplay || username,
+              username,
+              usernameDisplay,
               userToken: encodedToken,
               completedSurveys: normalizeSurveys(completedSurveys),
               msUsername: msUsername?.msUsername

--- a/api/src/routes/public/user.test.ts
+++ b/api/src/routes/public/user.test.ts
@@ -206,7 +206,8 @@ const publicUserData = {
   profileUI: testUserData.profileUI,
   savedChallenges: testUserData.savedChallenges,
   twitter: 'https://twitter.com/foobar',
-  username: testUserData.usernameDisplay, // It defaults to usernameDisplay
+  username: testUserData.username,
+  usernameDisplay: testUserData.usernameDisplay,
   website: testUserData.website,
   yearsTopContributor: testUserData.yearsTopContributor
 };

--- a/api/src/routes/public/user.ts
+++ b/api/src/routes/public/user.ts
@@ -166,7 +166,7 @@ export const userPublicGetRoutes: FastifyPluginCallbackTypebox = (
                 isLocked: true,
                 profileUI: normalizedProfileUI,
                 username: user.username,
-                usernameDisplay: user.usernameDisplay
+                usernameDisplay: user.usernameDisplay || user.username,
               }
             }
           },

--- a/api/src/routes/public/user.ts
+++ b/api/src/routes/public/user.ts
@@ -166,7 +166,7 @@ export const userPublicGetRoutes: FastifyPluginCallbackTypebox = (
                 isLocked: true,
                 profileUI: normalizedProfileUI,
                 username: user.username,
-                usernameDisplay: user.usernameDisplay || user.username,
+                usernameDisplay: user.usernameDisplay || user.username
               }
             }
           },
@@ -197,7 +197,8 @@ export const userPublicGetRoutes: FastifyPluginCallbackTypebox = (
           // setting control it? Same applies to website, githubProfile,
           // and linkedin.
           twitter: normalizeTwitter(user.twitter),
-          yearsTopContributor: user.yearsTopContributor
+          yearsTopContributor: user.yearsTopContributor,
+          usernameDisplay: user.usernameDisplay || user.username
         };
         return reply.send({
           // TODO(Post-MVP): just return a user object (i.e. returnedUser) and

--- a/api/src/routes/public/user.ts
+++ b/api/src/routes/public/user.ts
@@ -150,7 +150,6 @@ export const userPublicGetRoutes: FastifyPluginCallbackTypebox = (
         'unsubscribeId',
         'donationEmails',
         'externalId',
-        'usernameDisplay',
         'isBanned'
       ]);
 
@@ -166,7 +165,8 @@ export const userPublicGetRoutes: FastifyPluginCallbackTypebox = (
               [user.username]: {
                 isLocked: true,
                 profileUI: normalizedProfileUI,
-                username: user.username
+                username: user.username,
+                usernameDisplay: user.usernameDisplay
               }
             }
           },

--- a/api/src/schemas/user/get-session-user.ts
+++ b/api/src/schemas/user/get-session-user.ts
@@ -117,6 +117,7 @@ export const getSessionUser = {
           joinDate: Type.String(),
           savedChallenges: Type.Optional(Type.Array(savedChallenge)),
           username: Type.String(),
+          usernameDisplay: Type.Union([Type.String(), Type.Null()]),
           userToken: Type.Optional(Type.String()),
           completedSurveys: Type.Array(
             Type.Object({

--- a/api/src/schemas/user/get-session-user.ts
+++ b/api/src/schemas/user/get-session-user.ts
@@ -117,7 +117,7 @@ export const getSessionUser = {
           joinDate: Type.String(),
           savedChallenges: Type.Optional(Type.Array(savedChallenge)),
           username: Type.String(),
-          usernameDisplay: Type.Union([Type.String(), Type.Null()]),
+          usernameDisplay: Type.String(),
           userToken: Type.Optional(Type.String()),
           completedSurveys: Type.Array(
             Type.Object({

--- a/api/src/schemas/users/get-public-profile.ts
+++ b/api/src/schemas/users/get-public-profile.ts
@@ -102,9 +102,7 @@ export const getPublicProfile = {
               joinDate: Type.String(),
               savedChallenges: Type.Array(savedChallenge),
               username: Type.String(),
-              usernameDisplay: Type.Optional(
-                Type.Union([Type.String(), Type.Null()])
-              ),
+              usernameDisplay: Type.String(),
               msUsername: Type.Optional(Type.String())
             })
           ])

--- a/api/src/schemas/users/get-public-profile.ts
+++ b/api/src/schemas/users/get-public-profile.ts
@@ -102,6 +102,9 @@ export const getPublicProfile = {
               joinDate: Type.String(),
               savedChallenges: Type.Array(savedChallenge),
               username: Type.String(),
+              usernameDisplay: Type.Optional(
+                Type.Union([Type.String(), Type.Null()])
+              ),
               msUsername: Type.Optional(Type.String())
             })
           ])

--- a/client/src/client-only-routes/show-profile-or-four-oh-four.tsx
+++ b/client/src/client-only-routes/show-profile-or-four-oh-four.tsx
@@ -29,7 +29,8 @@ interface ShowProfileOrFourOhFourProps {
 const makeMapStateToProps =
   () =>
   (state: unknown, { maybeUser = '' }) => {
-    const username = maybeUser.toLowerCase();
+    // const username = maybeUser.toLowerCase();
+    const username = maybeUser;
     const requestedUser = (
       createUserByNameSelector as (
         maybeUser: string

--- a/client/src/client-only-routes/show-profile-or-four-oh-four.tsx
+++ b/client/src/client-only-routes/show-profile-or-four-oh-four.tsx
@@ -29,8 +29,7 @@ interface ShowProfileOrFourOhFourProps {
 const makeMapStateToProps =
   () =>
   (state: unknown, { maybeUser = '' }) => {
-    // const username = maybeUser.toLowerCase();
-    const username = maybeUser;
+    const username = maybeUser.toLowerCase();
     const requestedUser = (
       createUserByNameSelector as (
         maybeUser: string


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #61565 

NOTE: This now introduces a small break where the `username` is shown in the client everywhere the `usernameDisplay` used to be shown.

That is to say, instead of showing `developmentUser` on the profile page, it will show `developmentuser`.