### PR TITLE
fix(client): prevent client double prefixing i18n paths on quiz exit

### DIFF
--- a/client/src/templates/Challenges/quiz/show.tsx
+++ b/client/src/templates/Challenges/quiz/show.tsx
@@ -1,4 +1,4 @@
-import { graphql, navigate } from 'gatsby';
+import { graphql } from 'gatsby';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import Helmet from 'react-helmet';
 import { ObserveKeys } from 'react-hotkeys';
@@ -128,7 +128,7 @@ const ShowQuiz = ({
 
   const [showUnanswered, setShowUnanswered] = useState(false);
 
-  const [exitConfirmed, setExitConfirmed] = useState(false);
+  const exitConfirmed = useRef(false);
 
   const [exitPathname, setExitPathname] = useState(blockHashSlug);
 
@@ -247,8 +247,8 @@ const ShowQuiz = ({
   };
 
   const handleExitQuizModalBtnClick = () => {
-    setExitConfirmed(true);
-    void navigate(exitPathname || '/learn');
+    exitConfirmed.current = true;
+    void reachNavigate(exitPathname || '/learn');
     closeExitQuizModal();
   };
 
@@ -267,7 +267,7 @@ const ShowQuiz = ({
       //   - If they don't pass, the Finish Quiz button is disabled, there isn't anything for them to do other than leaving the page
       //   - If they pass, the Submit-and-go button shows up, and campers should be allowed to leave the page
       // - When they have clicked the exit button on the exit modal
-      if (hasSubmitted || exitConfirmed) {
+      if (hasSubmitted || exitConfirmed.current) {
         return;
       }
 
@@ -283,13 +283,7 @@ const ShowQuiz = ({
       void reachNavigate(`${curLocation.pathname}`);
       openExitQuizModal();
     },
-    [
-      curLocation.pathname,
-      hasSubmitted,
-      exitConfirmed,
-      openExitQuizModal,
-      blockHashSlug
-    ]
+    [curLocation.pathname, hasSubmitted, openExitQuizModal, blockHashSlug]
   );
 
   usePageLeave({


### PR DESCRIPTION
We can't use gatsby navigate to send someone to /espanol/blah, since it will helpfully prefix the path with the language and send them to /espanol/espanol/blah.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #58299

<!-- Feel free to add any additional description of changes below this line -->
