### PR TITLE
fix(tools): insert step with appropriate challenge type

### DIFF
--- a/tools/challenge-helper-scripts/commands.ts
+++ b/tools/challenge-helper-scripts/commands.ts
@@ -43,15 +43,20 @@ async function insertStep(stepNum: number): Promise<void> {
       }.`
     );
 
-  const challengeSeeds =
-    stepNum > 1
-      ? getChallenge(challengeOrder[stepNum - 2].id).challengeFiles
-      : [];
+  const previousChallenge =
+    stepNum > 1 ? getChallenge(challengeOrder[stepNum - 2].id) : null;
+  const nextChallenge =
+    stepNum <= challengeOrder.length
+      ? getChallenge(challengeOrder[stepNum - 1].id)
+      : null;
 
-  console.log(challengeSeeds);
+  const challengeSeeds = previousChallenge?.challengeFiles ?? [];
+  const challengeType =
+    previousChallenge?.challengeType ?? nextChallenge?.challengeType;
 
   const stepId = createStepFile({
     stepNum,
+    challengeType,
     challengeSeeds
   });
 

--- a/tools/challenge-helper-scripts/commands.ts
+++ b/tools/challenge-helper-scripts/commands.ts
@@ -4,7 +4,7 @@ import { getMetaData } from './helpers/project-metadata';
 import {
   createStepFile,
   deleteStepFromMeta,
-  getChallengeSeeds,
+  getChallenge,
   insertStepIntoMeta,
   updateStepTitles
 } from './utils';
@@ -45,10 +45,10 @@ async function insertStep(stepNum: number): Promise<void> {
 
   const challengeSeeds =
     stepNum > 1
-      ? getChallengeSeeds(
-          `${getProjectPath()}${challengeOrder[stepNum - 2].id}.md`
-        )
-      : {};
+      ? getChallenge(challengeOrder[stepNum - 2].id).challengeFiles
+      : [];
+
+  console.log(challengeSeeds);
 
   const stepId = createStepFile({
     stepNum,

--- a/tools/challenge-helper-scripts/create-project.ts
+++ b/tools/challenge-helper-scripts/create-project.ts
@@ -205,13 +205,13 @@ async function createFirstChallenge(block: string): Promise<ObjectID> {
 
   // TODO: would be nice if the extension made sense for the challenge, but, at
   // least until react I think they're all going to be html anyway.
-  const challengeSeeds = {
-    indexhtml: {
+  const challengeSeeds = [
+    {
       contents: '',
       ext: 'html',
       editableRegionBoundaries: [0, 2]
     }
-  };
+  ];
   // including trailing slash for compatibility with createStepFile
   return createStepFile({
     projectPath: newChallengeDir + '/',

--- a/tools/challenge-helper-scripts/helpers/get-step-template.test.ts
+++ b/tools/challenge-helper-scripts/helpers/get-step-template.test.ts
@@ -37,8 +37,8 @@ Test 1
 
     const props = {
       challengeId: new ObjectID('60d4ebe4801158d1abe1b18f'),
-      challengeSeeds: {
-        indexhtml: {
+      challengeSeeds: [
+        {
           contents: '',
           editableRegionBoundaries: [0, 2],
           ext: 'html',
@@ -48,7 +48,7 @@ Test 1
           name: 'index',
           tail: ''
         }
-      },
+      ],
       stepNum: 5,
       challengeType: 0
     };

--- a/tools/challenge-helper-scripts/helpers/get-step-template.ts
+++ b/tools/challenge-helper-scripts/helpers/get-step-template.ts
@@ -22,7 +22,7 @@ ${content}`
 
 type StepOptions = {
   challengeId: ObjectID;
-  challengeSeeds: Record<string, ChallengeSeed>;
+  challengeSeeds: ChallengeSeed[];
   stepNum: number;
   challengeType?: number;
   isFirstChallenge?: boolean;
@@ -44,8 +44,8 @@ function getStepTemplate({
   challengeType,
   isFirstChallenge = false
 }: StepOptions): string {
-  const seedTexts = Object.values(challengeSeeds)
-    .map(({ contents, ext, editableRegionBoundaries }: ChallengeSeed) => {
+  const seedTexts = challengeSeeds
+    .map(({ contents, ext, editableRegionBoundaries }) => {
       let fullContents = contents;
       if (editableRegionBoundaries.length >= 2) {
         fullContents = insertErms(contents, editableRegionBoundaries);
@@ -54,14 +54,14 @@ function getStepTemplate({
     })
     .join('\n');
 
-  const seedHeads = Object.values(challengeSeeds)
-    .filter(({ head }: ChallengeSeed) => head)
-    .map(({ ext, head }: ChallengeSeed) => getCodeBlock(ext, head))
+  const seedHeads = challengeSeeds
+    .filter(({ head }) => head)
+    .map(({ ext, head }) => getCodeBlock(ext, head))
     .join('\n');
 
-  const seedTails = Object.values(challengeSeeds)
-    .filter(({ tail }: ChallengeSeed) => tail)
-    .map(({ ext, tail }: ChallengeSeed) => getCodeBlock(ext, tail))
+  const seedTails = challengeSeeds
+    .filter(({ tail }) => tail)
+    .map(({ ext, tail }) => getCodeBlock(ext, tail))
     .join('\n');
 
   const stepDescription = `step ${stepNum} instructions`;

--- a/tools/challenge-helper-scripts/utils.ts
+++ b/tools/challenge-helper-scripts/utils.ts
@@ -17,7 +17,7 @@ interface Options {
   stepNum: number;
   challengeType?: number;
   projectPath?: string;
-  challengeSeeds?: Record<string, ChallengeSeed>;
+  challengeSeeds?: ChallengeSeed[];
   isFirstChallenge?: boolean;
 }
 
@@ -32,7 +32,7 @@ const createStepFile = ({
   stepNum,
   challengeType,
   projectPath = getProjectPath(),
-  challengeSeeds = {},
+  challengeSeeds = [],
   isFirstChallenge = false
 }: Options): ObjectID => {
   const challengeId = new ObjectID();
@@ -248,11 +248,15 @@ const updateTaskMarkdownFiles = (): void => {
   });
 };
 
-const getChallengeSeeds = (
-  challengeFilePath: string
-): Record<string, ChallengeSeed> => {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
-  return parseMDSync(challengeFilePath).challengeFiles;
+type Challenge = {
+  challengeType: number;
+  challengeFiles: ChallengeSeed[];
+};
+
+const getChallenge = (challengeId: string): Challenge => {
+  const challengePath = path.join(getProjectPath(), `${challengeId}.md`);
+  const challenge = parseMDSync(challengePath) as Challenge;
+  return challenge;
 };
 
 const validateBlockName = (block: string): boolean | string => {
@@ -272,7 +276,7 @@ export {
   updateStepTitles,
   updateTaskMeta,
   updateTaskMarkdownFiles,
-  getChallengeSeeds,
+  getChallenge,
   insertChallengeIntoMeta,
   insertStepIntoMeta,
   deleteChallengeFromMeta,


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Ona.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Now if you `insert-step` in a block it will try to find the most appropriate challengeType for the new challenge.

Closes https://github.com/freeCodeCamp/freeCodeCamp/issues/62170

<!-- Feel free to add any additional description of changes below this line -->
