### PR TITLE
fix(client): allow transcript expanded state to not persist

### DIFF
--- a/client/src/templates/Challenges/components/challenge-transcript.test.tsx
+++ b/client/src/templates/Challenges/components/challenge-transcript.test.tsx
@@ -1,15 +1,16 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import store from 'store';
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import ChallengeTranscript from './challenge-transcript';
 
 const baseProps = {
-  transcript: 'Sample transcript text'
+  transcript: 'Sample transcript text',
+  shouldPersistExpanded: false
 };
 
 describe('<ChallengeTranscript />', () => {
-  beforeEach(() => {
+  afterEach(() => {
     store.clearAll();
   });
 
@@ -35,10 +36,26 @@ describe('<ChallengeTranscript />', () => {
     expect(screen.getByText('Sample transcript text')).not.toBeVisible();
   });
 
-  it("renders expanded when 'fcc-transcript-expanded = true'", () => {
+  it("renders expanded when 'fcc-transcript-expanded = true' and shouldPersistExpanded = true", () => {
     store.set('fcc-transcript-expanded', true);
-    render(<ChallengeTranscript {...baseProps} />);
+    render(<ChallengeTranscript {...baseProps} shouldPersistExpanded={true} />);
     expect(screen.getByTestId('challenge-transcript')).toHaveAttribute('open');
     expect(screen.getByText('Sample transcript text')).toBeVisible();
+  });
+
+  it('writes to localstorage when shouldPersistExpanded = true', () => {
+    const setSpy = vi.spyOn(store, 'set');
+    render(<ChallengeTranscript {...baseProps} shouldPersistExpanded={true} />);
+    fireEvent.click(screen.getByText('learn.transcript'));
+    expect(setSpy).toHaveBeenCalledWith('fcc-transcript-expanded', true);
+    setSpy.mockRestore();
+  });
+
+  it('does not write to localstorage when shouldPersistExpanded = false', () => {
+    const setSpy = vi.spyOn(store, 'set');
+    render(<ChallengeTranscript {...baseProps} />);
+    fireEvent.click(screen.getByText('learn.transcript'));
+    expect(setSpy).not.toHaveBeenCalled();
+    setSpy.mockRestore();
   });
 });

--- a/client/src/templates/Challenges/components/challenge-transcript.tsx
+++ b/client/src/templates/Challenges/components/challenge-transcript.tsx
@@ -7,21 +7,27 @@ import './challenge-transcript.css';
 
 interface ChallengeTranscriptProps {
   transcript: string;
+  shouldPersistExpanded?: boolean;
 }
 
 function ChallengeTranscript({
-  transcript
+  transcript,
+  shouldPersistExpanded
 }: ChallengeTranscriptProps): JSX.Element {
   const { t } = useTranslation();
 
   // default to collapsed
-  const [isOpen, setIsOpen] = useState(
-    () => (store.get('fcc-transcript-expanded') as boolean | null) ?? false
+  const [isOpen, setIsOpen] = useState(() =>
+    shouldPersistExpanded
+      ? (store.get('fcc-transcript-expanded') as boolean | null) ?? false
+      : false
   );
 
   function toggleExpandedState(e: React.MouseEvent<HTMLDetailsElement>) {
     e.preventDefault();
-    store.set('fcc-transcript-expanded', !isOpen);
+    if (shouldPersistExpanded) {
+      store.set('fcc-transcript-expanded', !isOpen);
+    }
     setIsOpen(!isOpen);
   }
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Language challenges use the `ChallengeTranscript` component to display the audio transcript. The component was previously used mainly for lectures in the Full Stack Developer curriculum, where persisting the expanded state was preferred. In language challenges, however, the transcript is meant as an accessibility aid, and we want to encourage campers to listen to the audio to complete the challenges.

After discussing with the Language Curricula team, we've decided that transcripts should be collapsed by default, and the expanded state should not persist across challenges. This adds some friction to opening the transcript.

One consequence of this change is that campers with audio issues or hearing impairments will now need to click to expand the transcript on each challenge. I think this is acceptable and we aren't putting them at a disadvantage, as other users would also have to click Play on every challenge to listen to the audio.

---

This PR adds a `shouldPersistExpanded` prop to the `ChallengeTranscript` component. This prop is false/undefined by default as the only places using this component are the language challenges (we no longer use this component in FSD).

Testing:
- Go to `/learn/a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/task-52`
- Verify that the transcript is collapsed by default
- Expand the transcript
- Go to `/learn/a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/task-53`
- Verify that the transcript is collapsed again

<!-- Feel free to add any additional description of changes below this line -->
