### PR TITLE
feat(challenge-helper): auto add prefix to new language block

### DIFF
--- a/tools/challenge-helper-scripts/create-language-block.ts
+++ b/tools/challenge-helper-scripts/create-language-block.ts
@@ -10,6 +10,7 @@ import {
   languageSuperBlocks,
   chapterBasedSuperBlocks
 } from '../../shared/config/curriculum';
+
 import { BlockLayouts, BlockLabel } from '../../shared/config/blocks';
 import {
   getContentConfig,
@@ -233,7 +234,37 @@ function getBlockPrefix(
 ): string | null {
   // Only chapter-based super blocks use blockLabel so prefix only applies to them.
   if (!chapterBasedSuperBlocks.includes(superBlock)) return null;
-  return `${superBlock}-${blockLabel}-`;
+
+  let langLevel;
+
+  switch (superBlock) {
+    case SuperBlocks.A2English:
+      langLevel = 'en-a2';
+      break;
+    case SuperBlocks.B1English:
+      langLevel = 'en-b1';
+      break;
+    case SuperBlocks.A1Spanish:
+      langLevel = 'es-a1';
+      break;
+    case SuperBlocks.A2Spanish:
+      langLevel = 'es-a2';
+      break;
+    case SuperBlocks.A1Chinese:
+      langLevel = 'zh-a1';
+      break;
+    case SuperBlocks.A2Chinese:
+      langLevel = 'zh-a2';
+      break;
+    default:
+      langLevel = superBlock;
+  }
+
+  if (blockLabel === BlockLabel.exam) {
+    return `${langLevel}-`;
+  }
+
+  return `${langLevel}-${blockLabel}-`;
 }
 
 void getAllBlocks()
@@ -271,10 +302,15 @@ void getAllBlocks()
 
             // Check if user accidentally included block label at the end
             if (answers.blockLabel) {
-              const blockLabelValues = Object.values(BlockLabel);
+              // Exclude exam as it is an exception
+              const blockLabelValues = Object.values(BlockLabel).filter(
+                label => label !== BlockLabel.exam
+              );
+
               const endsWithLabel = blockLabelValues.some(label =>
                 uniquePart.endsWith(`-${label}`)
               );
+
               if (endsWithLabel) {
                 return `Block name should not end with a block label (e.g., '-${answers.blockLabel}'). The label is already in the prefix.`;
               }

--- a/tools/challenge-helper-scripts/create-language-block.ts
+++ b/tools/challenge-helper-scripts/create-language-block.ts
@@ -51,7 +51,7 @@ interface CreateBlockArgs {
   chapter?: string;
   module?: string;
   position?: number;
-  blockLabel?: string;
+  blockLabel?: BlockLabel;
   blockLayout?: string;
   questionCount?: number;
 }
@@ -64,7 +64,7 @@ async function createLanguageBlock(
   chapter?: string,
   module?: string,
   position?: number,
-  blockLabel?: string,
+  blockLabel?: BlockLabel,
   blockLayout?: string,
   questionCount?: number
 ) {
@@ -142,7 +142,7 @@ async function createMetaJson(
   title: string,
   helpCategory: string,
   challengeId: ObjectID,
-  blockLabel?: string,
+  blockLabel?: BlockLabel,
   blockLayout?: string
 ) {
   const newMeta = getBaseMeta('Language');
@@ -229,7 +229,7 @@ function withTrace<Args extends unknown[], Result>(
 
 function getBlockPrefix(
   superBlock: SuperBlocks,
-  blockLabel?: string
+  blockLabel?: BlockLabel
 ): string | null {
   // Only chapter-based super blocks use blockLabel so prefix only applies to them.
   if (!chapterBasedSuperBlocks.includes(superBlock)) return null;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

The dashed names of blocks in language super blocks must follow this pattern:

```
[lang]-[level]-[block-label]-[block-name]
```

This PR:
- Updates the `create-new-language-block` script so the super block and block label are prompted first, and their values are used to construct the prefix
- Adds a check to catch cases where block label appears at the end (we should have `review-topic-one` instead of `topic-one-review`).
  - The only exception is exams, as `en-a2-exam-certification` doesn't make much sense.

<details>
<summary>Screen recording - Non-exam</summary>

https://github.com/user-attachments/assets/861da64e-2b38-419d-ba2e-9179afeb1292

</details>

<details>
<summary>Screen recording - Exam</summary>

https://github.com/user-attachments/assets/7b4a3976-4cb4-4925-95a5-4da2fe909f30

</details>

<!-- Feel free to add any additional description of changes below this line -->
