### PR TITLE
feat(UI): adds navgation warning for projects

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -590,6 +590,12 @@
       "heading": "Fill in the blank",
       "blank": "blank"
     },
+    "classic": {
+      "exit-modal-header": "Exit",
+      "exit-modal-body": "Are you sure you want to leave? You will lose any unsaved progress you have made.",
+      "exit-modal-yes": "Yes, I want to leave",
+      "exit-modal-no": "No, I would like to continue"
+    },
     "quiz": {
       "correct-answer": "Correct!",
       "incorrect-answer": "Incorrect.",

--- a/client/src/components/seo/index.tsx
+++ b/client/src/components/seo/index.tsx
@@ -87,7 +87,7 @@ const SEO: React.FC<SEOProps> = ({ title, children }) => {
         '@type': 'Course',
         url: `${siteUrl}/learn/${superBlock}`,
         name: i18nTitle,
-        description: introText.at(0),
+        description: introText?.at(0) || '',
         provider: {
           '@type': 'Organization',
           name: 'freeCodeCamp',

--- a/client/src/templates/Challenges/classic/exit-classic-modal.tsx
+++ b/client/src/templates/Challenges/classic/exit-classic-modal.tsx
@@ -13,8 +13,7 @@ interface ExitClassicModalProps {
 }
 
 const mapStateToProps = (state: unknown) => ({
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  isExitClassicModalOpen: isExitClassicModalOpenSelector(state)
+  isExitClassicModalOpen: isExitClassicModalOpenSelector(state) as boolean
 });
 
 const mapDispatchToProps = {

--- a/client/src/templates/Challenges/classic/exit-classic-modal.tsx
+++ b/client/src/templates/Challenges/classic/exit-classic-modal.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { useTranslation } from 'react-i18next';
+import { Button, Modal, Spacer } from '@freecodecamp/ui';
+
+import { closeModal } from '../redux/actions';
+import { isExitClassicModalOpenSelector } from '../redux/selectors';
+
+interface ExitClassicModalProps {
+  closeExitClassicModal: () => void;
+  isExitClassicModalOpen: boolean;
+  onExit: () => void;
+}
+
+const mapStateToProps = (state: unknown) => ({
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  isExitClassicModalOpen: isExitClassicModalOpenSelector(state)
+});
+
+const mapDispatchToProps = {
+  closeExitClassicModal: () => closeModal('exitClassic')
+};
+
+const ExitClassicModal = ({
+  closeExitClassicModal,
+  isExitClassicModalOpen,
+  onExit
+}: ExitClassicModalProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <Modal
+      onClose={closeExitClassicModal}
+      open={isExitClassicModalOpen}
+      variant='danger'
+    >
+      <Modal.Header closeButtonClassNames='close'>
+        {t('learn.classic.exit-modal-header')}
+      </Modal.Header>
+      <Modal.Body alignment='center'>
+        {t('learn.classic.exit-modal-body')}
+      </Modal.Body>
+      <Modal.Footer>
+        <Button block variant='primary' onClick={closeExitClassicModal}>
+          {t('learn.classic.exit-modal-no')}
+        </Button>
+        <Spacer size='xxs' />
+        <Button block variant='danger' onClick={onExit}>
+          {t('learn.classic.exit-modal-yes')}
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+};
+
+ExitClassicModal.displayName = 'ExitClassicModal';
+
+export default connect(mapStateToProps, mapDispatchToProps)(ExitClassicModal);

--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -1,4 +1,4 @@
-import { graphql, navigate } from 'gatsby';
+import { graphql } from 'gatsby';
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import Helmet from 'react-helmet';
 import { useTranslation } from 'react-i18next';
@@ -254,8 +254,10 @@ function ShowClassic({
   const curLocation = useLocation();
   const [resizing, setResizing] = useState(false);
   const [usingKeyboardInTablist, setUsingKeyboardInTablist] = useState(false);
-  const [exitConfirmed, setExitConfirmed] = useState(false);
-  const [exitPathname, setExitPathname] = useState(blockHashSlug);
+  const exitConfirmed = useRef<boolean>(false);
+  const [exitPathname, setExitPathname] = useState<string>(
+    typeof blockHashSlug === 'string' ? blockHashSlug : ''
+  );
   const containerRef = useRef<HTMLElement>(null);
   const editorRef = useRef<editor.IStandaloneCodeEditor>();
   const instructionsPanelRef = useRef<HTMLDivElement>(null);
@@ -474,26 +476,23 @@ function ShowClassic({
   };
 
   const handleExitClassicModalBtnClick = () => {
-    setExitConfirmed(true);
-    void navigate(exitPathname);
+    exitConfirmed.current = true;
+    void reachNavigate(exitPathname);
     closeExitClassicModal();
   };
 
-  const onWindowClose = useCallback(
-    (event: BeforeUnloadEvent) => {
-      event.preventDefault();
-      event.returnvalue = t('misc.navigation-warning');
-    },
-    [t]
-  );
+  const onWindowClose = useCallback((event: BeforeUnloadEvent) => {
+    event.preventDefault();
+  }, []);
 
   const onHistoryChange = useCallback(
     (targetPathname: string) => {
-      if (exitConfirmed) return;
+      if (exitConfirmed.current) return;
 
-      const newPathname = targetPathname.startsWith('/learn')
-        ? blockHashSlug
-        : targetPathname;
+      const newPathname =
+        targetPathname.startsWith('/learn') && typeof blockHashSlug === 'string'
+          ? blockHashSlug
+          : targetPathname;
 
       // Save the pathname of the page the user wants to navigate to before we block the navigation.
       setExitPathname(newPathname);

--- a/client/src/templates/Challenges/redux/index.js
+++ b/client/src/templates/Challenges/redux/index.js
@@ -43,6 +43,7 @@ const initialState = {
     reset: false,
     exitExam: false,
     finishExam: false,
+    exitClassic: false,
     exitQuiz: false,
     finishQuiz: false,
     examResults: false,

--- a/client/src/templates/Challenges/redux/selectors.js
+++ b/client/src/templates/Challenges/redux/selectors.js
@@ -46,6 +46,8 @@ export const isFinishExamModalOpenSelector = state =>
 export const isSurveyModalOpenSelector = state => state[ns].modal.survey;
 export const isExamResultsModalOpenSelector = state =>
   state[ns].modal.examResults;
+export const isExitClassicModalOpenSelector = state =>
+  state[ns].modal.exitClassic;
 export const isExitQuizModalOpenSelector = state => state[ns].modal.exitQuiz;
 export const isFinishQuizModalOpenSelector = state =>
   state[ns].modal.finishQuiz;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #54796 

<!-- Feel free to add any additional description of changes below this line -->

This PR addresses the lack of a warning message when navigating away from certification projects. 
An exit-classic-modal is created following the exit-quiz-modal which prompts:

"Are you sure you want to leave? You will lose any unsaved progress you have made."
"Yes, I want to leave"
"No, I would like to continue"

How to Test:
- Navigate to: https://www.freecodecamp.org/learn/2022/responsive-web-design/build-a-survey-form-project/build-a-survey-form
- Attempt to navigate away from the page by any method (closing tab, refresh, back, new link)
- Click yes or no