### PR TITLE
Fix(curriculam) :minor grammatical error in installation instructions…

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-introduction-to-python/67fe8567f141d632afaeb71b.md
+++ b/curriculum/challenges/english/blocks/lecture-introduction-to-python/67fe8567f141d632afaeb71b.md
@@ -18,7 +18,7 @@ We'll go over how to install Python on a computer running macOS first:
 - Click on the button showing the current version of Python (from the previous modal), and you'll start downloading a `.pkg` installation file automatically.
 - Once the `.pkg` installer is finished downloading, open it, then click "Continue" in the window that opens up.
 - Continue clicking the "Continue" button until you get to the "Installation Type" section. There, click the "Install" button.
-- Enter in your password if necessary, then start the installation.
+- Enter your password if necessary, then start the installation.
 - After that, you should get a congratulations message saying that Python has been successfully installed.
 - Click the "Close" button, and you're done!
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #64029

<!-- Feel free to add any additional description of changes below this line -->

What this PR is about?
Fixes #64029

Describing the Issue
Remove the 'in' from sentence  : It is unnessasary in the sentence 'Enter in the password'

Steps to Reproduce
Visit page https://www.freecodecamp.org/learn/python-v9/lecture-introduction-to-python/how-do-you-install-configure-and-use-python-in-your-local-environment and search for 'enter in'
<img width="1143" height="398" alt="image" src="https://github.com/user-attachments/assets/9b03fb8b-9a20-483a-806a-08be581c5f76" />

What i did
Removed 'in' from the file:
https://github.com/freeCodeCamp/freeCodeCamp/blob/main/curriculum/challenges/english/blocks/lecture-introduction-to-python/67fe8567f141d632afaeb71b.md