### PR TITLE
fix(curriculum): remove duplicate title in UTF-8 lesson

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-understanding-recursion-and-the-call-stack/6733b02d1e556005a544c5e3.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-recursion-and-the-call-stack/6733b02d1e556005a544c5e3.md
@@ -5,68 +5,54 @@ challengeType: 19
 dashedName: what-is-recursion-and-how-does-it-work
 ---
 
-# --interactive--
+# --description--
+
+Let's learn how recursion works in JavaScript.
 
 Recursion is a complicated feature that allows you to call a function repeatedly until a base-case is reached. Unlike a traditional loop, recursion allows you to handle something with an unknown depth, such as deeply nested objects/arrays, or a file tree. But you can also use it for more basic tasks, such as counting down from a given number.
 
 Let's construct a function to do exactly that. We’ll call our function `recursiveCountdown`, and it needs to accept a number. We’ll have it print this number to the console:
 
-:::interactive_editor
-
 ```js
 const recursiveCountdown = (number) => {
   console.log(number);
 };
-
-recursiveCountdown(5);
 ```
-
-:::
 
 Now if we call this and pass the number 5, we’ll see the number print to our terminal. But nothing else happens – and the number 5 certainly isn’t a countdown.
 
 Before we start building the recursive portion of our function, we need to establish our base case first. If you don’t have a base case established, your code will run until it exceeds your memory allocation and crashes.
 
-:::interactive_editor
-
 ```js
 const recursiveCountdown = (number) => {
-  if (number < 1) {
-    return;
-  }
-  console.log(number);
-};
+    if (number < 1) {
+        return;
+    }
+    console.log(number);
+  };
 
 recursiveCountdown(5);
 ```
-
-:::
 
 For our base case, we want the countdown to stop if the number is less than 1. When we hit that base-case, we can return to break out of the function execution.
 
 Now that we’ve safely prepared a base-case, we can set up the recursion. The key point that makes a function recursive is that it calls itself in its execution. In this case, we want to call the function after we print the number. But in order to count down, our new number needs to be one less:
 
-:::interactive_editor
-
 ```js
 const recursiveCountdown = (number) => {
-  if (number < 1) {
-      return;
-  }
-  console.log(number);
-  recursiveCountdown(number - 1);
-};
+    if (number < 1) {
+        return;
+    }
+    console.log(number);
+    recursiveCountdown(number - 1);
+  };
 
-recursiveCountdown(5); 
+recursiveCountdown(5); // 
 ```
-
-:::
 
 This would log the numbers 5, 4, 3, 2, and 1 to the console.
 
 We do get our five numbers! But what if we wanted to count up instead? Rather than writing an entirely new function, we can swap the order of our log and our recursive call:
-
-:::interactive_editor
 
 ```js
 const recursiveCountdown = (number) => {
@@ -80,30 +66,24 @@ const recursiveCountdown = (number) => {
 recursiveCountdown(5);
 ```
 
-:::
-
 This would log the numbers 1, 2, 3, 4, and 5 to the console.
 
 But why does that work? Well, to understand this you need to understand the call stack. The call stack is how JavaScript tracks and resolves function calls. The stack functions as a last-in-first-out queue of sorts. To understand this better, let’s add some logging to our function:
 
-:::interactive_editor
-
 ```js
 const recursiveCountdown = (number) => {
-  console.log(`Function execution started for number: ${number}`);
-  if (number < 1) {
-      console.log(`Base case reached, begin resolving stack`);
-      return;
-  }
-  console.log(`Calling recursiveCountdown with number: ${number - 1}`);
-  recursiveCountdown(number - 1);
-  console.log(`Function execution completed for number: ${number}`);
-};
+    console.log(`Function execution started for number: ${number}`);
+    if (number < 1) {
+        console.log(`Base case reached, begin resolving stack`);
+        return;
+    }
+    console.log(`Calling recursiveCountdown with number: ${number - 1}`);
+    recursiveCountdown(number - 1);
+    console.log(`Function execution completed for number: ${number}`);
+  };
 
 recursiveCountdown(5);
 ```
