### PR TITLE
docs(curriculum): fix mismatch between example code and description in filter documentation

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-css-transforms-overflow-and-filters/672bccae6e556cd81cef6af2.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-css-transforms-overflow-and-filters/672bccae6e556cd81cef6af2.md
@@ -86,7 +86,7 @@ If an element has no content, padding, or border, its top and bottom margins can
 
 :::
 
-In this example the `empty-block`s top and bottom margins collapse into a single 30 pixels margin, the larger of the two.
+In this example, the `empty-block`'s top and bottom margins collapse into a single 20 pixels margin, the larger of the two.
 
 Here's another example of preventing collapse using padding: 
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-css-transforms-overflow-and-filters/672bccebe1fc82d911c3f078.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-css-transforms-overflow-and-filters/672bccebe1fc82d911c3f078.md
@@ -129,7 +129,7 @@ img {
 
 :::
 
-This rule applies increased contrast, slightly increased brightness, and a subtle sepia effect to elements with the class `multi-filter`. 
+This rule applies increased contrast, slightly increased brightness, and a subtle sepia effect to the image.
 
 By combining filters you can create complex and unique visual effects tailored to your design needs. The CSS filter property is a versatile tool that allows for creative visual manipulation of web elements. 
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

This PR corrects a discrepancy in the filter property tutorial.

The example code applies the `filter` property directly to the `img` selector, but the description incorrectly states that the effects apply to elements with the `multi-filter` class. 

https://www.freecodecamp.org/learn/full-stack-developer/lecture-working-with-css-transforms-overflow-and-filters/what-is-the-css-filter-property

This improves accuracy and avoids confusion for users following the tutorial.