### PR TITLE
fix(client): only show missing prerequisites if signed in

### DIFF
--- a/client/src/templates/Challenges/exam-download/show.tsx
+++ b/client/src/templates/Challenges/exam-download/show.tsx
@@ -246,7 +246,10 @@ function ShowExamDownload({
               {title}
             </ChallengeTitle>
             <Spacer size='m' />
-            {missingPrerequisites.length > 0 ? (
+            {isSignedIn &&
+            !examIdsQuery.isLoading &&
+            !getExamsQuery.isLoading &&
+            missingPrerequisites.length > 0 ? (
               <MissingPrerequisites
                 missingPrerequisites={missingPrerequisites}
               />

--- a/client/src/templates/Challenges/exam-download/show.tsx
+++ b/client/src/templates/Challenges/exam-download/show.tsx
@@ -228,6 +228,9 @@ function ShowExamDownload({
     };
   });
 
+  const showPrereqAlert =
+    isSignedIn && !examIdsQuery.isLoading && !getExamsQuery.isLoading;
+
   return (
     <LearnLayout>
       <Helmet>
@@ -246,18 +249,16 @@ function ShowExamDownload({
               {title}
             </ChallengeTitle>
             <Spacer size='m' />
-            {isSignedIn &&
-            !examIdsQuery.isLoading &&
-            !getExamsQuery.isLoading &&
-            missingPrerequisites.length > 0 ? (
-              <MissingPrerequisites
-                missingPrerequisites={missingPrerequisites}
-              />
-            ) : (
-              <Callout className='exam-qualified' variant='info'>
-                <p>{t('learn.exam.qualified')}</p>
-              </Callout>
-            )}
+            {showPrereqAlert &&
+              (missingPrerequisites.length > 0 ? (
+                <MissingPrerequisites
+                  missingPrerequisites={missingPrerequisites}
+                />
+              ) : (
+                <Callout className='exam-qualified' variant='info'>
+                  <p>{t('learn.exam.qualified')}</p>
+                </Callout>
+              ))}
             <h2>{t('exam.download-header')}</h2>
             <p>{t('exam.explanation')}</p>
             <Spacer size='l' />


### PR DESCRIPTION
Also, do not show missing prerequisites success message unless data is finished loading

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Fixes:
a) Missing Prerequisites "congratulations" message showing up for signed-out users
b) "Congrats" message showing whilst prerequisite data is loading