### PR TITLE
fix: allow implicit labels in checkout lab tests

### DIFF
--- a/curriculum/challenges/english/blocks/lab-checkout-page/66da326c02141df538f29ba5.md
+++ b/curriculum/challenges/english/blocks/lab-checkout-page/66da326c02141df538f29ba5.md
@@ -113,7 +113,11 @@ All of your `input` elements that aren't a `type` of `submit` should have a `lab
 ```js
 const inputs = document.querySelectorAll('input:not([type="submit"])');
 assert.isAtLeast(inputs.length, 1);
-inputs.forEach(input => assert.exists(document.querySelector(`label[for="${input.id}"]`)));
+inputs.forEach(input => {
+  const label = document.querySelector(`label[for="${input.id}"]`) || input.parentElement;
+  assert.exists(label);
+  assert.equal(label.tagName, "LABEL");
+});
 ```
 
 You should have at least two `input` elements with the `required` attribute.
@@ -133,7 +137,9 @@ const requiredInputs = Array.from(document.querySelectorAll('input'))
 assert.isNotEmpty(requiredInputs);
 
 requiredInputs.forEach(input => {
-  const label = document.querySelector(`label[for="${input.id}"]`);
+  const label = document.querySelector(`label[for="${input.id}"]`) || input.parentElement;
+  assert.exists(label);
+  assert.equal(label.tagName, "LABEL");
   const span = label?.querySelector('span');
   assert.equal(span?.textContent.trim(), '*');
 });
@@ -148,7 +154,9 @@ const requiredInputs = Array.from(document.querySelectorAll('input'))
 assert.isNotEmpty(requiredInputs);
 
 requiredInputs.forEach(input => {
-  const label = document.querySelector(`label[for="${input.id}"]`);
+  const label = document.querySelector(`label[for="${input.id}"]`) || input.parentElement;
+  assert.exists(label);
+  assert.equal(label.tagName, "LABEL");
   const span = label?.querySelector('span');
   assert.equal(span?.getAttribute('aria-hidden'), 'true');
 });
@@ -161,7 +169,10 @@ const cardNumberInput = document.getElementById('card-number');
 const cardNumberHelp = document.getElementById('card-number-help');
 
 assert.exists(cardNumberHelp);
-assert.equal(cardNumberInput.nextElementSibling, cardNumberHelp);
+const nextElement = cardNumberInput.parentElement?.tagName === 'LABEL'
+  ? cardNumberInput.parentElement.nextElementSibling
+  : cardNumberInput.nextElementSibling;
+assert.equal(nextElement, cardNumberHelp);
 ```
 
 Your card number help text should not be empty.


### PR DESCRIPTION
## Description
- update the checkout lab tests so they accept both implicit and explicit label associations
- clarify the lab instructions to note that either association method is valid

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #63785

<!-- Feel free to add any additional description of changes below this line -->
