### PR TITLE
fix(curriculum): Clarifiy the explanation of Python’s `//` (floor division) operator.

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-introduction-to-python/67fe859e9d3b3635197781c8.md
+++ b/curriculum/challenges/english/blocks/lecture-introduction-to-python/67fe859e9d3b3635197781c8.md
@@ -276,7 +276,7 @@ What does the double slash (`//`) operator do in Python?
 
 ## --answers--
 
-It divides two numbers and returns the largest integer less than or equal to the result (the mathematical floor).
+It divides two numbers and returns the greatest integer less than or equal to the result.
 
 ---
 

--- a/curriculum/challenges/english/blocks/lecture-introduction-to-python/67fe859e9d3b3635197781c8.md
+++ b/curriculum/challenges/english/blocks/lecture-introduction-to-python/67fe859e9d3b3635197781c8.md
@@ -146,7 +146,7 @@ print('Integer Modulus:', mod_ints) # Integer Modulus: 8
 print('Float Modulus:', mod_floats) # Float Modulus: 1.1999999999999993
 ```
 
-Floor division divides two numbers and returns the largest integer less than or equal to the result (the mathematical floor). This is done with the double forward slash operator (`//`):
+Floor division divides two numbers and returns the greatest integer less than or equal to the result. This is done with the double forward slash operator (`//`):
 
 ```python
 my_int_1 = 56

--- a/curriculum/challenges/english/blocks/lecture-introduction-to-python/67fe859e9d3b3635197781c8.md
+++ b/curriculum/challenges/english/blocks/lecture-introduction-to-python/67fe859e9d3b3635197781c8.md
@@ -146,7 +146,7 @@ print('Integer Modulus:', mod_ints) # Integer Modulus: 8
 print('Float Modulus:', mod_floats) # Float Modulus: 1.1999999999999993
 ```
 
-Floor division divides two numbers and rounds down the result to the nearest whole number. This is done with the double forward slash operator (`//`):
+Floor division divides two numbers and returns the largest integer less than or equal to the result (the mathematical floor). This is done with the double forward slash operator (`//`):
 
 ```python
 my_int_1 = 56
@@ -276,7 +276,7 @@ What does the double slash (`//`) operator do in Python?
 
 ## --answers--
 
-It performs floor division, rounding down the result to the nearest whole number.
+It divides two numbers and returns the largest integer less than or equal to the result (the mathematical floor).
 
 ---
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Ona.

The current wording says it “rounds down to the nearest whole number”, which is misleading for negative values. For example:

`-7 // 3  # -3, not -2`

<img width="120" height="418" alt="Screenshot from 2025-09-21 18-08-30" src="https://github.com/user-attachments/assets/d9d7ce11-7f71-42fb-9d53-cd584a0ac3ca" />


This happens because // applies the mathematical floor, not rounding toward zero.

The updated explanation makes more explicit, that improves accuracy while keeping the definition clear and beginner-friendly.