### PR TITLE
fix(curriculum): unify checklist message text in steps 46–50

### DIFF
--- a/curriculum/challenges/english/blocks/learn-how-to-plan-future-events/6752133caed6e849142fcc19.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-plan-future-events/6752133caed6e849142fcc19.md
@@ -18,7 +18,7 @@ This is a message Jake sent to his team:
 
 `Hi Team,`
 
-`Here is the checklist for the upcoming system update. All tasks must be completed on time:`  
+`Here is the checklist for the upcoming system update. Please ensure all tasks are completed on time:`  
 
 `- Thursday afternoon: The training session for the new security protocols is planned.`  
 `- Friday afternoon: All security patches are ready to be deployed.`  

--- a/curriculum/challenges/english/blocks/learn-how-to-plan-future-events/6752136c94c79a4ad803f0cf.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-plan-future-events/6752136c94c79a4ad803f0cf.md
@@ -18,7 +18,7 @@ This is a message Jake sent to his team:
 
 `Hi Team,`
 
-`Here is the checklist for the upcoming system update. All tasks must be completed on time:`  
+`Here is the checklist for the upcoming system update. Please ensure all tasks are completed on time:`
 
 `- Thursday afternoon: The training session for the new security protocols is planned.`  
 `- Friday afternoon: All security patches are ready to be deployed.`  

--- a/curriculum/challenges/english/blocks/learn-how-to-plan-future-events/675213a1aa7da34c876d94e9.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-plan-future-events/675213a1aa7da34c876d94e9.md
@@ -18,7 +18,7 @@ This is a message Jake sent to his team:
 
 `Hi Team,`
 
-`Here is the checklist for the upcoming system update. All tasks must be completed on time:`  
+`Here is the checklist for the upcoming system update. Please ensure all tasks are completed on time:`  
 
 `- Thursday afternoon: The training session for the new security protocols is planned.`  
 `- Friday afternoon: All security patches are ready to be deployed.`  

--- a/curriculum/challenges/english/blocks/learn-how-to-plan-future-events/675213f5a47d9e4ef23d9050.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-plan-future-events/675213f5a47d9e4ef23d9050.md
@@ -18,7 +18,7 @@ This is a message Jake sent to his team:
 
 `Hi Team,`
 
-`Here is the checklist for the upcoming system update. All tasks must be completed on time:`  
+`Here is the checklist for the upcoming system update. Please ensure all tasks are completed on time:`  
 
 `- Thursday afternoon: The training session for the new security protocols is planned.`  
 `- Friday afternoon: All security patches are ready to be deployed.`  


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

* [x] I have read and followed the [[contribution guidelines](https://contribute.freecodecamp.org/)](https://contribute.freecodecamp.org).
* [x] I have read and followed the [[how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/)](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
* [x] My pull request targets the `main` branch of freeCodeCamp.
* [x] I have tested these changes either locally on my machine or in GitHub Codespaces.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. -->

Closes #62899

<!-- Feel free to add any additional description of changes below this line -->

This pull request fixes a text inconsistency in the "Learn How to Plan Future Events" lesson (Tasks 46–50).

Steps 47–50 contained a slightly different version of the sample message than Step 46.
This PR updates all steps to match Step 46 for clarity and consistency:

"Here is the checklist for the upcoming system update. Please ensure all tasks are completed on time:"