### PR TITLE
fix(curriculum): expand on null in javascript comparisons and conditionals review

### DIFF
--- a/curriculum/challenges/english/blocks/review-javascript-comparisons-and-conditionals/6723c554025f449f4f39c3f5.md
+++ b/curriculum/challenges/english/blocks/review-javascript-comparisons-and-conditionals/6723c554025f449f4f39c3f5.md
@@ -12,15 +12,28 @@ dashedName: review-javascript-comparisons-and-conditionals
 - **Comparisons and `undefined`**: A variable is `undefined` when it has been declared but hasn't been assigned a value. It's the default value of uninitialized variables and function parameters that weren't provided an argument. `undefined` converts to `NaN` in numeric contexts, which makes all numeric comparisons with `undefined` return `false`.
 
 ```js
-console.log(undefined > 0);  // false
-console.log(undefined < 0);  // false
-console.log(undefined == 0); // false
+console.log(undefined < 0); // false (NaN < 0 is false)
+console.log(undefined >= 0); // false (NaN >= 0 is false)
 ```
 
-- **Comparisons and `null`**: The `null` type represents the intentional absence of a value. When using the equality operator, `null` and `undefined` are considered equal. However, when using the strict equality operator (`===`), which checks both value and type without performing type coercion, `null` and `undefined` are not equal:
+- **Comparisons and `null`**: The `null` type represents the intentional absence of a value. `null` converts to `0` in numeric contexts, which may result in unexpected behaviour in numeric comparisions:
+
+```js
+console.log(null < 0); // false (0 < 0 is false)
+console.log(null >= 0); // true (0 >= 0 is true)
+```
+
+- When using the equality operator (`==`), `null` and `undefined` only equal each other and themselves:
 
 ```js
 console.log(null == undefined); // true
+console.log(null == 0); // false
+console.log(undefined == NaN); // false
+```
+
+- However, when using the strict equality operator (`===`), which checks both value and type without performing type coercion, `null` and `undefined` are not equal:
+
+```js
 console.log(null === undefined); // false
 ```
 

--- a/curriculum/challenges/english/blocks/review-javascript/6723d3cfdd0717d3f1bf27e3.md
+++ b/curriculum/challenges/english/blocks/review-javascript/6723d3cfdd0717d3f1bf27e3.md
@@ -600,15 +600,28 @@ console.log(Number.isNaN(undefined));  // false
 - **Comparisons and `undefined`**: A variable is `undefined` when it has been declared but hasn't been assigned a value. It's the default value of uninitialized variables and function parameters that weren't provided an argument. `undefined` converts to `NaN` in numeric contexts, which makes all numeric comparisons with `undefined` return `false`.
 
 ```js
-console.log(undefined > 0);  // false
-console.log(undefined < 0);  // false
-console.log(undefined == 0); // false
+console.log(undefined < 0); // false (NaN < 0 is false)
+console.log(undefined >= 0); // false (NaN >= 0 is false)
 ```
 
-- **Comparisons and `null`**: The `null` type represents the intentional absence of a value. When using the equality operator, `null` and `undefined` are considered equal. However, when using the strict equality operator (`===`), which checks both value and type without performing type coercion, `null` and `undefined` are not equal:
+- **Comparisons and `null`**: The `null` type represents the intentional absence of a value. `null` converts to `0` in numeric contexts, which may result in unexpected behaviour in numeric comparisions:
+
+```js
+console.log(null < 0); // false (0 < 0 is false)
+console.log(null >= 0); // true (0 >= 0 is true)
+```
+
+- When using the equality operator (`==`), `null` and `undefined` only equal each other and themselves:
 
 ```js
 console.log(null == undefined); // true
+console.log(null == 0); // false
+console.log(undefined == NaN); // false
+```
+
+- However, when using the strict equality operator (`===`), which checks both value and type without performing type coercion, `null` and `undefined` are not equal:
+
+```js
 console.log(null === undefined); // false
 ```
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #63647

<!-- Feel free to add any additional description of changes below this line -->

I’ve added a section on numeric comparisons with `null`. In the process, I realised a slight restructuring of the surrounding material would be beneficial.