### PR TITLE
fix(client): navbar logo now visible in high contrast mode

### DIFF
--- a/client/src/assets/icons/freecodecamp-logo.tsx
+++ b/client/src/assets/icons/freecodecamp-logo.tsx
@@ -75,35 +75,35 @@ function FreeCodeCampLogo(
           id='d'
         />
       </defs>
-      <use fill='#ffffff' xlinkHref='#k' />
+      <use fill='currentColor' xlinkHref='#k' />
       <use fillOpacity={0} stroke='#000000' strokeOpacity={0} xlinkHref='#k' />
-      <use fill='#ffffff' xlinkHref='#j' />
+      <use fill='currentColor' xlinkHref='#j' />
       <use fillOpacity={0} stroke='#000000' strokeOpacity={0} xlinkHref='#j' />
-      <use fill='#ffffff' xlinkHref='#b' />
+      <use fill='currentColor' xlinkHref='#b' />
       <use fillOpacity={0} stroke='#000000' strokeOpacity={0} xlinkHref='#b' />
-      <use fill='#ffffff' xlinkHref='#n' />
+      <use fill='currentColor' xlinkHref='#n' />
       <use fillOpacity={0} stroke='#000000' strokeOpacity={0} xlinkHref='#n' />
-      <use fill='#ffffff' xlinkHref='#l' />
+      <use fill='currentColor' xlinkHref='#l' />
       <use fillOpacity={0} stroke='#000000' strokeOpacity={0} xlinkHref='#l' />
-      <use fill='#ffffff' xlinkHref='#c' />
+      <use fill='currentColor' xlinkHref='#c' />
       <use fillOpacity={0} stroke='#000000' strokeOpacity={0} xlinkHref='#c' />
-      <use fill='#ffffff' xlinkHref='#e' />
+      <use fill='currentColor' xlinkHref='#e' />
       <use fillOpacity={0} stroke='#000000' strokeOpacity={0} xlinkHref='#e' />
-      <use fill='#ffffff' xlinkHref='#m' />
+      <use fill='currentColor' xlinkHref='#m' />
       <use fillOpacity={0} stroke='#000000' strokeOpacity={0} xlinkHref='#m' />
-      <use fill='#ffffff' xlinkHref='#a' />
+      <use fill='currentColor' xlinkHref='#a' />
       <use fillOpacity={0} stroke='#000000' strokeOpacity={0} xlinkHref='#a' />
-      <use fill='#ffffff' xlinkHref='#i' />
+      <use fill='currentColor' xlinkHref='#i' />
       <use fillOpacity={0} stroke='#000000' strokeOpacity={0} xlinkHref='#i' />
-      <use fill='#ffffff' xlinkHref='#f' />
+      <use fill='currentColor' xlinkHref='#f' />
       <use fillOpacity={0} stroke='#000000' strokeOpacity={0} xlinkHref='#f' />
-      <use fill='#ffffff' xlinkHref='#g' />
+      <use fill='currentColor' xlinkHref='#g' />
       <use fillOpacity={0} stroke='#000000' strokeOpacity={0} xlinkHref='#g' />
-      <use fill='#ffffff' xlinkHref='#h' />
+      <use fill='currentColor' xlinkHref='#h' />
       <use fillOpacity={0} stroke='#000000' strokeOpacity={0} xlinkHref='#h' />
-      <use fill='#ffffff' xlinkHref='#o' />
+      <use fill='currentColor' xlinkHref='#o' />
       <use fillOpacity={0} stroke='#000000' strokeOpacity={0} xlinkHref='#o' />
-      <use fill='#ffffff' xlinkHref='#d' />
+      <use fill='currentColor' xlinkHref='#d' />
       <use fillOpacity={0} stroke='#000000' strokeOpacity={0} xlinkHref='#d' />
     </svg>
   );


### PR DESCRIPTION
Checklist:

- [ x ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ x ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ x ] My pull request targets the `main` branch of freeCodeCamp.
- [ x ] I have tested these changes either locally on my machine, or Gitpod.


Closes #58807

<!-- Feel free to add any additional description of changes below this line -->

Changed the freeCodeCamp SVG logo's fill attribute from a fixed '#ffffff' to 'currentColor'. This aligns the logo's color with the text color of the surrounding element, allowing it to automatically invert or change color when a user has a high-contrast theme enabled. This change improves the logo's visibility and overall accessibility.

I will be adding screen shots of different high contrast modes available on windows 11 and comparing them from the current https://www.freecodecamp.org/ to the local test that I have running. These screenshots are performed on Mozilla firefox, but I can confirm that they are the same result in chrome.

Default windows theme - No changes from what I can see
https://www.freecodecamp.org/
<img width="2559" height="1439" alt="image" src="https://github.com/user-attachments/assets/de5cb431-b1c1-4ffb-ab8a-f5614a97da1f" />
Local
<img width="2558" height="1394" alt="image" src="https://github.com/user-attachments/assets/2b92a7af-ccd1-4f69-95ff-c0b9dafc1ea9" />

Aquatic high contrast theme - No changes from what I can see
https://www.freecodecamp.org/
<img width="2557" height="1390" alt="image" src="https://github.com/user-attachments/assets/130247fe-ee51-40fa-afc6-db7278c17580" />
Local
<img width="2558" height="1389" alt="image" src="https://github.com/user-attachments/assets/c1da34d3-958b-44fc-b14b-4f911a30dc5e" />

Desert high contrast theme - The freeCodeCamp() logo is now visible in local testing
https://www.freecodecamp.org/
<img width="2557" height="1391" alt="image" src="https://github.com/user-attachments/assets/faedb621-0d68-46a1-a2b3-87d9cc89270d" />
Local
<img width="2558" height="1391" alt="image" src="https://github.com/user-attachments/assets/9ca89a86-0539-491c-bab4-c2f8c6a3fa46" />

For brevity's sake I will not include the other two high contrast settings (dusk and night sky) because those are unaffected like the aquatic theme.

