### PR TITLE
fix(curriculum) hardware compatibility testing focuses on types ,not RAM size.

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lecture-understanding-the-different-types-of-testing/67d2ff6f069dce9feacb7d25.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-understanding-the-different-types-of-testing/67d2ff6f069dce9feacb7d25.md
@@ -15,7 +15,7 @@ Different types of compatibility testing include backwards and forwards compatib
 
 Let's take a look at each of the types in more detail by starting with backwards and forwards compatibility. Backwards compatibility refers to when current software is compatible with earlier versions. Forwards compatibility is when software and systems will work with future versions of itself.
 
-The next type of testing is for hardware. Hardware compatibility testing focuses on the software's ability to work properly in different hardware configurations. This includes components like processors, memory, different storage types, and graphics cards.
+The next type of testing is for hardware. Hardware compatibility testing focuses on the software's ability to work properly in different hardware configurations. This includes different types of processors, memory,storage, and graphics cards.Note that RAM size is a performance consideration,not a compatibility issue.
 
 Another type of compatibility testing is for operating systems. You don't want to design software that works smoothly on Mac devices but has bugs on Windows or vice versa. You also need to consider Linux distributions like Ubuntu and Fedora.
 


### PR DESCRIPTION
Updated the lecture text to clarify that hardware compaibility testing focuses on hardware types like RAM type,processor type,not RAM size.this avoids confusion for learners who might think RAM size is a compatibility issue.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x ] My pull request targets the `main` branch of freeCodeCamp.
- [x ] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #61806

<!-- Feel free to add any additional description of changes below this line -->
