### PR TITLE
fix: add missing question mark

### DIFF
--- a/curriculum/challenges/english/blocks/lab-html-audio-and-video-player/68de40f53fcaf106f51cc20f.md
+++ b/curriculum/challenges/english/blocks/lab-html-audio-and-video-player/68de40f53fcaf106f51cc20f.md
@@ -215,7 +215,7 @@ assert.match(srcAttr, /\.(mp3|wav|ogg|aac|flac)$/i);
     <h1>HTML Audio and Video Lab</h1>
 
     <section>
-      <h2>What is the map method and how does it work</h2>
+      <h2>What is the map method and how does it work?</h2>
       <video controls width="640">
         <source src="https://cdn.freecodecamp.org/curriculum/labs/what-is-the-map-method-and-how-does-it-work.mp4" type="video/mp4" />
       </video>


### PR DESCRIPTION
Added the missing question mark to the `<h2>` heading in the # --solutions-- section to match the video thumbnail text.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x ] My pull request targets the `main` branch of freeCodeCamp.
- [ x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the is63649sue number.-->

Closes #63649

<!-- Feel free to add any additional description of changes below this line -->
