### PR TITLE
test: add case to validate diagonal win condition in Tic-Tac-Toe lab

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lab-tic-tac-toe/67e3a6b7f60b4085588189e6.md
+++ b/curriculum/challenges/english/25-front-end-development/lab-tic-tac-toe/67e3a6b7f60b4085588189e6.md
@@ -248,6 +248,50 @@ async () => {
 }
 ```
 
+The game should end when there is a diagonal winning pattern.
+
+```js
+async () => {
+  await reset(assert);
+  const els = document.querySelectorAll("button.square");
+
+  try {
+    // X: top-left
+    els[0].click();
+    clock.tick(50);
+
+    // O: top-middle (just to alternate turns)
+    els[1].click();
+    clock.tick(50);
+
+    // X: top-center
+    els[4].click();
+    clock.tick(50);
+
+    // O: top-right (just alterning)
+    els[2].click();
+    clock.tick(50);
+
+    // X: bottom-right to complete diagonal [0, 4, 8]
+    els[8].click();
+    clock.tick(50);
+
+    // Verify winner message is displayed
+    const statusText = getInnertextExcept("button.square");
+    assert.includes(statusText, "Winner: X"); 
+
+    // Verify that no more moves are possible
+    const preClick = els[3].textContent;
+    els[3].click();
+    clock.tick(50);
+    assert.equal(els[3].textContent, preClick);
+  } catch (e) {
+    console.error(e);
+    throw e;
+  }
+}
+```
+
 The game should display a message indicating the winner to be `X` or `O`.
 
 ```js


### PR DESCRIPTION
Checklist:
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

Closes #60731

This PR adds a new test case in the Tic-Tac-Toe lab challenge hints to ensure the game correctly ends when there is a **diagonal winning pattern**.

- Previously, the tests only checked for horizontal and vertical wins, meaning a solution could ignore diagonal checks and still pass.
- The new test verifies:
  - Diagonal `[0, 4, 8]` results in a winner being declared (`Winner: X`).
  - No further moves are allowed once a diagonal win is achieved.

### Screenshots
<img width="1919" height="834" alt="Screenshot 2025-08-19 135103" src="https://github.com/user-attachments/assets/1b5e0aa3-2502-44c7-9648-d527363738ee" />
