### PR TITLE
fix(curriculum): add note about infinite loop protection in Pyramid Generator step 33

### DIFF
--- a/curriculum/challenges/english/blocks/learn-introductory-javascript-by-building-a-pyramid-generator/660f17d4e9f227d86e834abd.md
+++ b/curriculum/challenges/english/blocks/learn-introductory-javascript-by-building-a-pyramid-generator/660f17d4e9f227d86e834abd.md
@@ -19,6 +19,7 @@ for (iterator; condition; iteration) {
 
 In the upcoming steps, you'll explore each component of a loop in detail. For now, construct a `for` loop that includes the terms `"iterator"`, `"condition"`, and `"iteration"` for the three components. Keep the loop <dfn>body</dfn>, the section within the curly braces `{}`, empty.
 
+⚠️ Note: If you accidentaly write an incorrect `for` loop, it may take a few seconds for the infinite loop protection to stop your code. This is expected.Once corrected, your solution will pass the tests.
 
 # --hints--
 


### PR DESCRIPTION
## Description

This PR updates the description of step 33 in the Pyramid Generetor project.

It add a short note to clarify that if learners accidentally create an incorrect `for` loop,
the infinite loop protection may take a few seconds to stop their code.

This behavior is expected, and once corrected, the solution will pass the tests.

Closes #62075

## Checklist

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes locally on my machine.