### PR TITLE
fix(curriculum): fix typo in lab-user-config-manager

### DIFF
--- a/curriculum/challenges/english/blocks/lab-user-configuration-manager/684aaf9ec670c68d20efd0d0.md
+++ b/curriculum/challenges/english/blocks/lab-user-configuration-manager/684aaf9ec670c68d20efd0d0.md
@@ -128,7 +128,7 @@ The `add_setting` function should have two parameters.
 })
 ```
 
-`add_setting({'theme': 'light'}, ('volume', 'high')` should add a new key-value pair and return the success message `Setting 'volume' added with value 'high' successfully!`.
+`add_setting({'theme': 'light'}, ('volume', 'high'))` should add a new key-value pair and return the success message `Setting 'volume' added with value 'high' successfully!`.
 
 ```js
 ({


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #62567

This PR fixes a bug, the invalid syntax in the curriculum/challenges/english/blocks/lab-user-configuration-manager/684aaf9ec670c68d20efd0d0.md

<!-- Feel free to add any additional description of changes below this line -->
