### PR TITLE
fix(curriculum): typo test 38

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-markdown-to-html-converter/66f55eac933ff64ce654ca74.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-markdown-to-html-converter/66f55eac933ff64ce654ca74.md
@@ -638,7 +638,7 @@ When the value of `#markdown-input` is `![alt-text](image-source)` followed by `
 
 ```js
 const input = document.querySelector("#markdown-input");
-input.value = "!![alt-text](image-source)\n![alt-text-2](image-source-2)";
+input.value = "![alt-text](image-source)\n![alt-text-2](image-source-2)";
 const testDiv = document.createElement("div");
 testDiv.innerHTML = convertMarkdown();
 const imgs = testDiv.querySelectorAll("img");


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #60034

<!-- Feel free to add any additional description of changes below this line -->

The test had a typo, a double bang (!!), causing it to fail incorrectly.
>When the value of `#markdown-input` is `![alt-text](image-source) followed by `![alt-text-2](image-source-2)` on a new line, `convertMarkdown()` should return `<img alt="alt-text" src="image-source"><img alt="alt-text-2" src="image-source-2">`.
```
input.value = "!![alt-text](image-source)\n![alt-text-2](image-source-2)";
```

**There is a second part to the original Issue involving a false positive but I'll open that as a new Issue instead.** 
