### PR TITLE
fix(a11y): add skip to content link in html.tsx

### DIFF
--- a/client/src/html.tsx
+++ b/client/src/html.tsx
@@ -36,9 +36,16 @@ export default function HTML({
           content='width=device-width, initial-scale=1.0, shrink-to-fit=no'
           name='viewport'
         />
+               
         {headComponents}
+         
+        
       </head>
       <body {...bodyAttributes}>
+  <a href="#__gatsby" className="skip-link">Skip to content</a>
+        
+        
+        
         {preBodyComponents}
         <div
           className='tex2jax_ignore'


### PR DESCRIPTION
This pull request adds a skip-link anchor ("Skip to content") inside the <body> of html.tsx. The link targets the Gatsby root element (#__gatsby), enabling keyboard and screen reader users to skip directly to the main content and improve accessibility.

The change is small and does not affect application behavior beyond providing a convenient keyboard navigation aid.