### PR TITLE
fix(curriculum): change toFix to toFixed in lesson content

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-types-and-objects/6732c69d82814160951b1aa7.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-types-and-objects/6732c69d82814160951b1aa7.md
@@ -7,7 +7,7 @@ dashedName: what-is-the-number-constructor-and-how-does-it-work-for-type-coercio
 
 # --description--
 
-The `Number()` constructor is used to create a number object. The number object contains a few helpful properties and methods like the `isNaN` and the `toFix` method. Here's an example using the `Number()` constructor with the `new` keyword:
+The `Number()` constructor is used to create a number object. The number object contains a few helpful properties and methods like the `isNaN` and the `toFixed` method. Here's an example using the `Number()` constructor with the `new` keyword:
 
 ```js
 const myNum = new Number("34");


### PR DESCRIPTION
Corrected a typo in the "Working with Types and Objects" lecture (Full Stack Curriculum). The lesson previously referred to a `toFix` method, which does not exist in JavaScript. It has been updated to the correct `toFixed` method.  

Checklist:
- [x] I have read and followed the contribution guidelines.
- [x] I have read and followed the how to open a pull request guide.
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

Closes #61839
