### PR TITLE
fix: remove video references and update challengeType to 19 in CSS Variable and grid

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-grid/672aa8ac4631d1623ec5cd86.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-grid/672aa8ac4631d1623ec5cd86.md
@@ -1,8 +1,7 @@
 ---
 id: 672aa8ac4631d1623ec5cd86
 title: What Is CSS Grid, and How Does It Differ from Flexbox?
-challengeType: 11
-videoId: uh0EzmmlpwQ
+challengeType: 19
 dashedName: what-is-css-grid
 ---
 
@@ -11,8 +10,6 @@ dashedName: what-is-css-grid
 Watch the video or read the transcript and answer the questions below.
 
 # --transcript--
-
-What is CSS Grid, and how does it differ from Flexbox?
 
 CSS Grid is a powerful layout system that allows web developers to create complex and responsive web page layouts with ease.
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-grid/673226732b19aa1cacd0a75c.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-grid/673226732b19aa1cacd0a75c.md
@@ -1,8 +1,8 @@
 ---
 id: 673226732b19aa1cacd0a75c
 title: How Can You Create Flexible Grids with the fr Unit?
-challengeType: 11
-videoId: frGW2L836GU
+challengeType: 19
+
 dashedName: how-can-you-create-flexible-grids-with-the-fr-unit
 ---
 
@@ -12,9 +12,9 @@ Watch the video or read the transcript and answer the questions below.
 
 # --transcript--
 
-How can you create flexible grids with the `fr` unit?
 
-In the previous lecture video, you were introduced to CSS grid which can be used to create complex and fluid layouts in your web pages. In this video, we will explore how to create flexible grid layouts using the `fr` unit.
+
+In the previous lecture, you were introduced to CSS grid which can be used to create complex and fluid layouts in your web pages. In this video, we will explore how to create flexible grid layouts using the `fr` unit.
 
 Let's start with this HTML markup which is going to represent our grid container:
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-grid/6732267ecab2151ced471cd4.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-grid/6732267ecab2151ced471cd4.md
@@ -1,8 +1,8 @@
 ---
 id: 6732267ecab2151ced471cd4
 title: How Can You Create Gaps Between Tracks in a Grid?
-challengeType: 11
-videoId: f8jbUFfvZ_Q
+challengeType: 19
+
 dashedName: how-can-you-create-gaps-between-tracks-in-a-grid
 ---
 
@@ -12,9 +12,8 @@ Watch the video or read the transcript and answer the questions below.
 
 # --transcript--
 
-How can you create gaps between tracks in a grid?
 
-In the previous lecture videos, we talked a little bit about how to create space between grid items. But in this video, we will dive into more detail about how to use the `row-gap`, `column-gap` and `gap` properties in a grid layout.
+In the previous lecture, we talked a little bit about how to create space between grid items. But in this video, we will dive into more detail about how to use the `row-gap`, `column-gap` and `gap` properties in a grid layout.
 
 But first we need to review what a track is in CSS grid. A track is the space between two neighboring grid lines. These lines are automatically created when you use CSS Grid. In this context, tracks generally refer to the rows and columns that make up the grid layout.
 
@@ -141,7 +140,7 @@ The `gap` between columns is set to 10
 
 ### --feedback--
 
-Review the beginning of the video where this was discussed.
+Think about the spacing for columns here..
 
 ---
 
@@ -149,7 +148,7 @@ The `gap` between columns is set to -1
 
 ### --feedback--
 
-Review the beginning of the video where this was discussed.
+Think about the spacing for columns here.
 
 ---
 
@@ -157,7 +156,7 @@ The `gap` between columns is set to 14
 
 ### --feedback--
 
-Review the beginning of the video where this was discussed.
+Think about the spacing for columns here.
 
 ---
 
@@ -177,7 +176,7 @@ Which of the following is the correct property used as a shorthand for creating 
 
 ### --feedback--
 
-Review the end of the video where the correct property is discussed.
+Think about the spacing for columns here..
 
 ---
 
@@ -185,7 +184,7 @@ Review the end of the video where the correct property is discussed.
 
 ### --feedback--
 
