### PR TITLE
fix(curriculum): use trim() for innerText assertion in cat photo app step 1

### DIFF
--- a/curriculum/challenges/english/blocks/cat-photo-app/5dc174fcf86c76b9248c6eb2.md
+++ b/curriculum/challenges/english/blocks/cat-photo-app/5dc174fcf86c76b9248c6eb2.md
@@ -41,7 +41,7 @@ assert.match(code, /<\/h1\>/);
 Your `h1` element's text should be `CatPhotoApp`. You have either omitted the text, have a typo, or it is not between the `h1` element's opening and closing tags.
 
 ```js
-assert.equal(document.querySelector('h1')?.innerText.toLowerCase(), 'catphotoapp');
+assert.equal(document.querySelector('h1')?.innerText.trim().toLowerCase(), 'catphotoapp');
 ```
 
 
@@ -53,7 +53,7 @@ assert.equal(document.querySelector('h1')?.innerText.toLowerCase(), 'catphotoapp
 <html>
   <body>
 --fcc-editable-region--
-   
+
 --fcc-editable-region--
   </body>
 </html>


### PR DESCRIPTION
### Checklist
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org/).
- [x] I have tested these changes locally.

### Description
This PR addresses a fragile test (flaky assertion) in the **Cat Photo App (Step 1)** caused by strict `innerText` matching.

### The Context (Diagnosis)
As identified in my analysis, the current test engine uses `assert.equal` with strict string matching against the element's `innerText`. This creates a **False Negative** scenario: if a student writes valid HTML but introduces formatting (newlines/indentation) or extra spaces, the test fails because `innerText` captures the whitespace, causing a mismatch against the expected string.

### Methodology (Data-Driven Validation)
I performed a local reproduction using a Data-Driven approach to validate the fix against different HTML inputs:

| Scenario ID | Input Data (Student Code) | Expected Result (Old Logic) | Result with Fix (New Logic) | Status |
| :--- | :--- | :--- | :--- | :--- |
| **TC-001** | `<h1>CatPhotoApp</h1>` (Standard) | PASS | **PASS** | Baseline |
| **TC-002** | `<h1>\n CatPhotoApp \n</h1>` (Formatted) | **FAIL (False Negative)** | **PASS** | ✅ Fixed |
| **TC-003** | `<h1>Wrong Text</h1>` (Invalid) | FAIL | **FAIL** | Regression OK |

### The Fix
I applied the `.trim()` method to the assertion logic to normalize the input data before comparison. This ensures the test focuses on the semantic content rather than stylistic syntax or whitespace.

```javascript
// Before (Fragile):
assert.equal(document.querySelector('h1')?.innerText.toLowerCase(), 'catphotoapp');

// After (Robust):
assert.equal(document.querySelector('h1')?.innerText.trim().toLowerCase(), 'catphotoapp');
Related Issue
Relates to #60690 (Identified the same assertion fragility pattern in the Legacy RWD curriculum).

