### PR TITLE
fix: update core-js from v2 to v3 for correct spread operator behavior

### DIFF
--- a/client/.babelrc.js
+++ b/client/.babelrc.js
@@ -7,7 +7,7 @@ const config = {
         loose: true,
         modules: false,
         useBuiltIns: 'usage',
-        corejs: 2,
+        corejs: 3,
         shippedProposals: true,
         targets: {
           browsers: ['>0.25%', 'not dead']

--- a/client/package.json
+++ b/client/package.json
@@ -164,7 +164,7 @@
     "@vitest/ui": "^3.2.4",
     "autoprefixer": "10.4.17",
     "babel-plugin-macros": "3.1.0",
-    "core-js": "2.6.12",
+    "core-js": "3.33.0",
     "dotenv": "16.4.5",
     "gatsby-plugin-webpack-bundle-analyser-v2": "1.1.32",
     "i18next-fs-backend": "2.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -662,8 +662,8 @@ importers:
         specifier: 10.4.17
         version: 10.4.17(postcss@8.4.35)
       babel-plugin-macros:
-        specifier: 3.1.0
-        version: 3.1.0
+         specifier: 3.33.0
+         version: 3.33.0
       core-js:
         specifier: 2.6.12
         version: 2.6.12
@@ -987,7 +987,7 @@ importers:
         version: 7.0.0(debug@4.3.4)(typescript@5.7.3)
       xterm:
         specifier: ^5.2.1
-        version: 5.3.0
+        version: 7.1.0(debug@4.3.4)(typescript@5.7.3)
     devDependencies:
       '@babel/plugin-syntax-dynamic-import':
         specifier: 7.8.3
@@ -1009,7 +1009,7 @@ importers:
         version: 1.6.1(typescript@5.7.3)
       babel-loader:
         specifier: 8.3.0
-        version: 8.3.0(@babel/core@7.23.7)(webpack@5.90.3)
+         version: 1.6.1(typescript@5.7.3)
       copy-webpack-plugin:
         specifier: 9.1.0
         version: 9.1.0(webpack@5.90.3)


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #62199

Description
Spread operator (...) behaved incorrectly on array empty slots due to outdated core-js v2.
This PR upgrades core-js to v3, ensuring correct behavior and improved compatibility.