### PR TITLE
fix: add missing 'have' in instructions (#62113)

### DIFF
--- a/curriculum/challenges/english/blocks/lab-book-catalog-table/66ec4c8e9878d8441956516f.md
+++ b/curriculum/challenges/english/blocks/lab-book-catalog-table/66ec4c8e9878d8441956516f.md
@@ -109,11 +109,11 @@ The `td` element in your `tfoot` element's row should have it's `colspan` attrib
 assert.equal(document.querySelector('tfoot tr td')?.colSpan, 4);
 ```
 
-The `td` element in your `tfoot` element's row should have the text `Total Books: [number of books in your table]`.
+The `td` element in your `tfoot` element's row should have the text `Total Books: N` where `N` is the number of books in your table.
 
 ```js
 const numberOfBooks = document.querySelectorAll('tbody tr')?.length;
-assert.equal(document.querySelector('tfoot tr td').textContent, `Total Books: ${numberOfBooks}`);
+assert.equal(document.querySelector('tfoot tr td').textContent.trim(), `Total Books: ${numberOfBooks}`);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/lab-lightbox-viewer/66db57ad34c7089b9b41bfd6.md
+++ b/curriculum/challenges/english/blocks/lab-lightbox-viewer/66db57ad34c7089b9b41bfd6.md
@@ -70,7 +70,7 @@ for (let image of images) {
 assert.strictEqual(srcCount, 1);
 ```
 
-Within the `.gallery` element, you should an `img` element with the `src` set to `https://cdn.freecodecamp.org/curriculum/labs/storm-thumbnail.jpg`.
+Within the `.gallery` element, you should have an `img` element with the `src` set to `https://cdn.freecodecamp.org/curriculum/labs/storm-thumbnail.jpg`.
 
 ```js
 const images = document.querySelectorAll(".gallery .gallery-item");
@@ -86,7 +86,7 @@ for (let image of images) {
 assert.strictEqual(srcCount, 1);
 ```
 
-Within the `.gallery` element, you should an `img` element with the `src` set to `https://cdn.freecodecamp.org/curriculum/labs/trees-thumbnail.jpg`.
+Within the `.gallery` element, you should have an `img` element with the `src` set to `https://cdn.freecodecamp.org/curriculum/labs/trees-thumbnail.jpg`.
 
 ```js
 const images = document.querySelectorAll(".gallery .gallery-item");

--- a/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a9577022877d72d8f43b4f.md
+++ b/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a9577022877d72d8f43b4f.md
@@ -15,7 +15,7 @@ Inside the `fieldset` element, add a `legend` element with the text `Why did you
 
 # --hints--
 
-You should a `fieldset` element.
+You should have a `fieldset` element.
 
 ```js
 assert.lengthOf(document.querySelectorAll('fieldset'), 3);


### PR DESCRIPTION
This PR fixes missing 'have' in multiple curriculum instructions:
- lab-lightbox-viewer (lines 73 and 89)
- workshop-hotel-feedback-form (line 18)

These grammar fixes improve clarity for learners.
