### PR TITLE
fix: accept both spaces and semicolons in iframe allow attribute

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-media/671682b3983489a819507553.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-media/671682b3983489a819507553.md
@@ -20,6 +20,8 @@ First, what exactly is the `iframe` element? `iframe` stands for inline frame. I
 
 The `src` attribute specifies the URL of the page you want to embed. The `width` attribute specifies the width of the `iframe`. The `height` attribute specifies the height of the `iframe`. The `allowfullscreen` attribute allows the user to display the `iframe` in full screen mode. It's also a good practice to specify a `title` attribute for the `iframe`, as it's important for accessibility.
 
+The `allow` attribute is a permissions policy that controls which browser features the `iframe` can use. You can separate the values in the `allow` attribute with either spaces or semicolons, and both are valid according to the HTML specification. In real-world examples, you'll often see both separators used, sometimes even together.
+
 To embed a video within an `iframe` you can copy it directly from popular video services like YouTube and Vimeo, or define it yourself with the `src` attribute pointing to the URL of that video. Here's an example of embedding a popular freeCodeCamp course from YouTube:
 
 ```html

--- a/curriculum/challenges/english/blocks/workshop-build-a-video-display-using-iframe/68ba9c4f1688914d72876096.md
+++ b/curriculum/challenges/english/blocks/workshop-build-a-video-display-using-iframe/68ba9c4f1688914d72876096.md
@@ -17,7 +17,7 @@ Here's an `iframe` element with the `allow` attribute:
 ></iframe>
 ```
 
-Add the `allow` attribute with the value `accelerometer`, `autoplay`, and `clipboard-write`.
+Add the `allow` attribute with the value `accelerometer`, `autoplay`, and `clipboard-write`. You can separate these values with either spaces or semicolons, as both are valid according to the HTML specification.
 
 `accelerometer` lets the `iframe` use motion sensors so it can detect things like device tilting and rotation. `autoplay` lets the video start playing automatically, and `clipboard-write` lets the iframe write data to the user’s clipboard.
 
@@ -28,8 +28,8 @@ Your `iframe` element should have an `allow` attribute set to `accelerometer`.
 ```js
 const iframeEl = document.querySelector('iframe')
 const iframeElAllowAttr = iframeEl?.getAttribute('allow')
-const accelerometer = iframeElAllowAttr.trim().split(' ')[0]
-assert.strictEqual(accelerometer, 'accelerometer')
+const values = iframeElAllowAttr.trim().split(/[;\s]+/).map(v => v.trim()).filter(v => v)
+assert.strictEqual(values[0], 'accelerometer')
 ```
 
 The `allow` attribute of your `iframe` element should have `autoplay` as one of its values.
@@ -37,8 +37,8 @@ The `allow` attribute of your `iframe` element should have `autoplay` as one of 
 ```js
 const iframeEl = document.querySelector('iframe')
 const iframeElAllowAttr = iframeEl?.getAttribute('allow')
-const autoplay = iframeElAllowAttr.trim().split(' ')[1]
-assert.strictEqual(autoplay, 'autoplay')
+const values = iframeElAllowAttr.trim().split(/[;\s]+/).map(v => v.trim()).filter(v => v)
+assert.strictEqual(values[1], 'autoplay')
 ```
 
 The `allow` attribute of your `iframe` element should have `clipboard-write` as one of its values.
@@ -46,8 +46,8 @@ The `allow` attribute of your `iframe` element should have `clipboard-write` as 
 ```js
 const iframeEl = document.querySelector('iframe')
 const iframeElAllowAttr = iframeEl?.getAttribute('allow')
-const clipboardWrite = iframeElAllowAttr.trim().split(' ')[2]
-assert.strictEqual(clipboardWrite, 'clipboard-write')
+const values = iframeElAllowAttr.trim().split(/[;\s]+/).map(v => v.trim()).filter(v => v)
+assert.strictEqual(values[2], 'clipboard-write')
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-build-a-video-display-using-iframe/68ba9c4f1688914d72876097.md
+++ b/curriculum/challenges/english/blocks/workshop-build-a-video-display-using-iframe/68ba9c4f1688914d72876097.md
@@ -18,8 +18,8 @@ The `allow` attribute of your `iframe` element should have `encrypted-media` as 
 ```js
 const iframeEl = document.querySelector('iframe')
 const iframeElAllowAttr = iframeEl?.getAttribute('allow')
-const encryptedMedia = iframeElAllowAttr.trim().split(' ')[3]
-assert.strictEqual(encryptedMedia, 'encrypted-media')
+const values = iframeElAllowAttr.trim().split(/[;\s]+/).map(v => v.trim()).filter(v => v)
+assert.strictEqual(values[3], 'encrypted-media')
 ```
 
 The `allow` attribute of your `iframe` element should have `gyroscope` as one of its values.
@@ -27,8 +27,8 @@ The `allow` attribute of your `iframe` element should have `gyroscope` as one of
 ```js
 const iframeEl = document.querySelector('iframe')
 const iframeElAllowAttr = iframeEl?.getAttribute('allow')
-const gyroscope = iframeElAllowAttr.trim().split(' ')[4]
-assert.strictEqual(gyroscope, 'gyroscope')
+const values = iframeElAllowAttr.trim().split(/[;\s]+/).map(v => v.trim()).filter(v => v)
+assert.strictEqual(values[4], 'gyroscope')
 ```
 
 The `allow` attribute of your `iframe` element should have `web-share` as one of its values.
@@ -36,8 +36,8 @@ The `allow` attribute of your `iframe` element should have `web-share` as one of
 ```js
 const iframeEl = document.querySelector('iframe')
 const iframeElAllowAttr = iframeEl?.getAttribute('allow')
-const webShare = iframeElAllowAttr.trim().split(' ')[5]
-assert.strictEqual(webShare, 'web-share')
+const values = iframeElAllowAttr.trim().split(/[;\s]+/).map(v => v.trim()).filter(v => v)
+assert.strictEqual(values[5], 'web-share')
 ```
 
 # --seed--


### PR DESCRIPTION
Closes #62564

## Description
This PR fixes the incorrect formatting guidance for the `allow` attribute in iframe elements. Both spaces and semicolons are valid separators according to the HTML specification.

## Changes Made
1. **Lecture lesson** (`671682b3983489a819507553.md`): Added clarification that both spaces and semicolons are valid separators in the `allow` attribute
2. **Workshop Step 5** (`68ba9c4f1688914d72876096.md`): Updated description and tests to accept both separator formats
3. **Workshop Step 6** (`68ba9c4f1688914d72876097.md`): Updated tests to accept both separator formats

## Technical Implementation
Modified test logic to use regex pattern `/[;\s]+/` which accepts:
- Space-separated: `"accelerometer autoplay clipboard-write"`
- Semicolon-separated: `"accelerometer; autoplay; clipboard-write"`
- Mixed format: `"accelerometer; autoplay clipboard-write"`

This aligns with MDN documentation and W3C HTML specification examples.