### PR TITLE
fix(docs): Correct margin value in collapse example

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-css-transforms-overflow-and-filters/672bccae6e556cd81cef6af2.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-css-transforms-overflow-and-filters/672bccae6e556cd81cef6af2.md
@@ -86,7 +86,7 @@ If an element has no content, padding, or border, its top and bottom margins can
 
 :::
 
-In this example the `empty-block`s top and bottom margins collapse into a single 30 pixels margin, the larger of the two.
+In this example the `empty-block`s top and bottom margins collapse into a single 20 pixels margin, the larger of the two.
 
 Here's another example of preventing collapse using padding: 
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->

Closes #63351

This PR addresses an incorrect numerical value in the CSS margin collapsing curriculum.

The explanation incorrectly stated that a `20px` top margin and a `10px` bottom margin would collapse into `30px`. According to the CSS spec, the resulting margin should be the larger of the two values.

This change corrects the value from `30` to `20` to accurately reflect the behavior of collapsing margins.
