### PR TITLE
fix(curriculum): python daily challenge boolean tests

### DIFF
--- a/curriculum/challenges/english/blocks/daily-coding-challenges-python/6814d8e1516e86b171929de4.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-python/6814d8e1516e86b171929de4.md
@@ -20,7 +20,7 @@ Given a string, determine whether the number of vowels in the first half of the 
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertTrue(is_balanced("racecar"))`)
+TestCase().assertIs(is_balanced("racecar"), True)`)
 }})
 ```
 
@@ -29,7 +29,7 @@ TestCase().assertTrue(is_balanced("racecar"))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertTrue(is_balanced("Lorem Ipsum"))`)
+TestCase().assertIs(is_balanced("Lorem Ipsum"), True)`)
 }})
 ```
 
@@ -38,7 +38,7 @@ TestCase().assertTrue(is_balanced("Lorem Ipsum"))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertFalse(is_balanced("Kitty Ipsum"))`)
+TestCase().assertIs(is_balanced("Kitty Ipsum"), False)`)
 }})
 ```
 
@@ -47,7 +47,7 @@ TestCase().assertFalse(is_balanced("Kitty Ipsum"))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertFalse(is_balanced("string"))`)
+TestCase().assertIs(is_balanced("string"), False)`)
 }})
 ```
 
@@ -56,7 +56,7 @@ TestCase().assertFalse(is_balanced("string"))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertTrue(is_balanced(" "))`)
+TestCase().assertIs(is_balanced(" "), True)`)
 }})
 ```
 
@@ -65,7 +65,7 @@ TestCase().assertTrue(is_balanced(" "))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertFalse(is_balanced("abcdefghijklmnopqrstuvwxyz"))`)
+TestCase().assertIs(is_balanced("abcdefghijklmnopqrstuvwxyz"), False)`)
 }})
 ```
 
@@ -74,7 +74,7 @@ TestCase().assertFalse(is_balanced("abcdefghijklmnopqrstuvwxyz"))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertTrue(is_balanced("123A#b!E&*456-o.U"))`)
+TestCase().assertIs(is_balanced("123A#b!E&*456-o.U"), True)`)
 }})
 ```
 

--- a/curriculum/challenges/english/blocks/daily-coding-challenges-python/681cb05adab50c87ddb2e513.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-python/681cb05adab50c87ddb2e513.md
@@ -27,7 +27,7 @@ Given a string representing a number, and an integer base from 2 to 36, determin
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertTrue(is_valid_number("10101", 2))`);
+TestCase().assertIs(is_valid_number("10101", 2), True)`);
 }})
 ```
 
@@ -36,7 +36,7 @@ TestCase().assertTrue(is_valid_number("10101", 2))`);
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertFalse(is_valid_number("10201", 2))`)
+TestCase().assertIs(is_valid_number("10201", 2), False)`)
 }})
 ```
 
@@ -45,7 +45,7 @@ TestCase().assertFalse(is_valid_number("10201", 2))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertTrue(is_valid_number("76543210", 8))`)
+TestCase().assertIs(is_valid_number("76543210", 8), True)`)
 }})
 ```
 
@@ -54,7 +54,7 @@ TestCase().assertTrue(is_valid_number("76543210", 8))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertFalse(is_valid_number("9876543210", 8))`)
+TestCase().assertIs(is_valid_number("9876543210", 8), False)`)
 }})
 ```
 
@@ -63,7 +63,7 @@ TestCase().assertFalse(is_valid_number("9876543210", 8))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertTrue(is_valid_number("9876543210", 10))`)
+TestCase().assertIs(is_valid_number("9876543210", 10), True)`)
 }})
 ```
 
@@ -72,7 +72,7 @@ TestCase().assertTrue(is_valid_number("9876543210", 10))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertFalse(is_valid_number("ABC", 10))`)
+TestCase().assertIs(is_valid_number("ABC", 10), False)`)
 }})
 ```
 
