### PR TITLE
docs(contributing): remove broken path link to editing the doc site

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 ## Our contributing docs are available here: <https://contribute.freecodecamp.org>.
 
-Looking to edit these docs? Read [this document](https://contribute.freecodecamp.org/#/how-to-work-on-the-docs-theme) first.
+Looking to edit these docs? Read [this document](https://contribute.freecodecamp.org/how-to-work-on-the-docs-site/) first.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,2 @@
 ## Our contributing docs are available here: <https://contribute.freecodecamp.org>.
 
-Looking to edit these docs? Read [this document](https://contribute.freecodecamp.org/how-to-work-on-the-docs-site/) first.


### PR DESCRIPTION
Update `CONTRIBUTING.md`: fix the broken link to working on the documentation site

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #62737 

<!-- Feel free to add any additional description of changes below this line -->

The resultant page from the broken link before the fix in this PR:

<img width="952" height="376" alt="Image" src="https://github.com/user-attachments/assets/83894a67-ccc7-46f6-ba0f-0c0b72565a77" />

#

The resultant page from the proposed link fix in this PR:

<img width="1920" height="946" alt="Image" src="https://github.com/user-attachments/assets/f4b29a38-685a-4234-8ab2-993f42c6bd7a" />

# 

An alternative fix is to only remove the `#` in `https://contribute.freecodecamp.org/#/how-to-work-on-the-docs-theme`, but this fix redirects to the proposed solution.
