### PR TITLE
refactor(e2e): consolidate tests in preview.spec.ts

### DIFF
--- a/e2e/preview.spec.ts
+++ b/e2e/preview.spec.ts
@@ -9,7 +9,7 @@ test.beforeEach(async ({ page }) => {
 });
 
 test.describe('Challenge Preview Component', () => {
-  test('should render correct output of default code', async ({
+  test('should render correct output for default and changed code', async ({
     page,
     isMobile
   }) => {
@@ -18,30 +18,27 @@ test.describe('Challenge Preview Component', () => {
         .getByRole('tab', { name: translations.learn['editor-tabs'].preview })
         .click();
     }
+
+    // Check default code output
     await expect(
       page
         .frameLocator('.challenge-preview-frame')
-        .first()
         .getByRole('heading', { name: 'CatPhotoApp' })
     ).toBeVisible();
-  });
 
-  test('should render correct output of changed code', async ({
-    page,
-    isMobile
-  }) => {
+    // Change code
     await focusEditor({ page, isMobile });
-
     await page.keyboard.insertText('<h1>FreeCodeCamp</h1>');
     if (isMobile) {
       await page
         .getByRole('tab', { name: translations.learn['editor-tabs'].preview })
         .click();
     }
+
+    // Check changed code output
     await expect(
       page
         .frameLocator('.challenge-preview-frame')
-        .first()
         .getByRole('heading', { name: 'FreeCodeCamp' })
     ).toBeVisible();
   });


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Each `page.goto` call takes around 10 seconds to complete, while assertions run in just milliseconds:

<details>
<summary>Screenshot</summary>

<img width="628" height="268" alt="Screenshot 2025-11-08 at 07 03 06" src="https://github.com/user-attachments/assets/e3b82375-dfab-4415-9cc8-73230a426067" />

</details>

This PR consolidates tests in `preview.spec.ts` to save us a few seconds.

| Before | After |
| --- | --- |
| <img width="1436" height="986" alt="Screenshot 2025-11-08 at 18 24 14" src="https://github.com/user-attachments/assets/cfd306b7-dc4c-43b7-9cd3-28ffeb7e4ddb" /> | <img width="1438" height="947" alt="Screenshot 2025-11-08 at 18 16 33" src="https://github.com/user-attachments/assets/ac437219-7a17-4654-9593-84c0efe0e5e7" /> |


<!-- Feel free to add any additional description of changes below this line -->
