### PR TITLE
fix(curriculum): improve default width behavior explanation

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-what-is-css/672acc03c257524d6a5151e8.md
+++ b/curriculum/challenges/english/blocks/lecture-what-is-css/672acc03c257524d6a5151e8.md
@@ -11,14 +11,7 @@ In CSS, the `width` and `height` properties are used to control the dimensions o
 
 These properties can be defined in different units such as pixels (`px`), percentages (`%`), viewport units (`vw`, `vh`), and more.
 
-The `width` property specifies the width of an element. In most cases, if you do not specify a width, it defaults to `auto`. When a width is not specified:
-
-- non-replaced block-level elements expand to fill the full width of their parent container.
-- `inline` and `inline-block` elements take up the width their content requires.
-- `<img>` elements have default dimensions defined by the embedded image's intrinsic values.
-- `<iframe>` elements have a width of `300px`.
-
-<br />
+The `width` property specifies the width of an element. If you do not specify a width, then the default is set to `auto`. This lets the browser determine the element's width based on its content, parent, and display type. For a `div` element, `width: auto` makes it expand to fill the full width of its parent container.
 
 The `height` property specifies the height of an element. Similarly, the height is `auto` by default, which means it will adjust to the content inside.
 

--- a/curriculum/challenges/english/blocks/lecture-what-is-css/672acc03c257524d6a5151e8.md
+++ b/curriculum/challenges/english/blocks/lecture-what-is-css/672acc03c257524d6a5151e8.md
@@ -11,7 +11,14 @@ In CSS, the `width` and `height` properties are used to control the dimensions o
 
 These properties can be defined in different units such as pixels (`px`), percentages (`%`), viewport units (`vw`, `vh`), and more.
 
-The `width` property specifies the width of an element. If you do not specify a width, then the default is set to `auto`. This means the element will take up the full width of its parent container.
+The `width` property specifies the width of an element. In most cases, if you do not specify a width, it defaults to `auto`. When a width is not specified:
+
+- non-replaced block-level elements expand to fill the full width of their parent container.
+- `inline` and `inline-block` elements take up the width their content requires.
+- `<img>` elements have default dimensions defined by the embedded image's intrinsic values.
+- `<iframe>` elements have a width of `300px`.
+
+<br />
 
 The `height` property specifies the height of an element. Similarly, the height is `auto` by default, which means it will adjust to the content inside.
 

--- a/curriculum/challenges/english/blocks/review-basic-css/671a887a7e62c75e9ab1ee4a.md
+++ b/curriculum/challenges/english/blocks/review-basic-css/671a887a7e62c75e9ab1ee4a.md
@@ -38,7 +38,7 @@ Here is an example of inline CSS:
 
 ## Working With the `width` and `height` Properties
 
-- **`width` Property**: This property specifies the width of an element. If you do not specify a width, then the default is set to `auto`. This means the element will take up the full width of its parent container.
+- **`width` Property**: This property specifies the width of an element. If you do not specify a width, then the default is set to `auto`. This lets the browser determine the element's width based on its content, parent, and display type.
 - **`min-width` Property**: This property specifies the minimum width for an element.
 - **`max-width` Property**: This property specifies the maximum width for an element.
 - **`height` Property**: This property specifies the height of an element. Similarly, the height is `auto` by default, which means it will adjust to the content inside.

--- a/curriculum/challenges/english/blocks/review-css/671a9a0a140c2b9d6a75629f.md
+++ b/curriculum/challenges/english/blocks/review-css/671a9a0a140c2b9d6a75629f.md
@@ -24,7 +24,7 @@ Review the concepts below to prepare for the upcoming exam.
 
 ## Working With the `width` and `height` Properties
 
-- **`width` Property**: This property specifies the width of an element. If you do not specify a width, then the default is set to `auto`. This means the element will take up the full width of its parent container.
+- **`width` Property**: This property specifies the width of an element. If you do not specify a width, then the default is set to `auto`. This lets the browser determine the element's width based on its content, parent, and display type.
 - **`min-width` Property**: This property specifies the minimum width for an element.
 - **`max-width` Property**: This property specifies the maximum width for an element.
 - **`height` Property**: This property specifies the height of an element. Similarly, the height is `auto` by default, which means it will adjust to the content inside.


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine.

Closes #63057

Affected pages:


https://www.freecodecamp.org/learn/full-stack-developer/lecture-what-is-css/how-do-width-and-height-work
https://www.freecodecamp.org/learn/full-stack-developer/review-css/review-css
https://www.freecodecamp.org/learn/full-stack-developer/review-basic-css/review-basic-css


<details>

<summary>Screenshots:</summary>

Updated proposal:

<img width="1325" height="429" alt="image" src="https://github.com/user-attachments/assets/5732bc37-37b2-4858-90d0-096966bdac8e" />

Initial proposal:

<img width="1008" height="468" alt="image" src="https://github.com/user-attachments/assets/28787d8f-cda2-41bb-9226-838a4046c351" />

</details>