### PR TITLE
fix(tools): adjust challenge editor terminal path to match new curriculum structure

### DIFF
--- a/tools/challenge-editor/client/src/components/block/block.tsx
+++ b/tools/challenge-editor/client/src/components/block/block.tsx
@@ -102,8 +102,8 @@ const Block = () => {
           <p>
             Looking to add or remove challenges? Navigate to <br />
             <code>
-              freeCodeCamp/curriculum/challenges/english
-              {`/${params.block}/`}
+              curriculum/challenges/english/blocks
+              {`/${params.block}`}
             </code>
             <br />
             in your terminal and run the following commands:
@@ -140,8 +140,8 @@ const Block = () => {
           <p>
             Looking to add or remove challenges? Navigate to <br />
             <code>
-              freeCodeCamp/curriculum/challenges/english
-              {`/${params.superblock}/${params.block}/`}
+              curriculum/challenges/english/blocks
+              {`/${params.block}`}
             </code>
             <br />
             in your terminal and run the following commands:

--- a/tools/challenge-editor/client/src/components/chapter-based-block/chapter-block.tsx
+++ b/tools/challenge-editor/client/src/components/chapter-based-block/chapter-block.tsx
@@ -106,8 +106,8 @@ const ChapterBasedBlock = () => {
           <p>
             Looking to add or remove challenges? Navigate to <br />
             <code>
-              freeCodeCamp/curriculum/challenges/english
-              {`/${params.block}/`}
+              curriculum/challenges/english/blocks
+              {`/${params.block}`}
             </code>
             <br />
             in your terminal and run the following commands:
@@ -144,8 +144,8 @@ const ChapterBasedBlock = () => {
           <p>
             Looking to add or remove challenges? Navigate to <br />
             <code>
-              freeCodeCamp/curriculum/challenges/english
-              {`/${params.superblock}/${params.block}/`}
+              curriculum/challenges/english/blocks
+              {`/${params.block}`}
             </code>
             <br />
             in your terminal and run the following commands:


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #62572

I decided that `freeCodeCamp/` wasn't necessary. I think we can savely assume that the user is already in the freeCodeCamp directory, but let me know if you guys think otherwise. 

<!-- Feel free to add any additional description of changes below this line -->
