### PR TITLE
fix(docker): consistently use DB everywhere

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,33 +1,49 @@
 services:
   devcontainer:
     depends_on:
-      - mongo-db
-      - mongo-setup
+      - db
+      - setup
     image: mcr.microsoft.com/devcontainers/typescript-node:22
     volumes:
       - ../..:/workspaces:cached
-    network_mode: service:mongo-db
+    network_mode: service:db
     command: sleep infinity
 
-  mongo-db:
-    image: mongo
+  db:
+    image: mongo:8.0
+    container_name: mongodb
     command: mongod --replSet rs0
     restart: unless-stopped
     hostname: mongodb
     volumes:
-      - mongodb-data:/data/db
-  mongo-setup:
-    image: mongo
+      - db-data:/data/db
+    healthcheck:
+      test: ['CMD', 'mongosh', '--eval', "db.adminCommand('ping')"]
+      interval: 2s
+      retries: 5
+
+  setup:
+    image: mongo:8.0
     depends_on:
-      - mongo-db
+      db:
+        condition: service_healthy
     restart: on-failure
-    entrypoint: [
-        'bash',
-        '-c',
-        # This will try to initiate the replica set, until it succeeds twice (i.e. until the replica set is already initialized)
-        'mongosh --host mongo-db:27017 --eval ''try {var cfg = { _id: "rs0", members: [{ _id: 0, host: "mongodb:27017" }] }; rs.initiate(cfg); } catch (err) { if(err.codeName !== "AlreadyInitialized") throw err };'''
-      ]
+    # This will try to initiate the replica set, until it succeeds twice (i.e. until the replica set is already initialized)
+    command: >
+      mongosh --host mongodb:27017 --eval '
+        var cfg = {
+          _id: "rs0",
+          members: [
+            { _id: 0, host: "mongodb:27017" }
+          ]
+        };
+        try {
+          rs.initiate(cfg);
+        } catch (err) {
+          if(err.codeName !== "AlreadyInitialized") throw err;
+        }
+      '
 
 volumes:
-  mongodb-data:
+  db-data:
     driver: local

--- a/.github/workflows/e2e-third-party.yml
+++ b/.github/workflows/e2e-third-party.yml
@@ -94,15 +94,6 @@ jobs:
       matrix:
         browsers: [chromium]
         node-version: [22]
-    services:
-      mongodb:
-        image: mongo:8.0
-        ports:
-          - 27017:27017
-      mailpit:
-        image: axllent/mailpit
-        ports:
-          - 1025:1025
     steps:
       - name: Set Action Environment Variables
         run: |

--- a/.github/workflows/node.js-tests.yml
+++ b/.github/workflows/node.js-tests.yml
@@ -141,11 +141,7 @@ jobs:
           cat .env
 
       - name: Start MongoDB
-        uses: supercharge/mongodb-github-action@b0a1493307c4e9b82ed61f3858d606c5ff190c64 # v1.10.0
-        with:
-          mongodb-version: 8.0
-          mongodb-replica-set: test-rs
-          mongodb-port: 27017
+        run: docker compose -f docker/docker-compose.yml up -d
 
       - name: Install Dependencies
         run: |
@@ -192,11 +188,7 @@ jobs:
           cat .env
 
       - name: Start MongoDB
-        uses: supercharge/mongodb-github-action@b0a1493307c4e9b82ed61f3858d606c5ff190c64 # v1.10.0
-        with:
-          mongodb-version: 8.0
-          mongodb-replica-set: test-rs
-          mongodb-port: 27017
+        run: docker compose -f docker/docker-compose.yml up -d
 
       - name: Install Dependencies
         run: |

--- a/docker/docker-compose.e2e.yml
+++ b/docker/docker-compose.e2e.yml
@@ -12,8 +12,8 @@ services:
     environment:
       # The api cannot connect to mongodb or mailpit via localhost from inside the
       # container, so we have to override these variables.
-      - MONGOHQ_URL=mongodb://db:27017/freecodecamp?directConnection=true
-      - MAILHOG_HOST=mailpit
+      - MONGOHQ_URL=mongodb://mongodb:27017/freecodecamp?replicaSet=rs0
+      - MAILPIT_HOST=mailpit
       - HOST=0.0.0.0
     ports:
       - '3000:3000'

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: mongo
+    image: mongo:8.0
     container_name: mongodb
     command: mongod --replSet rs0
     restart: unless-stopped
@@ -15,14 +15,14 @@ services:
       retries: 5
 
   setup:
-    image: mongo
+    image: mongo:8.0
     depends_on:
       db:
         condition: service_healthy
     restart: on-failure
     # This will try to initiate the replica set, until it succeeds twice (i.e. until the replica set is already initialized)
     command: >
-      mongosh --host db:27017 --eval '
+      mongosh --host mongodb:27017 --eval '
         var cfg = {
           _id: "rs0",
           members: [


### PR DESCRIPTION
This should make it so that we are using the `docker/docker-compose.yml` for setting up the DB everywhere including the CI or local machines. There is accompanying change to devcontainers compose file too.

Point to note is the DB service name is `db` but the hostname is set as `mongodb`