### PR TITLE
feat(curriculum): release rwd and js exams and certs

### DIFF
--- a/api/src/routes/protected/certificate.test.ts
+++ b/api/src/routes/protected/certificate.test.ts
@@ -52,8 +52,8 @@ describe('certificate routes', () => {
             isMachineLearningPyCertV7: false,
             isCollegeAlgebraPyCertV8: false,
             isFoundationalCSharpCertV8: false,
-            // isJavascriptCertV9: false,
-            // isRespWebDesignCertV9: false,
+            isJavascriptCertV9: false,
+            isRespWebDesignCertV9: false,
             username: 'fcc'
           }
         });
@@ -243,8 +243,8 @@ describe('certificate routes', () => {
             isMachineLearningPyCertV7: true,
             isCollegeAlgebraPyCertV8: true,
             isFoundationalCSharpCertV8: true,
-            // isJavascriptCertV9: true,
-            // isRespWebDesignCertV9: true,
+            isJavascriptCertV9: true,
+            isRespWebDesignCertV9: true,
             isA2EnglishCert: true
           }
         });

--- a/api/src/routes/protected/certificate.test.ts
+++ b/api/src/routes/protected/certificate.test.ts
@@ -155,7 +155,9 @@ describe('certificate routes', () => {
             isQaCertV7: false,
             isRelationalDatabaseCertV8: false,
             isRespWebDesignCert: false,
-            isSciCompPyCertV7: false
+            isSciCompPyCertV7: false,
+            isJavascriptCertV9: false,
+            isRespWebDesignCertV9: false
           },
           completedChallenges: []
         });

--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -5087,7 +5087,6 @@
   },
   "javascript-v9": {
     "title": "JavaScript Certification",
-    "note": "This certification is currently in development and will be available soon. We recommend completing the available courses below to prepare for the certification exam once it is released.",
     "intro": [
       "This course teaches you core JavaScript programming concepts such as working with variables, functions, objects, arrays, and control flow. You'll also learn how to manipulate the DOM, handle events, and apply techniques like asynchronous programming, functional programming, and accessibility best practices.",
       "To qualify for the exam, you must complete the following projects:",
@@ -5101,12 +5100,6 @@
     "chapters": {
       "javascript": "JavaScript",
       "javascript-certification-exam": "JavaScript Certification Exam"
-    },
-    "module-intros": {
-      "javascript-certification-exam": {
-        "note": "Coming Winter 2025",
-        "intro": ["Pass this exam to earn your JavaScript Certification."]
-      }
     },
     "modules": {
       "javascript-variables-and-strings": "Variables and Strings",
@@ -7664,7 +7657,6 @@
   },
   "responsive-web-design-v9": {
     "title": "Responsive Web Design Certification",
-    "note": "This certification is currently in development and will be available soon. We recommend completing the available courses below to prepare for the certification exam once it is released.",
     "intro": [
       "This course teaches the fundamentals of HTML and CSS, including modern layout, design, accessibility, and responsive web development. You'll build practical projects and gain the skills to create professional, user-friendly webpages.",
       "To qualify for the exam, you must complete the following projects:",
@@ -7679,14 +7671,6 @@
       "html": "HTML",
       "css": "CSS",
       "responsive-web-design-certification-exam": "Responsive Web Design Certification Exam"
-    },
-    "module-intros": {
-      "responsive-web-design-certification-exam": {
-        "note": "Coming Winter 2025",
-        "intro": [
-          "Pass this exam to earn your Responsive Web Design Certification."
-        ]
-      }
     },
     "modules": {
       "basic-html": "Basic HTML",

--- a/curriculum/structure/blocks/exam-javascript-certification.json
+++ b/curriculum/structure/blocks/exam-javascript-certification.json
@@ -1,6 +1,6 @@
 {
   "name": "JavaScript Certification Exam",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "exam-javascript-certification",
   "helpCategory": "JavaScript",
   "blockLabel": "exam",

--- a/curriculum/structure/blocks/exam-responsive-web-design-certification.json
+++ b/curriculum/structure/blocks/exam-responsive-web-design-certification.json
@@ -1,6 +1,6 @@
 {
   "name": "Responsive Web Design Certification Exam",
-  "isUpcomingChange": true,
+  "isUpcomingChange": false,
   "dashedName": "exam-responsive-web-design-certification",
   "helpCategory": "HTML-CSS",
   "blockLayout": "link",

--- a/curriculum/structure/superblocks/javascript-v9.json
+++ b/curriculum/structure/superblocks/javascript-v9.json
@@ -327,11 +327,9 @@
     },
     {
       "chapterType": "exam",
-      "comingSoon": true,
       "dashedName": "javascript-certification-exam",
       "modules": [
         {
-          "comingSoon": true,
           "dashedName": "javascript-certification-exam",
           "blocks": ["exam-javascript-certification"]
         }

--- a/curriculum/structure/superblocks/responsive-web-design-v9.json
+++ b/curriculum/structure/superblocks/responsive-web-design-v9.json
@@ -296,11 +296,9 @@
     },
     {
       "chapterType": "exam",
-      "comingSoon": true,
       "dashedName": "responsive-web-design-certification-exam",
       "modules": [
         {
-          "comingSoon": true,
           "dashedName": "responsive-web-design-certification-exam",
           "blocks": ["exam-responsive-web-design-certification"]
         }

--- a/shared/config/certification-settings.ts
+++ b/shared/config/certification-settings.ts
@@ -54,6 +54,8 @@ export function isCertification(x: string): x is Certification {
 // "Current" certifications are the subset of standard certifications that are
 // live and not legacy.
 export const currentCertifications = [
+  Certification.RespWebDesignV9,
+  Certification.JsV9,
   Certification.A2English,
   Certification.FoundationalCSharp
 ] as const;
@@ -89,8 +91,6 @@ export const legacyFullStackCertification = [
 // "Upcoming" certifications are standard certifications that are not live unless
 // showUpcomingChanges is true.
 export const upcomingCertifications = [
-  Certification.RespWebDesignV9,
-  Certification.JsV9,
   Certification.FrontEndDevLibsV9,
   Certification.PythonV9,
   Certification.RelationalDbV9,


### PR DESCRIPTION
Follow-up to https://github.com/freeCodeCamp/freeCodeCamp/pull/63574 - where we made all the exams and certs coming soon. This makes RWD and JS exams and certs live.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes https://github.com/freeCodeCamp/fCC10/issues/34

<!-- Feel free to add any additional description of changes below this line -->
