### PR TITLE
fix(curriculum): use more recent target for TS compilation

### DIFF
--- a/tools/client-plugins/browser-scripts/modules/typescript-compiler.ts
+++ b/tools/client-plugins/browser-scripts/modules/typescript-compiler.ts
@@ -24,7 +24,7 @@ export class Compiler {
     const tsvfs = this.tsvfs;
 
     const compilerOptions: CompilerOptions = {
-      target: ts.ScriptTarget.ES2015,
+      target: ts.ScriptTarget.ES2024,
       module: ts.ModuleKind.Preserve, // Babel is handling module transformation, so TS should leave them alone.
       skipLibCheck: true, // TODO: look into why this is needed. Are we doing something wrong? Could it be that it's not "synced"  with this TS version?
       // from the docs: "Note: it's possible for this list to get out of


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Allows, for example, `Object.entries`. Which is necessary for https://github.com/freeCodeCamp/freeCodeCamp/pull/63083

<!-- Feel free to add any additional description of changes below this line -->
