### PR TITLE
fix(curriculum): correct “error” to “Error” constructor in debugging techniques lesson

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-debugging-techniques/6733bec70d86e13522e98a4f.md
+++ b/curriculum/challenges/english/blocks/lecture-debugging-techniques/6733bec70d86e13522e98a4f.md
@@ -119,7 +119,7 @@ Think of a way to catch and handle errors without crashing the program.
 
 ## --text--
 
-How do you use the `throw` statement in combination with the `error` constructor in JavaScript?
+How do you use the `throw` statement in combination with the `Error` constructor in JavaScript?
 
 ## --answers--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #63954


<!-- Feel free to add any additional description of changes below this line -->
Fix: Correct “error” to “Error” constructor in debugging techniques lesson.