### PR TITLE
fix(curriculum): correct typo 'rick-click' → 'right-click'

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/lecture-working-with-file-systems/672ac3c5d0e9fd31835ff772.md
+++ b/curriculum/challenges/english/25-front-end-development/lecture-working-with-file-systems/672ac3c5d0e9fd31835ff772.md
@@ -51,7 +51,7 @@ Usually, the file extension is added by the application automatically but you ca
 
 After saving the file, you can open Finder by clicking on the Finder icon in the Dock. You should see your new file in the folder where you saved it.
 
-To create a new folder, you should go to the location where you want to create that new folder and rick-click on an empty spot. You will see a list of options. The first option is "New Folder."
+To create a new folder, you should go to the location where you want to create that new folder and right-click on an empty spot. You will see a list of options. The first option is "New Folder."
 
 If you click on it, you can assign a name to your new folder. Write the name and press Enter to confirm.
 


### PR DESCRIPTION
Fixed the typo 
rick-click ---> right-click

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #61888

<!-- Feel free to add any additional description of changes below this line -->
This PR fixes a typo in the curriculum lesson on working with file systems.  
Changed "rick-click" → "right-click".  

This improves clarity for learners by correcting the text.



