### PR TITLE
feat(tools): add prettier formatting to CSS files in lint-staged config

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -20,5 +20,9 @@ module.exports = {
 
   './curriculum/challenges/**/*.md': files =>
     files.map(filename => `node ./tools/scripts/lint/index.js '${filename}'`),
-  '*.css': files => files.map(filename => `stylelint --fix '${filename}'`)
+
+  '*.css': files => [
+    ...files.map(filename => `stylelint --fix '${filename}'`),
+    ...files.map(filename => `prettier --write '${filename}'`)
+  ]
 };


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

I've edited several CSS files recently and kept getting `lint:prettier` failures in CI, while I expected all formatting issues to be fixed before commit. It turns out we don't run `prettier --write` on changed CSS files. 

(This seems to have been missing for a while, and I only noticed now - probably because I'm getting worse at coding.)

<!-- Feel free to add any additional description of changes below this line -->
