### PR TITLE
fix(client): add back exam token i18n key

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -1307,6 +1307,7 @@
     "invalidation-1": "It looks like you have a valid exam token. If you generate a new one, your existing token will be invalidated.",
     "invalidation-2": "If you generate a new token, your existing token will be invalidated.",
     "generate-exam-token": "Generate Exam Token",
+    "your-exam-token": "Your Exam Token is: {{token}}",
     "error": "There was an error generating your token, please try again in a moment.",
     "no-token": "It looks like you don't have a valid exam token.",
     "copy": "Copy Exam Token",


### PR DESCRIPTION
When you click the generate token on the settings page, you get this:

<img width="569" height="262" alt="Screenshot 2025-11-13 at 10 11 35 AM" src="https://github.com/user-attachments/assets/2af4731f-2d6c-442a-8f7a-13fd0f890536" />

This adds back the i18n key so it displays the text.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
