### PR TITLE
ci(crowdin): enable auto-merge for crowdin sync PRs

### DIFF
--- a/.github/workflows/crowdin-download.client-ui.yml
+++ b/.github/workflows/crowdin-download.client-ui.yml
@@ -334,6 +334,17 @@ jobs:
           REPOSITORY: 'freecodecamp/freecodecamp'
           BASE: 'main'
           TITLE: 'chore(i18n,client): processed translations'
+               # Enable auto-merge for crowdin-sync PRs
+     - name: Enable Auto-Merge for Crowdin PR
+       if: success()
+       run: |
+         # Get the latest PR created by crowdin
+         PR_NUMBER=$(gh pr list --author camperbot --label crowdin-sync --base main --limit 1 --state open --json number --jq '.[0].number')
+         if [ ! -z "$PR_NUMBER" ]; then
+           gh pr merge $PR_NUMBER --squash --auto
+         fi
+       env:
+         GH_TOKEN: ${{ secrets.CROWDIN_CAMPERBOT_PAT }}
           BODY: 'This PR was opened auto-magically by Crowdin.'
           LABELS: 'crowdin-sync'
           TEAM_REVIEWERS: 'i18n'


### PR DESCRIPTION
Add automatic merge capability for crowdin sync PRs when all checks pass.

This enables the workflow to automatically merge crowdin translation PRs using the GitHub CLI with squash merge strategy. The auto-merge will only trigger if the workflow succeeds and all status checks pass.

Benefit: Crowdin translation PRs no longer require manual merge actions once automated checks are complete.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