@@ -81,7 +81,7 @@ TestCase().assertFalse(is_valid_number("ABC", 10))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertTrue(is_valid_number("ABC", 16))`)
+TestCase().assertIs(is_valid_number("ABC", 16), True)`)
 }})
 ```
 
@@ -90,7 +90,7 @@ TestCase().assertTrue(is_valid_number("ABC", 16))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertTrue(is_valid_number("Z", 36))`)
+TestCase().assertIs(is_valid_number("Z", 36), True)`)
 }})
 ```
 
@@ -99,7 +99,7 @@ TestCase().assertTrue(is_valid_number("Z", 36))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertTrue(is_valid_number("ABC", 20))`)
+TestCase().assertIs(is_valid_number("ABC", 20), True)`)
 }})
 ```
 
@@ -108,7 +108,7 @@ TestCase().assertTrue(is_valid_number("ABC", 20))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertTrue(is_valid_number("4B4BA9", 16))`)
+TestCase().assertIs(is_valid_number("4B4BA9", 16), True)`)
 }})
 ```
 
@@ -117,7 +117,7 @@ TestCase().assertTrue(is_valid_number("4B4BA9", 16))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertFalse(is_valid_number("5G3F8F", 16))`)
+TestCase().assertIs(is_valid_number("5G3F8F", 16), False)`)
 }})
 ```
 
@@ -126,7 +126,7 @@ TestCase().assertFalse(is_valid_number("5G3F8F", 16))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertTrue(is_valid_number("5G3F8F", 17))`)
+TestCase().assertIs(is_valid_number("5G3F8F", 17), True)`)
 }})
 ```
 
@@ -135,7 +135,7 @@ TestCase().assertTrue(is_valid_number("5G3F8F", 17))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertFalse(is_valid_number("abc", 10))`)
+TestCase().assertIs(is_valid_number("abc", 10), False)`)
 }})
 ```
 
@@ -144,7 +144,7 @@ TestCase().assertFalse(is_valid_number("abc", 10))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertTrue(is_valid_number("abc", 16))`)
+TestCase().assertIs(is_valid_number("abc", 16), True)`)
 }})
 ```
 
@@ -153,7 +153,7 @@ TestCase().assertTrue(is_valid_number("abc", 16))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertTrue(is_valid_number("AbC", 16))`)
+TestCase().assertIs(is_valid_number("AbC", 16), True)`)
 }})
 ```
 
@@ -162,7 +162,7 @@ TestCase().assertTrue(is_valid_number("AbC", 16))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertTrue(is_valid_number("z", 36))`)
+TestCase().assertIs(is_valid_number("z", 36), True)`)
 }})
 ```
 

--- a/curriculum/challenges/english/blocks/daily-coding-challenges-python/681cb1afdab50c87ddb2e517.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-python/681cb1afdab50c87ddb2e517.md
@@ -18,7 +18,7 @@ Given two strings, determine if they are anagrams of each other (contain the sam
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertTrue(are_anagrams("listen", "silent"))`)
+TestCase().assertIs(are_anagrams("listen", "silent"), True)`)
 }})
 ```
 
@@ -27,7 +27,7 @@ TestCase().assertTrue(are_anagrams("listen", "silent"))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertTrue(are_anagrams("School master", "The classroom"))`)
+TestCase().assertIs(are_anagrams("School master", "The classroom"), True)`)
 }})
 ```
 
@@ -36,7 +36,7 @@ TestCase().assertTrue(are_anagrams("School master", "The classroom"))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertTrue(are_anagrams("A gentleman", "Elegant man"))`)
+TestCase().assertIs(are_anagrams("A gentleman", "Elegant man"), True)`)
 }})
 ```
 
@@ -45,7 +45,7 @@ TestCase().assertTrue(are_anagrams("A gentleman", "Elegant man"))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertFalse(are_anagrams("Hello", "World"))`)
+TestCase().assertIs(are_anagrams("Hello", "World"), False)`)
 }})
 ```
 
