### PR TITLE
fix(curriculum): add test to validate book filtering direction in lab-book-organizer

### DIFF
--- a/curriculum/challenges/english/blocks/lab-book-organizer/67172b43f84bcd2dec238a3d.md
+++ b/curriculum/challenges/english/blocks/lab-book-organizer/67172b43f84bcd2dec238a3d.md
@@ -89,6 +89,17 @@ assert.isBelow(filteredBooks.length, books.length)
 assert.isNotEmpty(filteredBooks)
 ```
 
+All books in the `filteredBooks` array should have a `releaseYear` before the earliest year in the books that were filtered out.
+
+```js
+const filteredYears = filteredBooks.map(book => book.releaseYear);
+const allYears = books.map(book => book.releaseYear);
+const removedYears = allYears.filter(year => !filteredYears.includes(year));
+const maxFilteredYear = Math.max(...filteredYears);
+const minRemovedYear = Math.min(...removedYears);
+assert.isBelow(maxFilteredYear, minRemovedYear, 'All books in filteredBooks should be released before the year used for filtering (books written after a certain year should be filtered out)');
+```
+
 You should call the `sort` higher order function by passing the `sortByYear` callback function on the `filteredBooks` array.
 
 ```js

--- a/curriculum/challenges/english/blocks/lab-book-organizer/67172b43f84bcd2dec238a3d.md
+++ b/curriculum/challenges/english/blocks/lab-book-organizer/67172b43f84bcd2dec238a3d.md
@@ -97,7 +97,7 @@ const allYears = books.map(book => book.releaseYear);
 const removedYears = allYears.filter(year => !filteredYears.includes(year));
 const maxFilteredYear = Math.max(...filteredYears);
 const minRemovedYear = Math.min(...removedYears);
-assert.isBelow(maxFilteredYear, minRemovedYear, 'All books in filteredBooks should be released before the year used for filtering (books written after a certain year should be filtered out)');
+assert.isBelow(maxFilteredYear, minRemovedYear);
 ```
 
 You should call the `sort` higher order function by passing the `sortByYear` callback function on the `filteredBooks` array.


### PR DESCRIPTION
- Added test to ensure books are filtered by release year in correct direction
- Test validates that filtered books have earlier years than removed books
- Fixes issue where both < and > operators would pass tests
- Resolves #63631

Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #63631

