### PR TITLE
fix(curriculum): correct typo in step-9 of Tailwind Pricing Component

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-tailwind-pricing-component/6864dafe72087c517e80f6e0.md
+++ b/curriculum/challenges/english/blocks/workshop-tailwind-pricing-component/6864dafe72087c517e80f6e0.md
@@ -9,7 +9,7 @@ dashedName: step-9
 
 The `h1` text is too close to the top of the page and the text below it, so you should add some spacing around it.
 
-In addition to the existing ones, assign the utility classes `mt-8 ` and `mb-12` to the `h1`.
+In addition to the existing ones, assign the utility classes `mt-8` and `mb-12` to the `h1`.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #62467

This pull request fixes a minor typo in the description of Step 9 in the Tailwind Pricing Component Workshop.

It removes an unintended trailing space in the class name `mt-8 ` so that it reads correctly as `mt-8`. This improves clarity for learners and aligns with the hint tests provided.
