### PR TITLE
fix(curriculum): minor improvements to aria-controls lecture

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lecture-understanding-aria-expanded-aria-live-and-common-aria-states/672a5507d857a891139abc7f.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-understanding-aria-expanded-aria-live-and-common-aria-states/672a5507d857a891139abc7f.md
@@ -26,7 +26,9 @@ In this example of a tabbed interface, we have a `div` element with a set of thr
 </div>
 ```
 
-Each button represents a tab and has a `role` attribute set to `tab`. In most tabbed interfaces, the first tab panel is visible by default, so the first tab button has an `aria-selected` attribute set to `true` to indicate that its associated section of content is currently visible The `aria-controls` attribute is used to associate each button with the section of content that it controls.
+The `div` uses `role="tablist"` to indicate that it serves as a container element for a group of tabs.
+
+Each button represents a tab and has a `role` attribute set to `tab`. In most tabbed interfaces, the first tab panel is visible by default, so the first tab button has an `aria-selected` attribute set to `true` to indicate that its associated section of content is currently visible. The `aria-controls` attribute is used to associate each button with the section of content that it controls.
 
 Here are the three sections of content that correspond to the tabs:
 
@@ -44,7 +46,7 @@ Here are the three sections of content that correspond to the tabs:
 </div>
 ```
 
-Each section of content has a `role` attribute set to `tabpanel` and an `aria-labelledby` attribute that points to the corresponding tab to give the panel an accessible name. The `hidden` attribute is used to hide the sections of content that are not currently selected. Each section id matches the value of the `aria-controls` attribute on the corresponding button. The `section1` id matches the `aria-controls` attribute on the first button, `section2` matches the `aria-controls` attribute on the second button, and `section3` matches the `aria-controls` attribute on the third button. This is how the association between the tabs and their sections of content is established.
+Each section of content has a `role` attribute set to `tabpanel` and an `aria-labelledby` attribute that points to the corresponding tab to give the panel an accessible name. The `hidden` attribute is used to hide the sections of content that are not currently selected. Each section ID matches the value of the `aria-controls` attribute on the corresponding button. The `section1` ID matches the `aria-controls` attribute on the first button, `section2` matches the `aria-controls` attribute on the second button, and `section3` matches the `aria-controls` attribute on the third button. This is how the association between the tabs and their sections of content is established.
 
 To switch between the different sections you will need to use JavaScript to update the `hidden` attribute on the section and the `aria-selected` attribute on the button based on which section is currently visible. Only one section can be visible at a time and it should not have the `hidden` attribute and `aria-selected` should be set to `true` on its button. The remaining hidden sections should all have the `hidden` attribute and `aria-selected` should be set to `false` on their buttons.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR:
- Adds definition of `role="tablist"` to the `What Is the aria-controls Attribute, and How Does It Work?` lecture
  - This role is currently introduced in the WAI-ARIA lecture, but we're removing it from the lecture (#61781)
- Fixes some minor typos
- Is related to https://github.com/freeCodeCamp/CurriculumExpansion/issues/966

<!-- Feel free to add any additional description of changes below this line -->
