### PR TITLE
fix(curriculum/english): remove extra backtick in Modal Verbs task

### DIFF
--- a/curriculum/challenges/english/blocks/learn-how-to-use-modal-verbs/67d839c6ac9ce79b6ea7745d.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-modal-verbs/67d839c6ac9ce79b6ea7745d.md
@@ -52,7 +52,7 @@ Lisa does not want to review employee access logs.
 
 # --explanation--
 
-``Extent` refers to the degree, scope, or limit of something. It's often used to describe how large, serious, or severe something is. For example:
+`Extent` refers to the degree, scope, or limit of something. It's often used to describe how large, serious, or severe something is. For example:
 
 - `We don't know the extent of the damage yet.` - They are not sure how bad the damage is.
 


### PR DESCRIPTION
Removed an extra leading backtick in the "Learn How to Use Modal Verbs — Task 143" lesson so the Markdown renders correctly.

Checklist:
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.


Closes #64086