### PR TITLE
fix(client): same font size for equivalent superblock headers

### DIFF
--- a/client/src/templates/Introduction/intro.css
+++ b/client/src/templates/Introduction/intro.css
@@ -106,6 +106,7 @@ a.cert-tag:active {
 }
 
 .block-grid-title {
+  font-size: 1rem;
   margin: 0;
   overflow-wrap: break-word;
 }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Before: 

<img width="645" height="253" alt="image" src="https://github.com/user-attachments/assets/2d1f74f3-bd01-4426-a728-f3baadbaf3bb" />

After:

<img width="645" height="253" alt="image" src="https://github.com/user-attachments/assets/d2fa594c-d1f3-447a-a051-d3edbf86f617" />

It's subtle, but the fact the font sizes are so close (1.1rem vs 1rem) while not being equal makes it nasty to look at.

@huyenltnguyen it's been a while since I styled anything, so please let me know if there's a better way.

<!-- Feel free to add any additional description of changes below this line -->
