### PR TITLE
fix(curriculum): allow multiple trailing spaces in factorial calculator regex

### DIFF
--- a/curriculum/challenges/english/blocks/lab-factorial-calculator/66c07238b01053abaf812065.md
+++ b/curriculum/challenges/english/blocks/lab-factorial-calculator/66c07238b01053abaf812065.md
@@ -74,8 +74,9 @@ assert.strictEqual(factorialCalculator(7), 5040);
 You should call your `factorialCalculator` function with the `num` variable as the argument.
 
 ```js
-assert.match(__helpers.removeJSComments(code), /factorialCalculator\(\s*num\s*\)\s*;?\s?$/m);
+assert.match(__helpers.removeJSComments(code), /factorialCalculator\(\s*num\s*\)\s*;?\s*$/m);
 ```
+
 
 You should define a `factorial` variable and assign the result of the `factorialCalculator` function to it.
 

--- a/curriculum/challenges/english/blocks/lab-factorial-calculator/66c07238b01053abaf812065.md
+++ b/curriculum/challenges/english/blocks/lab-factorial-calculator/66c07238b01053abaf812065.md
@@ -77,7 +77,6 @@ You should call your `factorialCalculator` function with the `num` variable as t
 assert.match(__helpers.removeJSComments(code), /factorialCalculator\(\s*num\s*\)\s*;?\s*$/m);
 ```
 
-
 You should define a `factorial` variable and assign the result of the `factorialCalculator` function to it.
 
 ```js


### PR DESCRIPTION
Updated the regex in the factorial calculator lab challenge to allow multiple spaces at the end of the line.

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or using GitHub Codespaces.


Closes #63701