### PR TITLE
fix(client): correct background color of links in help modal

### DIFF
--- a/client/src/templates/Challenges/components/help-modal.tsx
+++ b/client/src/templates/Challenges/components/help-modal.tsx
@@ -253,32 +253,30 @@ function HelpModal({
           </form>
         ) : (
           <>
-            <div className='alert'>
-              <div className='help-text-warning'>
-                <p>
-                  <Trans i18nKey='learn.tried-rsa'>
-                    <a href={RSA} rel='noopener noreferrer' target='_blank'>
-                      placeholder
-                    </a>
-                  </Trans>
-                </p>
-                <p>
-                  <Trans i18nKey='learn.rsa-forum'>
-                    <a
-                      href={generateSearchLink(
-                        challengeTitle,
-                        challengeBlock,
-                        superBlock
-                      )}
-                      rel='noopener noreferrer'
-                      target='_blank'
-                    >
-                      placeholder
-                    </a>
+            <div className='help-text-warning'>
+              <p>
+                <Trans i18nKey='learn.tried-rsa'>
+                  <a href={RSA} rel='noopener noreferrer' target='_blank'>
                     placeholder
-                  </Trans>
-                </p>
-              </div>
+                  </a>
+                </Trans>
+              </p>
+              <p>
+                <Trans i18nKey='learn.rsa-forum'>
+                  <a
+                    href={generateSearchLink(
+                      challengeTitle,
+                      challengeBlock,
+                      superBlock
+                    )}
+                    rel='noopener noreferrer'
+                    target='_blank'
+                  >
+                    placeholder
+                  </a>
+                  placeholder
+                </Trans>
+              </p>
             </div>
 
             <Button


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

The help modal content is wrapped in a div with an `alert` class, which causes links in the modal to have a blue background on hover.

<details>
<summary>Screenshot</summary>

<img width="575" height="173" alt="Screenshot 2025-10-08 at 04 16 46" src="https://github.com/user-attachments/assets/3e5476f7-ea49-4b60-a867-1aecbd1debaa" />

</details>

`.alert` the style is set here:

https://github.com/freeCodeCamp/freeCodeCamp/blob/940a38127b0ceb71cc09d23e48c57caf3c92c8ae/client/src/components/layouts/global.css#L589-L594

---

This PR removes the div as it's not needed.

<!-- Feel free to add any additional description of changes below this line -->
