### PR TITLE
chore(curriculum): remove backticks for platform name in Troubleshoot on GitHub

### DIFF
--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bbba66c53330f4316fd9f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bbba66c53330f4316fd9f.md
@@ -9,9 +9,9 @@ dashedName: task-4
 
 # --description--
 
-`GitHub` is a web-based platform used for version control and collaboration in software development. It allows multiple people to work on a project at the same time, track changes, and discuss issues. 
+GitHub is a web-based platform used for version control and collaboration in software development. It allows multiple people to work on a project at the same time, track changes, and discuss issues. 
 
-For example, developers use `GitHub` to manage code changes and collaborate on projects.
+For example, developers use GitHub to manage code changes and collaborate on projects.
 
 # --fillInTheBlank--
 
@@ -21,11 +21,11 @@ For example, developers use `GitHub` to manage code changes and collaborate on p
 
 ## --blanks--
 
-`GitHub`
+GitHub
 
 ### --feedback--
 
-`GitHub` is the platform where developers track and collaborate on software projects.
+GitHub is the platform where developers track and collaborate on software projects.
 
 # --scene--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bbba66c53330f4316fd9f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bbba66c53330f4316fd9f.md
@@ -11,7 +11,7 @@ dashedName: task-4
 
 `GitHub` is a web-based platform used for version control and collaboration in software development. It allows multiple people to work on a project at the same time, track changes, and discuss issues. 
 
-For example, developers use GitHub to manage code changes and collaborate on projects.
+For example, developers use `GitHub` to manage code changes and collaborate on projects.
 
 # --fillInTheBlank--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bbd3dea715a11ce02b670.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-how-to-help-a-coworker-troubleshoot-on-github/656bbd3dea715a11ce02b670.md
@@ -7,7 +7,7 @@ dashedName: task-7
 
 # --description--
 
-In coding, especially when using version control systems like `Git`, `push` means to upload changes from a local repository to a remote one. 
+In coding, especially when using version control systems like Git, `push` means to upload changes from a local repository to a remote one. 
 
 The past tense `pushed` indicates that this action has already been completed. 
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

The backticks were removed from the platform name.