### PR TITLE
fix(curriculum): capitalization error in What Is Accessibility lesson

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-importance-of-accessibility-and-good-html-structure/672a51e9e4fd8b8552eeb758.md
+++ b/curriculum/challenges/english/blocks/lecture-importance-of-accessibility-and-good-html-structure/672a51e9e4fd8b8552eeb758.md
@@ -25,7 +25,7 @@ These are just a few of many conditions that can impact users around the world.
 
 To help you create accessible websites, the World Wide Web Consortium, known as W3C, developed a set of international standards that you can follow to make your websites more accessible and easier to use for people with disabilities.
 
-These standards are known as "The Web Content Accessibility Guidelines" (WCAG).
+These standards are known as the "Web Content Accessibility Guidelines" (WCAG).
 
 These guidelines are designed with four core principles in mind, known as **POUR**.
 
@@ -83,7 +83,7 @@ Think about why you should make websites accessible.
 
 ## --text--
 
-What are The Web Content Accessibility Guidelines (WCAG)?
+What are the Web Content Accessibility Guidelines (WCAG)?
 
 ## --answers--
 

--- a/curriculum/challenges/english/blocks/lecture-importance-of-accessibility-and-good-html-structure/672a51e9e4fd8b8552eeb758.md
+++ b/curriculum/challenges/english/blocks/lecture-importance-of-accessibility-and-good-html-structure/672a51e9e4fd8b8552eeb758.md
@@ -119,7 +119,7 @@ Think about why you should make websites inclusive.
 
 ## --text--
 
-Which of the following is NOT a core principle of The Web Content Accessibility Guidelines (WCAG)?
+Which of the following is NOT a core principle of the Web Content Accessibility Guidelines (WCAG)?
 
 ## --answers--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #63744

<!-- Feel free to add any additional description of changes below this line -->
I have carefully read the targeted file and changed the minor error in language, which was removing 'The' from 'The Web Content Accessibility Guidelines' to make it Web Content Accessibility Guidelines (WCAG), as intended.
