### PR TITLE
test: only intercept the page-data for tested page

### DIFF
--- a/e2e/quiz-challenge.spec.ts
+++ b/e2e/quiz-challenge.spec.ts
@@ -23,13 +23,15 @@ interface PageData {
   };
 }
 
+const quizPath = '/learn/full-stack-developer/quiz-basic-html/quiz-basic-html';
+
 test.describe('Quiz challenge', () => {
   test.beforeEach(async ({ page }) => {
     const fixturePath = path.join(__dirname, 'fixtures', 'quiz-fixture.json');
     const fixture = JSON.parse(fs.readFileSync(fixturePath, 'utf8')) as Quiz[];
 
     // Intercept Gatsby page-data and inject a deterministic quiz fixture
-    await page.route('**/page-data/**/page-data.json', async route => {
+    await page.route(`**/page-data${quizPath}/page-data.json`, async route => {
       const response = await route.fetch();
       const body = await response.text();
 
@@ -42,9 +44,7 @@ test.describe('Quiz challenge', () => {
       });
     });
 
-    await page.goto(
-      '/learn/full-stack-developer/quiz-basic-html/quiz-basic-html'
-    );
+    await page.goto(quizPath);
   });
 
   test('should display a list of unanswered questions if user has not answered all questions', async ({


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

When reviewing https://github.com/freeCodeCamp/freeCodeCamp/pull/62011 my suggestion to remove try-catch broke the tests. The issue was that the mocking assumed a certain structure for the response that wasn't always the case.

Rather than reinstate the try-catch block, I've reduced the routes that we're mocking to ones that always have the expected structure.

<!-- Feel free to add any additional description of changes below this line -->
