### PR TITLE
fix(client): prevent duplicate console in interactive editor

### DIFF
--- a/client/src/templates/Challenges/components/interactive-editor.tsx
+++ b/client/src/templates/Challenges/components/interactive-editor.tsx
@@ -83,7 +83,7 @@ const showConsole = hasHtmlOrCss && hasScript;
           editorWidthPercentage: 60,
           showConsole: showConsole,
           showConsoleButton: showConsole,
-          layout: got('html') ? 'preview' : 'console',
+          layout: layout,
           showLineNumbers: true
         }}
       />

--- a/client/src/templates/Challenges/components/interactive-editor.tsx
+++ b/client/src/templates/Challenges/components/interactive-editor.tsx
@@ -45,10 +45,8 @@ const InteractiveEditor = ({ files }: Props) => {
 
   const hasHtmlOrCss = got('html') || got('css');
   const hasScript = got('js') || got('ts');
-  const isPureScript = hasScript && !hasHtmlOrCss;
-
-  const layout = isPureScript ? 'console' : 'preview';
-  const showConsole = layout === 'preview' && hasScript;
+const layout = hasHtmlOrCss ? 'preview' : 'console';
+const showConsole = hasHtmlOrCss && hasScript;
   const freeCodeCampDarkSyntax = {
     ...freeCodeCampDark.syntax,
     punctuation: '#ffff00',

--- a/client/src/templates/Challenges/components/interactive-editor.tsx
+++ b/client/src/templates/Challenges/components/interactive-editor.tsx
@@ -43,12 +43,12 @@ const InteractiveEditor = ({ files }: Props) => {
     return files.some(f => f.ext === ext);
   }
 
-  // 1. Check if the example is only JavaScript/TypeScript (no HTML or CSS)
-  const isPureScriptExample =
-    (got('js') || got('ts')) && !got('html') && !got('css');
+  const hasHtmlOrCss = got('html') || got('css');
+  const hasScript = got('js') || got('ts');
+  const isPureScript = hasScript && !hasHtmlOrCss;
 
-  const showConsole = isPureScriptExample ? false : got('js') || got('ts');
-
+  const layout = isPureScript ? 'console' : 'preview';
+  const showConsole = layout === 'preview' && hasScript;
   const freeCodeCampDarkSyntax = {
     ...freeCodeCampDark.syntax,
     punctuation: '#ffff00',

--- a/client/src/templates/Challenges/components/interactive-editor.tsx
+++ b/client/src/templates/Challenges/components/interactive-editor.tsx
@@ -43,7 +43,12 @@ const InteractiveEditor = ({ files }: Props) => {
     return files.some(f => f.ext === ext);
   }
 
-  const showConsole = got('js') || got('ts');
+  // 1. Check if the example is only JavaScript/TypeScript (no HTML or CSS)
+  const isPureScriptExample =
+    (got('js') || got('ts')) && !got('html') && !got('css');
+
+  const showConsole = isPureScriptExample ? false : got('js') || got('ts');
+
   const freeCodeCampDarkSyntax = {
     ...freeCodeCampDark.syntax,
     punctuation: '#ffff00',

--- a/client/src/templates/Challenges/components/interactive-editor.tsx
+++ b/client/src/templates/Challenges/components/interactive-editor.tsx
@@ -45,8 +45,9 @@ const InteractiveEditor = ({ files }: Props) => {
 
   const hasHtmlOrCss = got('html') || got('css');
   const hasScript = got('js') || got('ts');
-const layout = hasHtmlOrCss ? 'preview' : 'console';
-const showConsole = hasHtmlOrCss && hasScript;
+  const layout = hasHtmlOrCss ? 'preview' : 'console';
+  const showConsole = hasHtmlOrCss && hasScript;
+  
   const freeCodeCampDarkSyntax = {
     ...freeCodeCampDark.syntax,
     punctuation: '#ffff00',


### PR DESCRIPTION

Checklist:
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #62796

Description of Changes : 

This pull request resolves an issue where output was duplicated in interactive editor blocks containing only JavaScript or TypeScript, particularly in lecture examples.

Problem:
When a user used console.log() in a pure JS/TS block (without HTML/CSS), the Sandpack editor would display the output twice:

Once in the main preview panel (as the returned value of the last line).

Once in the dedicated console panel (from console.log).

Solution:
The logic in InteractiveEditor.tsx has been updated to check for pure script examples (those with only .js or .ts files). For these cases, the Sandpack options.showConsole flag is set to false, causing the dedicated console panel to be closed by default.

This ensures the learner sees a single, clean output in the top preview panel, matching the expected behavior for instructional materials. The console button remains available if the user needs to manually open the debug console.


<img width="1470" height="799" alt="Screenshot 2025-10-16 at 7 13 01 PM" src="https://github.com/user-attachments/assets/eb8ab615-93cb-40a2-8c20-521761958af3" />
