### PR TITLE
fix(curriculum): remove unnecessary punctuation from MCQ answers

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-html-tools/672a511bb408ec81c592eb68.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-html-tools/672a511bb408ec81c592eb68.md
@@ -57,7 +57,7 @@ What is the process of finding and fixing bugs in your code called?
 
 ## --answers--
 
-Scanning.
+Scanning
 
 ### --feedback--
 
@@ -65,7 +65,7 @@ Review the beginning of the lesson where this was discussed.
 
 ---
 
-Building.
+Building
 
 ### --feedback--
 
@@ -73,11 +73,11 @@ Review the beginning of the lesson where this was discussed.
 
 ---
 
-Debugging.
+Debugging
 
 ---
 
-Scripting.
+Scripting
 
 ### --feedback--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #62529

<!-- Feel free to add any additional description of changes below this line -->

Removed unnecessary full stops from first comprehension question answers in "How to Use the DOM Inspector and DevTools to Debug and Build Your Projects" lecture since they are not full sentences.