### PR TITLE
fix(curriculum): correct 'less then' → 'less than' typo in loop explanation

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-loops/6732c07238355642a9781dfb.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-loops/6732c07238355642a9781dfb.md
@@ -24,7 +24,7 @@ for (let i = 0; i < 10; i++) {
 
 :::
 
-In the example above, the loop starts counting at `0` and while `i` is less then `10`, the loop will continue to run.
+In the example above, the loop starts counting at `0` and while `i` is less than `10`, the loop will continue to run.
 
 Inside the loop, we check if `i` is equal to `5`. If it is, we use the `break` statement to exit the loop early. If not, we log the value of `i` to the console. So the output of the code will print the numbers `0`, `1`, `2`, `3`, and `4`.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x ] My pull request targets the `main` branch of freeCodeCamp.
- [x ] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #63869

<!-- Feel free to add any additional description of changes below this line -->

This PR corrects a small typographical error in the "Break and Continue Statements" section.

The incorrect text currently says:

"while i is less then 10"

This should be:

"while i is less than 10"

Updated file:
curriculum/challenges/english/blocks/lecture-working-with-loops/6732c07238355642a9781dfb.md

Closes #63869
