### PR TITLE
fix(labs): add missing subtitle file for multimedia player lab

### DIFF
--- a/curriculum/challenges/assets/labs/what-is-a-map-method.vtt
+++ b/curriculum/challenges/assets/labs/what-is-a-map-method.vtt
@@ -1,0 +1,21 @@
+WEBVTT
+
+1
+00:00:01.000 --> 00:00:05.000
+What is a map method and how does it work?
+
+2
+00:00:05.000 --> 00:00:10.000
+The map method is a powerful and widely used function in JavaScript that operates on arrays.
+
+3
+00:00:10.000 --> 00:00:15.000
+It's designed to create a new array by applying a given function to each element of the original array.
+
+4
+00:00:15.000 --> 00:00:20.000
+This method does not modify the original array, but instead returns a new array.
+
+5
+00:00:20.000 --> 00:00:25.000
+The new array contains the results of the function applied to each element.

--- a/curriculum/challenges/english/blocks/lab-multimedia-player/67fccc2463253b213a000142.md
+++ b/curriculum/challenges/english/blocks/lab-multimedia-player/67fccc2463253b213a000142.md
@@ -41,7 +41,7 @@ The `source` element can also be used in the `video` element like this:
 6. Inside the second `section` element, you should have an `h2` element for the title of the video playing.
 7. Below the `h2` element, you should have a `video` element with `controls`, `width` attributes and an `aria-label` attribute.
 8. Inside the `video` element, you should have a `source` element with a `src` attribute pointing to a video file and a `type` attribute. You are free to use this video URL if you like: `https://cdn.freecodecamp.org/curriculum/labs/What is the map method and how does it work.mp4`
-9. Below the `source` element, you should have a `track` element with a `src` attribute pointing to a subtitles file and a `kind` attribute, a `srclang` attribute and a `label` attribute.
+9. Below the `source` element, you should have a `track` element with a `src` attribute pointing to a subtitles file and a `kind` attribute, a `srclang` attribute and a `label` attribute. You are free to use this subtitles URL if you like: `https://cdn.freecodecamp.org/curriculum/labs/what-is-a-map-method.vtt`
 10. Inside the third `section` element, you should have an `h2` element for the title of the section eg. "Transcript".
 11. Below the `h2` element, you should have a `p` element with the transcript of the video.
 
@@ -326,7 +326,7 @@ assert.isAbove(transcript.textContent.trim().length, 0);
       <source src="https://cdn.freecodecamp.org/curriculum/labs/What is the map method and how does it work.mp4" type="video/mp4">
       
       <track 
-      src="what-is-a-map-method.vtt" 
+      src="https://cdn.freecodecamp.org/curriculum/labs/what-is-a-map-method.vtt"
       kind="captions" 
       srclang="en" 
       label="English" 


### PR DESCRIPTION
## What this PR fixes

 - Adds missing subtitle file and references for the Multimedia Player lab.

## Changes Made

1. **Created missing subtitle file**: `what-is-a-map-method.vtt` with captions for the video
2. **Fixed solution code**: Updated subtitle path from relative to absolute URL
3. **Added subtitle URL reference**: Included subtitle file URL in User Story #9, matching the pattern used for audio/video files

## Problem Solved

- Example project now has working captions (previously 404 error)
- Students have a subtitle file reference to use in their projects
- Completes the accessibility features of the multimedia player lab

## Testing

The subtitle file path now correctly points to: `https://cdn.freecodecamp.org/curriculum/labs/what-is-a-map-method.vtt`
