### PR TITLE
Fix typo: changed 'oder' to 'order' in curriculum challenge file

### DIFF
--- a/curriculum/challenges/english/blocks/learn-how-to-clarify-misunderstandings/67e7e77a7fe59f501cc3e8c1.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-clarify-misunderstandings/67e7e77a7fe59f501cc3e8c1.md
@@ -22,7 +22,7 @@ Which sentence uses the noun clause correctly?
 
 ### --feedback--
 
-Noun clause doesn't use the question oder.
+Noun clause doesn't use the question order.
 
 ---
 


### PR DESCRIPTION
this PR fixes a minor typo ( 'oder' to 'order') in curriculum/challenges/english/blocks/learn-how-to-clarify-misunderstandings/67e7e77a7fe59f501cc3e8c1.md