### PR TITLE
fix(client): make completionStateSelector support all chapter-based super blocks

### DIFF
--- a/client/src/redux/selectors.js
+++ b/client/src/redux/selectors.js
@@ -2,7 +2,12 @@ import { createSelector } from 'reselect';
 
 // TODO: source the superblock structure via a GQL query, rather than directly
 // from the curriculum
-import superBlockStructure from '../../../curriculum/structure/superblocks/full-stack-developer.json';
+import fullStackCert from '../../../curriculum/structure/superblocks/full-stack-developer.json';
+import fullStackOpen from '../../../curriculum/structure/superblocks/full-stack-open.json';
+import a1Spanish from '../../../curriculum/structure/superblocks/a1-professional-spanish.json';
+import javascriptV9 from '../../../curriculum/structure/superblocks/javascript-v9.json';
+import rwdV9 from '../../../curriculum/structure/superblocks/responsive-web-design-v9.json';
+import { SuperBlocks } from '../../../shared-dist/config/curriculum';
 import { randomBetween } from '../utils/random-between';
 import { getSessionChallengeData } from '../utils/session-storage';
 import { ns as MainApp } from './action-types';
@@ -133,10 +138,23 @@ export const completedDailyCodingChallengesIdsSelector = createSelector(
 );
 
 export const completionStateSelector = createSelector(
-  [allChallengesInfoSelector, completedChallengesIdsSelector],
-  (allChallengesInfo, completedChallengesIds) => {
-    const chapters = superBlockStructure.chapters;
+  [
+    allChallengesInfoSelector,
+    completedChallengesIdsSelector,
+    state => state.challenge.challengeMeta
+  ],
+  (allChallengesInfo, completedChallengesIds, challengeMeta) => {
     const { challengeNodes } = allChallengesInfo;
+
+    const superBlockMap = {
+      [SuperBlocks.FullStackDeveloper]: fullStackCert,
+      [SuperBlocks.ResponsiveWebDesignV9]: rwdV9,
+      [SuperBlocks.JavaScriptV9]: javascriptV9,
+      [SuperBlocks.A1Spanish]: a1Spanish,
+      [SuperBlocks.FullStackOpen]: fullStackOpen
+    };
+
+    const chapters = superBlockMap[challengeMeta.superBlock].chapters;
 
     const getCompletionState = ({
       chapters,


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR:
- Requires #62188 and #62039
- Updates the `completionStateSelector` to support all chapter-based super blocks
- Closes https://github.com/freeCodeCamp/fCC10/issues/94.

<!-- Feel free to add any additional description of changes below this line -->
