### PR TITLE
fix(api): can take exam if attempt not expired

### DIFF
--- a/api/prisma/exam-environment.prisma
+++ b/api/prisma/exam-environment.prisma
@@ -14,7 +14,6 @@ model ExamEnvironmentExam {
   /// The default must be incremented by 1, if anything in the schema changes
   version       Int                          @default(2)
 
-
   // Relations
   generatedExams           ExamEnvironmentGeneratedExam[]
   examAttempts             ExamEnvironmentExamAttempt[]
@@ -140,7 +139,6 @@ model ExamEnvironmentExamAttempt {
   /// The default must be incremented by 1, if anything in the schema changes
   version       Int                                 @default(2)
 
-
   // Relations
   user                          user                            @relation(fields: [userId], references: [id], onDelete: Cascade)
   exam                          ExamEnvironmentExam             @relation(fields: [examId], references: [id], onDelete: Cascade)
@@ -180,7 +178,6 @@ model ExamEnvironmentGeneratedExam {
   /// The default must be incremented by 1, if anything in the schema changes
   version      Int                                   @default(1)
 
-
   // Relations
   exam           ExamEnvironmentExam          @relation(fields: [examId], references: [id], onDelete: Cascade)
   EnvExamAttempt ExamEnvironmentExamAttempt[]
@@ -208,7 +205,6 @@ model ExamEnvironmentChallenge {
 
   version Int @default(1)
 
-
   exam ExamEnvironmentExam @relation(fields: [examId], references: [id], onDelete: Cascade)
 }
 
@@ -219,7 +215,6 @@ model ExamEnvironmentAuthorizationToken {
   expireAt DateTime @db.Date
   userId   String   @unique @db.ObjectId
   version  Int      @default(1)
-
 
   // Relations
   user user @relation(fields: [userId], references: [id], onDelete: Cascade)
@@ -238,12 +233,11 @@ model ExamEnvironmentExamModeration {
   /// Foreign key to moderator. This is `null` until the item is moderated.
   moderatorId    String?                             @db.ObjectId
 
-  /// Date the exam attempt was added to the moderation queue
+  /// Date the exam attempt expired
   submissionDate DateTime @default(now()) @db.Date
   /// Version of the record
   /// The default must be incremented by 1, if anything in the schema changes
-  version        Int      @default(1)
-
+  version        Int      @default(2)
 
   // Relations
   examAttempt ExamEnvironmentExamAttempt @relation(fields: [examAttemptId], references: [id], onDelete: Cascade)

--- a/api/src/exam-environment/routes/exam-environment.ts
+++ b/api/src/exam-environment/routes/exam-environment.ts
@@ -812,8 +812,17 @@ async function getExams(
       : exam.config.retakeTimeInMS;
     const retakeDateInMS =
       lastAttemptStartTime + examTotalTimeInMS + examRetakeTimeInMS;
-    const isRetakeTimePassed = Date.now() > retakeDateInMS;
 
+    const lastAttemptExpired =
+      Date.now() > lastAttemptStartTime + examTotalTimeInMS;
+    if (!lastAttemptExpired) {
+      logger.info(`Exam ${exam.id} in progress.`);
+      availableExam.canTake = true;
+      availableExams.push(availableExam);
+      continue;
+    }
+
+    const isRetakeTimePassed = Date.now() > retakeDateInMS;
     if (!isRetakeTimePassed) {
       logger.info(`Time until retake: ${retakeDateInMS - Date.now()} [ms]`);
       availableExam.canTake = false;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Makes a small doc-comment change about the submission time in the moderation record being when the attempt expires. The reason for this is to allow the attempt/moderation to be moderated at the earliest possible time - being more fair to when the Camper submitted (expired). See: https://github.com/freeCodeCamp/exam-services/commit/34f9c38e3d03d53380ba3c90fb0243809779b124