### PR TITLE
feat(curriculum): add new Spanish numbers audio from the CDN

### DIFF
--- a/curriculum/schema/scene-assets.js
+++ b/curriculum/schema/scene-assets.js
@@ -271,6 +271,7 @@ const availableAudios = [
   'ES_A1_2_vocabulary.mp3',
   'ES_A1_3.1.mp3',
   'ES_A1_3.2.mp3',
+  `ES_A1_first_questions_numbers.mp3`,
   'ES_A1_first_questions_warmup.mp3',
   'ES_A1_alphabet.mp3',
   'ES_A1_alphabet_practice.mp3',


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->

This PR adds an audio file to the scheme. This audio file contains the pronunciation of the numbers used in the First Questions module of the A1 Spanish curriculum. 

The audio file is added by this PR to the CDN: https://github.com/freeCodeCamp/cdn/pull/340
