### PR TITLE
fix(scripts): add hasEditableBoundaries property for workshop metadata

### DIFF
--- a/tools/challenge-helper-scripts/create-project.ts
+++ b/tools/challenge-helper-scripts/create-project.ts
@@ -185,7 +185,7 @@ async function createMetaJson(
     newMeta = getBaseMeta('FullStack');
     newMeta.blockType = blockType;
     newMeta.blockLayout = blockLayout;
-    if (blockType === 'workshop') {
+    if (blockType === BlockTypes.workshop) {
       newMeta.hasEditableBoundaries = true;
     }
   } else {

--- a/tools/challenge-helper-scripts/create-project.ts
+++ b/tools/challenge-helper-scripts/create-project.ts
@@ -185,6 +185,9 @@ async function createMetaJson(
     newMeta = getBaseMeta('FullStack');
     newMeta.blockType = blockType;
     newMeta.blockLayout = blockLayout;
+    if (blockType === 'workshop') {
+      newMeta.hasEditableBoundaries = true;
+    }
   } else {
     newMeta = getBaseMeta('Step');
     newMeta.order = order;


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #62411

Is this good enough? otherwise to make it fit the current schema it would need to be changed quite a lot as the template for the metadata seems to be used for at least labs too (unless I have misread the code)

or maybe that would be a good approach, but it would require more time. We have a limited number of challenge types we use, lab, workshop, lecture, review, quiz for coding, and the language curriculum will have its own limited number of challenge types, so maybe a template for each?