### PR TITLE
Update A2 English exam challengeType to 30

### DIFF
--- a/curriculum/challenges/english/blocks/a2-english-for-developers-certification-exam/6721db5d9f0c116e6a0fe25a.md
+++ b/curriculum/challenges/english/blocks/a2-english-for-developers-certification-exam/6721db5d9f0c116e6a0fe25a.md
@@ -1,7 +1,7 @@
 ---
 id: 6721db5d9f0c116e6a0fe25a
 title: A2 English for Developers Certification Exam
-challengeType: 24
+challengeType: 30
 dashedName: a2-english-for-developers-certification-exam
 prerequisites: []
 ---


### PR DESCRIPTION
### Description
This pull request updates the `challengeType` of the A2 English exam in the English curriculum to match the updated FSD exam challenge type. Previously, the `challengeType` was 24, but it should be 30.

### Changes
- Updated `challengeType` from 24 → 30 in:
  `curriculum/challenges/english/blocks/a2-english-for-developers-certification-exam/6721db5d9f0c116e6a0fe25a.md` (line 4)

### Motivation
The FSD exam challenge type was updated to 30 (#57325), but the A2 English exam was missed. This change ensures consistency across the curriculum.

### Notes
- First-time contributor friendly.
- No other changes made.
