### PR TITLE
feat(tools): script to create daily challenge files

### DIFF
--- a/tools/challenge-helper-scripts/create-daily-challenges.ts
+++ b/tools/challenge-helper-scripts/create-daily-challenges.ts
@@ -1,0 +1,124 @@
+/*
+  Script to create daily coding challenge files in the dev-playground superblock.
+  Accepts a number arg for how many challenges to create.
+*/
+
+import { readFileSync, writeFileSync } from 'fs';
+import path, { join } from 'path';
+import { fileURLToPath } from 'url';
+import ObjectID from 'bson-objectid';
+import { Meta } from './helpers/project-metadata';
+import { getArgValue } from './helpers/get-arg-value';
+import {
+  getDailyJavascriptChallengeTemplate,
+  getDailyPythonChallengeTemplate
+} from './helpers/get-challenge-template';
+
+const numberOfChallengesToCreate = getArgValue(process.argv);
+
+if (numberOfChallengesToCreate > 10) {
+  throw new Error('Are you sure you want to create that many challenges?');
+}
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const challengesPath = join(__dirname, '../../curriculum/challenges');
+const metaPath = join(challengesPath, '_meta');
+const devPlaygroundPath = join(challengesPath, 'english/99-dev-playground');
+
+const jsMetaPath = join(
+  metaPath,
+  'daily-coding-challenges-javascript/meta.json'
+);
+const pyMetaPath = join(metaPath, 'daily-coding-challenges-python/meta.json');
+
+for (let i = 0; i < numberOfChallengesToCreate; i++) {
+  const jsMeta = JSON.parse(readFileSync(jsMetaPath, 'utf-8')) as Meta;
+  const pyMeta = JSON.parse(readFileSync(pyMetaPath, 'utf-8')) as Meta;
+
+  const numberOfJsChallenges = jsMeta.challengeOrder.length;
+  const numberOfPyChallenges = pyMeta.challengeOrder.length;
+
+  if (numberOfJsChallenges !== numberOfPyChallenges) {
+    throw new Error(
+      'Inconsistent number of challenges in each daily challenge language, cannot create new challenge.'
+    );
+  }
+
+  const newChallengeNumber = numberOfJsChallenges + 1;
+
+  createDailyJsChallenge({ challengeNumber: newChallengeNumber, meta: jsMeta });
+  createDailyPyChallenge({ challengeNumber: newChallengeNumber, meta: pyMeta });
+}
+
+interface CreateDailyChallengeOptions {
+  challengeNumber: number;
+  meta: Meta;
+}
+
+function createDailyJsChallenge({
+  challengeNumber,
+  meta
+}: CreateDailyChallengeOptions) {
+  const challengeId = new ObjectID();
+
+  const newMeta = {
+    ...meta,
+    challengeOrder: [
+      ...meta.challengeOrder,
+      {
+        // eslint-disable-next-line @typescript-eslint/no-base-to-string
+        id: challengeId.toString(),
+        title: `JavaScript Challenge ${challengeNumber}`
+      }
+    ]
+  };
+
+  writeFileSync(jsMetaPath, JSON.stringify(newMeta, null, 2));
+
+  const jsTemplate = getDailyJavascriptChallengeTemplate({
+    challengeId,
+    challengeNumber
+  });
+
+  const jsChallengePath = join(
+    devPlaygroundPath,
+    `daily-coding-challenges-javascript/javascript-challenge-${challengeNumber}.md`
+  );
+
+  writeFileSync(jsChallengePath, jsTemplate);
+}
+
+function createDailyPyChallenge({
+  challengeNumber,
+  meta
+}: CreateDailyChallengeOptions) {
+  const challengeId = new ObjectID();
+
+  const newMeta = {
+    ...meta,
+    challengeOrder: [
+      ...meta.challengeOrder,
+      {
+        // eslint-disable-next-line @typescript-eslint/no-base-to-string
+        id: challengeId.toString(),
+        title: `Python Challenge ${challengeNumber}`
+      }
+    ]
+  };
+
+  writeFileSync(pyMetaPath, JSON.stringify(newMeta, null, 2));
+
+  const pyTemplate = getDailyPythonChallengeTemplate({
+    challengeId,
+    challengeNumber
+  });
+
+  const pyChallengePath = join(
+    devPlaygroundPath,
+    `daily-coding-challenges-python/python-challenge-${challengeNumber}.md`
+  );
+
+  writeFileSync(pyChallengePath, pyTemplate);
+}

