### PR TITLE
fix(curriculum): remove class references and align text with code in CSS filter tutorial

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-css-transforms-overflow-and-filters/672bccebe1fc82d911c3f078.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-css-transforms-overflow-and-filters/672bccebe1fc82d911c3f078.md
@@ -7,7 +7,7 @@ dashedName: what-is-the-css-filter-property
 
 # --interactive--
 
-The CSS `filter` property is a powerful tool that allows you to apply  graphical effects to elements on a web page. It's particularly useful for adjusting the visual presentation of images, backgrounds and even text without modifying the original asset.
+The CSS `filter` property is a powerful tool that allows you to apply graphical effects to elements on a web page. It's particularly useful for adjusting the visual presentation of images, backgrounds and even text without modifying the original asset.
 
 The `filter` property can be used to create various effects, such as blurring, color shifting, and contrast adjustments. Let's discuss how the filter property works and explore some common examples. The basic syntax for a `filter` property is straightforward:
 
@@ -34,7 +34,7 @@ img {
 
 :::
 
-The `blur` function applies a gaussian blur to the element, the amount is specified in pixels and represents the radius of the blur. This CSS rule will apply a 5 pixel blur to all images on the page. The `blur` effect can be useful for creating depth in your design or for obscuring parts of an image. 
+The `blur` function applies a gaussian blur to the element, the amount is specified in pixels and represents the radius of the blur. This CSS rule will apply a 2 pixel blur to all images on the page. The `blur` effect can be useful for creating depth in your design or for obscuring parts of an image. 
 
 The `brightness` function adjusts the brightness of the element. A value of `0%` will make the element completely black, while values over `100%` will increase the brightness. 
 
@@ -53,7 +53,7 @@ img {
 
 :::
 
-This CSS rule increases the brightness of elements with the class `bright-image` by `50%`. Brightness adjustments can be used to make images pop or create a washed-out effect.
+This CSS rule increases the brightness of the image element by `50%`. Brightness adjustments can be used to make images pop or create a washed-out effect.
 
 The `grayscale` function converts the element to grayscale. The amount is defined as a percentage, where `100%` is completely grayscale and `0%` leaves the image unchanged.
 
@@ -72,7 +72,7 @@ img {
 
 :::
 
-This rule will convert elements with the class `gray-image` to complete grayscale. `grayscale` can be used to create a vintage look or de-emphasize certain elements on a page.
+This rule will convert the image element to complete grayscale. `grayscale` can be used to create a vintage look or de-emphasize certain elements on a page.
 
 The `sepia` function applies a sepia tone to the element. Like grayscale, it uses a percentage value: 
 
@@ -91,7 +91,7 @@ img {
 
 :::
 
-This rule applies an `80%` sepia effect to elements with the class `old-photo`. The sepia effect is great for creating a vintage or old-timey look.
+This rule applies an `80%` sepia effect to the image element. The sepia effect is great for creating a vintage or old-timey look.
 
 The `hue-rotate` function applies the hue rotation to the element. The value is defined in degrees, and represents a rotation around the color circle. 
 
@@ -110,7 +110,7 @@ img {
 
 :::
 
-This rule rotates the hue of elements with the class `color-shift` by `90` degrees. Hue rotation can be used to create psychedelic effects or to adjust the overall color scheme of an image.
+This rule rotates the hue of the image element by `90` degrees. Hue rotation can be used to create psychedelic effects or to adjust the overall color scheme of an image.
 
 One of the most powerful aspects of the `filter` property is the ability to combine multiple effects. You can apply several filters to the same element by separating them with spaces: 
 
@@ -129,11 +129,11 @@ img {
 
 :::
 
-This rule applies increased contrast, slightly increased brightness, and a subtle sepia effect to elements with the class `multi-filter`. 
+This rule applies increased contrast, slightly increased brightness, and a subtle sepia effect to the image element. 
 
 By combining filters you can create complex and unique visual effects tailored to your design needs. The CSS filter property is a versatile tool that allows for creative visual manipulation of web elements. 
 
-While we have covered some of the most common filter functions, there are others available, such as `contrast`, `invert`, and `saturate`. As with any powerful feature, it's important to kind of be careful with how you use the filters to enhance your design without overwhelming your users or compromising accessibility.
+While we have covered some of the most common filter functions, there are others available, such as `contrast`, `invert`, and `saturate`. As with any powerful feature, it's important to be careful with how you use the filters to enhance your design without overwhelming your users or compromising accessibility.
 
 # --questions--
 


### PR DESCRIPTION
This PR resolves issue #63350 by fixing inconsistencies between the example code and descriptive text in the “What Is the CSS Filter Property?” tutorial.

✅ Changes made:
- Removed non-existent class references
- Matched code examples with described effects

---

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #63350

<!-- Feel free to add any additional description of changes below this line -->
