### PR TITLE
fix(client): initialize theme during gatsby SSR

### DIFF
--- a/client/gatsby-ssr.js
+++ b/client/gatsby-ssr.js
@@ -8,7 +8,11 @@ import i18n from './i18n/config';
 import { stripe } from './src/utils/stripe';
 import { createStore } from './src/redux/create-store';
 import layoutSelector from './utils/gatsby/layout-selector';
-import { getheadTagComponents, getPostBodyComponents } from './utils/tags';
+import {
+  getheadTagComponents,
+  getPostBodyComponents,
+  getPreBodyThemeScript
+} from './utils/tags';
 import GrowthBookProvider from './src/components/growth-book/growth-book-wrapper';
 
 const store = createStore();
@@ -34,9 +38,11 @@ export const wrapPageElement = layoutSelector;
 export const onRenderBody = ({
   pathname,
   setHeadComponents,
+  setPreBodyComponents,
   setPostBodyComponents
 }) => {
   setHeadComponents(getheadTagComponents());
+  setPreBodyComponents(getPreBodyThemeScript());
   setPostBodyComponents(getPostBodyComponents(pathname));
 };
 

--- a/client/utils/tags.tsx
+++ b/client/utils/tags.tsx
@@ -62,3 +62,36 @@ export function getPostBodyComponents(superblock: string): JSX.Element[] {
 
   return scripts.filter(Boolean);
 }
+
+export function getPreBodyThemeScript(): JSX.Element[] {
+  const script = (
+    <script
+      key='prebody-theme-init'
+      dangerouslySetInnerHTML={{
+        __html: `
+(function(){
+  let theme = 'light';
+  const localTheme = localStorage.getItem('theme');
+
+  if (localTheme !== null) {
+    theme = localTheme === 'dark' ? 'dark' : 'light';
+  } else if (
+    window.matchMedia &&
+    window.matchMedia('(prefers-color-scheme: dark)').matches
+  ) {
+    theme = 'dark';
+  }
+
+  const bodyEl = document && document.body;
+
+  if (bodyEl && bodyEl.classList) {
+    bodyEl.classList.remove('light-palette');
+    bodyEl.classList.remove('dark-palette');
+    bodyEl.classList.add(theme + '-palette');
+  }
+})();`
+      }}
+    />
+  );
+  return [script];
+}


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

## Problem

Currently if dark mode is selected, the page initially displays a white flash on load before transitioning to the dark theme.

This is because:
- We set the initial theme to `light` in redux:

    https://github.com/freeCodeCamp/freeCodeCamp/blob/28383824819bdc1695f51f3f2705a40d0a0e715b/client/src/redux/index.js#L59

- We then dispatch an action to set the correct theme:
    https://github.com/freeCodeCamp/freeCodeCamp/blob/28383824819bdc1695f51f3f2705a40d0a0e715b/client/src/components/layouts/default.tsx#L157-L160
- But this action happens after React hydrates and requires the fetch user action to complete, which causes a delay and results in the flash.

  https://github.com/freeCodeCamp/freeCodeCamp/blob/28383824819bdc1695f51f3f2705a40d0a0e715b/client/src/redux/theme-saga.js#L16-L18

## Solution

While we can use local storage or the system preference to determine the initial theme there, a white flash still occurs because the page must finish loading and Redux has initialized.

To fix this, the theme needs to be set as early as possible, during Gatsby SSR, so it takes effect before the first paint.

## Result

<details>
<summary>Refreshing a page - Before</summary>

https://github.com/user-attachments/assets/1b92b64c-5bac-4eef-8b32-d4a25ad47c30 

</details>

<details>
<summary>Refreshing a page - After</summary>

https://github.com/user-attachments/assets/5d8daa15-bbd6-4988-959d-f1f53431cdfe

</details>





<!-- Feel free to add any additional description of changes below this line -->
