### PR TITLE
Fix minor typo in text (paidcooooooodeworld → paidcoooooooodeworld)

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-regular-expressions/6733c5f20cc9584cada942a4.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-regular-expressions/6733c5f20cc9584cada942a4.md
@@ -64,7 +64,7 @@ In a `replace` call, you achieve a backreference by using a dollar sign (`$`) fo
 
 ```js
 const regex = /free(co+de)camp/i;
-console.log("freecoooooooodecamp".replace(regex, "paid$1world")); // paidcooooooooworld
+console.log("freecoooooooodecamp".replace(regex, "paid$1world")); // paidcoooooooodeworld
 ```
 
 We have now successfully preserved an unknown number of `o` characters when converting `freecodecamp` into `paidcodeworld`. But backreferences aren't just limited to the replace call. You can actually use them directly in a regular expression.


### PR DESCRIPTION
## Description
This pull request fixes a small typo in the text where "paidcooooooodeworld" was corrected to "paidcoooooooodeworld" for consistency and clarity.

## Type of change
- [x] Typo fix / documentation update

## Checklist
- [x] Code compiles correctly
- [x] Changes are clear and improve readability
- [x] No other files were unintentionally modified

## Additional context
Minor edit for better accuracy. No functionality or logic has been changed.
