### PR TITLE
fix(curriculum): sentence in build a mathbot step 1 fixed

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-mathbot/66ea7adae8053065a64f9002.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-mathbot/66ea7adae8053065a64f9002.md
@@ -49,7 +49,7 @@ Your `greeting` variable should be a string.
 assert.isString(greeting);
 ```
 
-You should use assign the following sentence to the `greeting` variable: `"Hi there! My name is [MathBot goes here] and I am here to teach you about the Math object!"`. Make sure to replace `[MathBot goes here]` with the `botName` variable.
+You should assign the following sentence to the `greeting` variable: `"Hi there! My name is [MathBot goes here] and I am here to teach you about the Math object!"`. Make sure to replace `[MathBot goes here]` with the `botName` variable.
 
 ```js
 assert.strictEqual(greeting, "Hi there! My name is MathBot and I am here to teach you about the Math object!");


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #61578 

<!-- Feel free to add any additional description of changes below this line -->
As suggested, the word use was removed from the sentence.
