### PR TITLE
fix(curriculum): move punctuation mark outside of backticks

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-understanding-comparisons-and-conditionals/672d26917a8ab3220c038a42.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-comparisons-and-conditionals/672d26917a8ab3220c038a42.md
@@ -150,7 +150,8 @@ Think about how `undefined` behaves in different types of comparisons.
 
 ---
 
-`undefined < 0` evaluates to `true.`
+`undefined < 0` evaluates to `true`
+
 
 ### --feedback--
 

--- a/curriculum/challenges/english/blocks/lecture-understanding-comparisons-and-conditionals/672d26917a8ab3220c038a42.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-comparisons-and-conditionals/672d26917a8ab3220c038a42.md
@@ -150,7 +150,7 @@ Think about how `undefined` behaves in different types of comparisons.
 
 ---
 
-`undefined < 0` evaluates to `true`
+`undefined < 0` evaluates to `true`.
 
 
 ### --feedback--

--- a/curriculum/challenges/english/blocks/lecture-understanding-comparisons-and-conditionals/672d26917a8ab3220c038a42.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-comparisons-and-conditionals/672d26917a8ab3220c038a42.md
@@ -152,7 +152,6 @@ Think about how `undefined` behaves in different types of comparisons.
 
 `undefined < 0` evaluates to `true`.
 
-
 ### --feedback--
 
 Think about how `undefined` behaves in different types of comparisons.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->

This PR fixes a minor typo in the "How Do Comparisons Work with Null and Undefined Data Types?" lecture.

Changed "`undefined < 0` evaluates to `true.`" to "`undefined < 0` evaluates to `true`".

Closes #62157
