### PR TITLE
fix(curriculum): update digit length in Phone Number Formatter (2025-09-30) instructions

### DIFF
--- a/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/68b7cadffed0e75a517da671.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/68b7cadffed0e75a517da671.md
@@ -7,7 +7,7 @@ dashedName: challenge-51
 
 # --description--
 
-Given a string of ten digits, return the string as a phone number in this format: `"+D (DDD) DDD-DDDD"`.
+Given a string of eleven digits, return the string as a phone number in this format: `"+D (DDD) DDD-DDDD"`.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/daily-coding-challenges-python/68b7cadffed0e75a517da671.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-python/68b7cadffed0e75a517da671.md
@@ -7,7 +7,7 @@ dashedName: challenge-51
 
 # --description--
 
-Given a string of ten digits, return the string as a phone number in this format: `"+D (DDD) DDD-DDDD"`.
+Given a string of eleven digits, return the string as a phone number in this format: `"+D (DDD) DDD-DDDD"`.
 
 # --hints--
 


### PR DESCRIPTION
Corrected the instructions in both JavaScript and Python files to reflect that the input string contains 11 digits, not 10.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #62427 

<!-- Feel free to add any additional description of changes below this line -->
