### PR TITLE
fix(curriculum): type attribute check and added new test case

### DIFF
--- a/curriculum/challenges/english/blocks/lab-html-audio-and-video-player/68de40f53fcaf106f51cc20f.md
+++ b/curriculum/challenges/english/blocks/lab-html-audio-and-video-player/68de40f53fcaf106f51cc20f.md
@@ -112,6 +112,37 @@ const typeAttr = source.getAttribute('type');
 assert.isNotEmpty(typeAttr);
 ```
 
+The `source` element must have a valid `type` attribute that correctly matches the file extension of its src.
+
+```js
+// Select the source element of the first video
+const section = document.querySelector('section');
+const source = section?.querySelector('h2 + video > source');
+
+// Get src and type
+const srcAttr = source?.getAttribute('src');
+const typeAttr = source?.getAttribute('type');
+
+// Ensure type attribute exists
+assert.isNotEmpty(typeAttr, 'The source element must have a type attribute');
+
+// Ensure src has a valid video extension
+const match = srcAttr?.match(/\.(mp4|webm|ogg|avi|mov)$/i);
+assert.isNotNull(match, 'The video src must have a valid extension');
+
+// Convert extension to MIME type
+const ext = match[1].toLowerCase();
+const expectedType = `video/${ext === 'ogv' ? 'ogg' : ext}`;
+
+// Verify type matches src extension
+assert.include(
+  typeAttr.toLowerCase(),
+  expectedType,
+  `Expected type="${expectedType}" for a .${ext} file`
+);
+
+```
+
 Inside the second `section` element, you should have an `h2` element for the title of the song playing.
 
 ```js


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #62503 

This pull request introduces a new test case for the **HTML Audio and Video Lab** to ensure that the type attribute of the <source> element correctly matches the file extension of the src attribute.

Previously, a mismatch between type and file extension (e.g. .mp4 file with video/ogg type) would still pass validation. This new test makes the lab more robust and semantically accurate

### Before Change
In the existing lab, this invalid combination passes the test:

`<source src="video.mp4" type="video/ogg" />
`
### Explanation
Here, if we check the code the `video source` file extension is `.mp4` but the `video type` is "video/ogg". It is wrong but still passed the test case .

<img width="1913" height="469" alt="image" src="https://github.com/user-attachments/assets/a074308c-57a5-41c0-b19e-c75c6ba9eafd" />

### After Change

**1)Inavlid Test Case** 

Here if we check the html code the `video source` file extension is `.mp4` but the `video type` is `video/ogg` . It is wrong so it is failed the test case.

<img width="1897" height="652" alt="Screenshot 2025-10-04 165135" src="https://github.com/user-attachments/assets/c1c3f511-c5cd-4ce1-98ff-e38cda02c521" />

**2) Valid Test Case**

Here, if we check the html code , the `video source` file extension and `type` is both matched. It is passed the test case.

<img width="1919" height="666" alt="Screenshot 2025-10-04 165206" src="https://github.com/user-attachments/assets/61315120-6255-48ef-9299-a667665a3613" />


Finally, it verifies that the type attribute contains the correct MIME value (e.g., video/mp4 for .mp4).

 

<!-- Feel free to add any additional description of changes below this line -->
