### PR TITLE
feat(curriculum): add new fsd superblock

### DIFF
--- a/client/config/cert-and-project-map.ts
+++ b/client/config/cert-and-project-map.ts
@@ -32,13 +32,13 @@ const collegeAlgebraPyBase = '/learn/college-algebra-with-python';
 const takeHomeBase = '/learn/coding-interview-prep/take-home-projects';
 const foundationalCSharpBase =
   '/learn/foundational-c-sharp-with-microsoft/foundational-c-sharp-with-microsoft-certification-exam';
-const fullStackDeveloperBase = '/learn/full-stack-developer';
 const respWebV9Base = '/learn/responsive-web-design-v9';
 const jsV9Base = '/learn/javascript-v9';
 const frontEndDevLibsV9Base = '/learn/front-end-development-libraries-v9';
 const pythonV9Base = '/learn/python-v9';
 const relationalDbV9Base = '/learn/relational-databases-v9';
 const backEndDevApisV9Base = '/learn/back-end-development-and-apis-v9';
+const fullStackDeveloperV9Base = '/learn/full-stack-developer-v9';
 const a2EnglishBase = '/learn/a2-english-for-developers';
 const b1EnglishBase = '/learn/b1-english-for-developers';
 const a2SpanishBase = '/learn/a2-professional-spanish';
@@ -807,19 +807,6 @@ const allStandardCerts = [
   },
   // Upcoming Certifications
   {
-    id: '64514fda6c245de4d11eb7bb',
-    title: 'Certified Full Stack Developer',
-    certSlug: Certification.FullStackDeveloper,
-    projects: [
-      {
-        id: '645147516c245de4d11eb7ba',
-        title: 'Certified Full Stack Developer Exam',
-        link: `${fullStackDeveloperBase}/exam-certified-full-stack-developer/exam-certified-full-stack-developer`,
-        certSlug: Certification.FullStackDeveloper
-      }
-    ]
-  },
-  {
     id: '68db314d3c11a8bff07c7535',
     title: 'Responsive Web Design',
     certSlug: Certification.RespWebDesignV9,
@@ -894,6 +881,19 @@ const allStandardCerts = [
         title: 'Back End Development and APIs Certification Exam',
         link: `${backEndDevApisV9Base}/exam-back-end-development-and-apis-certification/exam-back-end-development-and-apis-certification`,
         certSlug: Certification.BackEndDevApisV9
+      }
+    ]
+  },
+  {
+    id: '64514fda6c245de4d11eb7bb',
+    title: 'Certified Full Stack Developer',
+    certSlug: Certification.FullStackDeveloperV9,
+    projects: [
+      {
+        id: '645147516c245de4d11eb7ba',
+        title: 'Certified Full Stack Developer Exam',
+        link: `${fullStackDeveloperV9Base}/exam-certified-full-stack-developer/exam-certified-full-stack-developer`,
+        certSlug: Certification.FullStackDeveloperV9
       }
     ]
   },

--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -7316,6 +7316,35 @@
       }
     }
   },
