### PR TITLE
fix: remove trailing periods from answer choices in accessibility quiz

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-importance-of-accessibility-and-good-html-structure/672a533e6041c28ad680eb8f.md
+++ b/curriculum/challenges/english/blocks/lecture-importance-of-accessibility-and-good-html-structure/672a533e6041c28ad680eb8f.md
@@ -44,7 +44,7 @@ What kind of device are trackball, joystick, and touchpad?
 
 ## --answers--
 
-Output devices.
+Output devices
 
 ### --feedback--
 
@@ -52,7 +52,7 @@ Look out for the general name for the devices that help you interact with and co
 
 ---
 
-Input/output devices.
+Input/output devices
 
 ### --feedback--
 
@@ -60,11 +60,11 @@ Look out for the general name for the devices that help you interact with and co
 
 ---
 
-Pointing devices.
+Pointing devices
 
 ---
 
-VDU devices.
+VDU devices
 
 ### --feedback--
 
@@ -80,7 +80,7 @@ Which device supports multi-touch gestures like pinch-to-zoom, two-finger scroll
 
 ## --answers--
 
-The traditional mouse.
+The traditional mouse
 
 ### --feedback--
 
@@ -88,11 +88,11 @@ Think about the device that allows for direct touch interactions and supports va
 
 ---
 
-Touchpad.
+Touchpad
 
 ---
 
-Joystick.
+Joystick
 
 ### --feedback--
 
@@ -100,7 +100,7 @@ Think about the device that allows for direct touch interactions and supports va
 
 ---
 
-Trackballs.
+Trackballs
 
 ### --feedback--
 
@@ -116,11 +116,11 @@ Which pointing device is primarily designed for games and specific industrial ap
 
 ## --answers--
 
-Joystick.
+Joystick
 
 ---
 
-Trackball.
+Trackball
 
 ### --feedback--
 
@@ -129,7 +129,7 @@ discussed.
 
 ---
 
-Mouse.
+Mouse
 
 ### --feedback--
 
@@ -137,7 +137,7 @@ Pointing device that provides precise control in gaming. Review the middle part 
 
 ---
 
-Trackpad or touchpad.
+Trackpad or touchpad
 
 ### --feedback--
 


### PR DESCRIPTION
## Overview
This PR removes trailing periods from answer choices in the accessibility and good HTML structure curriculum challenge. The trailing periods were inconsistent with the standard format for answer choices in the freeCodeCamp curriculum.

## Checklist
- [x] Code changes are made to curriculum content
- [x] No functional changes to code logic
- [x] No tests needed for content-only changes
- [x] Documentation updated (curriculum content)
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.


## Proof
The changes are simple text modifications to remove trailing periods from answer choices in the quiz. This maintains consistency with the curriculum style guide which specifies that answer choices should not have trailing punctuation. The changes affect answer choices for questions about device types, pointing devices, and input methods.

Closes #63749