### PR TITLE
fix(curriculum): Regex should only allow == or === in equality check

### DIFF
--- a/curriculum/challenges/english/blocks/project-euler-problems-1-to-100/5900f3c51000cf542c50fed7.md
+++ b/curriculum/challenges/english/blocks/project-euler-problems-1-to-100/5900f3c51000cf542c50fed7.md
@@ -23,14 +23,14 @@ In addition to the three rules given above, if subtractive combinations are used
 
 For example, it would appear that there are at least six ways of writing the number sixteen:
 
-<div style="margin-left: 4em; font-family: 'courier new', monospace;">
-  IIIIIIIIIIIIIIII<br>
-  VIIIIIIIIIII<br>
-  VVIIIIII<br>
-  XIIIIII<br>
-  VVVI<br>
-  XVI<br><br>
-</div>
+```md
+IIIIIIIIIIIIIIII
+VIIIIIIIIIII
+VVIIIIII
+XIIIIII
+VVVI
+XVI
+```
 
 However, according to the rules only XIIIIII and XVI are valid, and the last example is considered to be the most efficient, as it uses the least number of numerals.
 

--- a/curriculum/challenges/english/blocks/project-euler-problems-1-to-100/5900f3c51000cf542c50fed7.md
+++ b/curriculum/challenges/english/blocks/project-euler-problems-1-to-100/5900f3c51000cf542c50fed7.md
@@ -23,14 +23,14 @@ In addition to the three rules given above, if subtractive combinations are used
 
 For example, it would appear that there are at least six ways of writing the number sixteen:
 
-```md
-IIIIIIIIIIIIIIII
-VIIIIIIIIIII
-VVIIIIII
-XIIIIII
-VVVI
-XVI
-```
+<div style="margin-left: 4em; font-family: 'courier new', monospace;">
+  IIIIIIIIIIIIIIII<br>
+  VIIIIIIIIIII<br>
+  VVIIIIII<br>
+  XIIIIII<br>
+  VVVI<br>
+  XVI<br><br>
+</div>
 
 However, according to the rules only XIIIIII and XVI are valid, and the last example is considered to be the most efficient, as it uses the least number of numerals.
 

--- a/curriculum/challenges/english/blocks/workshop-note-taking-app/6881436e1e2afae400e8b4fe.md
+++ b/curriculum/challenges/english/blocks/workshop-note-taking-app/6881436e1e2afae400e8b4fe.md
@@ -18,7 +18,7 @@ Above your `currentContent = newContent;` line, add an `if` statement to check i
 You should add an `if` statement to check if `currentContent` is equal to `newContent`. If so, return.
 
 ```js
-assert.match(code, /if\s*\(\s*currentContent\s*=={2,3}\s*newContent\s*\)\s*(?:{\s*return;?\s*}|return\s*;?)/);
+assert.match(code, /if\s*\(\s*currentContent\s*={2,3}\s*newContent\s*\)\s*(?:{\s*return;?\s*}|return\s*;?)/);
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or Gitpod.
- 
Closes #62123

Regex should only allow == or === in equality check
