### PR TITLE
fix(curriculum): add generate-btn click to sort-btn test

### DIFF
--- a/curriculum/challenges/english/blocks/lab-sorting-visualizer/6716249b5405164036fd0b0d.md
+++ b/curriculum/challenges/english/blocks/lab-sorting-visualizer/6716249b5405164036fd0b0d.md
@@ -286,11 +286,13 @@ try {
 When you click the `#sort-btn`, you should make use of the `highlightCurrentEls` function to highlight the elements being compared in each step.
 
 ```js
+const genBtn = document.querySelector("#generate-btn");
 const sortBtn = document.querySelector("#sort-btn");
 let flag = false;
 const temp = highlightCurrentEls;
 highlightCurrentEls = () => flag = true;
 try {
+    generateBtn.dispatchEvent(new Event("click"));
     sortBtn.dispatchEvent(new Event("click"));
     assert.isTrue(flag);
 } finally {

--- a/curriculum/challenges/english/blocks/lab-sorting-visualizer/6716249b5405164036fd0b0d.md
+++ b/curriculum/challenges/english/blocks/lab-sorting-visualizer/6716249b5405164036fd0b0d.md
@@ -292,7 +292,7 @@ let flag = false;
 const temp = highlightCurrentEls;
 highlightCurrentEls = () => flag = true;
 try {
-    generateBtn.dispatchEvent(new Event("click"));
+    genBtn.dispatchEvent(new Event("click"));
     sortBtn.dispatchEvent(new Event("click"));
     assert.isTrue(flag);
 } finally {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Ona.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #62080

<!-- Feel free to add any additional description of changes below this line -->

This PR fixes issue #62080 by adding a click event for `#generate-btn` before `#sort-btn` in the test to ensure the array is generated before sorting.

Changes:
- Added `const genBtn = document.querySelector("#generate-btn");` to the test in `6716249b5405164036fd0b0d.md`.
- Added `genBtn.dispatchEvent(new Event("click"));` before the `#sort-btn` click event.

I'm a beginner in open source contributions, so I'm not entirely sure if my changes are correct or if there's a better way to implement this fix. Any feedback or guidance would be greatly appreciated! 