### PR TITLE
fix(curriculum): change card and cvv input types to text

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-checkout-page/66da326c02141df538f29ba5.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-checkout-page/66da326c02141df538f29ba5.md
@@ -157,7 +157,7 @@ assert.isAtLeast(requiredInputs?.length, 2)
                 </div>
                 <div>
                     <label for="card-number">Card Number</label>
-                    <input type="number" id="card-number" name="card-number" required aria-required="true">
+                    <input type="text" id="card-number" name="card-number" required aria-required="true">
                 </div>
                 <div>
                     <label for="expiry-date">Expiry Date</label>
@@ -165,7 +165,7 @@ assert.isAtLeast(requiredInputs?.length, 2)
                 </div>
                 <div>
                     <label for="cvv">CVV</label>
-                    <input type="number" id="cvv" name="cvv" required aria-required="true" aria-label="Card Verification Value">
+                    <input type="text" id="cvv" name="cvv" required aria-required="true" aria-label="Card Verification Value">
                 </div>
                 <input type="submit" value="Place Order">
             </form>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #61826 

<!-- Feel free to add any additional description of changes below this line -->
This PR addresses the issue by changing the input `type` for the card number and CVV fields from "number" to "text" in the checkout page lab.
