### PR TITLE
Fix false-positive test in quiz game challenge

### DIFF
--- a/curriculum/challenges/english/blocks/lab-quiz-game/66f17db06803d11a1bd19a20.md
+++ b/curriculum/challenges/english/blocks/lab-quiz-game/66f17db06803d11a1bd19a20.md
@@ -112,8 +112,11 @@ Your `getResults` function should take the question object as the first paramete
 
 ```js
 assert.equal(getResults(questions[0], questions[0].answer), `The computer's choice is correct!`);
-assert.notEqual(getResults(questions[0].answer, questions[0]), `The computer's choice is correct!`);
-```
+assert.notStrictEqual(
+  getResults(questions[0].answer, questions[0]),
+  "The computer's choice is correct!",
+  "The test should not pass when only a partial match occurs."
+);```
 
 If the computer choice matches the answer, `getResults` should return `The computer's choice is correct!`
 


### PR DESCRIPTION
This PR fixes a false-positive issue in the quiz game challenge test.
The previous test could pass when a partial string match occurred
(e.g., "Ham" matching "Hamburger"). The updated test ensures strict
type and value comparison, preventing incorrect validations.
