### PR TITLE
fix: add introduction and move API data shape above Objective in Weat…

### DIFF
--- a/client/src/pages/learn/full-stack-developer/lab-weather-app/index.md
+++ b/client/src/pages/learn/full-stack-developer/lab-weather-app/index.md
@@ -7,3 +7,15 @@ superBlock: full-stack-development
 ## Introduction to the Build a Weather App
 
 In this lab you will build a Weather App using an API to fetch the data.
+
+**API Data Shape:**
+
+The API returns a JSON response with the following structure:
+
+```json
+{
+  "location": "City Name",
+  "temperature": "20°C",
+  "condition": "Sunny"
+}
+```


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

Closes #61713

<!-- Feel free to add any additional description of changes below this line -->

Added the missing "Introduction to the Build a Weather App" heading at the top and moved the API data shape example above the Objective section for better clarity.
