### PR TITLE
fix(curriculum): add multi-run sampling approach to testing fortune teller lab

### DIFF
--- a/curriculum/challenges/english/blocks/lab-fortune-teller/66c06d618d075c7f7f1b890a.md
+++ b/curriculum/challenges/english/blocks/lab-fortune-teller/66c06d618d075c7f7f1b890a.md
@@ -79,8 +79,16 @@ assert.match(__helpers.removeJSComments(code), /Math\.random\(\)/);
 You should generate a random number between 1 and 5, inclusive, and assign it to the variable `randomNumber`.
 
 ```js
-assert.isNotNull(randomNumber);
-assert.include([1,2,3,4,5], randomNumber);
+const userCode_return_randomNumber = new Function(`${code};return randomNumber`);
+const setOfExpectedNumbers = new Set([1, 2, 3, 4, 5]);
+const setOfNumbersFromRepetitions = new Set();
+
+for (let i = 0; i < 1000; i++) {
+  const randomNumber = userCode_return_randomNumber();
+  setOfNumbersFromRepetitions.add(randomNumber);
+}
+
+assert(setOfNumbersFromRepetitions.symmetricDifference(setOfExpectedNumbers).size === 0);
 ```
 
 You should have a `selectedFortune` variable that is assigned a value based on the value of `randomNumber`.
@@ -92,13 +100,22 @@ assert.isNotNull(selectedFortune);
 The `randomNumber` should correspond to its fortune. For example, if `randomNumber` is 1, the `selectedFortune` should be equal to `fortune1` and so on.
 
 ```js
-const condition1 = randomNumber === 1 && selectedFortune === fortune1;
-const condition2 = randomNumber === 2 && selectedFortune === fortune2;
-const condition3 = randomNumber === 3 && selectedFortune === fortune3;
-const condition4 = randomNumber === 4 && selectedFortune === fortune4;
-const condition5 = randomNumber === 5 && selectedFortune === fortune5;
+const userCode_return_randomNumber_selectedFortune = new Function(`${code};return [randomNumber, selectedFortune]`);
 
-assert.isTrue(condition1 || condition2 || condition3 || condition4 || condition5);
+for (let i = 0; i < 1000; i++) {
+  const resultFromRepetion = userCode_return_randomNumber_selectedFortune();
+  const randomNumberFromRepetition = resultFromRepetion[0];
+  const selectedFortuneFromRepetition = resultFromRepetion[1];
+  console.log(`${randomNumberFromRepetition}: ${selectedFortuneFromRepetition}`);
+  
+  const condition1 = randomNumberFromRepetition === 1 && selectedFortuneFromRepetition === fortune1;
+  const condition2 = randomNumberFromRepetition === 2 && selectedFortuneFromRepetition === fortune2;
+  const condition3 = randomNumberFromRepetition === 3 && selectedFortuneFromRepetition === fortune3;
+  const condition4 = randomNumberFromRepetition === 4 && selectedFortuneFromRepetition === fortune4;
+  const condition5 = randomNumberFromRepetition === 5 && selectedFortuneFromRepetition === fortune5;
+  
+  assert.isTrue(condition1 || condition2 || condition3 || condition4 || condition5);
+}
 ```
 
 You should output the `selectedFortune` to the console.

--- a/curriculum/challenges/english/blocks/lab-fortune-teller/66c06d618d075c7f7f1b890a.md
+++ b/curriculum/challenges/english/blocks/lab-fortune-teller/66c06d618d075c7f7f1b890a.md
@@ -88,7 +88,7 @@ for (let i = 0; i < 1000; i++) {
   setOfNumbersFromRepetitions.add(randomNumber);
 }
 
-assert(setOfNumbersFromRepetitions.symmetricDifference(setOfExpectedNumbers).size === 0);
+assert.lengthOf(setOfNumbersFromRepetitions.symmetricDifference(setOfExpectedNumbers), 0);
 ```
 
 You should have a `selectedFortune` variable that is assigned a value based on the value of `randomNumber`.
@@ -103,10 +103,9 @@ The `randomNumber` should correspond to its fortune. For example, if `randomNumb
 const userCode_return_randomNumber_selectedFortune = new Function(`${code};return [randomNumber, selectedFortune]`);
 
 for (let i = 0; i < 1000; i++) {
-  const resultFromRepetion = userCode_return_randomNumber_selectedFortune();
-  const randomNumberFromRepetition = resultFromRepetion[0];
-  const selectedFortuneFromRepetition = resultFromRepetion[1];
-  console.log(`${randomNumberFromRepetition}: ${selectedFortuneFromRepetition}`);
+  const resultFromRepetition = userCode_return_randomNumber_selectedFortune();
+  const randomNumberFromRepetition = resultFromRepetition[0];
+  const selectedFortuneFromRepetition = resultFromRepetition[1];
   
   const condition1 = randomNumberFromRepetition === 1 && selectedFortuneFromRepetition === fortune1;
   const condition2 = randomNumberFromRepetition === 2 && selectedFortuneFromRepetition === fortune2;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #59607

<!-- Feel free to add any additional description of changes below this line -->

Replace single-shot assertions with multi-run sampling to verify:
- The user’s randomNumber can produce every integer in 1–5.
- The selectedFortune always matches the fortune corresponding to the sampled randomNumber.

This is a proof of concept. I ran the lab locally and manually tested it, which was successful. If this multi-run sampling approach aligns with FreeCodeCamp’s testing philosophy, I would need some help making the code more robust.