### PR TITLE
fix(curriculum): unify sample message text in steps 46–50

### DIFF
--- a/curriculum/challenges/english/blocks/learn-how-to-plan-future-events/6752100607e30e31bd85af76.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-plan-future-events/6752100607e30e31bd85af76.md
@@ -18,7 +18,7 @@ This is a message Jake sent to his team:
 
 `Hi Team,`
 
-`Here is the checklist for the upcoming system update. Please ensure all tasks are completed on time:`
+`Here is the checklist for the upcoming system update. All tasks must be completed on time:`
 
 `- Thursday afternoon: The training session for the new security protocols is planned.`  
 `- Friday afternoon: All security patches are ready to be deployed.`  


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes locally on my machine.

---

### Description
This PR fixes an inconsistency in the lesson text for the **"Learn How to Plan Future Events"** challenge in the **B1 English for Developers** certification.

- **Step 46** originally said:  
  `Here is the checklist for the upcoming system update. Please ensure all tasks are completed on time:`

- **Steps 47–50** said:  
  `Here is the checklist for the upcoming system update. All tasks must be completed on time:`

**Change:**  
Updated Step 46’s message to match Steps 47–50 for consistency across the lesson.

---

Closes #62899 

