### PR TITLE
fix(config): change LinkedIn ID of JS checkpoint cert

### DIFF
--- a/shared/config/certification-settings.ts
+++ b/shared/config/certification-settings.ts
@@ -338,7 +338,7 @@ export const linkedInCredentialIds = {
   [Certification.FoundationalCSharp]: 'fcswm',
   [Certification.FullStackDeveloper]: 'fsd',
   [Certification.RespWebDesignV9]: 'rwdv9',
-  [Certification.JsV9]: 'js',
+  [Certification.JsV9]: 'jsv9',
   [Certification.FrontEndDevLibsV9]: 'felv9',
   [Certification.PythonV9]: 'pyv9',
   [Certification.RelationalDbV9]: 'rdv9',


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR:
- Changes the LinkedIn ID of JS v9 to `jsv9` so it's consistent with other v9 certs.
- Closes https://github.com/freeCodeCamp/fCC10/issues/108

<!-- Feel free to add any additional description of changes below this line -->
