### PR TITLE
fix(curriculum): correct spelling error from exlamation to exclamation

### DIFF
--- a/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/68ffb91507a5b645769328c5.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/68ffb91507a5b645769328c5.md
@@ -34,10 +34,10 @@ assert.equal(longestWord("Hello coding challenge."), "challenge");
 assert.equal(longestWord("Do Try This At Home."), "This");
 ```
 
-`longestWord("This sentence... has commas, ellipses, and an exlamation point!")` should return `"exlamation"`.
+`longestWord("This sentence... has commas, ellipses, and an exclamation point!")` should return `"exclamation"`.
 
 ```js
-assert.equal(longestWord("This sentence... has commas, ellipses, and an exlamation point!"), "exlamation");
+assert.equal(longestWord("This sentence... has commas, ellipses, and an exclamation point!"), "exclamation");
 ```
 
 `longestWord("A tie? No way!")` should return `"tie"`.

--- a/curriculum/challenges/english/blocks/daily-coding-challenges-python/68ffb91507a5b645769328c5.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-python/68ffb91507a5b645769328c5.md
@@ -43,12 +43,12 @@ TestCase().assertEqual(longest_word("Do Try This At Home."), "This")`)
 }})
 ```
 
-`longest_word("This sentence... has commas, ellipses, and an exlamation point!")` should return `"exlamation"`.
+`longest_word("This sentence... has commas, ellipses, and an exclamation point!")` should return `"exclamation"`.
 
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertEqual(longest_word("This sentence... has commas, ellipses, and an exlamation point!"), "exlamation")`)
+TestCase().assertEqual(longest_word("This sentence... has commas, ellipses, and an exclamation point!"), "exclamation")`)
 }})
 ```
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
