### PR TITLE
fix: add missing 'to' in favicon description in Basic HTML - Theory

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-understanding-the-html-boilerplate/670838977810401844af6fe0.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-the-html-boilerplate/670838977810401844af6fe0.md
@@ -53,7 +53,7 @@ Another common use case for the `link` element is to link to icons. Here is an e
 <link rel="icon" href="favicon.ico" />
 ```
 
-A favicon, which is short for favorite icon, is a small icon typically displayed in the browser tab next the site title. A lot of websites will use a favicon to display their brand icon.
+A favicon, which is short for favorite icon, is a small icon typically displayed in the browser tab next to the site title. A lot of websites will use a favicon to display their brand icon.
 
 # --questions--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x ] My pull request targets the `main` branch of freeCodeCamp.
- [x ] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #62745

<!-- Feel free to add any additional description of changes below this line -->

### Summary
This PR fixes a small grammar issue in the Basic HTML - Theory lesson.

**Before:**
> A favicon, which is short for favorite icon, is a small icon typically displayed in the browser tab next the site title.

**After:**
> A favicon, which is short for favorite icon, is a small icon typically displayed in the browser tab next to the site title.
