### PR TITLE
fix(client): apply i18n prefix to test-runner

### DIFF
--- a/client/gatsby-config.js
+++ b/client/gatsby-config.js
@@ -5,11 +5,11 @@ const {
   replaceChallengeNodes,
   localeChallengesRootDir
 } = require('./utils/build-challenges');
+const { pathPrefix } = require('./utils/gatsby/path-prefix');
 
-const { clientLocale, curriculumLocale, homeLocation } = envData;
+const { curriculumLocale, homeLocation } = envData;
 
 const curriculumIntroRoot = path.resolve(__dirname, './src/pages');
-const pathPrefix = clientLocale === 'english' ? '' : '/' + clientLocale;
 
 module.exports = {
   flags: {

--- a/client/src/templates/Challenges/utils/frame.ts
+++ b/client/src/templates/Challenges/utils/frame.ts
@@ -12,6 +12,7 @@ import type {
   PythonDocument
 } from '../../../../../tools/client-plugins/browser-scripts';
 import { Hooks } from '../../../redux/prop-types';
+import { pathPrefix } from '../../../../utils/gatsby/path-prefix';
 
 export const helperVersion = _helperVersion;
 
@@ -85,7 +86,7 @@ export const scrollManager = new ScrollManager();
 export const mainPreviewId = 'fcc-main-frame';
 // the project preview frame demos the finished project
 export const projectPreviewId = 'fcc-project-preview-frame';
-const ASSET_PATH = `/js/test-runner/${helperVersion}/`;
+const ASSET_PATH = `${pathPrefix}/js/test-runner/${helperVersion}/`;
 
 const DOCUMENT_NOT_FOUND_ERROR = 'misc.document-notfound';
 

--- a/client/utils/gatsby/path-prefix.js
+++ b/client/utils/gatsby/path-prefix.js
@@ -1,0 +1,5 @@
+const envData = require('../../config/env.json');
+
+const { clientLocale } = envData;
+
+exports.pathPrefix = clientLocale === 'english' ? '' : '/' + clientLocale;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Otherwise it always tries to use the root e.g. fcc.org/js/...

If we can deploy new i18n clients then https://github.com/freeCodeCamp/freeCodeCamp/issues/62509 will be closed by this, otherwise we need to host the missing test-runner versions at the root. i.e. https://www.freecodecamp.org/js/test-runner/5.4.1/index.js and related files need to exist as well as 6.0.1.

<!-- Feel free to add any additional description of changes below this line -->
