### PR TITLE
docs(curriculum): proofread-edit description text

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-introduction-to-python/6839b3295323f563efc68f5c.md
+++ b/curriculum/challenges/english/blocks/lecture-introduction-to-python/6839b3295323f563efc68f5c.md
@@ -143,7 +143,7 @@ If you're wondering if increment and decrement operators (`++` and  `--`) work 
 
 Instead of `x++`, you can simply write `x += 1`, which makes it obvious that you're incrementing the value of `x` by `1`.
 
-Writing `++x` in Python just applies the unary plus twice, and increment anything:
+Writing `++x` in Python just applies the unary plus twice, and does not increment anything:
 
 ```python
 my_var = 5


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

File: 
curriculum/challenges/english/blocks/lecture-introduction-to-python/6839b3295323f563efc68f5c.md

Summary:
Proofread edit to line 146, missing key negation in description of unary increment operator.

Description of pre-post edit:

Line 146 pre-edit:
Writing ++x in Python just applies the unary plus twice, and increment anything:

Line 146 post-edit (highlighted in bold here for clarity of changes):
Writing ++x in Python just applies the unary plus twice, and **does not** increment anything:
