### PR TITLE
fix(curriculum): remove product column from 2NF lesson example

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-sql/68816f386bc30d36f59e9563.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-sql/68816f386bc30d36f59e9563.md
@@ -59,7 +59,7 @@ The Second Normal Form (2NF) is based on addressing partial dependencies. A part
 For example, let's say we have an `orders` table with these columns:
 
 ```sql
-| order_id | item_id | order_date | quantity | order_shipping_city |
+ order_id | item_id | order_date | quantity | order_shipping_city 
 ```
 
 In this table, the primary key is the combination of `order_id` and `item_id` because the same item ID can be in different orders, but their combination will be unique. You can see that there is a partial dependency between `order_id` and `order_shipping_city`. `order_id` is part of the primary key. `order_shipping_city` depends on `order_id` because every order with the same ID will have the same shipping city. However, the shipping city does not depend on the `item_id`, but this is also part of the primary key. Therefore, `order_shipping_city` does not depend on the entire primary key.
@@ -73,7 +73,7 @@ order_id | order_date | order_shipping_city
 In the `order_items` table, you could store information about the items in the different orders that were submitted:
 
 ```sql
-| order_id | item_id | quantity |
+ order_id | item_id | quantity 
 ```
 
 With these changes, both tables will be in Second Normal Form (2NF).

--- a/curriculum/challenges/english/blocks/lecture-working-with-sql/68816f386bc30d36f59e9563.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-sql/68816f386bc30d36f59e9563.md
@@ -59,7 +59,7 @@ The Second Normal Form (2NF) is based on addressing partial dependencies. A part
 For example, let's say we have an `orders` table with these columns:
 
 ```sql
-order_id | item_id | order_date | product | quantity | order_shipping_city
+| order_id | item_id | order_date | quantity | order_shipping_city |
 ```
 
 In this table, the primary key is the combination of `order_id` and `item_id` because the same item ID can be in different orders, but their combination will be unique. You can see that there is a partial dependency between `order_id` and `order_shipping_city`. `order_id` is part of the primary key. `order_shipping_city` depends on `order_id` because every order with the same ID will have the same shipping city. However, the shipping city does not depend on the `item_id`, but this is also part of the primary key. Therefore, `order_shipping_city` does not depend on the entire primary key.
@@ -73,7 +73,7 @@ order_id | order_date | order_shipping_city
 In the `order_items` table, you could store information about the items in the different orders that were submitted:
 
 ```sql
-order_id | item_id | product | quantity
+| order_id | item_id | quantity |
 ```
 
 With these changes, both tables will be in Second Normal Form (2NF).


### PR DESCRIPTION
Removed the `product` column from the "What is Normalization in SQL?" lesson examples to clarify the 2NF explanation.

Checklist:


- [x ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ x] My pull request targets the `main` branch of freeCodeCamp.
- [ x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #63700