### PR TITLE
fix(curriculum): make v9 exams their own chapter

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -5034,7 +5034,10 @@
       "- Build a Weather App",
       "Pass the exam to earn your JavaScript Certification."
     ],
-    "chapters": { "javascript": "JavaScript" },
+    "chapters": {
+      "javascript": "JavaScript",
+      "javascript-certification-exam": "JavaScript Certification Exam"
+    },
     "modules": {
       "javascript-variables-and-strings": "Variables and Strings",
       "javascript-booleans-and-numbers": "Booleans and Numbers",
@@ -6197,7 +6200,7 @@
           "You'll practice how to fetch data from the API, store and display it on your app."
         ]
       },
-      "review-asynchronous-javascrip": {
+      "review-asynchronous-javascript": {
         "title": "Asynchronous JavaScript Review",
         "intro": [
           "Review asynchronous JavaScript concepts to prepare for the upcoming quiz."
@@ -6231,7 +6234,8 @@
       "- Pass the Front End Development Libraries Certification exam."
     ],
     "chapters": {
-      "front-end-development-libraries": "Front End Development Libraries"
+      "front-end-development-libraries": "Front End Development Libraries",
+      "front-end-development-libraries-certification-exam": "Front End Development Libraries Certification Exam"
     },
     "modules": {
       "react-fundamentals": "React Fundamentals",
@@ -6571,7 +6575,8 @@
       "- Pass the Python Certification exam."
     ],
     "chapters": {
-      "python": "Python"
+      "python": "Python",
+      "python-certification-exam": "Python Certification Exam"
     },
     "modules": {
       "python-basics": "Python Basics",
@@ -7009,7 +7014,10 @@
       "- Complete the five required projects to qualify for the certification exam.",
       "- Pass the Relational Databases Certification exam."
     ],
-    "chapters": { "relational-databases": "Relational Databases" },
+    "chapters": {
+      "relational-databases": "Relational Databases",
+      "relational-databases-certification-exam": "Relational Databases Certification Exam"
+    },
     "modules": {
       "code-editors": "Code Editors",
       "bash-fundamentals": "Bash Fundamentals",
@@ -7241,7 +7249,8 @@
       "- Pass the Back End Development and APIs Certification exam."
     ],
     "chapters": {
-      "back-end-development-and-apis": "Back End Development and APIs"
+      "back-end-development-and-apis": "Back End Development and APIs",
+      "back-end-development-and-apis-certification-exam": "Back End Development and APIs Certification Exam"
     },
     "modules": {
       "nodejs-core-libraries": "Node.js Core Libraries",

--- a/curriculum/structure/superblocks/back-end-development-and-apis-v9.json
+++ b/curriculum/structure/superblocks/back-end-development-and-apis-v9.json
@@ -51,10 +51,15 @@
           "dashedName": "tooling-and-deployment",
           "comingSoon": true,
           "blocks": []
-        },
+        }
+      ]
+    },
+    {
+      "chapterType": "exam",
+      "dashedName": "back-end-development-and-apis-certification-exam",
+      "comingSoon": true,
+      "modules": [
         {
-          "moduleType": "exam",
-          "comingSoon": true,
           "dashedName": "back-end-development-and-apis-certification-exam",
           "blocks": ["exam-back-end-development-and-apis-certification"]
         }

--- a/curriculum/structure/superblocks/front-end-development-libraries-v9.json
+++ b/curriculum/structure/superblocks/front-end-development-libraries-v9.json
@@ -90,10 +90,15 @@
           "comingSoon": true,
           "dashedName": "review-front-end-libraries",
           "blocks": ["review-front-end-libraries"]
-        },
+        }
+      ]
+    },
+    {
+      "chapterType": "exam",
+      "dashedName": "front-end-development-libraries-certification-exam",
+      "comingSoon": true,
+      "modules": [
         {
-          "moduleType": "exam",
-          "comingSoon": true,
           "dashedName": "front-end-development-libraries-certification-exam",
           "blocks": ["exam-front-end-development-libraries-certification"]
         }

--- a/curriculum/structure/superblocks/javascript-v9.json
+++ b/curriculum/structure/superblocks/javascript-v9.json
@@ -313,11 +313,16 @@
           "moduleType": "review",
           "dashedName": "review-javascript",
           "blocks": ["review-javascript"]
-        },
+        }
+      ]
+    },
+    {
+      "chapterType": "exam",
+      "dashedName": "javascript-certification-exam",
+      "comingSoon": true,
+      "modules": [
         {
-          "moduleType": "exam",
           "dashedName": "javascript-certification-exam",
-          "comingSoon": true,
           "blocks": ["exam-javascript-certification"]
         }
       ]

--- a/curriculum/structure/superblocks/python-v9.json
+++ b/curriculum/structure/superblocks/python-v9.json
@@ -128,10 +128,15 @@
           "moduleType": "review",
           "dashedName": "review-python",
           "blocks": ["review-python"]
-        },
+        }
+      ]
+    },
+    {
+      "chapterType": "exam",
+      "dashedName": "python-certification-exam",
+      "comingSoon": true,
+      "modules": [
         {
-          "moduleType": "exam",
-          "comingSoon": true,
           "dashedName": "python-certification-exam",
           "blocks": ["exam-python-certification"]
         }

--- a/curriculum/structure/superblocks/relational-databases-v9.json
+++ b/curriculum/structure/superblocks/relational-databases-v9.json
@@ -82,10 +82,15 @@
           "moduleType": "review",
           "dashedName": "review-relational-databases",
           "blocks": ["review-relational-databases"]
-        },
+        }
+      ]
+    },
+    {
+      "chapterType": "exam",
+      "dashedName": "relational-databases-certification-exam",
+      "comingSoon": true,
+      "modules": [
         {
-          "moduleType": "exam",
-          "comingSoon": true,
           "dashedName": "relational-databases-certification-exam",
           "blocks": ["exam-relational-databases-certification"]
         }


### PR DESCRIPTION
This moves all the v9 exam modules/challenges to their own chapter so the display in their own area on the superblock pages:

<img width="822" height="310" alt="Screenshot 2025-10-30 at 11 10 24 AM" src="https://github.com/user-attachments/assets/6bb449c7-3865-4e29-b378-e908e63e0428" />

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
