### PR TITLE
docs(curriculum): make Step 53 localStorage instructions browser-agnostic (Application vs Storage tab)

### DIFF
--- a/curriculum/challenges/english/blocks/learn-localstorage-by-building-a-todo-app/64fb29348a60361ccd45c1e2.md
+++ b/curriculum/challenges/english/blocks/learn-localstorage-by-building-a-todo-app/64fb29348a60361ccd45c1e2.md
@@ -19,7 +19,7 @@ localStorage.setItem("key", value); // value could be string, number, or any oth
 
 A `myTaskArr` array has been provided for you. Use the `setItem()` method to save it with a key of `data`.
 
-After that, open your browser console and go to the `Applications` tab, select `Local Storage`, and the freeCodeCamp domain you see.
+After that, open your browser's developer tools and navigate to the storage panel. In Chrome/Edge this is the `Application` tab, and in Firefox/Safari it's the `Storage` tab. Then select `Local Storage` and the freeCodeCamp domain you see.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64fb29348a60361ccd45c1e2.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64fb29348a60361ccd45c1e2.md
@@ -19,7 +19,7 @@ localStorage.setItem("key", value); // value could be string, number, or any oth
 
 A `myTaskArr` array has been provided for you. Use the `setItem()` method to save it with a key of `data`.
 
-After that, open your browser console and go to the `Applications` tab, select `Local Storage`, and the freeCodeCamp domain you see.
+After that, open your browser's developer tools and navigate to the storage panel. In Chrome/Edge this is the `Application` tab, and in Firefox/Safari it's the `Storage` tab. Then select `Local Storage` and the freeCodeCamp domain you see.
 
 # --hints--
 


### PR DESCRIPTION
Clarify Step 53 instructions to be browser-agnostic: Chrome/Edge use the Application tab; Firefox/Safari use the Storage tab.

Files changed:
- curriculum/challenges/english/blocks/learn-localstorage-by-building-a-todo-app/64fb29348a60361ccd45c1e2.md
- curriculum/challenges/english/blocks/workshop-todo-app/64fb29348a60361ccd45c1e2.md

Closes #60508