-Review the end of the video where the correct property is discussed.
+Think about the spacing for columns here.
 
 ---
 
@@ -193,7 +192,7 @@ Review the end of the video where the correct property is discussed.
 
 ### --feedback--
 
-Review the end of the video where the correct property is discussed.
+Think about the spacing for columns here.
 
 ---
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-grid/6732268d05c3661d32a0fee8.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-grid/6732268d05c3661d32a0fee8.md
@@ -1,8 +1,8 @@
 ---
 id: 6732268d05c3661d32a0fee8
 title: How Can You Repeat Track Listings in a Grid Layout?
-challengeType: 11
-videoId: d2wi5br6o0E
+challengeType: 19
+
 dashedName: how-can-you-repeat-track-listings-in-a-grid-layout
 ---
 
@@ -12,7 +12,7 @@ Watch the video or read the transcript and answer the questions below.
 
 # --transcript--
 
-How can you repeat track listings in a grid layout?
+
 
 In the previous lecture videos, we have been working with the `grid-template-columns` property and setting the value to a few fractional units.
 
@@ -88,7 +88,7 @@ Which of the following is the correct syntax for repeating track listings?
 
 ### --feedback--
 
-Review the beginning of the video where this was discussed.
+The `repeat()` function uses the syntax `repeat(count, track-size)`. The count comes first, followed by a comma, then the track size
 
 ---
 
@@ -112,7 +112,7 @@ Review the beginning of the video where this was discussed.
 
 ### --feedback--
 
-Review the beginning of the video where this was discussed.
+`repeat()` takes two parameters separated by a comma - first the number of repetitions, then the track size. Remove "times" and swap the order.
 
 ---
 
@@ -126,7 +126,7 @@ Review the beginning of the video where this was discussed.
 
 ### --feedback--
 
-Review the beginning of the video where this was discussed.
+`repeat()` takes two parameters separated by a comma - first the number of repetitions, then the track size. Remove "times" and swap the order.
 
 ## --video-solution--
 
@@ -179,7 +179,7 @@ It creates four columns all set to `1fr` wide.
 
 ### --feedback--
 
-Review the end of the video where this was discussed.
+
 
 ---
 
@@ -187,7 +187,7 @@ It creates two columns where each is set to `20px` wide.
 
 ### --feedback--
 
-Review the end of the video where this was discussed.
+
 
 ---
 
@@ -199,7 +199,7 @@ It creates three columns where the first and second are `20px` wide, and the thi
 
 ### --feedback--
 
-Review the end of the video where this was discussed.
+
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-grid/6732269a7aa2ca1d6b6574fe.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-grid/6732269a7aa2ca1d6b6574fe.md
@@ -1,8 +1,8 @@
 ---
 id: 6732269a7aa2ca1d6b6574fe
 title: What Is the Difference Between an Implicit and Explicit Grid?
-challengeType: 11
-videoId: QMqRqHE_t8k
+challengeType: 19
+
 dashedName: what-is-the-difference-between-an-implicit-and-explicit-grid
 ---
 
@@ -12,7 +12,7 @@ Watch the video or read the transcript and answer the questions below.
 
 # --transcript--
 
-What is the difference between an implicit and explicit grid?
+
 
 Implicit grid refers to the rows and columns automatically created by the browser when placing items in a grid layout – those not explicitly defined using `grid-template-rows` or `grid-template-columns`.
 
@@ -116,7 +116,7 @@ Which properties are used to define explicit rows and columns in a CSS grid layo
 
 ### --feedback--
 
-Review the beginning of the video where this was discussed.
+Think about properties that define implicit grid tracks.
 
 ---
 
@@ -124,7 +124,7 @@ Review the beginning of the video where this was discussed.
 
 ### --feedback--
 
-Review the beginning of the video where this was discussed.
+Think about properties that define implicit grid tracks.
 
 ---
 
@@ -136,7 +136,7 @@ Review the beginning of the video where this was discussed.
 
 ### --feedback--
 