-
-:::
 
 We’ve added four key statements here. The first log runs when a function call begins executing. The third log runs just before the recursive function is called. And the fourth log runs when the function execution has ended. The result is:
 

--- a/curriculum/challenges/english/blocks/lecture-understanding-recursion-and-the-call-stack/6733b02d1e556005a544c5e3.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-recursion-and-the-call-stack/6733b02d1e556005a544c5e3.md
@@ -5,55 +5,69 @@ challengeType: 19
 dashedName: what-is-recursion-and-how-does-it-work
 ---
 
-# --description--
-
-Let's learn how recursion works in JavaScript.
+# --interactive--
 
 Recursion is a complicated feature that allows you to call a function repeatedly until a base-case is reached. Unlike a traditional loop, recursion allows you to handle something with an unknown depth, such as deeply nested objects/arrays, or a file tree. But you can also use it for more basic tasks, such as counting down from a given number.
 
 Let's construct a function to do exactly that. We’ll call our function `recursiveCountdown`, and it needs to accept a number. We’ll have it print this number to the console:
 
+:::interactive_editor
+
 ```js
 const recursiveCountdown = (number) => {
   console.log(number);
 };
+
+recursiveCountdown(5);
 ```
+
+:::
 
 Now if we call this and pass the number 5, we’ll see the number print to our terminal. But nothing else happens – and the number 5 certainly isn’t a countdown.
 
 Before we start building the recursive portion of our function, we need to establish our base case first. If you don’t have a base case established, your code will run until it exceeds your memory allocation and crashes.
 
+:::interactive_editor
+
 ```js
 const recursiveCountdown = (number) => {
-    if (number < 1) {
-        return;
-    }
-    console.log(number);
-  };
+  if (number < 1) {
+    return;
+  }
+  console.log(number);
+};
 
 recursiveCountdown(5);
 ```
+
+:::
 
 For our base case, we want the countdown to stop if the number is less than 1. When we hit that base-case, we can return to break out of the function execution.
 
 Now that we’ve safely prepared a base-case, we can set up the recursion. The key point that makes a function recursive is that it calls itself in its execution. In this case, we want to call the function after we print the number. But in order to count down, our new number needs to be one less:
 
+:::interactive_editor
+
 ```js
 const recursiveCountdown = (number) => {
-    if (number < 1) {
-        return;
-    }
-    console.log(number);
-    recursiveCountdown(number - 1);
-  };
+  if (number < 1) {
+      return;
+  }
+  console.log(number);
+  recursiveCountdown(number - 1);
+};
 
-recursiveCountdown(5); // 
+recursiveCountdown(5); 
 ```
+
+:::
 
 This would log the numbers 5, 4, 3, 2, and 1 to the console.
 
 We do get our five numbers! But what if we wanted to count up instead? Rather than writing an entirely new function, we can swap the order of our log and our recursive call:
 
+:::interactive_editor
+
 ```js
 const recursiveCountdown = (number) => {
     if (number < 1) {
@@ -66,24 +80,30 @@ const recursiveCountdown = (number) => {
 recursiveCountdown(5);
 ```
 
+:::
+
 This would log the numbers 1, 2, 3, 4, and 5 to the console.
 
 But why does that work? Well, to understand this you need to understand the call stack. The call stack is how JavaScript tracks and resolves function calls. The stack functions as a last-in-first-out queue of sorts. To understand this better, let’s add some logging to our function:
 
+:::interactive_editor
+
 ```js
 const recursiveCountdown = (number) => {
-    console.log(`Function execution started for number: ${number}`);
-    if (number < 1) {
-        console.log(`Base case reached, begin resolving stack`);
-        return;
-    }
-    console.log(`Calling recursiveCountdown with number: ${number - 1}`);
-    recursiveCountdown(number - 1);
-    console.log(`Function execution completed for number: ${number}`);
-  };
+  console.log(`Function execution started for number: ${number}`);
+  if (number < 1) {
+      console.log(`Base case reached, begin resolving stack`);
+      return;
+  }
+  console.log(`Calling recursiveCountdown with number: ${number - 1}`);
+  recursiveCountdown(number - 1);
+  console.log(`Function execution completed for number: ${number}`);
+};
 
 recursiveCountdown(5);
 ```
