### PR TITLE
feat(curriculum): enhance explanation of React keys and reconciliation

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-data-in-react/673500b41af8500191febedc.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-data-in-react/673500b41af8500191febedc.md
@@ -28,7 +28,6 @@ However, when rendering lists in React, it is important not to forget the `key` 
 
 If you forget the key, React will show a warning in the console, but it will not throw a fatal error. The application might still render and function, but you may encounter subtle bugs, especially when the list changes. These bugs can be difficult to debug because the UI might look correct initially.
 
-### Using Indexes as Keys
 
 A common mistake is to use the array index as the key, like this:
 
@@ -38,7 +37,6 @@ A common mistake is to use the array index as the key, like this:
 
 While this silences the warning, it is generally considered an anti-pattern. Using the index as a key can cause issues when the list is reordered, sorted, or filtered. React uses the key to track elements. If the list order changes, React might incorrectly reuse component state or fail to update the DOM efficiently because the keys (indexes) stay the same even if the content at that index has changed.
 
-### Unique IDs
 
 The best practice is to use a stable, unique identifier for each item. This is typically an ID from your database, like a UUID or a database ID.
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-data-in-react/673500b41af8500191febedc.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-data-in-react/673500b41af8500191febedc.md
@@ -28,7 +28,6 @@ However, when rendering lists in React, it is important not to forget the `key` 
 
 If you forget the key, React will show a warning in the console, but it will not throw a fatal error. The application might still render and function, but you may encounter subtle bugs, especially when the list changes. These bugs can be difficult to debug because the UI might look correct initially.
 
-
 A common mistake is to use the array index as the key, like this:
 
 ```jsx
@@ -36,7 +35,6 @@ A common mistake is to use the array index as the key, like this:
 ```
 
 While this silences the warning, it is generally considered an anti-pattern. Using the index as a key can cause issues when the list is reordered, sorted, or filtered. React uses the key to track elements. If the list order changes, React might incorrectly reuse component state or fail to update the DOM efficiently because the keys (indexes) stay the same even if the content at that index has changed.