@@ -54,7 +54,7 @@ TestCase().assertFalse(are_anagrams("Hello", "World"))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertFalse(are_anagrams("apple", "banana"))`)
+TestCase().assertIs(are_anagrams("apple", "banana"), False)`)
 }})
 ```
 
@@ -63,7 +63,7 @@ TestCase().assertFalse(are_anagrams("apple", "banana"))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertFalse(are_anagrams("cat", "dog"))`)
+TestCase().assertIs(are_anagrams("cat", "dog"), False)`)
 }})
 ```
 

--- a/curriculum/challenges/english/blocks/daily-coding-challenges-python/6821ebc9237de8297eaee78f.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-python/6821ebc9237de8297eaee78f.md
@@ -20,7 +20,7 @@ Given an integer, determine if that number is a prime number or a negative prime
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertFalse(is_unnatural_prime(1))`)
+TestCase().assertIs(is_unnatural_prime(1), False)`)
 }})
 ```
 
@@ -29,7 +29,7 @@ TestCase().assertFalse(is_unnatural_prime(1))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertFalse(is_unnatural_prime(-1))`)
+TestCase().assertIs(is_unnatural_prime(-1), False)`)
 }})
 ```
 
@@ -38,7 +38,7 @@ TestCase().assertFalse(is_unnatural_prime(-1))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertTrue(is_unnatural_prime(19))`)
+TestCase().assertIs(is_unnatural_prime(19), True)`)
 }})
 ```
 
@@ -47,7 +47,7 @@ TestCase().assertTrue(is_unnatural_prime(19))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertTrue(is_unnatural_prime(-23))`)
+TestCase().assertIs(is_unnatural_prime(-23), True)`)
 }})
 ```
 
@@ -56,7 +56,7 @@ TestCase().assertTrue(is_unnatural_prime(-23))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertFalse(is_unnatural_prime(0))`)
+TestCase().assertIs(is_unnatural_prime(0), False)`)
 }})
 ```
 
@@ -65,7 +65,7 @@ TestCase().assertFalse(is_unnatural_prime(0))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertTrue(is_unnatural_prime(97))`)
+TestCase().assertIs(is_unnatural_prime(97), True)`)
 }})
 ```
 
@@ -74,7 +74,7 @@ TestCase().assertTrue(is_unnatural_prime(97))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertTrue(is_unnatural_prime(-61))`)
+TestCase().assertIs(is_unnatural_prime(-61), True)`)
 }})
 ```
 
@@ -83,7 +83,7 @@ TestCase().assertTrue(is_unnatural_prime(-61))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertFalse(is_unnatural_prime(99))`)
+TestCase().assertIs(is_unnatural_prime(99), False)`)
 }})
 ```
 
@@ -92,7 +92,7 @@ TestCase().assertFalse(is_unnatural_prime(99))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertFalse(is_unnatural_prime(-44))`)
+TestCase().assertIs(is_unnatural_prime(-44), False)`)
 }})
 ```
 

--- a/curriculum/challenges/english/blocks/daily-coding-challenges-python/6821ec02237de8297eaee79a.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-python/6821ec02237de8297eaee79a.md
@@ -19,7 +19,7 @@ Given a word or sentence and a string of lowercase letters, determine if the wor
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertTrue(is_pangram("hello", "helo"))`)
+TestCase().assertIs(is_pangram("hello", "helo"), True)`)
 }})
 ```
 
@@ -28,7 +28,7 @@ TestCase().assertTrue(is_pangram("hello", "helo"))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertFalse(is_pangram("hello", "hel"))`)
+TestCase().assertIs(is_pangram("hello", "hel"), False)`)
 }})
 ```
 
@@ -37,7 +37,7 @@ TestCase().assertFalse(is_pangram("hello", "hel"))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertFalse(is_pangram("hello", "helow"))`)
+TestCase().assertIs(is_pangram("hello", "helow"), False)`)
 }})
 ```
 
