### PR TITLE
Fix punctuation in accessibility tool descriptions

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-importance-of-accessibility-and-good-html-structure/672a537f05f3798bd4f57d2d.md
+++ b/curriculum/challenges/english/blocks/lecture-importance-of-accessibility-and-good-html-structure/672a537f05f3798bd4f57d2d.md
@@ -44,7 +44,7 @@ Which of these best describes an accessibility auditing tool?
 
 ## --answers--
 
-It automatically fixes all accessibility issues
+It automatically fixes all accessibility issues.
 
 ### --feedback--
 
@@ -52,11 +52,11 @@ Consider the role of the tool in assessing accessibility.
 
 ---
 
-It evaluates how accessible your digital content is
+It evaluates how accessible your digital content is.
 
 ---
 
-It only checks mobile apps
+It only checks mobile apps.
 
 ### --feedback--
 
@@ -64,7 +64,7 @@ Consider the role of the tool in assessing accessibility.
 
 ---
 
-It requires no manual input
+It requires no manual input.
 
 ### --feedback--
 


### PR DESCRIPTION
Corrected punctuation in accessibility auditing tool descriptions.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #63750

<!-- Feel free to add any additional description of changes below this line -->
