### PR TITLE
docs(curriculum): correct typo “by click on the” → “by clicking on the”

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-file-systems/672ac3f129efbf327742eb33.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-file-systems/672ac3f129efbf327742eb33.md
@@ -35,7 +35,7 @@ When you open Spotlight, you'll see the Spotlight Search, where you can search f
 
 You can also expand a specific category by clicking on "Show More."
 
-Another way to search for files that you have recently opened is to open Finder by click on the Finder icon in the Dock. Then, go to "Recents" in the Finder sidebar. And there, you'll find all the files that you've recently viewed.
+Another way to search for files that you have recently opened is to open Finder by clicking on the Finder icon in the Dock. Then, go to "Recents" in the Finder sidebar. And there, you'll find all the files that you've recently viewed.
 
 This is how you can search for files and folders on macOS. With these search tools, you can optimize your workflow and find the files and folders you need very quickly.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the 63819 below with the issue number.-->

Closes #63819

<!-- Feel free to add any additional description of changes below this line -->

Summary
This PR corrects a small typo in the Responsive Web Design lesson “How to Search for Files and Folders on Your Computer.”
The phrase “by click on the” has been corrected to “by clicking on the.”
This improves the readability and clarity of the lesson.

Context
The typo was reported so that learners following the curriculum can understand the instructions without confusion.
This is a documentation-only change and does not affect functionality.

Testing
This is a text-only change.
No local testing required since it does not affect layout, code, or interactive behavior.
