### PR TITLE
(fix): fix nav background color in high-contrast mode #59963

### DIFF
--- a/client/src/components/Header/components/universal-nav.css
+++ b/client/src/components/Header/components/universal-nav.css
@@ -14,6 +14,12 @@
     padding: 0 15px;
   }
 }
+@media (forced-colors: active) {
+  .universal-nav {
+    forced-color-adjust: none;
+    background-color: var(--gray-90);
+  }
+}
 
 .universal-nav a {
   text-decoration: none;


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.
<img width="1512" height="982" alt="Screenshot 2025-09-01 at 5 11 57 PM" src="https://github.com/user-attachments/assets/f0c5ec93-2ee1-466a-b5a7-f329b0ec7af4" />


Closes #59963

Rendering SVGs defaults will be different based on browser. Rendering SVGs will fill with currentColor property. Chrome and Edge on Windows have a specific user-agent style for SVG that sets forced-color-adjust: none.  No guaranty that the SVG will have appropriate contrast or even be visible. On Firefox, SVG's currentColor is forced to the WindowText/CanvasText color. 

Chrome and Edge will set the value of the prefers-color-scheme in high contrast mode depending on the Window/Canvas color used by the high contrast theme.

refers: https://www.w3.org/TR/css-color-adjust-1/#forced, https://developer.mozilla.org/en-US/docs/Web/CSS/forced-color-adjust

Note: forced-color-adjust property is not supported by Safari, Safari on iOS, and WebView on iOS

Question: do you require test coverage with playwright?