### PR TITLE
correct-challenge-type-a2-english-exam

### DIFF
--- a/curriculum/challenges/english/21-a2-english-for-developers/a2-english-for-developers-certification-exam/6721db5d9f0c116e6a0fe25a.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/a2-english-for-developers-certification-exam/6721db5d9f0c116e6a0fe25a.md
@@ -1,7 +1,7 @@
 ---
 id: 6721db5d9f0c116e6a0fe25a
 title: A2 English for Developers Certification Exam
-challengeType: 24
+challengeType: 30
 dashedName: a2-english-for-developers-certification-exam
 prerequisites: []
 ---


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes locally on my machine and/or on Gitpod.

Closes #61954

This pull request updates the `challengeType` value for the **A2 English exam** from `24` to `30`, as described in the issue. This ensures consistency with the updates applied to other exams (see #57325).
