### PR TITLE
fix(a11y): color contrast in interactive editor

### DIFF
--- a/client/src/templates/Challenges/components/interactive-editor.css
+++ b/client/src/templates/Challenges/components/interactive-editor.css
@@ -7,7 +7,23 @@
   color: var(--gray-45);
 }
 
-.sp-tab-button:hover {
+.sp-tabs .sp-tab-button {
+  color: var(--gray-10) !important;
+}
+
+.sp-tabs .sp-tab-button[aria-selected='true'],
+.sp-tabs .sp-tab-button:hover {
   background-color: var(--gray-10);
   color: var(--gray-90) !important;
+}
+
+.sp-preview-actions .sp-button {
+  background-color: var(--gray-90);
+  color: var(--gray-10) !important;
+}
+
+.sp-preview-actions .sp-button:hover {
+  background-color: var(--gray-10);
+  color: var(--gray-90) !important;
+  border-color: var(--gray-90);
 }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR:
- Fixes the color of the preview actions on hover
- Makes the selected tab/file stand out a bit more (it's currently hard to tell which tab is selected as the colors are too similar)

<details>
<summary>Screen recording - Before</summary>

https://github.com/user-attachments/assets/23f78d8a-00df-4708-97fc-b677023d311e

</details>

<details>
<summary>Screen recording - After</summary>

https://github.com/user-attachments/assets/1287ac5b-4734-4125-b47f-f5c714e893b4

</details>

<!-- Feel free to add any additional description of changes below this line -->
