### PR TITLE
fix: rewrite Budget App lab description to match standard format

### DIFF
--- a/client/src/pages/learn/full-stack-developer/lab-weather-app/index.md
+++ b/client/src/pages/learn/full-stack-developer/lab-weather-app/index.md
@@ -7,3 +7,15 @@ superBlock: full-stack-development
 ## Introduction to the Build a Weather App
 
 In this lab you will build a Weather App using an API to fetch the data.
+
+**API Data Shape:**
+
+The API returns a JSON response with the following structure:
+
+```json
+{
+  "location": "City Name",
+  "temperature": "20°C",
+  "condition": "Sunny"
+}
+```

--- a/curriculum/challenges/english/25-front-end-development/lab-budget-app/5e44413e903586ffb414c94e.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-budget-app/5e44413e903586ffb414c94e.md
@@ -7,76 +7,20 @@ dashedName: build-a-budget-app
 
 # --description--
 
-Complete the `Category` class. It should be able to instantiate objects based on different budget categories like *food*, *clothing*, and *entertainment*. When objects are created, they are passed in the name of the category. The class should have an instance variable called `ledger` that is a list. The class should also contain the following methods:
+In this lab, you will build a budget app that supports deposits, withdrawals, transfers between categories, and generates a text-based spend chart. This will help you practice using classes, instance methods, string formatting, and working with lists and dictionaries.
 
-- A `deposit` method that accepts an amount and description. If no description is given, it should default to an empty string. The method should append an object to the ledger list in the form of `{'amount': amount, 'description': description}`.
-- A `withdraw` method that is similar to the `deposit` method, but the amount passed in should be stored in the ledger as a negative number. If there are not enough funds, nothing should be added to the ledger. This method should return `True` if the withdrawal took place, and `False` otherwise.
-- A `get_balance` method that returns the current balance of the budget category based on the deposits and withdrawals that have occurred.
-- A `transfer` method that accepts an amount and another budget category as arguments. The method should add a withdrawal with the amount and the description 'Transfer to [Destination Budget Category]'. The method should then add a deposit to the other budget category with the amount and the description 'Transfer from [Source Budget Category]'. If there are not enough funds, nothing should be added to either ledgers. This method should return `True` if the transfer took place, and `False` otherwise.
-- A `check_funds` method that accepts an amount as an argument. It returns `False` if the amount is greater than the balance of the budget category and returns `True` otherwise. This method should be used by both the `withdraw` method and `transfer` method.
+**Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab.
 
-When the budget object is printed it should display:
+**User Stories:**
 
-- A title line of 30 characters where the name of the category is centered in a line of `*` characters.
-- A list of the items in the ledger. Each line should show the description and amount. The first 23 characters of the description should be displayed, then the amount. The amount should be right aligned, contain two decimal places, and display a maximum of 7 characters.
-- A line displaying the category total.
-
-Here is an example usage:
-
-```py
-food = Category('Food')
-food.deposit(1000, 'deposit')
-food.withdraw(10.15, 'groceries')
-food.withdraw(15.89, 'restaurant and more food for dessert')
-clothing = Category('Clothing')
-food.transfer(50, clothing)
-print(food)
-```
-
-And here is an example of the output:
-
-```bash
-*************Food*************
-initial deposit        1000.00
-groceries               -10.15
-restaurant and more foo -15.89
-Transfer to Clothing    -50.00
-Total: 923.96
-```
-
-Besides the `Category` class, create a function (outside of the class) called `create_spend_chart` that takes a list of categories as an argument. It should return a string that is a bar chart.
-
-The chart should show the percentage spent in each category passed in to the function. The percentage spent should be calculated only with withdrawals and not with deposits, and it should be the percentage of the amount spent for each category to the total spent for all categories. Down the left side of the chart should be labels 0 - 100. The 'bars' in the bar chart should be made out of the 'o' character. The height of each bar should be rounded down to the nearest 10. The horizontal line below the bars should go two spaces past the final bar. Each category name should be written vertically below the bar. There should be a title at the top that says 'Percentage spent by category'.
-
-This function will be tested with up to four categories.
-
-Look at the example output below very closely and make sure the spacing of the output matches the example exactly.
-
-```bash
-Percentage spent by category
-100|          
- 90|          
- 80|          
- 70|          
- 60| o        
- 50| o        
- 40| o        
- 30| o        
- 20| o  o     
- 10| o  o  o  
-  0| o  o  o  
-    ----------
-     F  C  A  
-     o  l  u  
-     o  o  t  
-     d  t  o  
-        h     
-        i     
-        n     
-        g     
-```
-
-Note: open the browser console with F12 to see a more verbose output of the tests.
+1. I can create a `Category` class that is initialized with a category name and contains a `ledger` list.
+2. I can call a `deposit` method to add funds to the category with an optional description.
+3. I can call a `withdraw` method to remove funds with a description, storing it as a negative amount, and it returns True or False depending on available funds.
+4. I can check the current balance using the `get_balance` method.
+5. I can transfer funds to another category with the `transfer` method, including appropriate descriptions and balance checks.
+6. I can use the `check_funds` method to verify if sufficient funds exist.
+7. When I print the category, it displays a formatted title, ledger entries (with description and amount), and the total.
+8. I can use a `create_spend_chart` function (outside the class) that takes a list of categories and returns a bar chart showing percentage spent per category.
 
 # --hints--
 

