### PR TITLE
Changing slug output for readability

### DIFF
--- a/tools/challenge-auditor/index.ts
+++ b/tools/challenge-auditor/index.ts
@@ -145,13 +145,8 @@ async function auditSlugs(lang: string, certs: SuperBlocks[]) {
     const slug = `/learn/${superBlock}/${block}/${dashedName}`;
     // Skipping certifications
     const isCertification = challenge.challengeType === 7;
-    if (certs.includes(superBlock) && !isCertification && slugs.has(slug)) {
-      console.log(
-        `${slug} appears more than once: ${slugs.get(slug) ?? ''} and ${
-          challenge.id
-        }`
-      );
-      auditPassed = false;
+    if (slugs.has(slug)) {
+      console.warn(`Duplicate slug found:\n- ${slug}\n- IDs: ${slugs.get(slug)} and ${challenge.id}`);
     }
     slugs.set(slug, challenge.id);
   }


### PR DESCRIPTION
changed the output of finding duplicate slugs in order provide a readable experience for users. Important especially for newer developers and easier experience

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X ] My pull request targets the `main` branch of freeCodeCamp.
- [ X] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #61752
Improving slug warning in auditSlugs output #61752

<!-- Feel free to add any additional description of changes below this line -->
