### PR TITLE
fix: rebuild challenge pages if source is updated

### DIFF
--- a/client/gatsby-config.js
+++ b/client/gatsby-config.js
@@ -2,7 +2,7 @@ const path = require('path');
 const envData = require('./config/env.json');
 const {
   buildChallenges,
-  replaceChallengeNode,
+  replaceChallengeNodes,
   localeChallengesRootDir
 } = require('./utils/build-challenges');
 
@@ -57,7 +57,7 @@ module.exports = {
       options: {
         name: 'challenges',
         source: buildChallenges,
-        onSourceChange: replaceChallengeNode(curriculumLocale),
+        onSourceChange: replaceChallengeNodes(curriculumLocale),
         curriculumPath: localeChallengesRootDir
       }
     },

--- a/client/utils/build-challenges.js
+++ b/client/utils/build-challenges.js
@@ -10,6 +10,7 @@ const {
   getBlockCreator
 } = require('../../curriculum/build-curriculum');
 const { getBlockStructure } = require('../../curriculum/file-handler');
+const { getSuperblocks } = require('../../curriculum/build-curriculum');
 
 const { curriculumLocale } = envData;
 
@@ -17,21 +18,27 @@ exports.localeChallengesRootDir = getContentDir(curriculumLocale);
 
 const blockCreator = getBlockCreator(curriculumLocale);
 
