### PR TITLE
Add space before ? in toggle text example (step 13) — fixes #62494

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-toggle-text-app/67cd61c24bfc0a240132fd2f.md
+++ b/curriculum/challenges/english/blocks/workshop-toggle-text-app/67cd61c24bfc0a240132fd2f.md
@@ -14,7 +14,7 @@ Earlier, you reviewed how to work with inline conditional rendering. You are goi
 Here is an example of using the ternary operator to conditionally show the words `Hide` and `Show`:
 
 ```jsx
-<button>{isMenuVisible? "Hide" : "Show"} Menu</button>
+<button>{isMenuVisible ? "Hide" : "Show"} Menu</button>
 ```
 
 For the last step of the workshop, use the ternary operator to conditionally display the words `Hide` or `Show` for the message button. Place the condition before the `Message` text so it displays `Show Message` or `Hide Message`.


### PR DESCRIPTION
## Description
This pull request fixes a small formatting issue in the "toggle text example" step (step 13).
Added a space before the `?` in the JSX expression for better readability.

## Change Details
**File modified:**
`curriculum/challenges/english/blocks/workshop-toggle-text-app/67cd61c24bfc0a240132fd2f.md`

**Change made:**
```diff
- <button>{isMenuVisible? "Hide" : "Show"} Menu</button>
+ <button>{isMenuVisible ? "Hide" : "Show"} Menu</button>

