### PR TITLE
fix(full-stack): replace incorrect quiz option "keys()" with "charAt()" (#61802)

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/quiz-javascript-arrays/66edcccbba6dacdb65a59067.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-javascript-arrays/66edcccbba6dacdb65a59067.md
@@ -434,7 +434,7 @@ Which of the following is NOT an array method?
 
 #### --answer--
 
-`keys()`
+`charAt()`
 
 ### --question--
 


### PR DESCRIPTION
…)" (#61802)

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

This fixes an error in the JavaScript Arrays quiz for the Full Stack Developer certification.
`keys()` is actually a valid array method, so it has been replaced with `charAt()`, which is a string method.

Fixes #61802

