### PR TITLE
fix(curriculum): allow extra whitespace for regex in step 33

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-music-player/67516a431252ed30832fa7c6.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-music-player/67516a431252ed30832fa7c6.md
@@ -15,7 +15,7 @@ Now, use the **OR** operator to add the `start` parameter as a second condition 
 You should use the **OR** operator to add the `start` parameter as a second condition to the `if` statement after `userData.currentSong === null`. 
 
 ```js
-assert.match(__helpers.removeJSComments(code), /if\s*\(\s*userData\s*\.\s*currentSong\s*===\s*null\s*\|\|\s*start(\s*(==|===)\s*true\s*)?\s*\)\s*\{/);
+assert.match(__helpers.removeJSComments(code), /if\s*\(\s*userData\s*\.\s*currentSong\s*===\s*null\s*\|\|\s*start(\s*===?\s*true\s*)?\s*\)\s*\{/);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-music-player/67516a431252ed30832fa7c6.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-music-player/67516a431252ed30832fa7c6.md
@@ -15,7 +15,7 @@ Now, use the **OR** operator to add the `start` parameter as a second condition 
 You should use the **OR** operator to add the `start` parameter as a second condition to the `if` statement after `userData.currentSong === null`. 
 
 ```js
-assert.match(__helpers.removeJSComments(code), /if\s*\(\s*userData\s*\.\s*currentSong\s*===\s*null\s*\|\|\s*start(\s*=\s*true\s*)?\s*\)\s*\{/);
+assert.match(__helpers.removeJSComments(code), /if\s*\(\s*userData\s*\.\s*currentSong\s*===\s*null\s*\|\|\s*start(\s*(==|===)\s*true\s*)?\s*\)\s*\{/);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/25-front-end-development/workshop-music-player/67516a431252ed30832fa7c6.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-music-player/67516a431252ed30832fa7c6.md
@@ -15,7 +15,7 @@ Now, use the **OR** operator to add the `start` parameter as a second condition 
 You should use the **OR** operator to add the `start` parameter as a second condition to the `if` statement after `userData.currentSong === null`. 
 
 ```js
-assert.match(__helpers.removeJSComments(code), /if\s+\(\s*userData\s*\.\s*currentSong\s*===\s*null\s+\|\|\s+start(\s*\=\s*true\s*)?\)\s*\{/)
+assert.match(__helpers.removeJSComments(code), /if\s*\(\s*userData\s*\.\s*currentSong\s*===\s*null\s*\|\|\s*start(\s*=\s*true\s*)?\s*\)\s*\{/);
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #61645

<!-- Feel free to add any additional description of changes below this line -->

This PR fixes the whitespace formatting in the `if` statement in step 33 of the `workshop-music-player` project.
