### PR TITLE
fix(curriculum): missing assignment text for bash and sql review page

### DIFF
--- a/curriculum/challenges/english/blocks/review-bash-and-sql/6724e46581a1742244e45b59.md
+++ b/curriculum/challenges/english/blocks/review-bash-and-sql/6724e46581a1742244e45b59.md
@@ -237,3 +237,5 @@ WHERE orders.order_id IN (SELECT order_id FROM orders LIMIT 50);
 Always look for opportunities to combine related data into a single query.
 
 # --assignment--
+
+Review the Bash and SQL topics and concepts.


### PR DESCRIPTION
Missed this in the last review of the bash and sql PR. There is missing text under the assignment header. 


Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.


