### PR TITLE
feat: relax challenge auditor

### DIFF
--- a/tools/challenge-auditor/index.ts
+++ b/tools/challenge-auditor/index.ts
@@ -1,4 +1,4 @@
-import { access, readdir } from 'fs/promises';
+import { readdir } from 'fs/promises';
 import { join, resolve } from 'path';
 
 import { flatten } from 'lodash/fp';
@@ -82,30 +82,9 @@ void (async () => {
   for (const language of langsToCheck) {
     console.log(`\n=== ${language} ===`);
     const certs = getAuditedSuperBlocks({ language });
-    const langCurriculumDirectory = join(
-      process.cwd(),
-      'curriculum',
-      'i18n-curriculum',
-      'curriculum',
-      'challenges',
-      language
-    );
-    // TODO: decide if we need to audit files at all.
-    const auditedFiles = englishFilePaths;
-    // const auditedFiles = englishFilePaths.filter(file =>
-    //   certs.some(
-    //     cert =>
-    //       // we're not ready to audit the new curriculum yet
-    //       (cert !== SuperBlocks.JsAlgoDataStructNew ||
-    //         process.env.SHOW_UPCOMING_CHANGES === 'true') &&
-    //       file.startsWith(superBlockToFolderMap[cert])
-    //   )
-    // );
-    const noMissingFiles = await auditChallengeFiles(auditedFiles, {
-      langCurriculumDirectory
-    });
+
     const noDuplicateSlugs = await auditSlugs(language, certs);
-    if (noMissingFiles && noDuplicateSlugs) {
+    if (noDuplicateSlugs) {
       console.log(`All challenges pass.`);
     } else {
       actionShouldFail = true;
@@ -113,24 +92,6 @@ void (async () => {
   }
   process.exit(actionShouldFail ? 1 : 0);
 })();
-
-async function auditChallengeFiles(
-  auditedFiles: string[],
-  { langCurriculumDirectory }: { langCurriculumDirectory: string }
-) {
-  let auditPassed = true;
-  for (const file of auditedFiles) {
-    const filePath = join(langCurriculumDirectory, file);
-    const fileExists = await access(filePath)
-      .then(() => true)
-      .catch(() => false);
-    if (!fileExists) {
-      console.log(`${filePath} does not exist.`);
-      auditPassed = false;
-    }
-  }
-  return auditPassed;
-}
 
 async function auditSlugs(lang: string, certs: SuperBlocks[]) {
   let auditPassed = true;


### PR DESCRIPTION
Since missing challenges fallback to English and we're missing a lot of translations in the supposedly audited sections, I'm not convinced this is very useful.

See: https://github.com/freeCodeCamp/freeCodeCamp/actions/runs/18323172233

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->
