### PR TITLE
fix(client): filter out empty blocks from super block accordion

### DIFF
--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -543,7 +543,7 @@ export class Block extends Component<BlockProps> {
           isExpanded={isExpanded}
           percentageCompleted={percentageCompleted}
           accordion={accordion}
-          blockUrl={challenges?.[0]?.fields?.slug ?? ''}
+          blockUrl={challenges[0].fields.slug}
         />
       </>
     );

--- a/client/src/templates/Introduction/components/super-block-accordion.test.tsx
+++ b/client/src/templates/Introduction/components/super-block-accordion.test.tsx
@@ -1,8 +1,52 @@
 import React from 'react';
-import { render, screen, within } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
+import { Provider } from 'react-redux';
+import { render, screen, within, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { createStore } from '../../../redux/create-store';
 import { SuperBlocks } from '../../../../../shared-dist/config/curriculum';
+import {
+  BlockLayouts,
+  BlockLabel
+} from '../../../../../shared-dist/config/blocks';
 import { SuperBlockAccordion } from './super-block-accordion';
+
+const t = (key: string) => {
+  const translations: Record<
+    string,
+    string | string[] | { note: string; intro: string[] }
+  > = {
+    'intro:responsive-web-design.chapters.test-chapter': 'Test Chapter',
+    'intro:responsive-web-design.modules.test-module': 'Test Module',
+    'intro:responsive-web-design.module-intros.test-module': {
+      note: '',
+      intro: []
+    },
+    'intro:responsive-web-design.blocks.block1.title': 'Lab Block',
+    'intro:responsive-web-design.blocks.block2.title': 'Workshop Block',
+    'learn.not-started': 'Not Started'
+  };
+  return translations[key];
+};
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t }),
+  withTranslation:
+    () =>
+    <P extends Record<string, unknown>>(Component: React.ComponentType<P>) => {
+      const WrappedComponent = (props: P) => <Component {...props} t={t} />;
+      WrappedComponent.displayName = `WithTranslationComp`;
+      return WrappedComponent;
+    }
+}));
+
+vi.mock('../../../utils/get-words');
+
+function renderWithRedux(
+  ui: JSX.Element,
+  preloadedState: Record<string, unknown> = {}
+) {
+  return render(<Provider store={createStore(preloadedState)}>{ui}</Provider>);
+}
 
 const mockStructure = {
   superBlock: SuperBlocks.RespWebDesign,
@@ -12,7 +56,7 @@ const mockStructure = {
       modules: [
         {
           dashedName: 'test-module',
-          blocks: ['test-block']
+          blocks: ['block1', 'block2']
         }
       ]
     }
@@ -34,10 +78,132 @@ describe('SuperBlockAccordion', () => {
     expect(screen.queryByTestId('green-pass')).not.toBeInTheDocument();
 
     const chapterButtons = screen.getAllByRole('button', {
-      name: /test-chapter/i
+      name: /test chapter/i
     });
     const chapterButton = chapterButtons[0];
     const checkmark = within(chapterButton).getByTestId('green-not-completed');
     expect(checkmark).toBeInTheDocument();
+  });
+
+  it('should render all blocks when all have challenges', () => {
+    const mockChallenges = [
+      {
+        id: '1',
+        block: 'block1',
+        blockLabel: BlockLabel.lab,
+        title: 'Lab 1',
+        fields: { slug: 'lab-1' },
+        dashedName: 'lab-1',
+        challengeType: 1,
+        blockLayout: BlockLayouts.Link,
+        superBlock: SuperBlocks.RespWebDesign
+      },
+      {
+        id: '2',
+        block: 'block2',
+        blockLabel: BlockLabel.workshop,
+        title: 'Step 1',
+        fields: { slug: 'step-1' },
+        dashedName: 'step-1',
+        challengeType: 1,
+        blockLayout: BlockLayouts.ChallengeGrid,
+        superBlock: SuperBlocks.RespWebDesign
+      },
+      {
+        id: '3',
+        block: 'block2',
+        blockLabel: BlockLabel.workshop,
+        title: 'Step 2',
+        fields: { slug: 'step-2' },
+        dashedName: 'step-2',
+        challengeType: 1,
+        blockLayout: BlockLayouts.ChallengeGrid,
+        superBlock: SuperBlocks.RespWebDesign
+      }
+    ];
+
+    renderWithRedux(
+      <SuperBlockAccordion
+        challenges={mockChallenges}
+        superBlock={SuperBlocks.RespWebDesign}
+        structure={mockStructure}
+        chosenBlock='block1'
+        completedChallengeIds={[]}
+      />
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Test Chapter' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Test Module' })
+    ).toBeInTheDocument();
+
+    const labHeading = screen.getByRole('heading', {
+      name: 'Lab Block , Not Started'
+    });
+    expect(labHeading).toBeInTheDocument();
+    expect(
+      within(labHeading).getByRole('link', { name: 'Lab Block , Not Started' })
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('heading', { name: 'Workshop Block , Not Started' })
+    ).toBeInTheDocument();
+
+    // Expand block 2
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Workshop Block , Not Started' })
+    );
+
+    expect(screen.getByRole('link', { name: '1' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '2' })).toBeInTheDocument();
+  });
+
+  it('should filter out blocks without challenges', () => {
+    const mockChallenges = [
+      {
+        id: '1',
+        block: 'block1',
+        blockLabel: BlockLabel.lab,
+        title: 'Challenge 1',
+        fields: { slug: 'challenge-1' },
+        dashedName: 'challenge-1',
+        challengeType: 1,
+        blockLayout: BlockLayouts.Link,
+        superBlock: SuperBlocks.RespWebDesign
+      }
+    ];
+
+    renderWithRedux(
+      <SuperBlockAccordion
+        challenges={mockChallenges}
+        superBlock={SuperBlocks.RespWebDesign}
+        structure={mockStructure}
+        chosenBlock={'block1'}
+        completedChallengeIds={[]}
+      />
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Test Chapter' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Test Module' })
+    ).toBeInTheDocument();
+
+    const labHeading = screen.getByRole('heading', {
+      name: 'Lab Block , Not Started'
+    });
+    expect(labHeading).toBeInTheDocument();
+    expect(
+      within(labHeading).getByRole('link', { name: 'Lab Block , Not Started' })
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole('heading', { name: 'Workshop Block , Not Started' })
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: '1' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: '2' })).not.toBeInTheDocument();
   });
 });

