### PR TITLE
fix(client): uncheck chapter checkmarks when no challenges

### DIFF
--- a/client/src/assets/icons/green-not-completed.tsx
+++ b/client/src/assets/icons/green-not-completed.tsx
@@ -16,6 +16,7 @@ function GreenNotCompleted(props: GreenNotCompletedProps): JSX.Element {
         <span className='sr-only'>{t('icons.not-passed')}</span>
       )}
       <svg
+        data-testid='green-not-completed'
         aria-hidden='true'
         height='15'
         viewBox='0 0 200 200'

--- a/client/src/assets/icons/green-pass.tsx
+++ b/client/src/assets/icons/green-pass.tsx
@@ -11,6 +11,7 @@ function GreenPass(props: GreenPassProps): JSX.Element {
   const { hushScreenReaderText = false, ...rest } = props;
   return (
     <svg
+      data-testid='green-pass'
       {...(hushScreenReaderText && { 'aria-hidden': true })}
       {...(!hushScreenReaderText && { 'aria-label': t('icons.passed') })}
       height='15'

--- a/client/src/templates/Challenges/components/__snapshots__/challenge-title.test.tsx.snap
+++ b/client/src/templates/Challenges/components/__snapshots__/challenge-title.test.tsx.snap
@@ -15,6 +15,7 @@ exports[`<ChallengeTitle/> > renders correctly 1`] = `
     </h1>
     <svg
       aria-label="icons.passed"
+      data-testid="green-pass"
       height="15"
       viewBox="0 0 200 200"
       width="15"

--- a/client/src/templates/Introduction/components/super-block-accordion.test.tsx
+++ b/client/src/templates/Introduction/components/super-block-accordion.test.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { SuperBlocks } from '../../../../../shared-dist/config/curriculum';
+import { SuperBlockAccordion } from './super-block-accordion';
+
+const mockStructure = {
+  superBlock: SuperBlocks.RespWebDesign,
+  chapters: [
+    {
+      dashedName: 'test-chapter',
+      modules: [
+        {
+          dashedName: 'test-module',
+          blocks: ['test-block']
+        }
+      ]
+    }
+  ]
+};
+
+describe('SuperBlockAccordion', () => {
+  it('does not show completed checkmark when there are zero challenges in a chapter', () => {
+    render(
+      <SuperBlockAccordion
+        challenges={[]}
+        superBlock={SuperBlocks.RespWebDesign}
+        structure={mockStructure}
+        chosenBlock={''}
+        completedChallengeIds={[]}
+      />
+    );
+
+    expect(screen.queryByTestId('green-pass')).not.toBeInTheDocument();
+
+    const chapterButtons = screen.getAllByRole('button', {
+      name: /test-chapter/i
+    });
+    const chapterButton = chapterButtons[0];
+    const checkmark = within(chapterButton).getByTestId('green-not-completed');
+    expect(checkmark).toBeInTheDocument();
+  });
+});

--- a/client/src/templates/Introduction/components/super-block-accordion.tsx
+++ b/client/src/templates/Introduction/components/super-block-accordion.tsx
@@ -96,7 +96,7 @@ const Chapter = ({
   examSlug
 }: ChapterProps) => {
   const { t } = useTranslation();
-  const isComplete = completedSteps === totalSteps;
+  const isComplete = completedSteps === totalSteps && totalSteps > 0;
   const chapterLabel = t(`intro:${superBlock}.chapters.${dashedName}`);
 
   const chapterButtonContent = (


### PR DESCRIPTION
Current Prod:

<img width="783" height="187" alt="Screenshot 2025-11-05 at 12 45 45 PM" src="https://github.com/user-attachments/assets/cf706887-bff4-4ee8-81f8-10242f5cf964" />

^ no challenges in those two chapters - and they're checked as completed. This PR unchecks the circles.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
