### PR TITLE
fix: clarify OTP generator user story to match tests

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-one-time-password-generator/67c562286b29447da020d407.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-one-time-password-generator/67c562286b29447da020d407.md
@@ -10,7 +10,7 @@ demoType: onClick
 
 In this lab, you will generate a 6-digit OTP (One-Time Password) and display it to the user. The OTP will expire after 5 seconds, and a new OTP will be generated when the user clicks the `"Generate New OTP"` button.
 
-**Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab. 
+**Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab.
 
 **User Stories:**
 
@@ -59,7 +59,7 @@ assert.exists(h1);
 assert.equal(h1.textContent, "OTP Generator");
 ```
 
-The `.container` should contain an `h2` element with the ID `otp-display` that displays the OTP when generated. 
+The `.container` should contain an `h2` element with the ID `otp-display` that displays the OTP when generated.
 
 ```js
 const h2 = document.querySelector(".container h2#otp-display");
@@ -72,7 +72,11 @@ Initially, the `h2` inside `.container` should display the message `"Click 'Gene
 assert.strictEqual(document.querySelector('.container h2#otp-display').textContent.trim(), "Click 'Generate OTP' to get a code");
 ```
 
-Initially, there should be a `.container` element that does not contain any `<p>` elements.
+A `<p>` element with the ID otp-timer that appears only after the "Generate OTP" button is clicked.
+
+While the countdown is running, it displays: "Expires in: X seconds".
+
+After the countdown reaches 0, it displays: "OTP expired. Click the button to generate a new OTP."
 
 ```js
 const container = document.querySelector('.container');
@@ -81,7 +85,7 @@ const pElements = document.querySelectorAll('.container p');
 assert.strictEqual(pElements.length, 0, "Initially, there should be no <p> elements inside '.container'");
 ```
 
-The `.container` should contain a `button` element with the ID `generate-otp-button` and text `"Generate OTP"`. 
+The `.container` should contain a `button` element with the ID `generate-otp-button` and text `"Generate OTP"`.
 
 ```js
 const button = document.querySelector('.container button#generate-otp-button').textContent;
@@ -177,7 +181,7 @@ try {
   const button = document.querySelector(".container button#generate-otp-button");
   button.click();
   clock.tick(1);
-  
+
   assert.isTrue(button.disabled);
 } finally {
   await clock.runAllAsync();
@@ -193,7 +197,7 @@ async () => {
 const button = document.querySelector(".container button#generate-otp-button");
 button.click();
 await clock.tickAsync(6000);
-  
+
 assert.isFalse(button.disabled);
 }
 ```

--- a/curriculum/challenges/english/25-front-end-development/lab-one-time-password-generator/67c562286b29447da020d407.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-one-time-password-generator/67c562286b29447da020d407.md
@@ -20,8 +20,8 @@ In this lab, you will generate a 6-digit OTP (One-Time Password) and display it 
 
     - An `h1` element with the ID `otp-title` and text `"OTP Generator"`.
     - An `h2` element with the ID `otp-display` that either displays the message `"Click 'Generate OTP' to get a code"` or shows the generated OTP if one is available.
-    - A `p` element with the ID `otp-timer` that:
-        - Starts off empty.
+    - A `P` element with the ID otp-timer that:
+      Initially, there should be a .container element that does not contain any `<p>` elements.
         - Displays `"Expires in: X seconds"` after the button is clicked, where `X` represents the remaining time before the OTP expires.
         - Shows the message `"OTP expired. Click the button to generate a new OTP."` once the countdown reaches `0`.
     - A `button` element with the ID `generate-otp-button` labeled `"Generate OTP"`. When clicked, it should generate a new OTP and start a 5-second countdown.
@@ -72,11 +72,7 @@ Initially, the `h2` inside `.container` should display the message `"Click 'Gene
 assert.strictEqual(document.querySelector('.container h2#otp-display').textContent.trim(), "Click 'Generate OTP' to get a code");
 ```
 
