### PR TITLE
feat(client): add sticky MCQ status toolbar with per-question navigation

### DIFF
--- a/client/src/templates/Challenges/components/multiple-choice-questions.tsx
+++ b/client/src/templates/Challenges/components/multiple-choice-questions.tsx
@@ -35,7 +35,11 @@ function MultipleChoiceQuestions({
         }
       />
       {questions.map((question, questionIndex) => (
-        <fieldset key={questionIndex}>
+        <fieldset
+          key={questionIndex}
+          id={`mcq-question-${questionIndex}`}
+          tabIndex={-1}
+        >
           <legend className='mcq-question-text'>
             <PrismFormatted className={'line-numbers'} text={question.text} />
           </legend>

--- a/client/src/templates/Challenges/generic/show.tsx
+++ b/client/src/templates/Challenges/generic/show.tsx
@@ -163,6 +163,13 @@ const ShowGeneric = ({
 
   const [showFeedback, setShowFeedback] = useState(false);
 
+  const scrollToQuestion = (questionIndex: number) => {
+    const el = document.getElementById(`mcq-question-${questionIndex}`);
+    el?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    // attempt to move focus for accessibility if possible
+    el?.focus();
+  };
+
   const handleMcqOptionChange = (
     questionIndex: number,
     answerIndex: number
@@ -284,18 +291,86 @@ const ShowGeneric = ({
                 <p className='text-center'>{t('learn.answered-mcq')}</p>
               )}
 
-              <Button block={true} variant='primary' onClick={handleSubmit}>
-                {blockType === BlockTypes.review
-                  ? t('buttons.submit')
-                  : t('buttons.check-answer')}
-              </Button>
-              <Spacer size='xxs' />
-              <Button block={true} variant='primary' onClick={openHelpModal}>
-                {t('buttons.ask-for-help')}
-              </Button>
-
               <Spacer size='l' />
             </Col>
+            {questions.length > 0 && (
+              <div
+                className='mcq-toolbar'
+                role='region'
+                aria-label='Answer status and actions'
+              >
+                <div
+                  className='mcq-toolbar-left'
+                  role='status'
+                  aria-live='polite'
+                >
+                  {questions.map((q, i) => {
+                    const submitted = submittedMcqAnswers[i];
+                    const correctIndex = q.solution - 1;
+                    const status =
+                      !showFeedback || submitted === null
+                        ? 'unanswered'
+                        : submitted === correctIndex
+                          ? 'correct'
+                          : 'incorrect';
+                    return (
+                      <button
+                        key={i}
+                        type='button'
+                        className={`mcq-status-item ${status}`}
+                        onClick={() => scrollToQuestion(i)}
+                        aria-label={`Question ${i + 1}: ${status}`}
+                        title={`Question ${i + 1}: ${status}`}
+                      >
+                        {status === 'correct' ? (
+                          // check icon
+                          <svg
+                            width='18'
+                            height='18'
+                            viewBox='0 0 24 24'
+                            aria-hidden='true'
+                            focusable='false'
+                          >
+                            <path
+                              fill='currentColor'
+                              d='M9 16.2 4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4z'
+                            />
+                          </svg>
+                        ) : status === 'incorrect' ? (
+                          // cross icon
+                          <svg
+                            width='18'
+                            height='18'
+                            viewBox='0 0 24 24'
+                            aria-hidden='true'
+                            focusable='false'
+                          >
+                            <path
+                              fill='currentColor'
+                              d='M18.3 5.7 12 12l6.3 6.3-1.4 1.4L10.6 13.4 4.3 19.7 2.9 18.3 9.2 12 2.9 5.7 4.3 4.3l6.3 6.3 6.3-6.3z'
+                            />
+                          </svg>
+                        ) : (
+                          // empty placeholder
+                          <span className='mcq-status-dot' aria-hidden='true' />
+                        )}
+                      </button>
+                    );
+                  })}
+                </div>
+                <div className='mcq-toolbar-right'>
+                  <Button variant='primary' onClick={openHelpModal}>
+                    {t('buttons.ask-for-help')}
+                  </Button>
+                  <span className='mcq-toolbar-gap' />
+                  <Button variant='primary' onClick={handleSubmit}>
+                    {blockType === BlockTypes.review
+                      ? t('buttons.submit')
+                      : t('buttons.check-answer')}
+                  </Button>
+                </div>
+              </div>
+            )}
             <CompletionModal />
             <HelpModal
               challengeTitle={title}

--- a/client/src/templates/Challenges/video.css
+++ b/client/src/templates/Challenges/video.css
@@ -157,3 +157,76 @@ input:focus-visible + .video-quiz-input-visible {
   color: var(--primary-color);
   margin: 0;
 }
+
+/* New full-width toolbar with chips on left and actions on right */
+.mcq-toolbar {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 1rem calc(0.75rem + env(safe-area-inset-bottom));
+  background: var(--primary-background);
+  border-top: 1px solid var(--tertiary-background);
+  z-index: 1000;
+}
+
+.mcq-toolbar-left {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.mcq-toolbar-right {
+  display: flex;
+  align-items: center;
+}
+
+.mcq-toolbar-gap {
+  width: 0.5rem;
+  display: inline-block;
+}
+
+.mcq-status-item {
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 999px;
+  border: 2px solid var(--tertiary-background);
+  background: var(--secondary-background);
+  color: var(--primary-color);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.mcq-status-item.correct {
+  border-color: var(--success-background);
+  color: #fff;
+  background: var(--success-background);
+}
+
+.mcq-status-item.incorrect {
+  border-color: var(--danger-background);
+  color: #fff;
+  background: var(--danger-background);
+}
+
+.mcq-status-item.unanswered {
+  opacity: 0.6;
+}
+
+.mcq-status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: var(--tertiary-background);
+  display: inline-block;
+}
+
+.mcq-status-item:focus-visible {
+  outline: 3px solid var(--focus-outline-color);
+  outline-offset: 3px;
+}


### PR DESCRIPTION
… focus

Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

Closes #60592

Summary This improves the Multiple-Choice Question (MCQ) challenge UX by adding a sticky bottom toolbar that:

- Shows a compact, per-question status after “Check your answers” (correct, incorrect, unanswered).
- Lets learners jump directly to any question by clicking a status chip.
- Keeps the primary actions (“Ask for help” and “Check your answers”/“Submit”) in view.

Motivation Learners currently scroll a lot to find which questions are right/wrong after checking their answers. This toolbar surfaces status immediately and enables one-click navigation to any question, reducing friction and time to correct mistakes.

Changes

[show.tsx]
- Added a sticky toolbar that renders when there are MCQs.
- Left: status chips for each question (correct/incorrect/unanswered).
- Right: “Ask for help” and “Check your answers/Submit” buttons.
- Added scrollToQuestion(index): smooth scrolls and focuses the fieldset for accessibility.
- ARIA: region label for toolbar, status region with aria-live; aria-label per chip (e.g., “Question 3: incorrect”).

[multiple-choice-questions.tsx]
- Ensured each question fieldset has a stable id (mcq-question-{index}) and tabIndex={-1} so focus can be moved after scrolling.

[video.css]

- New styles for the toolbar and chips (mcq-toolbar*, mcq-status-item*, mcq-status-dot).
- Uses existing CSS variables for light/dark theming and focus outlines.
- Removed duplicate/legacy selectors flagged by stylelint.

Accessibility

Keyboard and screen reader friendly:

  - Chips are buttons with aria-labels.
  - Toolbar uses role="region" and a labelled status section with aria-live for changes after checking.
  - Focus moves to the question fieldset after clicking a chip.
  - Visible focus styles use var(--focus-outline-color).
  
Screenshot(after):

<img width="1918" height="873" alt="image" src="https://github.com/user-attachments/assets/e62753e7-bc05-4fc9-9888-b924591f8144" />
