### PR TITLE
fix(a11y, curriculum): Removed gray color text in workshop-greeting-card challenge

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-greeting-card/673333130a2c40204162f0c7.md
+++ b/curriculum/challenges/english/blocks/workshop-greeting-card/673333130a2c40204162f0c7.md
@@ -10,7 +10,6 @@ dashedName: step-17
 The `.message` element needs some styling. Give it:
 
 - a `font-size` of `1.2em`,
-- a `color` of `gray`,
 - a `margin-bottom` of `20px`.
 
 # --hints--
@@ -25,12 +24,6 @@ The `.message` selector should have a `font-size` property set to `1.2em`.
 
 ```js
 assert.strictEqual(new __helpers.CSSHelp(document).getStyle(".message")?.getPropertyValue("font-size"), "1.2em");
-```
-
-The `.message` selector should have a `color` property set to `gray`.
-
-```js
-assert.strictEqual(new __helpers.CSSHelp(document).getStyle(".message")?.getPropertyValue("color"), "gray");
 ```
 
 The `.message` selector should have a `margin-bottom` property set to `20px`.

--- a/curriculum/challenges/english/blocks/workshop-greeting-card/6733352ce2a5642827b4f7f0.md
+++ b/curriculum/challenges/english/blocks/workshop-greeting-card/6733352ce2a5642827b4f7f0.md
@@ -114,7 +114,6 @@ h1::after {
 
 .message {
   font-size: 1.2em;
-  color: gray;
   margin-bottom: 20px;
 }
 

--- a/curriculum/challenges/english/blocks/workshop-greeting-card/673337337f794d3025ded433.md
+++ b/curriculum/challenges/english/blocks/workshop-greeting-card/673337337f794d3025ded433.md
@@ -135,7 +135,6 @@ h1::after {
 
 .message {
   font-size: 1.2em;
-  color: gray;
   margin-bottom: 20px;
 }
 

--- a/curriculum/challenges/english/blocks/workshop-greeting-card/673338ebd152d736d1bd2aa4.md
+++ b/curriculum/challenges/english/blocks/workshop-greeting-card/673338ebd152d736d1bd2aa4.md
@@ -103,7 +103,6 @@ h1::after {
 
 .message {
   font-size: 1.2em;
-  color: gray;
   margin-bottom: 20px;
 }
 

--- a/curriculum/challenges/english/blocks/workshop-greeting-card/67333a3a400b0a3c68854bcc.md
+++ b/curriculum/challenges/english/blocks/workshop-greeting-card/67333a3a400b0a3c68854bcc.md
@@ -98,7 +98,6 @@ h1::after {
 
 .message {
   font-size: 1.2em;
-  color: gray;
   margin-bottom: 20px;
 }
 

--- a/curriculum/challenges/english/blocks/workshop-greeting-card/67333aa0e231d43e7556c644.md
+++ b/curriculum/challenges/english/blocks/workshop-greeting-card/67333aa0e231d43e7556c644.md
@@ -101,7 +101,6 @@ h1::after {
 
 .message {
   font-size: 1.2em;
-  color: gray;
   margin-bottom: 20px;
 }
 

--- a/curriculum/challenges/english/blocks/workshop-greeting-card/67333b1d5f4a7340a121973a.md
+++ b/curriculum/challenges/english/blocks/workshop-greeting-card/67333b1d5f4a7340a121973a.md
@@ -101,7 +101,6 @@ h1::after {
 
 .message {
   font-size: 1.2em;
-  color: gray;
   margin-bottom: 20px;
 }
 

--- a/curriculum/challenges/english/blocks/workshop-greeting-card/67333ba820f99c43904c9eff.md
+++ b/curriculum/challenges/english/blocks/workshop-greeting-card/67333ba820f99c43904c9eff.md
@@ -98,7 +98,6 @@ h1::after {
 
 .message {
   font-size: 1.2em;
-  color: gray;
   margin-bottom: 20px;
 }
 

--- a/curriculum/challenges/english/blocks/workshop-greeting-card/67333c34e357d34620217615.md
+++ b/curriculum/challenges/english/blocks/workshop-greeting-card/67333c34e357d34620217615.md
@@ -128,7 +128,6 @@ h1::after {
 
 .message {
   font-size: 1.2em;
-  color: gray;
   margin-bottom: 20px;
 }
 

--- a/curriculum/challenges/english/blocks/workshop-greeting-card/67333d70431f8a4b02596f3c.md
+++ b/curriculum/challenges/english/blocks/workshop-greeting-card/67333d70431f8a4b02596f3c.md
@@ -109,7 +109,6 @@ h1::after {
 
 .message {
   font-size: 1.2em;
-  color: gray;
   margin-bottom: 20px;
 }
 

--- a/curriculum/challenges/english/blocks/workshop-greeting-card/67333f5462f7aa53fc47bb2f.md
+++ b/curriculum/challenges/english/blocks/workshop-greeting-card/67333f5462f7aa53fc47bb2f.md
@@ -109,7 +109,6 @@ h1::after {
 
 .message {
   font-size: 1.2em;
-  color: gray;
   margin-bottom: 20px;
 }
 
@@ -236,7 +235,6 @@ h1::after {
 
 .message {
   font-size: 1.2em;
-  color: gray;
   margin-bottom: 20px;
 }
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #63432

Ran the code locally and confirm that the changes are working as expected. I also ran the tests locally and I found no error there as well

**Doubt**: The css property `color: gray` is also present in various language challenges which can be found in [i18n-curriculum](https://github.com/freeCodeCamp/i18n-curriculum) repo. I think I need to raise a similar PR for that repo as well, can you confirm the same and I will raise it as well.

## Screenshots ( local testing )
<img width="591" height="340" alt="image" src="https://github.com/user-attachments/assets/9257be31-4d6a-45f7-810c-3540640e9d98" />


for `pnpm run test:curriculum:content`
<img width="891" height="84" alt="image" src="https://github.com/user-attachments/assets/91af1d71-d4f8-4af0-a234-fee8185d4ef9" />