@@ -46,7 +46,7 @@ TestCase().assertFalse(is_pangram("hello", "helow"))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertTrue(is_pangram("hello world", "helowrd"))`)
+TestCase().assertIs(is_pangram("hello world", "helowrd"), True)`)
 }})
 ```
 
@@ -55,7 +55,7 @@ TestCase().assertTrue(is_pangram("hello world", "helowrd"))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertTrue(is_pangram("Hello World!", "helowrd"))`)
+TestCase().assertIs(is_pangram("Hello World!", "helowrd"), True)`)
 }})
 ```
 
@@ -64,7 +64,7 @@ TestCase().assertTrue(is_pangram("Hello World!", "helowrd"))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertFalse(is_pangram("Hello World!", "heliowrd"))`)
+TestCase().assertIs(is_pangram("Hello World!", "heliowrd"), False)`)
 }})
 ```
 
@@ -73,7 +73,7 @@ TestCase().assertFalse(is_pangram("Hello World!", "heliowrd"))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertFalse(is_pangram("freeCodeCamp", "frcdmp"))`)
+TestCase().assertIs(is_pangram("freeCodeCamp", "frcdmp"), False)`)
 }})
 ```
 
@@ -82,7 +82,7 @@ TestCase().assertFalse(is_pangram("freeCodeCamp", "frcdmp"))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertTrue(is_pangram("The quick brown fox jumps over the lazy dog.", "abcdefghijklmnopqrstuvwxyz"))`)
+TestCase().assertIs(is_pangram("The quick brown fox jumps over the lazy dog.", "abcdefghijklmnopqrstuvwxyz"), True)`)
 }})
 ```
 

--- a/curriculum/challenges/english/blocks/daily-coding-challenges-python/68adce01c0e1144d0a902958.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-python/68adce01c0e1144d0a902958.md
@@ -20,7 +20,7 @@ Given a string, determine if it is a valid IPv4 Address. A valid IPv4 address co
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertTrue(is_valid_ipv4("192.168.1.1"))`)
+TestCase().assertIs(is_valid_ipv4("192.168.1.1"), True)`)
 }})
 ```
 
@@ -29,7 +29,7 @@ TestCase().assertTrue(is_valid_ipv4("192.168.1.1"))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertTrue(is_valid_ipv4("0.0.0.0"))`)
+TestCase().assertIs(is_valid_ipv4("0.0.0.0"), True)`)
 }})
 ```
 
@@ -38,7 +38,7 @@ TestCase().assertTrue(is_valid_ipv4("0.0.0.0"))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertFalse(is_valid_ipv4("255.01.50.111"))`)
+TestCase().assertIs(is_valid_ipv4("255.01.50.111"), False)`)
 }})
 ```
 
@@ -47,7 +47,7 @@ TestCase().assertFalse(is_valid_ipv4("255.01.50.111"))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertFalse(is_valid_ipv4("255.00.50.111"))`)
+TestCase().assertIs(is_valid_ipv4("255.00.50.111"), False)`)
 }})
 ```
 
@@ -56,7 +56,7 @@ TestCase().assertFalse(is_valid_ipv4("255.00.50.111"))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertFalse(is_valid_ipv4("256.101.50.115"))`)
+TestCase().assertIs(is_valid_ipv4("256.101.50.115"), False)`)
 }})
 ```
 
@@ -65,7 +65,7 @@ TestCase().assertFalse(is_valid_ipv4("256.101.50.115"))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertFalse(is_valid_ipv4("192.168.101."))`)
+TestCase().assertIs(is_valid_ipv4("192.168.101."), False)`)
 }})
 ```
 
@@ -74,7 +74,7 @@ TestCase().assertFalse(is_valid_ipv4("192.168.101."))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertFalse(is_valid_ipv4("192168145213"))`)
+TestCase().assertIs(is_valid_ipv4("192168145213"), False)`)
 }})
 ```
 

