### PR TITLE
fix(curriculum): rephrased instructions for assigning the variable currentContent

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-note-taking-app/688141e05e367de0e3ef7635.md
+++ b/curriculum/challenges/english/blocks/workshop-note-taking-app/688141e05e367de0e3ef7635.md
@@ -7,7 +7,7 @@ dashedName: step-7
 
 # --description--
 
-Right now, `currentContent` is initialized with the value of an empty string. But the desired result would be to have `currentContent` hold the value of the current note text. 
+Right now, `currentContent` is initialized with the value of an empty string. But the desired result would be to have `currentContent` hold the value of the current note text.
 
 In an earlier lecture, you learned how to work with the `DOMContentLoaded` event like this:
 
@@ -19,7 +19,7 @@ window.addEventListener("DOMContentLoaded", () => {
 
 When everything in the HTML document has been loaded and parsed, you will be able to access the `noteEl` safely.
 
-Start by attaching an `addEventListener` method to the `window` object. The first argument for the `addEventListener` method should be the `"DOMContentLoaded"` event. The second argument should be an arrow function. Inside the body of the arrow function, reassign `currentContent` to the value of `noteEl.textContent`.
+Start by attaching an `addEventListener` method to the `window` object. The first argument for the `addEventListener` method should be the `"DOMContentLoaded"` event. The second argument should be an arrow function. Inside the body of the arrow function, assign the value of `noteEl.textContent` to `currentContent`.
 
 # --hints--
 
@@ -35,7 +35,7 @@ Your event listener should listen for the `"DOMContentLoaded"` event.
 assert.match(code, /window\.addEventListener\(['"]DOMContentLoaded['"]\,/);
 ```
 
-Inside the body of the arrow function, you should reassign `currentContent` to the value of `noteEl.textContent`.
+Inside the body of the arrow function, assign the value of `noteEl.textContent` to `currentContent`.
 
 ```js
 const event = new Event("DOMContentLoaded");
@@ -61,15 +61,15 @@ assert.equal(currentContent, noteEl.textContent);
     <p class="helper-text">Click or tap on the card to edit your note.</p>
 
     <div id="note" class="note" contenteditable="true" aria-label="Note editor">
-      Many languages have words that carry meanings so specific or culturally rooted that they can't be neatly translated into English. 
-        
+      Many languages have words that carry meanings so specific or culturally rooted that they can't be neatly translated into English.
+
       One example is the Japanese word "tsundoku", which refers to the habit of acquiring books and letting them pile up unread, something many book lovers can relate to. Another is the Portuguese word "saudade", describing a deep, bittersweet longing for something or someone that is absent. Meanwhile, the French word "Dépaysement" captures the disorienting yet exciting feeling of being in a new place, far from home.
-        
+
       These unique words remind us that language is more than vocabulary: it's a window into the values, habits, and emotions of the cultures that create it.
     </div>
 
     <div id="status" aria-live="polite"></div>
-    
+
     <script src="script.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Ona.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #62292

<!-- Feel free to add any additional description of changes below this line -->

Regarding the changes in lines 10, 64, 65, 67, and 72, I didn’t make them intentionally. Perhaps my editor did. Is this a problem?