### PR TITLE
fix(curriculum): add 'should' to correct typo in step 68

### DIFF
--- a/curriculum/challenges/english/07-scientific-computing-with-python/learn-special-methods-by-building-a-vector-space/66019258a7c71d4ae50da42e.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/learn-special-methods-by-building-a-vector-space/66019258a7c71d4ae50da42e.md
@@ -25,7 +25,7 @@ Your `__le__` method should have two parameters, `self` and `other`.
 ({ test: () => assert(runPython(`_Node(_code).find_class("R2Vector").find_function("__le__").has_args("self, other")`)) })
 ```
 
-Your `__le__` method return the opposite of `self > other`.
+Your `__le__` method should return the opposite of `self > other`.
 
 ```js
 ({ test: () => assert(runPython(`_Node(_code).find_class("R2Vector").find_function("__le__").has_return("not self > other")`)) })


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #61912

<!-- Feel free to add any additional description of changes below this line -->
Correct typo for step 68 in file curriculum/challenges/english/07-scientific-computing-with-python/learn-special-methods-by-building-a-vector-space/66019258a7c71d4ae50da42e.md