### PR TITLE
fix(curriculum): correct typo in feedback

### DIFF
--- a/curriculum/challenges/english/blocks/learn-how-to-clarify-misunderstandings/67ee58d54be9087f91df3e03.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-clarify-misunderstandings/67ee58d54be9087f91df3e03.md
@@ -32,7 +32,7 @@ The problem could be related to the hardware.
 
 ### --feedback--
 
-Lisa does't mention any hardware issue.
+Lisa doesn't mention any hardware issue.
 
 ---
 


### PR DESCRIPTION
This PR fixes a minor typo in the feedback section to improve clarity for learners.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #63916

<!-- Feel free to add any additional description of changes below this line -->

This PR fixes a minor typo in the feedback section to improve clarity for learners.