### PR TITLE
fix(curriculum): add spacing in ternary operator example (Toggle Text App step 13) — closes #62494

### DIFF
--- a/curriculum/challenges/english/blocks/lab-user-configuration-manager/684aaf9ec670c68d20efd0d0.md
+++ b/curriculum/challenges/english/blocks/lab-user-configuration-manager/684aaf9ec670c68d20efd0d0.md
@@ -128,7 +128,7 @@ The `add_setting` function should have two parameters.
 })
 ```
 
-`add_setting({'theme': 'light'}, ('volume', 'high')` should add a new key-value pair and return the success message `Setting 'volume' added with value 'high' successfully!`.
+`add_setting({'theme': 'light'}, ('volume', 'high'))` should add a new key-value pair and return the success message `Setting 'volume' added with value 'high' successfully!`.
 
 ```js
 ({

--- a/curriculum/challenges/english/blocks/workshop-toggle-text-app/67cd61c24bfc0a240132fd2f.md
+++ b/curriculum/challenges/english/blocks/workshop-toggle-text-app/67cd61c24bfc0a240132fd2f.md
@@ -14,7 +14,7 @@ Earlier, you reviewed how to work with inline conditional rendering. You are goi
 Here is an example of using the ternary operator to conditionally show the words `Hide` and `Show`:
 
 ```jsx
-<button>{isMenuVisible? "Hide" : "Show"} Menu</button>
+<button>{isMenuVisible ? "Hide" : "Show"} Menu</button>
 ```
 
 For the last step of the workshop, use the ternary operator to conditionally display the words `Hide` or `Show` for the message button. Place the condition before the `Message` text so it displays `Show Message` or `Hide Message`.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ x] My pull request targets the `main` branch of freeCodeCamp.
- [ x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #62494

<!-- Feel free to add any additional description of changes below this line -->
This PR adds a space before the '?' in the ternary expression example to match typical formatting and the rest of the curriculum:

Before:
<button>{isMenuVisible? "Hide" : "Show"} Menu</button>

After:
<button>{isMenuVisible ? "Hide" : "Show"} Menu</button>

Small docs-style / example formatting change only.