### PR TITLE
fix: remove extra space from mt-8 class in tailwind pricing component

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-tailwind-pricing-component/6864dafe72087c517e80f6e0.md
+++ b/curriculum/challenges/english/blocks/workshop-tailwind-pricing-component/6864dafe72087c517e80f6e0.md
@@ -9,7 +9,7 @@ dashedName: step-9
 
 The `h1` text is too close to the top of the page and the text below it, so you should add some spacing around it.
 
-In addition to the existing ones, assign the utility classes `mt-8 ` and `mb-12` to the `h1`.
+In addition to the existing ones, assign the utility classes `mt-8` and `mb-12` to the `h1`.
 
 # --hints--
 


### PR DESCRIPTION


## Description
Fixed a typo in the workshop-tailwind-pricing-component where the `mt-8` utility class had an extra space between the backticks.

## Changes Made
- Removed the extra space from `mt-8 ` to `mt-8` in the curriculum file
- Location: `freeCodeCamp/curriculum/challenges/english/blocks/workshop-tailwind-pricing-component/6864dafe72087c517e80f6e0.md`

## Checklist:
- [x] I have read and followed the contribution guidelines
- [x] I have read and followed the how to open a pull request guide
- [x] My pull request targets the `main` branch of freeCodeCamp
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces

Closes : #62467