### PR TITLE
Add note clarifying CSS usage before introduction in curriculum

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-accessible-media-elements/672a55fbc2d95a9453151caf.md
+++ b/curriculum/challenges/english/blocks/lecture-accessible-media-elements/672a55fbc2d95a9453151caf.md
@@ -74,6 +74,8 @@ Another way to make the keyboard accessible in your apps is to make sure you pro
 
 Here is an example of styling the focus state for an HTML element:
 
+_The following example is written in **CSS**, which we will cover later in the curriculum._
+
 ```css
 element:focus {
   outline: 2px solid #005fcc;

--- a/curriculum/challenges/english/blocks/quiz-javascript-fundamentals/66edcd875b0d91de1fbbb492.md
+++ b/curriculum/challenges/english/blocks/quiz-javascript-fundamentals/66edcd875b0d91de1fbbb492.md
@@ -500,57 +500,60 @@ Which of the following examples exports the `calculateSum` function from a `util
 export default function calculateSum(a, b) {
   return a + b;
 }
-```
 
-```js
 // app.js
 import { calculateSum } from './utils.js';
 console.log(calculateSum(2, 3));
+
 ```
 
 ---
 
 ```js
+
 // utils.js
 export function calculateSum(a, b) {
   return a + b;
 }
-```
 
-```js
+
+
 // app.js
 import calculateSum from './utils.js';
 console.log(calculateSum(2, 3));
+
 ```
 
 ---
 
 ```js
+
 // utils.js
 function calculateSum(a, b) {
   return a + b;
 }
-```
 
-```js
+
+
 export default calculateSum;
 
 // app.js
 import * as utils from './utils.js';
 console.log(utils.calculateSum(2, 3));
+
 ```
 
 #### --answer--
 
 ```js
+
 // utils.js
 export function calculateSum(a, b) {
   return a + b;
 }
-```
 
-```js
 // app.js
 import { calculateSum } from './utils.js';
 console.log(calculateSum(2, 3));
+
 ```


### PR DESCRIPTION
Checklist:
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #62447

Description : 
This PR adds a short note clarifying that the example shown is written in CSS, even though CSS has not yet been introduced in the curriculum.

Before : 
Here is an example of styling the focus state for an HTML element:
```css
element:focus {
  outline: 2px solid #005fcc;
}
```

After :
Here is an example of styling the focus state for an HTML element:
_The following example is written in **CSS**, which we will cover later in the curriculum._
```css
element:focus {
  outline: 2px solid #005fcc;
}
``` 