--- a/tools/challenge-helper-scripts/create-daily-challenges.ts
+++ b/tools/challenge-helper-scripts/create-daily-challenges.ts
@@ -96,7 +96,8 @@ function createDailyJsChallenge({
 
   const jsChallengePath = join(
     jsChallengesPath,
-    `javascript-challenge-${challengeNumber}.md`
+    // eslint-disable-next-line @typescript-eslint/no-base-to-string
+    `${challengeId.toString()}.md`
   );
 
   writeFileSync(jsChallengePath, jsTemplate);
@@ -129,7 +130,8 @@ function createDailyPyChallenge({
 
   const pyChallengePath = join(
     pyChallengesPath,
-    `python-challenge-${challengeNumber}.md`
+    // eslint-disable-next-line @typescript-eslint/no-base-to-string
+    `${challengeId.toString()}.md`
   );
 
   writeFileSync(pyChallengePath, pyTemplate);

--- a/tools/challenge-helper-scripts/create-daily-challenges.ts
+++ b/tools/challenge-helper-scripts/create-daily-challenges.ts
@@ -23,19 +23,31 @@ if (numberOfChallengesToCreate > 10) {
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const challengesPath = join(__dirname, '../../curriculum/challenges');
-const metaPath = join(challengesPath, '_meta');
-const devPlaygroundPath = join(challengesPath, 'english/99-dev-playground');
+const curriculumPath = join(__dirname, '../../curriculum');
+const challengeBlocksPath = join(curriculumPath, '/challenges/english/blocks');
+const structureBlocksPath = join(curriculumPath, '/structure/blocks');
 
-const jsMetaPath = join(
-  metaPath,
-  'daily-coding-challenges-javascript/meta.json'
+const jsChallengesPath = join(
+  challengeBlocksPath,
+  '/daily-coding-challenges-javascript'
 );
-const pyMetaPath = join(metaPath, 'daily-coding-challenges-python/meta.json');
+const pyChallengesPath = join(
+  challengeBlocksPath,
+  '/daily-coding-challenges-python'
+);
+
+const jsStructurePath = join(
+  structureBlocksPath,
+  '/daily-coding-challenges-javascript.json'
+);
+const pyStructurePath = join(
+  structureBlocksPath,
+  '/daily-coding-challenges-python.json'
+);
 
 for (let i = 0; i < numberOfChallengesToCreate; i++) {
-  const jsMeta = JSON.parse(readFileSync(jsMetaPath, 'utf-8')) as Meta;
-  const pyMeta = JSON.parse(readFileSync(pyMetaPath, 'utf-8')) as Meta;
+  const jsMeta = JSON.parse(readFileSync(jsStructurePath, 'utf-8')) as Meta;
+  const pyMeta = JSON.parse(readFileSync(pyStructurePath, 'utf-8')) as Meta;
 
   const numberOfJsChallenges = jsMeta.challengeOrder.length;
   const numberOfPyChallenges = pyMeta.challengeOrder.length;
@@ -75,19 +87,14 @@ function createDailyJsChallenge({
     ]
   };
 
-  writeFileSync(jsMetaPath, JSON.stringify(newMeta, null, 2));
+  writeFileSync(jsStructurePath, JSON.stringify(newMeta, null, 2));
 
   const jsTemplate = getDailyJavascriptChallengeTemplate({
     challengeId,
     challengeNumber
   });
 
-  const jsChallengePath = join(
-    devPlaygroundPath,
-    `daily-coding-challenges-javascript/javascript-challenge-${challengeNumber}.md`
-  );
-
-  writeFileSync(jsChallengePath, jsTemplate);
+  writeFileSync(jsChallengesPath, jsTemplate);
 }
 
 function createDailyPyChallenge({
@@ -108,17 +115,12 @@ function createDailyPyChallenge({
     ]
   };
 
-  writeFileSync(pyMetaPath, JSON.stringify(newMeta, null, 2));
+  writeFileSync(pyStructurePath, JSON.stringify(newMeta, null, 2));
 
   const pyTemplate = getDailyPythonChallengeTemplate({
     challengeId,
     challengeNumber
   });
 
-  const pyChallengePath = join(
-    devPlaygroundPath,
-    `daily-coding-challenges-python/python-challenge-${challengeNumber}.md`
-  );
-
-  writeFileSync(pyChallengePath, pyTemplate);
+  writeFileSync(pyChallengesPath, pyTemplate);
 }

--- a/tools/challenge-helper-scripts/create-daily-challenges.ts
+++ b/tools/challenge-helper-scripts/create-daily-challenges.ts
@@ -24,18 +24,8 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const curriculumPath = join(__dirname, '../../curriculum');
-const challengeBlocksPath = join(curriculumPath, '/challenges/english/blocks');
+
 const structureBlocksPath = join(curriculumPath, '/structure/blocks');
-
-const jsChallengesPath = join(
-  challengeBlocksPath,
-  '/daily-coding-challenges-javascript'
-);
-const pyChallengesPath = join(
-  challengeBlocksPath,
-  '/daily-coding-challenges-python'
-);
-
 const jsStructurePath = join(
   structureBlocksPath,
   '/daily-coding-challenges-javascript.json'
@@ -43,6 +33,16 @@ const jsStructurePath = join(
 const pyStructurePath = join(
   structureBlocksPath,
   '/daily-coding-challenges-python.json'
+);
+
+const challengeBlocksPath = join(curriculumPath, '/challenges/english/blocks');
+const jsChallengesPath = join(
+  challengeBlocksPath,
+  '/daily-coding-challenges-javascript'
+);
+const pyChallengesPath = join(
+  challengeBlocksPath,
+  '/daily-coding-challenges-python'
 );
 
 for (let i = 0; i < numberOfChallengesToCreate; i++) {
@@ -94,7 +94,12 @@ function createDailyJsChallenge({
     challengeNumber
   });
 
-  writeFileSync(jsChallengesPath, jsTemplate);
+  const jsChallengePath = join(
+    jsChallengesPath,
+    `javascript-challenge-${challengeNumber}.md`
+  );
+
+  writeFileSync(jsChallengePath, jsTemplate);
 }
 
 function createDailyPyChallenge({
@@ -122,5 +127,10 @@ function createDailyPyChallenge({
     challengeNumber
   });
 
-  writeFileSync(pyChallengesPath, pyTemplate);
+  const pyChallengePath = join(
+    pyChallengesPath,
+    `python-challenge-${challengeNumber}.md`
+  );
+
+  writeFileSync(pyChallengePath, pyTemplate);
 }

--- a/tools/challenge-helper-scripts/helpers/get-challenge-template.ts
+++ b/tools/challenge-helper-scripts/helpers/get-challenge-template.ts
@@ -372,6 +372,8 @@ assert.isTrue(true);
 
 # --seed--
 
+## --seed-contents--
+
 \`\`\`js
 function placeholder(arg) {
 
@@ -415,6 +417,8 @@ TestCase().assertTrue(True)\`)
 \`\`\`
 
 # --seed--
+
+## --seed-contents--
 
 \`\`\`js
 def placeholder(arg):

--- a/tools/challenge-helper-scripts/helpers/get-challenge-template.ts
+++ b/tools/challenge-helper-scripts/helpers/get-challenge-template.ts
@@ -428,7 +428,6 @@ def placeholder(arg):
 def placeholder(arg):
 
     return arg
-}
 \`\`\`
 `;
 

--- a/tools/challenge-helper-scripts/helpers/get-challenge-template.ts
+++ b/tools/challenge-helper-scripts/helpers/get-challenge-template.ts
@@ -343,6 +343,95 @@ Generic challenge description.
 Do the assignment.
 `;
 
+interface DailyCodingChallengeOptions {
+  challengeId: ObjectID;
+  challengeNumber: number;
+}
+
+export const getDailyJavascriptChallengeTemplate = ({
+  challengeId,
+  challengeNumber
+}: DailyCodingChallengeOptions) => `---
+id: ${challengeId.toString()}
+title: "JavaScript Challenge ${challengeNumber}: Placeholder"
+challengeType: 28
+dashedName: javascript-challenge-${challengeNumber}
+---
+
+# --description--
+
+Placeholder description
+
+# --hints--
+
+Placeholder test
+
+\`\`\`js
+assert.isTrue(true);
+\`\`\`
+
+# --seed--
+
+\`\`\`js
+function placeholder(arg) {
+
+  return arg;
+}
+\`\`\`
+
+# --solutions--
+
+\`\`\`js
+function placeholder(arg) {
+
+  return arg;
+}
+\`\`\`
+`;
+
+export const getDailyPythonChallengeTemplate = ({
+  challengeId,
+  challengeNumber
+}: DailyCodingChallengeOptions) => `---
+id: ${challengeId.toString()}
+title: "Python Challenge ${challengeNumber}: Placeholder"
+challengeType: 29
+dashedName: python-challenge-${challengeNumber}
+---
+
+# --description--
+
+Placeholder description
+
+# --hints--
+
+Placeholder test
+
+\`\`\`js
+({test: () => { runPython(\`
+from unittest import TestCase
+TestCase().assertTrue(True)\`)
+}})
+\`\`\`
+
+# --seed--
+
+\`\`\`js
+def placeholder(arg):
+
+    return arg
+\`\`\`
+
+# --solutions--
+
+\`\`\`js
+def placeholder(arg):
+
+    return arg
+}
+\`\`\`
+`;
+
 type Template = (opts: ChallengeOptions) => string;
 
 export const getTemplate = (challengeType: string): Template => {

--- a/tools/challenge-helper-scripts/helpers/get-challenge-template.ts
+++ b/tools/challenge-helper-scripts/helpers/get-challenge-template.ts
@@ -420,7 +420,7 @@ TestCase().assertTrue(True)\`)
 
 ## --seed-contents--
 
-\`\`\`js
+\`\`\`py
 def placeholder(arg):
 
     return arg
@@ -428,7 +428,7 @@ def placeholder(arg):
 
 # --solutions--
 
-\`\`\`js
+\`\`\`py
 def placeholder(arg):
 
     return arg

--- a/tools/challenge-helper-scripts/package.json
+++ b/tools/challenge-helper-scripts/package.json
@@ -20,6 +20,7 @@
   "main": "utils.js",
   "scripts": {
     "test": "mocha --delay --reporter progress --bail",
+    "create-daily-challenges": "tsx create-daily-challenges",
     "create-project": "tsx create-project",
     "create-language-block": "tsx create-language-block",
     "create-quiz": "tsx create-quiz"


### PR DESCRIPTION
To test:
`cd tools/challenge-helper-scripts`
run `pnpm create-daily-challenges 5`

It will create placeholder files for the next five daily challenges - e.g: 5 JS and 5 Python challenge files in the dev-playground superblock and update the meta.json files to include the new challenges.

Probably some more code optimizing that could be done, but I think this is fine.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
