### PR TITLE
feat: allow filtering by block and challengeId

### DIFF
--- a/client/gatsby-node.js
+++ b/client/gatsby-node.js
@@ -341,6 +341,7 @@ exports.createSchemaCustomization = ({ actions }) => {
       superOrder: Int
       template: String
       tests: [Test]
+      fields: ChallengeFields
       title: String
       transcript: String
       translationPending: Boolean
@@ -466,7 +467,11 @@ exports.createSchemaCustomization = ({ actions }) => {
       beforeAll: String
       afterAll: String
     }
-
+    type ChallengeFields {
+      slug: String
+      blockName: String
+      tests: [Test]
+    }
     type Nodule {
       type: String
       data: JSON

--- a/curriculum/src/build-curriculum.ts
+++ b/curriculum/src/build-curriculum.ts
@@ -335,18 +335,13 @@ export async function parseCurriculumStructure(filter?: Filter) {
 
 export async function buildCurriculum(lang: string, filters?: Filter) {
   const contentDir = getContentDir(lang);
-  const fccSuperblock = process.env.FCC_SUPERBLOCK;
-
-  const combinedFilters: Filter | undefined = fccSuperblock
-    ? { ...filters, superBlock: fccSuperblock }
-    : filters;
 
   const builder = new SuperblockCreator(
-    getBlockCreator(lang, !isEmpty(combinedFilters))
+    getBlockCreator(lang, !isEmpty(filters))
   );
 
   const { fullSuperblockList, certifications } =
-    await parseCurriculumStructure(combinedFilters);
+    await parseCurriculumStructure(filters);
 
   const fullCurriculum: {
     [key: string]: unknown;

--- a/curriculum/src/build-curriculum.ts
+++ b/curriculum/src/build-curriculum.ts
@@ -334,10 +334,13 @@ export async function parseCurriculumStructure(filter?: Filter) {
 }
 
 export async function buildCurriculum(lang: string, filters?: Filter) {
+  // Block validation assumes the entire block is being built, if that's not the
+  // case, skip validation
+  const skipBlockValidation = filters?.challengeId !== undefined;
   const contentDir = getContentDir(lang);
 
   const builder = new SuperblockCreator(
-    getBlockCreator(lang, !isEmpty(filters))
+    getBlockCreator(lang, skipBlockValidation)
   );
 
   const { fullSuperblockList, certifications } =

--- a/curriculum/src/config.ts
+++ b/curriculum/src/config.ts
@@ -28,10 +28,15 @@ export const FCC_CHALLENGE_ID = process.env.FCC_CHALLENGE_ID
   ? process.env.FCC_CHALLENGE_ID.trim()
   : undefined;
 
+const FCC_BLOCK = process.env.FCC_BLOCK
+  ? process.env.FCC_BLOCK.trim()
+  : undefined;
+const FCC_SUPERBLOCK = process.env.FCC_SUPERBLOCK
+  ? process.env.FCC_SUPERBLOCK.trim()
+  : undefined;
+
 export const curriculumFilter = {
-  block: process.env.FCC_BLOCK ? process.env.FCC_BLOCK.trim() : undefined,
-  challengeId: FCC_CHALLENGE_ID,
-  superBlock: process.env.FCC_SUPERBLOCK
-    ? process.env.FCC_SUPERBLOCK.trim()
-    : undefined
+  ...(FCC_CHALLENGE_ID && { challengeId: FCC_CHALLENGE_ID }),
+  ...(FCC_BLOCK && { block: FCC_BLOCK }),
+  ...(FCC_SUPERBLOCK && { superBlock: FCC_SUPERBLOCK })
 };

--- a/curriculum/src/get-challenges.ts
+++ b/curriculum/src/get-challenges.ts
@@ -5,6 +5,7 @@ import { promisify } from 'util';
 import { availableLangs } from '../../shared-dist/config/i18n.js';
 import { buildCurriculum } from './build-curriculum.js';
 import { curriculumFilter } from './config.js';
+import type { Filter } from './filter.js';
 
 const { curriculum: curriculumLangs } = availableLangs;
 
@@ -12,11 +13,7 @@ const access = promisify(_access);
 
 export async function getChallengesForLang(
   lang: string,
-  filters: {
-    superBlock?: string;
-    block?: string;
-    challengeId?: string;
-  } = curriculumFilter // default to global curriculum filter, but allow override (e.g. when testing specific blocks)
+  filters: Filter = curriculumFilter // default to global curriculum filter, but allow override (e.g. when testing specific blocks)
 ) {
   const invalidLang = !curriculumLangs.includes(lang);
   if (invalidLang)

--- a/curriculum/src/get-challenges.ts
+++ b/curriculum/src/get-challenges.ts
@@ -4,6 +4,7 @@ import { promisify } from 'util';
 
 import { availableLangs } from '../../shared-dist/config/i18n.js';
 import { buildCurriculum } from './build-curriculum.js';
+import { curriculumFilter } from './config.js';
 
 const { curriculum: curriculumLangs } = availableLangs;
 
@@ -11,11 +12,11 @@ const access = promisify(_access);
 
 export async function getChallengesForLang(
   lang: string,
-  filters?: {
+  filters: {
     superBlock?: string;
     block?: string;
     challengeId?: string;
-  }
+  } = curriculumFilter // default to global curriculum filter, but allow override (e.g. when testing specific blocks)
 ) {
   const invalidLang = !curriculumLangs.includes(lang);
   if (invalidLang)

--- a/tools/scripts/build/build-curriculum.ts
+++ b/tools/scripts/build/build-curriculum.ts
@@ -15,7 +15,10 @@ import {
 
 const globalConfigPath = path.resolve(__dirname, '../../../shared-dist/config');
 
-const isSelectiveBuild = !!process.env.FCC_SUPERBLOCK;
+const isSelectiveBuild =
+  process.env.FCC_SUPERBLOCK ||
+  process.env.FCC_BLOCK ||
+  process.env.FCC_CHALLENGE_ID;
 
 void getChallengesForLang('english')
   .then(result => {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Builds on https://github.com/freeCodeCamp/freeCodeCamp/pull/63081 to let people pick specific blocks or challenges (by id) when developing.

As it stands challenges without tests will not work, because Gatsby needs to query for tests and will not be able to find them in the schema. ~However, fixing that is a little involved, so I'll do that separately.~

The proper fix (removing fields entirely) is a little involved, but updating the schema was trivial and should work for now.

<!-- Feel free to add any additional description of changes below this line -->
