### PR TITLE
feat(Curriculum): Add new BlockType tags for the Language Curricula Chapter Based Certifications

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -647,7 +647,10 @@
       "lab": "Lab",
       "review": "Review",
       "quiz": "Quiz",
-      "exam": "Exam"
+      "exam": "Exam",
+      "warm-up": "Warm-up",
+      "learn": "Learn",
+      "practice": "Practice"
     }
   },
   "donate": {

--- a/client/src/templates/Introduction/intro.css
+++ b/client/src/templates/Introduction/intro.css
@@ -61,6 +61,22 @@
   color: var(--quaternary-color);
 }
 
+/* The tag block-label styles below are related to the Language Curricula Chapter based certifications*/
+.block-label-warm-up {
+  border-color: var(--yellow-color);
+  color: var(--yellow-color);
+}
+
+.block-label-learn {
+  border-color: var(--highlight-color);
+  color: var(--highlight-color);
+}
+
+.block-label-practice {
+  border-color: var(--success-color);
+  color: var(--success-color);
+}
+
 .block-header {
   display: flex;
   justify-content: space-between;

--- a/client/src/templates/Introduction/intro.css
+++ b/client/src/templates/Introduction/intro.css
@@ -61,7 +61,6 @@
   color: var(--quaternary-color);
 }
 
-/* The tag block-label styles below are related to the Language Curricula Chapter based certifications*/
 .block-label-warm-up {
   border-color: var(--yellow-color);
   color: var(--yellow-color);

--- a/curriculum/schema/challenge-schema.js
+++ b/curriculum/schema/challenge-schema.js
@@ -137,7 +137,10 @@ const schema = Joi.object().keys({
       'lecture',
       'review',
       'quiz',
-      'exam'
+      'exam',
+      'warm-up',
+      'learn',
+      'practice'
     ).required(),
     otherwise: Joi.valid(null)
   }),

--- a/curriculum/schema/meta-schema.js
+++ b/curriculum/schema/meta-schema.js
@@ -21,7 +21,10 @@ const schema = Joi.object()
       'lecture',
       'review',
       'quiz',
-      'exam'
+      'exam',
+      'warm-up',
+      'learn',
+      'practice'
     ),
     isUpcomingChange: Joi.boolean().required(),
     dashedName: Joi.string().regex(slugRE).required(),

--- a/shared/config/blocks.ts
+++ b/shared/config/blocks.ts
@@ -4,7 +4,11 @@ export enum BlockTypes {
   lab = 'lab',
   review = 'review',
   quiz = 'quiz',
-  exam = 'exam'
+  exam = 'exam',
+  /* The tags below refer to the Language Curricula chapter based certifications*/
+  warmup = 'warm-up',
+  learn = 'learn',
+  practice = 'practice'
 }
 
 export enum BlockLayouts {

--- a/tools/scripts/build/external-data-schema-v1.js
+++ b/tools/scripts/build/external-data-schema-v1.js
@@ -1,4 +1,7 @@
 const Joi = require('joi');
+const {
+  chapterBasedSuperBlocks
+} = require('../../../shared/config/curriculum');
 
 const blockSchema = Joi.object({}).keys({
   desc: Joi.array().min(1),
@@ -40,9 +43,12 @@ const blockSchema = Joi.object({}).keys({
         'lab',
         'review',
         'quiz',
-        'exam'
+        'exam',
+        'warm-up',
+        'learn',
+        'practice'
       ).when('superBlock', {
-        is: 'full-stack-developer',
+        is: chapterBasedSuperBlocks,
         then: Joi.required(),
         otherwise: Joi.optional()
       }),

--- a/tools/scripts/build/external-data-schema-v2.js
+++ b/tools/scripts/build/external-data-schema-v2.js
@@ -45,7 +45,10 @@ const blockSchema = Joi.object().keys({
         'lab',
         'review',
         'quiz',
-        'exam'
+        'exam',
+        'warm-up',
+        'learn',
+        'practice'
       ).when('superBlock', {
         is: chapterBasedSuperBlocks,
         then: Joi.required(),


### PR DESCRIPTION
This PR adds new blockTypes (warm-up, learn, and practice) to support the chapter based certifications of the language-curricula. 

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
