### PR TITLE
fix(curriculum): remove extra quotes from lunch picker user stories

### DIFF
--- a/curriculum/challenges/english/blocks/lab-lunch-picker-program/66db529d37ad966480ebb633.md
+++ b/curriculum/challenges/english/blocks/lab-lunch-picker-program/66db529d37ad966480ebb633.md
@@ -17,33 +17,33 @@ In this lab, you'll build a program that helps in managing lunch options. You'll
 
 2. You should create a function `addLunchToEnd` that takes an array as the first argument and a string as the second argument. The function should:
     - Add the string to the end of the array.
-    - Log the string `"[Lunch Item] added to the end of the lunch menu."` to the console, where `[Lunch Item]` is the string passed to the function.
+    - Log the string `[Lunch Item] added to the end of the lunch menu.` to the console, where `[Lunch Item]` is the string passed to the function.
     - Return the updated array.
 
 3. You should create a function `addLunchToStart` that takes an array as the first argument and a string as the second argument. The function should:
     - Add the string to the start of the array.
-    - Log the string `"[Lunch Item] added to the start of the lunch menu."` to the console, where `[Lunch Item]` is the string passed to the function.
+    - Log the string `[Lunch Item] added to the start of the lunch menu.` to the console, where `[Lunch Item]` is the string passed to the function.
     - Return the updated array.
 
 4. You should create a function `removeLastLunch` that takes an array as its argument. The function should:
    - Remove the last element from the array.
-   - If  the removal is successful, log the string `"[Lunch Item] removed from the end of the lunch menu."` to the console, where `[Lunch Item]` is the element removed from the array.
+   - If  the removal is successful, log the string `[Lunch Item] removed from the end of the lunch menu.` to the console, where `[Lunch Item]` is the element removed from the array.
    - If the array is empty, log the string `"No lunches to remove."` to the console.
    - Return the updated array.
 
 5. You should create a function `removeFirstLunch` that takes an array as its argument. The function should:
    - Remove the first element from the array.
-   - If the removal is successful, log the string `"[Lunch Item] removed from the start of the lunch menu."` to the console, where `[Lunch Item]` is the element removed from the array.
+   - If the removal is successful, log the string `[Lunch Item] removed from the start of the lunch menu.` to the console, where `[Lunch Item]` is the element removed from the array.
    - If the array is empty, log the string `"No lunches to remove."` to the console.
    - Return the updated array.
 
 6. You should create a function `getRandomLunch` that takes an array as its argument. The function should:
    - Select a random element from the array.
-   - If successful, log the string `"Randomly selected lunch: [Lunch Item]"` to the console, where `[Lunch Item]` is a random element in the array.
+   - If successful, log the string `Randomly selected lunch: [Lunch Item]` to the console, where `[Lunch Item]` is a random element in the array.
    - If the array is empty, log the string `"No lunches available."` to the console.
 
 7. You should create a function `showLunchMenu` that takes an array as its argument and:
-   - If there are elements in the array, logs the string `"Menu items: [Lunch Item], [Lunch Item]..."` to the console, where each `[Lunch item]` is one of the elements in the array, in order.
+   - If there are elements in the array, logs the string `Menu items: [Lunch Item], [Lunch Item]...` to the console, where each `[Lunch item]` is one of the elements in the array, in order.
    - If the array is empty, logs the string `"The menu is empty."` to the console.
 
 # --hints--
@@ -297,7 +297,7 @@ try {
 }
 ```
 
-When the input array is not empty, the function `getRandomLunch` should log a string in the format `"Randomly selected lunch: [Lunch Item]"` to the console.
+When the input array is not empty, the function `getRandomLunch` should log a string in the format `Randomly selected lunch: [Lunch Item]` to the console.
 
 ```js
 const testLunches = ["Fish", "Fries", "Roast"];


### PR DESCRIPTION
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #63668

This update removes unnecessary quotation marks around placeholder text (e.g., `[Lunch Item]`) in the Lunch Picker Lab user stories. 
Now, only actual string literals remain quoted (like `"No lunches to remove."`), which improves readability and consistency.
