### PR TITLE
fix(ui): directly display output in output.tsx

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -125,7 +125,6 @@
     "redux-saga": "1.2.3",
     "reselect": "4.1.8",
     "rxjs": "6.6.7",
-    "sanitize-html": "2.11.0",
     "store": "2.0.12",
     "stream-browserify": "3.0.0",
     "tone": "14.7.77",

--- a/client/src/templates/Challenges/components/output.tsx
+++ b/client/src/templates/Challenges/components/output.tsx
@@ -14,16 +14,18 @@ function Output({ defaultOutput, output }: OutputProps): JSX.Element {
   const message = sanitizeHtml(!isEmpty(output) ? output : defaultOutput, {
     allowedTags: ['b', 'i', 'em', 'strong', 'code', 'wbr']
   });
+
   return (
     <pre
       className='output-text'
       data-playwright-test-label='output-text'
-      dangerouslySetInnerHTML={{ __html: message }}
       role='region'
       aria-label={i18next.t('learn.editor-tabs.console')}
       // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
       tabIndex={0}
-    />
+    >
+      <p>{message}</p>
+    </pre>
   );
 }
 

--- a/client/src/templates/Challenges/components/output.tsx
+++ b/client/src/templates/Challenges/components/output.tsx
@@ -10,6 +10,24 @@ interface OutputProps {
   output: string;
 }
 
