### PR TITLE
fix(curriculum): correct Step 7 assignment in note-taking app

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-note-taking-app/688141e05e367de0e3ef7635.md
+++ b/curriculum/challenges/english/blocks/workshop-note-taking-app/688141e05e367de0e3ef7635.md
@@ -125,12 +125,9 @@ const noteEl = document.getElementById("note");
 const statusEl = document.getElementById("status");
 
 let currentContent = "";
-
 --fcc-editable-region--
 window.addEventListener("DOMContentLoaded", () => {
   currentContent = noteEl.textContent;
 });
-
-
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-note-taking-app/688141e05e367de0e3ef7635.md
+++ b/curriculum/challenges/english/blocks/workshop-note-taking-app/688141e05e367de0e3ef7635.md
@@ -127,6 +127,10 @@ const statusEl = document.getElementById("status");
 let currentContent = "";
 
 --fcc-editable-region--
+window.addEventListener("DOMContentLoaded", () => {
+  currentContent = noteEl.textContent;
+});
+
 
 --fcc-editable-region--
 ```


### PR DESCRIPTION
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes locally.



Closes  #62292

## Description
This PR corrects Step 7 of the note-taking app workshop:

- Clarifies the instruction so it’s clear that `currentContent` should be reassigned to the value of `noteEl.textContent`.
- Updates the seed code to use `currentContent = noteEl.textContent;` instead of the confusing alternative.
- Ensures that on `DOMContentLoaded`, the variable reflects the existing note text.

This prevents ambiguity for learners and aligns the instructions with the test logic.

