### PR TITLE
feat(client): add details to daily challenges calendar

### DIFF
--- a/client/src/components/daily-coding-challenge/calendar-day.tsx
+++ b/client/src/components/daily-coding-challenge/calendar-day.tsx
@@ -3,24 +3,49 @@ import { useTranslation } from 'react-i18next';
 import { Link } from '../helpers';
 import GreenPass from '../../assets/icons/green-pass';
 import GreenNotCompleted from '../../assets/icons/green-not-completed';
+import JavaScriptIcon from '../../assets/icons/javascript';
+import PythonIcon from '../../assets/icons/python';
 import { formatDisplayDate } from './helpers';
 
 interface CalendarDayProps {
   dayNumber: number;
   date?: string;
-  isCompleted?: boolean;
+  challengeNumber?: number;
+  completedLanguages?: string[];
   isAvailable?: boolean;
+  title?: string;
 }
 
-// Todo: Change this to render checkmarks for JS and Python
+function Checkmark({ completed }: { completed: boolean }): JSX.Element {
+  return completed ? (
+    <span
+      className='dc-checkmark dc-small-checkmark completed'
+      data-playwright-test-label='calendar-day-completed'
+    >
+      <GreenPass />
+    </span>
+  ) : (
+    <span
+      className='dc-checkmark dc-small-checkmark not-completed'
+      data-playwright-test-label='calendar-day-not-completed'
+    >
+      <GreenNotCompleted />
+    </span>
+  );
+}
 
 function DailyCodingChallengeCalendarDay({
   dayNumber,
   date,
-  isCompleted = false,
-  isAvailable = false
+  isAvailable = false,
+  title,
+  completedLanguages = [],
+  challengeNumber
 }: CalendarDayProps): JSX.Element {
   const { t } = useTranslation();
+
+  console.log(completedLanguages);
+
   // dayNumber = 0 -> render nothing
   if (dayNumber === 0) return <div></div>;
 
@@ -50,21 +75,39 @@ function DailyCodingChallengeCalendarDay({
         {dayNumber}
       </span>
 
-      {isCompleted ? (
-        <span
-          className='completed'
-          data-playwright-test-label='calendar-day-completed'
-        >
-          <GreenPass />
-        </span>
-      ) : (
-        <span
-          className='not-completed'
-          data-playwright-test-label='calendar-day-not-completed'
-        >
-          <GreenNotCompleted />
-        </span>
-      )}
+      <span className='dc-number'>#{challengeNumber}</span>
+
+      <div className='dc-info'>
+        <div className='dc-title'>{title}</div>
+
+        <hr />
+
+        {completedLanguages.length === 2 ? (
+          <span className='dc-checkmark dc-big-checkmark completed'>
+            <GreenPass />
+          </span>
+        ) : (
+          <div className='dc-languages'>
+            <div className='dc-language'>
+              <div className='dc-language-icon'>
+                <JavaScriptIcon />
+              </div>
+              <div className='dc-language-name'>JavaScript</div>
+              <Checkmark
+                completed={completedLanguages.includes('javascript')}
+              />
+            </div>
+
+            <div className='dc-language'>
+              <div className='dc-language-icon'>
+                <PythonIcon />
+              </div>
+              <div className='dc-language-name'>Python</div>
+              <Checkmark completed={completedLanguages.includes('python')} />
+            </div>
+          </div>
+        )}
+      </div>
     </Link>
   );
 }

--- a/client/src/components/daily-coding-challenge/calendar-day.tsx
+++ b/client/src/components/daily-coding-challenge/calendar-day.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { Spacer } from '@freecodecamp/ui';
 import { Link } from '../helpers';
 import GreenPass from '../../assets/icons/green-pass';
 import GreenNotCompleted from '../../assets/icons/green-not-completed';
@@ -75,19 +76,23 @@ function DailyCodingChallengeCalendarDay({
         {dayNumber}
       </span>
 
-      <span className='dc-number'>#{challengeNumber}</span>
+      <div className='dc-number'>#{challengeNumber}</div>
 
       <div className='dc-info'>
         <div className='dc-title'>{title}</div>
 
-        <hr />
+        {/* <hr /> */}
 
         {completedLanguages.length === 2 ? (
           <span className='dc-checkmark dc-big-checkmark completed'>
+            <span className='dc-spacer'>
+              <Spacer size='s' />
+            </span>
             <GreenPass />
           </span>
         ) : (
           <div className='dc-languages'>
+            <hr />
             <div className='dc-language'>
               <div className='dc-language-icon'>
                 <JavaScriptIcon />

--- a/client/src/components/daily-coding-challenge/calendar-day.tsx
+++ b/client/src/components/daily-coding-challenge/calendar-day.tsx
@@ -45,8 +45,6 @@ function DailyCodingChallengeCalendarDay({
 }: CalendarDayProps): JSX.Element {
   const { t } = useTranslation();
 
-  console.log(completedLanguages);
-
   // dayNumber = 0 -> render nothing
   if (dayNumber === 0) return <div></div>;
 
@@ -80,8 +78,6 @@ function DailyCodingChallengeCalendarDay({
 
       <div className='dc-info'>
         <div className='dc-title'>{title}</div>
-
-        {/* <hr /> */}
 
         {completedLanguages.length === 2 ? (
           <span className='dc-checkmark dc-big-checkmark completed'>

--- a/client/src/components/daily-coding-challenge/calendar.css
+++ b/client/src/components/daily-coding-challenge/calendar.css
@@ -2,6 +2,9 @@
   display: grid;
   grid-template-columns: repeat(7, 1fr);
   text-align: center;
+  margin: 0 auto;
+  max-width: 1500px;
+  padding: 0 20px;
 }
 
 .calendar-head {
@@ -18,18 +21,87 @@
   display: grid;
   grid-template-columns: repeat(7, 1fr); /* 7 columns for days of the week */
   gap: 4px;
+  margin: 0 auto;
+  max-width: 1500px;
+  padding: 0 20px;
 }
 
 .calendar-day {
-  display: flex;
-  justify-content: center;
-  align-items: center;
   position: relative;
-  padding: 10px;
-  min-height: 100px;
+  padding: 10px 10px 20px;
+  min-height: 200px;
   border: 1px solid var(--tertiary-color);
-  text-align: center;
   background-color: var(--primary-background);
+  text-decoration: none;
+}
+
+.calendar-day-number {
+  position: absolute;
+  top: 0;
+  left: 5px;
+}
+
+.dc-number {
+  font-style: italic;
+  color: var(--gray-45);
+  position: absolute;
+  bottom: 0;
+  right: 5px;
+}
+
+.dc-info {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.dc-title {
+  width: 100%;
+  text-align: center;
+  align-self: center;
+  margin-top: 20px;
+  height: 50px;
+  margin-bottom: -5px;
+}
+
+.dc-languages {
+  padding: 0 15px;
+}
+
+.dc-language {
+  font-size: 0.8rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+}
+
+.dc-language-icon {
+  fill: var(--primary-color);
+}
+
+.dc-language-icon svg {
+  width: 25px;
+  height: 25px;
+}
+
+.dc-small-checkmark {
+  position: relative;
+  /* top: -5px; */
+}
+
+.dc-small-checkmark svg {
+  width: 20px;
+  height: 20px;
+}
+
+.dc-big-checkmark {
+  margin: 0 auto;
+}
+
+.dc-big-checkmark svg {
+  width: 50px;
+  height: 50px;
 }
 
 .not-available:hover,
@@ -38,20 +110,27 @@
   background-color: var(--primary-background);
 }
 
-.not-available:hover .calendar-day-number,
-.not-available:active .calendar-day-number {
-  color: var(--primary-color);
-}
-
 .available:hover,
 .available:active {
   cursor: pointer;
   background-color: var(--primary-color);
 }
 
+.not-available:hover .calendar-day-number,
+.not-available:active .calendar-day-number {
+  color: var(--primary-color);
+}
+
 .available:hover .calendar-day-number,
 .available:active .calendar-day-number {
   color: var(--primary-background);
+}
+
+.available:hover .language-icon svg path,
+.available:active .language-icon svg path,
+.available:hover .completed svg circle,
+.available:active .completed svg circle {
+  fill: var(--primary-background);
 }
 
 .available:hover .completed svg circle,
@@ -72,13 +151,7 @@
   stroke: var(--primary-color);
 }
 
-.calendar-day-number {
-  position: absolute;
-  top: 0;
-  left: 5px;
-}
-
-.calendar-day svg,
+/* .calendar-day svg,
 .empty-cirle {
   width: calc(10px + 2vw);
   height: calc(10px + 2vw);
@@ -93,10 +166,79 @@
   max-height: 40px;
   border-radius: 50%;
   border: 2px solid var(--primary-color);
-}
+} */
 
 @media (max-width: 500px) {
   .calendar-day {
     min-height: 75px;
+  }
+}
+
+/* @media (max-width: 1050px) {
+  .calendar-weekday-labels,
+  .calendar-grid {
+    margin: 0;
+  }
+} */
+
+@media (max-width: 1345px) {
+  .calendar-day-number,
+  .dc-number,
+  .dc-title {
+    font-size: 0.8rem;
+  }
+
+  .dc-info hr {
+    margin: 10px 0;
+  }
+
+  .calendar-day {
+    min-height: 170px;
+  }
+
+  .dc-language {
+    justify-content: center;
+  }
+
+  .dc-language-name {
+    display: none;
+  }
+}
+
+@media (max-width: 1115px) {
+  .calendar-grid {
+    max-width: unset;
+  }
+
+  .calendar-day {
+    min-height: 125px;
+    padding: 10px;
+  }
+
+  .dc-title,
+  .dc-info hr {
+    display: none;
+  }
+
+  .dc-info {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+}
+
+@media (max-width: 815px) {
+  .calendar-day {
+    min-height: 100px;
+    padding: 0;
+  }
+
+  .dc-languages {
+    padding: 0;
+  }
+
+  .dc-big-checkmark svg {
+    width: 30px;
+    height: 30px;
   }
 }

--- a/client/src/components/daily-coding-challenge/calendar.css
+++ b/client/src/components/daily-coding-challenge/calendar.css
@@ -44,9 +44,7 @@
 .dc-number {
   font-style: italic;
   color: var(--gray-45);
-  position: absolute;
-  bottom: 0;
-  right: 5px;
+  text-align: center;
 }
 
 .dc-info {
@@ -59,7 +57,7 @@
   width: 100%;
   text-align: center;
   align-self: center;
-  margin-top: 20px;
+  margin-top: 5px;
   height: 50px;
   margin-bottom: -5px;
 }
@@ -126,13 +124,8 @@
   color: var(--primary-background);
 }
 
-.available:hover .language-icon svg path,
-.available:active .language-icon svg path,
-.available:hover .completed svg circle,
-.available:active .completed svg circle {
-  fill: var(--primary-background);
-}
-
+.available:hover .dc-language-icon svg path,
+.available:active .dc-language-icon svg path,
 .available:hover .completed svg circle,
 .available:active .completed svg circle {
   fill: var(--primary-background);
@@ -151,35 +144,23 @@
   stroke: var(--primary-color);
 }
 
-/* .calendar-day svg,
-.empty-cirle {
-  width: calc(10px + 2vw);
-  height: calc(10px + 2vw);
-  max-width: 40px;
-  max-height: 40px;
+.available:hover .dc-title,
+.available:active .dc-title,
+.available:hover .dc-language-name,
+.available:active .dc-language-name {
+  color: var(--primary-background);
 }
 
-.empty-cirle {
-  width: calc(10px + 2vw);
-  height: calc(10px + 2vw);
-  max-width: 40px;
-  max-height: 40px;
-  border-radius: 50%;
-  border: 2px solid var(--primary-color);
-} */
+.available:hover .dc-number,
+.available:active .dc-number {
+  color: var(--quaternary-background);
+}
 
 @media (max-width: 500px) {
   .calendar-day {
     min-height: 75px;
   }
 }
-
-/* @media (max-width: 1050px) {
-  .calendar-weekday-labels,
-  .calendar-grid {
-    margin: 0;
-  }
-} */
 
 @media (max-width: 1345px) {
   .calendar-day-number,
@@ -224,6 +205,11 @@
     display: flex;
     justify-content: center;
     align-items: center;
+    height: 80%;
+  }
+
+  .dc-spacer {
+    display: none;
   }
 }
 
@@ -233,12 +219,17 @@
     padding: 0;
   }
 
+  .dc-number {
+    text-align: right;
+    padding-right: 5px;
+  }
+
   .dc-languages {
     padding: 0;
   }
 
   .dc-big-checkmark svg {
-    width: 30px;
-    height: 30px;
+    width: 40px;
+    height: 40px;
   }
 }

--- a/client/src/components/daily-coding-challenge/calendar.tsx
+++ b/client/src/components/daily-coding-challenge/calendar.tsx
@@ -1,12 +1,15 @@
 import React, { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
 import { useTranslation } from 'react-i18next';
-import { Button, Callout, Col, Spacer } from '@freecodecamp/ui';
+import { Button, Callout, Container, Col, Row, Spacer } from '@freecodecamp/ui';
 import {
   completedDailyCodingChallengesSelector,
   isSignedInSelector
 } from '../../redux/selectors';
-import { CompletedDailyCodingChallenge } from '../../redux/prop-types';
+import {
+  CompletedDailyCodingChallenge,
+  DailyCodingChallengeLanguages
+} from '../../redux/prop-types';
 import { Loader } from '../helpers';
 import envData from '../../../config/env.json';
 import Login from '../Header/components/login';
@@ -40,9 +43,9 @@ interface AllDailyChallengeFromDb {
 interface DailyChallengeMap {
   id: string;
   date: string;
-  isCompleted: boolean;
   challengeNumber: number;
   title: string;
+  completedLanguages: DailyCodingChallengeLanguages[];
 }
 
 type DailyChallengesMap = Map<string, DailyChallengeMap>;
@@ -85,16 +88,20 @@ const getMonthInfo = (
     });
 
     const challengeData = dailyChallengesMap.get(formattedDate);
-    const isCompleted = challengeData?.isCompleted || false;
+    const completedLanguages = challengeData?.completedLanguages || [];
+    const title = challengeData?.title || '';
     const isAvailable = challengeData !== undefined;
+    const challengeNumber = challengeData?.challengeNumber;
 
     days.push(
       <CalendarDay
         key={`day-${day}`}
         date={formattedDate}
         dayNumber={day}
-        isCompleted={isCompleted}
+        challengeNumber={challengeNumber}
+        title={title}
         isAvailable={isAvailable}
+        completedLanguages={completedLanguages}
       />
     );
   }
@@ -117,10 +124,6 @@ function DailyCodingChallengeCalendar({
   const { t } = useTranslation();
 
   const todayUsCentral = getTodayUsCentral();
-
-  const completedDailyCodingChallengeIds = completedDailyCodingChallenges.map(
-    c => c.id
-  );
 
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(false);
@@ -145,7 +148,9 @@ function DailyCodingChallengeCalendar({
           newDailyChallengesMap.set(date, {
             ...c,
             date,
-            isCompleted: completedDailyCodingChallengeIds.includes(c.id)
+            completedLanguages:
+              completedDailyCodingChallenges.find(ch => ch.id === c.id)
+                ?.languages ?? []
           });
         });
 
@@ -231,18 +236,22 @@ function DailyCodingChallengeCalendar({
 
   return (
     <>
-      <Col md={8} mdOffset={2} sm={10} smOffset={1} xs={12}>
-        <Callout variant='info'>
-          {t('daily-coding-challenges.release-note')}
-        </Callout>
+      <Container>
+        <Row>
+          <Col md={8} mdOffset={2} sm={10} smOffset={1} xs={12}>
+            <Callout variant='info'>
+              {t('daily-coding-challenges.release-note')}
+            </Callout>
 
-        <Button
-          block={true}
-          href={`/learn/daily-coding-challenge/${todayUsCentral}`}
-        >
-          {t('buttons.go-to-dcc-today')}
-        </Button>
-      </Col>
+            <Button
+              block={true}
+              href={`/learn/daily-coding-challenge/${todayUsCentral}`}
+            >
+              {t('buttons.go-to-dcc-today')}
+            </Button>
+          </Col>
+        </Row>
+      </Container>
 
       <Spacer size='l' />
 

--- a/client/src/pages/learn/daily-coding-challenge/archive.tsx
+++ b/client/src/pages/learn/daily-coding-challenge/archive.tsx
@@ -9,25 +9,26 @@ function Archive(): JSX.Element {
   const { t } = useTranslation();
 
   return (
-    <Container>
-      <Row>
-        <Col md={12} sm={12} xs={12}>
-          <Spacer size='l' />
-          <h1 className='text-center big-heading'>
-            {t('daily-coding-challenges.title')}
-          </h1>
-          <Spacer size='m' />
-          <DailyCodingChallengeIcon className='cert-header-icon' />
-          <Spacer size='l' />
-          <DailyCodingChallengeCalendar />
-        </Col>
-        <Col md={8} mdOffset={2} sm={10} smOffset={1} xs={12}>
-          <Spacer size='l' />
-          <Map />
-          <Spacer size='l' />
-        </Col>
-      </Row>
-    </Container>
+    <>
+      <Spacer size='l' />
+      <h1 className='text-center big-heading'>
+        {t('daily-coding-challenges.title')}
+      </h1>
+      <Spacer size='m' />
+      <DailyCodingChallengeIcon className='cert-header-icon' />
+      <Spacer size='l' />
+      <DailyCodingChallengeCalendar />
+
+      <Container>
+        <Row>
+          <Col md={8} mdOffset={2} sm={10} smOffset={1} xs={12}>
+            <Spacer size='l' />
+            <Map />
+            <Spacer size='l' />
+          </Col>
+        </Row>
+      </Container>
+    </>
   );
 }
 

--- a/client/src/redux/prop-types.ts
+++ b/client/src/redux/prop-types.ts
@@ -322,7 +322,7 @@ export type DailyCodingChallengeLanguages = 'javascript' | 'python';
 export interface CompletedDailyCodingChallenge {
   id: string;
   completedDate: number;
-  completedLanguages: DailyCodingChallengeLanguages[];
+  languages: DailyCodingChallengeLanguages[];
 }
 
 type Quiz = {

--- a/e2e/daily-coding-challenge.spec.ts
+++ b/e2e/daily-coding-challenge.spec.ts
@@ -232,6 +232,6 @@ test.describe('Daily Coding Challenge Archive', () => {
 
     await expect(page.getByTestId('calendar-day-completed')).toHaveCount(1);
 
-    await expect(page.getByTestId('calendar-day-not-completed')).toHaveCount(1);
+    await expect(page.getByTestId('calendar-day-not-completed')).toHaveCount(3);
   });
 });


### PR DESCRIPTION
<details><summary>before</summary>

<img width="1188" height="695" alt="Screenshot 2025-10-23 at 2 16 46 PM" src="https://github.com/user-attachments/assets/7825d17d-3524-43fc-9ded-bd6dff908608" />

</details>

<details><summary>after</summary>

<img width="1434" height="1106" alt="Screenshot 2025-10-23 at 2 15 29 PM" src="https://github.com/user-attachments/assets/1da877e8-ef53-4a24-ad48-f930e5a75bdc" />

</details>

hoping this will encourage people to do complete the challenge in both languages.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