-Review the beginning of the video where this was discussed.
+Think about properties that define implicit grid tracks.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-grid/673226a62eb2121da41a3d68.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-grid/673226a62eb2121da41a3d68.md
@@ -1,8 +1,8 @@
 ---
 id: 673226a62eb2121da41a3d68
 title: What Is the minmax() Function and How Does It Work?
-challengeType: 11
-videoId: rpWiq2k2B_8
+challengeType: 19
+
 dashedName: what-is-the-minmax-function-and-how-does-it-work
 ---
 
@@ -12,7 +12,6 @@ Watch the video or read the transcript and answer the questions below.
 
 # --transcript--
 
-What is the `minmax()` function, and how does it work?
 
 The `minmax()` function defines the range for the size of a grid track, specifying how much space a row or column can occupy.
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-grid/673226afcd33991dd751937a.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-grid/673226afcd33991dd751937a.md
@@ -1,8 +1,8 @@
 ---
 id: 673226afcd33991dd751937a
 title: How Do the grid-column and grid-row Properties Work?
-challengeType: 11
-videoId: ZX_jBMv3GJg
+challengeType: 19
+
 dashedName: how-do-the-grid-column-and-grid-row-properties-work
 ---
 
@@ -11,8 +11,6 @@ dashedName: how-do-the-grid-column-and-grid-row-properties-work
 Watch the video or read the transcript and answer the questions below.
 
 # --transcript--
-
-How do the `grid-column` and `grid-row` properties work?
 
 The `grid-column` and `grid-row` properties let you specify the horizontal and vertical placement of grid items within a grid layout.
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-grid/673226b97d4a731e0577ae93.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-grid/673226b97d4a731e0577ae93.md
@@ -1,8 +1,8 @@
 ---
 id: 673226b97d4a731e0577ae93
 title: How Can You Position Items on the Grid Using the grid-template-areas Property?
-challengeType: 11
-videoId: PV83v-6vxKw
+challengeType: 19
+
 dashedName: how-can-you-position-items-on-the-grid-using-the-grid-template-areas-property
 ---
 
@@ -12,7 +12,6 @@ Watch the video or read the transcript and answer the questions below.
 
 # --transcript--
 
-How can you position items on the grid using the `grid-template-areas` property?
 
 The `grid-template-areas` property lets you design a visual grid layout by using named labels.
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-variables/672aa8985acb7361e656f94c.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-variables/672aa8985acb7361e656f94c.md
@@ -1,8 +1,7 @@
 ---
 id: 672aa8985acb7361e656f94c
 title: What Are CSS Custom Properties, and How Do They Work?
-challengeType: 11
-videoId: rG9-26gM3eU
+challengeType: 19
 dashedName: what-are-css-custom-properties
 ---
 
@@ -12,7 +11,7 @@ Watch the video or read the transcript and answer the questions below.
 
 # --transcript--
 
-What are CSS custom properties, and how do they work?
+
 
 CSS custom properties, also known as CSS variables, are entities defined by CSS authors that contain specific values to be reused throughout a document. They are a powerful feature that allows for more efficient, maintainable, and flexible stylesheets.
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-variables/672cf3ca326da9f63683e236.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-css-variables/672cf3ca326da9f63683e236.md
@@ -1,8 +1,7 @@
 ---
 id: 672cf3ca326da9f63683e236
 title: What Is the @property Rule, and How Does It Work with Fallbacks?
-challengeType: 11
-videoId: lFwXJzcJ9fg
+challengeType: 19
 dashedName: what-is-the-at-property-rule
 ---
 
@@ -12,7 +11,6 @@ Watch the video or read the transcript and answer the questions below.
 
 # --transcript--
 
-What is the `@property` rule, and how does it work with fallbacks?
 
 The `@property` rule is a powerful CSS feature that allows developers to define custom properties with greater control over their behavior, including how they animate and their initial values. 
 


### PR DESCRIPTION
- Removed `videoId` from all related lecture files
- Changed `challengeType` to 19
- Removed transcript intros referring to videos
- Rewrote any feedback that referenced video content
- Removed duplicate titles from `--description--` where present

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #61594

<!-- Feel free to add any additional description of changes below this line -->
