### PR TITLE
fix(curriculum): correct function name typo in daily coding challenge

### DIFF
--- a/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/681cb05adab50c87ddb2e513.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/681cb05adab50c87ddb2e513.md
@@ -40,7 +40,8 @@ assert.isFalse(isValidNumber("10201", 2))
 assert.isTrue(isValidNumber("76543210", 8))
 ```
 
-`isValidCode("9876543210", 8)` should return `false`.
+`isValidNumber("9876543210", 8)` should return `false`.
+
 
 ```js
 assert.isFalse(isValidNumber("9876543210", 8))


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).  
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).  
- [x] My pull request targets the `main` branch of freeCodeCamp.  
- [x] I have tested these changes locally on my machine.  

Closes #62172  

### Description of Changes
Corrected a typo in the JavaScript daily coding challenge. The function name `isValidCode` was incorrectly used; it has been updated to the correct function name `isValidNumber`.  

Example corrected:  
```js
// Before
`isValidCode("9876543210", 8)` should return `false`;

// After
`isValidNumber("9876543210", 8)` should return `false`;
