### PR TITLE
fix(curriculum): refactor import from lesson 25 of learning react - work with forms

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-forms-in-react/67e2a4cab99d4e8bc795e99d.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-forms-in-react/67e2a4cab99d4e8bc795e99d.md
@@ -217,7 +217,8 @@ To fix this issue, you need to wrap the action in `startTransition`:
 ```jsx
 "use client";
 
-import { startTransition, useActionState } from "react";
+// import startTransition from React
+import { useActionState, startTransition } from "react";
 import { getUsers } from "./actions/getUsers";
 
 export default function FetchUsers() {

--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-forms-in-react/67e2a4cab99d4e8bc795e99d.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-forms-in-react/67e2a4cab99d4e8bc795e99d.md
@@ -217,11 +217,8 @@ To fix this issue, you need to wrap the action in `startTransition`:
 ```jsx
 "use client";
 
-import { useActionState } from "react";
+import { startTransition, useActionState } from "react";
 import { getUsers } from "./actions/getUsers";
-
-// import startTransition from React
-import { startTransition } from "react";
 
 export default function FetchUsers() {
   const [users, fetchAction, isPending] = useActionState(getUsers, []);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #61795

<!-- Feel free to add any additional description of changes below this line -->

This PR aims at refactoring an import on lesson 25 of Learning React - Working with forms.
It's importing 2 objects from 'react' in separate lines -> goal is to group related imports.