+
+:::
 
 We’ve added four key statements here. The first log runs when a function call begins executing. The third log runs just before the recursive function is called. And the fourth log runs when the function execution has ended. The result is:
 
@@ -136,30 +156,6 @@ And `recursiveCountdown(5)` resolves and is removed from the stack. Our call sta
 This is a basic overview of how recursion works in JavaScript. It’s a complicated concept, and you should play around with some code and log statements until you’re comfortable with the behavior of the call stack.
 
 For a little fun fact, we talked about how a lack of a base-case can cause your code to crash when it runs out of memory. This is because the recursion keeps piling more and more function calls into the call stack until the stack overflows. Just like the name of the popular programming community.
-
-Now let’s try one more example to *see* how recursion and the call stack work visually.
-
-The example below prints “Entering” and “Exiting” messages with indentation — 
-so you can observe how deeper recursive calls are added to the call stack and then removed as they return.
-
-:::interactive_editor
-
-```js
-function visualizeRecursion(n, depth = 0) {
-  console.log(' '.repeat(depth * 2) + `Entering call with n = ${n}`);
-
-  if (n === 0) {
-    console.log(' '.repeat(depth * 2) + 'Base case reached! Returning...');
-    return;
-  }
-
-  visualizeRecursion(n - 1, depth + 1);
-
-  console.log(' '.repeat(depth * 2) + `Exiting call with n = ${n}`);
-}
-
-// Try changing the number below to see how deep the recursion goes
-visualizeRecursion(3);
 
 # --questions--
 

--- a/curriculum/challenges/english/blocks/lecture-understanding-recursion-and-the-call-stack/6733b02d1e556005a544c5e3.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-recursion-and-the-call-stack/6733b02d1e556005a544c5e3.md
@@ -137,6 +137,30 @@ This is a basic overview of how recursion works in JavaScript. It’s a complica
 
 For a little fun fact, we talked about how a lack of a base-case can cause your code to crash when it runs out of memory. This is because the recursion keeps piling more and more function calls into the call stack until the stack overflows. Just like the name of the popular programming community.
 
+Now let’s try one more example to *see* how recursion and the call stack work visually.
+
+The example below prints “Entering” and “Exiting” messages with indentation — 
+so you can observe how deeper recursive calls are added to the call stack and then removed as they return.
+
+:::interactive_editor
+
+```js
+function visualizeRecursion(n, depth = 0) {
+  console.log(' '.repeat(depth * 2) + `Entering call with n = ${n}`);
+
+  if (n === 0) {
+    console.log(' '.repeat(depth * 2) + 'Base case reached! Returning...');
+    return;
+  }
+
+  visualizeRecursion(n - 1, depth + 1);
+
+  console.log(' '.repeat(depth * 2) + `Exiting call with n = ${n}`);
+}
+
+// Try changing the number below to see how deep the recursion goes
+visualizeRecursion(3);
+
 # --questions--
 
 ## --text--

--- a/curriculum/challenges/english/blocks/lecture-understanding-the-html-boilerplate/670839051794aa19fcef6dc8.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-the-html-boilerplate/670839051794aa19fcef6dc8.md
@@ -7,7 +7,6 @@ dashedName: what-is-utf-8-character-encoding
 
 # --description--
 
-What is UTF-8 character encoding, and why is it needed?
 
 UTF-8, or UCS Transformation Format 8, is a standardized character encoding widely used on the web. Character encoding is the method computers use to store characters as data. Essentially, all text on a web page is a sequence of characters stored as one or more bytes. In computing, a byte is a unit of data consisting of 8 bits, or binary digits. UTF-8 supports every character in the Unicode character set - and this includes characters and symbols from all writing systems, languages, and technical symbols. Here is an example of using the `meta` element with the `charset` attribute to set the character encoding to `UTF-8`:
 


### PR DESCRIPTION
Removed duplicate title text ("What is UTF-8 character encoding, and why is it needed?") from the UTF-8 lesson.

- The title already appears above the description section.
- The lesson now starts directly with the explanation.

Closes #63641
---

 Checklist

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes locally on my machine.
