### PR TITLE
fix: correct grammar in Fingerprint Test description

### DIFF
--- a/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/68f6587287ad1f4ad39b0c85.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/68f6587287ad1f4ad39b0c85.md
@@ -10,9 +10,9 @@ dashedName: challenge-99
 Given two strings representing fingerprints, determine if they are a match using the following rules:
 
 - Each fingerprint will consist only of lowercase letters (`a-z`).
-- Two fingerprints are considered a match if:
+- Two fingerprints are considered a match if:cd 
   - They are the same length.
-  - The number of differing characters does not exceeded 10% of the fingerprint length.
+  - The number of differing characters does not exceed 10% of the fingerprint length.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/68f6587287ad1f4ad39b0c85.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/68f6587287ad1f4ad39b0c85.md
@@ -10,7 +10,7 @@ dashedName: challenge-99
 Given two strings representing fingerprints, determine if they are a match using the following rules:
 
 - Each fingerprint will consist only of lowercase letters (`a-z`).
-- Two fingerprints are considered a match if:cd 
+- Two fingerprints are considered a match if:
   - They are the same length.
   - The number of differing characters does not exceed 10% of the fingerprint length.
 

--- a/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/68f6587287ad1f4ad39b0c85.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/68f6587287ad1f4ad39b0c85.md
@@ -12,7 +12,7 @@ Given two strings representing fingerprints, determine if they are a match using
 - Each fingerprint will consist only of lowercase letters (`a-z`).
 - Two fingerprints are considered a match if:
   - They are the same length.
-  - The number of differing characters does not exceded 10% of the fingerprint length.
+  - The number of differing characters does not exceeded 10% of the fingerprint length.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/daily-coding-challenges-python/68f6587287ad1f4ad39b0c85.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-python/68f6587287ad1f4ad39b0c85.md
@@ -12,7 +12,7 @@ Given two strings representing fingerprints, determine if they are a match using
 - Each fingerprint will consist only of lowercase letters (`a-z`).
 - Two fingerprints are considered a match if:
   - They are the same length.
-  - The number of differing characters does not exceded 10% of the fingerprint length.
+  - The number of differing characters does not exceeded 10% of the fingerprint length.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/daily-coding-challenges-python/68f6587287ad1f4ad39b0c85.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-python/68f6587287ad1f4ad39b0c85.md
@@ -12,7 +12,7 @@ Given two strings representing fingerprints, determine if they are a match using
 - Each fingerprint will consist only of lowercase letters (`a-z`).
 - Two fingerprints are considered a match if:
   - They are the same length.
-  - The number of differing characters does not exceeded 10% of the fingerprint length.
+  - The number of differing characters does not exceed 10% of the fingerprint length.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #63485

<!-- Feel free to add any additional description of changes below this line -->
### 📝 Summary
This follow-up pull request corrects a minor grammatical issue in the Fingerprint Test challenge description that was merged in a previous PR.

### 🔧 Changes Made
- Updated “does not exceeded” → “does not exceed” in:
  - `curriculum/challenges/english/blocks/daily-coding-challenges-javascript/68f6587287ad1f4ad39b0c85.md`
  - `curriculum/challenges/english/blocks/daily-coding-challenges-python/68f6587287ad1f4ad39b0c85.md`

### 🧠 Reason for Change
In English grammar, when using *does not* as an auxiliary verb, the main verb should remain in its base form (*exceed*).  
This ensures the text reads naturally and accurately.

### ✅ Testing
- Verified markdown rendering.
- No logic or code behavior affected.
- Only text correction applied.

### 🙌 Acknowledgment
Thanks to @jmferreirab  for catching this!
