### PR TITLE
fix: improve header spacing and search bar styling

### DIFF
--- a/client/src/components/Header/components/universal-nav.css
+++ b/client/src/components/Header/components/universal-nav.css
@@ -11,7 +11,7 @@
 
 @media (min-width: 401px) {
   .universal-nav {
-    padding: 0 15px;
+    padding: 25px 15px;
   }
 }
 

--- a/client/src/components/Header/header.css
+++ b/client/src/components/Header/header.css
@@ -3,6 +3,7 @@
   top: 0;
   width: 100%;
   z-index: var(--z-index-site-header);
+  
 }
 
 .skip-to-content-button {

--- a/client/src/components/search/searchBar/searchbar.css
+++ b/client/src/components/search/searchBar/searchbar.css
@@ -21,6 +21,7 @@
 
 .fcc_search_wrapper {
   position: relative;
+
 }
 
 .ais-SearchBox-loadingIndicator {
@@ -35,6 +36,8 @@
   grid-template-areas: 'submit input reset';
   grid-template-columns: 26px auto 36px;
   margin-bottom: 0;
+  border-radius: 25px; 
+  overflow: hidden; 
 }
 
 .ais-SearchBox-input {
@@ -44,6 +47,8 @@
   font-size: 18px;
   display: inline-block;
   height: var(--header-element-size);
+  border-radius: 12px;
+
 }
 
 .ais-SearchBox-submit,
@@ -58,13 +63,14 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  padding-left: 2px;
 }
 
 .ais-SearchBox-reset {
   grid-area: reset;
-  display: flex;
   align-items: center;
   justify-content: center;
+  padding-left: 2px;
 }
 
 .ais-SearchBox-form button:hover {


### PR DESCRIPTION
## Summary
This PR addresses two design issues in the header section:

1. **Header Spacing**  
   - Previously, the header had very little padding.  
   - The logo, search bar, and menu items appeared squashed and sticky.  
   - Added consistent padding to improve spacing and readability.

2. **Search Bar Styling**  
   - The search bar was square and inconsistent with the design.  
   - Added rounded borders to make it cleaner and modern.

## Changes
- Adjusted header padding
- Applied border-radius to search bar

## Testing
- Verified changes locally on the homepage
- Checked responsiveness on different screen sizes

## Checklist

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes locally on my machine.

and further any issues arise i am willing to solve them.
these are the comparison  image
<img width="1366" height="768" alt="Screenshot (33)" src="https://github.com/user-attachments/assets/fe5c7071-792a-44f9-bb80-d43d49030203" />
 
<img width="1366" height="768" alt="Screenshot (32)" src="https://github.com/user-attachments/assets/19a3e01b-43f9-4402-8640-af5378c9d908" />

 
