### PR TITLE
fix(i18n): standardize 'Back End' naming in chapter titles

### DIFF
--- a/client/i18n/locales/chinese-traditional/intro.json
+++ b/client/i18n/locales/chinese-traditional/intro.json
@@ -1745,7 +1745,7 @@
       "javascript": "JavaScript",
       "frontend-libraries": "Front End Libraries",
       "relational-databases": "Relational Databases",
-      "backend-javascript": "Backend JavaScript",
+      "backend-javascript": "Back End JavaScript",
       "python": "Python",
       "career": "Career"
     },

--- a/client/i18n/locales/chinese/intro.json
+++ b/client/i18n/locales/chinese/intro.json
@@ -1745,7 +1745,7 @@
       "javascript": "JavaScript",
       "frontend-libraries": "Front End Libraries",
       "relational-databases": "Relational Databases",
-      "backend-javascript": "Backend JavaScript",
+      "backend-javascript": "Back End JavaScript",
       "python": "Python",
       "career": "Career"
     },

--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -1759,7 +1759,7 @@
       "javascript": "JavaScript",
       "frontend-libraries": "Front End Libraries",
       "relational-databases": "Relational Databases",
-      "backend-javascript": "Backend JavaScript",
+      "backend-javascript": "Back End JavaScript",
       "python": "Python",
       "career": "Career"
     },

--- a/client/i18n/locales/german/intro.json
+++ b/client/i18n/locales/german/intro.json
@@ -1759,7 +1759,7 @@
       "javascript": "JavaScript",
       "frontend-libraries": "Front End Libraries",
       "relational-databases": "Relational Databases",
-      "backend-javascript": "Backend JavaScript",
+      "backend-javascript": "Back End JavaScript",
       "python": "Python",
       "career": "Career"
     },

--- a/client/i18n/locales/italian/intro.json
+++ b/client/i18n/locales/italian/intro.json
@@ -1759,7 +1759,7 @@
       "javascript": "JavaScript",
       "frontend-libraries": "Front End Libraries",
       "relational-databases": "Relational Databases",
-      "backend-javascript": "Backend JavaScript",
+      "backend-javascript": "Back End JavaScript",
       "python": "Python",
       "career": "Career"
     },

--- a/client/i18n/locales/japanese/intro.json
+++ b/client/i18n/locales/japanese/intro.json
@@ -1759,7 +1759,7 @@
       "javascript": "JavaScript",
       "frontend-libraries": "Front End Libraries",
       "relational-databases": "Relational Databases",
-      "backend-javascript": "Backend JavaScript",
+      "backend-javascript": "Back End JavaScript",
       "python": "Python",
       "career": "Career"
     },

--- a/client/i18n/locales/korean/intro.json
+++ b/client/i18n/locales/korean/intro.json
@@ -1759,7 +1759,7 @@
       "javascript": "JavaScript",
       "frontend-libraries": "Front End Libraries",
       "relational-databases": "Relational Databases",
-      "backend-javascript": "Backend JavaScript",
+      "backend-javascript": "Back End JavaScript",
       "python": "Python",
       "career": "Career"
     },

--- a/client/i18n/locales/portuguese/intro.json
+++ b/client/i18n/locales/portuguese/intro.json
@@ -1759,7 +1759,7 @@
       "javascript": "JavaScript",
       "frontend-libraries": "Bibliotecas Front End",
       "relational-databases": "Relational Databases",
-      "backend-javascript": "Backend JavaScript",
+      "backend-javascript": "Back End JavaScript",
       "python": "Python",
       "career": "Career"
     },

--- a/client/i18n/locales/swahili/intro.json
+++ b/client/i18n/locales/swahili/intro.json
@@ -1759,7 +1759,7 @@
       "javascript": "JavaScript",
       "frontend-libraries": "Front End Libraries",
       "relational-databases": "Relational Databases",
-      "backend-javascript": "Backend JavaScript",
+      "backend-javascript": "Back End JavaScript",
       "python": "Python",
       "career": "Career"
     },


### PR DESCRIPTION
## Summary
- Standardized the naming convention from "Backend JavaScript" to "Back End JavaScript" across all locale files
- This change ensures consistency with the existing "Front End" naming convention used throughout the codebase
- Updated 9 translation files (English + 8 other locales) to maintain uniform terminology

## Related Issue
Fixes #62247 

## Motivation
As noted in the issue, the platform had inconsistent naming with "Front End" (with space) and "Backend" (without space). This PR standardizes all references to use "Back End" (with space) to match the "Front End" convention, improving readability and consistency across the learning platform.

## Changes Made
- Changed `"backend-javascript": "Backend JavaScript"` to `"backend-javascript": "Back End JavaScript"` in:
  - English locale
  - Chinese (Simplified and Traditional)
  - German
  - Italian  
  - Japanese
  - Korean
  - Portuguese
  - Swahili

## Test Plan
- [x] All JSON files remain valid
- [x] Prettier formatting checks pass
- [x] Changes are limited to the specific string replacement only
- [x] No functional changes, only text updates

🤖 Generated with [Claude Code](https://claude.ai/code)