### PR TITLE
fix(curriculum): standardize "Front End" vs "Frontend" in /learn and cert names (#62247)

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -1759,7 +1759,7 @@
       "javascript": "JavaScript",
       "frontend-libraries": "Front End Libraries",
       "relational-databases": "Relational Databases",
-      "backend-javascript": "Backend JavaScript",
+      "backend-javascript": "Back End JavaScript",
       "python": "Python",
       "career": "Career"
     },


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Ona.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

 Closes #62247

Updated English curriculum and certification names to consistently use
"Frontend" instead of "Front End".
