### PR TITLE
fix(tools): s/MailHog/Mailpit/g

### DIFF
--- a/.github/workflows/e2e-third-party.yml
+++ b/.github/workflows/e2e-third-party.yml
@@ -99,8 +99,8 @@ jobs:
         image: mongo:8.0
         ports:
           - 27017:27017
-      mailhog:
-        image: mailhog/mailhog
+      mailpit:
+        image: axllent/mailpit
         ports:
           - 1025:1025
     steps:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -18,10 +18,10 @@ ports:
     visibility: public
   - port: 3300 # challenge editor client
     visibility: public
-  - port: 8025 # MailHog
+  - port: 8025 # Mailpit
     visibility: public
     onOpen: ignore
-  - port: 1025 # MailHog
+  - port: 1025 # Mailpit
     onOpen: ignore
   - port: 9323 # Playwright
     visibility: public

--- a/api/src/plugins/mail-providers/nodemailer.ts
+++ b/api/src/plugins/mail-providers/nodemailer.ts
@@ -11,8 +11,8 @@ export class NodemailerProvider implements MailProvider {
   private transporter: Transporter;
 
   /**
-   * Sets up nodemailer, with hardcodeded configuration.  This is intended for
-   * use in development.
+   * Sets up nodemailer, with hardcoded configuration. This is intended for
+   * use in development with Mailpit.
    */
   constructor() {
     this.transporter = nodemailer.createTransport({

--- a/api/src/utils/env.ts
+++ b/api/src/utils/env.ts
@@ -157,7 +157,7 @@ if (process.env.FREECODECAMP_NODE_ENV !== 'development') {
 }
 
 export const HOME_LOCATION = process.env.HOME_LOCATION;
-// Mailhog is used in development and test environments, hence the localhost
+// Mailpit is used in development and test environments, hence the localhost
 // default.
 export const MAILHOG_HOST = process.env.MAILHOG_HOST ?? 'localhost';
 export const MONGOHQ_URL =

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,9 +15,9 @@ services:
         # This will try to initiate the replica set, until it succeeds twice (i.e. until the replica set is already initialized)
         'mongosh --host mongo:27017 --eval ''try {rs.initiate();} catch (err) { if(err.codeName !== "AlreadyInitialized") throw err };'''
       ]
-  mailhog:
+  mailpit:
     restart: unless-stopped
-    image: mailhog/mailhog
+    image: axllent/mailpit
     ports:
       - '1025:1025'
       - '8025:8025'
@@ -25,15 +25,15 @@ services:
     restart: unless-stopped
     depends_on:
       - mongo
-      - mailhog
+      - mailpit
     image: fcc-api
     env_file:
       - .env
     environment:
-      # The api cannot connect to mongodb or mailhog via localhost from inside the
+      # The api cannot connect to mongodb or mailpit via localhost from inside the
       # container, so we have to override these variables.
       - MONGOHQ_URL=mongodb://mongo:27017/freecodecamp?directConnection=true
-      - MAILHOG_HOST=mailhog
+      - MAILHOG_HOST=mailpit
       - HOST=0.0.0.0
     ports:
       - '3000:3000'

--- a/e2e/certification.spec.ts
+++ b/e2e/certification.spec.ts
@@ -30,7 +30,7 @@ test.describe('Claim a certification - almost certified user', () => {
     // verify that an email is sent
     await expect(async () => {
       const emails = await getAllEmails();
-      expect(emails.items).toHaveLength(1);
+      expect(emails.messages).toHaveLength(1);
       expect(getSubject(getFirstEmail(emails))).toBe(
         'Congratulations on completing all of the freeCodeCamp certifications!'
       );

--- a/e2e/report-user.spec.ts
+++ b/e2e/report-user.spec.ts
@@ -39,7 +39,7 @@ test('should be possible to report a user from their profile page', async ({
 
   await expect(async () => {
     const emails = await getAllEmails();
-    expect(emails.items).toHaveLength(1);
+    expect(emails.messages).toHaveLength(1);
     expect(getSubject(getFirstEmail(emails))).toBe(
       "Abuse Report : Reporting twaha's profile."
     );

--- a/e2e/update-email.spec.ts
+++ b/e2e/update-email.spec.ts
@@ -69,7 +69,7 @@ test.describe('The update-email page when the user is signed in', () => {
     await submitButton.click();
     await expect(async () => {
       const emails = await getAllEmails();
-      expect(emails.items).toHaveLength(1);
+      expect(emails.messages).toHaveLength(1);
       expect(getSubject(getFirstEmail(emails))).toBe(
         'Please confirm your updated email address for freeCodeCamp.org'
       );

--- a/e2e/utils/mailhog.ts
+++ b/e2e/utils/mailhog.ts
@@ -1,26 +1,29 @@
 type Email = {
-  Content: { Headers: { Subject: string[] } };
+  Subject: string;
+  ID: string;
+  From: { Address: string; Name: string };
+  To: Array<{ Address: string; Name: string }>;
 };
 
 type AllEmails = {
-  items: Email[];
+  messages: Email[];
+  total: number;
+  count: number;
 };
 
 const host = process.env.MAILHOG_HOST || 'localhost';
 
 export const getAllEmails = async (): Promise<AllEmails> => {
-  const res = await fetch(`http://${host}:8025/api/v2/messages`);
+  const res = await fetch(`http://${host}:8025/api/v1/messages`);
   return res.json() as Promise<AllEmails>;
 };
 
-export const getFirstEmail = (allEmails: { items: Email[] }) => {
-  return allEmails.items[0];
+export const getFirstEmail = (allEmails: { messages: Email[] }) => {
+  return allEmails.messages[0];
 };
 
-export const getSubject = (email: {
-  Content: { Headers: { Subject: string[] } };
-}) => {
-  return email.Content.Headers.Subject[0];
+export const getSubject = (email: { Subject: string }) => {
+  return email.Subject;
 };
 
 export const deleteAllEmails = async () => {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -87,9 +87,9 @@ export default defineConfig({
     // }
   ],
 
-  /* Some tests make the api send emails, so we need mailhog to catch them */
+  /* Some tests make the api send emails, so we need mailpit to catch them */
   webServer: {
-    command: 'docker run -d -p 1025:1025 -p 8025:8025 mailhog/mailhog',
+    command: 'docker run --rm -p 1025:1025 -p 8025:8025 axllent/mailpit',
     port: 1025,
     reuseExistingServer: true,
     timeout: 180000


### PR DESCRIPTION
This swaps MailHog for Mailpit, because the former is no longer maintained and doesn't even have `arm` images and I could never properly run our E2E tests.