### PR TITLE
chore: hide interactive editor from screenreaders

### DIFF
--- a/client/src/templates/Challenges/components/interactive-editor.tsx
+++ b/client/src/templates/Challenges/components/interactive-editor.tsx
@@ -52,7 +52,7 @@ const InteractiveEditor = ({ files }: Props) => {
   };
 
   return (
-    <div className='interactive-editor-wrapper'>
+    <div className='interactive-editor-wrapper' aria-hidden='true'>
       <Sandpack
         template={
           got('tsx')


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

relates https://github.com/freeCodeCamp/freeCodeCamp/issues/62895

<!-- Feel free to add any additional description of changes below this line -->
This hides the interactive editor from the screenreader so that no content inside of the editor is read by the screenreader. It was tested with the NVDA screenreader on Windows and none of the text in the editor was read. 
