### PR TITLE
refactor(client): source super block structures in graphql and store in redux

### DIFF
--- a/client/src/redux/action-types.js
+++ b/client/src/redux/action-types.js
@@ -37,6 +37,7 @@ export const actionTypes = createTypes(
     'updateUserToken',
     'postChargeProcessing',
     'updateAllChallengesInfo',
+    'updateSuperBlockStructures',
     'updateCardRedirecting',
     ...createAsyncTypes('updateCard'),
     ...createAsyncTypes('fetchUser'),

--- a/client/src/redux/actions.ts
+++ b/client/src/redux/actions.ts
@@ -55,6 +55,10 @@ export const updateAllChallengesInfo = createAction(
   actionTypes.updateAllChallengesInfo
 );
 
+export const updateSuperBlockStructures = createAction(
+  actionTypes.updateSuperBlockStructures
+);
+
 export const postCharge = createAction(actionTypes.postCharge);
 export const postChargeProcessing = createAction(
   actionTypes.postChargeProcessing

--- a/client/src/redux/index.js
+++ b/client/src/redux/index.js
@@ -68,6 +68,7 @@ const initialState = {
     challengeNodes: [],
     certificateNodes: []
   },
+  superBlockStructures: {},
   userProfileFetchState: {
     ...defaultFetchState
   },
@@ -171,6 +172,10 @@ export const reducer = handleActions(
     [actionTypes.updateAllChallengesInfo]: (state, { payload }) => ({
       ...state,
       allChallengesInfo: { ...payload }
+    }),
+    [actionTypes.updateSuperBlockStructures]: (state, { payload }) => ({
+      ...state,
+      superBlockStructures: { ...payload }
     }),
     [actionTypes.fetchUser]: state => ({
       ...state,

--- a/client/src/redux/prop-types.ts
+++ b/client/src/redux/prop-types.ts
@@ -335,6 +335,20 @@ export type AllChallengesInfo = {
   certificateNodes: CertificateNode[];
 };
 
+export type SuperBlockStructure = {
+  superBlock: string;
+  chapters: Array<{
+    dashedName: string;
+    comingSoon?: boolean;
+    modules: Array<{
+      dashedName: string;
+      comingSoon?: boolean;
+      moduleType?: string;
+      blocks: string[];
+    }>;
+  }>;
+};
+
 export type AllChallengeNode = {
   edges: [
     {

--- a/client/src/redux/root-reducer.ts
+++ b/client/src/redux/root-reducer.ts
@@ -11,7 +11,9 @@ import {
 } from '../templates/Challenges/redux';
 import {
   ns as curriculumMapNameSpace,
-  reducer as curriculumMap
+  reducer as curriculumMap,
+  superBlockStructuresNs as superBlockStructuresNameSpace,
+  superBlockStructuresReducer as superBlockStructures
 } from '../templates/Introduction/redux';
 import { examAttempts } from '../utils/ajax';
 import { ns as appNameSpace } from './action-types';
@@ -23,6 +25,7 @@ export default combineReducers({
   [appNameSpace]: app,
   [challengeNameSpace]: challenge,
   [curriculumMapNameSpace]: curriculumMap,
+  [superBlockStructuresNameSpace]: superBlockStructures,
   [flashNameSpace]: flash,
   [searchNameSpace]: search,
   [settingsNameSpace]: settings,

--- a/client/src/redux/selectors.js
+++ b/client/src/redux/selectors.js
@@ -1,10 +1,8 @@
 import { createSelector } from 'reselect';
 
-// TODO: source the superblock structure via a GQL query, rather than directly
-// from the curriculum
-import superBlockStructure from '../../../curriculum/structure/superblocks/full-stack-developer.json';
 import { randomBetween } from '../utils/random-between';
 import { getSessionChallengeData } from '../utils/session-storage';
+import { superBlockStructuresNs } from '../templates/Introduction/redux';
 import { ns as MainApp } from './action-types';
 
 export const savedChallengesSelector = state =>
@@ -121,6 +119,10 @@ export const createUserByNameSelector = username => state => {
 export const userFetchStateSelector = state => state[MainApp].userFetchState;
 export const allChallengesInfoSelector = state =>
   state[MainApp].allChallengesInfo;
+export const superBlockStructuresSelector = state =>
+  state[superBlockStructuresNs] || {};
+export const getSuperBlockStructure = (state, superBlock) =>
+  superBlockStructuresSelector(state)[superBlock];
 
 export const completedChallengesIdsSelector = createSelector(
   completedChallengesSelector,
@@ -133,10 +135,24 @@ export const completedDailyCodingChallengesIdsSelector = createSelector(
 );
 
 export const completionStateSelector = createSelector(
-  [allChallengesInfoSelector, completedChallengesIdsSelector],
-  (allChallengesInfo, completedChallengesIds) => {
-    const chapters = superBlockStructure.chapters;
+  [
+    allChallengesInfoSelector,
+    completedChallengesIdsSelector,
+    superBlockStructuresSelector,
+    state => state.challenge.challengeMeta
+  ],
+  (
+    allChallengesInfo,
+    completedChallengesIds,
+    superBlockStructures,
+    challengeMeta
+  ) => {
     const { challengeNodes } = allChallengesInfo;
+
+    const structure = superBlockStructures[challengeMeta.superBlock];
+    if (!structure) return [];
+
+    const chapters = structure.chapters;
 
     const getCompletionState = ({
       chapters,

--- a/client/src/templates/Introduction/components/super-block-accordion.tsx
+++ b/client/src/templates/Introduction/components/super-block-accordion.tsx
@@ -5,11 +5,6 @@ import { Disclosure } from '@headlessui/react';
 
 import { SuperBlocks } from '../../../../../shared-dist/config/curriculum';
 import DropDown from '../../../assets/icons/dropdown';
-// TODO: source the superblock structure via a GQL query, rather than directly
-// from the curriculum
-import fullStackCert from '../../../../../curriculum/structure/superblocks/full-stack-developer.json';
-import fullStackOpen from '../../../../../curriculum/structure/superblocks/full-stack-open.json';
-import a1Spanish from '../../../../../curriculum/structure/superblocks/a1-professional-spanish.json';
 
 import { ChapterIcon } from '../../../assets/chapter-icon';
 import { type Chapter } from '../../../../../shared-dist/config/chapters';
@@ -61,6 +56,9 @@ interface Challenge {
 interface SuperBlockAccordionProps {
   challenges: Challenge[];
   superBlock: SuperBlocks;
+  structure?: {
+    chapters: Chapter[];
+  };
   chosenBlock: string;
   completedChallengeIds: string[];
 }
@@ -176,25 +174,15 @@ const LinkBlock = ({
 export const SuperBlockAccordion = ({
   challenges,
   superBlock,
+  structure,
   chosenBlock,
   completedChallengeIds
 }: SuperBlockAccordionProps) => {
-  function getSuperblockStructure(superBlock: SuperBlocks): {
-    chapters: Chapter[];
-  } {
-    switch (superBlock) {
-      case SuperBlocks.FullStackOpen:
-        return fullStackOpen;
-      case SuperBlocks.FullStackDeveloper:
-        return fullStackCert;
-      case SuperBlocks.A1Spanish:
-        return a1Spanish;
-      default:
-        throw new Error("The SuperBlock structure hasn't been imported.");
-    }
+  if (!structure) {
+    throw new Error(`No structure provided for superblock: ${superBlock}`);
   }
 
-  const superBlockStructure = getSuperblockStructure(superBlock);
+  const superBlockStructure = structure;
 
   const modules = superBlockStructure.chapters.flatMap<Module>(
     ({ modules }) => modules

--- a/client/src/templates/Introduction/redux/index.js
+++ b/client/src/templates/Introduction/redux/index.js
@@ -39,3 +39,26 @@ export const reducer = handleActions(
   },
   initialState
 );
+
+export const superBlockStructuresNs = 'superBlockStructures';
+
+const sbInitialState = {};
+
+const sbTypes = createTypes(
+  ['updateSuperBlockStructures'],
+  superBlockStructuresNs
+);
+
+export const updateSuperBlockStructures = createAction(
+  sbTypes.updateSuperBlockStructures
+);
+
+export const superBlockStructuresReducer = handleActions(
+  {
+    [sbTypes.updateSuperBlockStructures]: (state, { payload }) => ({
+      ...state,
+      ...payload
+    })
+  },
+  sbInitialState
+);

--- a/tools/client-plugins/gatsby-source-challenges/gatsby-node.js
+++ b/tools/client-plugins/gatsby-source-challenges/gatsby-node.js
@@ -1,9 +1,10 @@
+const path = require('path');
 const chokidar = require('chokidar');
 
 const { createChallengeNode } = require('./create-challenge-nodes');
 
 exports.sourceNodes = function sourceChallengesSourceNodes(
-  { actions, reporter },
+  { actions, reporter, createNodeId, createContentDigest },
   pluginOptions
 ) {
   const { source, onSourceChange, curriculumPath } = pluginOptions;
@@ -67,9 +68,13 @@ exports.sourceNodes = function sourceChallengesSourceNodes(
   function sourceAndCreateNodes() {
     return source()
       .then(challenges => Promise.all(challenges))
-      .then(challenges =>
-        challenges.map(challenge => createVisibleChallenge(challenge))
-      )
+      .then(challenges => {
+        // create challenge nodes
+        challenges.forEach(challenge => createVisibleChallenge(challenge));
+        // create superblock structure nodes
+        createSuperBlockStructureNodes();
+        return Promise.resolve();
+      })
       .catch(e => {
         console.log(e);
         reporter.panic(`fcc-source-challenges
@@ -82,6 +87,64 @@ exports.sourceNodes = function sourceChallengesSourceNodes(
 
   function createVisibleChallenge(challenge, options) {
     createNode(createChallengeNode(challenge, reporter, options));
+  }
+
+  function createSuperBlockStructureNodes() {
+    const sharedConfigPath = path.resolve(
+      curriculumPath,
+      '..',
+      '..',
+      '..',
+      'shared-dist',
+      'config',
+      'curriculum'
+    );
+    const sharedConfig = require(sharedConfigPath);
+    const chapterBasedSuperBlocks = sharedConfig.chapterBasedSuperBlocks || [];
+
+    const buildCurriculumPath = path.resolve(
+      curriculumPath,
+      '..',
+      '..',
+      'build-curriculum'
+    );
+    const buildCurriculum = require(buildCurriculumPath);
+    const superBlockToFilename = buildCurriculum.superBlockToFilename || {};
+
+    chapterBasedSuperBlocks.forEach(superBlock => {
+      const filename = superBlockToFilename[superBlock] || superBlock;
+      try {
+        const structurePath = path.resolve(
+          curriculumPath,
+          '..',
+          '..',
+          'structure',
+          'superblocks',
+          `${filename}.json`
+        );
+        const structure = require(structurePath);
+
+        const nodeId = createNodeId(`SuperBlockStructure-${superBlock}`);
+        const nodeContent = JSON.stringify(structure);
+
+        createNode({
+          ...structure,
+          superBlock,
+          id: nodeId,
+          parent: null,
+          children: [],
+          internal: {
+            type: 'SuperBlockStructure',
+            content: nodeContent,
+            contentDigest: createContentDigest(structure)
+          }
+        });
+      } catch (err) {
+        reporter.warn(
+          `Could not load structure for ${superBlock} (${filename}.json): ${err.message}`
+        );
+      }
+    });
   }
 
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ ] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR demonstrates the approach of moving the super block structures to GraphQL and storing them in Redux when the super block intro page loads.

Concerns:
- Campers can access a challenge page directly. In this case, the super block structures will not be available in the Redux store, which will cause issues.

<!-- Feel free to add any additional description of changes below this line -->
