### PR TITLE
fix(curriculum): add missing question mark in lecture title

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-understanding-computer-internet-and-tooling-basics/672ab82c1a9bbd0e3aabc39d.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-computer-internet-and-tooling-basics/672ab82c1a9bbd0e3aabc39d.md
@@ -1,6 +1,6 @@
 ---
 id: 672ab82c1a9bbd0e3aabc39d
-title: How Can You Effectively Work With Your Keyboard, Mouse, and Other Pointing Devices
+title: How Can You Effectively Work With Your Keyboard, Mouse, and Other Pointing Devices?
 challengeType: 19
 dashedName: how-to-effectively-work-with-your-keyboard-mouse-and-other-pointing-devices
 ---

--- a/curriculum/structure/blocks/lecture-understanding-computer-internet-and-tooling-basics.json
+++ b/curriculum/structure/blocks/lecture-understanding-computer-internet-and-tooling-basics.json
@@ -11,7 +11,7 @@
     },
     {
       "id": "672ab82c1a9bbd0e3aabc39d",
-      "title": "How Can You Effectively Work With Your Keyboard, Mouse, and Other Pointing Devices"
+      "title": "How Can You Effectively Work With Your Keyboard, Mouse, and Other Pointing Devices?"
     },
     {
       "id": "672ab83c4297910eade53c2e",


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #62904 

<!-- Feel free to add any additional description of changes below this line -->
Fixed missing question marks at the end of the lecture title:

- curriculum/challenges/english/blocks/lecture-understanding-computer-internet-and-tooling-basics/672ab82c1a9bbd0e3aabc39d.md
 ```title: How Can You Effectively Work With Your Keyboard, Mouse, and Other Pointing Devices?```

- curriculum/structure/blocks/lecture-understanding-computer-internet-and-tooling-basics.json
    ```title: How Can You Effectively Work With Your Keyboard, Mouse, and Other Pointing Devices?``` 

   As mentioned in the issue i am a first time contributor. looking for your feedback @raisedadead @ilenia-magoni 