### PR TITLE
fix(tools): adjust create language block helper script

### DIFF
--- a/tools/challenge-helper-scripts/create-language-block.ts
+++ b/tools/challenge-helper-scripts/create-language-block.ts
@@ -54,7 +54,7 @@ async function createLanguageBlock(
   const superblockFilename = (
     superBlockToFilename as Record<SuperBlocks, string>
   )[superBlock];
-  void updateSimpleSuperblockStructure(block, { order: 0 }, superblockFilename);
+  void updateSimpleSuperblockStructure(block, {}, superblockFilename);
   // TODO: remove once we stop relying on markdown in the client.
   await createIntroMD(superBlock, block, title);
 }

--- a/tools/challenge-helper-scripts/helpers/create-project.test.ts
+++ b/tools/challenge-helper-scripts/helpers/create-project.test.ts
@@ -70,6 +70,26 @@ describe('updateSimpleSuperblockStructure', () => {
       }
     );
   });
+
+  it('should insert the block into the blocks array at the end when no order is given', async () => {
+    const existingBlocks = ['block1', 'block2'];
+    const superblockFilename = 'test-superblock';
+    const newBlock = 'block3';
+
+    mockGetSuperblockStructure.mockReturnValue({
+      blocks: existingBlocks
+    });
+
+    await updateSimpleSuperblockStructure(newBlock, {}, superblockFilename);
+
+    expect(mockGetSuperblockStructure).toHaveBeenCalledWith(superblockFilename);
+    expect(mockWriteSuperblockStructure).toHaveBeenCalledWith(
+      superblockFilename,
+      {
+        blocks: ['block1', 'block2', 'block3']
+      }
+    );
+  });
 });
 
 describe('updateChapterModuleSuperblockStructure', () => {

--- a/tools/challenge-helper-scripts/helpers/create-project.ts
+++ b/tools/challenge-helper-scripts/helpers/create-project.ts
@@ -8,14 +8,20 @@ import { insertInto } from './utils';
 
 export async function updateSimpleSuperblockStructure(
   block: string,
-  position: { order: number },
+  position: { order?: number },
   superblockFilename: string
 ) {
   const existing = getSuperblockStructure(superblockFilename) as {
     blocks: string[];
   };
+
+  const order =
+    typeof position.order === 'number'
+      ? position.order
+      : existing.blocks.length;
+
   const updated = {
-    blocks: insertInto(existing.blocks, position.order, block)
+    blocks: insertInto(existing.blocks, order, block)
   };
   await writeSuperblockStructure(superblockFilename, updated);
 }


### PR DESCRIPTION
The `pnpm create-new-language-block` helper script was adding blocks to the beginning of the superblock. This moves it to add the blocks at the end.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
