### PR TITLE
Add tests for module progress in SuperBlockAccordion

### DIFF
--- a/client/src/templates/Introduction/components/super-block-accordion.test.tsx
+++ b/client/src/templates/Introduction/components/super-block-accordion.test.tsx
@@ -40,4 +40,114 @@ describe('SuperBlockAccordion', () => {
     const checkmark = within(chapterButton).getByTestId('green-not-completed');
     expect(checkmark).toBeInTheDocument();
   });
+
+    it('displays module progress when totalSteps is provided and module is not coming soon', () => {
+    const mockWithProgress = {
+      superBlock: SuperBlocks.RespWebDesign,
+      chapters: [
+        {
+          dashedName: 'test-chapter',
+          modules: [
+            {
+              dashedName: 'test-module',
+              blocks: ['test-block']
+            }
+          ]
+        }
+      ]
+    };
+
+    const mockChallenge = {
+      id: 'test-challenge-id',
+      block: 'test-block',
+      title: 'Test Challenge',
+      fields: { slug: '/test-slug' },
+      dashedName: 'test-challenge',
+      challengeType: 0,
+      superBlock: SuperBlocks.RespWebDesign
+    };
+
+    render(
+      <SuperBlockAccordion
+        challenges={[mockChallenge]}
+        superBlock={SuperBlocks.RespWebDesign}
+        structure={mockWithProgress}
+        chosenBlock={'test-block'}
+        completedChallengeIds={[]}
+      />
+    );
+
+    const moduleSteps = screen.getByText(/0 of 1 steps completed/i);
+    expect(moduleSteps).toBeInTheDocument();
+    expect(moduleSteps).toHaveClass('module-steps');
+  });
+
+  it('does not display module progress when module is coming soon', () => {
+    const mockComingSoon = {
+      superBlock: SuperBlocks.RespWebDesign,
+      chapters: [
+        {
+          dashedName: 'test-chapter',
+          modules: [
+            {
+              dashedName: 'test-module',
+              blocks: ['test-block'],
+              comingSoon: true
+            }
+          ]
+        }
+      ]
+    };
+
+    const mockChallenge = {
+      id: 'test-challenge-id',
+      block: 'test-block',
+      title: 'Test Challenge',
+      fields: { slug: '/test-slug' },
+      dashedName: 'test-challenge',
+      challengeType: 0,
+      superBlock: SuperBlocks.RespWebDesign
+    };
+
+    render(
+      <SuperBlockAccordion
+        challenges={[mockChallenge]}
+        superBlock={SuperBlocks.RespWebDesign}
+        structure={mockComingSoon}
+        chosenBlock={'test-block'}
+        completedChallengeIds={[]}
+      />
+    );
+
+    expect(screen.queryByText(/steps completed/i)).not.toBeInTheDocument();
+  });
+
+  it('does not display module progress when totalSteps is zero', () => {
+    const mockNoSteps = {
+      superBlock: SuperBlocks.RespWebDesign,
+      chapters: [
+        {
+          dashedName: 'test-chapter',
+          modules: [
+            {
+              dashedName: 'test-module',
+              blocks: []
+            }
+          ]
+        }
+      ]
+    };
+
+    render(
+      <SuperBlockAccordion
+        challenges={[]}
+        superBlock={SuperBlocks.RespWebDesign}
+        structure={mockNoSteps}
+        chosenBlock={''}
+        completedChallengeIds={[]}
+      />
+    );
+
+    expect(screen.queryByText(/steps completed/i)).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
This PR adds test coverage for the module progress feature that was introduced in PR #63966.

Tests added:
- Verify that module progress is displayed when totalSteps is provided and the module is not coming soon
- Verify that module progress is NOT displayed when the module is marked as coming soon
- Verify that module progress is NOT displayed when totalSteps is zero (no challenges in module)

Fixes #63994

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ ] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
