### PR TITLE
fix(curriculum): remove image placeholder from Vite lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-introduction-to-javascript-libraries-and-frameworks/6734e88cc46e6dc679420040.md
+++ b/curriculum/challenges/english/blocks/lecture-introduction-to-javascript-libraries-and-frameworks/6734e88cc46e6dc679420040.md
@@ -23,8 +23,6 @@ This command creates a new React project named `my-react-app` using Vite's React
 
 You can then open up the new project and see the React boilerplate code that Vite has provided for you.
 
-[Image showing the boilerplate Vite files and folders in a code editor, including the `public` and `src` folders, and the `.gitignore`, `eslint.config.js`, `index.html`, `package.json`, `README.md`, and `vite.config.js` files.]
-
 The great thing about Vite is that it will only provide the files that are absolutely necessary to get started with your React project.
 
 To actually run the project as-is, you will need to install the dependencies using the following commands in the command line:


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #61838

<!-- Feel free to add any additional description of changes below this line -->
This PR removes the placeholder text for a missing image from the Vite lecture.

As discussed in the issue, any static image or text representation of the Vite boilerplate would quickly become outdated. Removing the placeholder is the cleanest solution.