### PR TITLE
Fix grammar in SPA navigation challenges section

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-introduction-to-javascript-libraries-and-frameworks/6734e867bbf41cc5b11648c4.md
+++ b/curriculum/challenges/english/blocks/lecture-introduction-to-javascript-libraries-and-frameworks/6734e867bbf41cc5b11648c4.md
@@ -13,7 +13,7 @@ SPAs heavily use JavaScript to manage the application's state and render content
 
 SPAs have some common issues. One significant issue is that screen readers may struggle with dynamically updated content. When content changes without a page reload/refresh, screen readers might not notify these changes, which makes our users unaware of updates on our web app.
 
-Another challenge with SPAs is with navigation and browser history. Users expect the back and forward buttons to work as they do on traditional websites. This might not work properly in SPAs because technically, the URL of the web app doesn’t change. Since, the URL of the web app doesn’t change, they can’t bookmark any specific page. Refreshing the page might reset the application to its initial state, rather than maintaining the current view.
+Another challenge with SPAs is with navigation and browser history. Users expect the back and forward buttons to work as they do on traditional websites. This might not work properly in SPAs because technically, the URL of the web app doesn’t change. Since the URL of the web app doesn’t change, they can’t bookmark any specific page. Refreshing the page might reset the application to its initial state, rather than maintaining the current view.
 
 SPAs can pose challenges for SEO optimization. Search engines like Google can have difficulty indexing dynamically loaded content because they may not execute JavaScript properly or may miss content that isn’t included in the initial HTML page. This can lead to pages not being indexed correctly.
 


### PR DESCRIPTION
Corrected a grammatical error in the explanation of SPAs and their challenges regarding navigation and browser history. Removed unnecessary and incorrect comma.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ ] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
