### PR TITLE
fix(client): exam token widget

### DIFF
--- a/client/src/components/settings/exam-token.tsx
+++ b/client/src/components/settings/exam-token.tsx
@@ -88,7 +88,7 @@ function ExamToken(): JSX.Element {
         <Panel.Heading>{t('exam-token.exam-token')}</Panel.Heading>
         <Panel.Body>
           <p>{t('exam-token.note')}</p>
-          <strong>{t('exam-token.invalidation')}</strong>
+          <strong>{t('exam-token.invalidation-2')}</strong>
           <Spacer size='s' />
           <Button
             block={true}


### PR DESCRIPTION
I changed [the translation key here](https://github.com/freeCodeCamp/freeCodeCamp/pull/62623/files#diff-39ed34967deb8a2f5fe59aa9b42b6f62e0484cb1a8e757849913fab697466413L1283) - whoops

The widget is on the settings page - need upcoming changes shown to see it.

<details><summary>before</summary>

<img width="793" height="282" alt="Screenshot 2025-11-04 at 4 37 26 PM" src="https://github.com/user-attachments/assets/cb0f4f5d-ea76-4a18-a620-732dd2fb1f96" />

</details>

<details><summary>after</summary>

<img width="787" height="283" alt="Screenshot 2025-11-04 at 4 37 48 PM" src="https://github.com/user-attachments/assets/3e56fad7-5f5f-4788-95fb-9ca9a27379ea" />

</details>

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
