### PR TITLE
fix : removed completion message from pop up modal for certification projects

### DIFF
--- a/client/src/templates/Challenges/components/completion-modal.tsx
+++ b/client/src/templates/Challenges/components/completion-modal.tsx
@@ -22,6 +22,7 @@ import {
 import Progress from '../../../components/Progress';
 import GreenPass from '../../../assets/icons/green-pass';
 import { MAX_MOBILE_WIDTH } from '../../../../config/misc';
+import { liveCerts } from '../../../config/cert-and-project-map';
 import './completion-modal.css';
 import callGA from '../../../analytics/call-ga';
 
@@ -154,12 +155,18 @@ class CompletionModal extends Component<
       message,
       t,
       dashedName,
-      submitChallenge
+      submitChallenge,
+      id
     } = this.props;
 
     const isMacOS = navigator.userAgent.includes('Mac OS');
 
     const isDesktop = window.innerWidth > MAX_MOBILE_WIDTH;
+
+    // Check if this is a certification project
+    const isCertificationProject = liveCerts.some(cert =>
+      cert.projects?.some((project: { id: string }) => project.id === id)
+    );
 
     let buttonText;
     if (isDesktop) {
@@ -186,7 +193,9 @@ class CompletionModal extends Component<
         // eslint-disable-next-line @typescript-eslint/unbound-method
         onKeyDown={isOpen ? this.handleKeypress : undefined}
       >
-        <Modal.Header closeButtonClassNames='close'>{message}</Modal.Header>
+        <Modal.Header closeButtonClassNames='close'>
+          {isCertificationProject ? '' : message}
+        </Modal.Header>
         <Modal.Body className='completion-modal-body'>
           <GreenPass
             className='completion-success-icon'


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #63919

<!-- Feel free to add any additional description of changes below this line -->
- Hide congratulatory message in completion modal for certification projects
- Regular challenges continue to show random compliment messages
- Fixes #63919

