### PR TITLE
fix(curriculum): incorrect order for svg workshop

### DIFF
--- a/curriculum/superblock-structure/full-stack.json
+++ b/curriculum/superblock-structure/full-stack.json
@@ -43,13 +43,13 @@
               "dashedName": "lecture-working-with-images-and-svgs"
             },
             {
+              "dashedName": "workshop-build-a-heart-icon"
+            },
+            {
               "dashedName": "lecture-working-with-media"
             },
             {
               "dashedName": "lab-video-compilation-page"
-            },
-            {
-              "dashedName": "workshop-build-a-heart-icon"
             },
             {
               "dashedName": "lecture-working-with-links"


### PR DESCRIPTION
I missed when approving the SVG workshop PR. The order was correct in the `intro.json` but the `full-stack.json` determines the order. So this PR moves this workshop in the correct spot as shown in this issue here 

https://github.com/freeCodeCamp/CurriculumExpansion/issues/844

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.


