### PR TITLE
fix(curriculum): Fix failing unit test on Step 24 FE workshop hotel feedback form

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a962954f4e0d76223b37ed.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-hotel-feedback-form/66a962954f4e0d76223b37ed.md
@@ -56,7 +56,7 @@ assert.strictEqual(document.querySelectorAll("fieldset:nth-of-type(3) label + in
 You should have a `label` element with the text of `Reputation` below the location checkbox.
 
 ```js
-assert.isNotNull(document.querySelectorAll('fieldset:nth-of-type(3) input[value="location"] + label')?.textContent, 'Reputation');
+assert.strictEqual(document.querySelector('fieldset:nth-of-type(3) input[value="location"] + label')?.textContent?.trim(), 'Reputation');
 ```
 
 Your `label` should have the `for` attribute set to `"reputation"`.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #61635

<!-- Feel free to add any additional description of changes below this line -->

Basically changed to `strictEqual`; added `trim()` for defensive programming purposes. Also, added `?` as a matter of safety in case the result of the DOM query returns undefined.
