### PR TITLE
fix(curriculum): correct arguments for `isNotEmpty`

### DIFF
--- a/curriculum/challenges/english/blocks/build-a-tribute-page-project/bd7158d8c442eddfaeb5bd18.md
+++ b/curriculum/challenges/english/blocks/build-a-tribute-page-project/bd7158d8c442eddfaeb5bd18.md
@@ -63,7 +63,7 @@ Your `#title` should not be empty.
 ```js
 const el = document.getElementById('title');
 assert.isNotNull(el);
-assert.isNotEmpty(el.innerText, 0);
+assert.isNotEmpty(el.innerText.trim());
 ```
 
 You should have a `figure` or `div` element with an `id` of `img-div`.

--- a/curriculum/challenges/english/blocks/lab-tribute-page/bd7158d8c442eddfaeb5bd18.md
+++ b/curriculum/challenges/english/blocks/lab-tribute-page/bd7158d8c442eddfaeb5bd18.md
@@ -61,7 +61,7 @@ Your `#title` should not be empty.
 ```js
 const el = document.getElementById('title');
 assert.isNotNull(el);
-assert.isNotEmpty(el.innerText, 0);
+assert.isNotEmpty(el.innerText.trim());
 ```
 
 You should have a `figure` or `div` element with an `id` of `img-div`.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Ona.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #62380

<!-- Feel free to add any additional description of changes below this line -->
Update the wrong `isNotEmpty` arguments in the `bd7158d8c442eddfaeb5bd18.md` and  `bd7158d8c442eddfaeb5bd18.md`
```diff
 from
- assert.isNotEmpty(el.innerText, 0);
 to
+ assert.isNotEmpty(el.innerText.trim());
```
