### PR TITLE
fix(curriculum): remove backticks around console

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-greeting-bot/66adcf383276814776aba3ca.md
+++ b/curriculum/challenges/english/blocks/workshop-greeting-bot/66adcf383276814776aba3ca.md
@@ -13,7 +13,7 @@ Use string concatenation to join the string `"My favorite subject is "` with the
 
 Assign the result to the `favoriteSubjectSentence` variable.
 
-Then, log the value of `favoriteSubjectSentence` to the `console`.
+Then, log the value of `favoriteSubjectSentence` to the console.
 
 # --hints--
 
@@ -41,7 +41,7 @@ You should have a `console` statement in your code.
 assert.lengthOf(__helpers.removeJSComments(code).match(/console\.log(.*)/g), 8);
 ```
 
-You should log the value of `favoriteSubjectSentence` to the `console`.
+You should log the value of `favoriteSubjectSentence` to the console.
 
 ```js
 assert.match(__helpers.removeJSComments(code), /console\.log\s*\(\s*favoriteSubjectSentence\s*\)/);


### PR DESCRIPTION
Hi! I noticed in step 14 of the Greeting Bot workshop that the word 'console' was wrapped in backticks in two places, which was inconsistent with how it's used in other steps of the workshop.

This small change removes those backticks to maintain consistency throughout the tutorial. It makes the documentation cleaner and easier to follow for learners going through the workshop.

## Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #63798