### PR TITLE
fix(curriculum): clarify newline character wording

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-library-manager/681dbe48ee5df6842385d735.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-library-manager/681dbe48ee5df6842385d735.md
@@ -11,7 +11,7 @@ The rest of the objects representing the books have been filled in for you.
 
 Now would be a good time to start working on displaying the book information in the console. Over the next few steps, you will learn how to work with the `map()` method to achieve this goal.
 
-Begin by logging the message `"Books in the Library:\n"` to the console. The newline character is added here because there should be a space between this message and the list of books.
+Begin by logging the message `"Books in the Library:\n"` to the console. The newline character `\n` ensures a line break between this message and the list of books. 
 
 # --hints--
 

--- a/curriculum/challenges/english/25-front-end-development/workshop-library-manager/682264d807fe00058c1ea013.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-library-manager/682264d807fe00058c1ea013.md
@@ -9,7 +9,7 @@ dashedName: step-10
 
 For the next part of the workshop, you will focus on displaying a list of book summaries to the console.
 
-Begin by logging the message `"\nList of book summaries:\n"` to the console. The newline character is added here because there should be a space before and after the message here.
+Begin by logging the message `"\nList of book summaries:\n"` to the console. The newline character `\n` ensures a line break before and after this message.
 
 # --hints--
 


### PR DESCRIPTION
Closes #61809. Rephrased Step 4 and Step 10 to explain the use of the newline character `\n` more clearly.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #61809 

<!-- Feel free to add any additional description of changes below this line -->
