### PR TITLE
fix(curriculum): correct superBlock name in Build a Weather App lab

### DIFF
--- a/client/src/pages/learn/full-stack-developer/lab-weather-app/index.md
+++ b/client/src/pages/learn/full-stack-developer/lab-weather-app/index.md
@@ -1,7 +1,7 @@
 ---
 title: Introduction to the Build a Weather App
 block: lab-weather-app
-superBlock: full-stack-development
+superBlock: full-stack-developer
 ---
 
 ## Introduction to the Build a Weather App


### PR DESCRIPTION

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Ona.

Closes #62323

Updated the `superBlock` field in the “Build a Weather App” lab from `full-stack-development` to `full-stack-developer`.



