### PR TITLE
fix: clarify hint and improve test flexibility in book catalog exercise

### DIFF
--- a/curriculum/challenges/english/blocks/lab-book-catalog-table/66ec4c8e9878d8441956516f.md
+++ b/curriculum/challenges/english/blocks/lab-book-catalog-table/66ec4c8e9878d8441956516f.md
@@ -109,11 +109,11 @@ The `td` element in your `tfoot` element's row should have it's `colspan` attrib
 assert.equal(document.querySelector('tfoot tr td')?.colSpan, 4);
 ```
 
-The `td` element in your `tfoot` element's row should have the text `Total Books: [number of books in your table]`.
+The `td` element in your `tfoot` element's row should have the text `Total Books: N` where `N` is the number of books in your table.
 
 ```js
 const numberOfBooks = document.querySelectorAll('tbody tr')?.length;
-assert.equal(document.querySelector('tfoot tr td').textContent, `Total Books: ${numberOfBooks}`);
+assert.equal(document.querySelector('tfoot tr td').textContent.trim(), `Total Books: ${numberOfBooks}`);
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #62119

<!-- Feel free to add any additional description of changes below this line -->

This PR fixes issue #62119.

- Updated hint wording to be clearer by explicitly using "Total Books: N" where N is the number of books.  
- Improved the test by trimming `textContent` before comparison for flexibility.  

These changes make the exercise instructions less confusing and ensure the test is more robust.




