### PR TITLE
feat(client): add disabled blocks growthbook feature

### DIFF
--- a/client/config/growthbook-features-default.json
+++ b/client/config/growthbook-features-default.json
@@ -141,5 +141,8 @@
         "name": "prod-landing-two-button-cta"
       }
     ]
+  },
+  "disabled_blocks": {
+    "defaultValue": []
   }
 }

--- a/client/src/templates/Introduction/super-block-intro.tsx
+++ b/client/src/templates/Introduction/super-block-intro.tsx
@@ -10,6 +10,7 @@ import { scroller } from 'react-scroll';
 import { bindActionCreators, Dispatch } from 'redux';
 import { createSelector } from 'reselect';
 import { Container, Col, Row, Spacer } from '@freecodecamp/ui';
+import { useFeatureValue } from '@growthbook/growthbook-react';
 
 import {
   chapterBasedSuperBlocks,
@@ -151,6 +152,11 @@ const SuperBlockIntroductionPage = (props: SuperBlockProps) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  const disabledBlocksFeature = useFeatureValue<string[]>(
+    'disabled_blocks',
+    []
+  );
+
   const {
     data: {
       allChallengeNode: { nodes },
@@ -288,22 +294,26 @@ const SuperBlockIntroductionPage = (props: SuperBlockProps) => {
                 />
               ) : (
                 <div className='block-ui'>
-                  {blocks.map(block => {
-                    const blockChallenges = superBlockChallenges.filter(
-                      c => c.block === block
-                    );
-                    const blockLabel = blockChallenges[0].blockLabel;
+                  {blocks
+                    .filter(block => {
+                      return !disabledBlocksFeature.includes(block);
+                    })
+                    .map(block => {
+                      const blockChallenges = superBlockChallenges.filter(
+                        c => c.block === block
+                      );
+                      const blockLabel = blockChallenges[0].blockLabel;
 
-                    return (
-                      <Block
-                        key={block}
-                        block={block}
-                        blockLabel={blockLabel}
-                        challenges={blockChallenges}
-                        superBlock={superBlock}
-                      />
-                    );
-                  })}
+                      return (
+                        <Block
+                          key={block}
+                          block={block}
+                          blockLabel={blockLabel}
+                          challenges={blockChallenges}
+                          superBlock={superBlock}
+                        />
+                      );
+                    })}
                   {showCertification && !!user && (
                     <CertChallenge
                       certification={certification}


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related to #62968 

This was way easier to implement than I thought. I am not set on the idea, though.

> [!NOTE]
> This is a blacklist, because that is easier to maintain...supposedly. That is, it should tend to shrink.

<details>

This could then be used to selectively deploy the A2 english exam like so:

<img width="1161" height="158" alt="image" src="https://github.com/user-attachments/assets/b815c63e-0e1d-4715-bc0e-f0bc240b2ed7" />

</details>