### PR TITLE
feat(tools): allow tsx tabs

### DIFF
--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -188,6 +188,7 @@ const modeMap = {
   js: 'javascript',
   jsx: 'javascript',
   ts: 'typescript',
+  tsx: 'typescript',
   py: 'python',
   python: 'python'
 };

--- a/client/src/templates/Challenges/classic/multifile-editor.tsx
+++ b/client/src/templates/Challenges/classic/multifile-editor.tsx
@@ -96,12 +96,12 @@ const MultifileEditor = (props: MultifileEditorProps) => {
 
   // The order of the keys should match the order set by sortChallengeFiles
   if (indexjsx) editorKeys.push('indexjsx');
+  if (indextsx) editorKeys.push('indextsx');
   if (indexhtml) editorKeys.push('indexhtml');
   if (stylescss) editorKeys.push('stylescss');
   if (scriptjs) editorKeys.push('scriptjs');
   if (mainpy) editorKeys.push('mainpy');
   if (indexts) editorKeys.push('indexts');
-  if (indextsx) editorKeys.push('indextsx');
 
   const editorAndSplitterKeys = editorKeys.reduce((acc: string[] | [], key) => {
     if (acc.length === 0) {

--- a/client/src/templates/Challenges/classic/multifile-editor.tsx
+++ b/client/src/templates/Challenges/classic/multifile-editor.tsx
@@ -17,6 +17,7 @@ export type VisibleEditors = {
   stylescss?: boolean;
   scriptjs?: boolean;
   indexts?: boolean;
+  indextsx?: boolean;
   mainpy?: boolean;
 };
 type MultifileEditorProps = Pick<
@@ -70,6 +71,7 @@ const MultifileEditor = (props: MultifileEditorProps) => {
       scriptjs,
       indexts,
       indexjsx,
+      indextsx,
       mainpy
     },
     usesMultifileEditor,
@@ -99,6 +101,7 @@ const MultifileEditor = (props: MultifileEditorProps) => {
   if (scriptjs) editorKeys.push('scriptjs');
   if (mainpy) editorKeys.push('mainpy');
   if (indexts) editorKeys.push('indexts');
+  if (indextsx) editorKeys.push('indextsx');
 
   const editorAndSplitterKeys = editorKeys.reduce((acc: string[] | [], key) => {
     if (acc.length === 0) {

--- a/client/utils/__fixtures__/challenges.ts
+++ b/client/utils/__fixtures__/challenges.ts
@@ -70,5 +70,19 @@ export const challengeFiles: ChallengeFile[] = [
     editableRegionBoundaries: [],
     usesMultifileEditor: true,
     path: 'index.jsx',
+  },
+  {
+    contents: 'some tsx',
+    error: null,
+    ext: 'tsx',
+    head: '',
+    history: ['index.tsx'],
+    fileKey: 'indextsx',
+    name: 'index',
+    seed: 'some tsx',
+    tail: '',
+    editableRegionBoundaries: [],
+    usesMultifileEditor: true,
+    path: 'index.tsx',
   }
 ]

--- a/client/utils/sort-challengefiles.test.ts
+++ b/client/utils/sort-challengefiles.test.ts
@@ -14,7 +14,7 @@ describe('sort-files', () => {
       expect(sorted.length).toEqual(expected.length);
     });
 
-    it('should sort the objects into jsx, html, css, js, ts order', () => {
+    it('should sort the objects into jsx, html, css, js, ts,tsx order', () => {
       const sorted = sortChallengeFiles(challengeFiles);
       const sortedKeys = sorted.map(({ fileKey }) => fileKey);
       const expected = [
@@ -22,7 +22,8 @@ describe('sort-files', () => {
         'indexhtml',
         'stylescss',
         'scriptjs',
-        'indexts'
+        'indexts',
+        'indextsx'
       ];
       expect(sortedKeys).toStrictEqual(expected);
     });

--- a/client/utils/sort-challengefiles.test.ts
+++ b/client/utils/sort-challengefiles.test.ts
@@ -14,7 +14,7 @@ describe('sort-files', () => {
       expect(sorted.length).toEqual(expected.length);
     });
 
-    it('should sort the objects into jsx, html, css, js, ts,tsx order', () => {
+    it('should sort the objects into jsx, html, css, js, ts, tsx order', () => {
       const sorted = sortChallengeFiles(challengeFiles);
       const sortedKeys = sorted.map(({ fileKey }) => fileKey);
       const expected = [

--- a/client/utils/sort-challengefiles.test.ts
+++ b/client/utils/sort-challengefiles.test.ts
@@ -14,16 +14,16 @@ describe('sort-files', () => {
       expect(sorted.length).toEqual(expected.length);
     });
 
-    it('should sort the objects into jsx, html, css, js, ts, tsx order', () => {
+    it('should sort the objects into jsx, tsx, html, css, js, ts order', () => {
       const sorted = sortChallengeFiles(challengeFiles);
       const sortedKeys = sorted.map(({ fileKey }) => fileKey);
       const expected = [
         'indexjsx',
+        'indextsx',
         'indexhtml',
         'stylescss',
         'scriptjs',
-        'indexts',
-        'indextsx'
+        'indexts'
       ];
       expect(sortedKeys).toStrictEqual(expected);
     });

--- a/client/utils/sort-challengefiles.ts
+++ b/client/utils/sort-challengefiles.ts
@@ -12,6 +12,8 @@ export function sortChallengeFiles<File extends { fileKey: string }>(
     if (b.fileKey === 'scriptjs') return 1;
     if (a.fileKey === 'indexts') return -1;
     if (b.fileKey === 'indexts') return 1;
+    if (a.fileKey === 'indextsx') return -1;
+    if (b.fileKey === 'indextsx') return 1;
     return 0;
   });
 }

--- a/client/utils/sort-challengefiles.ts
+++ b/client/utils/sort-challengefiles.ts
@@ -4,6 +4,8 @@ export function sortChallengeFiles<File extends { fileKey: string }>(
   return challengeFiles.toSorted((a, b) => {
     if (a.fileKey === 'indexjsx') return -1;
     if (b.fileKey === 'indexjsx') return 1;
+    if (a.fileKey === 'indextsx') return -1;
+    if (b.fileKey === 'indextsx') return 1;
     if (a.fileKey === 'indexhtml') return -1;
     if (b.fileKey === 'indexhtml') return 1;
     if (a.fileKey === 'stylescss') return -1;
@@ -12,8 +14,6 @@ export function sortChallengeFiles<File extends { fileKey: string }>(
     if (b.fileKey === 'scriptjs') return 1;
     if (a.fileKey === 'indexts') return -1;
     if (b.fileKey === 'indexts') return 1;
-    if (a.fileKey === 'indextsx') return -1;
-    if (b.fileKey === 'indextsx') return 1;
     return 0;
   });
 }

--- a/shared/utils/polyvinyl.ts
+++ b/shared/utils/polyvinyl.ts
@@ -1,7 +1,7 @@
 // originally based off of https://github.com/gulpjs/vinyl
 import invariant from 'invariant';
 
-const exts = ['js', 'html', 'css', 'jsx', 'ts', 'py'] as const;
+const exts = ['js', 'html', 'css', 'jsx', 'ts', 'tsx', 'py'] as const;
 export type Ext = (typeof exts)[number];
 
 export interface IncompleteChallengeFile {

--- a/tools/challenge-parser/parser/plugins/add-seed.test.js
+++ b/tools/challenge-parser/parser/plugins/add-seed.test.js
@@ -194,7 +194,7 @@ describe('add-seed plugin', () => {
     expect.assertions(1);
     expect(() => plugin(cCodeAST, file)).toThrow(
       "On line 30 'c' is not a supported language.\n" +
-        ' Please use one of js, css, html, jsx or py'
+        ' Please use one of js, css, html, jsx, ts, tsx or py'
     );
   });
 

--- a/tools/challenge-parser/parser/plugins/utils/get-file-visitor.js
+++ b/tools/challenge-parser/parser/plugins/utils/get-file-visitor.js
@@ -8,7 +8,7 @@ const keyToSection = {
   head: 'before-user-code',
   tail: 'after-user-code'
 };
-const supportedLanguages = ['js', 'css', 'html', 'jsx', 'py', 'ts'];
+const supportedLanguages = ['js', 'css', 'html', 'jsx', 'py', 'ts', 'tsx'];
 const longToShortLanguages = {
   javascript: 'js',
   typescript: 'ts',
@@ -54,7 +54,7 @@ function codeToData(node, seeds, seedKey, validate) {
     throw Error(`On line ${
       position.start(node).line
     } '${shortLang}' is not a supported language.
- Please use one of js, css, html, jsx or py
+ Please use one of js, css, html, jsx, ts, tsx or py
 `);
 
   const fileId = `index${shortLang}`;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
We didn't have the necessary infrastructure for Typescript React challenges in place. This allows the tabs to appear in the editor and have syntax highlighting. 

I'm hoping this might also allow for proper handling of these challenges as well, but I don't remember how the React projects work under the hood. 