### PR TITLE
Clarify Step 4 hint to explicitly assign concatenated string to shifted_alphabet

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-caesar-cipher/680a549f60f5a3fedfc0edd9.md
+++ b/curriculum/challenges/english/blocks/workshop-caesar-cipher/680a549f60f5a3fedfc0edd9.md
@@ -42,7 +42,7 @@ assert _first or _second
 --fcc-editable-region--
 alphabet = 'abcdefghijklmnopqrstuvwxyz'
 shift = 5
-shifted_alphabet = alphabet[shift:]
+shifted_alphabet = alphabet[shift:] + alphabet[:shift]
 print(shifted_alphabet)
 --fcc-editable-region--
 ```


### PR DESCRIPTION
Body Clarifies the Step 4 hint to explicitly assign the concatenation to shifted_alphabet.

Updates: curriculum/challenges/english/blocks/workshop-caesar-cipher/680a549f60f5a3fedfc0edd9.md (--hints-- section).

Checklist:

- [ x ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ x ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ x ]My pull request targets the `main` branch of freeCodeCamp.
- [ x ] I have tested these changes either locally on my machine, or Gitpod.

Before

<img width="1133" height="183" alt="image" src="https://github.com/user-attachments/assets/ea624db0-d9e3-4998-ad98-c6b22d9e68a4" />


After 

<img width="1133" height="183" alt="image" src="https://github.com/user-attachments/assets/cb64bece-94d6-4646-ad35-f4b29b8894ae" />


Closes #62064

