### PR TITLE
fix(curriculum): updating note in Problem-89 Roman Numerals

### DIFF
--- a/curriculum/challenges/english/blocks/project-euler-problems-1-to-100/5900f3c51000cf542c50fed7.md
+++ b/curriculum/challenges/english/blocks/project-euler-problems-1-to-100/5900f3c51000cf542c50fed7.md
@@ -38,7 +38,7 @@ The array, `roman`, will contain numbers written with valid, but not necessarily
 
 Find the number of characters saved by writing each of these in their minimal form.
 
-**Note:** You can assume that all the Roman numerals in the array contain no more than four consecutive identical units.
+**Note:** The Roman numerals in the array may contain more than four consecutive identical units. Your task is to convert them into their minimal form.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

- [X ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ X] My pull request targets the `main` branch of freeCodeCamp.
- [X ] I have tested these changes either locally on my machine, or Gitpod.

Closes #61929 

Problem Description:-

The original note stated that all Roman numerals in the array contain no more than four consecutive identical units. However, one of the test cases (e.g. XIIIIII) breaks this rule, which may create confusion.

I have updated the note to clearly explain that Roman numerals in the array may contain more than four consecutive identical units. You have to convert them into their minimal form.


