### PR TITLE
fix(client): display upcoming exam on super block page

### DIFF
--- a/client/src/templates/Introduction/components/super-block-accordion.tsx
+++ b/client/src/templates/Introduction/components/super-block-accordion.tsx
@@ -279,10 +279,7 @@ export const SuperBlockAccordion = ({
           >
             {chapter.modules.map(module => {
               if (module.comingSoon && !showUpcomingChanges) {
-                if (
-                  module.moduleType === 'review' ||
-                  module.moduleType === 'exam'
-                ) {
+                if (module.moduleType === 'review') {
                   return null;
                 }
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Requires #62659.

This PR reverts this change https://github.com/freeCodeCamp/freeCodeCamp/pull/62039/files#diff-a0e7c3d0df31e6f51a3ea780768349415b4f932b5255c0047f2db94c26d6acf9R212.

I don't think we need to hide upcoming exams, but just show the module intro instead.

<details>
<summary>Screenshots</summary>

| Before | After |
| --- | --- |
| <img width="787" height="809" alt="Screenshot 2025-10-18 at 01 34 35" src="https://github.com/user-attachments/assets/32e52c8e-e708-4208-9f2d-b922b74b6531" /> | <img width="702" height="873" alt="Screenshot 2025-10-18 at 01 35 32" src="https://github.com/user-attachments/assets/87224abe-2537-4037-912f-e7245065459e" /> |

</details>

<!-- Feel free to add any additional description of changes below this line -->
