### PR TITLE
fix: filter by challengeId when building blocks

### DIFF
--- a/curriculum/test/test-challenges.js
+++ b/curriculum/test/test-challenges.js
@@ -60,14 +60,16 @@ async function newPageContext() {
   return globalThis.__fccPuppeteerPages[poolId];
 }
 
-export async function defineTestsForBlock({ block }) {
+export async function defineTestsForBlock(testFilter) {
   const lang = testedLang();
-  const challenges = await getChallenges(lang, { block });
+  const challenges = await getChallenges(lang, testFilter);
   const nonCertificationChallenges = challenges.filter(
     ({ challengeType }) => challengeType !== 7
   );
   if (isEmpty(nonCertificationChallenges)) {
-    console.warn(`No non-certification challenges to test for block ${block}.`);
+    console.warn(
+      `No non-certification challenges to test for block ${testFilter.block}.`
+    );
     describe('Check challenges', () => {
       it('No non-certification challenges to test', () => {});
     });

--- a/curriculum/test/utils/generate-block-tests.mjs
+++ b/curriculum/test/utils/generate-block-tests.mjs
@@ -32,17 +32,17 @@ async function main() {
 
   for (const block of blocks) {
     const filePath = path.join(GENERATED_DIR, `${block}.test.js`);
-    const contents = generateSingleBlockFile({ block });
+    const contents = generateSingleBlockFile({ ...testFilter, block });
     await fs.promises.writeFile(filePath, contents, 'utf8');
   }
 
   console.log(`Generated ${blocks.length} block test file(s).`);
 }
 
-function generateSingleBlockFile({ block }) {
+function generateSingleBlockFile(testFilter) {
   return `import { defineTestsForBlock } from '../test-challenges.js';
 
-await defineTestsForBlock({ block: ${JSON.stringify(block)} });
+await defineTestsForBlock(${JSON.stringify(testFilter)});
 `;
 }
 


### PR DESCRIPTION
We need the next challenge to get the solution, but we don't want to test it. We just want the one specified by FCC_CHALLENGE_ID.

The issue was that filtering by challengeId was not happening. All the block's challenges would arrive to be tested, then all but the first one would be discarded.

Closes #62606

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
