### PR TITLE
fix(curriculum): improve test for profile card step 4

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-reusable-profile-card-component/674ef2d357676e50e469165a.md
+++ b/curriculum/challenges/english/blocks/workshop-reusable-profile-card-component/674ef2d357676e50e469165a.md
@@ -19,14 +19,17 @@ You should export an `App` functional component.
 assert.isFunction(window.index.App);
 ```
 
-Your `App` component should return an empty string.
+Your `App` component should return a pair of parentheses with an empty string inside.
 
 ```js
-// This isn't a perfect test, since various return values are converted into
-// empty strings, but it has to be a valid React component.
-async() => {
-  const testElem = await __helpers.prepTestComponent(window.index.App);
-  assert.equal(testElem.textContent, '');
+async () => {
+  const functionRegex = __helpers.functionRegex("App", null, { capture: true });
+  const match = code.match(functionRegex);
+  const functionDefinition = match[0];
+  assert.match(
+    functionDefinition,
+    /\s*{\s*return\s*\(\s*(''|""|``)\s*\)\s*;?\s*}|\s*=>\s*\(\s*(''|""|``)\s*\)/
+  );
 }
 ```
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #60931

<!-- Feel free to add any additional description of changes below this line -->

This PR fixes the test in Step 4, which was passing incorrect code. The new test now checks the function's return statement directly.

The actual regex is borrowed directly from the test in Step 1 of the same workshop to ensure the testing style is consistent.

The screenshots below show the 2 cases mentioned in the issue now correctly failing:

<img width="434" height="311" alt="Screenshot 2025-08-30 at 14 50 28" src="https://github.com/user-attachments/assets/ace6127e-b8b4-4484-b12d-a81a2b271b68" />
<img width="430" height="273" alt="Screenshot 2025-08-30 at 14 51 43" src="https://github.com/user-attachments/assets/c475f6cd-57c4-49df-b773-646753ab4be5" />
