### PR TITLE
fix(curriculum): make static property example sandbox-compatible (#63…

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-understanding-how-to-work-with-classes-in-javascript/673403dbf5c9835898632c84.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-how-to-work-with-classes-in-javascript/673403dbf5c9835898632c84.md
@@ -153,13 +153,19 @@ In this example, we have a static `numberOfPizzasSold` property.
 
 ```js
 class Pizza {
-  static numberOfPizzasSold = 0;
-
   constructor(type) {
     this.type = type;
     Pizza.numberOfPizzasSold++;
   }
 }
+
+Pizza.numberOfPizzasSold = 0;
+
+let pizza1 = new Pizza("Margherita");
+let pizza2 = new Pizza("Neapolitan");
+
+console.log(Pizza.numberOfPizzasSold);
+
 ```
 
 It's static because it doesn't belong to any particular pizza instance, it belongs to the class itself.


### PR DESCRIPTION
…565)

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Fixes #63565

Replaced ES2022 static class field syntax (`static numberOfPizzasSold = 0;`)
with a sandbox-compatible initialization (`Pizza.numberOfPizzasSold = 0;`).

This prevents the SyntaxError in the freeCodeCamp interactive playground and
keeps the example behavior identical.

