### PR TITLE
fix(curriculum): improve getResults test to prevent TypeError in lab-quiz-game

### DIFF
--- a/curriculum/challenges/english/blocks/lab-quiz-game/66f17db06803d11a1bd19a20.md
+++ b/curriculum/challenges/english/blocks/lab-quiz-game/66f17db06803d11a1bd19a20.md
@@ -111,8 +111,10 @@ assert.isFunction(getResults);
 Your `getResults` function should take the question object as the first parameter and the computer's choice as the second parameter.
 
 ```js
-assert.equal(getResults(questions[0], questions[0].answer), `The computer's choice is correct!`);
-assert.notEqual(getResults(questions[0].answer, questions[0]), `The computer's choice is correct!`);
+const testQuestion = questions[0];
+const wrongChoice = questions[0].choices.find(choice => choice !== questions[0].answer);
+assert.equal(getResults(testQuestion, testQuestion.answer), `The computer's choice is correct!`);
+assert.equal(getResults(testQuestion, wrongChoice), `The computer's choice is wrong. The correct answer is: ${testQuestion.answer}`);
 ```
 
 If the computer choice matches the answer, `getResults` should return `The computer's choice is correct!`

--- a/curriculum/challenges/english/blocks/lab-quiz-game/66f17db06803d11a1bd19a20.md
+++ b/curriculum/challenges/english/blocks/lab-quiz-game/66f17db06803d11a1bd19a20.md
@@ -129,6 +129,13 @@ If the computer choice doesn't match the answer, `getResults` should return `The
 assert.equal(getResults({category: 'misc', choices: ['a', 'b', 'c'], question: "question?", answer: "b"}, "a"), `The computer's choice is wrong. The correct answer is: b`)
 ```
 
+Your `getResults` function should use exact equality comparison, not substring matching.
+
+```js
+assert.equal(getResults({category: 'food', choices: ['Ham', 'Hamburger', 'Hot Dog'], question: "What food?", answer: "Hamburger"}, "Ham"), `The computer's choice is wrong. The correct answer is: Hamburger`);
+assert.equal(getResults({category: 'food', choices: ['Ham', 'Hamburger', 'Hot Dog'], question: "What food?", answer: "Ham"}, "Hamburger"), `The computer's choice is wrong. The correct answer is: Ham`);
+```
+
 # --seed--
 
 ## --seed-contents--


### PR DESCRIPTION
Checklist:


- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.



Closes #63899

---

## Fix parameter order test in lab-quiz-game

### Changes
- Replaced swapped-parameter test that caused TypeError with `.includes()` implementation
- New test explicitly validates correct and incorrect answer scenarios
- Provides clearer feedback without confusing errors

### Why
The original `assert.notEqual(getResults(questions[0].answer, questions[0]), ...)` threw `TypeError: Cannot read property 'includes' of undefined` when students used `.includes()` instead of strict equality.

The new test achieves the same validation goal while providing actionable feedback.

Substring matching is still properly validated by existing tests at lines 132-138.

