### PR TITLE
fix(curriculum): correct selector for ::backdrop pseudo-element

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-user-centered-design/672bb015cfc889794359c4e0.md
+++ b/curriculum/challenges/english/blocks/lecture-user-centered-design/672bb015cfc889794359c4e0.md
@@ -38,7 +38,7 @@ dialog {
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
 }
 
-body::backdrop {
+dialog::backdrop {
   background: rgba(0, 0, 0, 0.5);
 }
 ```


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ x] My pull request targets the `main` branch of freeCodeCamp.
- [ x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
Closes #63359

## Description
This pull request corrects an inaccurate CSS selector in the "Learn User-Centered Design" curriculum.

The lesson incorrectly used the body::backdrop selector to style the backdrop of a <dialog> element. The correct pseudo-element for this purpose is dialog::backdrop.

This change updates the code to use the correct selector, ensuring the curriculum provides an accurate and functional example.
