### PR TITLE
fix(client): gracefully handle errors while fetching user

### DIFF
--- a/client/src/components/layouts/default.tsx
+++ b/client/src/components/layouts/default.tsx
@@ -181,7 +181,7 @@ function DefaultLayout({
 
   const isJapanese = clientLocale === 'japanese';
 
-  if (fetchState.pending) {
+  if (!fetchState.complete) {
     return <Loader fullScreen={true} messageDelay={5000} />;
   } else {
     return (

--- a/client/src/redux/action-types.js
+++ b/client/src/redux/action-types.js
@@ -46,7 +46,8 @@ export const actionTypes = createTypes(
     ...createAsyncTypes('showCert'),
     ...createAsyncTypes('reportUser'),
     ...createAsyncTypes('deleteUserToken'),
-    ...createAsyncTypes('saveChallenge')
+    ...createAsyncTypes('saveChallenge'),
+    'fetchUserTimeout'
   ],
   ns
 );

--- a/client/src/redux/actions.ts
+++ b/client/src/redux/actions.ts
@@ -50,6 +50,7 @@ export const acceptTermsError = createAction(actionTypes.acceptTermsError);
 
 export const fetchUser = createAction(actionTypes.fetchUser);
 export const fetchUserComplete = createAction(actionTypes.fetchUserComplete);
+export const fetchUserTimeout = createAction(actionTypes.fetchUserTimeout);
 export const fetchUserError = createAction(actionTypes.fetchUserError);
 
 export const toggleTheme = createAction(actionTypes.toggleTheme);

--- a/client/src/redux/fetch-user-saga.js
+++ b/client/src/redux/fetch-user-saga.js
@@ -8,14 +8,8 @@ import {
 } from './actions';
 
 function* fetchSessionUser() {
-  let timeoutId;
   try {
-    const abortController = new AbortController();
-    timeoutId = setTimeout(() => {
-      abortController.abort(Error('Request timed out after 5 seconds'));
-    }, 5000);
-
-    const res = yield call(getSessionUser, abortController.signal);
+    const res = yield call(getSessionUser, AbortSignal.timeout(5000));
 
     const isSignedOut = res.response.status === 401;
     if (!res.response.ok && !isSignedOut) {
@@ -29,8 +23,6 @@ function* fetchSessionUser() {
   } catch (e) {
     console.log('failed to fetch user', e);
     yield put(fetchUserError(e));
-  } finally {
-    clearTimeout(timeoutId);
   }
 }
 

--- a/client/src/redux/fetch-user-saga.js
+++ b/client/src/redux/fetch-user-saga.js
@@ -18,7 +18,8 @@ function* fetchSessionUser() {
       throw new Error('Request timed out after 5 seconds');
     }
 
-    if (!res.response.ok) {
+    const isSignedOut = res.response.status === 401;
+    if (!res.response.ok && !isSignedOut) {
       throw new Error(
         `HTTP Error: ${res.response.status} ${res.response.statusText}`
       );

--- a/client/src/redux/index.js
+++ b/client/src/redux/index.js
@@ -222,7 +222,7 @@ export const reducer = handleActions(
       ...state,
       userFetchState: {
         pending: false,
-        complete: false,
+        complete: true,
         errored: true,
         error: payload
       }

--- a/client/src/redux/index.js
+++ b/client/src/redux/index.js
@@ -218,6 +218,17 @@ export const reducer = handleActions(
         error: null
       }
     }),
+    [actionTypes.fetchUserTimeout]: state => ({
+      ...state,
+      userFetchState: {
+        // Pending because the fetch may still complete. This allows the UI to
+        // render what it can while waiting for the fetch to complete.
+        pending: true,
+        complete: true,
+        errored: false,
+        error: null
+      }
+    }),
     [actionTypes.fetchUserError]: (state, { payload }) => ({
       ...state,
       userFetchState: {

--- a/client/src/utils/ajax.ts
+++ b/client/src/utils/ajax.ts
@@ -37,10 +37,14 @@ export interface ResponseWithData<T> {
 
 // TODO: Might want to handle flash messages as close to the request as possible
 // to make use of the Response object (message, status, etc)
-async function get<T>(path: string): Promise<ResponseWithData<T>> {
+async function get<T>(
+  path: string,
+  signal?: AbortSignal
+): Promise<ResponseWithData<T>> {
   const response = await fetch(`${base}${path}`, {
     ...defaultOptions,
-    headers: { 'CSRF-Token': getCSRFToken() }
+    headers: { 'CSRF-Token': getCSRFToken() },
+    signal
   });
 
   return combineDataWithResponse(response);
@@ -144,9 +148,12 @@ function mapKeyToFileKey<K>(
   return files.map(({ key, ...rest }) => ({ ...rest, fileKey: key }));
 }
 
-export function getSessionUser(): Promise<ResponseWithData<User | null>> {
+export function getSessionUser(
+  signal?: AbortSignal
+): Promise<ResponseWithData<User | null>> {
   const responseWithData: Promise<ResponseWithData<ApiUserResponse>> = get(
-    '/user/get-session-user'
+    '/user/get-session-user',
+    signal
   );
   // TODO: Once DB is migrated, no longer need to parse `files` -> `challengeFiles` etc.
   return responseWithData.then(({ response, data }) => {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Prior to this PR the client would get stuck in a loader (if the fetch did not resolve) or render a mostly empty page (if there was an error during the fetch). Now the client will render properly if the fetch fails and stop showing the loader after waiting 5 seconds.

<!-- Feel free to add any additional description of changes below this line -->
