### PR TITLE
fix(curriculum): update test to check diagonal win conditions

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-tic-tac-toe/67e3a6b7f60b4085588189e6.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-tic-tac-toe/67e3a6b7f60b4085588189e6.md
@@ -298,6 +298,22 @@ async () => {
     assert.notEqual(preOWin, postOWin);
     // There should be a difference between `O` and `X` winning.
     assert.notEqual(postXWin, postOWin);
+
+    // Test diagonal win for X
+    await reset(assert);
+    
+    els[0].click(); clock.tick(50);
+    els[1].click(); clock.tick(50);
+    els[4].click(); clock.tick(50);
+    els[2].click(); clock.tick(50);
+    
+    const preDiagonalWin = getInnerTextExcept("button.square");
+    // Click winning button for X
+    els[8].click(); clock.tick(50);
+    
+    const postDiagonalWin = getInnerTextExcept("button.square");
+    assert.notEqual(preDiagonalWin, postDiagonalWin);
+    assert.include(postDiagonalWin, "Winner message should be displayed for diagonal win");
   } catch(e) {
     console.error(e);
     throw e;

--- a/curriculum/challenges/english/25-front-end-development/lab-tic-tac-toe/67e3a6b7f60b4085588189e6.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-tic-tac-toe/67e3a6b7f60b4085588189e6.md
@@ -302,18 +302,30 @@ async () => {
     // Test diagonal win for X
     await reset(assert);
     
-    els[0].click(); clock.tick(50);
-    els[1].click(); clock.tick(50);
-    els[4].click(); clock.tick(50);
-    els[2].click(); clock.tick(50);
+    // X moves: top-left
+    els[0].click(); 
+    clock.tick(50);
+    
+    // O moves: top-center
+    els[1].click();
+    clock.tick(50);
+    
+    // X moves: center
+    els[4].click();
+    clock.tick(50);
+    
+    // O moves: top-right
+    els[2].click();
+    clock.tick(50);
     
     const preDiagonalWin = getInnerTextExcept("button.square");
-    // Click winning button for X
-    els[8].click(); clock.tick(50);
+    // X moves: bottom-right (completes diagonal win)
+    els[8].click();
+    clock.tick(50);
     
     const postDiagonalWin = getInnerTextExcept("button.square");
     assert.notEqual(preDiagonalWin, postDiagonalWin);
-    assert.include(postDiagonalWin,"Winner: X");
+    assert.include(postDiagonalWin, "Winner: X");
   } catch(e) {
     console.error(e);
     throw e;

--- a/curriculum/challenges/english/25-front-end-development/lab-tic-tac-toe/67e3a6b7f60b4085588189e6.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-tic-tac-toe/67e3a6b7f60b4085588189e6.md
@@ -313,7 +313,7 @@ async () => {
     
     const postDiagonalWin = getInnerTextExcept("button.square");
     assert.notEqual(preDiagonalWin, postDiagonalWin);
-    assert.include(postDiagonalWin, "Winner message should be displayed for diagonal win");
+    assert.include(postDiagonalWin,"Winner: X");
   } catch(e) {
     console.error(e);
     throw e;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #60731

<!-- Feel free to add any additional description of changes below this line -->

### What this PR does:
Updates a test case to check if the game correctly ends when player wins via a diagonal pattern.

### Why it's needed:
Currently, there’s no test for diagonal wins. Solutions that miss diagonal checks can still pass. This test ensures completeness.

### Added code:
```js
// Test diagonal win for X
await reset(assert);

els[0].click(); clock.tick(50);
els[1].click(); clock.tick(50);
els[4].click(); clock.tick(50);
els[2].click(); clock.tick(50);

const preDiagonalWin = getInnerTextExcept("button.square");

// Click winning button for X
els[8].click(); clock.tick(50);

const postDiagonalWin = getInnerTextExcept("button.square");
assert.notEqual(preDiagonalWin, postDiagonalWin);
assert.include(postDiagonalWin, "Winner message should be displayed for diagonal win");
```

### Snapshots:
<img width="1920" height="1080" alt="Screenshot From 2025-08-05 22-14-35" src="https://github.com/user-attachments/assets/51838c5e-44ce-454c-aa2d-47b58871904c" />