--- a/curriculum/challenges/english/blocks/daily-coding-challenges-python/68af0687ef34c76c28ffa547.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-python/68af0687ef34c76c28ffa547.md
@@ -18,7 +18,7 @@ Given a string, determine if all the characters in the string are unique.
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertTrue(all_unique("abc"))`)
+TestCase().assertIs(all_unique("abc"), True)`)
 }})
 ```
 
@@ -27,7 +27,7 @@ TestCase().assertTrue(all_unique("abc"))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertTrue(all_unique("aA"))`)
+TestCase().assertIs(all_unique("aA"), True)`)
 }})
 ```
 
@@ -36,7 +36,7 @@ TestCase().assertTrue(all_unique("aA"))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertTrue(all_unique("QwErTy123!@"))`)
+TestCase().assertIs(all_unique("QwErTy123!@"), True)`)
 }})
 ```
 
@@ -45,7 +45,7 @@ TestCase().assertTrue(all_unique("QwErTy123!@"))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertTrue(all_unique("~!@#$%^&*()_+"))`)
+TestCase().assertIs(all_unique("~!@#$%^&*()_+"), True)`)
 }})
 ```
 
@@ -54,7 +54,7 @@ TestCase().assertTrue(all_unique("~!@#$%^&*()_+"))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertFalse(all_unique("hello"))`)
+TestCase().assertIs(all_unique("hello"), False)`)
 }})
 ```
 
@@ -63,7 +63,7 @@ TestCase().assertFalse(all_unique("hello"))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertFalse(all_unique("freeCodeCamp"))`)
+TestCase().assertIs(all_unique("freeCodeCamp"), False)`)
 }})
 ```
 
@@ -72,7 +72,7 @@ TestCase().assertFalse(all_unique("freeCodeCamp"))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertFalse(all_unique("!@#*$%^&*()aA"))`)
+TestCase().assertIs(all_unique("!@#*$%^&*()aA"), False)`)
 }})
 ```
 

--- a/curriculum/challenges/english/blocks/daily-coding-challenges-python/68af0687ef34c76c28ffa54d.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-python/68af0687ef34c76c28ffa54d.md
@@ -20,7 +20,7 @@ Given an input array of seven integers, representing a week's time, where each i
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertFalse(too_much_screen_time([1, 2, 3, 4, 5, 6, 7]))`)
+TestCase().assertIs(too_much_screen_time([1, 2, 3, 4, 5, 6, 7]), False)`)
 }})
 ```
 
@@ -29,7 +29,7 @@ TestCase().assertFalse(too_much_screen_time([1, 2, 3, 4, 5, 6, 7]))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertFalse(too_much_screen_time([7, 8, 8, 4, 2, 2, 3]))`)
+TestCase().assertIs(too_much_screen_time([7, 8, 8, 4, 2, 2, 3]), False)`)
 }})
 ```
 
@@ -38,7 +38,7 @@ TestCase().assertFalse(too_much_screen_time([7, 8, 8, 4, 2, 2, 3]))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertFalse(too_much_screen_time([5, 6, 6, 6, 6, 6, 6]))`)
+TestCase().assertIs(too_much_screen_time([5, 6, 6, 6, 6, 6, 6]), False)`)
 }})
 ```
 
@@ -47,7 +47,7 @@ TestCase().assertFalse(too_much_screen_time([5, 6, 6, 6, 6, 6, 6]))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertTrue(too_much_screen_time([1, 2, 3, 11, 1, 3, 4]))`)
+TestCase().assertIs(too_much_screen_time([1, 2, 3, 11, 1, 3, 4]), True)`)
 }})
 ```
 
@@ -56,7 +56,7 @@ TestCase().assertTrue(too_much_screen_time([1, 2, 3, 11, 1, 3, 4]))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertTrue(too_much_screen_time([1, 2, 3, 10, 2, 1, 0]))`)
+TestCase().assertIs(too_much_screen_time([1, 2, 3, 10, 2, 1, 0]), True)`)
 }})
 ```
 
