### PR TITLE
chore(curriculum): Update javascript trivia bot test to accept concat method

### DIFF
--- a/curriculum/challenges/english/blocks/lab-javascript-trivia-bot/66ed41f912d0bb1dc62da5dd.md
+++ b/curriculum/challenges/english/blocks/lab-javascript-trivia-bot/66ed41f912d0bb1dc62da5dd.md
@@ -100,7 +100,8 @@ You should give `codingFact` a value that includes `favoriteLanguage`.
 ```js
 const codeWithoutComments = __helpers.removeJSComments(code);
 assert.match(code, /let\s+codingFact/);
-assert.match(code, /codingFact\s*=\s*(("|'|`)?.+?\1?\s*\+\s*|favoriteLanguage\s*\+\s*(("|'|`)?.+?\3?))/);
+assert.match(codeWithoutComments, /codingFact\s*=\s*.*(\+|\.concat\(.*\))/s);
+assert.notMatch(codeWithoutComments, /codingFact\s*=\s*`.*`/s);
 assert.exists(codingFact);
 assert.isNotEmpty(codingFact);
 assert.include(String(codingFact), favoriteLanguage);
@@ -119,12 +120,12 @@ You should assign a new value to `codingFact` that also contains `favoriteLangua
 
 ```js
 const codeWithoutComments = __helpers.removeJSComments(code);
-const loggingCodingFacts = codeWithoutComments.match(/console\.log\(\s*codingFact\s*\)/g)
-const [first, second, third] = codeWithoutComments.match(/(let )?\s*codingFact\s*=\s*(("|')?.+?\2?\s*\+\s*|favoriteLanguage\s*\+\s*(("|')?.+?\2?))/g);
+const loggingCodingFacts = codeWithoutComments.match(/console\.log\(\s*codingFact\s*\)/g);
+assert.match(codeWithoutComments, /codingFact\s*=\s*.*(\+|\.concat\(.*\))/s);
+assert.notMatch(codeWithoutComments, /codingFact\s*=\s*`.*`/s);
 assert.include(getLogs()[4], favoriteLanguage);
 assert.notEqual(getLogs()[4], getLogs()[3]);
 assert.isAtLeast(loggingCodingFacts.length, 2);
-assert.exists(second);
 assert.isNotEmpty(codingFact); 
 ```
 

--- a/curriculum/challenges/english/blocks/lab-javascript-trivia-bot/66ed41f912d0bb1dc62da5dd.md
+++ b/curriculum/challenges/english/blocks/lab-javascript-trivia-bot/66ed41f912d0bb1dc62da5dd.md
@@ -100,11 +100,10 @@ You should give `codingFact` a value that includes `favoriteLanguage`.
 ```js
 const codeWithoutComments = __helpers.removeJSComments(code);
 assert.match(code, /let\s+codingFact/);
-assert.match(codeWithoutComments, /codingFact\s*=\s*.*(\+|\.concat\(.*\))/s);
-assert.notMatch(codeWithoutComments, /codingFact\s*=\s*`.*`/s);
+assert.match(code, /codingFact\s*=\s*(("|'|`)?.+?\1?\s*(\+|\.concat\(\s*(("|'|`)?.+?\1?)\))?\s*|favoriteLanguage\s*(\+|\.concat\(\s*(("|'|`)?.+?\3?)\))?\s*(("|'|`)?.+?\3?))/);
 assert.exists(codingFact);
 assert.isNotEmpty(codingFact);
-assert.include(String(codingFact), favoriteLanguage); 
+assert.include(String(codingFact), favoriteLanguage);
 ```
 
 You should log `codingFact` to the console.
@@ -120,12 +119,12 @@ You should assign a new value to `codingFact` that also contains `favoriteLangua
 
 ```js
 const codeWithoutComments = __helpers.removeJSComments(code);
-const loggingCodingFacts = codeWithoutComments.match(/console\.log\(\s*codingFact\s*\)/g);
-assert.match(codeWithoutComments, /codingFact\s*=\s*.*(\+|\.concat\(.*\))/s);
-assert.notMatch(codeWithoutComments, /codingFact\s*=\s*`.*`/s);
+const loggingCodingFacts = codeWithoutComments.match(/console\.log\(\s*codingFact\s*\)/g)
+const [first, second, third] = codeWithoutComments.match(/(let )?\s*codingFact\s*=\s*(("|')?.+?\2?\s*(\+|\.concat\(\s*(("|')?.+?\2?)\))?\s*|favoriteLanguage\s*(\+|\.concat\(\s*(("|')?.+?\2?)\))?\s*(("|')?.+?\2?))/g);
 assert.include(getLogs()[4], favoriteLanguage);
 assert.notEqual(getLogs()[4], getLogs()[3]);
 assert.isAtLeast(loggingCodingFacts.length, 2);
+assert.exists(second);
 assert.isNotEmpty(codingFact); 
 ```
 

--- a/curriculum/challenges/english/blocks/lab-javascript-trivia-bot/66ed41f912d0bb1dc62da5dd.md
+++ b/curriculum/challenges/english/blocks/lab-javascript-trivia-bot/66ed41f912d0bb1dc62da5dd.md
@@ -104,7 +104,7 @@ assert.match(codeWithoutComments, /codingFact\s*=\s*.*(\+|\.concat\(.*\))/s);
 assert.notMatch(codeWithoutComments, /codingFact\s*=\s*`.*`/s);
 assert.exists(codingFact);
 assert.isNotEmpty(codingFact);
-assert.include(String(codingFact), favoriteLanguage);
+assert.include(String(codingFact), favoriteLanguage); 
 ```
 
 You should log `codingFact` to the console.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Ona.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #61798 and #62094

<!-- Feel free to add any additional description of changes below this line -->

## 1. Tests 11 and 13 pass with the `+` method:

<img width="1099" height="458" alt="Screenshot 2025-09-16 at 00 31 36" src="https://github.com/user-attachments/assets/6636409b-65e6-4242-b750-9da1abf3979f" />


## 2. Tests 11 and 13 pass with the `.concat()` method:

<img width="1099" height="458" alt="Screenshot 2025-09-15 at 19 14 46" src="https://github.com/user-attachments/assets/cd5bb2ab-12a5-438e-892f-ae53b18fc0f0" />

## 3. Tests 11 and 13 pass with both `+` and `.concat()` method:

<img width="1099" height="458" alt="Screenshot 2025-09-16 at 00 35 29" src="https://github.com/user-attachments/assets/82375e4f-eec1-4002-b19a-62d932512430" />

## 4. Tests 11 and 13 pass using template literals:

<img width="1099" height="442" alt="Screenshot 2025-09-16 at 00 36 14" src="https://github.com/user-attachments/assets/89a7c850-4f69-47c3-bad7-d85c608ab932" />
