### PR TITLE
fix: validate tests exist if filtering for challenges

### DIFF
--- a/curriculum/test/test-challenges.js
+++ b/curriculum/test/test-challenges.js
@@ -152,8 +152,18 @@ async function setup() {
   await page.setViewport({ width: 300, height: 150 });
 
   const lang = testedLang();
+  const challenges = await getChallenges(lang, testFilter);
+  const nonCertificationChallenges = challenges.filter(
+    ({ challengeType }) => challengeType !== 7
+  );
 
-  let challenges = await getChallenges(lang, testFilter);
+  if (isEmpty(nonCertificationChallenges)) {
+    throw Error(
+      `No challenges to test when using filter ${JSON.stringify(testFilter)}
+If the challenge file exists, try running 'build:curriculum' for more information.
+      `
+    );
+  }
 
   // the next few statements create a list of all blocks and superblocks
   // as they appear in the list of challenges


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Otherwise it's easy to miss the fact the reason your tests are passing is because none are being run.

<!-- Feel free to add any additional description of changes below this line -->
