### PR TITLE
fix(curriculum): add description for HTML snippet in Football Team Cards

### DIFF
--- a/curriculum/challenges/english/blocks/lab-football-team-cards/66e7ee20b79186306fc12da5.md
+++ b/curriculum/challenges/english/blocks/lab-football-team-cards/66e7ee20b79186306fc12da5.md
@@ -26,6 +26,8 @@ In this lab, you will build a set of football team cards. The user should be abl
 1. You should display the `headCoach`, `team` and `year` values on the page. These values should be displayed in the HTML elements with the `id` values of `head-coach`, `team` and `year`. 
 1. You should display the players data on the page inside the `#player-cards` element, each player should be displayed in a `div` with class of `player-card`, and nested in it, an `h2` containing the name of the player, and `(Captain)` in case of the player being captain, and a `p` containing `Position:` and the position of the player.
 
+    Here is an example of how the HTML should look like:
+
     ```html
     <div class="player-card">
       <h2>Sergio Batista</h2>


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes locally on my machine.

Closes #62348 

Added a simple line above the HTML snippet as description inside the indent level of the snippet. 

Localhost screenshot:

<img width="525" alt="image" src="https://github.com/user-attachments/assets/89926fa9-4e2c-47f4-970c-37888aaa8228" />
