### PR TITLE
fix(curriculum): capitalize 'You' in Step 3 hint

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-quincys-job-tips/68e90335bd53a901c41dfc13.md
+++ b/curriculum/challenges/english/blocks/workshop-quincys-job-tips/68e90335bd53a901c41dfc13.md
@@ -47,7 +47,7 @@ Inside your `q` element, the text must not have leading or trailing whitespace (
 assert.equal(document.querySelector('h1 + p > q')?.textContent, 'You can become a developer.');
 ```
 
-You should only add `q` tags around the appropriate part of the sentence without changing the original text. The `p` element should still read: `Learning to code is hard, but as Quincy Larson says, you can become a developer.`
+You should only add `q` tags around the appropriate part of the sentence without changing the original text. The `p` element should still read: `Learning to code is hard, but as Quincy Larson says, You can become a developer.`
 
 ```js
 const pElCleanedText = document.querySelector('h1 + p')?.innerText.trim().replaceAll(/ {2,}/g, ' ');


### PR DESCRIPTION
This PR fixes the incorrect capitalization in the Step 3 hint of the "Quincy's Tips for Getting a Developer Job" workshop.

The hint should match the exact text learners are expected to produce.

Before (incorrect):
Learning to code is hard, but as Quincy Larson says, you can become a developer.

After (correct):
Learning to code is hard, but as Quincy Larson says, You can become a developer.

Checklist:

- [x] I have read and followed the contribution guidelines.
- [x] I have read and followed the how to open a pull request guide.
- [x] My pull request targets the main branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #63720
