### PR TITLE
fix(curriculum): correct sentence about the nullish coalesing operator

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-conditional-logic-and-math-methods/6732720e95f6a0db526a2e4d.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-conditional-logic-and-math-methods/6732720e95f6a0db526a2e4d.md
@@ -111,7 +111,7 @@ const result = null ?? 'default';
 console.log(result); // default
 ```
 
-Since `null` is a falsy value, the string `default` would be logged to the console. The nullish coalescing operator is incredibly useful in situations where `null` or `undefined` are the only values that should trigger a fallback or default value. Here is an example of dealing with a user's preference settings:
+Since `null` is a nullish value, the string `default` would be logged to the console. The nullish coalescing operator is incredibly useful in situations where `null` or `undefined` are the only values that should trigger a fallback or default value. Here is an example of dealing with a user's preference settings:
 
 ```js
 const userSettings = {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #63409

<!-- Feel free to add any additional description of changes below this line -->
