### PR TITLE
fix(learn): Rename "Preview" button to "Terminal" for Python lessons

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -523,6 +523,7 @@
       "instructions": "Instructions",
       "notes": "Notes",
       "preview": "Preview",
+      "terminal": "Terminal",
       "editor": "Editor",
       "interactive-editor": "Interactive Editor"
     },

--- a/client/src/templates/Challenges/classic/action-row.tsx
+++ b/client/src/templates/Challenges/classic/action-row.tsx
@@ -6,8 +6,7 @@ import store from 'store';
 import { DailyCodingChallengeLanguages } from '../../../redux/prop-types';
 import { challengeTypes } from '../../../../../shared-dist/config/challenge-types';
 import EditorTabs from './editor-tabs';
-// Add this import to the top of ActionRow.tsx
-// The exact path may vary, but this is the standard freeCodeCamp structure.
+
 interface ClassicLayoutProps {
   dailyCodingChallengeLanguage: DailyCodingChallengeLanguages;
   hasNotes: boolean;
@@ -22,7 +21,6 @@ interface ClassicLayoutProps {
   showInstructions: boolean;
   showPreviewPane: boolean;
   showPreviewPortal: boolean;
-
   challengeType: number;
   togglePane: (pane: string) => void;
   hasInteractiveEditor?: never;
@@ -177,7 +175,6 @@ const ActionRow = (props: ActionRowProps): JSX.Element => {
               >
                 <span className='sr-only'>{getPreviewBtnsSrText().pane}</span>
                 <span aria-hidden='true'>{previewButtonText}</span>
-                {/* <span aria-hidden='true'>{t('learn.editor-tabs.preview')}</span> */}
               </button>
               <button
                 aria-expanded={!!showPreviewPortal}

--- a/client/src/templates/Challenges/classic/action-row.tsx
+++ b/client/src/templates/Challenges/classic/action-row.tsx
@@ -4,8 +4,10 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import store from 'store';
 import { DailyCodingChallengeLanguages } from '../../../redux/prop-types';
+import { challengeTypes } from '../../../../../shared-dist/config/challenge-types';
 import EditorTabs from './editor-tabs';
-
+// Add this import to the top of ActionRow.tsx
+// The exact path may vary, but this is the standard freeCodeCamp structure.
 interface ClassicLayoutProps {
   dailyCodingChallengeLanguage: DailyCodingChallengeLanguages;
   hasNotes: boolean;
@@ -20,6 +22,8 @@ interface ClassicLayoutProps {
   showInstructions: boolean;
   showPreviewPane: boolean;
   showPreviewPortal: boolean;
+
+  challengeType: number;
   togglePane: (pane: string) => void;
   hasInteractiveEditor?: never;
 }
@@ -70,7 +74,8 @@ const ActionRow = (props: ActionRowProps): JSX.Element => {
     showPreviewPortal,
     isDailyCodingChallenge,
     dailyCodingChallengeLanguage,
-    setDailyCodingChallengeLanguage
+    setDailyCodingChallengeLanguage,
+    challengeType
   } = props;
 
   // sets screen reader text for the two preview buttons
@@ -94,6 +99,16 @@ const ActionRow = (props: ActionRowProps): JSX.Element => {
 
     return previewBtnsSrText;
   }
+
+  const isPythonChallenge =
+    challengeType === challengeTypes.python ||
+    challengeType === challengeTypes.multifilePythonCertProject ||
+    challengeType === challengeTypes.pyLab ||
+    challengeType === challengeTypes.dailyChallengePy;
+
+  const previewButtonText = isPythonChallenge
+    ? t('learn.editor-tabs.terminal')
+    : t('learn.editor-tabs.preview');
 
   const handleLanguageChange = (language: DailyCodingChallengeLanguages) => {
     store.set('dailyCodingChallengeLanguage', language);
@@ -161,7 +176,8 @@ const ActionRow = (props: ActionRowProps): JSX.Element => {
                 onClick={() => togglePane('showPreviewPane')}
               >
                 <span className='sr-only'>{getPreviewBtnsSrText().pane}</span>
-                <span aria-hidden='true'>{t('learn.editor-tabs.preview')}</span>
+                <span aria-hidden='true'>{previewButtonText}</span>
+                {/* <span aria-hidden='true'>{t('learn.editor-tabs.preview')}</span> */}
               </button>
               <button
                 aria-expanded={!!showPreviewPortal}

--- a/client/src/templates/Challenges/classic/desktop-layout.tsx
+++ b/client/src/templates/Challenges/classic/desktop-layout.tsx
@@ -287,6 +287,7 @@ const DesktopLayout = (props: DesktopLayoutProps): JSX.Element => {
           showPreviewPane={showPreviewPane}
           showPreviewPortal={showPreviewPortal}
           togglePane={togglePane}
+          challengeType={challengeType}
           data-playwright-test-label='action-row'
         />
       )}


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.


Related to #63047

fix(learn): Use "Terminal" button label for Python challenges

Renames the action row button from "Preview" to "Terminal" for all Python-based challenge types (including Python, PyLab, and multifile Python projects).

This change improves UX by accurately reflecting the challenge environment: Python challenges execute code in an interactive Xterm terminal, not an HTML iframe preview.

- Updates the conditional logic in `ActionRow.tsx` to display "Terminal" based on the challenge's `challengeType`.
- Adds the missing `"terminal": "Terminal"` key to the English localization file to ensure the correct text is displayed.

before : 
<img width="910" height="591" alt="Screenshot 2025-10-26 at 2 58 14 PM" src="https://github.com/user-attachments/assets/c757c676-a293-4a2e-833b-99b28ef40dc3" />

After : 
<img width="1470" height="806" alt="Screenshot 2025-10-26 at 2 58 46 PM" src="https://github.com/user-attachments/assets/b2f40cb9-f9ac-494b-b4ac-955809328925" />



