### PR TITLE
chore: disable curriculum translation deletion

### DIFF
--- a/.github/workflows/crowdin-upload.curriculum.yml
+++ b/.github/workflows/crowdin-upload.curriculum.yml
@@ -49,11 +49,12 @@ jobs:
           # Uncomment below to debug
           # dryrun_action: true
 
-      - name: Remove deleted files
-        uses: freecodecamp/crowdin-action@main
-        env:
-          PLUGIN: 'remove-deleted-files'
-          FILE_PATHS: '["curriculum/challenges/english", "curriculum/dictionaries/english"]'
+      # restore once the translations have been migrated.
+      # - name: Remove deleted files
+      #   uses: freecodecamp/crowdin-action@main
+      #   env:
+      #     PLUGIN: 'remove-deleted-files'
+      #     FILE_PATHS: '["curriculum/challenges/english", "curriculum/dictionaries/english"]'
 
       - name: Hide Non-Translated Strings
         uses: freecodecamp/crowdin-action@main


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

The last run probably should not have happened at all, since it may make it harder to migrate the translations. Also, it timed out after 6 hours: https://github.com/freeCodeCamp/freeCodeCamp/actions/runs/17260360540

<!-- Feel free to add any additional description of changes below this line -->
