### PR TITLE
fix(curriculum): replace 'Ex.' with 'e.g.' in Cat Photo App step 42

### DIFF
--- a/curriculum/challenges/english/blocks/learn-html-by-building-a-cat-photo-app/5ef9b03c81a63668521804d9.md
+++ b/curriculum/challenges/english/blocks/learn-html-by-building-a-cat-photo-app/5ef9b03c81a63668521804d9.md
@@ -9,10 +9,10 @@ dashedName: step-42
 
 Placeholder text is used to give people a hint about what kind of information to enter into an input. 
 
-Here is an example of an `input` element with a placeholder set to `Ex. Jane Doe`:
+Here is an example of an `input` element with a placeholder set to `e.g. Jane Doe`:
 
 ```html
-<input type="text" placeholder="Ex. Jane Doe">
+<input type="text" placeholder="e.g. Jane Doe">
 ```
 
 Add the placeholder text `cat photo URL` to your `input` element.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #62398

<!-- Feel free to add any additional description of changes below this line -->

This PR updates Step 42 of the **Learn HTML by Building a Cat Photo App** curriculum.  
The placeholder example currently uses **"Ex."**, which is less common and potentially confusing.  
It has been replaced with the more conventional abbreviation **"e.g."** for clarity and consistency in technical writing.

**Before:**
```html
<input type="text" placeholder="Ex. Jane Doe">
```
**After**
```html
<input type="text" placeholder="e.g. Jane Doe">
```
This is a minor change but improves clarity, consistency, and professionalism in the curriculum content.
