### PR TITLE
fix(client): align text in chapter button to the left when multi-line

### DIFF
--- a/client/src/templates/Introduction/components/super-block-accordion.css
+++ b/client/src/templates/Introduction/components/super-block-accordion.css
@@ -35,7 +35,7 @@
 .super-block-accordion .chapter-button .chapter-button-left {
   display: flex;
   align-items: center;
-  text-align: left;
+  text-align: start;
   column-gap: 10px;
   font-size: 1.5em;
 }
@@ -71,6 +71,7 @@
 .super-block-accordion .module-button-left,
 .super-block-accordion .module-button-right {
   display: flex;
+  text-align: start;
   align-items: center;
   gap: 10px;
 }

--- a/client/src/templates/Introduction/components/super-block-accordion.css
+++ b/client/src/templates/Introduction/components/super-block-accordion.css
@@ -35,6 +35,7 @@
 .super-block-accordion .chapter-button .chapter-button-left {
   display: flex;
   align-items: center;
+  text-align: left;
   column-gap: 10px;
   font-size: 1.5em;
 }

--- a/client/src/templates/Introduction/components/super-block-accordion.css
+++ b/client/src/templates/Introduction/components/super-block-accordion.css
@@ -71,9 +71,16 @@
 .super-block-accordion .module-button-left,
 .super-block-accordion .module-button-right {
   display: flex;
-  text-align: start;
   align-items: center;
   gap: 10px;
+}
+
+.super-block-accordion .module-button-left {
+  text-align: start;
+}
+
+.super-block-accordion .module-button-right {
+  text-align: end;
 }
 
 .super-block-accordion .module-steps {


### PR DESCRIPTION
I have a new superblock coming up adding [Full Stack Open](https://fullstackopen.com/en/) and it has a chapter title that is longer than usual. This makes the text align to the left instead of the center.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->
Before:
<img width="765" height="190" alt="image" src="https://github.com/user-attachments/assets/a19de1f7-7f1e-4169-a164-2179f39c47e3" />
<!-- Feel free to add any additional description of changes below this line -->

After:
<img width="765" height="190" alt="image" src="https://github.com/user-attachments/assets/4aec7842-2865-48e1-b991-8f1624c0533e" />
