### PR TITLE
test: fix possible long lasting memory leak in Gatsby Node

### DIFF
--- a/tools/client-plugins/gatsby-source-challenges/gatsby-node.js
+++ b/tools/client-plugins/gatsby-source-challenges/gatsby-node.js
@@ -39,12 +39,6 @@ exports.sourceNodes = function sourceChallengesSourceNodes(
     cwd: curriculumPath
   });
 
-  process.on('exit', () => watcher.close());
-  process.on('SIGINT', () => {
-    watcher.close();
-    process.exit();
-  });
-
   function handleChallengeUpdate(filePath, action = 'changed') {
     return onSourceChange(filePath)
       .then(challenges => {

--- a/tools/client-plugins/gatsby-source-challenges/gatsby-node.js
+++ b/tools/client-plugins/gatsby-source-challenges/gatsby-node.js
@@ -36,8 +36,13 @@ exports.sourceNodes = function sourceChallengesSourceNodes(
     ignored: /(^|[/\\])\../,
     ignoreInitial: true,
     persistent: true,
-    usePolling: true,
     cwd: curriculumPath
+  });
+
+  process.on('exit', () => watcher.close());
+  process.on('SIGINT', () => {
+    watcher.close();
+    process.exit();
   });
 
   function handleChallengeUpdate(filePath, action = 'changed') {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x]  My pull request targets the `main` branch of freeCodeCamp.
- [x]  I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

The chokidar watcher was configured with usePolling: true, which caused it to continuously poll all 14,306 curriculum files every 100ms (~143k file system operations per second). This resulted in excessive memory and CPU usage during development that accumulated over time.

<!-- Feel free to add any additional description of changes below this line -->
