### PR TITLE
Fix typo package managers

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-routing-react-frameworks-and-dependency-management-tools/67d1ab248317a5a29058a763.md
+++ b/curriculum/challenges/english/blocks/lecture-routing-react-frameworks-and-dependency-management-tools/67d1ab248317a5a29058a763.md
@@ -65,7 +65,7 @@ Another important aspect of the `package.json` file are the dev dependencies:
 
 Dev dependencies are packages that are only used for development and not in production. An example of this would be a testing library like Jest. You would install Jest as a dev dependency because you only use it to test your project locally, and isn't needed for the application to run in production.
 
-For the majority of this lecture, we have been focusing on npm. But there are other package mangers like yarn and pnpm. So which package manager should you use for your project?
+For the majority of this lecture, we have been focusing on npm. But there are other package managers like yarn and pnpm. So which package manager should you use for your project?
 
 Well, the short answer is it depends.
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.


Closes #61981

This commit resolves the spelling issue of 'managers', which was previously
written as 'mangers'.
