### PR TITLE
fix(curriculum): add .trim() to  textContent for workshop-cafe-menu

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f332b23c2045fb843337579.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f332b23c2045fb843337579.md
@@ -38,7 +38,7 @@ assert.equal(document.querySelector('p')?.previousElementSibling?.tagName, 'H1')
 Your `p` element should have the text `Est. 2020`.
 
 ```js
-assert.equal(document.querySelector("p").innerText.trim(), "Est. 2020");
+assert.equal(document.querySelector("p")?.innerText.trim(), "Est. 2020");
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f332b23c2045fb843337579.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f332b23c2045fb843337579.md
@@ -38,7 +38,7 @@ assert.equal(document.querySelector('p')?.previousElementSibling?.tagName, 'H1')
 Your `p` element should have the text `Est. 2020`.
 
 ```js
-assert.equal(document.querySelector("p").innerText, "Est. 2020");
+assert.equal(document.querySelector("p").innerText.trim(), "Est. 2020");
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f344fbc22624a2976425065.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f344fbc22624a2976425065.md
@@ -40,7 +40,7 @@ Your `h2` element should have the text `Coffee`.
 
 ```js
 const h2 = document.querySelector('h2');
-assert.equal(h2.innerText, 'Coffee');
+assert.equal(h2.innerText.trim(), 'Coffee');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f344fbc22624a2976425065.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f344fbc22624a2976425065.md
@@ -40,7 +40,7 @@ Your `h2` element should have the text `Coffee`.
 
 ```js
 const h2 = document.querySelector('h2');
-assert.equal(h2.innerText.trim(), 'Coffee');
+assert.equal(h2?.innerText.trim(), 'Coffee');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3c866d28d7ad0de6470505.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3c866d28d7ad0de6470505.md
@@ -31,7 +31,7 @@ Your `flavor` class should be on the `p` element with the text `French Vanilla`.
 
 ```js
 const el = document.querySelector(".flavor");
-assert.equal(el.innerText, "French Vanilla");
+assert.equal(el.innerText.trim(), "French Vanilla");
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3c866d28d7ad0de6470505.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3c866d28d7ad0de6470505.md
@@ -31,7 +31,7 @@ Your `flavor` class should be on the `p` element with the text `French Vanilla`.
 
 ```js
 const el = document.querySelector(".flavor");
-assert.equal(el.innerText.trim(), "French Vanilla");
+assert.equal(el?.innerText.trim(), "French Vanilla");
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3ef6e0a81099d9a697b550.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3ef6e0a81099d9a697b550.md
@@ -42,7 +42,7 @@ assert.lengthOf(document.querySelectorAll("footer a"), 1);
 Your new `a` element should have the text `Visit our website`.
 
 ```js
-assert.equal(document.querySelector("footer > address > p > a")?.innerText, "Visit our website");
+assert.equal(document.querySelector("footer > address > p > a")?.innerText.trim(), "Visit our website");
 ```
 
 Your new `a` element should link to `https://www.freecodecamp.org`. Remember that `a` elements use the `href` attribute to create a link.

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f76967fad478126d6552b0d.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f76967fad478126d6552b0d.md
@@ -29,7 +29,7 @@ Your `price` class should be on the `p` element with the text `3.00`.
 
 ```js
 const el = document.querySelector('.price');
-assert.equal(el.innerText, "3.00");
+assert.equal(el.innerText.trim(), "3.00");
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f76967fad478126d6552b0d.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f76967fad478126d6552b0d.md
@@ -29,7 +29,7 @@ Your `price` class should be on the `p` element with the text `3.00`.
 
 ```js
 const el = document.querySelector('.price');
-assert.equal(el.innerText.trim(), "3.00");
+assert.equal(el?.innerText.trim(), "3.00");
 ```
 
 # --seed--


### PR DESCRIPTION
I noticed issue #62612 mentions **"workshop-accessibility-quiz"** in the title and **"workshop-cafe-menu"** in its description. So I decided to work on both folders, this PR fixes the issue in the **"workshop-cafe-menu"** folder.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
