### PR TITLE
fix(challenge-editor): use chapterBasedSuperBlocks from config

### DIFF
--- a/tools/challenge-editor/api/utils/get-blocks.ts
+++ b/tools/challenge-editor/api/utils/get-blocks.ts
@@ -1,5 +1,7 @@
 import { readFile } from 'fs/promises';
 import { join } from 'path';
+
+import { chapterBasedSuperBlocks } from '../../../../shared/config/curriculum';
 import {
   SUPERBLOCK_META_DIR,
   BLOCK_META_DIR,
@@ -20,8 +22,6 @@ type BlockLocation = {
   blocks: Block[];
   currentSuperBlock: string;
 };
-
-const chapterBasedSuperBlocks = ['full-stack-developer'];
 
 export const getBlocks = async (sup: string): Promise<BlockLocation> => {
   const superBlockDataPath = join(SUPERBLOCK_META_DIR, sup + '.json');


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Updates the challenge editor to use the `chapterBasedSuperBlocks` constant from `shared/config` instead of maintaining its own (outdated) list.

<!-- Feel free to add any additional description of changes below this line -->
