### PR TITLE
fix(text): remove duplicated 'or' in lecture on working with functions

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-functions/672d269da46786225e3fe3fd.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-functions/672d269da46786225e3fe3fd.md
@@ -17,7 +17,7 @@ function greet() {
 
 In this example, we have declared a function called `greet`.  Inside that function, we have a `console.log` that logs the message `Hello, Jessica!`. If we tried to run this code, we would not see the message appear in the console. This is because we need to call the function.
 
-A function call, or or invocation, is when we actually use or execute the function. To call a function, you will need to reference the function name followed by a set of parentheses:
+A function call, or invocation, is when we actually use or execute the function. To call a function, you will need to reference the function name followed by a set of parentheses:
 
 ```js
 function greet() {


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

This PR fixes a typo in the lecture on working with functions by removing the duplicated word "or".

Closes #61678
