### PR TITLE
dev(client): disable webpack console warnings

### DIFF
--- a/client/gatsby-node.js
+++ b/client/gatsby-node.js
@@ -263,13 +263,18 @@ exports.onCreateWebpackConfig = ({ stage, actions }) => {
     },
     plugins: newPlugins,
     ignoreWarnings: [
-      {
-        module: /env\.json/,
-        message: /only default export is available soon/
-      },
-      {
-        module: /mini-css-extract-plugin/,
-        message: /Conflicting order/
+      warning => {
+        if (warning instanceof Error) {
+          if (
+            warning.message.includes('only default export is available soon')
+          ) {
+            return true;
+          }
+          if (warning.message.includes('mini-css-extract-plugin')) {
+            return true;
+          }
+        }
+        return false;
       }
     ]
   });

--- a/client/gatsby-node.js
+++ b/client/gatsby-node.js
@@ -265,11 +265,6 @@ exports.onCreateWebpackConfig = ({ stage, actions }) => {
     ignoreWarnings: [
       warning => {
         if (warning instanceof Error) {
-          if (
-            warning.message.includes('only default export is available soon')
-          ) {
-            return true;
-          }
           if (warning.message.includes('mini-css-extract-plugin')) {
             return true;
           }

--- a/client/gatsby-node.js
+++ b/client/gatsby-node.js
@@ -261,7 +261,17 @@ exports.onCreateWebpackConfig = ({ stage, actions }) => {
         process: require.resolve('process/browser')
       }
     },
-    plugins: newPlugins
+    plugins: newPlugins,
+    ignoreWarnings: [
+      {
+        module: /env\.json/,
+        message: /only default export is available soon/
+      },
+      {
+        module: /mini-css-extract-plugin/,
+        message: /Conflicting order/
+      }
+    ]
   });
 };
 

--- a/client/package.json
+++ b/client/package.json
@@ -20,7 +20,7 @@
   "main": "none",
   "scripts": {
     "prebuild": "pnpm run common-setup && pnpm run build:scripts --env production",
-    "build": "NODE_OPTIONS=\"--max-old-space-size=7168\" gatsby build --prefix-paths",
+    "build": "NODE_OPTIONS=\"--max-old-space-size=7168 --no-deprecation\" gatsby build --prefix-paths",
     "build:scripts": "pnpm run -F=browser-scripts build",
     "clean": "gatsby clean",
     "common-setup": "pnpm -w run create:shared && pnpm run create:env && pnpm run create:trending && pnpm run create:search-placeholder",
@@ -28,7 +28,7 @@
     "create:trending": "tsx ./tools/download-trending.ts",
     "create:search-placeholder": "tsx ./tools/generate-search-placeholder",
     "predevelop": "pnpm run common-setup && pnpm run build:scripts --env development",
-    "develop": "NODE_OPTIONS=\"--max-old-space-size=7168\" gatsby develop --inspect=9230",
+    "develop": "NODE_OPTIONS=\"--max-old-space-size=7168 --no-deprecation\" gatsby develop --inspect=9230",
     "lint": "tsx ./i18n/schema-validation.ts",
     "serve": "gatsby serve -p 8000",
     "serve-ci": "serve -l 8000 -c serve.json public",


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Just removes some warnings when running `pnpm run develop:client`. This removes the ones we cannot fix sans a migration from Gatsby 3.