### PR TITLE
fix(client): update CTA for daily challenges

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -118,11 +118,8 @@
     "share-on-threads": "Share on Threads",
     "play-scene": "Press Play",
     "download-latest-version": "Download the Latest Version",
-    "start": "Start",
-    "go-to-today": "Go to Today's Challenge",
-    "go-to-today-long": "Go to Today's Coding Challenge",
-    "go-to-archive": "Go to Archive",
-    "go-to-archive-long": "Go to Daily Coding Challenge Archive"
+    "go-to-dcc-today": "Go to Today's Challenge",
+    "go-to-dcc-archive": "Go to Daily Coding Challenge Archive"
   },
   "daily-coding-challenges": {
     "title": "Daily Coding Challenges",

--- a/client/src/components/daily-coding-challenge/calendar.tsx
+++ b/client/src/components/daily-coding-challenge/calendar.tsx
@@ -240,7 +240,7 @@ function DailyCodingChallengeCalendar({
           block={true}
           href={`/learn/daily-coding-challenge/${todayUsCentral}`}
         >
-          {t('buttons.go-to-today')}
+          {t('buttons.go-to-dcc-today')}
         </Button>
       </Col>
 

--- a/client/src/components/daily-coding-challenge/not-found.tsx
+++ b/client/src/components/daily-coding-challenge/not-found.tsx
@@ -43,11 +43,11 @@ function DailyCodingChallengeNotFound(): JSX.Element {
               block={true}
               href={`/learn/daily-coding-challenge/${getTodayUsCentral()}`}
             >
-              {t(`buttons.go-to-today-long`)}
+              {t(`buttons.go-to-dcc-today`)}
             </Button>
             <Spacer size='xs' />
             <Button block={true} href='/learn/daily-coding-challenge/archive'>
-              {t(`buttons.go-to-archive-long`)}
+              {t(`buttons.go-to-dcc-archive`)}
             </Button>
           </div>
           <Spacer size='l' />

--- a/client/src/components/daily-coding-challenge/widget.tsx
+++ b/client/src/components/daily-coding-challenge/widget.tsx
@@ -34,7 +34,7 @@ function DailyCodingChallengeWidget({
         >
           <div className='daily-coding-challenge-button'>
             <DailyCodingChallengeIcon className='map-icon' />
-            {t(`buttons.start`)}
+            {t(`buttons.go-to-dcc-today`)}
           </div>
           {forLanding && <LinkButton />}
         </ButtonLink>
@@ -51,7 +51,7 @@ function DailyCodingChallengeWidget({
             >
               <div className='daily-coding-challenge-button'>
                 <CalendarIcon className='map-icon' />
-                {t(`buttons.go-to-archive`)}
+                {t(`buttons.go-to-dcc-archive`)}
               </div>
             </ButtonLink>
           </>

--- a/e2e/daily-coding-challenge.spec.ts
+++ b/e2e/daily-coding-challenge.spec.ts
@@ -220,7 +220,11 @@ test.describe('Daily Coding Challenge Archive', () => {
     ).toBeVisible();
 
     await expect(
-      page.getByRole('link', { name: /go to today/i })
+      page
+        .locator('div')
+        .filter({ hasText: /New challenges are released/ })
+        .getByRole('link', { name: /go to today/i })
+        .first()
     ).toBeVisible();
 
     const totalCalendarDays = await page.getByTestId('calendar-day').count();

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "rename-challenges": "tsx tools/challenge-helper-scripts/rename-challenge-files.ts",
     "seed": "pnpm seed:surveys && pnpm seed:exams && DEBUG=fcc:* node ./tools/scripts/seed/seed-demo-user",
     "seed:certified-user": "pnpm seed:surveys && pnpm seed:exams && pnpm seed:ms-username && DEBUG=fcc:* node ./tools/scripts/seed/seed-demo-user --certified-user",
+    "seed:daily-challenges": "cd tools/daily-challenges && pnpm seed-daily-challenges",
     "seed:exams": "DEBUG=fcc:* node tools/scripts/seed-exams/create-exams",
     "seed:env-exam": "cd api && pnpm run seed:env-exam",
     "seed:surveys": "DEBUG=fcc:* node ./tools/scripts/seed/seed-surveys",


### PR DESCRIPTION
This PR updates the CTA's for the daily coding challenge to be their long form ones. Using long form and explict labels is one of our design principles. This should also eliminate a potential conflict with the coursework archive page and the term "archive" in general. 


