### PR TITLE
fix(client): improve FormFields type safety and accessibility

### DIFF
--- a/client/src/components/formHelpers/form-fields.tsx
+++ b/client/src/components/formHelpers/form-fields.tsx
@@ -25,7 +25,8 @@ export type FormOptions = {
   isLocalLinkAllowed?: boolean;
   isSourceCodeLinkRequired?: boolean;
   required?: string[];
-  types?: { [key: string]: string };
+  types?: { [key: string]: 
+  React.HTMLInputTypeAttribute };
   placeholders?: { [key: string]: string };
 };
 
@@ -46,12 +47,12 @@ function FormFields({ formFields, options }: FormFieldsProps): JSX.Element {
   } = options;
 
   const nullOrWarning = (
-    value: string,
+    value: string | undefined,
     error: unknown,
     isURL: boolean,
     name: string
   ) => {
-    if (typeof value !== 'string') return null;
+    if (!value) return null;
     let validationError: string | undefined;
     if (value && isURL) {
       try {
@@ -95,7 +96,7 @@ function FormFields({ formFields, options }: FormFieldsProps): JSX.Element {
       {formFields
         .filter(formField => !ignored.includes(formField.name))
         .map(({ name, label }) => (
-          <Field key={`${name}-field`} name={name}>
+          <Field<string | undefined> key={`${name}-field`} name={name}>
             {({ input: { value, onChange }, meta: { pristine, error } }) => {
               const placeholder =
                 name in placeholders ? placeholders[name] : '';

--- a/client/src/components/formHelpers/form-fields.tsx
+++ b/client/src/components/formHelpers/form-fields.tsx
@@ -25,8 +25,7 @@ export type FormOptions = {
   isLocalLinkAllowed?: boolean;
   isSourceCodeLinkRequired?: boolean;
   required?: string[];
-  types?: { [key: string]: 
-  React.HTMLInputTypeAttribute };
+  types?: { [key: string]: React.HTMLInputTypeAttribute };
   placeholders?: { [key: string]: string };
 };
 

--- a/client/src/components/formHelpers/form-fields.tsx
+++ b/client/src/components/formHelpers/form-fields.tsx
@@ -51,6 +51,7 @@ function FormFields({ formFields, options }: FormFieldsProps): JSX.Element {
     isURL: boolean,
     name: string
   ) => {
+    if (typeof value !== 'string') return null;
     let validationError: string | undefined;
     if (value && isURL) {
       try {
@@ -82,7 +83,7 @@ function FormFields({ formFields, options }: FormFieldsProps): JSX.Element {
       validationError ||
       validationWarning) as string;
     return message ? (
-      <HelpBlock>
+      <HelpBlock id={`${name}-message`}>
         <Alert variant={error || validationError ? 'danger' : 'info'}>
           {message}
         </Alert>
@@ -94,7 +95,6 @@ function FormFields({ formFields, options }: FormFieldsProps): JSX.Element {
       {formFields
         .filter(formField => !ignored.includes(formField.name))
         .map(({ name, label }) => (
-          // TODO: verify if the value is always a string
           <Field key={`${name}-field`} name={name}>
             {({ input: { value, onChange }, meta: { pristine, error } }) => {
               const placeholder =
@@ -115,8 +115,9 @@ function FormFields({ formFields, options }: FormFieldsProps): JSX.Element {
                     placeholder={placeholder}
                     required={required.includes(name)}
                     rows={4}
-                    type='url'
+                    type={types[name] || 'text'}
                     value={value as string}
+                    aria-describedby={`${name}-message`}
                     data-playwright-test-label={`${name}-form-control`}
                   />
                   {nullOrWarning(


### PR DESCRIPTION
This PR improves the `FormFields` component by adding a type guard to ensure `value` is always a string before validation, dynamically setting the input `type` instead of hardcoding `'url'`, linking error messages to inputs with` aria-describedby` for better accessibility and cleaning up the old TODO comment. These changes enhance reliability and accessibility without affecting existing functionality.