### PR TITLE
fix: handle NaN percentage completion for completed lab challenges

### DIFF
--- a/client/src/utils/get-completion-percentage.test.ts
+++ b/client/src/utils/get-completion-percentage.test.ts
@@ -1,0 +1,277 @@
+import { describe, it, expect } from 'vitest';
+import type { AllChallengesInfo, ChallengeNode } from '../redux/prop-types';
+import { challengeTypes } from '../../../shared-dist/config/challenge-types';
+import {
+  getCompletedPercentage,
+  getCompletedChallengesInBlock,
+  getCurrentBlockIds
+} from './get-completion-percentage';
+
+describe('get-completion-percentage', () => {
+  describe('getCompletedPercentage', () => {
+    it('calculates percentage when challenge not yet completed', () => {
+      const completedChallengesIds = ['challenge-1', 'challenge-2'];
+      const currentBlockIds = [
+        'challenge-1',
+        'challenge-2',
+        'challenge-3',
+        'challenge-4',
+        'challenge-5'
+      ];
+      const currentChallengeId = 'challenge-3';
+
+      const result = getCompletedPercentage(
+        completedChallengesIds,
+        currentBlockIds,
+        currentChallengeId
+      );
+
+      expect(result).toBe(60);
+    });
+
+    it('calculates percentage when challenge already completed', () => {
+      const completedChallengesIds = [
+        'challenge-1',
+        'challenge-2',
+        'challenge-3'
+      ];
+      const currentBlockIds = [
+        'challenge-1',
+        'challenge-2',
+        'challenge-3',
+        'challenge-4',
+        'challenge-5'
+      ];
+      const currentChallengeId = 'challenge-3';
+
+      const result = getCompletedPercentage(
+        completedChallengesIds,
+        currentBlockIds,
+        currentChallengeId
+      );
+
+      expect(result).toBe(60);
+    });
+
+    it('caps percentage at 100', () => {
+      const completedChallengesIds = [
+        'challenge-1',
+        'challenge-2',
+        'challenge-3'
+      ];
+      const currentBlockIds = ['challenge-1', 'challenge-2'];
+      const currentChallengeId = 'challenge-3';
+
+      const result = getCompletedPercentage(
+        completedChallengesIds,
+        currentBlockIds,
+        currentChallengeId
+      );
+
+      expect(result).toBe(100);
+    });
+
+    it('handles undefined completedChallengesIds', () => {
+      const currentBlockIds = ['challenge-1', 'challenge-2', 'challenge-3'];
+      const currentChallengeId = 'challenge-1';
+
+      const result = getCompletedPercentage(
+        undefined,
+        currentBlockIds,
+        currentChallengeId
+      );
+
+      expect(result).toBe(33);
+    });
+  });
+
+  describe('getCompletedChallengesInBlock', () => {
+    it('counts new challenge when not already completed', () => {
+      const completedChallengesIds = ['challenge-1', 'challenge-2'];
+      const currentBlockIds = [
+        'challenge-1',
+        'challenge-2',
+        'challenge-3',
+        'challenge-4'
+      ];
+      const currentChallengeId = 'challenge-3';
+
+      const result = getCompletedChallengesInBlock(
+        completedChallengesIds,
+        currentBlockIds,
+        currentChallengeId
+      );
+
+      expect(result).toBe(3);
+    });
+
+    it('does not double-count when challenge already completed', () => {
+      const completedChallengesIds = [
+        'challenge-1',
+        'challenge-2',
+        'challenge-3'
+      ];
+      const currentBlockIds = [
+        'challenge-1',
+        'challenge-2',
+        'challenge-3',
+        'challenge-4'
+      ];
+      const currentChallengeId = 'challenge-3';
+
+      const result = getCompletedChallengesInBlock(
+        completedChallengesIds,
+        currentBlockIds,
+        currentChallengeId
+      );
+
+      expect(result).toBe(3);
+    });
+
+    it('only counts challenges in the current block', () => {
+      const completedChallengesIds = [
+        'block1-challenge-1',
+        'block1-challenge-2',
+        'block2-challenge-1',
+        'block2-challenge-2'
+      ];
+      const currentBlockIds = ['block1-challenge-1', 'block1-challenge-2'];
+      const currentChallengeId = 'block1-challenge-3';
+
+      const result = getCompletedChallengesInBlock(
+        completedChallengesIds,
+        currentBlockIds,
+        currentChallengeId
+      );
+
+      expect(result).toBe(3);
+    });
+  });
+
+  describe('getCurrentBlockIds', () => {
+    it('returns block IDs for non-project-based challenges', () => {
+      const allChallengesInfo: AllChallengesInfo = {
+        challengeNodes: [
+          {
+            challenge: {
+              id: 'block-challenge-1',
+              block: 'basic-html',
+              certification: 'responsive-web-design'
+            }
+          } as Partial<ChallengeNode> as ChallengeNode,
+          {
+            challenge: {
+              id: 'block-challenge-2',
+              block: 'basic-html',
+              certification: 'responsive-web-design'
+            }
+          } as Partial<ChallengeNode> as ChallengeNode,
+          {
+            challenge: {
+              id: 'other-block-challenge',
+              block: 'basic-css',
+              certification: 'responsive-web-design'
+            }
+          } as Partial<ChallengeNode> as ChallengeNode
+        ],
+        certificateNodes: []
+      };
+
+      const result = getCurrentBlockIds(
+        allChallengesInfo,
+        'basic-html',
+        'responsive-web-design',
+        challengeTypes.step
+      );
+
+      expect(result).toEqual(['block-challenge-1', 'block-challenge-2']);
+    });
+
+    it('returns certificate IDs for project-based challenges when available', () => {
+      const allChallengesInfo: AllChallengesInfo = {
+        challengeNodes: [],
+        certificateNodes: [
+          {
+            challenge: {
+              certification: 'responsive-web-design',
+              tests: [
+                { id: 'cert-project-1' },
+                { id: 'cert-project-2' },
+                { id: 'cert-project-3' }
+              ]
+            }
+          }
+        ]
+      };
+
+      const result = getCurrentBlockIds(
+        allChallengesInfo,
+        'responsive-web-design-projects',
+        'responsive-web-design',
+        challengeTypes.frontEndProject
+      );
+
+      expect(result).toEqual([
+        'cert-project-1',
+        'cert-project-2',
+        'cert-project-3'
+      ]);
+    });
+
+    // this is a provisional fix to the issue mentioned in #63773
+    it('falls back to block IDs when certificate not available', () => {
+      const allChallengesInfo: AllChallengesInfo = {
+        challengeNodes: [
+          {
+            challenge: {
+              id: 'project-1',
+              block: 'back-end-projects',
+              certification: 'back-end-development'
+            }
+          } as Partial<ChallengeNode> as ChallengeNode,
+          {
+            challenge: {
+              id: 'project-2',
+              block: 'back-end-projects',
+              certification: 'back-end-development'
+            }
+          } as Partial<ChallengeNode> as ChallengeNode
+        ],
+        certificateNodes: []
+      };
+
+      const result = getCurrentBlockIds(
+        allChallengesInfo,
+        'back-end-projects',
+        'back-end-development',
+        challengeTypes.backEndProject
+      );
+
+      expect(result).toEqual(['project-1', 'project-2']);
+    });
+
+    it('returns empty array when no matching challenges found', () => {
+      const allChallengesInfo: AllChallengesInfo = {
+        challengeNodes: [
+          {
+            challenge: {
+              id: 'challenge-1',
+              block: 'different-block',
+              certification: 'responsive-web-design'
+            }
+          } as Partial<ChallengeNode> as ChallengeNode
+        ],
+        certificateNodes: []
+      };
+
+      const result = getCurrentBlockIds(
+        allChallengesInfo,
+        'non-existent-block',
+        'responsive-web-design',
+        challengeTypes.step
+      );
+
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/client/src/utils/get-completion-percentage.ts
+++ b/client/src/utils/get-completion-percentage.ts
@@ -48,7 +48,11 @@ export const getCurrentBlockIds = (
     .filter(node => node.challenge.block === block)
     .map(node => node.challenge.id);
 
-  return isProjectBased(challengeType)
-    ? currentCertificateIds
-    : currentBlockIds;
+  if (isProjectBased(challengeType)) {
+    return currentCertificateIds.length > 0
+      ? currentCertificateIds
+      : currentBlockIds;
+  }
+
+  return currentBlockIds;
 };


### PR DESCRIPTION
Checklist:
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #63414

## Summary

This PR fixes the NaN% Completion for Lab Challenges on resubmission. To reproduce the bug, complete a lab challenge (e.g., `lab-sentence-maker/build-a-sentence-maker`) **AND** submit it. Then, go back to the lab and repeat the process.
<img width="3000" height="1876" alt="image" src="https://github.com/user-attachments/assets/afbc1ccb-2041-4fe9-86ab-d5e0917b854b" />

If you don't submit it after completing it, you won't be able to reproduce it. Resetting it will yield the same bug.

## Description

The bug was traced to `getCompletedChallengesInBlock`  in `client/src/utils/get-completion-percentage.ts`.

On the first submission, the challenge wasn't in `completedChallengesIds` yet, so the function returned `oldCompletionCount + 1 = 1`. With currentBlockIds still populated from challenge nodes, the calculation was `1 / 1) * 100 = 100%`.

On resubmission, the challenge was in `completedChallengesIds`, so it returned `oldCompletionCount`. BUT `currentBlockIds` was now empty (because labs have no certificate tests), so `oldCompletionCount = 0`. 

The result was `(0 / 0) * 100 = NaN`.

In `client/src/components/Progress/progress.tsx`, we have this node:
```graphql
allCertificateNode {
  nodes {
    challenge {
      certification
      tests {
        id
      }
    }
  }
}
```

Then, in `client/src/utils/get-completion-percentage.ts`:
```ts
const currentCertificateIds =
  certificateNodes
    .filter(node => node.challenge.certification === certification)[0]
    ?.challenge.tests.map(test => test.id) ?? [];
```

This filter filters `certificateNodes` for nodes where `certification === "full-stack-developer"`. Only `full-stack-developer-v9` exists. So it returns an empty array, which causes the NaN.

I verified that by putting a console.log statement for `certificateNodes`in `getCurrentBlockIds`:
```json
    {
        "challenge": {
            "certification": "full-stack-developer-v9",
            "tests": [
                {
                    "id": "645147516c245de4d11eb7ba"
                }
            ]
        }
    }
```

So `full-stack-developer-v9` fails the filter, and the return array is empty.


## Solution

Modified `getCurrentBlockIds()` in `/client/src/utils/get-completion-percentage.ts`:
```ts
if (isProjectBased(challengeType)) {
  return currentCertificateIds.length > 0
    ? currentCertificateIds
    : currentBlockIds;
}

return currentBlockIds;
```

This ensures that labs fall back to block IDs. If certificate IDs are available, they will be used, so it doesn't break other challenge types.
