### PR TITLE
feat(curriculum): add `inputType` property to challenge schema

### DIFF
--- a/curriculum/schema/challenge-schema.js
+++ b/curriculum/schema/challenge-schema.js
@@ -5,7 +5,8 @@ const { challengeTypes } = require('../../shared-dist/config/challenge-types');
 const {
   chapterBasedSuperBlocks,
   catalogSuperBlocks,
-  languageSuperBlocks
+  languageSuperBlocks,
+  SuperBlocks
 } = require('../../shared-dist/config/curriculum');
 const {
   availableCharacters,
@@ -232,6 +233,15 @@ const schema = Joi.object().keys({
     is: languageSuperBlocks,
     then: Joi.valid('en-US', 'es', 'zh-CN').required(),
     otherwise: Joi.valid('en')
+  }),
+  inputType: Joi.when('challengeType', {
+    is: challengeTypes.fillInTheBlank,
+    then: Joi.when('superBlock', {
+      is: Joi.valid(SuperBlocks.A1Chinese, SuperBlocks.A2Chinese),
+      then: Joi.string().valid('pinyin-tone', 'pinyin-to-hanzi').optional(),
+      otherwise: Joi.forbidden()
+    }),
+    otherwise: Joi.forbidden()
   }),
   instructions: Joi.string().when('challengeType', {
     is: [challengeTypes.pythonProject, challengeTypes.codeAllyCert],


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR:
- Adds `inputType` to challenge schema. This property will be used to determine the input for Chinese fill-in-the-blank challenges.
- Closes https://github.com/freeCodeCamp/language-curricula/issues/20

<!-- Feel free to add any additional description of changes below this line -->
