### PR TITLE
fix(api): daily coding challenge test

### DIFF
--- a/api/src/daily-coding-challenge/routes/daily-coding-challenge.test.ts
+++ b/api/src/daily-coding-challenge/routes/daily-coding-challenge.test.ts
@@ -249,16 +249,20 @@ describe('/daily-coding-challenge', () => {
           challengeNumber: todaysChallenge.challengeNumber,
           date: todaysChallenge.date.toISOString(),
           title: todaysChallenge.title
-        },
-        {
+        }
+      ];
+
+      // Only include yesterday's challenge if today is not the 1st of the month
+      if (todayUsCentral.getDate() !== 1) {
+        expectedResponse.push({
           id: yesterdaysChallenge.id,
           challengeNumber: yesterdaysChallenge.challengeNumber,
           date: yesterdaysChallenge.date.toISOString(),
           title: yesterdaysChallenge.title
-        }
-      ];
+        });
+      }
 
-      expect(res.body).toHaveLength(2);
+      expect(res.body).toHaveLength(expectedResponse.length);
       expect(res.body).toEqual(expectedResponse);
     });
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

The `/daily-coding-challenge/month/${currentMonth}` endpoint only returns challenges from the given month. There is a test case that expects the endpoint to return both yesterday's and today's challenges. Since today is October 1, the endpoint returns only one challenge, which causes the test to fail.

We're seeing the failure on main: https://github.com/freeCodeCamp/freeCodeCamp/actions/runs/18156547783/job/51678862239.

<!-- Feel free to add any additional description of changes below this line -->
