### PR TITLE
fix: correct Tailwind CTA component title and fix typo

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -4103,7 +4103,7 @@
         ]
       },
       "workshop-tailwind-cta-component": {
-        "title": "Build a Taiwlind CTA Compoent",
+        "title": "Build a CTA Component",
         "intro": [
           "In this workshop, you will build a call to action (CTA) component using Tailwind CSS."
         ]

--- a/client/src/pages/learn/full-stack-developer/workshop-tailwind-cta-component/index.md
+++ b/client/src/pages/learn/full-stack-developer/workshop-tailwind-cta-component/index.md
@@ -1,9 +1,9 @@
 ---
-title: Introduction to the Build a Tailwind CTA Component
+title: Introduction to the Build a CTA Component
 block: workshop-tailwind-cta-component
 superBlock: full-stack-developer
 ---
 
-## Introduction to the Build a Tailwind CTA Component
+## Introduction to the Build a CTA Component
 
 This is workshop will cover how to use Tailwind CSS to build a call to action (CTA) component.

--- a/curriculum/challenges/_meta/workshop-tailwind-cta-component/meta.json
+++ b/curriculum/challenges/_meta/workshop-tailwind-cta-component/meta.json
@@ -1,5 +1,5 @@
 {
-  "name": "Build a Tailwind CTA Component",
+  "name": "Build a CTA Component",
   "isUpcomingChange": true,
   "dashedName": "workshop-tailwind-cta-component",
   "superBlock": "full-stack-developer",


### PR DESCRIPTION
- Fix typo 'Taiwlind CTA Compoent' to 'Build a CTA Component' in intro.json
- Update component name from 'Build a Tailwind CTA Component' to 'Build a CTA Component' in meta.json
- Update title and heading in index.md to match the shortened component name

Resolves issue with incorrect Tailwind CTA component title across multiple files

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #61668

<!-- Feel free to add any additional description of changes below this line -->
