### PR TITLE
fix(curriculum): trim whitespace in address innerText assertion for accessibility quiz

### DIFF
--- a/curriculum/challenges/english/blocks/learn-accessibility-by-building-a-quiz/6145f8f8bcd4370f6509078e.md
+++ b/curriculum/challenges/english/blocks/learn-accessibility-by-building-a-quiz/6145f8f8bcd4370f6509078e.md
@@ -23,7 +23,7 @@ The `br` tags will allow each part of the address to be on its own line and are 
 You should add the above text including the `<br />` tags to the `address` element.
 
 ```js
-assert.equal(document.querySelector('address')?.innerText, 'freeCodeCamp\nSan Francisco\nCalifornia\nUSA');
+assert.equal(document.querySelector('address')?.innerText.trim(), 'freeCodeCamp\nSan Francisco\nCalifornia\nUSA');
 ```
 
 # --seed--
@@ -145,7 +145,7 @@ assert.equal(document.querySelector('address')?.innerText, 'freeCodeCamp\nSan Fr
 --fcc-editable-region--
     <footer>
       <address>
-
+        
       </address>
     </footer>
 --fcc-editable-region--


### PR DESCRIPTION
### Checklist
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org/).
- [x] I have tested these changes locally.

### Description
This PR improves the robustness of the assertion in **Learn Accessibility by Building a Quiz (Step 43)**.

Currently, the test uses a strict `innerText` equality check against the address string. This causes a **False Negative** if a student formats their HTML code with indentation or newlines (a common best practice), as `innerText` preserves this whitespace in the testing environment.

### Diagnosis
Using a local reproduction with JSDOM, I confirmed that adding standard indentation to the `<address>` element causes the test to fail:
```text
AssertionError: expected '\n  freeCodeCamp\n  San Francisco...' to equal 'freeCodeCamp\nSan Francisco...'
The Fix
Applied .trim() to the innerText before comparison to normalize whitespace.

JavaScript

// Before:
assert.equal(document.querySelector('address')?.innerText, '...');

// After:
assert.equal(document.querySelector('address')?.innerText.trim(), '...');
Related Issue
Closes #64036