### PR TITLE
Fix: (Curriculum) Replaced office-cafe.png by cafe.png

### DIFF
--- a/curriculum/challenges/english/blocks/learn-how-to-provide-explanations-when-helping-others/662637442baaf548015d56d9.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-provide-explanations-when-helping-others/662637442baaf548015d56d9.md
@@ -18,7 +18,7 @@ Watch the video
 ```json
 {
   "setup": {
-    "background": "office-cafe.png",
+    "background": "cafe.png",
     "characters": [
       {
         "character": "David",
@@ -88,7 +88,7 @@ Watch the video
       "startTime": 8.66
     },
     {
-      "background": "office-cafe.png",
+      "background": "cafe.png",
       "character": "David",
       "opacity": 1,
       "startTime": 8.66
@@ -137,7 +137,7 @@ Watch the video
       "startTime": 16.26
     },
     {
-      "background": "office-cafe.png",
+      "background": "cafe.png",
       "character": "David",
       "opacity": 1,
       "startTime": 16.26
@@ -186,7 +186,7 @@ Watch the video
       "startTime": 25.26
     },
     {
-      "background": "office-cafe.png",
+      "background": "cafe.png",
       "character": "David",
       "opacity": 1,
       "startTime": 25.26

--- a/curriculum/challenges/english/blocks/learn-how-to-provide-explanations-when-helping-others/662637b4ae77ed48d6d5ba8d.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-provide-explanations-when-helping-others/662637b4ae77ed48d6d5ba8d.md
@@ -38,7 +38,7 @@ It means moving in one side and out of the other side of something, often indica
 ```json
 {
   "setup": {
-    "background": "office-cafe.png",
+    "background": "cafe.png",
     "characters": [
       {
         "character": "David",

--- a/curriculum/challenges/english/blocks/learn-how-to-provide-explanations-when-helping-others/66263800f12d8d4a6edffdcd.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-provide-explanations-when-helping-others/66263800f12d8d4a6edffdcd.md
@@ -54,7 +54,7 @@ David is seeking help for navigation, not improvement suggestions.
 ```json
 {
   "setup": {
-    "background": "office-cafe.png",
+    "background": "cafe.png",
     "characters": [
       {
         "character": "David",

--- a/curriculum/challenges/english/blocks/learn-how-to-provide-explanations-when-helping-others/662638ca74be054d04c448fa.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-provide-explanations-when-helping-others/662638ca74be054d04c448fa.md
@@ -103,7 +103,7 @@ While he is still confused, David doesn't comment on the helpfulness of the vide
       "startTime": 3.8
     },
     {
-      "background": "office-cafe.png",
+      "background": "cafe.png",
       "character": "David",
       "opacity": 1,
       "startTime": 3.8

--- a/curriculum/challenges/english/blocks/learn-how-to-provide-explanations-when-helping-others/662639212dc5664e08ec05f6.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-provide-explanations-when-helping-others/662639212dc5664e08ec05f6.md
@@ -54,7 +54,7 @@ Maria offers a specific solution to help with his confusion.
 ```json
 {
   "setup": {
-    "background": "office-cafe.png",
+    "background": "cafe.png",
     "characters": [
       {
         "character": "David",

--- a/curriculum/challenges/english/blocks/learn-how-to-provide-explanations-when-helping-others/6626396c2fd2604f117731b2.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-provide-explanations-when-helping-others/6626396c2fd2604f117731b2.md
@@ -112,7 +112,7 @@ David doesn't ask for clarification; he agrees to check it out.
       "startTime": 5.72
     },
     {
-      "background": "office-cafe.png",
+      "background": "cafe.png",
       "character": "David",
       "opacity": 1,
       "startTime": 5.72

--- a/curriculum/challenges/english/blocks/learn-how-to-provide-explanations-when-helping-others/66263b5ca3878d54811f9ac2.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-provide-explanations-when-helping-others/66263b5ca3878d54811f9ac2.md
@@ -56,7 +56,7 @@ David indicates he'll follow Maria's suggestion, not seek help elsewhere.
 ```json
 {
   "setup": {
-    "background": "office-cafe.png",
+    "background": "cafe.png",
     "characters": [
       {
         "character": "David",


### PR DESCRIPTION
There will be some changed on the CDN repo and office-cafe is among them. So, I've replaced it by another background.
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
