### PR TITLE
fix(curriculum): fixed fill-in-the-blank sentence to match dialogue

### DIFF
--- a/curriculum/challenges/english/blocks/learn-how-to-describe-places-and-events/66b56714407eff03b29e4fd4.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-describe-places-and-events/66b56714407eff03b29e4fd4.md
@@ -16,7 +16,7 @@ Listen to the audio to complete the sentence below.
 
 ## --sentence--
 
-`I'm BLANK of using a real-life BLANK this time.`
+`I'm BLANK of using real-life BLANK this time.`
 
 ## --blanks--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x ] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #63898

<!-- Feel free to add any additional description of changes below this line -->
Minor text change did not test on my machine.

Update file 66b56714407eff03b29e4fd4.md and made the changes requested in task #63898. I modified line #19 and replace the "using a real-life" with "using real-life" to match the dialog.