### PR TITLE
refactor(curriculum,client): rename a2 exam block to en-a2-certification-exam

### DIFF
--- a/client/config/cert-and-project-map.ts
+++ b/client/config/cert-and-project-map.ts
@@ -905,7 +905,7 @@ const allStandardCerts = [
       {
         id: '6721db5d9f0c116e6a0fe25a',
         title: 'A2 English for Developers Certification Exam',
-        link: `${a2EnglishBase}/a2-english-for-developers-certification-exam/a2-english-for-developers-certification-exam`,
+        link: `${a2EnglishBase}/en-a2-certification-exam/en-a2-certification-exam`,
         certSlug: Certification.A2English
       }
     ]

--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -1564,7 +1564,7 @@
           "This course will provide you with ways to explain things to other people while assisting them."
         ]
       },
-      "a2-english-for-developers-certification-exam": {
+      "en-a2-certification-exam": {
         "title": "A2 English for Developers Certification Exam",
         "intro": [
           "This exam is required to claim the A2 English for Developers Certification."

--- a/client/src/pages/learn/a2-english-for-developers/en-a2-certification-exam/index.md
+++ b/client/src/pages/learn/a2-english-for-developers/en-a2-certification-exam/index.md
@@ -1,6 +1,6 @@
 ---
 title: A2 English for Developers Certification Exam
-block: a2-english-for-developers-certification-exam
+block: en-a2-certification-exam
 superBlock: a2-english-for-developers
 ---
 

--- a/curriculum/challenges/english/blocks/en-a2-certification-exam/6721db5d9f0c116e6a0fe25a.md
+++ b/curriculum/challenges/english/blocks/en-a2-certification-exam/6721db5d9f0c116e6a0fe25a.md
@@ -2,7 +2,7 @@
 id: 6721db5d9f0c116e6a0fe25a
 title: A2 English for Developers Certification Exam
 challengeType: 30
-dashedName: a2-english-for-developers-certification-exam
+dashedName: en-a2-certification-exam
 prerequisites: []
 ---
 

--- a/curriculum/structure/blocks/en-a2-certification-exam.json
+++ b/curriculum/structure/blocks/en-a2-certification-exam.json
@@ -1,7 +1,7 @@
 {
   "name": "A2 English for Developers Certification Exam",
   "isUpcomingChange": true,
-  "dashedName": "a2-english-for-developers-certification-exam",
+  "dashedName": "en-a2-certification-exam",
   "helpCategory": "English",
   "challengeOrder": [
     {

--- a/curriculum/structure/superblocks/a2-english-for-developers.json
+++ b/curriculum/structure/superblocks/a2-english-for-developers.json
@@ -27,6 +27,6 @@
     "learn-how-to-offer-technical-support-and-guidance",
     "learn-how-to-request-and-receive-guidance",
     "learn-how-to-provide-explanations-when-helping-others",
-    "a2-english-for-developers-certification-exam"
+    "en-a2-certification-exam"
   ]
 }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Renames the A2 English exam block to align with the Language Curricula naming convention:

```
[lang]-[level]-[block-name]
```

I discussed with Nielda and we decided to go with `-certification-exam` to keep it future-proof, in case we want to have prep exams later.

<!-- Feel free to add any additional description of changes below this line -->
