### PR TITLE
fix: make trivia bot tests compatible with template literals

### DIFF
--- a/curriculum/challenges/english/blocks/lab-javascript-trivia-bot/66ed41f912d0bb1dc62da5dd.md
+++ b/curriculum/challenges/english/blocks/lab-javascript-trivia-bot/66ed41f912d0bb1dc62da5dd.md
@@ -100,7 +100,7 @@ You should give `codingFact` a value that includes `favoriteLanguage`.
 ```js
 const codeWithoutComments = __helpers.removeJSComments(code);
 assert.match(code, /let\s+codingFact/);
-assert.match(code, /codingFact\s*=\s*(("|'|`)?.+?\1?\s*\+\s*|favoriteLanguage\s*\+\s*(("|'|`)?.+?\3?))/);
+assert.match(code, /codingFact\s*=\s*(`|('|").*?\+.*`|('|").* favoriteLanguage\s*`|('|").*`\s*\+\s*)/);
 assert.exists(codingFact);
 assert.isNotEmpty(codingFact);
 assert.include(String(codingFact), favoriteLanguage);
@@ -120,7 +120,7 @@ You should assign a new value to `codingFact` that also contains `favoriteLangua
 ```js
 const codeWithoutComments = __helpers.removeJSComments(code);
 const loggingCodingFacts = codeWithoutComments.match(/console\.log\(\s*codingFact\s*\)/g)
-const [first, second, third] = codeWithoutComments.match(/(let )?\s*codingFact\s*=\s*(("|')?.+?\2?\s*\+\s*|favoriteLanguage\s*\+\s*(("|')?.+?\2?))/g);
+const [first, second, third] = codeWithoutComments.match(/(let )?\s*codingFact\s*=\s*(`|('|").*?\+.*`|('|").*favoriteLanguage\s*`|('|").*`\s*\+\s*)/g);
 assert.include(getLogs()[4], favoriteLanguage);
 assert.notEqual(getLogs()[4], getLogs()[3]);
 assert.isAtLeast(loggingCodingFacts.length, 2);


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.


Closes #62094 

