### PR TITLE
docs: add About freeCodeCamp section for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,3 +263,11 @@ The content of this repository is bound by the following licenses:
 
 - The computer software is licensed under the [BSD-3-Clause](LICENSE.md) license.
 - The learning resources in the [`/curriculum`](/curriculum) directory including their subdirectories therein are copyright © 2025 freeCodeCamp.org
+
+## About freeCodeCamp
+
+freeCodeCamp.org is a nonprofit community that helps millions of people learn to code for free. 
+It provides interactive coding challenges, project-based certifications, and thousands of tutorials 
+covering topics from web development to data science. 
+
+If you're new here, check out [freecodecamp.org/learn](https://www.freecodecamp.org/learn) to start your learning journey.


### PR DESCRIPTION
Added a short About section before License to help new contributors and readers understand the mission of freeCodeCamp.