### PR TITLE
fix(curriculum): update references to 'coach' to 'headCoach' in user story description

### DIFF
--- a/curriculum/challenges/english/blocks/lab-football-team-cards/66e7ee20b79186306fc12da5.md
+++ b/curriculum/challenges/english/blocks/lab-football-team-cards/66e7ee20b79186306fc12da5.md
@@ -23,7 +23,7 @@ In this lab, you will build a set of football team cards. The user should be abl
 1. The `name` property should contain the name of the player as a string.
 1. The `position` property should have one of the following values: `"forward"`, `"midfielder"`, `"defender"`, or `"goalkeeper"`.
 1. The `isCaptain` property should have value of a boolean. One of the players should have their `isCaptain` property set to `true`.
-1. You should display the `coach`, `team` and `year` values on the page. These values should be displayed in the HTML elements with the `id` values of `head-coach`, `team` and `year`. 
+1. You should display the `headCoach`, `team` and `year` values on the page. These values should be displayed in the HTML elements with the `id` values of `head-coach`, `team` and `year`. 
 1. You should display the players data on the page inside the `#player-cards` element, each player should be displayed in a `div` with class of `player-card`, and nested in it, an `h2` containing the name of the player, and `(Captain)` in case of the player being captain, and a `p` containing `Position:` and the position of the player.
 
     ```html
@@ -106,7 +106,7 @@ const listOfCaptains = footballTeam.players.filter(({isCaptain}) => isCaptain);
 assert.lengthOf(listOfCaptains, 1);
 ```
 
-You should display the `coach`, `team` and `year` values from the `footballTeam` object in the HTML elements with the `id` values of `head-coach`, `team` and `year`. 
+You should display the `headCoach`, `team` and `year` values from the `footballTeam` object in the HTML elements with the `id` values of `head-coach`, `team` and `year`. 
 
 ```js
 const teamElement = document.querySelector('.team-stats #team');


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Ona.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #62307 

<!-- Feel free to add any additional description of changes below this line -->

#### Description
This PR addresses an inconsistency in the user story descriptions for the "Build a Set of Football Team Cards" lab. User story 10 incorrectly referenced the property `coach` instead of `headCoach`, which is inconsistent with the object structure and other user stories.

#### Changes Made
- Updated line 26 to replace `coach` with `headCoach` in the user story description.
- Updated line 109 to replace `coach` with `headCoach` in the explanation of the expected behavior.