### PR TITLE
fix: direct import from curriculum

### DIFF
--- a/tools/client-plugins/gatsby-source-challenges/gatsby-node.js
+++ b/tools/client-plugins/gatsby-source-challenges/gatsby-node.js
@@ -1,6 +1,8 @@
-const path = require('path');
 const chokidar = require('chokidar');
 const { getSuperblockStructure } = require('../../../curriculum/file-handler');
+const {
+  superBlockToFilename
+} = require('../../../curriculum/build-curriculum');
 
 const { createChallengeNode } = require('./create-challenge-nodes');
 
@@ -91,21 +93,6 @@ exports.sourceNodes = function sourceChallengesSourceNodes(
   }
 
   function createSuperBlockStructureNodes() {
-    const buildCurriculumPath = path.resolve(
-      curriculumPath,
-      '..',
-      '..',
-      'build-curriculum'
-    );
-    const buildCurriculum = require(buildCurriculumPath);
-    const superBlockToFilename = buildCurriculum.superBlockToFilename;
-
-    if (!superBlockToFilename) {
-      reporter.panic(
-        'superBlockToFilename is missing from build-curriculum. This map is required.'
-      );
-    }
-
     Object.keys(superBlockToFilename).forEach(superBlock => {
       const filename = superBlockToFilename[superBlock] || superBlock;
       try {


### PR DESCRIPTION
'curriculumPath' is dynamic and reflects the location of the content, but the build scripts are always in the same place. Therefore a dynamic require is not what we want.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Ref: https://github.com/freeCodeCamp/freeCodeCamp/actions/runs/18712536593/job/53364207084

<!-- Feel free to add any additional description of changes below this line -->
