### PR TITLE
fix(curriculum): adjust editable region indentation in workshop-library-manager

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-library-manager/67116d7584d0b469b14579bf.md
+++ b/curriculum/challenges/english/blocks/workshop-library-manager/67116d7584d0b469b14579bf.md
@@ -85,7 +85,7 @@ assert.propertyVal(library[0], "pages", 320);
 ```js
 const library = [
 --fcc-editable-region--
-
+  
 --fcc-editable-region--
 ];
 ```

--- a/curriculum/challenges/english/blocks/workshop-library-manager/67116d7584d0b469b14579c2.md
+++ b/curriculum/challenges/english/blocks/workshop-library-manager/67116d7584d0b469b14579c2.md
@@ -157,6 +157,6 @@ console.log(getBookInformation(library));
 console.log("\nList of book summaries:\n");
 
 --fcc-editable-region--
-  
+
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-library-manager/67116d7584d0b469b14579c3.md
+++ b/curriculum/challenges/english/blocks/workshop-library-manager/67116d7584d0b469b14579c3.md
@@ -173,6 +173,6 @@ console.log(getBookSummaries(library));
 console.log("\nList of books by Arvid Kahl:\n");
 
 --fcc-editable-region--
-  
+
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-library-manager/67116d7584d0b469b14579c4.md
+++ b/curriculum/challenges/english/blocks/workshop-library-manager/67116d7584d0b469b14579c4.md
@@ -167,7 +167,7 @@ console.log(getBooksByAuthor(library, "James Clear"));
 console.log("\nTotal number of pages for all library books:\n");
 
 --fcc-editable-region--
-  
+
 --fcc-editable-region--
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-library-manager/681dbe48ee5df6842385d735.md
+++ b/curriculum/challenges/english/blocks/workshop-library-manager/681dbe48ee5df6842385d735.md
@@ -79,6 +79,6 @@ const library = [
 ];
 
 --fcc-editable-region--
-  
+
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-library-manager/681dc1bbbf0d2e85ac499cf6.md
+++ b/curriculum/challenges/english/blocks/workshop-library-manager/681dc1bbbf0d2e85ac499cf6.md
@@ -83,6 +83,6 @@ const library = [
 console.log("Books in the Library:\n");
 
 --fcc-editable-region--
-  
+
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-library-manager/681dc623b2b18887266777b1.md
+++ b/curriculum/challenges/english/blocks/workshop-library-manager/681dc623b2b18887266777b1.md
@@ -123,7 +123,7 @@ console.log("Books in the Library:\n");
 
 --fcc-editable-region--
 function getBookInformation(catalog) {
-
+  
 }
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-library-manager/682277e2d3a05f0c5cf34d19.md
+++ b/curriculum/challenges/english/blocks/workshop-library-manager/682277e2d3a05f0c5cf34d19.md
@@ -103,6 +103,6 @@ function getBooksByAuthor(catalog, author) {
 }
 
 --fcc-editable-region--
-  
+
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-library-manager/6827deed7fc01f074c90fc0d.md
+++ b/curriculum/challenges/english/blocks/workshop-library-manager/6827deed7fc01f074c90fc0d.md
@@ -111,6 +111,6 @@ function getBooksByAuthor(catalog, author) {
 console.log(getBooksByAuthor(library, "Arvid Kahl"));
 
 --fcc-editable-region--
-  
+
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-library-manager/6827e10547fdd308bca1c73d.md
+++ b/curriculum/challenges/english/blocks/workshop-library-manager/6827e10547fdd308bca1c73d.md
@@ -104,6 +104,6 @@ console.log("\nList of books by James Clear:\n");
 console.log(getBooksByAuthor(library, "James Clear"));
 
 --fcc-editable-region--
-  
+
 --fcc-editable-region--
 ```


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

I was doing the project on my own, and the uneven indentation of the editable region was botherint me a lot so I fixed it