### PR TITLE
fix: update lint-staged config to format markdown files correctly

### DIFF
--- a/.lintstagedrc.mjs
+++ b/.lintstagedrc.mjs
@@ -1,7 +1,4 @@
+/* eslint-disable filenames-simple/naming-convention */
 import { createLintStagedConfig } from '@freecodecamp/eslint-config/lintstaged';
 
-export default {
-  ...createLintStagedConfig(import.meta.dirname),
-  './curriculum/challenges/**/*.md': files =>
-    files.map(filename => `node ./tools/scripts/lint/index.js '${filename}'`)
-};
+export default createLintStagedConfig(import.meta.dirname);

--- a/curriculum/.lintstagedrc.mjs
+++ b/curriculum/.lintstagedrc.mjs
@@ -1,4 +1,8 @@
 /* eslint-disable filenames-simple/naming-convention */
 import { createLintStagedConfig } from '@freecodecamp/eslint-config/lintstaged';
 
-export default createLintStagedConfig(import.meta.dirname);
+export default {
+  ...createLintStagedConfig(import.meta.dirname),
+  './challenges/**/*.md': files =>
+    files.map(filename => `node ../tools/scripts/lint/index.js '${filename}'`)
+};

--- a/packages/eslint-config/.lintstagedrc.js
+++ b/packages/eslint-config/.lintstagedrc.js
@@ -24,7 +24,7 @@ export const createLintStagedConfig = cwd => {
             ...prettierCommand
           ];
     },
-    '*.!(mjs|js|ts|tsx|css)': files =>
+    '*.!(mjs|js|ts|tsx|css|md)': files =>
       files.map(filename => `prettier --write --ignore-unknown '${filename}'`),
 
     '*.css': files => [


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Challenge files are not being formatted properly, as they get processed by Prettier.

To reproduce:
- Open a challenge file and change a word, for example: `66c64ad16796c7f2419b45c5.md`
- Commit the change
- See that the `--fcc-editable-region--` gets formatted to `--fcc - editable - region--;`

---

The cause is that we recently moved lintstaged to per workspace (#63835), with:
- The curriculum lintstaged using the base config, without any custom rules:
  - https://github.com/freeCodeCamp/freeCodeCamp/blob/b85cbc0fdf2f42f463b45f51923eb84c4b3d513e/curriculum/.lintstagedrc.mjs#L4
- While the base config doesn't exclude `.md` from Prettier:
  - https://github.com/freeCodeCamp/freeCodeCamp/blob/b85cbc0fdf2f42f463b45f51923eb84c4b3d513e/packages/eslint-config/.lintstagedrc.js#L27-L28
- And the curriculum config relies on the root config for markdown rule instead:
  - https://github.com/freeCodeCamp/freeCodeCamp/blob/b85cbc0fdf2f42f463b45f51923eb84c4b3d513e/.lintstagedrc.mjs#L5-L6

The issue is, `lint-staged` only uses the nearest config, so the root config becomes ineffective: https://github.com/lint-staged/lint-staged#how-to-use-lint-staged-in-a-multi-package-monorepo, and the markdown files end up being formatted by Prettier.

---

The fix:
- Add `md` to the base config, so Prettier skips them
- Add curriculum-specific rule to `curriculum/.lintstagedrc.mjs`
- Remove the curriculum rule from the root config, since it has no effect.

<!-- Feel free to add any additional description of changes below this line -->
