### PR TITLE
fix(curriculum): correct misleading hint in screen readers question

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-importance-of-accessibility-and-good-html-structure/672a5310d7e46b8a34d48dfd.md
+++ b/curriculum/challenges/english/blocks/lecture-importance-of-accessibility-and-good-html-structure/672a5310d7e46b8a34d48dfd.md
@@ -133,7 +133,7 @@ Braille output.
 
 ### --feedback--
 
-Think about converting written content into spoken words.
+Think about converting spoken words into written text.
 
 ---
 
@@ -141,7 +141,7 @@ Web browsing support.
 
 ### --feedback--
 
-Think about converting written content into spoken words.
+Think about converting spoken words into written text.
 
 ## --video-solution--
 


### PR DESCRIPTION
The hint for the “Which of these is not a feature of screen readers?” question previously described *text-to-speech* behavior.
Since the correct answer is *speech-to-text*, the hint was misleading.

✅ Updated the feedback text to:
“Think about converting spoken words into written text.”

Closes #62896