### PR TITLE
refactor(client,curriculum): remove isComingSoon property

### DIFF
--- a/client/gatsby-node.js
+++ b/client/gatsby-node.js
@@ -323,7 +323,6 @@ exports.createSchemaCustomization = ({ actions }) => {
       hooks: Hooks
       id: String
       instructions: String
-      isComingSoon: Boolean
       isLastChallengeInBlock: Boolean
       isPrivate: Boolean
       module: String

--- a/client/src/redux/prop-types.ts
+++ b/client/src/redux/prop-types.ts
@@ -213,7 +213,6 @@ export type ChallengeNode = {
     hooks?: Hooks;
     id: string;
     instructions: string;
-    isComingSoon: boolean;
     internal?: {
       content: string;
       contentDigest: string;

--- a/client/src/templates/Introduction/components/block.test.tsx
+++ b/client/src/templates/Introduction/components/block.test.tsx
@@ -47,7 +47,6 @@ const defaultProps = {
       helpCategory: 'mockHelpCategory',
       id: 'mockId',
       instructions: 'mockInstructions',
-      isComingSoon: false,
       internal: {
         content: 'mockContent',
         contentDigest: 'mockContentDigest',

--- a/curriculum/schema/challenge-schema.js
+++ b/curriculum/schema/challenge-schema.js
@@ -248,7 +248,6 @@ const schema = Joi.object().keys({
     then: Joi.string().min(1).required(),
     otherwise: Joi.string().allow('')
   }),
-  isComingSoon: Joi.bool(),
   module: Joi.string().when('superBlock', {
     is: chapterBasedSuperBlocks,
     then: Joi.required(),


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This `isComingSoon` property appears to be unused.

<!-- Feel free to add any additional description of changes below this line -->
