### PR TITLE
fix(curriculum): replaced incorrect quiz option "keys()" with "trim()"

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/quiz-javascript-arrays/66edcccbba6dacdb65a59067.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-javascript-arrays/66edcccbba6dacdb65a59067.md
@@ -434,7 +434,7 @@ Which of the following is NOT an array method?
 
 #### --answer--
 
-`keys()`
+`trim()`
 
 ### --question--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #61802

<!-- Feel free to add any additional description of changes below this line -->
In the JavaScript Arrays quiz for the Full Stack Developer certification, keys() is a valid array method, so i replaced it with trim(), which is a string method.