### PR TITLE
fix(curriculum): Misleading hint in HTML curriculum

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-importance-of-accessibility-and-good-html-structure/672a5310d7e46b8a34d48dfd.md
+++ b/curriculum/challenges/english/blocks/lecture-importance-of-accessibility-and-good-html-structure/672a5310d7e46b8a34d48dfd.md
@@ -125,7 +125,7 @@ Text-to-speech.
 
 ### --feedback--
 
-Think about converting written content into spoken words.
+Think about what would not be useful to navigate a webpage without sight.
 
 ---
 
@@ -133,7 +133,7 @@ Braille output.
 
 ### --feedback--
 
-Think about converting written content into spoken words.
+Think about what would not be useful to navigate a webpage without sight.
 
 ---
 
@@ -141,7 +141,7 @@ Web browsing support.
 
 ### --feedback--
 
-Think about converting written content into spoken words.
+Think about what would not be useful to navigate a webpage without sight.
 
 ## --video-solution--
 


### PR DESCRIPTION
Checklist:

- [ x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x ] My pull request targets the `main` branch of freeCodeCamp.
- [ x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #62896

Description

This PR fixes a misleading hint in the “What Are Screen Readers” challenge under the Importance of Accessibility and Good HTML Structure section.

The previous hint said:

“Think about converting written content into spoken words.”

This could confuse learners since the correct answer (“Speech-to-text”) means converting spoken words into written text, not the other way around.

Updated hint:
“Think about what would not be useful to navigate a webpage without sight.”

This provides a clearer and more accurate hint, improving accessibility understanding.