-A `<p>` element with the ID otp-timer that appears only after the "Generate OTP" button is clicked.
-
-While the countdown is running, it displays: "Expires in: X seconds".
-
-After the countdown reaches 0, it displays: "OTP expired. Click the button to generate a new OTP."
+Initially, there should be a .container element that does not contain any `<p>` elements.
 
 ```js
 const container = document.querySelector('.container');

--- a/curriculum/challenges/english/25-front-end-development/lab-one-time-password-generator/67c562286b29447da020d407.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-one-time-password-generator/67c562286b29447da020d407.md
@@ -20,7 +20,7 @@ In this lab, you will generate a 6-digit OTP (One-Time Password) and display it 
 
     - An `h1` element with the ID `otp-title` and text `"OTP Generator"`.
     - An `h2` element with the ID `otp-display` that either displays the message `"Click 'Generate OTP' to get a code"` or shows the generated OTP if one is available.
-    - A `P` element with the ID otp-timer that:
+    - A `p` element with the ID `otp-timer` that:
      Initially the .container element should not include any `<p>` elements.
         - Displays `"Expires in: X seconds"` after the button is clicked, where `X` represents the remaining time before the OTP expires.
         - Shows the message `"OTP expired. Click the button to generate a new OTP."` once the countdown reaches `0`.

--- a/curriculum/challenges/english/25-front-end-development/lab-one-time-password-generator/67c562286b29447da020d407.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-one-time-password-generator/67c562286b29447da020d407.md
@@ -21,7 +21,7 @@ In this lab, you will generate a 6-digit OTP (One-Time Password) and display it 
     - An `h1` element with the ID `otp-title` and text `"OTP Generator"`.
     - An `h2` element with the ID `otp-display` that either displays the message `"Click 'Generate OTP' to get a code"` or shows the generated OTP if one is available.
     - A `P` element with the ID otp-timer that:
-      Initially, there should be a .container element that does not contain any `<p>` elements.
+     Initially the .container element should not include any `<p>` elements.
         - Displays `"Expires in: X seconds"` after the button is clicked, where `X` represents the remaining time before the OTP expires.
         - Shows the message `"OTP expired. Click the button to generate a new OTP."` once the countdown reaches `0`.
     - A `button` element with the ID `generate-otp-button` labeled `"Generate OTP"`. When clicked, it should generate a new OTP and start a 5-second countdown.

--- a/curriculum/challenges/english/25-front-end-development/lab-one-time-password-generator/67c562286b29447da020d407.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-one-time-password-generator/67c562286b29447da020d407.md
@@ -21,7 +21,8 @@ In this lab, you will generate a 6-digit OTP (One-Time Password) and display it 
     - An `h1` element with the ID `otp-title` and text `"OTP Generator"`.
     - An `h2` element with the ID `otp-display` that either displays the message `"Click 'Generate OTP' to get a code"` or shows the generated OTP if one is available.
     - A `p` element with the ID `otp-timer` that:
-     Initially the .container element should not include any `<p>` elements.
+     Before the button is clicked, the .container element should not contain any `<p>` elements. After the button is clicked, a `<p>` element with the ID `otp-timer` should appear.
+     
         - Displays `"Expires in: X seconds"` after the button is clicked, where `X` represents the remaining time before the OTP expires.
         - Shows the message `"OTP expired. Click the button to generate a new OTP."` once the countdown reaches `0`.
     - A `button` element with the ID `generate-otp-button` labeled `"Generate OTP"`. When clicked, it should generate a new OTP and start a 5-second countdown.


### PR DESCRIPTION
Title:  fix #61829 : clarify OTP generator user story


This PR updates the OTP Generator lab's user story to match the behavior expected by the tests.

**Problem:**
- Original user story says the `<p>` with id `otp-timer` "starts off empty".
- Test 6 expects no `<p>` in the initial render.


**Fix:**
- Clarified that the `<p>` appears only after the "Generate OTP" button is clicked.
- Added detail for both countdown and expired states.



- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

Closes #61829 