### PR TITLE
fix(client): include colab challenge type in project based check

### DIFF
--- a/client/src/utils/curriculum-layout.test.ts
+++ b/client/src/utils/curriculum-layout.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { challengeTypes } from '../../../shared-dist/config/challenge-types';
+import { isProjectBased } from './curriculum-layout';
+
+describe('isProjectBased logic', () => {
+  it('should identify a FrontEndProject as a project', () => {
+    expect(isProjectBased(challengeTypes.frontEndProject)).toBe(true);
+  });
+
+  it('should identify a Lab challenge as a project', () => {
+    expect(isProjectBased(challengeTypes.lab)).toBe(true);
+  });
+
+  it('should identify a Colab challenge as a project', () => {
+    expect(isProjectBased(challengeTypes.colab)).toBe(true);
+  });
+});

--- a/client/src/utils/curriculum-layout.ts
+++ b/client/src/utils/curriculum-layout.ts
@@ -1,7 +1,6 @@
 import { challengeTypes } from '../../../shared-dist/config/challenge-types';
 
-// Show a single project in a certification layout
-
+// Show a single project in a certification Layout
 const projectBasedChallengeTypes = [
   challengeTypes.frontEndProject,
   challengeTypes.backEndProject,
@@ -16,7 +15,8 @@ const projectBasedChallengeTypes = [
   challengeTypes.jsLab,
   challengeTypes.pyLab,
   challengeTypes.dailyChallengeJs,
-  challengeTypes.dailyChallengePy
+  challengeTypes.dailyChallengePy,
+  challengeTypes.colab
 ];
 
 export const isProjectBased = (


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #63939

**Description**
This PR fixes a bug where the URL and browser history were not updating when hovering over "Colab" based challenges in the certification map.

The issue occurred because `challengeTypes.colab` was missing from the `isProjectBased` utility function, causing the application to treat these challenges as standard steps instead of projects.

**Changes proposed:**
1. Added `challengeTypes.colab` to the `projectBasedChallengeTypes` list in `client/src/utils/curriculum-layout.ts`.
2. Added a new unit test file `client/src/utils/curriculum-layout.test.ts` to verify that `isProjectBased` correctly returns `true` for colab challenges, preventing future regressions.