### PR TITLE
fix(curriculum): clarify aria-describedby lesson for modal dialog reference

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-introduction-to-aria/672a551975938a916c74802c.md
+++ b/curriculum/challenges/english/blocks/lecture-introduction-to-aria/672a551975938a916c74802c.md
@@ -67,6 +67,22 @@ Another good use case for the `aria-describedby` attribute is when you have a de
 
 Just like in the earlier example, we associate the delete button with the message using the `aria-describedby` attribute. The `id` value and the value of the `aria-describedby` attribute must match. 
 
+A `modal dialog` is a popup that appears on top of the main content and requires the user to interact with it before returning to the page. For example, a confirmation box or alert with a close button is considered a modal dialog. You can use aria-describedby on the close button to point to a description of the modal, which helps screen readers announce additional information about the popup.
+
+:::interactive_editor
+
+```html
+<div role="dialog" id="myModal">
+  <p id="modalDesc">This is a modal dialog with important info.</p>
+  <button aria-describedby="modalDesc">Close</button>
+</div>
+
+```
+
+:::
+
+Here, the `button` uses `aria-describedby` to reference the description of the modal. This ensures that users of assistive technologies understand the purpose of the close button in context.
+
 The `aria-describedby` attribute is a powerful attribute that can be used to help ensure that additional information about an element is provided to screen reader users when they interact with the element. It is most commonly used to associate instructions and error messages with form inputs in order to reduce the chance that screen reader users will miss these messages as they navigate the form. 
 
 # --questions--


### PR DESCRIPTION
This pull request adds clarifying information to the "What Is the aria-describedby Attribute, and How Does It Work?" lesson.

The final quiz question refers to a "close button and modal dialog," but the lesson content previously did not mention or explain a modal dialog. This update adds a short explanation and example to align the lesson with the quiz question, improving clarity for learners.

Changes made:
- Added a brief section describing how `aria-describedby` can be used in a modal dialog with a close button.
- Ensured consistency between lesson content and quiz question context.

Checklist:
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.


Closes #62863 


