### PR TITLE
fix: sign-in e2e

### DIFF
--- a/e2e/header.spec.ts
+++ b/e2e/header.spec.ts
@@ -243,9 +243,9 @@ test.describe('Header', () => {
     const page = await context.newPage();
     await page.goto('/');
 
-    const signInButton = page.getByRole('link', {
-      name: translations.buttons['sign-in']
-    });
+    const signInButton = page
+      .locator('header')
+      .getByRole('link', { name: translations.buttons['sign-in'] });
 
     const apiLocation = process.env.API_LOCATION || 'http://localhost:3000';
 


### PR DESCRIPTION
This PR fixes the failing e2e test of the header sign-in button.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
