### PR TITLE
fix(curriculum): correct typo in CSS overflow lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-css-transforms-overflow-and-filters/672aa7e03c2e365e906e5733.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-css-transforms-overflow-and-filters/672aa7e03c2e365e906e5733.md
@@ -19,7 +19,7 @@ div {
 }
 ```
 
-TThis resolves the overflow problem but now the extra content becomes completely unreachable. Instead we can use scroll to force the element to become scrollable:
+This resolves the overflow problem but now the extra content becomes completely unreachable. Instead we can use scroll to force the element to become scrollable:
   
 ```css
 div {


### PR DESCRIPTION
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

---

### Description of Changes

This PR fixes a small typo in the lecture "What Is Overflow in CSS, and How Does It Work?".  
The word "TThis" was corrected to "This" to improve readability.

I am a fresher and this is my **first contribution to open source**. Excited to start contributing to freeCodeCamp!  

Closes #62139

