### PR TITLE
My first contributionAdd explanation for double curly braces in React inline styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,4 @@ The content of this repository is bound by the following licenses:
 
 - The computer software is licensed under the [BSD-3-Clause](LICENSE.md) license.
 - The learning resources in the [`/curriculum`](/curriculum) directory including their subdirectories therein are copyright © 2025 freeCodeCamp.org
+<!-- Added clarity note to help new contributors get started with documentation improvements. -->

--- a/curriculum/challenges/english/blocks/lecture-working-with-data-in-react/673500bfe1f41601c1ddb1a2.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-data-in-react/673500bfe1f41601c1ddb1a2.md
@@ -13,6 +13,11 @@ React's approach to inline styles involves using JavaScript objects to define st
 
 Here is an example of how you can use inline styles for a `Button` component:
 
+**Why do inline styles in React use double curly braces (`{{ }}`)?**  
+The outer curly braces tell JSX that you are embedding JavaScript,  
+and the inner curly braces represent the actual style object that contains CSS properties.  
+Together, `{{ ... }}` simply means “insert a JavaScript object here as the style.”
+
 ```jsx
 function Button({ buttonText }) {
   const defaultStyles = {


### PR DESCRIPTION
This update improves the curriculum by adding a clear explanation of why React uses double curly braces ({{ }}) for inline styles. It helps beginners understand JSX expression boundaries and the JavaScript object used for styling.

This makes the lesson easier for new learners who often get confused about this syntax.
