### PR TITLE
feat: show python syntax-error message if a NameError occurs

### DIFF
--- a/client/src/templates/Challenges/redux/execute-challenge-saga.js
+++ b/client/src/templates/Challenges/redux/execute-challenge-saga.js
@@ -222,7 +222,11 @@ export function* executeTests(testRunner, tests, testTimeout = 5000) {
         newTest.stack = stack;
       }
 
-      if (type === 'IndentationError' || type === 'SyntaxError') {
+      if (
+        type === 'IndentationError' ||
+        type === 'SyntaxError' ||
+        type === 'NameError'
+      ) {
         const msgKey =
           type === 'IndentationError'
             ? 'learn.indentation-error'


### PR DESCRIPTION
This might be an issue if we need to have learner code generate errors, but we can deal with that if it happens

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes https://github.com/freeCodeCamp/freeCodeCamp/issues/62861

<!-- Feel free to add any additional description of changes below this line -->
