### PR TITLE
fix: correct typo in Tailwind CTA Component titles

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -4103,7 +4103,7 @@
         ]
       },
       "workshop-tailwind-cta-component": {
-        "title": "Build a Taiwlind CTA Compoent",
+        "title": "Build a CTA Component",
         "intro": [
           "In this workshop, you will build a call to action (CTA) component using Tailwind CSS."
         ]

--- a/client/src/pages/learn/full-stack-developer/workshop-tailwind-cta-component/index.md
+++ b/client/src/pages/learn/full-stack-developer/workshop-tailwind-cta-component/index.md
@@ -4,6 +4,6 @@ block: workshop-tailwind-cta-component
 superBlock: full-stack-developer
 ---
 
-## Build a CTA Component
+## Introduction to Build a CTA Component
 
 This is workshop will cover how to use Tailwind CSS to build a call to action (CTA) component.

--- a/client/src/pages/learn/full-stack-developer/workshop-tailwind-cta-component/index.md
+++ b/client/src/pages/learn/full-stack-developer/workshop-tailwind-cta-component/index.md
@@ -1,9 +1,9 @@
 ---
-title: Introduction to the Build a Tailwind CTA Component
+title: Build a CTA Component
 block: workshop-tailwind-cta-component
 superBlock: full-stack-developer
 ---
 
-## Introduction to the Build a Tailwind CTA Component
+## Build a CTA Component
 
 This is workshop will cover how to use Tailwind CSS to build a call to action (CTA) component.

--- a/client/src/pages/learn/full-stack-developer/workshop-tailwind-cta-component/index.md
+++ b/client/src/pages/learn/full-stack-developer/workshop-tailwind-cta-component/index.md
@@ -1,5 +1,5 @@
 ---
-title: Build a CTA Component
+title: Introduction to Build a CTA Component
 block: workshop-tailwind-cta-component
 superBlock: full-stack-developer
 ---

--- a/curriculum/challenges/_meta/workshop-tailwind-cta-component/meta.json
+++ b/curriculum/challenges/_meta/workshop-tailwind-cta-component/meta.json
@@ -1,5 +1,5 @@
 {
-  "name": "Build a Tailwind CTA Component",
+  "name": "Build a CTA Component",
   "isUpcomingChange": true,
   "dashedName": "workshop-tailwind-cta-component",
   "superBlock": "full-stack-developer",


### PR DESCRIPTION
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.
                                                                                                                                                                                                               Closes #61668
                                                                                                                                                                                                                            This PR fixes the title of the Tailwind CTA Component workshop by changing all incorrect instances to the correct title "Build a CTA Component".

Files updated:
- client/i18n/locales/english/intro.json
- curriculum/challenges/_meta/workshop-tailwind-cta-component/meta.json
- client/src/pages/learn/full-stack-developer/workshop-tailwind-cta-component/index.md

These changes correct spelling errors (“Taiwlind CTA Compoent” and “Tailwind CTA Component”) and ensure consistency across the workshop's title and headings.
