### PR TITLE
fix(curriculum): use challenge-list layout for all A1 Spanish review blocks

### DIFF
--- a/curriculum/structure/blocks/es-a1-review-first-questions.json
+++ b/curriculum/structure/blocks/es-a1-review-first-questions.json
@@ -3,7 +3,7 @@
   "isUpcomingChange": true,
   "dashedName": "es-a1-review-first-questions",
   "helpCategory": "English",
-  "blockLayout": "link",
+  "blockLayout": "challenge-list",
   "challengeOrder": [{ "id": "68dc75d172549d787975d2fc", "title": "Task 1" }],
   "blockLabel": "review"
 }

--- a/curriculum/structure/blocks/es-a1-review-greetings-and-farewells.json
+++ b/curriculum/structure/blocks/es-a1-review-greetings-and-farewells.json
@@ -3,7 +3,7 @@
   "isUpcomingChange": true,
   "dashedName": "es-a1-review-greetings-and-farewells",
   "helpCategory": "English",
-  "blockLayout": "link",
+  "blockLayout": "challenge-list",
   "blockLabel": "review",
   "challengeOrder": [
     { "id": "68c850ed23d494c9be5cb22a", "title": "Grammar Highlights" },

--- a/curriculum/structure/blocks/es-a1-review-introducing-yourself.json
+++ b/curriculum/structure/blocks/es-a1-review-introducing-yourself.json
@@ -3,7 +3,7 @@
   "isUpcomingChange": true,
   "dashedName": "es-a1-review-introducing-yourself",
   "helpCategory": "English",
-  "blockLayout": "link",
+  "blockLayout": "challenge-list",
   "challengeOrder": [
     { "id": "68dc753010b6b271ac564e93", "title": "Dialogue 1: I'm Tom" }
   ],


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Changes all A1 Spanish review blocks to use the `challenge-list` layout (there are four review blocks in total but `es-a1-review-the-alphabet` already uses `challenge-list`).

<details>
<summary>Screenshot</summary>

<img width="780" height="552" alt="Screenshot 2025-11-06 at 00 04 33" src="https://github.com/user-attachments/assets/cce5ecfb-5abc-4219-8cbe-2d25d9cb315d" />

</details>

<!-- Feel free to add any additional description of changes below this line -->
