### PR TITLE
fix: add missing question mark to heading in audio/video lab

### DIFF
--- a/curriculum/challenges/english/blocks/lab-html-audio-and-video-player/68de40f53fcaf106f51cc20f.md
+++ b/curriculum/challenges/english/blocks/lab-html-audio-and-video-player/68de40f53fcaf106f51cc20f.md
@@ -215,7 +215,7 @@ assert.match(srcAttr, /\.(mp3|wav|ogg|aac|flac)$/i);
     <h1>HTML Audio and Video Lab</h1>
 
     <section>
-      <h2>What is the map method and how does it work</h2>
+      <h2>What is the map method and how does it work?</h2>
       <video controls width="640">
         <source src="https://cdn.freecodecamp.org/curriculum/labs/what-is-the-map-method-and-how-does-it-work.mp4" type="video/mp4" />
       </video>


### PR DESCRIPTION
## Overview
This PR fixes a typo in the HTML Audio and Video lab challenge by adding a missing question mark to the heading text. The issue was that the heading "What is the map method and how does it work" was missing proper punctuation at the end.

## Checklist
- [ ] Code changes are complete
- [ ] Tests pass
- [ ] Documentation updated (if applicable)

## Proof that changes are correct
The fix is a simple punctuation addition that corrects the heading text from "What is the map method and how does it work" to "What is the map method and how does it work?". This change aligns the heading with proper grammar and matches the expected text format for question headings in the curriculum.