### PR TITLE
Fix(curriculum): Correct code block language in loops lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-loops/6732c05595ca7d422b9e55ff.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-loops/6732c05595ca7d422b9e55ff.md
@@ -157,7 +157,7 @@ for (const prop in fruit) {
 
 ## --answers--
 
-```js
+```md
 apple
 apple
 apple
@@ -169,7 +169,7 @@ Review the beginning of the lesson to learn what the `for...in` loop does.
 
 ---
 
-```js
+```md
 name
 color
 price
@@ -181,7 +181,7 @@ Review the beginning of the lesson to learn what the `for...in` loop does.
 
 ---
 
-```js
+```md
 apple
 red
 0.99
@@ -189,7 +189,7 @@ red
 
 ---
 
-```js
+```md
 fruit
 fruit
 fruit


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #63358

<!-- Feel free to add any additional description of changes below this line -->
This PR fixes the code block language for the multiple-choice answers in the "What Is the For...in Loop" lecture. The language was incorrectly set to `js` and has been corrected to `md`.
