### PR TITLE
fix(curriculum): correct word order in Heart Icon Step 3 lesson

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-build-a-heart-icon/686daa7ed79ceacd0b264e7e.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-build-a-heart-icon/686daa7ed79ceacd0b264e7e.md
@@ -10,7 +10,7 @@ dashedName: step-3
 You are getting closer. The next thing to do is to set the `viewBox` attribute of the `svg` element. This will
 control how much of the image is visible. The first two numbers set the center of the image.
 
-The following two numbers set the size of the image can we see; width followed by height.
+The following two numbers set the size of the image we can see; width followed by height.
 
 Since here the entirety of the icon should be visible, you should set the `viewBox` attribute to `0 0 24 24`.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #61845 

<!-- Feel free to add any additional description of changes below this line -->

This PR corrects the word order in Step 3 of the "Build a Heart Icon" workshop.  
It changes the sentence from "… can we see" → "… we can see" for clarity.  