-
 
 The best practice is to use a stable, unique identifier for each item. This is typically an ID from your database, like a UUID or a database ID.
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-data-in-react/673500b41af8500191febedc.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-data-in-react/673500b41af8500191febedc.md
@@ -24,7 +24,25 @@ function FruitList() {
 
 In this example, the `map` function iterates over each item in the `fruits` array. For each fruit, it creates a new `li` element containing the fruit's name. The newly created array of `li` elements is then displayed inside the `ul` parent tags.
 
-However, when rendering lists in React, it is important not to forget the `key` prop for each element in the list. The key must always be unique and it helps React identify which items have changed, been added, or been removed, which is essential for efficient rendering and updating the list. 
+However, when rendering lists in React, it is important not to forget the `key` prop for each element in the list. The key must always be unique and it helps React identify which items have changed, been added, or been removed, which is essential for efficient rendering and updating the list.
+
+If you forget the key, React will show a warning in the console, but it will not throw a fatal error. The application might still render and function, but you may encounter subtle bugs, especially when the list changes. These bugs can be difficult to debug because the UI might look correct initially.
+
+### Using Indexes as Keys
+
+A common mistake is to use the array index as the key, like this:
+
+```jsx
+{fruits.map((fruit, index) => <li key={index}>{fruit}</li>)}
+```
+
+While this silences the warning, it is generally considered an anti-pattern. Using the index as a key can cause issues when the list is reordered, sorted, or filtered. React uses the key to track elements. If the list order changes, React might incorrectly reuse component state or fail to update the DOM efficiently because the keys (indexes) stay the same even if the content at that index has changed.
+
+### Unique IDs
+
+The best practice is to use a stable, unique identifier for each item. This is typically an ID from your database, like a UUID or a database ID.
+
+If your data doesn't have a unique ID, you can generate one when the data is created (e.g., using `crypto.randomUUID()` or a library like `uuid`), or use a combination of fields that are guaranteed to be unique. However, you should avoid generating keys on the fly during rendering (e.g., `key={Math.random()}`), as this will cause React to recreate the DOM elements on every render, hurting performance and losing focus/state. 
 
 Let's modify our example to include keys:
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-data-in-react/673500b41af8500191febedc.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-data-in-react/673500b41af8500191febedc.md
@@ -38,7 +38,7 @@ While this silences the warning, it is generally considered an anti-pattern. Usi
 
 The best practice is to use a stable, unique identifier for each item. This is typically an ID from your database, like a UUID or a database ID.
 
-If your data doesn't have a unique ID, you can generate one when the data is created (e.g., using `crypto.randomUUID()` or a library like `uuid`), or use a combination of fields that are guaranteed to be unique. However, you should avoid generating keys on the fly during rendering (e.g., `key={Math.random()}`), as this will cause React to recreate the DOM elements on every render, hurting performance and losing focus/state. 
+If your data doesn't have a unique ID, you can generate one when the data is created (e.g., using `crypto.randomUUID()` or a library like `uuid`), or use a combination of fields that are guaranteed to be unique. However, you should avoid generating keys on the fly during rendering (e.g., `key={Math.random()}`), as this will cause React to recreate the DOM elements on every render and reset their state.
 
 Let's modify our example to include keys:
 

--- a/curriculum/challenges/english/blocks/react/5a24c314108439a4d403618b.md
+++ b/curriculum/challenges/english/blocks/react/5a24c314108439a4d403618b.md
@@ -8,9 +8,43 @@ dashedName: give-sibling-elements-a-unique-key-attribute
 
 # --description--
 
-The last challenge showed how the `map` method is used to dynamically render a number of elements based on user input. However, there was an important piece missing from that example. When you create an array of elements, each one needs a `key` attribute set to a unique value. React uses these keys to keep track of which items are added, changed, or removed. This helps make the re-rendering process more efficient when the list is modified in any way.  
+The last challenge showed how the `map` method is used to dynamically render a number of elements based on user input. However, there was an important piece missing from that example. When you create an array of elements, each one needs a `key` attribute set to a unique value. React uses these keys to keep track of which items are added, changed, or removed. This helps make the re-rendering process more efficient when the list is modified in any way.
 
 **Note:** Keys only need to be unique between sibling elements, they don't need to be globally unique in your application.
+
+### Warning vs. Error
+
+It is important to note that if you forget to provide a `key` prop, React will not throw a fatal error that stops your app. Instead, you will see a warning in the console. While your UI might still render correctly in simple cases, missing keys can lead to hard-to-debug issues with component state and focus management.
+
+### Index as Key Anti-pattern
+
+You might be tempted to use the array index as the key, like this:
+
+```jsx
+// Bad Practice: Using index as key
+{todos.map((todo, index) => (
+  <li key={index}>{todo.text}</li>
+))}
+```
+
+This is generally considered an anti-pattern. If your list can be reordered, sorted, or filtered, using the index as a key can cause React to incorrectly identify elements. This can lead to performance issues and subtle bugs where the state of one component "leaks" into another.
+
+**Note:** For this specific challenge, the `frontEndFrameworks` array is static (it will not change order). In this case, using the index as a key is acceptable and is the expected solution. However, in most real-world applications with dynamic data, you should use a unique ID.
+
+### Unique IDs & Reconciliation
+
+The best practice is to use a stable, unique identifier for each item, such as an ID from your database or a UUID.
+
+```jsx
+// Best Practice: Using unique ID as key
+{todos.map((todo) => (
+  <li key={todo.id}>{todo.text}</li>
+))}
+```
+
+**Why is this important?**
+
+React uses a process called **Reconciliation** to update the DOM. When a list changes, React compares the new list with the old one. Keys act as stable identities for your elements. If an item's key stays the same, React knows it's the same component and can just update it. If the key changes (or if you use indices and the order changes), React might destroy and recreate the component unnecessarily, or worse, update the wrong component with the wrong state.
 
 # --instructions--
 

--- a/curriculum/challenges/english/blocks/react/5a24c314108439a4d403618b.md
+++ b/curriculum/challenges/english/blocks/react/5a24c314108439a4d403618b.md
@@ -8,43 +8,9 @@ dashedName: give-sibling-elements-a-unique-key-attribute
 
 # --description--
 
-The last challenge showed how the `map` method is used to dynamically render a number of elements based on user input. However, there was an important piece missing from that example. When you create an array of elements, each one needs a `key` attribute set to a unique value. React uses these keys to keep track of which items are added, changed, or removed. This helps make the re-rendering process more efficient when the list is modified in any way.
+The last challenge showed how the `map` method is used to dynamically render a number of elements based on user input. However, there was an important piece missing from that example. When you create an array of elements, each one needs a `key` attribute set to a unique value. React uses these keys to keep track of which items are added, changed, or removed. This helps make the re-rendering process more efficient when the list is modified in any way.  
 
 **Note:** Keys only need to be unique between sibling elements, they don't need to be globally unique in your application.
-
-### Warning vs. Error
-
-It is important to note that if you forget to provide a `key` prop, React will not throw a fatal error that stops your app. Instead, you will see a warning in the console. While your UI might still render correctly in simple cases, missing keys can lead to hard-to-debug issues with component state and focus management.
-
-### Index as Key Anti-pattern
-
-You might be tempted to use the array index as the key, like this:
-
-```jsx
-// Bad Practice: Using index as key
-{todos.map((todo, index) => (
-  <li key={index}>{todo.text}</li>
-))}
-```
-
-This is generally considered an anti-pattern. If your list can be reordered, sorted, or filtered, using the index as a key can cause React to incorrectly identify elements. This can lead to performance issues and subtle bugs where the state of one component "leaks" into another.
-
-**Note:** For this specific challenge, the `frontEndFrameworks` array is static (it will not change order). In this case, using the index as a key is acceptable and is the expected solution. However, in most real-world applications with dynamic data, you should use a unique ID.
-
-### Unique IDs & Reconciliation
-
-The best practice is to use a stable, unique identifier for each item, such as an ID from your database or a UUID.
-
-```jsx
-// Best Practice: Using unique ID as key
-{todos.map((todo) => (
-  <li key={todo.id}>{todo.text}</li>
-))}
-```
-
-**Why is this important?**
-
-React uses a process called **Reconciliation** to update the DOM. When a list changes, React compares the new list with the old one. Keys act as stable identities for your elements. If an item's key stays the same, React knows it's the same component and can just update it. If the key changes (or if you use indices and the order changes), React might destroy and recreate the component unnecessarily, or worse, update the wrong component with the wrong state.
 
 # --instructions--
 


### PR DESCRIPTION
This PR updates the description for the "Give Sibling Elements a Unique Key Attribute" lesson in the Front End Development Libraries certification.

**Changes proposed in this pull request:**

- Clarified the distinction between console warnings and fatal errors when missing keys.
- Explained the "Index as Key" anti-pattern and why it causes issues in dynamic lists.
- Added a note to clarify that using the index is acceptable for this specific challenge (since the list is static), reducing cognitive dissonance for learners.
- Expanded on the concept of **Reconciliation** to explain *why* React needs unique IDs for performance and state management.

Closes #64003

---

**Checklist:**

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.