### PR TITLE
fix(curriculum): allow spaces in book catalog table lab inside elements

### DIFF
--- a/curriculum/challenges/english/blocks/lab-book-catalog-table/66ec4c8e9878d8441956516f.md
+++ b/curriculum/challenges/english/blocks/lab-book-catalog-table/66ec4c8e9878d8441956516f.md
@@ -50,10 +50,10 @@ Your four `th` elements should have the text `Title`, `Author`, `Genre`, and `Pu
 
 ```js
 const ths = document.querySelectorAll('thead tr th');
-assert.equal(ths[0]?.textContent, 'Title');
-assert.equal(ths[1]?.textContent, 'Author');
-assert.equal(ths[2]?.textContent, 'Genre');
-assert.equal(ths[3]?.textContent, 'Publication Year');
+assert.equal(ths[0]?.textContent.trim(), 'Title');
+assert.equal(ths[1]?.textContent.trim(), 'Author');
+assert.equal(ths[2]?.textContent.trim(), 'Genre');
+assert.equal(ths[3]?.textContent.trim(), 'Publication Year');
 ```
 
 You should have one `tbody` element within your `table` element.
@@ -87,7 +87,7 @@ const tds = document.querySelectorAll('tbody tr td');
 assert.isAtLeast(tds.length, 1);
 
 tds.forEach(td => {
-  assert.isAtLeast(td.textContent.length, 1);
+  assert.isAtLeast(td.textContent.trim().length, 1);
 });
 ```
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Ona.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related to https://github.com/freeCodeCamp/freeCodeCamp/issues/60690

<!-- Feel free to add any additional description of changes below this line -->

Right now code like
```html
    <thead>
      <tr>
        <th>Title</th>
        <th>
          Author
        </th>
        <th>Genre</th>
        <th>Publication Year</th>
        </tr>
      </thead>
```
would fail the tests even if it looks correct, as the spaces around would make it fail. with `trim` this is solved.
