### PR TITLE
docs(curriculum): add explanation for inline styles double curlies sy…

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-data-in-react/673500bfe1f41601c1ddb1a2.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-data-in-react/673500bfe1f41601c1ddb1a2.md
@@ -50,6 +50,8 @@ function Button({ buttonText }) {
 }
 ```
 
+You might notice the "double curlies" syntax `{{}}` in this example. The outer set of curly braces `{}` tells JSX that we're embedding a JavaScript expression, while the inner set of curly braces `{}` represents the JavaScript object containing our style properties. This is a common pattern in React that can initially be confusing for newcomers. Think of it this way: `style={styleObject}` where `styleObject` happens to be defined inline as `{backgroundColor: "#007BFF", color: "white"}`.
+
 Sometimes you might want to pass in an object directly if there are only a few properties like shown here. Otherwise, passing in a name to an object would be better like in the first example.
 
 It's important to note that while CSS property names are typically written in kebab case, like `font-size`, in React's inline styles, we use camel case, like `fontSize`. This is because the style object is a JavaScript object, and kebab case names are not valid as object keys in JavaScript without using quotes.


### PR DESCRIPTION
…ntax

Addresses issue #64002

Added explanation about the "double curlies" syntax {{}} used in inline styles. Clarified that the outer curly braces are for JSX expression embedding while the inner curly braces represent the JavaScript object containing style properties.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ ] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
