### PR TITLE
fix(client): rm unnecessary styling to resolve the conflict in action row

### DIFF
--- a/client/src/templates/Challenges/classic/action-row.tsx
+++ b/client/src/templates/Challenges/classic/action-row.tsx
@@ -130,26 +130,24 @@ const ActionRow = (props: ActionRowProps): JSX.Element => {
           <EditorTabs data-playwright-test-label='editor-tabs' />
         </div>
         {/* middle - only used with daily coding challenges for now */}
-        <div className='tabs-row-middle'>
-          {isDailyCodingChallenge && (
-            <>
-              <button
-                aria-expanded={dailyCodingChallengeLanguage === 'javascript'}
-                disabled={dailyCodingChallengeLanguage === 'javascript'}
-                onClick={() => handleLanguageChange('javascript')}
-              >
-                JavaScript
-              </button>
-              <button
-                aria-expanded={dailyCodingChallengeLanguage === 'python'}
-                disabled={dailyCodingChallengeLanguage === 'python'}
-                onClick={() => handleLanguageChange('python')}
-              >
-                Python
-              </button>
-            </>
-          )}
-        </div>
+        {isDailyCodingChallenge && (
+          <div className='tabs-row-middle'>
+            <button
+              aria-expanded={dailyCodingChallengeLanguage === 'javascript'}
+              disabled={dailyCodingChallengeLanguage === 'javascript'}
+              onClick={() => handleLanguageChange('javascript')}
+            >
+              JavaScript
+            </button>
+            <button
+              aria-expanded={dailyCodingChallengeLanguage === 'python'}
+              disabled={dailyCodingChallengeLanguage === 'python'}
+              onClick={() => handleLanguageChange('python')}
+            >
+              Python
+            </button>
+          </div>
+        )}
         {/* right */}
         <div className='tabs-row-right panel-display-tabs'>
           <button

--- a/client/src/templates/Challenges/classic/classic.css
+++ b/client/src/templates/Challenges/classic/classic.css
@@ -70,23 +70,19 @@
 }
 
 .tabs-row-left {
-  width: 30%;
   display: flex;
   gap: 10px;
 }
 
 .tabs-row-middle {
-  width: 30%;
   display: flex;
   justify-content: center;
   gap: 3px;
 }
 
 .tabs-row-right {
-  width: 30%;
   display: flex;
   justify-content: flex-end;
-  margin-inline-start: auto;
 }
 
 .monaco-editor-tabs button + button {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ x ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ x ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ x ] My pull request targets the `main` branch of freeCodeCamp.
- [ x ] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #63766

<!-- Feel free to add any additional description of changes below this line -->
Since the<code>.tabs-row</code> parent element has been set <code>justify-content: space-between </code>, it is not necessary to set widths for its children. The <code>margin-inline-start: auto </code> property in <code>.tabs-row-right</code> also overrides the effect of <code>justify-content</code>.
<img width="542" height="165" alt="tabs-row" src="https://github.com/user-attachments/assets/45922b39-8449-4798-99c6-88dba5c43577" />
