### PR TITLE
fix(client): transform user code alongside injected code

### DIFF
--- a/client/src/templates/Challenges/utils/build.ts
+++ b/client/src/templates/Challenges/utils/build.ts
@@ -217,7 +217,7 @@ export async function buildDOMChallenge(
 
   return {
     challengeType,
-    build: concatHtml(toBuild),
+    build: toBuild ? concatHtml(toBuild) : '',
     sources: buildSourceMap(finalFiles),
     loadEnzyme: requiresReact16,
     error
@@ -253,7 +253,7 @@ export async function buildJSChallenge(
       challengeType,
       build: '',
       sources: buildSourceMap(finalFiles) as unknown,
-      error: foundError
+      error: foundError as Error
     };
   }
 

--- a/client/src/templates/Challenges/utils/build.ts
+++ b/client/src/templates/Challenges/utils/build.ts
@@ -208,7 +208,7 @@ export async function buildDOMChallenge(
   // if there is an error, we just build the test runner so that it can be
   // used to run tests against the code without actually running the code.
   const toBuild = error
-    ? {}
+    ? undefined
     : {
         required,
         template,


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the 47646 below with the issue number.-->

Closes #47646

### Description

This PR fixes the issue where user code was not being transformed alongside the injected seed code (#47646). Previously, some edge cases, like reassigning a `const` in a challenge, would not throw errors because Babel evaluated the tail separately from the contents.  

With this fix, both the user’s code and the injected code are evaluated together using Babel, ensuring proper error detection and correct behavior in challenges such as:

- `/learn/javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/make-a-person`

### How to Test

1. Navigate to the above challenge in the local FreeCodeCamp environment.
2. Attempt to reassign a `const` in the challenge code.
3. Confirm that an error is thrown as expected.
4. Verify that all existing tests pass successfully.