### PR TITLE
Changed blockLayout from dialogue-grid to link for zh-a1 quiz and review blocks

### DIFF
--- a/curriculum/structure/blocks/zh-a1-quiz-check-your-introduction.json
+++ b/curriculum/structure/blocks/zh-a1-quiz-check-your-introduction.json
@@ -3,7 +3,7 @@
   "isUpcomingChange": true,
   "dashedName": "zh-a1-quiz-check-your-introduction",
   "helpCategory": "English",
-  "blockLayout": "dialogue-grid",
+  "blockLayout": "link",
   "challengeOrder": [
     {
       "id": "68fa38c9cc3f26d19bc97772",

--- a/curriculum/structure/blocks/zh-a1-quiz-describing-skills.json
+++ b/curriculum/structure/blocks/zh-a1-quiz-describing-skills.json
@@ -3,7 +3,7 @@
   "isUpcomingChange": true,
   "dashedName": "zh-a1-quiz-describing-skills",
   "helpCategory": "English",
-  "blockLayout": "dialogue-grid",
+"blockLayout": "link",
   "challengeOrder": [
     {
       "id": "68fa3b88b437a9e2a365106a",

--- a/curriculum/structure/blocks/zh-a1-quiz-discussing-team-skills.json
+++ b/curriculum/structure/blocks/zh-a1-quiz-discussing-team-skills.json
@@ -3,7 +3,7 @@
   "isUpcomingChange": true,
   "dashedName": "zh-a1-quiz-discussing-team-skills",
   "helpCategory": "English",
-  "blockLayout": "dialogue-grid",
+  "blockLayout": "link",
   "challengeOrder": [
     {
       "id": "68fa3be75fd89ce730060f0f",

--- a/curriculum/structure/blocks/zh-a1-quiz-greetings-and-introductions.json
+++ b/curriculum/structure/blocks/zh-a1-quiz-greetings-and-introductions.json
@@ -3,7 +3,7 @@
   "isUpcomingChange": true,
   "dashedName": "zh-a1-quiz-greetings-and-introductions",
   "helpCategory": "English",
-  "blockLayout": "dialogue-grid",
+  "blockLayout": "link",
   "challengeOrder": [
     {
       "id": "68fa4006bf11f8f8d1a4b838",

--- a/curriculum/structure/blocks/zh-a1-quiz-introduction-questions.json
+++ b/curriculum/structure/blocks/zh-a1-quiz-introduction-questions.json
@@ -3,7 +3,7 @@
   "isUpcomingChange": true,
   "dashedName": "zh-a1-quiz-introduction-questions",
   "helpCategory": "English",
-  "blockLayout": "dialogue-grid",
+  "blockLayout": "link", 
   "challengeOrder": [
     {
       "id": "68fa37b3666140c87dccbaef",

--- a/curriculum/structure/blocks/zh-a1-quiz-pinyin.json
+++ b/curriculum/structure/blocks/zh-a1-quiz-pinyin.json
@@ -3,7 +3,7 @@
   "isUpcomingChange": true,
   "dashedName": "zh-a1-quiz-pinyin",
   "helpCategory": "English",
-  "blockLayout": "dialogue-grid",
+ "blockLayout": "link",
   "challengeOrder": [
     {
       "id": "68fa3f7908e4fcf3f81d1be0",

--- a/curriculum/structure/blocks/zh-a1-quiz-team-introduction.json
+++ b/curriculum/structure/blocks/zh-a1-quiz-team-introduction.json
@@ -3,7 +3,7 @@
   "isUpcomingChange": true,
   "dashedName": "zh-a1-quiz-team-introduction",
   "helpCategory": "English",
-  "blockLayout": "dialogue-grid",
+  "blockLayout": "link",
   "challengeOrder": [
     {
       "id": "68fa3a185c66aadc3525bcb2",

--- a/curriculum/structure/blocks/zh-a1-review-describing-skills.json
+++ b/curriculum/structure/blocks/zh-a1-review-describing-skills.json
@@ -3,7 +3,7 @@
   "isUpcomingChange": true,
   "dashedName": "zh-a1-review-describing-skills",
   "helpCategory": "English",
-  "blockLayout": "dialogue-grid",
+  "blockLayout": "link",
   "challengeOrder": [
     {
       "id": "68fa3b75398eb8e18f07518e",

--- a/curriculum/structure/blocks/zh-a1-review-discussing-team-skills.json
+++ b/curriculum/structure/blocks/zh-a1-review-discussing-team-skills.json
@@ -3,7 +3,7 @@
   "isUpcomingChange": true,
   "dashedName": "zh-a1-review-discussing-team-skills",
   "helpCategory": "English",
-  "blockLayout": "dialogue-grid",
+  "blockLayout": "link",
   "challengeOrder": [
     {
       "id": "68fa3bd62340efe637189b4d",

--- a/curriculum/structure/blocks/zh-a1-review-greetings-and-introductions.json
+++ b/curriculum/structure/blocks/zh-a1-review-greetings-and-introductions.json
@@ -3,7 +3,7 @@
   "isUpcomingChange": true,
   "dashedName": "zh-a1-review-greetings-and-introductions",
   "helpCategory": "English",
-  "blockLayout": "dialogue-grid",
+  "blockLayout": "link",
   "challengeOrder": [
     {
       "id": "68fa3feda781cdf645e7d9a0",

--- a/curriculum/structure/blocks/zh-a1-review-introducing-others.json
+++ b/curriculum/structure/blocks/zh-a1-review-introducing-others.json
@@ -3,7 +3,7 @@
   "isUpcomingChange": true,
   "dashedName": "zh-a1-review-introducing-others",
   "helpCategory": "English",
-  "blockLayout": "dialogue-grid",
+  "blockLayout": "link",
   "challengeOrder": [
     {
       "id": "68fa393a2a3cd1d42a7b8131",

--- a/curriculum/structure/blocks/zh-a1-review-introduction-questions.json
+++ b/curriculum/structure/blocks/zh-a1-review-introduction-questions.json
@@ -3,7 +3,7 @@
   "isUpcomingChange": true,
   "dashedName": "zh-a1-review-introduction-questions",
   "helpCategory": "English",
-  "blockLayout": "dialogue-grid",
+  "blockLayout": "link",
   "challengeOrder": [
     {
       "id": "68fa376a7ec0adc64d68519a",

--- a/curriculum/structure/blocks/zh-a1-review-pinyin.json
+++ b/curriculum/structure/blocks/zh-a1-review-pinyin.json
@@ -3,7 +3,7 @@
   "isUpcomingChange": true,
   "dashedName": "zh-a1-review-pinyin",
   "helpCategory": "English",
-  "blockLayout": "dialogue-grid",
+  "blockLayout": "link",
   "challengeOrder": [
     {
       "id": "68fa3f5ec14d92f2f77d9c1b",

--- a/curriculum/structure/blocks/zh-a1-review-team-introduction.json
+++ b/curriculum/structure/blocks/zh-a1-review-team-introduction.json
@@ -3,7 +3,7 @@
   "isUpcomingChange": true,
   "dashedName": "zh-a1-review-team-introduction",
   "helpCategory": "English",
-  "blockLayout": "dialogue-grid",
+  "blockLayout": "link",
   "challengeOrder": [
     {
       "id": "68fa3a07c1a93ddb1ed6d286",


### PR DESCRIPTION
This PR updates the blockLayout property from "dialogue-grid" to "link" 
for all zh-a1-quiz-* and zh-a1-review-* blocks as requested in issue #63510
