### PR TITLE
fix(curriculum): use C# highlighting in static typing discussion 

### DIFF
--- a/client/.babelrc.js
+++ b/client/.babelrc.js
@@ -39,8 +39,11 @@ const config = {
       {
         languages: [
           'bash',
+          'c',
           'clike',
+          'cpp',
           'css',
+          'csharp',
           'html',
           'javascript',
           'json',

--- a/client/src/templates/Challenges/utils/index.ts
+++ b/client/src/templates/Challenges/utils/index.ts
@@ -53,7 +53,11 @@ export function enhancePrismAccessibility(
     pug: 'pug',
     ts: 'TypeScript',
     typescript: 'TypeScript',
-    tsx: 'TSX'
+    tsx: 'TSX',
+    csharp: 'C#',
+    clike: 'CLike',
+    c: 'C',
+    cpp: 'C++'
   };
   const parent = prismEnv?.element?.parentElement;
   if (

--- a/curriculum/challenges/english/blocks/lecture-working-with-data-types/672d264645e289208e562f10.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-data-types/672d264645e289208e562f10.md
@@ -20,15 +20,16 @@ In this example, we have a variable called `example` with the data type of strin
 
 The flexibility of dynamic typing makes JavaScript more forgiving and easy to work with for quick scripting, but it can also introduce bugs that may be harder to catch, especially as your program grows larger.
 
-In statically typed languages like Java or C++, you must declare the data type of a variable when you create it, and that type cannot change.
+In statically typed languages like C# or C++, you must declare the data type of a variable when you create it, and that type cannot 
+change.
 
 For instance, if you declare a variable as `integer`, you can only assign it integer values. If you try to assign it a different type, the program will throw an error.
 
-Here's an example in Java language:
+Here's an example in C# language:
 
-```java
-int value = 42; // value must always be an integer
-value = "Hello"; // This would cause an error in Java
+```csharp
+int data = 42; // data must always be an integer
+data = "Hello"; // This would cause an error in C#
 ```
 
 The difference between dynamic typing and static typing lies in the flexibility vs. the safety of your code. Dynamically typed languages offer flexibility but at the cost of potential runtime errors.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #63811

<!-- Feel free to add any additional description of changes below this line -->
In the example I replaced Java with C# since FreeCodeCamp taught C# at one point. Additionally I've added C  and C++ because as far as I know, prism's C# rules might require those as rule dependencies. 

