### PR TITLE
fix(curriculum): correct typo in symmetric difference challenge test

### DIFF
--- a/curriculum/challenges/english/blocks/lab-symmetric-difference/68ad9821ee41baad9cb0fd4e.md
+++ b/curriculum/challenges/english/blocks/lab-symmetric-difference/68ad9821ee41baad9cb0fd4e.md
@@ -51,7 +51,7 @@ assert.deepEqual(diffArray(
 ), ["pink wool"]);
 ```
 
-`diffArray*["diorite", "andesite", "grass", "dirt", "pink wool", "dead shrub"], ["andesite", "grass", "dirt", "dead shrub"])` should return `["diorite", "pink wool"]`.
+`diffArray(["diorite", "andesite", "grass", "dirt", "pink wool", "dead shrub"], ["andesite", "grass", "dirt", "dead shrub"])` should return `["diorite", "pink wool"]`.
 
 ```js
 assert.deepEqual(diffArray(


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [✅] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [✅] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [✅] My pull request targets the `main` branch of freeCodeCamp.
- [✅] I have tested these changes either locally on my machine, or Ona.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #62206

<!-- Feel free to add any additional description of changes below this line -->

Description of Changes

This PR fixes a typo in test 4 of the Symmetric Difference lab.

Changed:

- diffArray*["diorite", "andesite", "grass", "dirt", "pink wool", "dead shrub"], ["andesite", "grass", "dirt", "dead shrub"])
+ diffArray(["diorite", "andesite", "grass", "dirt", "pink wool", "dead shrub"], ["andesite", "grass", "dirt", "dead shrub"])


✅ Replaced the incorrect * with an opening parenthesis (.
✅ Verified locally — the test now runs without syntax errors.
