### PR TITLE
fix: remove extra space in tailwind class name in step-9 lesson

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-tailwind-pricing-component/6864dafe72087c517e80f6e0.md
+++ b/curriculum/challenges/english/blocks/workshop-tailwind-pricing-component/6864dafe72087c517e80f6e0.md
@@ -9,7 +9,7 @@ dashedName: step-9
 
 The `h1` text is too close to the top of the page and the text below it, so you should add some spacing around it.
 
-In addition to the existing ones, assign the utility classes `mt-8 ` and `mb-12` to the `h1`.
+In addition to the existing ones, assign the utility classes `mt-8` and `mb-12` to the `h1`.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine or GitHub Codespaces.

Closes #62467

### Description
This PR fixes a typo in the workshop Tailwind pricing component step-9 lesson by removing an extra space inside the `mt-8` utility class.

**Before:**
> In addition to the existing ones, assign the utility classes `mt-8 ` and `mb-12` to the `h1`.

**After:**
> In addition to the existing ones, assign the utility classes `mt-8` and `mb-12` to the `h1`.
