### PR TITLE
fix(curriculum): avoid passing currency converter lab with wrong implementation

### DIFF
--- a/curriculum/challenges/english/blocks/lab-currency-converter/67eaa957114d373deb3a9149.md
+++ b/curriculum/challenges/english/blocks/lab-currency-converter/67eaa957114d373deb3a9149.md
@@ -105,13 +105,7 @@ Changing the value of the first `select` element should cause the converted amou
   const s = await __helpers.prepTestComponent(exports.CurrencyConverter);
   const [first, _second] = s.querySelectorAll('select');
   assert.exists(first);
-  await React.act(async () => {
-    // Find first option that is not selected
-    const notSelected = [...first.options].find((o) => !o.selected);
-    first.value = notSelected.value;
-    const ev = new Event("change", { bubbles: true, cancelable: false });
-    first[Object.keys(first).find((k) => k.startsWith("__reactProps"))].onChange({...ev, target: first});
-  });
+  await changeSelectValue(first);
   assert.equal(abuseMemo.calls.length, 2);
 ```
 
@@ -143,68 +137,59 @@ Changing the value of the second `select` element should not cause the converted
   const s = await __helpers.prepTestComponent(exports.CurrencyConverter);
   const [_first, second] = s.querySelectorAll('select');
   assert.exists(second);
-  await React.act(async () => {
-    // Find first option that is not selected
-    const notSelected = [...second.options].find((o) => !o.selected);
-    second.value = notSelected.value;
-    const ev = new Event("change", { bubbles: true, cancelable: false });
-    second[Object.keys(second).find((k) => k.startsWith("__reactProps"))].onChange({...ev, target: second});
-  });
+  await changeSelectValue(second);
   assert.equal(abuseMemo.calls.length, 1);
 ```
 
-Changing the value of the first `select` element should cause a textual change on the page.
+Changing the value of the first `select` element should display the new converted amount.
 
 ```js
   const s = await __helpers.prepTestComponent(window.index.CurrencyConverter);
 
   const nonFormContentBefore = getInnerTextExcept(s, "input,select");
+  const resultBefore = nonFormContentBefore.match(/(\d+\.\d{2})\s*([A-Z]{3})/);
 
   const [first, _second] = s.querySelectorAll('select');
   assert.exists(first);
-  await React.act(async () => {
-    // Find first option that is not selected
-    const notSelected = [...first.options].find((o) => !o.selected);
-    first.value = notSelected.value;
-    const ev = new Event("change", { bubbles: true, cancelable: false });
-    first[Object.keys(first).find((k) => k.startsWith("__reactProps"))].onChange({...ev, target: first});
-  });
+  await changeSelectValue(first);
 
   const nonFormContentAfter = getInnerTextExcept(s, "input,select");
+  const resultAfter = nonFormContentAfter.match(/(\d+\.\d{2})\s*([A-Z]{3})/);
 
   try {
     assert.notEqual(nonFormContentBefore, nonFormContentAfter);
+    assert.notEqual(resultBefore[1], resultAfter[1]);
+    assert.strictEqual(resultBefore[2], resultAfter[2]);
   } catch (e) {
     console.error(e);
     throw e;
   }
 ```
 
-Changing the value of the second `select` element should cause a textual change on the page.
+Changing the value of the second `select` element should display the new converted amount and currency.
 
 ```js
   const s = await __helpers.prepTestComponent(window.index.CurrencyConverter);
 
   const nonFormContentBefore = getInnerTextExcept(s, "input,select");
-
+  const resultBefore = nonFormContentBefore.match(/(\d+\.\d{2})\s*([A-Z]{3})/);
+  
   const [_first, second] = s.querySelectorAll('select');
   assert.exists(second);
-  await React.act(async () => {
-    // Find first option that is not selected
-    const notSelected = [...second.options].find((o) => !o.selected);
-    second.value = notSelected.value;
-    const ev = new Event("change", { bubbles: true, cancelable: false });
-    second[Object.keys(second).find((k) => k.startsWith("__reactProps"))].onChange({...ev, target: second});
-  });
+  await changeSelectValue(second);
 
   const nonFormContentAfter = getInnerTextExcept(s, "input,select");
+  const resultAfter = nonFormContentAfter.match(/(\d+\.\d{2})\s*([A-Z]{3})/);
 
   try {
     assert.notEqual(nonFormContentBefore, nonFormContentAfter);
-  } catch (e) {
-    console.error(e);
-    throw e;
-  }
+    assert.notEqual(resultBefore[1], resultAfter[1]);
+    assert.notEqual(resultBefore[2], resultAfter[2]);
+    assert.strictEqual(resultAfter[2], second.value);
+    } catch (e) {
+      console.error(e);
+      throw e;
+    }
 ```
 
 The converted amount should be displayed in the format `XX.XX CCC`, where `XX.XX` is the converted amount rounded to two decimal places and `CCC` is the currency code.
@@ -216,12 +201,8 @@ The converted amount should be displayed in the format `XX.XX CCC`, where `XX.XX
   assert.exists(inp);
   const [_first, second] = s.querySelectorAll('select');
   assert.exists(second);
+  await changeSelectValue(second);
   await React.act(async () => {
-    // Find first option that is not selected
-    const notSelected = [...second.options].find((o) => !o.selected);
-    second.value = notSelected.value;
-    const ev = new Event("change", { bubbles: true, cancelable: false });
-    second[Object.keys(second).find((k) => k.startsWith("__reactProps"))].onChange({...ev, target: second});
     inp.value = 10;
     const ev2 = new Event("change", { bubbles: true, cancelable: false });
     inp[Object.keys(inp).find((k) => k.startsWith("__reactProps"))].onChange({...ev2, target: inp});
@@ -298,6 +279,16 @@ function getInnerTextExcept(doc, removingSelector) {
 
   return body.innerText;
 }
+
+const changeSelectValue = async (selectElement) => {
+  await React.act(async () => {
+    const notSelected = [...selectElement.options].find((o) => !o.selected);
+    selectElement.value = notSelected.value;
+    const ev = new Event("change", { bubbles: true, cancelable: false });
+    selectElement[Object.keys(selectElement).find((k) => k.startsWith("__reactProps"))].onChange({...ev, target: selectElement});
+  });
+};
+
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #62334

Tested locally with the solution that (incorrectly) passed from the issue description, and with a correct solution. I added a more robust validation for the textual changes tests, as the one for select2 was passing although the converted amount value was not changing.