--- a/client/src/templates/Introduction/components/super-block-accordion.tsx
+++ b/client/src/templates/Introduction/components/super-block-accordion.tsx
@@ -282,18 +282,23 @@ export const SuperBlockAccordion = ({
   const blockToChapterMap = getBlockToChapterMap();
   const blockToModuleMap = getBlockToModuleMap();
   const allChapters = useMemo<PopulatedChapter[]>(() => {
+    // Blocks with `isUpcomingChange: true` don't have any challenges
+    // so they need to be filtered out
     const populateBlocks = (blocks: string[]): PopulatedBlock[] =>
-      blocks.map(block => {
-        const blockChallenges = challenges.filter(
-          ({ block: blockName }) => blockName === block
-        );
-
-        return {
-          name: block,
-          blockLabel: blockChallenges[0]?.blockLabel ?? null,
-          challenges: blockChallenges
-        };
-      });
+      blocks
+        .filter(block =>
+          challenges.some(({ block: blockName }) => blockName === block)
+        )
+        .map(block => {
+          const blockChallenges = challenges.filter(
+            ({ block: blockName }) => blockName === block
+          );
+          return {
+            name: block,
+            blockLabel: blockChallenges[0]?.blockLabel ?? null,
+            challenges: blockChallenges
+          };
+        });
 
     return superBlockStructure.chapters.map((chapter: Chapter) => ({
       name: chapter.dashedName,


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Addresses https://github.com/freeCodeCamp/freeCodeCamp/pull/63509#issuecomment-3488893197.

Steps to test:
- Set `SHOW_UPCOMING_CHANGES` to `false`
- Change `isUpcomingChange` to `true` in `curriculum/structure/blocks/workshop-string-inspector.json`
- Start the app
- Go to FSD page and click the Variables and Strings module
- The page shouldn't crash and the String Inspector workshop isn't rendered

<!-- Feel free to add any additional description of changes below this line -->
