### PR TITLE
refactor: clearer errors for curriculum tests

### DIFF
--- a/curriculum/test/test-challenges.js
+++ b/curriculum/test/test-challenges.js
@@ -329,7 +329,11 @@ seed goes here
                 it(
                   `Solution ${index + 1} must pass the tests`,
                   async function () {
-                    await testRunner(tests);
+                    try {
+                      await testRunner(tests);
+                    } catch (e) {
+                      expect(e).toBeUndefined();
+                    }
                   },
                   timePerTest * tests.length + 2000
                 );
@@ -385,12 +389,8 @@ async function createTestRunner(
         const newMessage = solutionFromNext
           ? 'Check next step for solution!\n' + text
           : text;
-        // if the stack is missing, the message should be included. Otherwise it
-        // is redundant.
-        err.message = err.stack
-          ? newMessage
-          : `${newMessage}
-      ${err.message}`;
+        err.message = `${newMessage}
+Original message: ${err.message}`;
         throw err;
       }
     }


### PR DESCRIPTION
Now always includes the error message as well as any extra properties generated by chai (e.g. the `actual` property)

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Ona.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
