### PR TITLE
changed in two css files with fixing the css in <400px devices

### DIFF
--- a/client/src/components/Header/components/universal-nav.css
+++ b/client/src/components/Header/components/universal-nav.css
@@ -420,6 +420,34 @@ li > button.nav-link-signout:not([aria-disabled='true']):is(:hover, :focus) {
   }
 }
 
+/* Small viewport: make the signup/login CTA compact (icon-only) to avoid overflow
+   without changing visual design. Kept conservative to not affect >=401px. */
+@media (max-width: 400px) {
+  .signup-btn {
+    padding-inline: 0; /* remove extra horizontal padding */
+    min-width: var(--header-element-size);
+    max-width: var(--header-element-size);
+    justify-content: center;
+  }
+
+  /* Hide text label and show the icon for login/signup buttons */
+  #universal-nav .login-btn-text,
+  #universal-nav .signup-btn .login-btn-text {
+    display: none !important;
+  }
+
+  #universal-nav .login-btn-icon,
+  .signup-btn .login-btn-icon {
+    display: inline-block !important;
+  }
+
+  /* Ensure the right-side nav doesn't force horizontal scroll */
+  .universal-nav-right {
+    gap: 6px;
+  }
+}
+
+
 /**
  * Handle submenu containers collapsed and expanded states
  */

--- a/client/src/templates/Challenges/components/completion-modal.css
+++ b/client/src/templates/Challenges/components/completion-modal.css
@@ -101,3 +101,21 @@
     font-size: 1rem;
   }
 }
+
+/* Small viewport: make modal login/signup button icon-only to avoid overflow */
+@media (max-width: 400px) {
+  .completion-modal-login-btn .signup-btn {
+    padding-inline: 0;
+    min-width: 40px;
+    max-width: 40px;
+    justify-content: center;
+  }
+
+  .completion-modal-login-btn .signup-btn .login-btn-text {
+    display: none !important;
+  }
+
+  .completion-modal-login-btn .signup-btn .login-btn-icon {
+    display: inline-block !important;
+  }
+}


### PR DESCRIPTION
This PR fixes a mobile responsiveness bug where the header sign-in button (and the completion modal sign-in button) cause horizontal overflow on very small viewports (< 400px). It keeps the existing design and behavior for larger screens and only applies a small media query to make the button icon-only on tiny screens so it no longer forces horizontal scrolling.

---
### Checklist
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #62773
