### PR TITLE
feat(curriculum): add interactive examples to regex lesson

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-regular-expressions/6733c5dc74176e4c496d09e6.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-regular-expressions/6733c5dc74176e4c496d09e6.md
@@ -5,9 +5,7 @@ challengeType: 19
 dashedName: what-are-lookaheads-and-lookbehind-assertions-and-how-do-they-work
 ---
 
-# --description--
-
-Let's learn about lookahead and lookbehind assertions in regular expressions.
+# --interactive--
 
 Lookahead and lookbehind assertions allow you to match specific patterns based on the presence or lack of surrounding patterns. There are four variations of these assertions.
 
@@ -23,6 +21,8 @@ const regex = /free(?=code)/i;
 
 Let's test the behavior of our pattern:
 
+:::interactive_editor
+
 ```js
 const regex = /free(?=code)/i;
 console.log(regex.test("freeCodeCamp")); // true
@@ -31,6 +31,8 @@ console.log(
   regex.test("I need someone for free to write code for me")
 ); // false
 ```
+
+:::
 
 Notice how only the string where `free` is immediately followed by `code` passes the test.
 
@@ -42,6 +44,8 @@ const regex = /free(?!code)/i;
 
 Let's test this against our same strings:
 
+:::interactive_editor
+
 ```js
 const regex = /free(?!code)/i;
 console.log(regex.test("freeCodeCamp")); // false
@@ -50,6 +54,8 @@ console.log(
   regex.test("I need someone for free to write code for me")
 ); // true
 ```
+
+:::
 
 As expected, the results are reversed. The only string that fails is the first string, where `free` is immediately followed by `code`.
 
@@ -63,6 +69,8 @@ const regex = /(?<=free)code/i;
 
 Just like with our positive lookahead, our positive lookbehind matches the first string because `code` is immediately preceded by `free`:
 
+:::interactive_editor
+
 ```js
 const regex = /(?<=free)code/i;
 console.log(regex.test("freeCodeCamp")); // true
@@ -72,13 +80,17 @@ console.log(
 ); // false
 ```
 
+:::
+
 To match `code` when it is NOT preceded by `free`, we can use a negative lookbehind. A negative lookbehind is defined by replacing `?<=` with `?<!`:
 
 ```js
 const regex = /(?<!free)code/i;
 ```
 
-This would match any occurrence of `code` that is NOT immediately preceded by `free`.
+This would match any occurrence of `code` that is NOT immediately preceded by `free`:
+
+:::interactive_editor
 
 ```js
 const regex = /(?<!free)code/i;
@@ -88,6 +100,8 @@ console.log(
   regex.test("I need someone for free to write code for me")
 ); // true
 ```
+
+:::
 
 Remember that `Regex.prototype.test` only confirms whether a string matches the regular expression. Let's use our negative lookbehind with `String.prototype.match` to see how assertions affect that:
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #63578

This PR updates the "Lookahead and Lookbehind Assertions" lesson to include the new interactive examples, as provided in the issue.