### PR TITLE
fix(curriculum): fix typo in Local Storage review (poses, not posses)

### DIFF
--- a/curriculum/challenges/english/blocks/review-local-storage-and-crud/6723d0ac516099c902394e8b.md
+++ b/curriculum/challenges/english/blocks/review-local-storage-and-crud/6723d0ac516099c902394e8b.md
@@ -117,7 +117,7 @@ The Cache API is a storage mechanism that stores Request and Response objects. W
 
 - **Excessive Tracking**: This refers to the practice of collecting and storing an overabundance of user data in client-side storage (such as cookies, local storage, or session storage) without clear, informed consent or a legitimate need. This often involves tracking user behavior, preferences, and interactions across multiple sites or sessions, which can infringe on user privacy. 
 - **Browser Fingerprinting**: A technique used to track and identify individual users based on unique characteristics of their device and browser, rather than relying on cookies or other traditional tracking methods. Unlike cookies, which are stored locally on a user's device, fingerprinting involves collecting a range of information that can be used to create a distinctive "fingerprint" of a user's browser session. 
-- **Setting Passwords in LocalStorage**: This might seem like a more obvious negative pattern, but setting any sensitive data like passwords in local storage posses a security risk. Local Storage is not encrypted and can be accessed easily. So you should never store any type of sensitive data in there.
+- **Setting Passwords in LocalStorage**: This might seem like a more obvious negative pattern, but setting any sensitive data like passwords in local storage poses a security risk. Local Storage is not encrypted and can be accessed easily. So you should never store any type of sensitive data in there.
 
 ## IndexedDB
 


### PR DESCRIPTION
docs(curriculum): fix typo in Local Storage review (poses, not posses)

Checklist:

- [x] I have read and followed the contribution guidelines: https://contribute.freecodecamp.org
- [x] I have read and followed the how to open a pull request guide: https://contribute.freecodecamp.org/how-to-open-a-pull-request/
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have reviewed the render and formatting of the changed Markdown; this is a docs-only change.

No linked issue for this minor typo fix.