### PR TITLE
fix(curriculum): correct hint formatting in email simulator step 5

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-email-simulator/68593ea22eac7e228ed585ce.md
+++ b/curriculum/challenges/english/blocks/workshop-email-simulator/68593ea22eac7e228ed585ce.md
@@ -11,7 +11,7 @@ Emails should track whether they've been read or not. Add a `read` attribute to 
 
 # --hints--
 
-You should assign `False` to ``self.read` in the `__init__` method.
+You should assign `False` to `self.read` in the `__init__` method.
 
 ```js
 ({ 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes on GitHub Codespaces.

Closes #64076

Description

Fixed a formatting issue in the hint text for the Email Simulator Workshop Step 5. The hint was displaying incorrectly due to malformed backticks and concatenated words.

**Before**: 
<img width="681" height="110" alt="image" src="https://github.com/user-attachments/assets/d62c792b-bfcf-4dea-bf3e-b0bfd3f0524c" />


**After**: "You should assign `False` to `self.read` in the `__init__` method."

This ensures proper inline code formatting and readability for students.