+  "full-stack-developer-v9": {
+    "title": "Certified Full Stack Developer Curriculum",
+    "intro": [
+      "This course provides a comprehensive pathway to becoming a Certified Full Stack Developer, covering all the essential technologies required to build modern, scalable web applications from start to finish.",
+      "Through a blend of interactive lessons, coding exercises, and real-world projects, you will master both frontend and backend development. You'll work with HTML, CSS, and JavaScript to build responsive user interfaces, explore React and TypeScript for advanced web applications, and learn to manage data with relational databases - and on the backend, you'll use Git, Npm, Node.js, and Python to create powerful server-side solutions.",
+      "By the end of this course, you'll have the practical skills and experience to confidently develop complete web applications, preparing you for a successful career as a Full Stack Developer.",
+      "This certification will take you a substantial amount of time and effort to complete. If you start now, you may be ready to start the remaining material and final exam when we launch it in the coming months."
+    ],
+    "chapters": {
+      "certified-full-stack-developer-exam": "Certified Full Stack Developer Exam"
+    },
+    "modules": {
+      "certified-full-stack-developer-exam": "Certified Full Stack Developer Exam"
+    },
+    "module-intros": {
+      "certified-full-stack-developer-exam": {
+        "note": "Coming Late 2026",
+        "intro": [
+          "This will be a 90 question exam testing what you have learned throughout this certification."
+        ]
+      }
+    },
+    "blocks": {
+      "exam-certified-full-stack-developer": {
+        "title": "Certified Full Stack Developer Exam",
+        "intro": ["Pass this exam to become a Certified Full Stack Developer."]
+      }
+    }
+  },
   "a1-professional-spanish": {
     "title": "A1 Professional Spanish Certification (Beta)",
     "note": "This certification is currently in active development. While there isn't a claimable certification available for this section at the moment, one will be available soon. In the meantime, you're welcome to explore the courses we have created below.",

--- a/client/src/assets/superblock-icon.tsx
+++ b/client/src/assets/superblock-icon.tsx
@@ -58,7 +58,8 @@ const iconMap = {
   [SuperBlocks.FrontEndDevLibsV9]: ReactIcon,
   [SuperBlocks.PythonV9]: PythonIcon,
   [SuperBlocks.RelationalDbV9]: DatabaseIcon,
-  [SuperBlocks.BackEndDevApisV9]: APIIcon
+  [SuperBlocks.BackEndDevApisV9]: APIIcon,
+  [SuperBlocks.FullStackDeveloperV9]: Code
 };
 
 type SuperBlockIconProps = {

--- a/client/src/components/settings/certification.tsx
+++ b/client/src/components/settings/certification.tsx
@@ -89,13 +89,13 @@ const createCertifiedMap = ({
   // LegacyFullStack cannot be handled by this because there are no projects to
   // be rendered. The new FullStackDeveloper certification is a normal
   // certification with projects.
-  [Certification.FullStackDeveloper]: false,
   [Certification.RespWebDesignV9]: isRespWebDesignCertV9,
   [Certification.JsV9]: isJavascriptCertV9,
   [Certification.FrontEndDevLibsV9]: false,
   [Certification.PythonV9]: false,
   [Certification.RelationalDbV9]: false,
   [Certification.BackEndDevApisV9]: false,
+  [Certification.FullStackDeveloperV9]: false,
   [Certification.A2English]: isA2EnglishCert,
   [Certification.B1English]: false,
   [Certification.A2Spanish]: false,

--- a/client/src/pages/learn/full-stack-developer-v9/index.md
+++ b/client/src/pages/learn/full-stack-developer-v9/index.md
@@ -1,0 +1,9 @@
+---
+title: Certified Full Stack Developer
+superBlock: full-stack-developer-v9
+certification: full-stack-developer-v9
+---
+
+## Certified Full Stack Developer
+
+Learn HTML, CSS, JavaScript, Relational Databases, React, and Node.js to become a Certified Full Stack Developer.

--- a/client/utils/index.ts
+++ b/client/utils/index.ts
@@ -23,6 +23,7 @@ const idToPath = new Map(
     '68e6bd5020effa1586e79855': Certification.PythonV9,
     '68e6bd5120effa1586e79856': Certification.RelationalDbV9,
     '68e6bd5120effa1586e79857': Certification.BackEndDevApisV9,
+    '64514fda6c245de4d11eb7bb': Certification.FullStackDeveloperV9,
     '651dd7e01d697d0aab7833b7': Certification.A2English
   })
 );

--- a/curriculum/challenges/english/certifications/full-stack-developer-v9.yml
+++ b/curriculum/challenges/english/certifications/full-stack-developer-v9.yml
@@ -1,7 +1,7 @@
 ---
 id: 64514fda6c245de4d11eb7bb
 title: Certified Full Stack Developer
-certification: full-stack-developer
+certification: full-stack-developer-v9
 challengeType: 7
 tests:
   - id: 645147516c245de4d11eb7ba

--- a/curriculum/src/build-curriculum.ts
+++ b/curriculum/src/build-curriculum.ts
@@ -205,7 +205,8 @@ export const superBlockNames = {
   'front-end-development-libraries-v9': SuperBlocks.FrontEndDevLibsV9,
   'python-v9': SuperBlocks.PythonV9,
   'relational-databases-v9': SuperBlocks.RelationalDbV9,
-  'back-end-development-and-apis-v9': SuperBlocks.BackEndDevApisV9
+  'back-end-development-and-apis-v9': SuperBlocks.BackEndDevApisV9,
+  'full-stack-developer-v9': SuperBlocks.FullStackDeveloperV9
 };
 
 export const superBlockToFilename = Object.entries(superBlockNames).reduce(

--- a/curriculum/structure/curriculum.json
+++ b/curriculum/structure/curriculum.json
@@ -36,7 +36,8 @@
     "front-end-development-libraries-v9",
     "python-v9",
     "relational-databases-v9",
-    "back-end-development-and-apis-v9"
+    "back-end-development-and-apis-v9",
+    "full-stack-developer-v9"
   ],
   "certifications": [
     "a2-english-for-developers",
@@ -49,7 +50,6 @@
     "data-visualization",
     "foundational-c-sharp-with-microsoft",
     "front-end-development-libraries",
-    "full-stack-developer",
     "information-security",
     "javascript-algorithms-and-data-structures",
     "javascript-algorithms-and-data-structures-v8",
@@ -69,6 +69,7 @@
     "front-end-development-libraries-v9",
     "python-v9",
     "relational-databases-v9",
-    "back-end-development-and-apis-v9"
+    "back-end-development-and-apis-v9",
+    "full-stack-developer-v9"
   ]
 }

--- a/curriculum/structure/superblocks/full-stack-developer-v9.json
+++ b/curriculum/structure/superblocks/full-stack-developer-v9.json
@@ -1,0 +1,16 @@
+{
+  "chapters": [
+    {
+      "chapterType": "exam",
+      "dashedName": "certified-full-stack-developer-exam",
+      "comingSoon": true,
+      "modules": [
+        {
+          "dashedName": "certified-full-stack-developer-exam",
+          "comingSoon": true,
+          "blocks": ["exam-certified-full-stack-developer"]
+        }
+      ]
+    }
+  ]
+}

--- a/shared/config/certification-settings.ts
+++ b/shared/config/certification-settings.ts
@@ -26,13 +26,13 @@ export enum Certification {
   CollegeAlgebraPy = 'college-algebra-with-python-v8',
   FoundationalCSharp = 'foundational-c-sharp-with-microsoft',
   // Upcoming certifications
-  FullStackDeveloper = 'full-stack-developer-v9',
   RespWebDesignV9 = 'responsive-web-design-v9',
   JsV9 = 'javascript-v9',
   FrontEndDevLibsV9 = 'front-end-development-libraries-v9',
   PythonV9 = 'python-v9',
   RelationalDbV9 = 'relational-databases-v9',
   BackEndDevApisV9 = 'back-end-development-and-apis-v9',
+  FullStackDeveloperV9 = 'full-stack-developer-v9',
   A2English = 'a2-english-for-developers-v8',
   B1English = 'b1-english-for-developers-v8',
   A2Spanish = 'a2-professional-spanish-v8',
@@ -88,13 +88,13 @@ export const legacyFullStackCertification = [
 // "Upcoming" certifications are standard certifications that are not live unless
 // showUpcomingChanges is true.
 export const upcomingCertifications = [
-  Certification.FullStackDeveloper,
   Certification.RespWebDesignV9,
   Certification.JsV9,
   Certification.FrontEndDevLibsV9,
   Certification.PythonV9,
   Certification.RelationalDbV9,
   Certification.BackEndDevApisV9,
+  Certification.FullStackDeveloperV9,
   Certification.A2English,
   Certification.B1English,
   Certification.A2Spanish,
@@ -153,6 +153,7 @@ export const certIds = {
   pythonV9Id: '68e6bd5020effa1586e79855',
   relationalDbV9Id: '68e6bd5120effa1586e79856',
   backEndDevApisV9Id: '68e6bd5120effa1586e79857',
+  fullStackDeveloperV9Id: '64514fda6c245de4d11eb7bb',
   a2EnglishId: '651dd7e01d697d0aab7833b7'
 };
 
@@ -312,13 +313,13 @@ export const superBlockToCertMap: {
   [SuperBlocks.FoundationalCSharp]: Certification.FoundationalCSharp,
   [SuperBlocks.RespWebDesignNew]: Certification.RespWebDesign,
   [SuperBlocks.JsAlgoDataStruct]: Certification.JsAlgoDataStruct,
-  [SuperBlocks.FullStackDeveloper]: Certification.FullStackDeveloper,
   [SuperBlocks.RespWebDesignV9]: Certification.RespWebDesignV9,
   [SuperBlocks.JsV9]: Certification.JsV9,
   [SuperBlocks.FrontEndDevLibsV9]: Certification.FrontEndDevLibsV9,
   [SuperBlocks.PythonV9]: Certification.PythonV9,
   [SuperBlocks.RelationalDbV9]: Certification.RelationalDbV9,
   [SuperBlocks.BackEndDevApisV9]: Certification.BackEndDevApisV9,
+  [SuperBlocks.FullStackDeveloperV9]: Certification.FullStackDeveloperV9,
   [SuperBlocks.A2English]: Certification.A2English,
   [SuperBlocks.B1English]: Certification.B1English,
   [SuperBlocks.A1Spanish]: null,
@@ -333,7 +334,8 @@ export const superBlockToCertMap: {
   [SuperBlocks.BasicHtml]: null,
   [SuperBlocks.SemanticHtml]: null,
   [SuperBlocks.DevPlayground]: null,
-  [SuperBlocks.FullStackOpen]: null
+  [SuperBlocks.FullStackOpen]: null,
+  [SuperBlocks.FullStackDeveloper]: null
 };
 
 export type CertSlug = (typeof Certification)[keyof typeof Certification];
@@ -357,13 +359,13 @@ export const linkedInCredentialIds = {
   [Certification.RelationalDb]: 'rd',
   [Certification.CollegeAlgebraPy]: 'cawp',
   [Certification.FoundationalCSharp]: 'fcswm',
-  [Certification.FullStackDeveloper]: 'fsd',
   [Certification.RespWebDesignV9]: 'rwdv9',
   [Certification.JsV9]: 'jsv9',
   [Certification.FrontEndDevLibsV9]: 'felv9',
   [Certification.PythonV9]: 'pyv9',
   [Certification.RelationalDbV9]: 'rdv9',
   [Certification.BackEndDevApisV9]: 'bedv9',
+  [Certification.FullStackDeveloperV9]: 'fsdv9',
   [Certification.JsAlgoDataStructNew]: 'jaads',
   [Certification.A2English]: 'a2efd',
   [Certification.B1English]: 'b1efd',

--- a/shared/config/curriculum.ts
+++ b/shared/config/curriculum.ts
@@ -40,7 +40,8 @@ export enum SuperBlocks {
   FrontEndDevLibsV9 = 'front-end-development-libraries-v9',
   PythonV9 = 'python-v9',
   RelationalDbV9 = 'relational-databases-v9',
-  BackEndDevApisV9 = 'back-end-development-and-apis-v9'
+  BackEndDevApisV9 = 'back-end-development-and-apis-v9',
+  FullStackDeveloperV9 = 'full-stack-developer-v9'
 }
 
 export const languageSuperBlocks = [
@@ -132,6 +133,7 @@ export const superBlockStages: StageMap = {
     SuperBlocks.PythonV9,
     SuperBlocks.RelationalDbV9,
     SuperBlocks.BackEndDevApisV9,
+    SuperBlocks.FullStackDeveloperV9,
     SuperBlocks.A1Spanish,
     SuperBlocks.A2Spanish,
     SuperBlocks.A2Chinese,
@@ -182,7 +184,8 @@ export const notAuditedSuperBlocks: NotAuditedSuperBlocks = {
     SuperBlocks.FrontEndDevLibsV9,
     SuperBlocks.PythonV9,
     SuperBlocks.RelationalDbV9,
-    SuperBlocks.BackEndDevApisV9
+    SuperBlocks.BackEndDevApisV9,
+    SuperBlocks.FullStackDeveloperV9
   ],
   [Languages.Chinese]: [
     SuperBlocks.CodingInterviewPrep,
@@ -204,7 +207,8 @@ export const notAuditedSuperBlocks: NotAuditedSuperBlocks = {
     SuperBlocks.FrontEndDevLibsV9,
     SuperBlocks.PythonV9,
     SuperBlocks.RelationalDbV9,
-    SuperBlocks.BackEndDevApisV9
+    SuperBlocks.BackEndDevApisV9,
+    SuperBlocks.FullStackDeveloperV9
   ],
   [Languages.ChineseTraditional]: [
     SuperBlocks.CodingInterviewPrep,
@@ -226,7 +230,8 @@ export const notAuditedSuperBlocks: NotAuditedSuperBlocks = {
     SuperBlocks.FrontEndDevLibsV9,
     SuperBlocks.PythonV9,
     SuperBlocks.RelationalDbV9,
-    SuperBlocks.BackEndDevApisV9
+    SuperBlocks.BackEndDevApisV9,
+    SuperBlocks.FullStackDeveloperV9
   ],
   [Languages.Italian]: [
     SuperBlocks.FoundationalCSharp,
@@ -248,7 +253,8 @@ export const notAuditedSuperBlocks: NotAuditedSuperBlocks = {
     SuperBlocks.FrontEndDevLibsV9,
     SuperBlocks.PythonV9,
     SuperBlocks.RelationalDbV9,
-    SuperBlocks.BackEndDevApisV9
+    SuperBlocks.BackEndDevApisV9,
+    SuperBlocks.FullStackDeveloperV9
   ],
   [Languages.Portuguese]: [
     SuperBlocks.JsAlgoDataStructNew,
@@ -268,7 +274,8 @@ export const notAuditedSuperBlocks: NotAuditedSuperBlocks = {
     SuperBlocks.FrontEndDevLibsV9,
     SuperBlocks.PythonV9,
     SuperBlocks.RelationalDbV9,
-    SuperBlocks.BackEndDevApisV9
+    SuperBlocks.BackEndDevApisV9,
+    SuperBlocks.FullStackDeveloperV9
   ],
   [Languages.Ukrainian]: [
     SuperBlocks.JsAlgoDataStructNew,
@@ -287,7 +294,8 @@ export const notAuditedSuperBlocks: NotAuditedSuperBlocks = {
     SuperBlocks.FrontEndDevLibsV9,
     SuperBlocks.PythonV9,
     SuperBlocks.RelationalDbV9,
-    SuperBlocks.BackEndDevApisV9
+    SuperBlocks.BackEndDevApisV9,
+    SuperBlocks.FullStackDeveloperV9
   ],
   [Languages.Japanese]: [
     SuperBlocks.JsAlgoDataStructNew,
@@ -307,7 +315,8 @@ export const notAuditedSuperBlocks: NotAuditedSuperBlocks = {
     SuperBlocks.FrontEndDevLibsV9,
     SuperBlocks.PythonV9,
     SuperBlocks.RelationalDbV9,
-    SuperBlocks.BackEndDevApisV9
+    SuperBlocks.BackEndDevApisV9,
+    SuperBlocks.FullStackDeveloperV9
   ],
   [Languages.German]: [
     SuperBlocks.RelationalDb,
@@ -336,7 +345,8 @@ export const notAuditedSuperBlocks: NotAuditedSuperBlocks = {
     SuperBlocks.FrontEndDevLibsV9,
     SuperBlocks.PythonV9,
     SuperBlocks.RelationalDbV9,
-    SuperBlocks.BackEndDevApisV9
+    SuperBlocks.BackEndDevApisV9,
+    SuperBlocks.FullStackDeveloperV9
   ],
   [Languages.Swahili]: [
     SuperBlocks.DataVis,
@@ -372,7 +382,8 @@ export const notAuditedSuperBlocks: NotAuditedSuperBlocks = {
     SuperBlocks.FrontEndDevLibsV9,
     SuperBlocks.PythonV9,
     SuperBlocks.RelationalDbV9,
-    SuperBlocks.BackEndDevApisV9
+    SuperBlocks.BackEndDevApisV9,
+    SuperBlocks.FullStackDeveloperV9
   ],
   [Languages.Korean]: [
     SuperBlocks.RespWebDesignNew,
@@ -409,7 +420,8 @@ export const notAuditedSuperBlocks: NotAuditedSuperBlocks = {
     SuperBlocks.FrontEndDevLibsV9,
     SuperBlocks.PythonV9,
     SuperBlocks.RelationalDbV9,
-    SuperBlocks.BackEndDevApisV9
+    SuperBlocks.BackEndDevApisV9,
+    SuperBlocks.FullStackDeveloperV9
   ]
 };
 
@@ -425,6 +437,7 @@ export const chapterBasedSuperBlocks = [
   SuperBlocks.PythonV9,
   SuperBlocks.RelationalDbV9,
   SuperBlocks.BackEndDevApisV9,
+  SuperBlocks.FullStackDeveloperV9,
   SuperBlocks.A1Chinese
 ];
 Object.freeze(chapterBasedSuperBlocks);


### PR DESCRIPTION
This adds a new FSD superblock we can use for the release of the new certs without affecting the existing fsd superblock. It moves the exam challenge from the existing FSD superblock to the new one since we won't be using it in the existing one.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related to: https://github.com/freeCodeCamp/fCC10/issues/85

<!-- Feel free to add any additional description of changes below this line -->
