### PR TITLE
fix(curriculum): remove stray backtick from greeting card instructions

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-greeting-card/6720b7f3155a9278d6b6a8b8.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-greeting-card/6720b7f3155a9278d6b6a8b8.md
@@ -35,7 +35,7 @@ You should set `padding` to `40px` in the `body` selector.
 assert.strictEqual(new __helpers.CSSHelp(document).getStyle("body")?.getPropertyValue("padding"), "40px");
 ```
 
-You should set `text-align` to `center` in the `body` selector.`
+You should set `text-align` to `center` in the `body` selector.
 
 ```js
 assert.strictEqual(new __helpers.CSSHelp(document).getStyle("body")?.getPropertyValue("text-align"), "center");


### PR DESCRIPTION
## Description

This PR fixes a small formatting issue in the `workshop-greeting-card` challenge.

**Before:**
> You should set `text-align` to `center` in the `body` selector.`

**After:**
> You should set `text-align` to `center` in the `body` selector.

This removes a stray backtick and improves clarity for learners.

---

## Checklist

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or Gitpod.

Closes #61629 