### PR TITLE
fix: clarify Step 26 instructions in Shopping Cart workshop

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-shopping-cart/63eff98ffb1d5a0d24ec79cb.md
+++ b/curriculum/challenges/english/blocks/workshop-shopping-cart/63eff98ffb1d5a0d24ec79cb.md
@@ -7,11 +7,11 @@ dashedName: step-26
 
 # --description--
 
-You haven't written the code to generate the HTML yet, but if a product has already been added to the user's cart then there will be a matching element which you'll need.
+You haven't written the code to generate the HTML yet, but when a product is added to the cart, you'll need to display how many of that product are in the cart. This will be shown in a `<span>` element that you'll create in later steps.
 
-Use `.getElementById()` to get the matching element - you'll be setting the `id` value to `product-count-for-id${product.id}`, so use a template literal to query that value.
+For now, you need to prepare to find that span element when it exists. Use `.getElementById()` to get the element that will have the `id` value `product-count-for-id${product.id}`. Use a template literal to create this query.
 
-Assign your query to a `currentProductCountSpan` variable.
+Assign your query to a `currentProductCountSpan` variable. (Note: this variable references a span element that you'll create later to display the count of each product.)
 
 # --hints--
 


### PR DESCRIPTION
**Description**
Improved clarity of Step 26 instructions in the Shopping Cart workshop to address student confusion about the `currentProductCountSpan` variable and its purpose.

**Changes Made:**
- Add context about span element creation in future steps
- Explain purpose of currentProductCountSpan variable
- Improve clarity for students about element purpose

Fixes #61905

**Checklist:**
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->
Closes #61905

<!-- Feel free to add any additional description of changes below this line -->
**Note:** As clarified by the maintainer, the original instructions were technically correct. However, I recognized that students were struggling with understanding the context and purpose of the `currentProductCountSpan` variable. This PR adds minor clarifications to improve the learning experience without changing the technical accuracy of the instructions.

The enhanced explanation helps students understand:
1. Why the variable references a "span" when they're currently working with buttons
2. That this span element will be created in future steps
3. The overall purpose of this preparation step in the workshop flow

This should reduce confusion while maintaining the existing instructional approach.