@@ -65,7 +65,7 @@ TestCase().assertTrue(too_much_screen_time([1, 2, 3, 10, 2, 1, 0]))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertTrue(too_much_screen_time([3, 3, 5, 8, 8, 9, 4]))`)
+TestCase().assertIs(too_much_screen_time([3, 3, 5, 8, 8, 9, 4]), True)`)
 }})
 ```
 
@@ -74,7 +74,7 @@ TestCase().assertTrue(too_much_screen_time([3, 3, 5, 8, 8, 9, 4]))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertTrue(too_much_screen_time([3, 9, 4, 8, 5, 7, 6]))`)
+TestCase().assertIs(too_much_screen_time([3, 9, 4, 8, 5, 7, 6]), True)`)
 }})
 ```
 

--- a/curriculum/challenges/english/blocks/daily-coding-challenges-python/68b1f72371a5ac895ac70a0a.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-python/68b1f72371a5ac895ac70a0a.md
@@ -20,7 +20,7 @@ Given two strings, determine if the second string is a mirror of the first.
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertFalse(is_mirror("helloworld", "helloworld"))`)
+TestCase().assertIs(is_mirror("helloworld", "helloworld"), False)`)
 }})
 ```
 
@@ -29,7 +29,7 @@ TestCase().assertFalse(is_mirror("helloworld", "helloworld"))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertTrue(is_mirror("Hello World", "dlroW olleH"))`)
+TestCase().assertIs(is_mirror("Hello World", "dlroW olleH"), True)`)
 }})
 ```
 
@@ -38,7 +38,7 @@ TestCase().assertTrue(is_mirror("Hello World", "dlroW olleH"))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertTrue(is_mirror("RaceCar", "raCecaR"))`)
+TestCase().assertIs(is_mirror("RaceCar", "raCecaR"), True)`)
 }})
 ```
 
@@ -47,7 +47,7 @@ TestCase().assertTrue(is_mirror("RaceCar", "raCecaR"))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertFalse(is_mirror("RaceCar", "RaceCar"))`)
+TestCase().assertIs(is_mirror("RaceCar", "RaceCar"), False)`)
 }})
 ```
 
@@ -56,7 +56,7 @@ TestCase().assertFalse(is_mirror("RaceCar", "RaceCar"))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertFalse(is_mirror("Mirror", "rorrim"))`)
+TestCase().assertIs(is_mirror("Mirror", "rorrim"), False)`)
 }})
 ```
 
@@ -65,7 +65,7 @@ TestCase().assertFalse(is_mirror("Mirror", "rorrim"))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertTrue(is_mirror("Hello World", "dlroW-olleH"))`)
+TestCase().assertIs(is_mirror("Hello World", "dlroW-olleH"), True)`)
 }})
 ```
 
@@ -74,7 +74,7 @@ TestCase().assertTrue(is_mirror("Hello World", "dlroW-olleH"))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertTrue(is_mirror("Hello World", "!dlroW !olleH"))`)
+TestCase().assertIs(is_mirror("Hello World", "!dlroW !olleH"), True)`)
 }})
 ```
 

--- a/curriculum/challenges/english/blocks/daily-coding-challenges-python/68b7687dded630607aceccab.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-python/68b7687dded630607aceccab.md
@@ -18,7 +18,7 @@ Given an integer, determine if it is a perfect square.
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertTrue(is_perfect_square(9))`)
+TestCase().assertIs(is_perfect_square(9), True)`)
 }})
 ```
 
@@ -27,7 +27,7 @@ TestCase().assertTrue(is_perfect_square(9))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertTrue(is_perfect_square(49))`)
+TestCase().assertIs(is_perfect_square(49), True)`)
 }})
 ```
 
@@ -36,7 +36,7 @@ TestCase().assertTrue(is_perfect_square(49))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertTrue(is_perfect_square(1))`)
+TestCase().assertIs(is_perfect_square(1), True)`)
 }})
 ```
 
