### PR TITLE
fix(curriculum): correct tuple typo in test description (Build a User…

### DIFF
--- a/curriculum/challenges/english/blocks/lab-user-configuration-manager/684aaf9ec670c68d20efd0d0.md
+++ b/curriculum/challenges/english/blocks/lab-user-configuration-manager/684aaf9ec670c68d20efd0d0.md
@@ -115,7 +115,7 @@ The `add_setting` function should have two parameters.
 })
 ```
 
-`add_setting({'theme': 'light'}, ('THEME': 'dark'))` should return the error message `Setting 'theme' already exists! Cannot add a new setting with this name.`.
+`add_setting({'theme', 'light'}, ('THEME', 'dark'))` should return the error message `Setting 'theme' already exists! Cannot add a new setting with this name.`.
 
 ```js
 ({


### PR DESCRIPTION
… Configuration Manager - Step 6) - closes #62566

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ x] My pull request targets the `main` branch of freeCodeCamp.
- [ x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #62566

<!-- Feel free to add any additional description of changes below this line -->
### What is fixed
This PR corrects a small typo in the Test 6 description for the "Build a User Configuration Manager" lab.

**Before**
`add_setting({'theme': 'light'}, ('THEME': 'dark'))` ...

**After**
`add_setting({'theme': 'light'}, ('THEME', 'dark'))` ...

This changes a colon to a comma inside the tuple in the example, which matches Python tuple syntax and fixes the confusing example.
