### PR TITLE
fix(curriculum): Improve hint for Caesar Cipher step 4

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-caesar-cipher/680a549f60f5a3fedfc0edd9.md
+++ b/curriculum/challenges/english/blocks/workshop-caesar-cipher/680a549f60f5a3fedfc0edd9.md
@@ -23,7 +23,7 @@ As a reminder, `sentence[start:stop]` returns the characters of `sentence` from 
 
 # --hints--
 
-You should concatenate the missing first portion of `alphabet` to `alphabet[shift:]` using the slicing syntax. Use `shift` to specify where to stop the slicing.
+You should assign the concatenation of `alphabet[shift:]` and the missing first portion of `alphabet` to the `shifted_alphabet` variable. Use `shift` to specify where to stop the slicing.
 
 ```js
 ({ test: () => runPython(`


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #62064

<!-- Feel free to add any additional description of changes below this line -->

This PR improves the hint for step 4 of the "Build a Caesar Cipher" workshop. The existing hint was slightly ambiguous and did not explicitly state that the result of the concatenation needed to be assigned to the shifted_alphabet variable. This change provides a clearer, more direct instruction for learners.

What I changed
I modified the hint text in curriculum/challenges/english/learn/blocks/workshop-caesar-cipher/680a549f60f5a3fedfc0edd9.md.

Why I changed it
The previous hint was causing confusion, as a user pointed out in issue #62064. My change makes the instruction explicit, reducing the cognitive load for beginners and helping them understand the concept of variable assignment more clearly. This directly improves the user experience for future learners.

