### PR TITLE
fix(curriculum): remove quiz reference from RBD review intro

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -4970,7 +4970,7 @@
       "review-relational-databases": {
         "title": "Relational Databases Review",
         "intro": [
-          "Review relational databases concepts to prepare for the upcoming quiz."
+          "Review relational databases concepts to prepare for the exam."
         ]
       },
       "lecture-understanding-the-http-request-response-model": {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ ] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #63008
<!-- Feel free to add any additional description of changes below this line -->

Changed "prepare for the upcoming quiz" to "prepare for the exam" in the Relational Databases Review intro text, as this is the last module of the chapter and no quiz follows it.
