### PR TITLE
fix(curriculum): add interactive examples to aria-label lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-introduction-to-aria/672a54a6675c168faa84252d.md
+++ b/curriculum/challenges/english/blocks/lecture-introduction-to-aria/672a54a6675c168faa84252d.md
@@ -5,7 +5,7 @@ challengeType: 19
 dashedName: what-are-the-roles-of-the-aria-label-and-aria-labelledby-attributes
 ---
 
-# --description--
+# --interactive--
 
 It is important to make sure that all users, including those living with disabilities, can access websites without issues.
 
@@ -21,7 +21,7 @@ Here is an example:
 
 ```html
 <button aria-label="Search">
-  <i class="fas fa-search"></i>
+  <i class="fa-solid fa-magnifying-glass"></i>
 </button>
 ```
 
@@ -35,13 +35,19 @@ The `aria-labelledby` attribute does the exact same thing as the `aria-label` at
 
 Here's an example:
 
+:::interactive_editor
+
 ```html
 <input type="text" aria-labelledby="search-btn">
 <button type="button" id="search-btn">Search</button>
 ```
 
+:::
+
 In this case, the text for the button is being used as the label for the search input. Screen readers will announce the input as something like `Search, edit`. If you later decide you want to change the button text to `Find`, the label for the input will automatically be updated to the new text since it is referencing the button text.
 Combining multiple `id` values into a single `aria-labelledby` attribute value is also possible. Here's how that works:
+
+:::interactive_editor
 
 ```html
 <div>
@@ -55,6 +61,8 @@ Combining multiple `id` values into a single `aria-labelledby` attribute value i
     aria-labelledby="volume-label volume-details">
 </div>
 ```
+
+:::
 
 For the slider, the screen reader will look out for the content of the `volume-label` and `volume-details` elements and announce `Volume Adjust the volume level`.
 


### PR DESCRIPTION
Checklist:
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #63782

This PR updates the ARIA label lecture to include interactive examples.
- Converts the lecture to use the `# --interactive--` section.
- Wraps the `aria-labelledby` input and slider examples in `:::interactive_editor` blocks.
- Updates the icon example to use `fa-solid fa-magnifying-glass`.