### PR TITLE
refactor(client): remove unused styles in help-modal.css

### DIFF
--- a/client/src/templates/Challenges/components/help-modal.css
+++ b/client/src/templates/Challenges/components/help-modal.css
@@ -1,12 +1,3 @@
-.alert > p > strong {
-  color: inherit;
-}
-
-.fa-circle-exclamation {
-  font-size: 3rem;
-  padding-bottom: 10px;
-}
-
 .help-form-legend {
   color: var(--secondary-color);
   border: 0;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR:
- Removes the `.alert` selector (following #62589)
- Removes the `.fa-circle-exclamation` selector
  - It looks like the help modal previously had a `faCircleExclamation` icon, but that icon has since been removed. The class was then unused, but now that `@freeCodeCamp/ui`'s `Callout` starts using `faCircleExclamation`, the styles conflict :(
  - Note: I encountered the issue as I was trying to upgrade `@freeCodeCamp/ui` to v5 - This issue is not in prod.
    <details>
      <summary>Screenshot</summary>
      <img width="737" height="215" alt="Screenshot 2025-10-16 at 02 19 31" src="https://github.com/user-attachments/assets/f2e42043-1ec8-4e80-be64-8952e39b7b64" />
    </details>

<!-- Feel free to add any additional description of changes below this line -->