--- a/curriculum/challenges/english/25-front-end-development/lab-budget-app/5e44413e903586ffb414c94e.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-budget-app/5e44413e903586ffb414c94e.md
@@ -7,20 +7,40 @@ dashedName: build-a-budget-app
 
 # --description--
 
-In this lab, you will build a budget app that supports deposits, withdrawals, transfers between categories, and generates a text-based spend chart. This will help you practice using classes, instance methods, string formatting, and working with lists and dictionaries.
+In this lab, you will implement a `Category` class that helps users manage and track spending across different budget categories like food, clothing, and entertainment. You will also create a function that generates a text-based bar chart showing the percentage spent by each category.
 
 **Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab.
 
 **User Stories:**
 
-1. I can create a `Category` class that is initialized with a category name and contains a `ledger` list.
-2. I can call a `deposit` method to add funds to the category with an optional description.
-3. I can call a `withdraw` method to remove funds with a description, storing it as a negative amount, and it returns True or False depending on available funds.
-4. I can check the current balance using the `get_balance` method.
-5. I can transfer funds to another category with the `transfer` method, including appropriate descriptions and balance checks.
-6. I can use the `check_funds` method to verify if sufficient funds exist.
-7. When I print the category, it displays a formatted title, ledger entries (with description and amount), and the total.
-8. I can use a `create_spend_chart` function (outside the class) that takes a list of categories and returns a bar chart showing percentage spent per category.
+1. You should be able to instantiate the `Category` class with a category name (e.g., `"Food"`, `"Clothing"`).
+2. Each category should have an instance variable `ledger` that is initialized as an empty list.
+3. The `deposit` method should accept an `amount` and an optional `description`. If no description is provided, it should default to an empty string. This method should append an object to the `ledger` list in the form: `{"amount": amount, "description": description}`.
+4. The `withdraw` method should work like `deposit`, but the `amount` should be stored as a negative number. If there are not enough funds, nothing should be added to the ledger. This method should return `True` if the withdrawal occurred and `False` otherwise.
+5. The `get_balance` method should return the current balance based on the amounts in the ledger (including deposits and withdrawals).
+6. The `transfer` method should move funds from one category to another. It should:
+   - Add a withdrawal to the current category with the description `'Transfer to [Destination Category]'`.
+   - Add a deposit to the target category with the description `'Transfer from [Source Category]'`.
+   - Return `True` if the transfer occurred successfully and `False` otherwise. No changes should occur if there are insufficient funds.
+7. The `check_funds` method should accept an `amount` and return `True` if there are enough funds, and `False` otherwise. This method should be used within both `withdraw` and `transfer`.
+8. When a category object is printed using `print(category)`, it should return a string formatted as follows:
+   - A title line of 30 characters, with the category name centered in a line of `*` characters (e.g., `*************Food*************`).
+   - Each item in the ledger should appear on its own line:
+     - The first 23 characters of the description should be displayed (truncated if longer).
+     - The amount should be right-aligned, contain exactly two decimal places, and fit within 7 characters.
+   - A line at the bottom should display the total balance in the format: `Total: [amount]`.
+9. You should also implement a standalone function called `create_spend_chart(categories)` that returns a string representing a bar chart.
+10. The bar chart should show the percentage of total spending (based only on withdrawals) for each category passed into the function.
+11. The percentage for each category should be rounded down to the nearest 10.
+12. The left side of the chart should display percentage labels from 100 to 0 in steps of 10 (e.g., `100|`, ` 90|`, ` 80|`, etc.).
+13. Each bar segment should be represented by the lowercase letter `'o'`, aligned with each category.
+14. A horizontal line should be drawn below the bars, extending two spaces past the last bar.
+15. The names of the categories should appear vertically below the bar chart, aligned with their respective columns.
+16. The chart title should be exactly: `Percentage spent by category`.
+17. The chart should support up to four categories.
+18. The spacing and formatting of the chart should exactly match the example output. Pay close attention to alignment, whitespace, and line breaks.
+
+
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

Closes #61715

This PR updates the description of the **Budget App** lab in the Front End Development certification to match the standardized lab schema format.

### Changes made:
- Added an introduction
- Added an "Objective" section
- Replaced the existing text with an ordered list of user stories

No changes were made to the actual tests or functionality of the lab.
