### PR TITLE
fix(tools): improve devcontainer experience

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,6 +3,23 @@
   "dockerComposeFile": "docker-compose.yml",
   "service": "devcontainer",
   "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
-  // "features": {},
-  "forwardPorts": [3000, 8000]
+  "forwardPorts": [3000, 8000],
+  "portsAttributes": {
+    "3000": {
+      "label": "API",
+      "onAutoForward": "silent"
+    },
+    "8000": {
+      "label": "Client",
+      "onAutoForward": "notify"
+    }
+  },
+  "otherPortsAttributes": {
+    "onAutoForward": "silent"
+  },
+  "onCreateCommand": "[ ! -f .env ] && cp sample.env .env || true",
+  "updateContentCommand": "pnpm install && pnpm seed",
+  "postAttachCommand": {
+    "instructions": "bash -c 'echo \"\n\n\n Start a new terminal and run \\`pnpm run develop\\` when you are ready.\n\n\n\"'"
+  }
 }


### PR DESCRIPTION
While it is possible to start up the `pnpm run develop` automatically, I think it is better to leave it as is because some users might be working on parts of the curriculum and may not want to start up the service. I added a quick "echo" instead.

This will still install the deps and seed the DBs.