### PR TITLE
fix(curriculum): standardize incorrect answer feedback for 672a53ae8f1ad28c8a1ed0f0

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-accessible-tables-forms/672a53ae8f1ad28c8a1ed0f0.md
+++ b/curriculum/challenges/english/blocks/lecture-accessible-tables-forms/672a53ae8f1ad28c8a1ed0f0.md
@@ -94,7 +94,7 @@ Place the `<label>` immediately after the `<input>` element in the DOM.
 
 ### --feedback--
 
-Order alone does not create an association that screen readers can use.
+Review the example in the lesson showing how for and id are used together.
 
 ---
 
@@ -102,7 +102,7 @@ Use the input's `placeholder` text instead of a label.
 
 ### --feedback--
 
-Placeholders are not a replacement for accessible, programmatically associated labels.
+Review the example in the lesson showing how for and id are used together.
 
 ## --video-solution--
 
@@ -130,7 +130,7 @@ It allows inputs to accept multiple data types automatically.
 
 ### --feedback--
 
-Data types are determined by the input's `type` attribute, not labels.
+Performance is not the benefit discussed in this lesson.
 
 ---
 
@@ -138,7 +138,7 @@ It automatically translates labels for international users.
 
 ### --feedback--
 
-Internationalization is outside the scope of what labels provide.
+Performance is not the benefit discussed in this lesson.
 
 ## --video-solution--
 


### PR DESCRIPTION
#### Changes
This Pull Request addresses issue #63860 

        |Question 2: The incorrect feedback for all wrong choices was unified to:
        Review the example in the lesson showing how for and id are used together.
        
        Question 3: The incorrect feedback for all wrong choices was unified to:
        Performance is not the benefit discussed in this lesson.


- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #63860

#### Description of Changes
This PR standardizes the feedback messages for incorrect answers in the comprehension questions found in the file `curriculum/challenges/english/blocks/lecture-accessible-tables-forms/672a53ae8f1ad28c8a1ed0f0.md`. This change ensures consistency across the challenge, aligning with the style guide of using the same feedback for all wrong choices.