### PR TITLE
chore: temporarily block E2E runs on main branch pushes

### DIFF
--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -1,10 +1,10 @@
 name: CI - E2E - Playwright
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows: ['CI - Node.js']
-    types:
-      - completed
+  # workflow_run:
+  #   workflows: ['CI - Node.js']
+  #   types:
+  #     - completed
   # TODO: refactor with a workflow_call
   pull_request:
     branches:


### PR DESCRIPTION
Blocking E2E tests from triggering on runs for `push` events (triggered via Node.js-tests workflow call). They are creating a thundering herd problem since we are merging a lot of PRs for the interactive challenges.

This PR should be reverted in a few weeks. As a consolation, manual workflow dispatch and runs on ALL PR events are still enabled.