### PR TITLE
fix: i18n node tests

### DIFF
--- a/.github/workflows/node.js-tests.yml
+++ b/.github/workflows/node.js-tests.yml
@@ -213,7 +213,7 @@ jobs:
     name: Test - i18n
     needs: build
     runs-on: ubuntu-22.04
-    if: github.event.pull_request.user.login === 'camperbot' && github.head_ref === 'chore/update-i18n-curriculum-submodule'
+    if: github.event.pull_request.user.login == 'camperbot' && github.head_ref == 'chore/update-i18n-curriculum-submodule'
 
     strategy:
       fail-fast: false

--- a/.github/workflows/node.js-tests.yml
+++ b/.github/workflows/node.js-tests.yml
@@ -209,68 +209,69 @@ jobs:
       - name: Run Tests
         run: pnpm test
 
-  # test-localization:
-  #   name: Test - i18n
-  #   needs: build
-  #   runs-on: ubuntu-22.04
-  #
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       node-version: [22]
-  #       locale: [portuguese, italian]
-  #
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-  #       with:
-  #         submodules: 'recursive'
-  #
-  #     - name: Use Node.js ${{ matrix.node-version }}
-  #       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
-  #       with:
-  #         node-version: ${{ matrix.node-version }}
-  #
-  #     - name: Install pnpm
-  #       uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
-  #       id: pnpm-install
-  #       with:
-  #         run_install: false
-  #
-  #     - name: Set Environment variables
-  #       run: |
-  #         cp sample.env .env
-  #         cat .env
-  #
-  #     - name: Start MongoDB
-  #       uses: supercharge/mongodb-github-action@b0a1493307c4e9b82ed61f3858d606c5ff190c64 # v1.10.0
-  #       with:
-  #         mongodb-version: 8.0
-  #         mongodb-replica-set: test-rs
-  #         mongodb-port: 27017
-  #
-  #     - name: Install Dependencies
-  #       env:
-  #         CURRICULUM_LOCALE: ${{ matrix.locale }}
-  #         CLIENT_LOCALE: ${{ matrix.locale }}
-  #       run: |
-  #         echo pnpm version $(pnpm -v)
-  #         pnpm install
-  #
-  #     # DONT REMOVE THIS STEP.
-  #     # TODO: Refactor and use re-usable workflow and shared artifacts
-  #     - name: Build Client in ${{ matrix.locale }}
-  #       env:
-  #         CURRICULUM_LOCALE: ${{ matrix.locale }}
-  #         CLIENT_LOCALE: ${{ matrix.locale }}
-  #       run: |
-  #         pnpm run build
-  #
-  #     - name: Install Chrome for Puppeteer
-  #       run: pnpm -F=curriculum install-puppeteer
-  #
-  #     - name: Run Tests
-  #       env:
-  #         CURRICULUM_LOCALE: ${{ matrix.locale }}
-  #         CLIENT_LOCALE: ${{ matrix.locale }}
-  #       run: pnpm test
+  test-localization:
+    name: Test - i18n
+    needs: build
+    runs-on: ubuntu-22.04
+    if: github.event.pull_request.user.login === 'camperbot' && github.head_ref === 'chore/update-i18n-curriculum-submodule'
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [22]
+        locale: [portuguese, italian]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          submodules: 'recursive'
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
+        id: pnpm-install
+        with:
+          run_install: false
+
+      - name: Set Environment variables
+        run: |
+          cp sample.env .env
+          cat .env
+
+      - name: Start MongoDB
+        uses: supercharge/mongodb-github-action@b0a1493307c4e9b82ed61f3858d606c5ff190c64 # v1.10.0
+        with:
+          mongodb-version: 8.0
+          mongodb-replica-set: test-rs
+          mongodb-port: 27017
+
+      - name: Install Dependencies
+        env:
+          CURRICULUM_LOCALE: ${{ matrix.locale }}
+          CLIENT_LOCALE: ${{ matrix.locale }}
+        run: |
+          echo pnpm version $(pnpm -v)
+          pnpm install
+
+      # DONT REMOVE THIS STEP.
+      # TODO: Refactor and use re-usable workflow and shared artifacts
+      - name: Build Client in ${{ matrix.locale }}
+        env:
+          CURRICULUM_LOCALE: ${{ matrix.locale }}
+          CLIENT_LOCALE: ${{ matrix.locale }}
+        run: |
+          pnpm run build
+
+      - name: Install Chrome for Puppeteer
+        run: pnpm -F=curriculum install-puppeteer
+
+      - name: Run Tests
+        env:
+          CURRICULUM_LOCALE: ${{ matrix.locale }}
+          CLIENT_LOCALE: ${{ matrix.locale }}
+        run: pnpm test


### PR DESCRIPTION
This uncomments some i18n tests and adds a line to only run them if it's camperbots PR and is the `chore/update-i18n-curriculum-submodule` branch


Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Ref: https://github.com/freeCodeCamp/freeCodeCamp/pull/62106

<!-- Feel free to add any additional description of changes below this line -->
