### PR TITLE
fix(curriculum): accept semicolons or spaces for iframe allow attribute and clarify docs (fixes #62564)

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-media/671682b3983489a819507553.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-media/671682b3983489a819507553.md
@@ -27,6 +27,8 @@ Here's an example of embedding a popular freeCodeCamp course from YouTube. To se
 
 :::
 
+Note: The `allow` attribute accepts a list of permissions separated by either semicolons or spaces. Both forms are valid in modern browsers. Many real-world examples (such as YouTube embeds) use semicolons, often with a space after each semicolon.
+
 The `src` attribute specifies the URL of the page you want to embed. The `width` attribute specifies the width of the `iframe`. The `height` attribute specifies the height of the `iframe`. The `allowfullscreen` attribute allows the user to display the `iframe` in full screen mode. It's also a good practice to specify a `title` attribute for the `iframe`, as it's important for accessibility.
 
 Note that the video can come from anywhere. It doesn't have to come from video services like YouTube and Vimeo.

--- a/curriculum/challenges/english/blocks/workshop-build-a-video-display-using-iframe/68ba9c4f1688914d72876096.md
+++ b/curriculum/challenges/english/blocks/workshop-build-a-video-display-using-iframe/68ba9c4f1688914d72876096.md
@@ -19,6 +19,8 @@ Here's an `iframe` element with the `allow` attribute:
 
 Add the `allow` attribute with the value `accelerometer`, `autoplay`, and `clipboard-write`.
 
+Note: The `allow` attribute accepts a list of permissions separated by either semicolons or spaces. Both forms are valid in modern browsers. Many real-world examples (like YouTube embeds) use semicolons, often with a space after each semicolon.
+
 `accelerometer` lets the `iframe` use motion sensors so it can detect things like device tilting and rotation. `autoplay` lets the video start playing automatically, and `clipboard-write` lets the iframe write data to the user’s clipboard.
 
 # --hints--
@@ -28,7 +30,8 @@ Your `iframe` element should have an `allow` attribute set to `accelerometer`.
 ```js
 const iframeEl = document.querySelector('iframe')
 const iframeElAllowAttr = iframeEl?.getAttribute('allow')
-const accelerometer = iframeElAllowAttr.trim().split(' ')[0]
+const parts = iframeElAllowAttr.trim().split(/[;\s]+/).filter(Boolean)
+const accelerometer = parts[0]
 assert.strictEqual(accelerometer, 'accelerometer')
 ```
 
@@ -37,7 +40,8 @@ The `allow` attribute of your `iframe` element should have `autoplay` as one of 
 ```js
 const iframeEl = document.querySelector('iframe')
 const iframeElAllowAttr = iframeEl?.getAttribute('allow')
-const autoplay = iframeElAllowAttr.trim().split(' ')[1]
+const parts = iframeElAllowAttr.trim().split(/[;\s]+/).filter(Boolean)
+const autoplay = parts[1]
 assert.strictEqual(autoplay, 'autoplay')
 ```
 
@@ -46,7 +50,8 @@ The `allow` attribute of your `iframe` element should have `clipboard-write` as 
 ```js
 const iframeEl = document.querySelector('iframe')
 const iframeElAllowAttr = iframeEl?.getAttribute('allow')
-const clipboardWrite = iframeElAllowAttr.trim().split(' ')[2]
+const parts = iframeElAllowAttr.trim().split(/[;\s]+/).filter(Boolean)
+const clipboardWrite = parts[2]
 assert.strictEqual(clipboardWrite, 'clipboard-write')
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-build-a-video-display-using-iframe/68ba9c4f1688914d72876097.md
+++ b/curriculum/challenges/english/blocks/workshop-build-a-video-display-using-iframe/68ba9c4f1688914d72876097.md
@@ -18,7 +18,8 @@ The `allow` attribute of your `iframe` element should have `encrypted-media` as 
 ```js
 const iframeEl = document.querySelector('iframe')
 const iframeElAllowAttr = iframeEl?.getAttribute('allow')
-const encryptedMedia = iframeElAllowAttr.trim().split(' ')[3]
+const parts = iframeElAllowAttr.trim().split(/[;\s]+/).filter(Boolean)
+const encryptedMedia = parts[3]
 assert.strictEqual(encryptedMedia, 'encrypted-media')
 ```
 
@@ -27,7 +28,8 @@ The `allow` attribute of your `iframe` element should have `gyroscope` as one of
 ```js
 const iframeEl = document.querySelector('iframe')
 const iframeElAllowAttr = iframeEl?.getAttribute('allow')
-const gyroscope = iframeElAllowAttr.trim().split(' ')[4]
+const parts = iframeElAllowAttr.trim().split(/[;\s]+/).filter(Boolean)
+const gyroscope = parts[4]
 assert.strictEqual(gyroscope, 'gyroscope')
 ```
 
@@ -36,7 +38,8 @@ The `allow` attribute of your `iframe` element should have `web-share` as one of
 ```js
 const iframeEl = document.querySelector('iframe')
 const iframeElAllowAttr = iframeEl?.getAttribute('allow')
-const webShare = iframeElAllowAttr.trim().split(' ')[5]
+const parts = iframeElAllowAttr.trim().split(/[;\s]+/).filter(Boolean)
+const webShare = parts[5]
 assert.strictEqual(webShare, 'web-share')
 ```
 


### PR DESCRIPTION

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #62564

---

Summary

- Clarifies that the iframe `allow` attribute accepts a serialized permissions policy with values separated by semicolons or spaces (both valid in modern browsers).
- Updates the “Build a Video Display Using iframe” workshop tests to accept both separators.

Changes

- curriculum/challenges/english/blocks/lecture-working-with-media/671682b3983489a819507553.md
  - Added a note explaining that `allow` entries may be separated by semicolons or spaces; real-world embeds often use semicolons with spaces after each.
- curriculum/challenges/english/blocks/workshop-build-a-video-display-using-iframe/68ba9c4f1688914d72876096.md (Step 5)
  - Updated test hints to parse the `allow` attribute with a flexible split: `/[;\s]+/`. Added a note about both separators being valid.
- curriculum/challenges/english/blocks/workshop-build-a-video-display-using-iframe/68ba9c4f1688914d72876097.md (Step 6)
  - Same parsing update to accept both separators.

Local testing

- Ran the curriculum tests for the updated block only:
  - Block: `workshop-build-a-video-display-using-iframe`
  - 33 tests passed.
- Environment: Windows, Node v22.17.0. Built `shared-dist`, built `browser-scripts` test runner assets, generated block tests, then ran vitest for the filtered block.

Notes

- Minimal scope: content/docs and inline test hints only; no client runtime changes.