-exports.replaceChallengeNode = () => {
-  return async function replaceChallengeNode(filePath) {
+exports.replaceChallengeNodes = () => {
+  return async function replaceChallengeNodes(filePath) {
     const parentDir = path.dirname(filePath);
     const block = path.basename(parentDir);
     const filename = path.basename(filePath);
 
     console.log(`Replacing challenge node for ${filePath}`);
     const meta = getBlockStructure(block);
+    const superblocks = getSuperblocks(block);
 
-    return await blockCreator.createChallenge({
+    const challenge = await blockCreator.createChallenge({
       filename,
       block,
       meta,
       isAudited: true
     });
+
+    return superblocks.map(superBlock => ({
+      ...challenge,
+      superBlock
+    }));
   };
 };
 

--- a/curriculum/build-curriculum.js
+++ b/curriculum/build-curriculum.js
@@ -244,6 +244,21 @@ function addBlockStructure(
   }));
 }
 
+/**
+ * Returns a list of all the superblocks that contain the given block
+ * @param {string} block
+ */
+function getSuperblocks(block) {
+  const { superblocks } = getCurriculumStructure();
+  const withStructure = addSuperblockStructure(superblocks);
+
+  return withStructure
+    .filter(({ blocks }) =>
+      blocks.some(({ dashedName }) => dashedName === block)
+    )
+    .map(({ name }) => name);
+}
+
 async function buildCurriculum(lang, filters) {
   const contentDir = getContentDir(lang);
   const builder = new SuperblockCreator({
@@ -289,5 +304,6 @@ module.exports = {
   getBlockStructure,
   getSuperblockStructure,
   createCommentMap,
-  superBlockToFilename
+  superBlockToFilename,
+  getSuperblocks
 };

--- a/curriculum/build-curriculum.js
+++ b/curriculum/build-curriculum.js
@@ -248,9 +248,12 @@ function addBlockStructure(
  * Returns a list of all the superblocks that contain the given block
  * @param {string} block
  */
-function getSuperblocks(block) {
+function getSuperblocks(
+  block,
+  _addSuperblockStructure = addSuperblockStructure
+) {
   const { superblocks } = getCurriculumStructure();
-  const withStructure = addSuperblockStructure(superblocks);
+  const withStructure = _addSuperblockStructure(superblocks);
 
   return withStructure
     .filter(({ blocks }) =>

--- a/curriculum/build-curriculum.test.js
+++ b/curriculum/build-curriculum.test.js
@@ -1,18 +1,15 @@
 jest.mock('./file-handler');
-jest.mock('./build-curriculum');
 
 const path = require('node:path');
 
 const {
   createCommentMap,
   addBlockStructure,
-  addSuperblockStructure,
   getSuperblocks
 } = require('./build-curriculum');
 const { getCurriculumStructure } = require('./file-handler');
 
 const mockGetCurriculumStructure = getCurriculumStructure;
-const mockAddSuperblockStructure = addSuperblockStructure;
 
 describe('createCommentMap', () => {
   const dictionaryDir = path.resolve(__dirname, '__fixtures__', 'dictionaries');
@@ -121,35 +118,39 @@ describe('getSuperblocks', () => {
     mockGetCurriculumStructure.mockReturnValue({
       superblocks: ['superblock-1'] // doesn't matter what this is, but must be defined
     });
-    mockAddSuperblockStructure.mockReturnValue([
+    const mockAddSuperblockStructure = () => [
       {
         blocks: [{ dashedName: 'block-1' }],
         name: 'superblock-1'
       }
-    ]);
+    ];
 
-    expect(getSuperblocks('nonexistent-block')).toEqual([]);
+    expect(
+      getSuperblocks('nonexistent-block', mockAddSuperblockStructure)
+    ).toEqual([]);
   });
 
   it('returns an array with one superblock if one superblock contains the given block', () => {
     mockGetCurriculumStructure.mockReturnValue({
       superblocks: ['superblock-1'] // doesn't matter what this is, but must be defined
     });
-    mockAddSuperblockStructure.mockReturnValue([
+    const mockAddSuperblockStructure = () => [
       {
         blocks: [{ dashedName: 'block-1' }, { dashedName: 'block-2' }],
         name: 'superblock-1'
       }
-    ]);
+    ];
 
-    expect(getSuperblocks('block-1')).toEqual(['superblock-1']);
+    expect(getSuperblocks('block-1', mockAddSuperblockStructure)).toEqual([
+      'superblock-1'
+    ]);
   });
 
   it('returns an array with multiple superblocks if multiple superblocks contain the given block', () => {
     mockGetCurriculumStructure.mockReturnValue({
       superblocks: ['superblock-1'] // doesn't matter what this is, but must be defined
     });
-    mockAddSuperblockStructure.mockReturnValue([
+    const mockAddSuperblockStructure = () => [
       {
         blocks: [{ dashedName: 'block-1' }, { dashedName: 'block-2' }],
         name: 'superblock-1'
@@ -158,8 +159,11 @@ describe('getSuperblocks', () => {
         blocks: [{ dashedName: 'block-3' }, { dashedName: 'block-1' }],
         name: 'superblock-2'
       }
-    ]);
+    ];
 
-    expect(getSuperblocks('block-1')).toEqual(['superblock-1', 'superblock-2']);
+    expect(getSuperblocks('block-1', mockAddSuperblockStructure)).toEqual([
+      'superblock-1',
+      'superblock-2'
+    ]);
   });
 });

--- a/curriculum/build-curriculum.test.js
+++ b/curriculum/build-curriculum.test.js
@@ -1,6 +1,18 @@
+jest.mock('./file-handler');
+jest.mock('./build-curriculum');
+
 const path = require('node:path');
 
-const { createCommentMap, addBlockStructure } = require('./build-curriculum');
+const {
+  createCommentMap,
+  addBlockStructure,
+  addSuperblockStructure,
+  getSuperblocks
+} = require('./build-curriculum');
+const { getCurriculumStructure } = require('./file-handler');
+
+const mockGetCurriculumStructure = getCurriculumStructure;
+const mockAddSuperblockStructure = addSuperblockStructure;
 
 describe('createCommentMap', () => {
   const dictionaryDir = path.resolve(__dirname, '__fixtures__', 'dictionaries');
@@ -101,5 +113,53 @@ describe('addBlockStructure', () => {
         ]
       }
     ]);
+  });
+});
+
+describe('getSuperblocks', () => {
+  it('returns an empty array if no superblocks contain the given block', () => {
+    mockGetCurriculumStructure.mockReturnValue({
+      superblocks: ['superblock-1'] // doesn't matter what this is, but must be defined
+    });
+    mockAddSuperblockStructure.mockReturnValue([
+      {
+        blocks: [{ dashedName: 'block-1' }],
+        name: 'superblock-1'
+      }
+    ]);
+
+    expect(getSuperblocks('nonexistent-block')).toEqual([]);
+  });
+
+  it('returns an array with one superblock if one superblock contains the given block', () => {
+    mockGetCurriculumStructure.mockReturnValue({
+      superblocks: ['superblock-1'] // doesn't matter what this is, but must be defined
+    });
+    mockAddSuperblockStructure.mockReturnValue([
+      {
+        blocks: [{ dashedName: 'block-1' }, { dashedName: 'block-2' }],
+        name: 'superblock-1'
+      }
+    ]);
+
+    expect(getSuperblocks('block-1')).toEqual(['superblock-1']);
+  });
+
+  it('returns an array with multiple superblocks if multiple superblocks contain the given block', () => {
+    mockGetCurriculumStructure.mockReturnValue({
+      superblocks: ['superblock-1'] // doesn't matter what this is, but must be defined
+    });
+    mockAddSuperblockStructure.mockReturnValue([
+      {
+        blocks: [{ dashedName: 'block-1' }, { dashedName: 'block-2' }],
+        name: 'superblock-1'
+      },
+      {
+        blocks: [{ dashedName: 'block-3' }, { dashedName: 'block-1' }],
+        name: 'superblock-2'
+      }
+    ]);
+
+    expect(getSuperblocks('block-1')).toEqual(['superblock-1', 'superblock-2']);
   });
 });

--- a/tools/client-plugins/gatsby-source-challenges/gatsby-node.js
+++ b/tools/client-plugins/gatsby-source-challenges/gatsby-node.js
@@ -39,13 +39,15 @@ exports.sourceNodes = function sourceChallengesSourceNodes(
   watcher.on('change', filePath =>
     /\.md?$/.test(filePath)
       ? onSourceChange(filePath)
-          .then(challenge => {
+          .then(challenges => {
             reporter.info(
               `
-File changed at ${filePath}, replacing challengeNode id ${challenge.id}
+File changed at ${filePath}, replacing challengeNodes with ids ${challenges.map(({ id }) => id).join(', ')}
               `
             );
-            createVisibleChallenge(challenge, { isReloading: true });
+            challenges.forEach(challenge =>
+              createVisibleChallenge(challenge, { isReloading: true })
+            );
           })
           .catch(e =>
             reporter.error(`fcc-replace-challenge
@@ -74,13 +76,15 @@ File changed at ${filePath}, replacing challengeNode id ${challenge.id}
           const { path: siblingPath } = entry;
           const relativePath = path.join(blockPath, siblingPath);
           onSourceChange(relativePath)
-            .then(challenge => {
+            .then(challenges => {
               reporter.info(
                 `
-File changed at ${relativePath}, replacing challengeNode id ${challenge.id}
+File changed at ${relativePath}, replacing challengeNodes with ids ${challenges.map(({ id }) => id).join(', ')}
             `
               );
-              createVisibleChallenge(challenge);
+              challenges.forEach(challenge =>
+                createVisibleChallenge(challenge)
+              );
             })
             .catch(e =>
               reporter.error(`fcc-replace-challenge


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

As of
https://github.com/freeCodeCamp/freeCodeCamp/pull/61459 updating a challenge markdown file would not rebuild the corresponding page.

Now, even if a challenge appears in multiple superblocks, each associated page should be recreated when the file is modified.

<!-- Feel free to add any additional description of changes below this line -->
