### PR TITLE
fix(api): throw during exam generation if empty config

### DIFF
--- a/api/src/exam-environment/utils/exam-environment.ts
+++ b/api/src/exam-environment/utils/exam-environment.ts
@@ -303,6 +303,10 @@ export function generateExam(
     };
   });
 
+  if (examCopy.config.questionSets.length === 0) {
+    throw `${examCopy.id}: Invalid exam config - no question sets config.`;
+  }
+
   // Convert question set config by type: [[all question sets of type], [another type], ...]
   const typeConvertedQuestionSetsConfig = examCopy.config.questionSets.reduce(
     (acc, curr) => {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This helps prevent accidental exam generations for exams that are not configured yet.