### PR TITLE
fix(curriculum): add test to ensure typeAttr matches srcAttr media type

### DIFF
--- a/curriculum/challenges/english/blocks/lab-html-audio-and-video-player/68de40f53fcaf106f51cc20f.md
+++ b/curriculum/challenges/english/blocks/lab-html-audio-and-video-player/68de40f53fcaf106f51cc20f.md
@@ -119,8 +119,16 @@ const section = document.querySelector('section');
 const source = section?.querySelector('h2 + video > source');
 const typeAttr = source.getAttribute('type');
 const srcAttr = source.getAttribute('src');
-const srcMediaType = 'video/' + srcAttr.match(/[^\.]+$/g)[0];
-assert.equal(typeAttr, srcMediaType);
+const srcFileExt = srcAttr.match(/[^\.]+$/g)[0];
+const fileExtToMediaTypes = {
+  mp4:    ['video/mp4'],
+  webm:   ['video/webm'],
+  ogg:    ['video/ogg'],
+  avi:    ['video/avi', 'video/vnd.avi', 'video/msvideo', 'video/x-msvideo'],
+  mov:    ['video/quicktime']
+};
+const srcMediaTypes = fileExtToMediaTypes[srcFileExt];
+assert.isTrue(srcMediaTypes.some((srcMediaType) => srcMediaType === typeAttr));
 ```
 
 Inside the second `section` element, you should have an `h2` element for the title of the song playing.

--- a/curriculum/challenges/english/blocks/lab-html-audio-and-video-player/68de40f53fcaf106f51cc20f.md
+++ b/curriculum/challenges/english/blocks/lab-html-audio-and-video-player/68de40f53fcaf106f51cc20f.md
@@ -128,7 +128,7 @@ const fileExtToMediaTypes = {
   mov:    ['video/quicktime']
 };
 const srcMediaTypes = fileExtToMediaTypes[srcFileExt];
-assert.isTrue(srcMediaTypes.some((srcMediaType) => srcMediaType === typeAttr));
+assert.oneOf(typeAttr, fileExtToMediaTypes);
 ```
 
 Inside the second `section` element, you should have an `h2` element for the title of the song playing.

--- a/curriculum/challenges/english/blocks/lab-html-audio-and-video-player/68de40f53fcaf106f51cc20f.md
+++ b/curriculum/challenges/english/blocks/lab-html-audio-and-video-player/68de40f53fcaf106f51cc20f.md
@@ -121,11 +121,11 @@ const typeAttr = source.getAttribute('type');
 const srcAttr = source.getAttribute('src');
 const srcFileExt = srcAttr.match(/[^\.]+$/g)[0];
 const fileExtToMediaTypes = {
-  mp4:    ['video/mp4'],
-  webm:   ['video/webm'],
-  ogg:    ['video/ogg'],
-  avi:    ['video/avi', 'video/vnd.avi', 'video/msvideo', 'video/x-msvideo'],
-  mov:    ['video/quicktime']
+  mp4: ['video/mp4'],
+  webm: ['video/webm'],
+  ogg: ['video/ogg'],
+  avi: ['video/avi', 'video/vnd.avi', 'video/msvideo', 'video/x-msvideo'],
+  mov: ['video/quicktime']
 };
 const srcMediaTypes = fileExtToMediaTypes[srcFileExt];
 assert.oneOf(typeAttr, srcMediaTypes);

--- a/curriculum/challenges/english/blocks/lab-html-audio-and-video-player/68de40f53fcaf106f51cc20f.md
+++ b/curriculum/challenges/english/blocks/lab-html-audio-and-video-player/68de40f53fcaf106f51cc20f.md
@@ -112,6 +112,17 @@ const typeAttr = source.getAttribute('type');
 assert.isNotEmpty(typeAttr);
 ```
 
+The `type` attribute should match the media type of the file extension of the `src` attribute.
+
+```js
+const section = document.querySelector('section');
+const source = section?.querySelector('h2 + video > source');
+const typeAttr = source.getAttribute('type');
+const srcAttr = source.getAttribute('src');
+const srcMediaType = 'video/' + srcAttr.match(/[^\/\.]+$/g)[0];
+assert.equal(typeAttr, srcMediaType);
+```
+
 Inside the second `section` element, you should have an `h2` element for the title of the song playing.
 
 ```js

--- a/curriculum/challenges/english/blocks/lab-html-audio-and-video-player/68de40f53fcaf106f51cc20f.md
+++ b/curriculum/challenges/english/blocks/lab-html-audio-and-video-player/68de40f53fcaf106f51cc20f.md
@@ -128,7 +128,7 @@ const fileExtToMediaTypes = {
   mov:    ['video/quicktime']
 };
 const srcMediaTypes = fileExtToMediaTypes[srcFileExt];
-assert.oneOf(typeAttr, fileExtToMediaTypes);
+assert.oneOf(typeAttr, srcMediaTypes);
 ```
 
 Inside the second `section` element, you should have an `h2` element for the title of the song playing.

--- a/curriculum/challenges/english/blocks/lab-html-audio-and-video-player/68de40f53fcaf106f51cc20f.md
+++ b/curriculum/challenges/english/blocks/lab-html-audio-and-video-player/68de40f53fcaf106f51cc20f.md
@@ -119,7 +119,7 @@ const section = document.querySelector('section');
 const source = section?.querySelector('h2 + video > source');
 const typeAttr = source.getAttribute('type');
 const srcAttr = source.getAttribute('src');
-const srcMediaType = 'video/' + srcAttr.match(/[^\/\.]+$/g)[0];
+const srcMediaType = 'video/' + srcAttr.match(/[^\.]+$/g)[0];
 assert.equal(typeAttr, srcMediaType);
 ```
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #62503

<!-- Feel free to add any additional description of changes below this line -->

For the `<source>` element inside the `<video>` element: I added a test to assert equality of the `type` attribute and the media type of the `src` attribute.
