### PR TITLE
fix(client): expand explanation on input change

### DIFF
--- a/client/src/templates/Challenges/components/challenge-explanation.tsx
+++ b/client/src/templates/Challenges/components/challenge-explanation.tsx
@@ -7,16 +7,18 @@ import './challenge-explanation.css';
 
 interface ChallengeExplanationProps {
   explanation: string;
+  isExpanded?: boolean;
 }
 
 function ChallengeExplanation({
-  explanation
+  explanation,
+  isExpanded
 }: ChallengeExplanationProps): JSX.Element {
   const { t } = useTranslation();
 
   return (
     <>
-      <details>
+      <details open={isExpanded}>
         <summary className='challenge-summary'>
           {t('learn.explanation')}
         </summary>

--- a/client/src/templates/Challenges/fill-in-the-blank/show.tsx
+++ b/client/src/templates/Challenges/fill-in-the-blank/show.tsx
@@ -17,7 +17,7 @@ import LearnLayout from '../../../components/layouts/learn';
 import { ChallengeNode, ChallengeMeta, Test } from '../../../redux/prop-types';
 import Hotkeys from '../components/hotkeys';
 import ChallengeTitle from '../components/challenge-title';
-import ChallegeExplanation from '../components/challenge-explanation';
+import ChallengeExplanation from '../components/challenge-explanation';
 import CompletionModal from '../components/completion-modal';
 import HelpModal from '../components/help-modal';
 import FillInTheBlanks from '../components/fill-in-the-blanks';
@@ -111,6 +111,7 @@ const ShowFillInTheBlank = ({
   const [allBlanksFilled, setAllBlanksFilled] = useState(false);
   const [feedback, setFeedback] = useState<string | null>(null);
   const [showFeedback, setShowFeedback] = useState(false);
+  const [isExplanationExpanded, setIsExplanationExpanded] = useState(false);
 
   const container = useRef<HTMLElement | null>(null);
 
@@ -164,12 +165,17 @@ const ShowFillInTheBlank = ({
     const inputIndex = parseInt(e.target.getAttribute('data-index') as string);
 
     const newUserAnswers = [...userAnswers];
-    newUserAnswers[inputIndex] = e.target.value;
+    const newValue = e.target.value;
+    newUserAnswers[inputIndex] = newValue;
 
     const newAnswersCorrect = [...answersCorrect];
     newAnswersCorrect[inputIndex] = null;
 
     const allBlanksFilled = newUserAnswers.every(a => a);
+
+    if (!isExplanationExpanded && newValue.trim() !== '') {
+      setIsExplanationExpanded(true);
+    }
 
     setUserAnswers(newUserAnswers);
     setAnswersCorrect(newAnswersCorrect);
@@ -238,7 +244,10 @@ const ShowFillInTheBlank = ({
               </ObserveKeys>
 
               {explanation ? (
-                <ChallegeExplanation explanation={explanation} />
+                <ChallengeExplanation
+                  explanation={explanation}
+                  isExpanded={isExplanationExpanded}
+                />
               ) : (
                 <Spacer size='m' />
               )}

--- a/client/src/templates/Challenges/generic/show.tsx
+++ b/client/src/templates/Challenges/generic/show.tsx
@@ -160,6 +160,8 @@ const ShowGeneric = ({
     questions.map<number | null>(() => null)
   );
 
+  const [isExplanationExpanded, setIsExplanationExpanded] = useState(false);
+
   const [hasAnsweredMcqCorrectly, sethasAnsweredMcqCorrectly] = useState(true);
 
   const [showFeedback, setShowFeedback] = useState(false);
@@ -173,6 +175,9 @@ const ShowGeneric = ({
         index === questionIndex ? answerIndex : option
       )
     );
+    if (!isExplanationExpanded) {
+      setIsExplanationExpanded(true);
+    }
   };
 
   const handleSubmit = () => {
@@ -282,7 +287,10 @@ const ShowGeneric = ({
               )}
 
               {explanation ? (
-                <ChallengeExplanation explanation={explanation} />
+                <ChallengeExplanation
+                  explanation={explanation}
+                  isExpanded={isExplanationExpanded}
+                />
               ) : null}
 
               {!hasAnsweredMcqCorrectly && (

--- a/e2e/fill-in-the-blanks.spec.ts
+++ b/e2e/fill-in-the-blanks.spec.ts
@@ -1,10 +1,67 @@
+import fs from 'fs';
+import path from 'path';
 import { test, expect } from '@playwright/test';
+
+interface FillInTheBlank {
+  sentence: string;
+  blanks: Array<{
+    answer: string;
+    feedback: string | null;
+  }>;
+}
+
+interface Fixture extends FillInTheBlank {
+  explanation?: string;
+}
+
+interface PageData {
+  result: {
+    data: {
+      challengeNode: {
+        challenge: {
+          fillInTheBlank: FillInTheBlank;
+          explanation?: string;
+        };
+      };
+    };
+  };
+}
+
+const challengePath =
+  '/learn/a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/task-47';
 
 test.describe('Fill in the blanks challenge', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto(
-      '/learn/a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/task-47'
+    const fixturePath = path.join(
+      __dirname,
+      'fixtures',
+      'fill-in-the-blank-fixture.json'
     );
+    const fixture = JSON.parse(fs.readFileSync(fixturePath, 'utf8')) as Fixture;
+
+    // Intercept Gatsby page-data and inject a deterministic fill-in-the-blank fixture
+    await page.route(
+      `**/page-data${challengePath}/page-data.json`,
+      async route => {
+        const response = await route.fetch();
+        const body = await response.text();
+
+        const pageData = JSON.parse(body) as PageData;
+        pageData.result.data.challengeNode.challenge.fillInTheBlank = {
+          sentence: fixture.sentence,
+          blanks: fixture.blanks
+        };
+        pageData.result.data.challengeNode.challenge.explanation =
+          fixture.explanation;
+
+        await route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify(pageData)
+        });
+      }
+    );
+
+    await page.goto(challengePath);
   });
 
   test('should display feedback if there is an incorrect answer', async ({
@@ -12,8 +69,8 @@ test.describe('Fill in the blanks challenge', () => {
   }) => {
     const blanks = page.getByRole('textbox', { name: 'blank' });
 
-    await blanks.first().fill('this'); // Answer the first blank correctly
-    await blanks.last().fill('bar'); // Answer the second blank incorrectly
+    await blanks.first().fill('foo'); // Answer the first blank correctly
+    await blanks.last().fill('wrong'); // Answer the second blank incorrectly
     await page.getByRole('button', { name: 'Check your answer' }).click();
 
     await expect(
@@ -31,8 +88,8 @@ test.describe('Fill in the blanks challenge', () => {
   }) => {
     const blanks = page.getByRole('textbox', { name: 'blank' });
 
-    await blanks.first().fill('this');
-    await blanks.last().fill('those');
+    await blanks.first().fill('foo');
+    await blanks.last().fill('bar');
     await page.getByRole('button', { name: 'Check your answer' }).click();
 
     // Close the completion modal
@@ -47,5 +104,22 @@ test.describe('Fill in the blanks challenge', () => {
 
     // There aren't any blanks as all the inputs are rendered as text
     await expect(blanks).toBeHidden();
+  });
+
+  test('should expand explanation when input is non-whitespace', async ({
+    page
+  }) => {
+    const blanks = page.getByRole('textbox', { name: 'blank' });
+    const explanationDetails = page.locator(
+      'details:has(summary:has-text("Explanation"))'
+    );
+
+    // Fill with only spaces
+    await blanks.first().fill('   ');
+    await expect(explanationDetails).not.toHaveAttribute('open', '');
+
+    // Fill with non-whitespace
+    await blanks.first().fill('foo');
+    await expect(explanationDetails).toHaveAttribute('open', '');
   });
 });

--- a/e2e/fixtures/fill-in-the-blank-fixture.json
+++ b/e2e/fixtures/fill-in-the-blank-fixture.json
@@ -1,0 +1,14 @@
+{
+  "sentence": "<p>This is BLANK simple BLANK with two blanks.</p>",
+  "blanks": [
+    {
+      "answer": "foo",
+      "feedback": "This is the first blank feedback."
+    },
+    {
+      "answer": "bar",
+      "feedback": "This is the second blank feedback."
+    }
+  ],
+  "explanation": "Test explanation."
+}


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Currently, language tasks have an explanation section at the bottom of the challenge page. This section is optional and always collapsed by default, which can be inconvenient for campers who want to read it.

After discussing with the Language Curricula team, we decided to update the disclosure behavior so that it expands when:

- An MCQ option is selected
- A blank is filled

We know this isn’t ideal, since ideally the section would expand only after the answer is validated. However, implementing that would be more involved because:
- When campers click "Check your answer" and get it correct, a completion modal appears. Most would likely move to the next challenge instead of closing the modal to read the explanation.
- We could change the submit button to skip the modal and become "Go to next challenge", but that would require adding a progress indicator to the page.
- Even then, the UX would be awkward — the explanation would expand after the "Check your answer" button is clicked, pushing the (now "Go to next challenge") button further down and forcing campers to scroll.

We're going with this approach for now, until we can do a larger UI revamp that aligns the layout with coding challenges and keeps everything in view. The explanation would then appear below the "Check your answer" / "Go to next challenge button".

<!-- Feel free to add any additional description of changes below this line -->
