### PR TITLE
fix(curriculum): remove unnecessary double backticks 

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-common-array-methods/67329f64e0ef5c5b7388158d.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-common-array-methods/67329f64e0ef5c5b7388158d.md
@@ -73,7 +73,7 @@ console.log(index);
 
 ### --feedback--
 
-The ``indexOf()`` method returns the index of the first occurrence of the given element in the array.
+The `indexOf()` method returns the index of the first occurrence of the given element in the array.
 
 ---
 
@@ -85,7 +85,7 @@ The ``indexOf()`` method returns the index of the first occurrence of the given 
 
 ### --feedback--
 
-The ``indexOf()`` method returns the index of the first occurrence of the given element in the array.
+The `indexOf()` method returns the index of the first occurrence of the given element in the array.
 
 ---
 
@@ -93,7 +93,7 @@ The ``indexOf()`` method returns the index of the first occurrence of the given 
 
 ### --feedback--
 
-The ``indexOf()`` method returns the index of the first occurrence of the given element in the array.
+The `indexOf()` method returns the index of the first occurrence of the given element in the array.
 
 ## --video-solution--
 
@@ -115,7 +115,7 @@ console.log(index);
 
 ### --feedback--
 
-The ``indexOf()`` method returns `-1` if the given element is not found in the array.
+The `indexOf()` method returns `-1` if the given element is not found in the array.
 
 ---
 
@@ -127,7 +127,7 @@ The ``indexOf()`` method returns `-1` if the given element is not found in the a
 
 ### --feedback--
 
-The ``indexOf()`` method returns `-1` if the given element is not found in the array.
+The `indexOf()` method returns `-1` if the given element is not found in the array.
 
 ---
 
@@ -135,7 +135,7 @@ An error will occur.
 
 ### --feedback--
 
-The ``indexOf()`` method returns `-1` if the given element is not found in the array.
+The `indexOf()` method returns `-1` if the given element is not found in the array.
 
 ## --video-solution--
 
@@ -157,7 +157,7 @@ console.log(index);
 
 ### --feedback--
 
-The ``indexOf()`` method can take a second argument to specify the starting index for the search.
+The `indexOf()` method can take a second argument to specify the starting index for the search.
 
 ---
 
@@ -165,7 +165,7 @@ The ``indexOf()`` method can take a second argument to specify the starting inde
 
 ### --feedback--
 
-The ``indexOf()`` method can take a second argument to specify the starting index for the search.
+The `indexOf()` method can take a second argument to specify the starting index for the search.
 
 ---
 
@@ -177,7 +177,7 @@ The ``indexOf()`` method can take a second argument to specify the starting inde
 
 ### --feedback--
 
-The ``indexOf()`` method can take a second argument to specify the starting index for the search.
+The `indexOf()` method can take a second argument to specify the starting index for the search.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-common-array-methods/6732b284901f8c1539e20bcb.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-common-array-methods/6732b284901f8c1539e20bcb.md
@@ -135,7 +135,7 @@ console.log(arr);
 
 ### --feedback--
 
-Consider what the second parameter (`0`) means in the ``splice()`` method.
+Consider what the second parameter (`0`) means in the `splice()` method.
 
 ---
 
@@ -143,7 +143,7 @@ Consider what the second parameter (`0`) means in the ``splice()`` method.
 
 ### --feedback--
 
-Consider what the second parameter (`0`) means in the ``splice()`` method.
+Consider what the second parameter (`0`) means in the `splice()` method.
 
 ---
 
@@ -151,7 +151,7 @@ Consider what the second parameter (`0`) means in the ``splice()`` method.
 
 ### --feedback--
 
-Consider what the second parameter (`0`) means in the ``splice()`` method.
+Consider what the second parameter (`0`) means in the `splice()` method.
 
 ## --video-solution--
 
@@ -199,7 +199,7 @@ Remember, array indices start from 0.
 
 ## --text--
 
-What does the ``splice()`` method return?
+What does the `splice()` method return?
 
 ## --answers--
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-common-array-methods/6732b28eeadda1158cdbff7b.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-common-array-methods/6732b28eeadda1158cdbff7b.md
@@ -86,7 +86,7 @@ console.log(arr.includes(3, 3));
 
 ### --feedback--
 
-The second parameter of ``includes()`` specifies the starting position for the search.
+The second parameter of `includes()` specifies the starting position for the search.
 
 ---
 
@@ -98,7 +98,7 @@ The second parameter of ``includes()`` specifies the starting position for the s
 
 ### --feedback--
 
-The second parameter of ``includes()`` specifies the starting position for the search.
+The second parameter of `includes()` specifies the starting position for the search.
 
 ---
 
@@ -106,7 +106,7 @@ This will throw an error.
 
 ### --feedback--
 
-The second parameter of ``includes()`` specifies the starting position for the search.
+The second parameter of `includes()` specifies the starting position for the search.
 
 ## --video-solution--
 
@@ -127,7 +127,7 @@ console.log(arr.includes("C"));
 
 ### --feedback--
 
-Remember that ``includes()`` is case-sensitive when dealing with strings.
+Remember that `includes()` is case-sensitive when dealing with strings.
 
 ---
 
@@ -139,7 +139,7 @@ Remember that ``includes()`` is case-sensitive when dealing with strings.
 
 ### --feedback--
 
-Remember that ``includes()`` is case-sensitive when dealing with strings.
+Remember that `includes()` is case-sensitive when dealing with strings.
 
 ---
 
@@ -147,7 +147,7 @@ This will throw an error.
 
 ### --feedback--
 
-Remember that ``includes()`` is case-sensitive when dealing with strings.
+Remember that `includes()` is case-sensitive when dealing with strings.
 
 ## --video-solution--
 
@@ -168,7 +168,7 @@ console.log(arr.includes("3"));
 
 ### --feedback--
 
-The ``includes()`` method uses strict equality (`===`) for comparison.
+The `includes()` method uses strict equality (`===`) for comparison.
 
 ---
 
@@ -180,7 +180,7 @@ The ``includes()`` method uses strict equality (`===`) for comparison.
 
 ### --feedback--
 
-The ``includes()`` method uses strict equality (`===`) for comparison.
+The `includes()` method uses strict equality (`===`) for comparison.
 
 ---
 
@@ -188,7 +188,7 @@ This will throw an error.
 
 ### --feedback--
 
-The ``includes()`` method uses strict equality (`===`) for comparison.
+The `includes()` method uses strict equality (`===`) for comparison.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-conditional-logic-and-math-methods/6732720e95f6a0db526a2e4d.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-conditional-logic-and-math-methods/6732720e95f6a0db526a2e4d.md
@@ -187,7 +187,7 @@ Think about when you want to provide a fallback value.
 
 ---
 
-It returns the second value only if the first is ``null`` or `undefined`.
+It returns the second value only if the first is `null` or `undefined`.
 
 ---
 

--- a/curriculum/challenges/english/blocks/quiz-python-basics/67f41242431cbf3db8ca79c7.md
+++ b/curriculum/challenges/english/blocks/quiz-python-basics/67f41242431cbf3db8ca79c7.md
@@ -390,7 +390,7 @@ print(joined_str)  # ?
 
 ---
 
-``'dashed name'``
+`'dashed name'`
 
 ---
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #64089

<!-- Feel free to add any additional description of changes below this line -->

### Description of Changes
This PR removes unnecessary double backticks from inline code examples across curriculum markdown files.
