### PR TITLE
fix(curriculum): fsd exam coming soon

### DIFF
--- a/client/src/templates/Introduction/components/super-block-accordion.css
+++ b/client/src/templates/Introduction/components/super-block-accordion.css
@@ -252,6 +252,11 @@ button .block-header-button-text {
   margin-bottom: 1rem;
 }
 
+.super-block-accordion .module-intro p:last-of-type {
+  margin-bottom: 0;
+  padding-bottom: 1rem;
+}
+
 .super-block-accordion
   .chapter-panel
   .chapter-button[aria-expanded='false']

--- a/curriculum/structure/superblocks/full-stack-developer.json
+++ b/curriculum/structure/superblocks/full-stack-developer.json
@@ -937,7 +937,6 @@
         { "dashedName": "capstone-project", "comingSoon": true, "blocks": [] },
         {
           "dashedName": "certified-full-stack-developer-exam",
-          "moduleType": "exam",
           "comingSoon": true,
           "blocks": ["exam-certified-full-stack-developer"]
         }


### PR DESCRIPTION
Following https://github.com/freeCodeCamp/freeCodeCamp/pull/63053/ - there was a few things to clean up.

The CSS changes fix the background at the bottom here:

<img width="835" height="202" alt="Screenshot 2025-10-30 at 8 49 43 AM" src="https://github.com/user-attachments/assets/302a88ef-a841-4cda-ba61-92d303839f7f" />

And the curriculum change makes the exam show the "coming soon" text again.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