+/**
+ *
+ * @param message Sanitized HTML code
+ * @returns Html code that is capable of correctly displaying escaped html entities
+ */
+function reformatHTMLEntities(message: string) {
+  console.log(message);
+  const reformattedHTML = message
+    .replace(/&amp;/g, '&amp;amp;') // `&amp;amp;` becomes `&amp;` in rendered html
+    .replace(/&apos;/g, '&amp;apos;') // `&amp;apos;` becomes `&apos;` in rendered html
+    .replace(/&quot;/g, '&amp;quot;') // `&amp;quot;` becomes `&quot;` in rendered html
+    .replace(/&gt;/g, '&amp;gt;') // `&amp;gt;` becomes `&gt;` in rendered html
+    .replace(/&lt;/g, '&amp;lt;'); // `&amp;lt;` becomes `&lt;` in rendered html
+
+  console.log(reformattedHTML);
+  return reformattedHTML;
+}
+
 function Output({ defaultOutput, output }: OutputProps): JSX.Element {
   const message = sanitizeHtml(!isEmpty(output) ? output : defaultOutput, {
     allowedTags: ['b', 'i', 'em', 'strong', 'code', 'wbr']
@@ -21,11 +39,10 @@ function Output({ defaultOutput, output }: OutputProps): JSX.Element {
       data-playwright-test-label='output-text'
       role='region'
       aria-label={i18next.t('learn.editor-tabs.console')}
+      dangerouslySetInnerHTML={{ __html: reformatHTMLEntities(message) }}
       // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
       tabIndex={0}
-    >
-      <p>{message}</p>
-    </pre>
+    ></pre>
   );
 }
 

--- a/client/src/templates/Challenges/components/output.tsx
+++ b/client/src/templates/Challenges/components/output.tsx
@@ -10,28 +10,8 @@ interface OutputProps {
   output: string;
 }
 
-/**
- *
- * @param message Sanitized HTML code
- * @returns Html code that is capable of correctly displaying escaped html entities
- */
-function reformatHTMLEntities(message: string) {
-  console.log(message);
-  const reformattedHTML = message
-    .replace(/&amp;/g, '&amp;amp;') // `&amp;amp;` becomes `&amp;` in rendered html
-    .replace(/&apos;/g, '&amp;apos;') // `&amp;apos;` becomes `&apos;` in rendered html
-    .replace(/&quot;/g, '&amp;quot;') // `&amp;quot;` becomes `&quot;` in rendered html
-    .replace(/&gt;/g, '&amp;gt;') // `&amp;gt;` becomes `&gt;` in rendered html
-    .replace(/&lt;/g, '&amp;lt;'); // `&amp;lt;` becomes `&lt;` in rendered html
-
-  console.log(reformattedHTML);
-  return reformattedHTML;
-}
-
 function Output({ defaultOutput, output }: OutputProps): JSX.Element {
-  const message = sanitizeHtml(!isEmpty(output) ? output : defaultOutput, {
-    allowedTags: ['b', 'i', 'em', 'strong', 'code', 'wbr']
-  });
+const message = (!isEmpty(output) ? output : defaultOutput;
 
   return (
     <pre
@@ -39,10 +19,11 @@ function Output({ defaultOutput, output }: OutputProps): JSX.Element {
       data-playwright-test-label='output-text'
       role='region'
       aria-label={i18next.t('learn.editor-tabs.console')}
-      dangerouslySetInnerHTML={{ __html: reformatHTMLEntities(message) }}
       // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
       tabIndex={0}
-    ></pre>
+    >
+      {message}
+    </pre>
   );
 }
 

--- a/client/src/templates/Challenges/components/output.tsx
+++ b/client/src/templates/Challenges/components/output.tsx
@@ -1,6 +1,5 @@
 import { isEmpty } from 'lodash-es';
 import React from 'react';
-import sanitizeHtml from 'sanitize-html';
 import i18next from 'i18next';
 
 import './output.css';
@@ -11,7 +10,7 @@ interface OutputProps {
 }
 
 function Output({ defaultOutput, output }: OutputProps): JSX.Element {
-const message = (!isEmpty(output) ? output : defaultOutput;
+  const message = !isEmpty(output) ? output : defaultOutput;
 
   return (
     <pre

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -549,9 +549,6 @@ importers:
       rxjs:
         specifier: 6.6.7
         version: 6.6.7
-      sanitize-html:
-        specifier: 2.11.0
-        version: 2.11.0
       store:
         specifier: 2.0.12
         version: 2.0.12
@@ -12291,9 +12288,6 @@ packages:
 
   sanitize-html@1.27.5:
     resolution: {integrity: sha512-M4M5iXDAUEcZKLXkmk90zSYWEtk5NH3JmojQxKxV371fnMh+x9t1rqdmXaGoyEHw3z/X/8vnFhKjGL5xFGOJ3A==}
-
-  sanitize-html@2.11.0:
-    resolution: {integrity: sha512-BG68EDHRaGKqlsNjJ2xUB7gpInPA8gVx/mvjO743hZaeMCZ2DwzW7xvsqZ+KNU4QKwj86HJ3uu2liISf2qBBUA==}
 
   sass.js@0.11.1:
     resolution: {integrity: sha512-X9AtzYFr/HZ+pDIxX6xN74w/H9JjnDHqZcsYY8mr/SpCyhDVN1pJ3G0Q9rb+z3pZ7obZdYuTYMbKl1ALuhbZDw==}
@@ -29382,15 +29376,6 @@ snapshots:
       lodash: 4.17.21
       parse-srcset: 1.0.2
       postcss: 7.0.39
-
-  sanitize-html@2.11.0:
-    dependencies:
-      deepmerge: 4.3.1
-      escape-string-regexp: 4.0.0
-      htmlparser2: 8.0.2
-      is-plain-object: 5.0.0
-      parse-srcset: 1.0.2
-      postcss: 8.4.35
 
   sass.js@0.11.1: {}
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related to #63788

<!-- Feel free to add any additional description of changes below this line -->
I have enough proof for my theory that it is `dangerouslySetInnerHTML` that re-encodes escaped HTML entities back to their un-escaped forms. 

I don't actually know if there is safer or not; or if any functionality is lost. But I needed a way to provide proof about what I was talking about. 

<img width="1430" height="600" alt="A screenshot of the user code and the console output. In the code it logs `Hamburgers < Pizza < Tacos`  to the console. In the console is `Hamburgers &lt; Pizza &lt; Tacos`" src="https://github.com/user-attachments/assets/f3cdf7fb-6017-4276-83db-5f0db342d1d2" />



