### PR TITLE
fix: horizontal bar footer appearance on smaller devices

### DIFF
--- a/client/src/templates/Introduction/components/super-block-accordion.css
+++ b/client/src/templates/Introduction/components/super-block-accordion.css
@@ -161,6 +161,8 @@
   flex-direction: column;
   align-items: center;
   padding: 20px;
+  margin-top: 40px;
+  margin-bottom: 40px;
 }
 
 .super-block-intro-page .btn-cta-big {
@@ -190,6 +192,23 @@
 
 .super-block-benefits h3 {
   color: var(--gray05);
+}
+
+@media screen and (max-width: 699px) {
+  .super-benefits-container {
+    border-radius: 12px;
+    margin-left: 15px;
+    margin-right: 15px;
+    width: calc(100vw - 30px);
+  }
+
+  .full-width-container {
+    margin-left: 0;
+    margin-right: 0;
+    left: 0;
+    right: 0;
+    width: 100%;
+  }
 }
 
 @media screen and (min-width: 700px) {


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Ona.



## Summary

This PR fixes the issue where the horizontal bar on the Full Stack Developer page appears like a footer on smaller devices.

## Changes Made

- Added vertical margins (`margin-top` and `margin-bottom`) to the `.super-benefits-container` to create visual separation from surrounding content
- Added mobile-specific styling for screens smaller than 700px:
  - Added rounded corners (`border-radius: 12px`) to make it look less like a footer bar
  - Added horizontal margins and adjusted width to create padding from screen edges
  - Adjusted the `.full-width-container` positioning on mobile to prevent the footer-like appearance

## Test Plan

1. Navigate to `/learn/full-stack-developer` page
2. Resize browser to mobile width (< 700px)
3. Verify the horizontal bar now appears as a distinct content section with:
   - Rounded corners
   - Proper spacing from edges
   - Clear visual separation from other content
4. Verify the desktop view (≥ 700px) still displays correctly with full-width background

## Screenshots

The horizontal bar now has better visual separation and rounded corners on mobile, making it clear it's not a footer but a content section.