### PR TITLE
fix(client): update 25 tier ab test

### DIFF
--- a/client/src/components/Donation/multi-tier-donation-form.tsx
+++ b/client/src/components/Donation/multi-tier-donation-form.tsx
@@ -183,15 +183,8 @@ const MultiTierDonationForm: React.FC<MultiTierDonationFormProps> = ({
   const [showDonateForm, setShowDonateForm] = useState(false);
 
   useEffect(() => {
-    const availableAmounts = replace20With25
-      ? subscriptionAmountsB
-      : subscriptionAmounts;
-    if (!availableAmounts.includes(donationAmount)) {
-      setDonationAmount(
-        replace20With25 ? defaultTierAmountB : defaultTierAmount
-      );
-    }
-  }, [donationAmount, replace20With25]);
+    setDonationAmount(replace20With25 ? defaultTierAmountB : defaultTierAmount);
+  }, [replace20With25]);
 
   useEffect(() => {
     if (setShowHeaderAndFooter) setShowHeaderAndFooter(!showDonateForm);

--- a/client/src/components/Donation/multi-tier-donation-form.tsx
+++ b/client/src/components/Donation/multi-tier-donation-form.tsx
@@ -83,7 +83,7 @@ function SelectionTabs({
         <Spacer size='xs' />
         <Tabs
           className={'donate-btn-group'}
-          defaultValue={donationAmount.toString()}
+          value={donationAmount.toString()}
           onValueChange={switchTab}
         >
           <TabsList className='nav-lists'>
@@ -181,6 +181,17 @@ const MultiTierDonationForm: React.FC<MultiTierDonationFormProps> = ({
   );
 
   const [showDonateForm, setShowDonateForm] = useState(false);
+
+  useEffect(() => {
+    const availableAmounts = replace20With25
+      ? subscriptionAmountsB
+      : subscriptionAmounts;
+    if (!availableAmounts.includes(donationAmount)) {
+      setDonationAmount(
+        replace20With25 ? defaultTierAmountB : defaultTierAmount
+      );
+    }
+  }, [donationAmount, replace20With25]);
 
   useEffect(() => {
     if (setShowHeaderAndFooter) setShowHeaderAndFooter(!showDonateForm);

--- a/client/src/pages/donate.tsx
+++ b/client/src/pages/donate.tsx
@@ -1,6 +1,5 @@
 import { Container, Col, Row, Spacer } from '@freecodecamp/ui';
 import type { TFunction } from 'i18next';
-import { useGrowthBook } from '@growthbook/growthbook-react';
 import React, { useEffect } from 'react';
 import Helmet from 'react-helmet';
 import { withTranslation } from 'react-i18next';
@@ -61,7 +60,6 @@ function DonatePage({
       action: `Displayed Donate Page`
     });
   }, []);
-  const growthbook = useGrowthBook();
 
   return showLoading ? (
     <Loader fullScreen={true} />

--- a/client/src/pages/donate.tsx
+++ b/client/src/pages/donate.tsx
@@ -1,5 +1,6 @@
 import { Container, Col, Row, Spacer } from '@freecodecamp/ui';
 import type { TFunction } from 'i18next';
+import { useGrowthBook } from '@growthbook/growthbook-react';
 import React, { useEffect } from 'react';
 import Helmet from 'react-helmet';
 import { withTranslation } from 'react-i18next';
@@ -60,8 +61,9 @@ function DonatePage({
       action: `Displayed Donate Page`
     });
   }, []);
+  const growthbook = useGrowthBook();
 
-  return showLoading ? (
+  return showLoading || !growthbook || !growthbook.ready ? (
     <Loader fullScreen={true} />
   ) : (
     <>

--- a/client/src/pages/donate.tsx
+++ b/client/src/pages/donate.tsx
@@ -63,7 +63,7 @@ function DonatePage({
   }, []);
   const growthbook = useGrowthBook();
 
-  return showLoading || !growthbook || !growthbook.ready ? (
+  return showLoading ? (
     <Loader fullScreen={true} />
   ) : (
     <>


### PR DESCRIPTION
This pr fixes the issue where growthbook loads after the page load and causes the following issue:

<img width="1728" height="957" alt="Screenshot 2025-10-06 at 2 20 10 PM" src="https://github.com/user-attachments/assets/6532c818-b771-44f3-b4b4-09a20658c679" />

The AB test is currently turned off.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
