### PR TITLE
fix(client): completion epic missing structure bug

### DIFF
--- a/client/src/redux/selectors.js
+++ b/client/src/redux/selectors.js
@@ -149,7 +149,7 @@ export const completionStateSelector = createSelector(
 
     const structure = superBlockStructures[challengeMeta.superBlock];
 
-    const chapters = structure.chapters ?? [];
+    const chapters = structure?.chapters ?? [];
 
     const getCompletionState = ({
       chapters,


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

It's unclear how this code is reached without the "structure" existing, but it seems to happen and prevents challenges from completing properly. I couldn't reproduce the bug without simply commenting out the `updateSuperBlockStructures` call inside progress.tsx, but doing that did recreate it. Presumably there's a race condition, but I don't see how.

Tentatively closes https://github.com/freeCodeCamp/freeCodeCamp/issues/62970

<!-- Feel free to add any additional description of changes below this line -->