@@ -45,7 +45,7 @@ TestCase().assertTrue(is_perfect_square(1))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertFalse(is_perfect_square(2))`)
+TestCase().assertIs(is_perfect_square(2), False)`)
 }})
 ```
 
@@ -54,7 +54,7 @@ TestCase().assertFalse(is_perfect_square(2))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertFalse(is_perfect_square(99))`)
+TestCase().assertIs(is_perfect_square(99), False)`)
 }})
 ```
 
@@ -63,7 +63,7 @@ TestCase().assertFalse(is_perfect_square(99))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertFalse(is_perfect_square(-9))`)
+TestCase().assertIs(is_perfect_square(-9), False)`)
 }})
 ```
 
@@ -72,7 +72,7 @@ TestCase().assertFalse(is_perfect_square(-9))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertTrue(is_perfect_square(0))`)
+TestCase().assertIs(is_perfect_square(0), True)`)
 }})
 ```
 
@@ -81,7 +81,7 @@ TestCase().assertTrue(is_perfect_square(0))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertTrue(is_perfect_square(25281))`)
+TestCase().assertIs(is_perfect_square(25281), True)`)
 }})
 ```
 

--- a/curriculum/challenges/english/blocks/daily-coding-challenges-python/68b7687dded630607aceccb1.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-python/68b7687dded630607aceccb1.md
@@ -27,7 +27,7 @@ Determine if it's a spam number based on the following criteria:
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertFalse(is_spam("+0 (200) 234-0182"))`)
+TestCase().assertIs(is_spam("+0 (200) 234-0182"), False)`)
 }})
 ```
 
@@ -36,7 +36,7 @@ TestCase().assertFalse(is_spam("+0 (200) 234-0182"))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertTrue(is_spam("+091 (555) 309-1922"))`)
+TestCase().assertIs(is_spam("+091 (555) 309-1922"), True)`)
 }})
 ```
 
@@ -45,7 +45,7 @@ TestCase().assertTrue(is_spam("+091 (555) 309-1922"))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertTrue(is_spam("+1 (555) 435-4792"))`)
+TestCase().assertIs(is_spam("+1 (555) 435-4792"), True)`)
 }})
 ```
 
@@ -54,7 +54,7 @@ TestCase().assertTrue(is_spam("+1 (555) 435-4792"))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertTrue(is_spam("+0 (955) 234-4364"))`)
+TestCase().assertIs(is_spam("+0 (955) 234-4364"), True)`)
 }})
 ```
 
@@ -63,7 +63,7 @@ TestCase().assertTrue(is_spam("+0 (955) 234-4364"))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertTrue(is_spam("+0 (155) 131-6943"))`)
+TestCase().assertIs(is_spam("+0 (155) 131-6943"), True)`)
 }})
 ```
 
@@ -72,7 +72,7 @@ TestCase().assertTrue(is_spam("+0 (155) 131-6943"))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertTrue(is_spam("+0 (555) 135-0192"))`)
+TestCase().assertIs(is_spam("+0 (555) 135-0192"), True)`)
 }})
 ```
 
@@ -81,7 +81,7 @@ TestCase().assertTrue(is_spam("+0 (555) 135-0192"))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertTrue(is_spam("+0 (555) 564-1987"))`)
+TestCase().assertIs(is_spam("+0 (555) 564-1987"), True)`)
 }})
 ```
 
@@ -90,7 +90,7 @@ TestCase().assertTrue(is_spam("+0 (555) 564-1987"))`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertFalse(is_spam("+00 (555) 234-0182"))`)
+TestCase().assertIs(is_spam("+00 (555) 234-0182"), False)`)
 }})
 ```
 


### PR DESCRIPTION
This changes all the daily challenge python tests that use `assertTrue` or `assertFalse` to `assertIs(..., True/False)` - the `assertTrue/False` checks for truthy/falsy

ref: https://docs.python.org/3/library/unittest.html#unittest.TestCase.assertTrue

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
