### PR TITLE
fix(client): enable Java syntax highlighting in Prism-rendered descriptions (#63811)

### DIFF
--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -10,6 +10,8 @@ import type {
 } from 'monaco-editor/esm/vs/editor/editor.api';
 import { OS } from 'monaco-editor/esm/vs/base/common/platform.js';
 import Prism from 'prismjs';
+import 'prismjs/components/prism-clike';
+import 'prismjs/components/prism-java';
 import React, { useEffect, Suspense, MutableRefObject, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { connect } from 'react-redux';

--- a/client/src/templates/Challenges/components/prism-formatted.tsx
+++ b/client/src/templates/Challenges/components/prism-formatted.tsx
@@ -1,4 +1,6 @@
 import Prism from 'prismjs';
+import 'prismjs/components/prism-clike';
+import 'prismjs/components/prism-java';
 import React, { useRef, useEffect } from 'react';
 import { enhancePrismAccessibility } from '../utils';
 


### PR DESCRIPTION
- Load Prism 'clike' and 'java' components in prism-formatted and classic editor so `java blocks are highlighted in lessons.
- Affects all challenge descriptions and instructions rendered via PrismFormatted.

Closes: #63811

Checklist:

[X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
[X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
[X] My pull request targets the `main` branch of freeCodeCamp.
[X] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #63811

