### PR TITLE
fix(curriculum): fix failing test case in step 24 hotel feedback form

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a962954f4e0d76223b37ed.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a962954f4e0d76223b37ed.md
@@ -20,7 +20,7 @@ For the checkbox `input`, the `id`, `name` and `value` attributes should be set 
 You should have a `label` element with the text of `Location`.
 
 ```js
-assert.strictEqual(document.querySelectorAll('fieldset:nth-of-type(3) label')[2]?.textContent?.trim(), 'Location');
+assert.strictEqual(document.querySelectorAll('fieldset:nth-of-type(3) label')[2]?.textContent, 'Location');
 ```
 
 Your `label` should have the `for` attribute set to `"location"`.

--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a962954f4e0d76223b37ed.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a962954f4e0d76223b37ed.md
@@ -20,7 +20,7 @@ For the checkbox `input`, the `id`, `name` and `value` attributes should be set 
 You should have a `label` element with the text of `Location`.
 
 ```js
-assert.strictEqual(document.querySelectorAll('fieldset:nth-of-type(3) label')[2]?.textContent, 'Location');
+assert.strictEqual(document.querySelectorAll('fieldset:nth-of-type(3) label')[2]?.textContent?.trim(), 'Location');
 ```
 
 Your `label` should have the `for` attribute set to `"location"`.
@@ -56,7 +56,7 @@ assert.strictEqual(document.querySelectorAll("fieldset:nth-of-type(3) label + in
 You should have a `label` element with the text of `Reputation` below the location checkbox.
 
 ```js
-assert.isNotNull(document.querySelectorAll('fieldset:nth-of-type(3) input[value="location"] + label')?.textContent, 'Reputation');
+assert.strictEqual(document.querySelector('fieldset:nth-of-type(3) input[value="location"] + label')?.textContent?.trim(), 'Reputation');
 ```
 
 Your `label` should have the `for` attribute set to `"reputation"`.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

- Fix querySelectorAll to querySelector for Reputation label test
- Add .trim() to text content assertions for consistent whitespace handling  
- Change assert.isNotNull to assert.strictEqual for proper value comparison

Related to #61635

<!-- Feel free to add any additional description of changes below this line -->
