### PR TITLE
fix(curriculum): correct sparse array display for Array(5) example

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-arrays-variables-and-naming-practices/6732c6ba2ea42b610b9f9ce1.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-arrays-variables-and-naming-practices/6732c6ba2ea42b610b9f9ce1.md
@@ -5,9 +5,11 @@ challengeType: 19
 dashedName: how-do-you-get-the-length-for-an-array-and-how-can-you-create-an-empty-array-of-fixed-length
 ---
 
-# --description--
+# --interactive--
 
 In prior lessons you were first introduced to the `length` property, this property returns the number of elements in an array. So here is a quick reminder on how it works:
+
+:::interactive_editor
 
 ```js
 const fruits = ['apple', 'banana', 'orange'];
@@ -19,6 +21,7 @@ It's possible to have arrays with empty slots. Empty slots are defined as slots 
 ```js
 const sparseArray = [1, , , 4];
 console.log(sparseArray.length); // 4
+console.log(sparseArray); // [1, , , 4]
 ```
 
 In this case even though we only have two defined elements, `1` and `4`. The length is `4` because the highest index (`3`) plus `1` gives us a length of `4`.
@@ -28,12 +31,14 @@ Now let's discuss how to create an empty array of fixed length. There are few wa
 ```js
 const emptyArray = new Array(5);
 console.log(emptyArray.length); // 5
-console.log(emptyArray); // [,,,,]
+console.log(emptyArray); // [ , , , , ]
 ```
 
-In this example, we create a new array using the `Array(5)`. This creates a sparse array with a length of `5` where all the slots are empty. 
+In this example, we create a new array using the `Array(5)`. This creates a sparse array with a length of `5` where all the slots are empty. Note that these are *empty slots* (sparse slots) — they are not actual values of `undefined` stored at each index. Many JS inspectors display empty slots visually as blank positions separated by commas (`,`) — e.g. `[ , , , ]`.
 
 Another way to create an empty array of fixed length is to use the `Array.from()` method with a length argument. This method creates an array of the specified length with all elements initialized to `undefined`: 
+
+:::interactive_editor
 
 ```js
 const fixedLengthArray = Array.from({ length: 5 });
@@ -43,7 +48,11 @@ console.log(fixedLengthArray.length); // 5
 console.log(fixedLengthArray);
 ```
 
+> Note: `Array.from({ length: n })` creates a real array with `n` entries that are set to `undefined`, while `new Array(n)` creates a sparse array with `n` empty slots. The two look different in runtime inspectors: `Array.from` will show explicit `undefined` values, while `new Array(n)` often displays as `[ , , , ]`.
+
 If you want to create an array of specific length and fill it with a default value, you can use the `Array.fill()` method: 
+
+:::interactive_editor
 
 ```js
 const filledArray = new Array(3).fill(0);
@@ -77,6 +86,10 @@ Remember that the `length` property returns the highest numeric index plus one, 
 
 `5`
 
+### --feedback--
+
+Correct. The highest index in `[1, 2, 3, , 5]` is `4`, so length is `4 + 1 = 5`. Empty slots count toward the array's `length` even though they are not filled with values.
+
 ---
 
 `3`
@@ -108,19 +121,19 @@ console.log(arr);
 
 ## --answers--
 
+`[ , , ]`
+
+### --feedback--
+
+Correct. `new Array(3)` creates a sparse array with three empty slots. Many JS environments display sparse slots as blank entries between commas (e.g. `[ , , ]`). These are empty slots, not explicit `undefined` values.
+
+---
+
 `[undefined, undefined, undefined]`
 
 ### --feedback--
 
-Consider how the `Array()` constructor behaves when given a single numeric argument.
-
----
-
-`[null, null, null]`
-
-### --feedback--
-
-Consider how the `Array()` constructor behaves when given a single numeric argument.
+This is what an array created by `Array.from({ length: 3 })` would look like when printed — `Array.from` creates defined entries set to `undefined`. `new Array(3)` instead creates three empty slots (a sparse array).
 
 ---
 
@@ -128,11 +141,15 @@ Consider how the `Array()` constructor behaves when given a single numeric argum
 
 ### --feedback--
 
-Consider how the `Array()` constructor behaves when given a single numeric argument.
+`new Array(3)` does not create an array containing the single element `3`. Passing a single numeric argument to the `Array` constructor sets the length to that number (a sparse array).
 
 ---
 
 `[<3 empty items>]`
+
+### --feedback--
+
+Some environments display sparse arrays using a notation such as `[ <3 empty items> ]`. This is another visual representation that indicates three empty slots. The lesson prefers the CodePen-style `[ , , ]` for clarity in examples.
 
 ## --video-solution--
 


### PR DESCRIPTION
Closes #63990

This PR applies the minimal update requested in the issue:

- Removes the `interactive_editor` wrapper only for the `emptyArray = new Array(5)` example.
- Updates the displayed output from `[undefined, undefined, ...]` to `[ , , , , ]`.
- Updates the comprehension question for `new Array(3)` to display `[ , , ]`.

No other examples, wording, or interactive editors were modified. Tested locally in VS Code.

- [x] I have read and followed the contribution guidelines.
- [x] I have read and followed the how-to-open-a-pull-request guide.
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes locally.
