### PR TITLE
docs: remove unnecessary 'in' to improve sentence clarity

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-introduction-to-python/67fe8567f141d632afaeb71b.md
+++ b/curriculum/challenges/english/blocks/lecture-introduction-to-python/67fe8567f141d632afaeb71b.md
@@ -18,7 +18,7 @@ We'll go over how to install Python on a computer running macOS first:
 - Click on the button showing the current version of Python (from the previous modal), and you'll start downloading a `.pkg` installation file automatically.
 - Once the `.pkg` installer is finished downloading, open it, then click "Continue" in the window that opens up.
 - Continue clicking the "Continue" button until you get to the "Installation Type" section. There, click the "Install" button.
-- Enter in your password if necessary, then start the installation.
+- Enter your password if necessary, then start the installation.
 - After that, you should get a congratulations message saying that Python has been successfully installed.
 - Click the "Close" button, and you're done!
 


### PR DESCRIPTION
Closes #64029

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine or on GitHub Codespaces.

---

### Description

This pull request fixes a typo in the curriculum content where the sentence:

> "Enter in your password if necessary"

was corrected to:

> "Enter your password if necessary"

This improves clarity by removing unnecessary wording.  
No functional changes — curriculum text cleanup only.
