### PR TITLE
fix(curriculum): use 'macOS' instead of 'Mac' when referencing the operating system

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lecture-browsing-the-web-effectively/672aa5bd69657d56ab49ec8a.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-browsing-the-web-effectively/672aa5bd69657d56ab49ec8a.md
@@ -11,7 +11,7 @@ Web browsers are applications you use to visit pages on the internet. If you are
 
 As of 2024, the most popular browsers are Microsoft Edge, Firefox, Google Chrome, and Safari. There are quite a few other options, and market shares are always changing, but these four are the most common at this time.
 
-Your operating system most likely comes with a browser installed by default. For Windows, you'd have Microsoft Edge. For Mac, you'd have Safari. For Linux, you'll probably have Firefox.
+Your operating system most likely comes with a browser installed by default. For Windows, you'd have Microsoft Edge. For macOS, you'd have Safari. For Linux, you'll probably have Firefox.
 
 But what if you want to use a different browser?
 
@@ -73,7 +73,7 @@ Internet Explorer
 
 ## --text--
 
-What is the default web browser that typically comes pre-installed on a Mac operating system?
+What is the default web browser that typically comes pre-installed on macOS?
 
 ## --answers--
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-common-design-tools/672bb619f0d4538d0528760d.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-common-design-tools/672bb619f0d4538d0528760d.md
@@ -36,7 +36,7 @@ Adobe XD is another vector-based design and prototyping tool for UI/UX design, k
 
 This integration makes workflows such as interactive prototyping and animations more efficient.
 
-Adobe XD is available for both Windows and MacOS and includes a cloud-based interface. For the best experience, however, you should use the app directly.
+Adobe XD is available for both Windows and macOS and includes a cloud-based interface. For the best experience, however, you should use the app directly.
 
 Another design tool worth mentioning is Canva. You can use Canva to create a wide range of visual content, including posters, cover photos, presentations, short videos, and more. Its user-friendly and simple design makes it ideal for beginners.
 

--- a/curriculum/challenges/english/25-front-end-development/lecture-importance-of-accessibility-and-good-html-structure/672a5361ef88158b25fbfba7.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-importance-of-accessibility-and-good-html-structure/672a5361ef88158b25fbfba7.md
@@ -26,7 +26,7 @@ Therefore, software developers need to make their digital products accessible to
 
 All the mainstay Operating Systems have at least one magnifier built into them by their manufacturers:
 
-- macOS and iOS both have Zoom. You can turn it on on Mac by going to Settings, filter by Accessibility, and then click on "Zoom". Toggle the "Use keyboard shortcuts to zoom" option to enable it.
+- macOS and iOS both have Zoom. You can turn it on on macOS by going to Settings, filter by Accessibility, and then click on "Zoom". Toggle the "Use keyboard shortcuts to zoom" option to enable it.
   - You can turn it on on iPhone through _Settings > Accessibility > Zoom_.
 - Android devices have Magnification. To turn it on, go to _Settings > Special Function > Accessibility> Magnification_. Since this may vary from device to device, you can search for "Magnification" on the settings homepage to access it.
 - Windows has Magnifier. You can use it by going to _Settings > Ease of Access > Magnifier_.
@@ -35,11 +35,11 @@ All the mainstay Operating Systems have at least one magnifier built into them b
 Apart from the ones built into operating systems, some useful third party screen magnifiers are:
 
 - ZoomText for Windows.
-- ClaroView for both Mac and Windows.
+- ClaroView for both macOS and Windows.
 - iZoom for Windows.
-- Zoomify - Screen Magnifier for Mac.
+- Zoomify - Screen Magnifier for macOS.
 - LunarPluse for Windows.
-- Loupe for Mac.
+- Loupe for macOS.
 
 # --questions--
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

Closes #61815

### Description
Replaced references to "Mac" with "macOS" when referring to the operating system in curriculum content for accuracy and consistency.
