### PR TITLE
fix(client): new chapter icons for v9 certs

### DIFF
--- a/client/src/assets/chapter-icon.tsx
+++ b/client/src/assets/chapter-icon.tsx
@@ -28,7 +28,8 @@ const iconMap = {
   [FsdChapters.PythonExam]: Graduation,
   [FsdChapters.RdbExam]: Graduation,
   [FsdChapters.Bed]: NodeIcon,
-  [FsdChapters.BedExam]: Graduation
+  [FsdChapters.BedExam]: Graduation,
+  [FsdChapters.FsdExam]: Graduation
 };
 
 type ChapterIconProps = {

--- a/client/src/assets/chapter-icon.tsx
+++ b/client/src/assets/chapter-icon.tsx
@@ -20,7 +20,15 @@ const iconMap = {
   [FsdChapters.RelationalDatabases]: DatabaseIcon,
   [FsdChapters.BackendJavascript]: NodeIcon,
   [FsdChapters.Python]: Python,
-  [FsdChapters.Career]: Graduation
+  [FsdChapters.Career]: Graduation,
+  [FsdChapters.RwdExam]: Graduation,
+  [FsdChapters.JsExam]: Graduation,
+  [FsdChapters.Fed]: ReactIcon,
+  [FsdChapters.FedExam]: Graduation,
+  [FsdChapters.PythonExam]: Graduation,
+  [FsdChapters.RdbExam]: Graduation,
+  [FsdChapters.Bed]: NodeIcon,
+  [FsdChapters.BedExam]: Graduation
 };
 
 type ChapterIconProps = {

--- a/shared/config/chapters.ts
+++ b/shared/config/chapters.ts
@@ -2,15 +2,28 @@ import type { Module } from './modules';
 
 // TODO: Dynamically create these from intro.json or full-stack.json
 export enum FsdChapters {
+  // original FSD
   Welcome = 'freecodecamp',
-  Html = 'html',
-  Css = 'css',
   Javascript = 'javascript',
   FrontendLibraries = 'frontend-libraries',
-  Python = 'python',
-  RelationalDatabases = 'relational-databases',
   BackendJavascript = 'backend-javascript',
-  Career = 'career'
+  Career = 'career',
+
+  // new FSD
+  RwdExam = 'responsive-web-design-certification-exam',
+  JsExam = 'javascript-certification-exam',
+  Fed = 'front-end-development-libraries',
+  FedExam = 'front-end-development-libraries-certification-exam',
+  PythonExam = 'python-certification-exam',
+  RdbExam = 'relational-databases-certification-exam',
+  Bed = 'back-end-development-and-apis',
+  BedExam = 'back-end-development-and-apis-certification-exam',
+
+  // used in both
+  Html = 'html',
+  Css = 'css',
+  Python = 'python',
+  RelationalDatabases = 'relational-databases'
 }
 
 export interface Chapter {

--- a/shared/config/chapters.ts
+++ b/shared/config/chapters.ts
@@ -18,6 +18,7 @@ export enum FsdChapters {
   RdbExam = 'relational-databases-certification-exam',
   Bed = 'back-end-development-and-apis',
   BedExam = 'back-end-development-and-apis-certification-exam',
+  FsdExam = 'certified-full-stack-developer-exam',
 
   // used in both
   Html = 'html',


### PR DESCRIPTION
Before:

<img width="800" height="211" alt="Screenshot 2025-11-05 at 10 16 03 PM" src="https://github.com/user-attachments/assets/ead953a5-36e3-4638-a960-0fca50a0f37a" />

After:

<img width="828" height="231" alt="Screenshot 2025-11-05 at 10 17 12 PM" src="https://github.com/user-attachments/assets/e971fd1e-c104-4520-aa02-fc17705bd97d" />

Also fixes icons in all the other new superblocks. 

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes https://github.com/freeCodeCamp/fCC10/issues/122

<!-- Feel free to add any additional description of changes below this line -->
