### PR TITLE
fix(curriculum): clarify HSLA alpha can be a percentage in HSL lesson

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-colors-in-css/672bc523324694be91d90d96.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-colors-in-css/672bc523324694be91d90d96.md
@@ -100,7 +100,7 @@ div {
 
 :::
 
-This code would give the `div` a semi-transparent red background, where the hue is set to `0` degrees (red), saturation is `100%`, lightness is `50%`, and alpha is `0.5` (50% opacity).
+This code would give the `div` a semi-transparent red background, where the hue is set to `0` degrees (red), saturation is `100%`, lightness is `50%`, and alpha is `0.5` (50% opacity). You can also specify the alpha as a percentage — for example, `hsla(0, 100%, 50%, 50%)` is equivalent to `hsla(0, 100%, 50%, 0.5)`.
 
 The HSL color model is particularly useful when you need to create color schemes and adjust shades or tints easily. 
 


### PR DESCRIPTION
Checklist:

- [ x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ x ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ x ] My pull request targets the `main` branch of freeCodeCamp.
- [ x ] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #63128

Adds a concise note to the HSL lesson clarifying that the hsla() alpha channel accepts both numbers and percentages per the CSS Color specification, with an example demonstrating the equivalence.
