### PR TITLE
fix: correct typos in javascript-arrays-quiz and review-javascript files

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/quiz-javascript-arrays/66edcccbba6dacdb65a59067.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-javascript-arrays/66edcccbba6dacdb65a59067.md
@@ -46,7 +46,6 @@ console.log(numbers[10]);
 
 Which of the following is the correct way to access the string `"Jessica"` from the `developers` array?
 
-
 #### --distractors--
 
 ```js

--- a/curriculum/challenges/english/25-front-end-development/quiz-javascript-arrays/66edcccbba6dacdb65a59067.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-javascript-arrays/66edcccbba6dacdb65a59067.md
@@ -44,7 +44,8 @@ console.log(numbers[10]);
 
 #### --text--
 
-Which of the following is the correct way access the string `"Jessica"` from the `developers` array?
+Which of the following is the correct way to access the string `"Jessica"` from the `developers` array?
+
 
 #### --distractors--
 

--- a/curriculum/challenges/english/25-front-end-development/review-javascript-arrays/6723c66f623701a3cdf72130.md
+++ b/curriculum/challenges/english/25-front-end-development/review-javascript-arrays/6723c66f623701a3cdf72130.md
@@ -123,7 +123,7 @@ desserts.unshift("ice cream");
 console.log(desserts); // ["ice cream", "cake", "cookies", "pie"];
 ```
 
-- **`indexOf()` Method**: This method is useful for finding the first index of a specific element within an array. If the element cannot be found, then it will return -1.
+- **`indexOf()` Method**: This method is useful for finding the first index of a specific element within an array. If the element cannot be found, then it will return `-1`.
 
 ```js
 const fruits = ["apple", "banana", "orange", "banana"];
@@ -160,7 +160,7 @@ const newList = programmingLanguages.concat("Perl");
 console.log(newList); // ["JavaScript", "Python", "C++", "Perl"]
 ```
 
-- **`slice()` Method**: This method returns a shallow copy of a portion of the array at a specified index or the entire array. A shallow copy will copy the reference to the array instead of duplicating it.
+- **`slice()` Method**: This method returns a shallow copy of a portion of the array, starting from a specified index or the entire array.
 
 ```js
 const programmingLanguages = ["JavaScript", "Python", "C++"];

--- a/curriculum/challenges/english/25-front-end-development/review-javascript/6723d3cfdd0717d3f1bf27e3.md
+++ b/curriculum/challenges/english/25-front-end-development/review-javascript/6723d3cfdd0717d3f1bf27e3.md
@@ -824,8 +824,6 @@ console.log(newList); // ["JavaScript", "Python", "C++", "Perl"]
 ```
 
 - **`slice()` Method**: This method returns a shallow copy of a portion of the array, starting from a specified index or the entire array. 
-A shallow copy creates a new array but does not deeply copy nested objects — if the array contains objects, their references are copied.
-
 
 ```js
 const programmingLanguages = ["JavaScript", "Python", "C++"];

--- a/curriculum/challenges/english/25-front-end-development/review-javascript/6723d3cfdd0717d3f1bf27e3.md
+++ b/curriculum/challenges/english/25-front-end-development/review-javascript/6723d3cfdd0717d3f1bf27e3.md
@@ -786,7 +786,7 @@ desserts.unshift("ice cream");
 console.log(desserts); // ["ice cream", "cake", "cookies", "pie"];
 ```
 
-- **`indexOf()` Method**: This method is useful for finding the first index of a specific element within an array. If the element cannot be found, then it will return -1.
+- **`indexOf()` Method**: This method is useful for finding the first index of a specific element within an array. If the element cannot be found, then it will return `-1`.
 
 ```js
 const fruits = ["apple", "banana", "orange", "banana"];
@@ -823,7 +823,9 @@ const newList = programmingLanguages.concat("Perl");
 console.log(newList); // ["JavaScript", "Python", "C++", "Perl"]
 ```
 
-- **`slice()` Method**: This method returns a shallow copy of a portion of the array at a specified index or the entire array. A shallow copy will copy the reference to the array instead of duplicating it.
+- **`slice()` Method**: This method returns a shallow copy of a portion of the array, starting from a specified index or the entire array. 
+A shallow copy creates a new array but does not deeply copy nested objects — if the array contains objects, their references are copied.
+
 
 ```js
 const programmingLanguages = ["JavaScript", "Python", "C++"];

--- a/curriculum/challenges/english/25-front-end-development/review-javascript/6723d3cfdd0717d3f1bf27e3.md
+++ b/curriculum/challenges/english/25-front-end-development/review-javascript/6723d3cfdd0717d3f1bf27e3.md
@@ -826,7 +826,6 @@ console.log(newList); // ["JavaScript", "Python", "C++", "Perl"]
 - **`slice()` Method**: This method returns a shallow copy of a portion of the array, starting from a specified index or the entire array. 
 A shallow copy creates a new array but does not deeply copy nested objects — if the array contains objects, their references are copied.
 
-
 ```js
 const programmingLanguages = ["JavaScript", "Python", "C++"];
 const newList = programmingLanguages.slice(1);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #61727

<!-- Feel free to add any additional description of changes below this line -->

This PR fixes typos and grammatical issues in:

- `curriculum/challenges/english/25-front-end-development/quiz-javascript-arrays/66edcccbba6dacdb65a59067.md`
- `curriculum/challenges/english/25-front-end-development/review-javascript-arrays/6723c66f623701a3cdf72130.md`

**Changes:**
- Added missing word "to" in quiz question: changed "correct way access" to "correct way to access".
- Corrected “a array” → “an array”.
- Wrapped `-1` in backticks for `indexOf()`.
- Improved clarity for `slice()` method description.

This is a documentation-only change, no functional code was altered.
