### PR TITLE
fix(curriculum): add void element reminder to cafe menu step 16

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3477cb2e27333b1ab2b955.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3477cb2e27333b1ab2b955.md
@@ -9,7 +9,7 @@ dashedName: step-16
 
 Now you need to link the `styles.css` file, so the styles will be applied again. Inside the `head` element, add a `link` element. Give it a `rel` attribute with the value of `"stylesheet"` and an `href` attribute with the value of `"styles.css"`.
 
-**Note:** The `link` element is a void element, which means it doesn't have a closing tag. Void elements are self-closing and should be written as `<link>` rather than `<link></link>`.
+**Note:** The `link` element is a void element, which means it doesn't have a closing tag. Void elements should be written as `<link>` rather than `<link></link>`.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3477cb2e27333b1ab2b955.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3477cb2e27333b1ab2b955.md
@@ -9,6 +9,8 @@ dashedName: step-16
 
 Now you need to link the `styles.css` file, so the styles will be applied again. Inside the `head` element, add a `link` element. Give it a `rel` attribute with the value of `"stylesheet"` and an `href` attribute with the value of `"styles.css"`.
 
+**Note:** The `link` element is a void element, which means it doesn't have a closing tag. Void elements are self-closing and should be written as `<link>` rather than `<link></link>`.
+
 # --hints--
 
 Your code should have a `link` element.


### PR DESCRIPTION
fix(curriculum): add void element reminder to cafe menu step 16

Closes #63850

This PR adds a short note to step 16 of the cafe menu workshop, reminding learners that the <a> element is a void element and does not require a closing tag.

Checklist:

- [ X ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ X ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-       pull-request/).
- [ X ] My pull request targets the `main` branch of freeCodeCamp.
- [ X ] I have tested these changes either locally on my machine, or GitHub Codespaces.
