### PR TITLE
fix(curriculum): Incorrect margin collapsing example value in curriculum

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-css-transforms-overflow-and-filters/672bccae6e556cd81cef6af2.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-css-transforms-overflow-and-filters/672bccae6e556cd81cef6af2.md
@@ -86,7 +86,7 @@ If an element has no content, padding, or border, its top and bottom margins can
 
 :::
 
-In this example the `empty-block`s top and bottom margins collapse into a single 30 pixels margin, the larger of the two.
+In this example, the `empty-block`'s top and bottom margins collapse into a single 20 pixels margin, the larger of the two.
 
 Here's another example of preventing collapse using padding: 
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #63351

<!-- Feel free to add any additional description of changes below this line -->

This corrects the explanation of vertical margin collapsing.

Currently the [docs](https://www.freecodecamp.org/learn/full-stack-developer/lecture-working-with-css-transforms-overflow-and-filters/what-is-margin-collapsing) state that a 20px top margin and 10px bottom margin collapse into a 30px margin. This is incorrect.

This PR updates the description accordingly to avoid confusion.