### PR TITLE
fix(curriculum): move editable region markers to wrap Navbar component

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-reusable-mega-navbar/67457ff2dc531fbed928a0f0.md
+++ b/curriculum/challenges/english/blocks/workshop-reusable-mega-navbar/67457ff2dc531fbed928a0f0.md
@@ -171,9 +171,9 @@ button:hover {
 ```
 
 ```jsx
+--fcc-editable-region--
 export const Navbar = () => {
-    --fcc-editable-region--
 
-    --fcc-editable-region--
-}
+  }
+--fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-reusable-mega-navbar/67457ff2dc531fbed928a0f0.md
+++ b/curriculum/challenges/english/blocks/workshop-reusable-mega-navbar/67457ff2dc531fbed928a0f0.md
@@ -173,7 +173,7 @@ button:hover {
 ```jsx
 --fcc-editable-region--
 export const Navbar = () => {
-
+  
 }
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-reusable-mega-navbar/67457ff2dc531fbed928a0f0.md
+++ b/curriculum/challenges/english/blocks/workshop-reusable-mega-navbar/67457ff2dc531fbed928a0f0.md
@@ -174,6 +174,6 @@ button:hover {
 --fcc-editable-region--
 export const Navbar = () => {
 
-  }
+}
 --fcc-editable-region--
 ```


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Ona.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #62374

<!-- Feel free to add any additional description of changes below this line -->

Changes made:
- Moved the markers to wrap around the ```Navbar``` component so it would be clearer for the users solving the task that the declaration is already there.
