### PR TITLE
fix(a11y): remove aria-controls and aria-expanded from links

### DIFF
--- a/client/src/templates/Introduction/components/block-header.test.tsx
+++ b/client/src/templates/Introduction/components/block-header.test.tsx
@@ -1,0 +1,173 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import BlockHeader from './block-header';
+
+const defaultProps = {
+  blockDashed: 'test-block',
+  blockTitle: 'Test Block Title',
+  blockLabel: null,
+  courseCompletionStatus: '50% completed',
+  completedCount: 5,
+  handleClick: vi.fn(),
+  isCompleted: false,
+  isExpanded: false,
+  percentageCompleted: 50,
+  blockIntroArr: ['Introduction paragraph 1', 'Introduction paragraph 2'],
+  accordion: false
+};
+
+describe('<BlockHeader />', () => {
+  it('should render as a button with aria-expanded and aria-controls when not a link', () => {
+    render(<BlockHeader {...defaultProps} />);
+
+    const button = screen.getByRole('button');
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+    expect(button).toHaveAttribute('aria-controls', 'test-block-panel');
+  });
+
+  it('should render as a link without aria-expanded and aria-controls when blockUrl is provided in accordion mode', () => {
+    render(
+      <BlockHeader
+        {...defaultProps}
+        accordion={true}
+        blockUrl='/learn/test-block'
+      />
+    );
+
+    const link = screen.getByRole('link');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', '/learn/test-block');
+    expect(link).not.toHaveAttribute('aria-expanded');
+    expect(link).not.toHaveAttribute('aria-controls');
+  });
+
+  it('should set aria-expanded to true when isExpanded is true', () => {
+    render(<BlockHeader {...defaultProps} isExpanded={true} />);
+
+    const button = screen.getByRole('button');
+    expect(button).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('should display the block title', () => {
+    render(<BlockHeader {...defaultProps} />);
+
+    expect(screen.getByText('Test Block Title')).toBeInTheDocument();
+  });
+
+  it('should display the course completion status in sr-only text', () => {
+    render(<BlockHeader {...defaultProps} />);
+
+    expect(screen.getByText(', 50% completed')).toBeInTheDocument();
+  });
+
+  it('should show progress percentage when not expanded, not completed, and has completed challenges', () => {
+    render(
+      <BlockHeader
+        {...defaultProps}
+        isExpanded={false}
+        isCompleted={false}
+        completedCount={5}
+      />
+    );
+
+    expect(screen.getByText('50%')).toBeInTheDocument();
+  });
+
+  it('should not show progress percentage when in accordion mode', () => {
+    render(
+      <BlockHeader
+        {...defaultProps}
+        accordion={true}
+        isExpanded={false}
+        isCompleted={false}
+        completedCount={5}
+      />
+    );
+
+    expect(screen.queryByText('50%')).not.toBeInTheDocument();
+  });
+
+  it('should not show progress percentage when expanded', () => {
+    render(
+      <BlockHeader
+        {...defaultProps}
+        isExpanded={true}
+        isCompleted={false}
+        completedCount={5}
+      />
+    );
+
+    expect(screen.queryByText('50%')).not.toBeInTheDocument();
+  });
+
+  it('should not show progress percentage when completed', () => {
+    render(
+      <BlockHeader
+        {...defaultProps}
+        isExpanded={false}
+        isCompleted={true}
+        completedCount={10}
+      />
+    );
+
+    expect(screen.queryByText('50%')).not.toBeInTheDocument();
+  });
+
+  it('should not show progress percentage when no challenges completed', () => {
+    render(
+      <BlockHeader
+        {...defaultProps}
+        isExpanded={false}
+        isCompleted={false}
+        completedCount={0}
+      />
+    );
+
+    expect(screen.queryByText('50%')).not.toBeInTheDocument();
+  });
+
+  it('should render BlockIntros when expanded and blockIntroArr is provided', () => {
+    render(<BlockHeader {...defaultProps} isExpanded={true} />);
+
+    expect(screen.getByText('Introduction paragraph 1')).toBeInTheDocument();
+    expect(screen.getByText('Introduction paragraph 2')).toBeInTheDocument();
+  });
+
+  it('should not render BlockIntros when not expanded', () => {
+    render(<BlockHeader {...defaultProps} isExpanded={false} />);
+
+    expect(
+      screen.queryByText('Introduction paragraph 1')
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('Introduction paragraph 2')
+    ).not.toBeInTheDocument();
+  });
+
+  it('should not render BlockIntros when blockIntroArr is empty', () => {
+    render(
+      <BlockHeader {...defaultProps} isExpanded={true} blockIntroArr={[]} />
+    );
+
+    expect(
+      screen.queryByText('Introduction paragraph 1')
+    ).not.toBeInTheDocument();
+  });
+
+  it('should not render BlockIntros when blockIntroArr is undefined', () => {
+    render(
+      <BlockHeader
+        {...defaultProps}
+        isExpanded={true}
+        blockIntroArr={undefined}
+      />
+    );
+
+    expect(
+      screen.queryByText('Introduction paragraph 1')
+    ).not.toBeInTheDocument();
+  });
+});

--- a/client/src/templates/Introduction/components/block-header.tsx
+++ b/client/src/templates/Introduction/components/block-header.tsx
@@ -42,11 +42,14 @@ function BlockHeader({
     <>
       <h3 className='block-grid-title'>
         <Button
-          aria-expanded={isExpanded ? 'true' : 'false'}
-          aria-controls={`${blockDashed}-panel`}
           className='block-header'
           onClick={handleClick}
-          {...(accordion && blockUrl ? { href: blockUrl } : {})}
+          {...(accordion && blockUrl
+            ? { href: blockUrl }
+            : {
+                'aria-expanded': isExpanded ? 'true' : 'false',
+                'aria-controls': `${blockDashed}-panel`
+              })}
         >
           <span className='block-header-button-text map-title'>
             {accordion &&


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

We've changed Review / Quiz / Exam to be presented as links instead of collapsibles (#63053). However, the `aria-controls` and `aria-expanded` attributes should also be excluded in that case, since they're only meaningful for elements that control the visibility of a panel/widget, which the links don't do.

On an unrelated note, we really need to stop hacking away at this component. It's getting increasingly difficult to read and maintain.

This PR:
- Fixes the conditional rendering to exclude those attributes from links
- Adds tests for the component

<!-- Feel free to add any additional description of changes below this line -->
