### PR TITLE
feat(api): add DELETE "/account" endpoint to API

### DIFF
--- a/api/src/routes/protected/user.test.ts
+++ b/api/src/routes/protected/user.test.ts
@@ -651,23 +651,6 @@ describe('userRoutes', () => {
         expect(res.status).toBe(204);
       });
 
-      test('handles concurrent requests to delete the same user', async () => {
-        const deletePromises = Array.from({ length: 2 }, () =>
-          superDelete(`/users/${defaultUserId}`)
-        );
-
-        const responses = await Promise.all(deletePromises);
-
-        const userCount = await fastifyTestInstance.prisma.user.count({
-          where: { email: testUserData.email }
-        });
-        responses.forEach(response => {
-          expect(response.status).toBe(204);
-          expect(response.body).toStrictEqual({});
-        });
-        expect(userCount).toBe(0);
-      });
-
       test("only deletes the logged in user's data", async () => {
         const initialCount = await fastifyTestInstance.prisma.user.count();
         await fastifyTestInstance.prisma.user.create({
@@ -687,7 +670,7 @@ describe('userRoutes', () => {
       });
 
       test('logs if it is asked to delete a non-existent user', async () => {
-        const spy = jest.spyOn(fastifyTestInstance.log, 'warn');
+        const spy = vi.spyOn(fastifyTestInstance.log, 'warn');
 
         const deletePromises = Array.from({ length: 2 }, () =>
           superDelete(`/users/${defaultUserId}`)

--- a/api/src/routes/protected/user.test.ts
+++ b/api/src/routes/protected/user.test.ts
@@ -685,8 +685,6 @@ describe('userRoutes', () => {
 
         await Promise.all(deletePromises);
 
-        // Allow additional warnings from other operations; ensure at least one
-        // is about the missing user deletion.
         const messages = spy.mock.calls.flat().map(String);
         expect(
           messages.some(m =>

--- a/api/src/routes/protected/user.test.ts
+++ b/api/src/routes/protected/user.test.ts
@@ -569,14 +569,14 @@ describe('userRoutes', () => {
         await clearEnvExam();
       });
 
-      test('DELETE returns 200 status code with empty object', async () => {
+      test('DELETE returns 204 status code with empty object', async () => {
         const response = await superDelete(`/users/${defaultUserId}`);
         const userCount = await fastifyTestInstance.prisma.user.count({
           where: { email: testUserData.email }
         });
 
         expect(response.body).toStrictEqual({});
-        expect(response.status).toBe(200);
+        expect(response.status).toBe(204);
         expect(userCount).toBe(0);
       });
 
@@ -634,7 +634,7 @@ describe('userRoutes', () => {
         const countAfter =
           await fastifyTestInstance.prisma.examEnvironmentExamAttempt.count();
         expect(countAfter).toBe(0);
-        expect(res.status).toBe(200);
+        expect(res.status).toBe(204);
       });
 
       test("DELETE deletes all the user's exam tokens", async () => {
@@ -648,7 +648,7 @@ describe('userRoutes', () => {
         const countAfter =
           await fastifyTestInstance.prisma.examEnvironmentAuthorizationToken.count();
         expect(countAfter).toBe(0);
-        expect(res.status).toBe(200);
+        expect(res.status).toBe(204);
       });
 
       test('handles concurrent requests to delete the same user', async () => {
@@ -662,7 +662,7 @@ describe('userRoutes', () => {
           where: { email: testUserData.email }
         });
         responses.forEach(response => {
-          expect(response.status).toBe(200);
+          expect(response.status).toBe(204);
           expect(response.body).toStrictEqual({});
         });
         expect(userCount).toBe(0);

--- a/api/src/routes/protected/user.ts
+++ b/api/src/routes/protected/user.ts
@@ -163,7 +163,7 @@ export const userRoutes: FastifyPluginCallbackTypebox = (
       }
       reply.clearOurCookies();
 
-      return {};
+      return reply.code(204).send();
     }
   );
 

--- a/api/src/routes/protected/user.ts
+++ b/api/src/routes/protected/user.ts
@@ -148,6 +148,7 @@ export const userRoutes: FastifyPluginCallbackTypebox = (
           where: { id: req.user.id }
         });
       } catch (err) {
+        // Whilst this is behind auth, this should never happen
         if (
           err instanceof PrismaClientKnownRequestError &&
           err.code === 'P2025'

--- a/api/src/schemas.ts
+++ b/api/src/schemas.ts
@@ -34,7 +34,10 @@ export { updateMySocials } from './schemas/settings/update-my-socials.js';
 export { updateMyTheme } from './schemas/settings/update-my-theme.js';
 export { updateMyUsername } from './schemas/settings/update-my-username.js';
 export { deleteMsUsername } from './schemas/user/delete-ms-username.js';
-export { deleteMyAccount } from './schemas/user/delete-my-account.js';
+export {
+  deleteMyAccount,
+  deleteUser
+} from './schemas/user/delete-my-account.js';
 export { deleteUserToken } from './schemas/user/delete-user-token.js';
 export { getSessionUser } from './schemas/user/get-session-user.js';
 export { postMsUsername } from './schemas/user/post-ms-username.js';

--- a/api/src/schemas/user/delete-my-account.ts
+++ b/api/src/schemas/user/delete-my-account.ts
@@ -7,3 +7,16 @@ export const deleteMyAccount = {
     default: genericError
   }
 };
+
+export const deleteUser = {
+  params: Type.Object({
+    userId: Type.String({ format: 'objectid' })
+  }),
+  response: {
+    204: Type.Null(),
+    default: Type.Object({
+      type: Type.String(),
+      message: Type.String()
+    })
+  }
+};

--- a/api/src/schemas/user/delete-my-account.ts
+++ b/api/src/schemas/user/delete-my-account.ts
@@ -10,7 +10,7 @@ export const deleteMyAccount = {
 
 export const deleteUser = {
   params: Type.Object({
-    userId: Type.String({ format: 'objectid' })
+    userId: Type.String({ format: 'objectid', maxLength: 24, minLength: 24 })
   }),
   response: {
     204: Type.Null(),


### PR DESCRIPTION
- **feat: add DELETE endpoint for account deletion**
- **fix(tests): remove unnecessary comments from user deletion test**

I think adding the new endpoint first and then updating the client is the correct way to go. As they are not deployed at the same time.

I wasn't sure about if we want the endpoint to be `/user/account` or `/account` so I chose the latter. Please let me know what you think.

ref #50301 
