### PR TITLE
fix(curriculum): fix typos in 'Working with Loops' lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-loops/67329f7f3d1bd75c17896c66.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-loops/67329f7f3d1bd75c17896c66.md
@@ -11,7 +11,7 @@ Loops in programming are used to repeat a block of code multiple times.
 
 An example of a loop would be when you are designing a program that needs to print out a list of items. You could use a loop to print out each one of the items in the list.
 
-Another example would be when you designing a game and you want to move a character across the screen. You could use a loop to move the character a certain number of pixels each time the loop runs. 
+Another example would be when you are designing a game and you want to move a character across the screen. You could use a loop to move the character a certain number of pixels each time the loop runs. 
 
 In JavaScript, there are several types of loops that you can use. In this lecture, we will cover the `for` loop. Here is the basic syntax for a `for` loop:
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-loops/6732c05595ca7d422b9e55ff.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-loops/6732c05595ca7d422b9e55ff.md
@@ -89,7 +89,7 @@ for (const prop in person) {
 }
 ```
 
-In this example have a custom function `isObject` that checks if the value is an object.
+In this example, we have a custom function `isObject` that checks if the value is an object.
 
 The `Array.isArray` method is used to check if the value is an array. By placing the logical NOT operator (`!`) in front of the method, we are checking if the value is not an array.
 


### PR DESCRIPTION
feat(curriculum): fix typos in 'Working with Loops' lecture (#62052)

This pull request addresses the typos found in the "Working with Loops" lecture, as outlined in issue #62052. The goal is to improve the clarity and readability of the lesson content for future learners.

---

Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

Closes #62052

The following changes were made:

* **File:** `curriculum/challenges/english/blocks/lecture-working-with-loops/67329f7f3d1bd75c17896c66.md`
    * Corrected "you designing" to "you are designing" on line 14.

* **File:** `curriculum/challenges/english/blocks/lecture-working-with-loops/6732c05595ca7d422b9e55ff.md`
    * Corrected "example have" to "example, we have" on line 92.
