### PR TITLE
fix(i18n,client): add note for deployment issues

### DIFF
--- a/client/src/pages/learn.tsx
+++ b/client/src/pages/learn.tsx
@@ -4,7 +4,7 @@ import Helmet from 'react-helmet';
 import { useTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
-import { Container, Col, Row, Spacer } from '@freecodecamp/ui';
+import { Container, Col, Row, Spacer, Callout } from '@freecodecamp/ui';
 
 import Intro from '../components/Intro';
 import Map from '../components/Map';
@@ -16,6 +16,8 @@ import {
 } from '../redux/selectors';
 
 import callGA from '../analytics/call-ga';
+import { clientLocale } from '../../config/env.json';
+import createLanguageRedirect from '../components/create-language-redirect';
 
 interface FetchState {
   pending: boolean;
@@ -99,6 +101,33 @@ function LearnPage({
               onLearnDonationAlertClick={onLearnDonationAlertClick}
               isDonating={isDonating}
             />
+            {clientLocale === 'english' ? null : (
+              <>
+                <Spacer size='m' />
+                <Callout variant='info'>
+                  <p className='text-center'>
+                    <strong style={{ color: 'var(--blue-dark)' }}>
+                      Warning: The localized content in this language is not
+                      being updated.
+                    </strong>
+                  </p>
+                  <p>
+                    Your previous progress is being saved, but you should{' '}
+                    <a
+                      href={createLanguageRedirect({
+                        clientLocale,
+                        lang: 'english'
+                      })}
+                    >
+                      visit the English version
+                    </a>{' '}
+                    for up to date content. We recognize this is not ideal and
+                    are working to fix it.
+                  </p>
+                  <p>We appreciate your patience.</p>
+                </Callout>
+              </>
+            )}
             <Map />
             <Spacer size='l' />
           </Col>


### PR DESCRIPTION
This PR adds a quick and dirty note to let users know that we are not deploying the localized content currently. Once this is up, we can disable all the failing workflows until we can figure out to update the content.

That should give us some breathing room and allow users to be aware of what's going on.

<details>
<summary>Screenshots</summary>

<img width="842" height="276" alt="image" src="https://github.com/user-attachments/assets/8695d30b-2ed9-40b0-beee-514f43ab7ac5" />


</details>