### PR TITLE
fix: align Daily Coding Challenge hint with test (Aug 11, 2025)

### DIFF
--- a/curriculum/challenges/english/99-dev-playground/daily-coding-challenges-javascript/javascript-challenge-1.md
+++ b/curriculum/challenges/english/99-dev-playground/daily-coding-challenges-javascript/javascript-challenge-1.md
@@ -51,7 +51,7 @@ assert.isTrue(isBalanced(" "));
 assert.isFalse(isBalanced("abcdefghijklmnopqrstuvwxyz"));
 ```
 
-`isBalanced("123A#b!E&#x26;*456-o.U")` should return `true`.
+`isBalanced("123A#b!E&*456-o.U")` should return `true`.
 
 ```js
 assert.isTrue(isBalanced("123A#b!E&*456-o.U"));

--- a/curriculum/challenges/english/99-dev-playground/daily-coding-challenges-python/python-challenge-1.md
+++ b/curriculum/challenges/english/99-dev-playground/daily-coding-challenges-python/python-challenge-1.md
@@ -69,7 +69,7 @@ TestCase().assertFalse(is_balanced("abcdefghijklmnopqrstuvwxyz"))`)
 }})
 ```
 
-`is_balanced("123A#b!E&#x26;*456-o.U")` should return `True`.
+`is_balanced("123A#b!E&*456-o.U")` should return `True`.
 
 ```js
 ({test: () => { runPython(`


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the contributing guidelines: https://contribute.freecodecamp.org
- [x] I have read and followed the guide on how to open a pull request: https://contribute.freecodecamp.org/how-to-open-a-pull-request/
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes locally (content-only change; verified formatting/lints).

Closes #61869

Additional description of changes:
- Fixes the hint string ampersand to match the actual test case in both English challenges (JS and Python).
- Ensures the hint accurately reflects the test to avoid confusion for campers.
- No functional code changes, only documentation content in the English curriculum.

Files changed:
- curriculum/challenges/english/99-dev-playground/daily-coding-challenges-javascript/javascript-challenge-1.md
- curriculum/challenges/english/99-dev-playground/daily-coding-challenges-python/python-challenge-1.md