### PR TITLE
refactor(tools, curriculum): use challenge type 31 for review pages

### DIFF
--- a/client/src/templates/Challenges/utils/build.ts
+++ b/client/src/templates/Challenges/utils/build.ts
@@ -143,7 +143,8 @@ export const runnerTypes: Record<
   [challengeTypes.jsLab]: 'javascript',
   [challengeTypes.pyLab]: 'python',
   [challengeTypes.dailyChallengeJs]: 'javascript',
-  [challengeTypes.dailyChallengePy]: 'python'
+  [challengeTypes.dailyChallengePy]: 'python',
+  [challengeTypes.review]: 'dom'
 };
 
 export async function getTestRunner(buildData: BuildChallengeData) {

--- a/curriculum/challenges/english/blocks/review-asynchronous-javascript/6723d35bb07d1bd220d0f28d.md
+++ b/curriculum/challenges/english/blocks/review-asynchronous-javascript/6723d35bb07d1bd220d0f28d.md
@@ -1,7 +1,7 @@
 ---
 id: 6723d35bb07d1bd220d0f28d
 title: Asynchronous JavaScript Review
-challengeType: 24
+challengeType: 31
 dashedName: review-asynchronous-javascript
 ---
 

--- a/curriculum/challenges/english/blocks/review-bash-and-sql/6724e46581a1742244e45b59.md
+++ b/curriculum/challenges/english/blocks/review-bash-and-sql/6724e46581a1742244e45b59.md
@@ -1,7 +1,7 @@
 ---
 id: 6724e46581a1742244e45b59
 title: Bash and SQL Review
-challengeType: 24
+challengeType: 31
 dashedName: review-bash-and-sql
 ---
 

--- a/curriculum/challenges/english/blocks/review-bash-commands/6724e387ee098d1ef33108ba.md
+++ b/curriculum/challenges/english/blocks/review-bash-commands/6724e387ee098d1ef33108ba.md
@@ -1,7 +1,7 @@
 ---
 id: 6724e387ee098d1ef33108ba
 title: Bash Commands Review
-challengeType: 24
+challengeType: 31
 dashedName: review-bash-commands
 ---
 

--- a/curriculum/challenges/english/blocks/review-bash-scripting/6724e417419c2f211bb41bfc.md
+++ b/curriculum/challenges/english/blocks/review-bash-scripting/6724e417419c2f211bb41bfc.md
@@ -1,7 +1,7 @@
 ---
 id: 6724e417419c2f211bb41bfc
 title: Bash Scripting Review
-challengeType: 24
+challengeType: 31
 dashedName: review-bash-scripting
 ---
 

--- a/curriculum/challenges/english/blocks/review-basic-css/671a887a7e62c75e9ab1ee4a.md
+++ b/curriculum/challenges/english/blocks/review-basic-css/671a887a7e62c75e9ab1ee4a.md
@@ -1,7 +1,7 @@
 ---
 id: 671a887a7e62c75e9ab1ee4a
 title: Basic CSS Review
-challengeType: 24
+challengeType: 31
 dashedName: review-basic-css
 ---
 

--- a/curriculum/challenges/english/blocks/review-basic-html/67072fc183c7ca6c588feb4d.md
+++ b/curriculum/challenges/english/blocks/review-basic-html/67072fc183c7ca6c588feb4d.md
@@ -1,7 +1,7 @@
 ---
 id: 67072fc183c7ca6c588feb4d
 title: Basic HTML Review
-challengeType: 24
+challengeType: 31
 dashedName: basic-html-review
 ---
 

--- a/curriculum/challenges/english/blocks/review-classes-and-objects/67f39d848979082814c07d9c.md
+++ b/curriculum/challenges/english/blocks/review-classes-and-objects/67f39d848979082814c07d9c.md
@@ -1,7 +1,7 @@
 ---
 id: 67f39d848979082814c07d9c
 title: Classes and Objects Review
-challengeType: 24
+challengeType: 31
 dashedName: review-classes-and-objects
 ---
 

--- a/curriculum/challenges/english/blocks/review-computer-basics/671a87e6dcef5b5bd765e5ed.md
+++ b/curriculum/challenges/english/blocks/review-computer-basics/671a87e6dcef5b5bd765e5ed.md
@@ -1,7 +1,7 @@
 ---
 id: 671a87e6dcef5b5bd765e5ed
 title: Computer Basics Review
-challengeType: 24
+challengeType: 31
 dashedName: review-computer-basics
 ---
 

--- a/curriculum/challenges/english/blocks/review-css-accessibility/671a955b74ab5588735800d1.md
+++ b/curriculum/challenges/english/blocks/review-css-accessibility/671a955b74ab5588735800d1.md
@@ -1,7 +1,7 @@
 ---
 id: 671a955b74ab5588735800d1
 title: CSS Accessibility Review
-challengeType: 24
+challengeType: 31
 dashedName: review-css-accessibility
 ---
 

--- a/curriculum/challenges/english/blocks/review-css-animations/671a999cc77b7f9bceb4caeb.md
+++ b/curriculum/challenges/english/blocks/review-css-animations/671a999cc77b7f9bceb4caeb.md
@@ -1,7 +1,7 @@
 ---
 id: 671a999cc77b7f9bceb4caeb
 title: CSS Animations Review
-challengeType: 24
+challengeType: 31
 dashedName: review-css-animations
 ---
 

--- a/curriculum/challenges/english/blocks/review-css-attribute-selectors/671a95990b86b68961340adc.md
+++ b/curriculum/challenges/english/blocks/review-css-attribute-selectors/671a95990b86b68961340adc.md
@@ -1,7 +1,7 @@
 ---
 id: 671a95990b86b68961340adc
 title: CSS Attribute Selectors Review
-challengeType: 24
+challengeType: 31
 dashedName: review-css-attribute-selectors
 ---
 

--- a/curriculum/challenges/english/blocks/review-css-backgrounds-and-borders/671a88d636cebc5fbd407b78.md
+++ b/curriculum/challenges/english/blocks/review-css-backgrounds-and-borders/671a88d636cebc5fbd407b78.md
@@ -1,7 +1,7 @@
 ---
 id: 671a88d636cebc5fbd407b78
 title: Lists, Links, CSS Background and Borders Review
-challengeType: 24
+challengeType: 31
 dashedName: review-css-backgrounds-and-borders
 ---
 

--- a/curriculum/challenges/english/blocks/review-css-colors/671a90c1cf517678b130419e.md
+++ b/curriculum/challenges/english/blocks/review-css-colors/671a90c1cf517678b130419e.md
@@ -1,7 +1,7 @@
 ---
 id: 671a90c1cf517678b130419e
 title: CSS Colors Review
-challengeType: 24
+challengeType: 31
 dashedName: review-css-colors
 ---
 

--- a/curriculum/challenges/english/blocks/review-css-flexbox/671a940c69cdee833d4cc312.md
+++ b/curriculum/challenges/english/blocks/review-css-flexbox/671a940c69cdee833d4cc312.md
@@ -1,7 +1,7 @@
 ---
 id: 671a940c69cdee833d4cc312
 title: CSS Flexbox Review
-challengeType: 24
+challengeType: 31
 dashedName: review-css-flexbox
 ---
 

--- a/curriculum/challenges/english/blocks/review-css-grid/671a99394bedfb9a5bc687c4.md
+++ b/curriculum/challenges/english/blocks/review-css-grid/671a99394bedfb9a5bc687c4.md
@@ -1,7 +1,7 @@
 ---
 id: 671a99394bedfb9a5bc687c4
 title: CSS Grid Review
-challengeType: 24
+challengeType: 31
 dashedName: review-css-grid
 ---
 

--- a/curriculum/challenges/english/blocks/review-css-layout-and-effects/671a9311a289ae7fff25d88e.md
+++ b/curriculum/challenges/english/blocks/review-css-layout-and-effects/671a9311a289ae7fff25d88e.md
@@ -1,7 +1,7 @@
 ---
 id: 671a9311a289ae7fff25d88e
 title: CSS Layouts and Effects Review
-challengeType: 24
+challengeType: 31
 dashedName: review-css-layout-and-effects
 ---
 

--- a/curriculum/challenges/english/blocks/review-css-libraries-and-frameworks/6724e2026e608219108d385a.md
+++ b/curriculum/challenges/english/blocks/review-css-libraries-and-frameworks/6724e2026e608219108d385a.md
@@ -1,7 +1,7 @@
 ---
 id: 6724e2026e608219108d385a
 title: CSS Libraries and Frameworks Review
-challengeType: 24
+challengeType: 31
 dashedName: review-css-libraries-and-frameworks
 ---
 

--- a/curriculum/challenges/english/blocks/review-css-positioning/671a967424a00e8c6561b182.md
+++ b/curriculum/challenges/english/blocks/review-css-positioning/671a967424a00e8c6561b182.md
@@ -1,7 +1,7 @@
 ---
 id: 671a967424a00e8c6561b182
 title: CSS Positioning Review
-challengeType: 24
+challengeType: 31
 dashedName: review-css-positioning
 ---
 

--- a/curriculum/challenges/english/blocks/review-css-pseudo-classes/671a907bad4538752765f2ff.md
+++ b/curriculum/challenges/english/blocks/review-css-pseudo-classes/671a907bad4538752765f2ff.md
@@ -1,7 +1,7 @@
 ---
 id: 671a907bad4538752765f2ff
 title: CSS Pseudo-classes Review
-challengeType: 24
+challengeType: 31
 dashedName: review-css-pseudo-classes
 ---
 

--- a/curriculum/challenges/english/blocks/review-css-relative-and-absolute-units/671a8f8350c20a7439015c98.md
+++ b/curriculum/challenges/english/blocks/review-css-relative-and-absolute-units/671a8f8350c20a7439015c98.md
@@ -1,7 +1,7 @@
 ---
 id: 671a8f8350c20a7439015c98
 title: CSS Relative and Absolute Units Review
-challengeType: 24
+challengeType: 31
 dashedName: review-css-relative-and-absolute-units
 ---
 

--- a/curriculum/challenges/english/blocks/review-css-typography/671a9528fc4f1487cf265444.md
+++ b/curriculum/challenges/english/blocks/review-css-typography/671a9528fc4f1487cf265444.md
@@ -1,7 +1,7 @@
 ---
 id: 671a9528fc4f1487cf265444
 title: CSS Typography Review
-challengeType: 24
+challengeType: 31
 dashedName: review-css-typography
 ---
 

--- a/curriculum/challenges/english/blocks/review-css-variables/671a98fbaabfba994e3d9a7c.md
+++ b/curriculum/challenges/english/blocks/review-css-variables/671a98fbaabfba994e3d9a7c.md
@@ -1,7 +1,7 @@
 ---
 id: 671a98fbaabfba994e3d9a7c
 title: CSS Variables Review
-challengeType: 24
+challengeType: 31
 dashedName: review-css-variables
 ---
 

--- a/curriculum/challenges/english/blocks/review-css/671a9a0a140c2b9d6a75629f.md
+++ b/curriculum/challenges/english/blocks/review-css/671a9a0a140c2b9d6a75629f.md
@@ -1,7 +1,7 @@
 ---
 id: 671a9a0a140c2b9d6a75629f
 title: CSS Review
-challengeType: 24
+challengeType: 31
 dashedName: review-css
 ---
 

--- a/curriculum/challenges/english/blocks/review-data-structures/67f39dc7129b092b27099d8c.md
+++ b/curriculum/challenges/english/blocks/review-data-structures/67f39dc7129b092b27099d8c.md
@@ -1,7 +1,7 @@
 ---
 id: 67f39dc7129b092b27099d8c
 title: Data Structures Review
-challengeType: 24
+challengeType: 31
 dashedName: review-data-structures
 ---
 

--- a/curriculum/challenges/english/blocks/review-debugging-javascript/6723cd54fc196dbd053f9dfb.md
+++ b/curriculum/challenges/english/blocks/review-debugging-javascript/6723cd54fc196dbd053f9dfb.md
@@ -1,7 +1,7 @@
 ---
 id: 6723cd54fc196dbd053f9dfb
 title: Debugging JavaScript Review
-challengeType: 24
+challengeType: 31
 dashedName: review-debugging-javascript
 ---
 

--- a/curriculum/challenges/english/blocks/review-design-fundamentals/671a892927fdba60db05edfe.md
+++ b/curriculum/challenges/english/blocks/review-design-fundamentals/671a892927fdba60db05edfe.md
@@ -1,7 +1,7 @@
 ---
 id: 671a892927fdba60db05edfe
 title: Design Fundamentals Review
-challengeType: 24
+challengeType: 31
 dashedName: review-design-fundamentals
 ---
 

--- a/curriculum/challenges/english/blocks/review-dictionaries-and-sets/67f39babe1e2ec1fb6eea32a.md
+++ b/curriculum/challenges/english/blocks/review-dictionaries-and-sets/67f39babe1e2ec1fb6eea32a.md
@@ -1,7 +1,7 @@
 ---
 id: 67f39babe1e2ec1fb6eea32a
 title: Dictionaries and Sets Review
-challengeType: 24
+challengeType: 31
 dashedName: review-dictionaries-and-sets
 ---
 

--- a/curriculum/challenges/english/blocks/review-dom-manipulation-and-click-events-with-javascript/6723cc7a8e7aa3b9befd4bac.md
+++ b/curriculum/challenges/english/blocks/review-dom-manipulation-and-click-events-with-javascript/6723cc7a8e7aa3b9befd4bac.md
@@ -1,7 +1,7 @@
 ---
 id: 6723cc7a8e7aa3b9befd4bac
 title: DOM Manipulation and Click Events with JavaScript Review
-challengeType: 24
+challengeType: 31
 dashedName: review-dom-manipulation-and-click-events-with-javascript
 ---
 

--- a/curriculum/challenges/english/blocks/review-dynamic-programming/67f39e2119042d2f2ca926ff.md
+++ b/curriculum/challenges/english/blocks/review-dynamic-programming/67f39e2119042d2f2ca926ff.md
@@ -1,7 +1,7 @@
 ---
 id: 67f39e2119042d2f2ca926ff
 title: Dynamic Programming Review
-challengeType: 24
+challengeType: 31
 dashedName: review-dynamic-programming
 ---
 

--- a/curriculum/challenges/english/blocks/review-error-handling/67f39bcb48373420f4f12d62.md
+++ b/curriculum/challenges/english/blocks/review-error-handling/67f39bcb48373420f4f12d62.md
@@ -1,7 +1,7 @@
 ---
 id: 67f39bcb48373420f4f12d62
 title: Error Handling Review
-challengeType: 24
+challengeType: 31
 dashedName: review-error-handling
 ---
 

--- a/curriculum/challenges/english/blocks/review-form-validation-with-javascript/6723ce555ff2dfc0cc04b69a.md
+++ b/curriculum/challenges/english/blocks/review-form-validation-with-javascript/6723ce555ff2dfc0cc04b69a.md
@@ -1,7 +1,7 @@
 ---
 id: 6723ce555ff2dfc0cc04b69a
 title: Form Validation with JavaScript Review
-challengeType: 24
+challengeType: 31
 dashedName: review-form-validation-with-javascript
 ---
 

--- a/curriculum/challenges/english/blocks/review-front-end-libraries/6724e2dbf723fe1c8883cc69.md
+++ b/curriculum/challenges/english/blocks/review-front-end-libraries/6724e2dbf723fe1c8883cc69.md
@@ -1,7 +1,7 @@
 ---
 id: 6724e2dbf723fe1c8883cc69
 title: Front End Libraries Review
-challengeType: 24
+challengeType: 31
 dashedName: review-front-end-libraries
 ---
 

--- a/curriculum/challenges/english/blocks/review-git/6724e4cfea0c4f2425a9d064.md
+++ b/curriculum/challenges/english/blocks/review-git/6724e4cfea0c4f2425a9d064.md
@@ -1,7 +1,7 @@
 ---
 id: 6724e4cfea0c4f2425a9d064
 title: Git Review
-challengeType: 24
+challengeType: 31
 dashedName: review-git
 ---
 

--- a/curriculum/challenges/english/blocks/review-graphs-and-trees/67f39e06b8a11b2de9ccd361.md
+++ b/curriculum/challenges/english/blocks/review-graphs-and-trees/67f39e06b8a11b2de9ccd361.md
@@ -1,7 +1,7 @@
 ---
 id: 67f39e06b8a11b2de9ccd361
 title: Graphs and Trees Review
-challengeType: 24
+challengeType: 31
 dashedName: review-graph-and-trees
 ---
 

--- a/curriculum/challenges/english/blocks/review-html-accessibility/671a87a39b88245a579c2271.md
+++ b/curriculum/challenges/english/blocks/review-html-accessibility/671a87a39b88245a579c2271.md
@@ -1,7 +1,7 @@
 ---
 id: 671a87a39b88245a579c2271
 title: HTML Accessibility Review
-challengeType: 24
+challengeType: 31
 dashedName: review-html-accessibility
 ---
 

--- a/curriculum/challenges/english/blocks/review-html-tables-and-forms/671a872c17382a582e455c4c.md
+++ b/curriculum/challenges/english/blocks/review-html-tables-and-forms/671a872c17382a582e455c4c.md
@@ -1,7 +1,7 @@
 ---
 id: 671a872c17382a582e455c4c
 title: HTML Tables and Forms Review
-challengeType: 24
+challengeType: 31
 dashedName: review-html-tables-and-forms
 ---
 

--- a/curriculum/challenges/english/blocks/review-html/671a883163d5ab5d47145880.md
+++ b/curriculum/challenges/english/blocks/review-html/671a883163d5ab5d47145880.md
@@ -1,7 +1,7 @@
 ---
 id: 671a883163d5ab5d47145880
 title: HTML Review
-challengeType: 24
+challengeType: 31
 dashedName: review-html
 ---
 

--- a/curriculum/challenges/english/blocks/review-javascript-arrays/6723c66f623701a3cdf72130.md
+++ b/curriculum/challenges/english/blocks/review-javascript-arrays/6723c66f623701a3cdf72130.md
@@ -1,7 +1,7 @@
 ---
 id: 6723c66f623701a3cdf72130
 title: JavaScript Arrays Review
-challengeType: 24
+challengeType: 31
 dashedName: review-javascript-arrays
 ---
 

--- a/curriculum/challenges/english/blocks/review-javascript-audio-and-video/6723cf27c6e9a0c3f3041385.md
+++ b/curriculum/challenges/english/blocks/review-javascript-audio-and-video/6723cf27c6e9a0c3f3041385.md
@@ -1,7 +1,7 @@
 ---
 id: 6723cf27c6e9a0c3f3041385
 title: JavaScript Audio and Video Review
-challengeType: 24
+challengeType: 31
 dashedName: review-javascript-audio-and-video
 ---
 

--- a/curriculum/challenges/english/blocks/review-javascript-classes/6723d13d756751caf871d59c.md
+++ b/curriculum/challenges/english/blocks/review-javascript-classes/6723d13d756751caf871d59c.md
@@ -1,7 +1,7 @@
 ---
 id: 6723d13d756751caf871d59c
 title: JavaScript Classes Review
-challengeType: 24
+challengeType: 31
 dashedName: review-javascript-classes
 ---
 

--- a/curriculum/challenges/english/blocks/review-javascript-comparisons-and-conditionals/6723c554025f449f4f39c3f5.md
+++ b/curriculum/challenges/english/blocks/review-javascript-comparisons-and-conditionals/6723c554025f449f4f39c3f5.md
@@ -1,7 +1,7 @@
 ---
 id: 6723c554025f449f4f39c3f5
 title: JavaScript Comparisons and Conditionals Review
-challengeType: 24
+challengeType: 31
 dashedName: review-javascript-comparisons-and-conditionals
 ---
 

--- a/curriculum/challenges/english/blocks/review-javascript-dates/6723ced0ba0b42c2a0ac14d2.md
+++ b/curriculum/challenges/english/blocks/review-javascript-dates/6723ced0ba0b42c2a0ac14d2.md
@@ -1,7 +1,7 @@
 ---
 id: 6723ced0ba0b42c2a0ac14d2
 title: JavaScript Dates Review
-challengeType: 24
+challengeType: 31
 dashedName: review-javascript-dates
 ---
 

--- a/curriculum/challenges/english/blocks/review-javascript-functional-programming/6723d2c154dd19d0025f7cd9.md
+++ b/curriculum/challenges/english/blocks/review-javascript-functional-programming/6723d2c154dd19d0025f7cd9.md
@@ -1,7 +1,7 @@
 ---
 id: 6723d2c154dd19d0025f7cd9
 title: JavaScript Functional Programming Review
-challengeType: 24
+challengeType: 31
 dashedName: review-javascript-functional-programming
 ---
 

--- a/curriculum/challenges/english/blocks/review-javascript-functions/6723c5b8601a40a100bb59c9.md
+++ b/curriculum/challenges/english/blocks/review-javascript-functions/6723c5b8601a40a100bb59c9.md
@@ -1,7 +1,7 @@
 ---
 id: 6723c5b8601a40a100bb59c9
 title: JavaScript Functions Review
-challengeType: 24
+challengeType: 31
 dashedName: review-javascript-functions
 ---
 

--- a/curriculum/challenges/english/blocks/review-javascript-fundamentals/6723ca166fe90eb0a3146848.md
+++ b/curriculum/challenges/english/blocks/review-javascript-fundamentals/6723ca166fe90eb0a3146848.md
@@ -1,7 +1,7 @@
 ---
 id: 6723ca166fe90eb0a3146848
 title: JavaScript Fundamentals Review
-challengeType: 24
+challengeType: 31
 dashedName: review-javascript-fundamentals
 ---
 

--- a/curriculum/challenges/english/blocks/review-javascript-higher-order-functions/6723ca6c6db3deb21cb1bf19.md
+++ b/curriculum/challenges/english/blocks/review-javascript-higher-order-functions/6723ca6c6db3deb21cb1bf19.md
@@ -1,7 +1,7 @@
 ---
 id: 6723ca6c6db3deb21cb1bf19
 title: JavaScript Higher Order Functions Review
-challengeType: 24
+challengeType: 31
 dashedName: review-javascript-higher-order-functions
 ---
 

--- a/curriculum/challenges/english/blocks/review-javascript-loops/6723c837cd3276aa73e6da25.md
+++ b/curriculum/challenges/english/blocks/review-javascript-loops/6723c837cd3276aa73e6da25.md
@@ -1,7 +1,7 @@
 ---
 id: 6723c837cd3276aa73e6da25
 title: JavaScript Loops Review
-challengeType: 24
+challengeType: 31
 dashedName: review-javascript-loops
 ---
 

--- a/curriculum/challenges/english/blocks/review-javascript-maps-and-sets/6723d027b02e4cc6ee5944da.md
+++ b/curriculum/challenges/english/blocks/review-javascript-maps-and-sets/6723d027b02e4cc6ee5944da.md
@@ -1,7 +1,7 @@
 ---
 id: 6723d027b02e4cc6ee5944da
 title: JavaScript Maps and Sets Review
-challengeType: 24
+challengeType: 31
 dashedName: review-javascript-maps-and-sets
 ---
 

--- a/curriculum/challenges/english/blocks/review-javascript-math/6723c463e51a2d9b747d7529.md
+++ b/curriculum/challenges/english/blocks/review-javascript-math/6723c463e51a2d9b747d7529.md
@@ -1,7 +1,7 @@
 ---
 id: 6723c463e51a2d9b747d7529
 title: JavaScript Math Review
-challengeType: 24
+challengeType: 31
 dashedName: review-javascript-math
 ---
 

--- a/curriculum/challenges/english/blocks/review-javascript-objects/6723c77d1a44b8a7599277dd.md
+++ b/curriculum/challenges/english/blocks/review-javascript-objects/6723c77d1a44b8a7599277dd.md
@@ -1,7 +1,7 @@
 ---
 id: 6723c77d1a44b8a7599277dd
 title: JavaScript Objects Review
-challengeType: 24
+challengeType: 31
 dashedName: review-javascript-objects
 ---
 

--- a/curriculum/challenges/english/blocks/review-javascript-regular-expressions/6723cdfa4ae237bf6b7e32eb.md
+++ b/curriculum/challenges/english/blocks/review-javascript-regular-expressions/6723cdfa4ae237bf6b7e32eb.md
@@ -1,7 +1,7 @@
 ---
 id: 6723cdfa4ae237bf6b7e32eb
 title: JavaScript Regular Expressions Review
-challengeType: 24
+challengeType: 31
 dashedName: review-javascript-regular-expressions
 ---
 

--- a/curriculum/challenges/english/blocks/review-javascript-strings/6723c1946e4cd7909a836bb4.md
+++ b/curriculum/challenges/english/blocks/review-javascript-strings/6723c1946e4cd7909a836bb4.md
@@ -1,7 +1,7 @@
 ---
 id: 6723c1946e4cd7909a836bb4
 title: JavaScript Strings Review
-challengeType: 24
+challengeType: 31
 dashedName: review-javascript-strings
 ---
 

--- a/curriculum/challenges/english/blocks/review-javascript-variables-and-data-types/6723be264695fb7e619fe1fa.md
+++ b/curriculum/challenges/english/blocks/review-javascript-variables-and-data-types/6723be264695fb7e619fe1fa.md
@@ -1,7 +1,7 @@
 ---
 id: 6723be264695fb7e619fe1fa
 title: JavaScript Variables and Data Types Review
-challengeType: 24
+challengeType: 31
 dashedName: review-javascript-variables-and-data-types
 ---
 

--- a/curriculum/challenges/english/blocks/review-javascript/6723d3cfdd0717d3f1bf27e3.md
+++ b/curriculum/challenges/english/blocks/review-javascript/6723d3cfdd0717d3f1bf27e3.md
@@ -1,7 +1,7 @@
 ---
 id: 6723d3cfdd0717d3f1bf27e3
 title: JavaScript Review
-challengeType: 24
+challengeType: 31
 dashedName: review-javascript
 ---
 

--- a/curriculum/challenges/english/blocks/review-js-a11y/683766860f71d4a96e429f3a.md
+++ b/curriculum/challenges/english/blocks/review-js-a11y/683766860f71d4a96e429f3a.md
@@ -1,7 +1,7 @@
 ---
 id: 683766860f71d4a96e429f3a
 title: JavaScript and Accessibility Review
-challengeType: 24
+challengeType: 31
 dashedName: review-js-a11y
 ---
 

--- a/curriculum/challenges/english/blocks/review-local-storage-and-crud/6723d0ac516099c902394e8b.md
+++ b/curriculum/challenges/english/blocks/review-local-storage-and-crud/6723d0ac516099c902394e8b.md
@@ -1,7 +1,7 @@
 ---
 id: 6723d0ac516099c902394e8b
 title: Local Storage and CRUD Review
-challengeType: 24
+challengeType: 31
 dashedName: review-local-storage-and-crud
 ---
 

--- a/curriculum/challenges/english/blocks/review-loops-and-sequences/67f39b91583dec1e1eddbb9e.md
+++ b/curriculum/challenges/english/blocks/review-loops-and-sequences/67f39b91583dec1e1eddbb9e.md
@@ -1,7 +1,7 @@
 ---
 id: 67f39b91583dec1e1eddbb9e
 title: Loops and Sequences Review
-challengeType: 24
+challengeType: 31
 dashedName: review-loops-and-sequences
 ---
 

--- a/curriculum/challenges/english/blocks/review-object-oriented-programming/67f39dac6c3fac29c3d54918.md
+++ b/curriculum/challenges/english/blocks/review-object-oriented-programming/67f39dac6c3fac29c3d54918.md
@@ -1,7 +1,7 @@
 ---
 id: 67f39dac6c3fac29c3d54918
 title: Object Oriented Programming Review
-challengeType: 24
+challengeType: 31
 dashedName: review-object-oriented-programming
 ---
 

--- a/curriculum/challenges/english/blocks/review-python-basics/67f39b40deaec81a3e40e0c5.md
+++ b/curriculum/challenges/english/blocks/review-python-basics/67f39b40deaec81a3e40e0c5.md
@@ -1,7 +1,7 @@
 ---
 id: 67f39b40deaec81a3e40e0c5
 title: Python Basics Review
-challengeType: 24
+challengeType: 31
 dashedName: review-python-basics
 ---
 

--- a/curriculum/challenges/english/blocks/review-python/67f39e391c9b373069def02c.md
+++ b/curriculum/challenges/english/blocks/review-python/67f39e391c9b373069def02c.md
@@ -1,7 +1,7 @@
 ---
 id: 67f39e391c9b373069def02c
 title: Python Review
-challengeType: 24
+challengeType: 31
 dashedName: review-python
 ---
 

--- a/curriculum/challenges/english/blocks/review-react-basics/67487e141bb6a7140a352e12.md
+++ b/curriculum/challenges/english/blocks/review-react-basics/67487e141bb6a7140a352e12.md
@@ -1,7 +1,7 @@
 ---
 id: 67487e141bb6a7140a352e12
 title: React Basics Review
-challengeType: 24
+challengeType: 31
 dashedName: review-react-basics
 ---
 

--- a/curriculum/challenges/english/blocks/review-react-forms-data-fetching-and-routing/67c9e932c6c4234532d46394.md
+++ b/curriculum/challenges/english/blocks/review-react-forms-data-fetching-and-routing/67c9e932c6c4234532d46394.md
@@ -1,7 +1,7 @@
 ---
 id: 67c9e932c6c4234532d46394
 title: React Forms, Data Fetching and Routing Review
-challengeType: 24
+challengeType: 31
 dashedName: review-react-forms-data-fetching-and-routing
 ---
 

--- a/curriculum/challenges/english/blocks/review-react-state-and-hooks/67c2bbd476f6e540b4c0b0d4.md
+++ b/curriculum/challenges/english/blocks/review-react-state-and-hooks/67c2bbd476f6e540b4c0b0d4.md
@@ -1,7 +1,7 @@
 ---
 id: 67c2bbd476f6e540b4c0b0d4
 title: React State and Hooks Review
-challengeType: 24
+challengeType: 31
 dashedName: review-react-state-and-hooks
 ---
 

--- a/curriculum/challenges/english/blocks/review-recursion/6723d1f0568292cd394d6fb6.md
+++ b/curriculum/challenges/english/blocks/review-recursion/6723d1f0568292cd394d6fb6.md
@@ -1,7 +1,7 @@
 ---
 id: 6723d1f0568292cd394d6fb6
 title: Recursion Review
-challengeType: 24
+challengeType: 31
 dashedName: review-recursion
 ---
 

--- a/curriculum/challenges/english/blocks/review-relational-database/6724e3d6e1cb0c1fec3a8e4f.md
+++ b/curriculum/challenges/english/blocks/review-relational-database/6724e3d6e1cb0c1fec3a8e4f.md
@@ -1,7 +1,7 @@
 ---
 id: 6724e3d6e1cb0c1fec3a8e4f
 title: Relational Database Review
-challengeType: 24
+challengeType: 31
 dashedName: review-relational-database
 ---
 

--- a/curriculum/challenges/english/blocks/review-relational-databases/6724e5e321bce627736ea145.md
+++ b/curriculum/challenges/english/blocks/review-relational-databases/6724e5e321bce627736ea145.md
@@ -1,7 +1,7 @@
 ---
 id: 6724e5e321bce627736ea145
 title: Relational Databases Review
-challengeType: 24
+challengeType: 31
 dashedName: review-relational-databases
 ---
 

--- a/curriculum/challenges/english/blocks/review-responsive-web-design/671a98927af7829722697dc2.md
+++ b/curriculum/challenges/english/blocks/review-responsive-web-design/671a98927af7829722697dc2.md
@@ -1,7 +1,7 @@
 ---
 id: 671a98927af7829722697dc2
 title: Responsive Web Design Review
-challengeType: 24
+challengeType: 31
 dashedName: review-responsive-web-design
 ---
 

--- a/curriculum/challenges/english/blocks/review-searching-and-sorting-algorithms/67f39de5ff88202c94798189.md
+++ b/curriculum/challenges/english/blocks/review-searching-and-sorting-algorithms/67f39de5ff88202c94798189.md
@@ -1,7 +1,7 @@
 ---
 id: 67f39de5ff88202c94798189
 title: Searching and Sorting Algorithms Review
-challengeType: 24
+challengeType: 31
 dashedName: review-searching-and-sorting-algorithms
 ---
 

--- a/curriculum/challenges/english/blocks/review-semantic-html/671a83934b61f64cefe87a61.md
+++ b/curriculum/challenges/english/blocks/review-semantic-html/671a83934b61f64cefe87a61.md
@@ -1,7 +1,7 @@
 ---
 id: 671a83934b61f64cefe87a61
 title: Semantic HTML Review
-challengeType: 24
+challengeType: 31
 dashedName: review-semantic-html
 ---
 

--- a/curriculum/challenges/english/blocks/review-styling-forms/671a915858de057ad84c5dbd.md
+++ b/curriculum/challenges/english/blocks/review-styling-forms/671a915858de057ad84c5dbd.md
@@ -1,7 +1,7 @@
 ---
 id: 671a915858de057ad84c5dbd
 title: Styling Forms Review
-challengeType: 24
+challengeType: 31
 dashedName: review-styling-forms
 ---
 

--- a/curriculum/challenges/english/blocks/review-testing/6724e24864b0771a4c4c9dc9.md
+++ b/curriculum/challenges/english/blocks/review-testing/6724e24864b0771a4c4c9dc9.md
@@ -1,7 +1,7 @@
 ---
 id: 6724e24864b0771a4c4c9dc9
 title: Testing Review
-challengeType: 24
+challengeType: 31
 dashedName: review-testing
 ---
 

--- a/curriculum/challenges/english/blocks/review-typescript/6724e296dceca21b82426229.md
+++ b/curriculum/challenges/english/blocks/review-typescript/6724e296dceca21b82426229.md
@@ -1,7 +1,7 @@
 ---
 id: 6724e296dceca21b82426229
 title: Typescript Review
-challengeType: 24
+challengeType: 31
 dashedName: review-typescript
 ---
 

--- a/curriculum/challenges/english/blocks/review-web-performance/6724e18296fa40173cc2437c.md
+++ b/curriculum/challenges/english/blocks/review-web-performance/6724e18296fa40173cc2437c.md
@@ -1,7 +1,7 @@
 ---
 id: 6724e18296fa40173cc2437c
 title: Web Performance Review
-challengeType: 24
+challengeType: 31
 dashedName: review-web-performance
 ---
 

--- a/curriculum/schema/challenge-schema.js
+++ b/curriculum/schema/challenge-schema.js
@@ -158,7 +158,7 @@ const schema = Joi.object().keys({
     otherwise: Joi.optional()
   }),
   certification: Joi.string().regex(slugWithSlashRE),
-  challengeType: Joi.number().min(0).max(30).required(),
+  challengeType: Joi.number().min(0).max(31).required(),
   checksum: Joi.number(),
   // TODO: require this only for normal challenges, not certs
   dashedName: Joi.string().regex(slugRE),

--- a/shared/config/challenge-types.ts
+++ b/shared/config/challenge-types.ts
@@ -30,6 +30,7 @@ const pyLab = 27;
 const dailyChallengeJs = 28;
 const dailyChallengePy = 29;
 const examDownload = 30;
+const review = 31;
 
 export const challengeTypes = {
   html,
@@ -63,7 +64,8 @@ export const challengeTypes = {
   pyLab,
   dailyChallengeJs,
   dailyChallengePy,
-  examDownload
+  examDownload,
+  review
 };
 
 export const hasNoSolution = (challengeType: number): boolean => {
@@ -87,7 +89,8 @@ export const hasNoSolution = (challengeType: number): boolean => {
     dialogue,
     fillInTheBlank,
     generic,
-    examDownload
+    examDownload,
+    review
   ];
 
   return noSolutions.includes(challengeType);
@@ -124,7 +127,8 @@ export const viewTypes = {
   [pyLab]: 'classic',
   [dailyChallengeJs]: 'classic',
   [dailyChallengePy]: 'classic',
-  [examDownload]: 'examDownload'
+  [examDownload]: 'examDownload',
+  [review]: 'generic'
 };
 
 // determine the type of submit function to use for the challenge on completion
@@ -162,7 +166,8 @@ export const submitTypes = {
   [pyLab]: 'tests',
   [dailyChallengeJs]: 'tests',
   [dailyChallengePy]: 'tests',
-  [examDownload]: 'examDownload'
+  [examDownload]: 'examDownload',
+  [review]: 'tests'
 };
 
 export const canSaveToDB = (challengeType: number): boolean =>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR:
- Adds a new challenge type (31) for the review pages. This change is to make the challenge type more specific as we're going to use it for conditional display of the (WIP) content outline
  - Side note: The original plan was to rename challenge type 24 from `generic` to `review`, since at the time of the PR it was only used for review pages. However, there are open PRs adding new language challenges with type 24. So the better approach is to introduce a new challenge type instead.
- Is related to #61643 



<!-- Feel free to add any additional description of changes below this line -->
