### PR TITLE
fix(client): exam prerequisites list

### DIFF
--- a/client/src/templates/Challenges/exam-download/show.tsx
+++ b/client/src/templates/Challenges/exam-download/show.tsx
@@ -66,7 +66,7 @@ interface ShowExamDownloadProps {
 function ShowExamDownload({
   data: {
     challengeNode: {
-      challenge: { id, title, translationPending }
+      challenge: { id, superBlock: examSuperBlock, title, translationPending }
     },
     allChallengeNode: { nodes }
   },
@@ -168,8 +168,10 @@ function ShowExamDownload({
   const unmetPrerequisites = exam?.prerequisites?.filter(
     prereq => !completedChallenges.some(challenge => challenge.id === prereq)
   );
-  const challenges = nodes.filter(({ challenge }) =>
-    unmetPrerequisites?.includes(challenge.id)
+  const challenges = nodes.filter(
+    ({ challenge }) =>
+      unmetPrerequisites?.includes(challenge.id) &&
+      challenge.superBlock === examSuperBlock
   );
   const missingPrerequisites = challenges.map(({ challenge }) => {
     return {
@@ -274,6 +276,7 @@ export const query = graphql`
     challengeNode(id: { eq: $id }) {
       challenge {
         id
+        superBlock
         title
         translationPending
       }
@@ -286,6 +289,7 @@ export const query = graphql`
           fields {
             slug
           }
+          superBlock
         }
       }
     }


### PR DESCRIPTION
I was testing the exam page for the new certs and saw this:

<img width="1382" height="1043" alt="Screenshot 2025-11-05 at 3 27 13 PM" src="https://github.com/user-attachments/assets/defcebd1-9d62-4c7b-be48-a02163c49328" />

Notice the URL at the bottom - the new cert isn't the 2022/rwd. It's listing all the challenges with the ID of a prerequisite. Since the same challenge (id) exists in multiple places, it was listing the challenge to all places.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
