### PR TITLE
feat(client): add alert if qualified for exam

### DIFF
--- a/client/src/templates/Challenges/exam-download/show.css
+++ b/client/src/templates/Challenges/exam-download/show.css
@@ -2,3 +2,7 @@
   display: flex;
   flex-direction: column;
 }
+
+.exam-qualified p:last-of-type {
+  margin-bottom: 0;
+}

--- a/client/src/templates/Challenges/exam-download/show.tsx
+++ b/client/src/templates/Challenges/exam-download/show.tsx
@@ -3,6 +3,7 @@ import { graphql } from 'gatsby';
 import Helmet from 'react-helmet';
 import {
   Button,
+  Callout,
   Dropdown,
   MenuItem,
   Spacer,
@@ -199,10 +200,14 @@ function ShowExamDownload({
               {title}
             </ChallengeTitle>
             <Spacer size='m' />
-            {!!missingPrerequisites.length && (
+            {missingPrerequisites.length > 0 ? (
               <MissingPrerequisites
                 missingPrerequisites={missingPrerequisites}
               />
+            ) : (
+              <Callout className='exam-qualified' variant='info'>
+                <p>{t('learn.exam.qualified')}</p>
+              </Callout>
             )}
             <h2>{t('exam.download-header')}</h2>
             <p>{t('exam.explanation')}</p>


### PR DESCRIPTION
Adds an alert if qualified for the exam:

<img width="817" height="979" alt="Screenshot 2025-11-06 at 1 11 58 PM" src="https://github.com/user-attachments/assets/3db074e2-247b-43ab-9a3f-24e297ab0f7f" />

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
