### PR TITLE
fix(curriculum): correct regex to only allow == or ===

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-note-taking-app/6881436e1e2afae400e8b4fe.md
+++ b/curriculum/challenges/english/blocks/workshop-note-taking-app/6881436e1e2afae400e8b4fe.md
@@ -18,7 +18,7 @@ Above your `currentContent = newContent;` line, add an `if` statement to check i
 You should add an `if` statement to check if `currentContent` is equal to `newContent`. If so, return.
 
 ```js
-assert.match(code, /if\s*\(\s*currentContent\s*=={2,3}\s*newContent\s*\)\s*(?:{\s*return;?\s*}|return\s*;?)/);
+assert.match(code, /if\s*\(\s*currentContent\s*={2,3}\s*newContent\s*\)\s*(?:{\s*return;?\s*}|return\s*;?)/);
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #62125

<!-- Feel free to add any additional description of changes below this line -->

This PR fixes the regex in the workshop note-taking app challenge.

- Previously it allowed `====`, which is not valid JavaScript.
- Now it only accepts `==` or `===` as intended.

These changes ensure the instructions and tests align with JavaScript syntax.
