### PR TITLE
fix(curriculum): correct typo in CSS overflow lecture (#62139)

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-css-transforms-overflow-and-filters/672aa7e03c2e365e906e5733.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-css-transforms-overflow-and-filters/672aa7e03c2e365e906e5733.md
@@ -19,7 +19,7 @@ div {
 }
 ```
 
-TThis resolves the overflow problem but now the extra content becomes completely unreachable. Instead we can use scroll to force the element to become scrollable:
+This resolves the overflow problem but now the extra content becomes completely unreachable. Instead we can use scroll to force the element to become scrollable:
   
 ```css
 div {


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the contribution guidelines.
- [x] I have read and followed the how to open a pull request guide.
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes locally on my machine.

Closes #62139

This PR fixes a typo in the lecture "What Is Overflow in CSS, and How Does It Work?"

- Changed `TThis resolves the overflow problem...` to `This resolves the overflow problem...`
