### PR TITLE
chore(api): prevent non-staff exam authz token gen on staging

### DIFF
--- a/api/src/exam-environment/routes/exam-environment.test.ts
+++ b/api/src/exam-environment/routes/exam-environment.test.ts
@@ -20,7 +20,8 @@ jest.mock('../../utils/env', () => {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   return {
     ...jest.requireActual('../../utils/env'),
-    FCC_ENABLE_EXAM_ENVIRONMENT: 'true'
+    FCC_ENABLE_EXAM_ENVIRONMENT: 'true',
+    DEPLOYMENT_ENV: 'production'
   };
 });
 

--- a/api/src/routes/protected/user.test.ts
+++ b/api/src/routes/protected/user.test.ts
@@ -1290,6 +1290,10 @@ Thanks and regards,
         mockDeploymentEnv = 'production';
       });
 
+      afterAll(() => {
+        mockDeploymentEnv = 'staging';
+      });
+
       afterEach(async () => {
         await fastifyTestInstance.prisma.examEnvironmentAuthorizationToken.deleteMany(
           {

--- a/api/src/routes/protected/user.test.ts
+++ b/api/src/routes/protected/user.test.ts
@@ -29,6 +29,14 @@ import { getMsTranscriptApiUrl } from './user';
 const mockedFetch = jest.fn();
 jest.spyOn(globalThis, 'fetch').mockImplementation(mockedFetch);
 
+jest.mock('../../utils/env', () => {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  return {
+    ...jest.requireActual('../../utils/env'),
+    DEPLOYMENT_ENV: 'production'
+  };
+});
+
 // This is used to build a test user.
 const testUserData: Prisma.userCreateInput = {
   ...createUserInput(defaultUserEmail),
@@ -1334,6 +1342,13 @@ Thanks and regards,
             }
           );
         expect(tokens).toHaveLength(1);
+      });
+
+      xtest('TODO: POST does not generate a new token in non-production environments', async () => {
+        // TODO: How to change environment variable mid-test?
+        const response = await superPost('/user/exam-environment/token');
+
+        expect(response.status).toBe(403);
       });
     });
   });

--- a/api/src/routes/protected/user.ts
+++ b/api/src/routes/protected/user.ts
@@ -529,7 +529,7 @@ async function examEnvironmentTokenHandler(
     void reply.code(403);
     return reply.send(
       ERRORS.FCC_ERR_EXAM_ENVIRONMENT(
-        'User not allowed to generate authorization token in this environment.'
+        `User not allowed to generate authorization token in ${DEPLOYMENT_ENV} environment.`
       )
     );
   }

--- a/api/src/routes/protected/user.ts
+++ b/api/src/routes/protected/user.ts
@@ -27,11 +27,12 @@ import {
   getPoints,
   ProgressTimestamp
 } from '../../utils/progress';
-import { JWT_SECRET } from '../../utils/env';
+import { DEPLOYMENT_ENV, JWT_SECRET } from '../../utils/env';
 import {
   getExamAttemptHandler,
   getExamAttemptsHandler
 } from '../../exam-environment/routes/exam-environment';
+import { ERRORS } from '../../exam-environment/utils/errors';
 
 /**
  * Helper function to get the api url from the shared transcript link.
@@ -498,7 +499,7 @@ export const userRoutes: FastifyPluginCallbackTypebox = (
   done();
 };
 
-// eslint-disable-next-line jsdoc/require-param
+// eslint-disable-next-line jsdoc/require-param, jsdoc/require-returns
 /**
  * Generate a new authorization token for the given user, and invalidates any existing tokens.
  *
@@ -515,6 +516,24 @@ async function examEnvironmentTokenHandler(
   if (!userId) {
     throw new Error('Unreachable. User should be authenticated.');
   }
+
+  // In non-production environments, only staff are allowed to generate a token
+  if (
+    DEPLOYMENT_ENV !== 'production' &&
+    (!req.user?.email?.endsWith('@freecodecamp.org') ||
+      !req.user?.emailVerified)
+  ) {
+    logger.info(
+      `User not allowed to generate authorization token on ${DEPLOYMENT_ENV}.`
+    );
+    void reply.code(403);
+    return reply.send(
+      ERRORS.FCC_ERR_EXAM_ENVIRONMENT(
+        'User not allowed to generate authorization token in this environment.'
+      )
+    );
+  }
+
   // Delete (invalidate) any existing tokens for the user.
   await this.prisma.examEnvironmentAuthorizationToken.deleteMany({
     where: {

--- a/api/src/schemas/user/exam-environment-token.ts
+++ b/api/src/schemas/user/exam-environment-token.ts
@@ -1,9 +1,12 @@
 import { Type } from '@fastify/type-provider-typebox';
+import { STANDARD_ERROR } from '../../exam-environment/utils/errors';
 
 export const userExamEnvironmentToken = {
   response: {
-    200: Type.Object({
+    201: Type.Object({
       examEnvironmentAuthorizationToken: Type.String()
-    })
+    }),
+    403: STANDARD_ERROR
+    // default: STANDARD_ERROR
   }
 };

--- a/api/src/utils/env.ts
+++ b/api/src/utils/env.ts
@@ -47,6 +47,7 @@ If so, ensure that the environment variable JEST_WORKER_ID is set.`
 
 assert.ok(process.env.HOME_LOCATION);
 assert.ok(isAllowedEnv(_FREECODECAMP_NODE_ENV));
+assert.ok(process.env.DEPLOYMENT_ENV);
 assert.ok(isAllowedProvider(_EMAIL_PROVIDER));
 assert.ok(process.env.AUTH0_CLIENT_ID);
 assert.ok(process.env.AUTH0_CLIENT_SECRET);
@@ -191,6 +192,7 @@ export const FCC_ENABLE_SENTRY_ROUTES = undefinedOrBool(
   process.env.FCC_ENABLE_SENTRY_ROUTES
 );
 export const FREECODECAMP_NODE_ENV = _FREECODECAMP_NODE_ENV;
+export const DEPLOYMENT_ENV = process.env.DEPLOYMENT_ENV;
 export const SENTRY_DSN =
   process.env.SENTRY_DSN === 'dsn_from_sentry_dashboard'
     ? ''


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

NOTE: `DEPLOYMENT_ENV` is already added to `deploy-api.yml`, even though it was not used until now.
