### PR TITLE
fix(curriculum): correct typo in python truthy/falsy lesson

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-introduction-to-python/68480f431e8568b2056b140b.md
+++ b/curriculum/challenges/english/blocks/lecture-introduction-to-python/68480f431e8568b2056b140b.md
@@ -71,7 +71,7 @@ print(is_citizen and age) # 25
 
 In the above example, the number 25 is printed to the terminal because the `and` operator will evaluate the second operand if the first operand is `True`. The `and` operator is known as a short-circuit operator. Short-circuiting means Python checks values from left to right and stops as soon as it determines the final result.
 
-You'll often use `and` within `if` statements to check if multiple conditions are met. Here’s how you can refactor the earlier example to uses the `and` operator instead of nested `if` statements:
+You'll often use `and` within `if` statements to check if multiple conditions are met. Here’s how you can refactor the earlier example to use the `and` operator instead of nested `if` statements:
 
 ```python
 is_citizen = True


### PR DESCRIPTION
### Description

This pull request addresses a minor grammatical typo in the Python Truthy/Falsy lesson within the curriculum. While reviewing the content, I noticed that one of the instructional sentences contains an incorrect verb form, which could slightly impact the readability and professionalism of the lesson.

The original sentence reads:

> "Here’s how you can refactor the earlier example to uses the and operator instead..."

The word **"uses"** is grammatically incorrect in this context. It has now been corrected to **"use"**, resulting in the following updated version:

> "Here’s how you can refactor the earlier example to use the and operator instead..."

### Why This Change Was Made

This improves the clarity and grammatical correctness of the lesson. No functional changes were made.

### How I Tested the Change

- Verified the edited markdown renders correctly.
- Ensured no unintended formatting or content changes were introduced.
- Confirmed the fix aligns with the referenced issue and matches the lesson link provided.

###After running on Local

<img width="1919" height="879" alt="image" src="https://github.com/user-attachments/assets/850fdcf9-37db-47bf-96b4-7524b7bcabeb" />


### Checklist

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

### Related Issue

Closes #63856

### Additional Notes

Thank you to the maintainers for reviewing this contribution. This is a small but meaningful improvement to the readability of the documentation, and I am excited to continue contributing to FreeCodeCamp's open-source curriculum.
