### PR TITLE
fix(ui): show correct FSD intro for new users

### DIFF
--- a/client/src/templates/Introduction/components/super-block-intro.tsx
+++ b/client/src/templates/Introduction/components/super-block-intro.tsx
@@ -226,7 +226,7 @@ function SuperBlockIntro({
   );
 
   const showFSDnewIntro = useFeatureIsOn('fsd-new-intro');
-
+  const isUserDataLoaded = Array.isArray(completedChallenges);
   const showIntroTopB =
     completedChallenges.length === 0 &&
     superBlock === SuperBlocks.FullStackDeveloper &&
@@ -234,7 +234,7 @@ function SuperBlockIntro({
 
   return (
     <>
-      {showIntroTopB ? introTopB : introTopA}
+      {isUserDataLoaded ? (showIntroTopB ? introTopB : introTopA) : introTopA}
       <ConditionalDonationAlert
         superBlock={superBlock}
         onCertificationDonationAlertClick={onCertificationDonationAlertClick}


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #62033

<!-- Feel free to add any additional description of changes below this line -->

Description
This PR fixes the issue where the Full Stack Developer intro flashes or shows incorrectly on page refresh.

Changes Made

- Updated logic in superblock-intro.tsx to display the new intro only for users:

> - who have completed 0 challenges,
> - are viewing the Full Stack Developer certification,
> - and when the fsd-new-intro feature flag is enabled.

- Ensures the default intro (introTopA) is shown immediately for all other cases to prevent flicker.

Testing
I tried running this code and the race condition I encountered earlier was no longer occurring
