### PR TITLE
Update inline-block examples with shorter text

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-what-is-css/672acc3f6f3e3c4e31ec3e12.md
+++ b/curriculum/challenges/english/blocks/lecture-what-is-css/672acc3f6f3e3c4e31ec3e12.md
@@ -31,8 +31,8 @@ Let's take a look at an example.
 <link href="styles.css" rel="stylesheet">
 
 <div class="container">
-  <span class="inline-block-element element1">Inline-Block Element 1</span>
-  <span class="inline-block-element element2">Inline-Block Element 2</span>
+  <span class="inline-block-element element1">Span element</span>
+  <span class="inline-block-element element2">Span element</span>
 </div>
 ```
 
@@ -70,8 +70,8 @@ Here is the revised CSS:
 <link href="styles.css" rel="stylesheet">
 
 <div class="container">
-  <span class="inline-block-element element1">Inline-Block Element 1</span>
-  <span class="inline-block-element element2">Inline-Block Element 2</span>
+  <span class="inline-block-element element1">Span element</span>
+  <span class="inline-block-element element2">Span element</span>
 </div>
 ```
 


### PR DESCRIPTION
Changed 'Inline-Block Element 1' and 'Inline-Block Element 2' to 'Span element' to make the examples clearer and use shorter text.

Fixes #63848

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or on GitHub Codespaces.

Closes #63848