### PR TITLE
feat(curriculum): update capturing groups lesson with interactive exa…

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-regular-expressions/6733c5f20cc9584cada942a4.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-regular-expressions/6733c5f20cc9584cada942a4.md
@@ -5,9 +5,7 @@ challengeType: 19
 dashedName: what-are-capturing-groups-and-backreferences-and-how-do-they-work
 ---
 
-# --description--
-
-Let's learn about capturing groups and backreferences in regular expressions.
+# --interactive--
 
 A capturing group allows you to "capture" a portion of the matched string to use however you might need. Capturing groups are defined by parentheses containing the pattern to capture, with no leading characters like a lookahead.
 
@@ -19,10 +17,14 @@ const regex = /free(code)camp/i;
 
 To confirm the behavior, we can test it against a `freecodecamp` string:
 
+:::interactive_editor
+
 ```js
 const regex = /free(code)camp/i;
 console.log(regex.test("freecodecamp")); // true
 ```
+
+:::
 
 But this doesn't actually make use of our captured group. Instead, let's take a look at the result of using `match`:
 
@@ -44,17 +46,25 @@ Notice how the capture group matches the exact pattern `code`, where a character
 
 But how can we actually use this? Well, capture groups are often used when replacing contents of a string. Let's set up some code to do that. We're going to turn `freecodecamp` into `paidcodeworld`:
 
+:::interactive_editor
+
 ```js
 const regex = /free(code)camp/i;
 console.log("freecodecamp".replace(regex, "paidcodeworld"));
 ```
 
+:::
+
 This works on its own, but what if we didn't know how many `o`'s were in `code`? If we need a quantifier for one or more `o`s:
+
+:::interactive_editor
 
 ```js
 const regex = /free(co+de)camp/i;
 console.log("freecoooooooodecamp".replace(regex, "paidcodeworld"));
 ```
+
+:::
 
 We're getting `paidcodeworld` as our result. We want to preserve the number of `o`'s, so we need to reuse what was captured by the regular expression.
 
@@ -62,10 +72,14 @@ This is where a backreference comes in. Instead of hardcoding the `code` portion
 
 In a `replace` call, you achieve a backreference by using a dollar sign (`$`) followed by the number of the capture group to use. In our case, that would be `$1`, since `code` is captured in the first capture group:
 
+:::interactive_editor
+
 ```js
 const regex = /free(co+de)camp/i;
 console.log("freecoooooooodecamp".replace(regex, "paid$1world")); // paidcoooooooodeworld
 ```
+
+:::
 
 We have now successfully preserved an unknown number of `o` characters when converting `freecodecamp` into `paidcodeworld`. But backreferences aren't just limited to the replace call. You can actually use them directly in a regular expression.
 
@@ -83,11 +97,15 @@ This current expression won't ensure that the number of `o` characters is the sa
 
 Inside a regular expression, a backreference is denoted with a backslash followed by the number of the capture group:
 
+:::interactive_editor
+
 ```js
 const regex = /free(co+de)camp.*free\1camp/i;
 console.log(regex.test("freecooooodecamp is great i love freecooooodecamp")); // true
 console.log(regex.test("freecooooodecamp is great i love freecodecamp")); // false
 ```
+
+:::
 
 And with that, we can see that a string with the correct number of `o`s matches, while a string with two different numbers of `o`s does not.
 
@@ -107,17 +125,25 @@ const regex = /free(?<code>co+de)camp.*free\k<code>camp/i;
 
 Now if we check our `test()` call, we can see that we still pass:
 
+:::interactive_editor
+
 ```js
 const regex = /free(?<code>co+de)camp.*free\k<code>camp/i;
 console.log(regex.test("freecooooodecamp is freecooooodecamp")); // true
 ```
 
+:::
+
 To use our named capture group in a `replace()` call, we'd insert a dollar sign into the string, followed by the name enclosed in less than and greater than signs:
+
+:::interactive_editor
 
 ```js
 const regex = /free(?<code>co+de)camp/i;
 console.log("freecooooodecamp".replace(regex, "paid$<code>camp")); // paidcooooodecamp
 ```
+
+:::
 
 Finally, sometimes you want to create a group of characters, but don't need the captured result.
 


### PR DESCRIPTION

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #63580 

<!-- Feel free to add any additional description of changes below this line -->

This PR updates the "What Are Capturing Groups and Backreferences, and How Do They Work?" lesson to use the new interactive code editor format.

✅ Replaced static code examples with `:::interactive_editor` blocks  
✅ Preserved challenge metadata (id, dashedName, challengeType)  
✅ Updated content formatting to match current curriculum standards  
✅ Passed `npm run test:curriculum` locally

Closes #63580
