### PR TITLE
fix : Improve Streak Calculation Logic (Grace Period Fix)

### DIFF
--- a/client/src/components/profile/components/stats.test.tsx
+++ b/client/src/components/profile/components/stats.test.tsx
@@ -74,7 +74,20 @@ vi.useFakeTimers();
 
 describe('calculateStreaks', () => {
   beforeEach(() => vi.setSystemTime(new Date(2025, 0, 15)));
-  test('Should return 0 for the current streak if the user has not made progress today', () => {
+  test('Should maintain the current streak if the user has made progress in the last 2 days', () => {
+    // oldStreakCalendar has last activity on Jan 14, and we're testing on Jan 15
+    // This is within the grace period, so streak should be maintained
+    const { longestStreak, currentStreak } =
+      calculateStreaks(oldStreakCalendar);
+
+    expect(longestStreak).toBe(5);
+    expect(currentStreak).toBe(5);
+  });
+
+  test('Should reset the current streak if more than 1 day has passed since the last activity', () => {
+    // oldStreakCalendar has last activity on Jan 14, and we're testing on Jan 16
+    // This is beyond the grace period, so streak should be reset
+    vi.setSystemTime(new Date(2025, 0, 16));
     const { longestStreak, currentStreak } =
       calculateStreaks(oldStreakCalendar);
 

--- a/client/src/components/profile/components/stats.tsx
+++ b/client/src/components/profile/components/stats.tsx
@@ -42,7 +42,10 @@ export const calculateStreaks = (calendar: Record<string, number>) => {
   );
 
   const lastDay = last(days);
-  const streakExpired = !lastDay || !isEqual(lastDay, startOfDay(Date.now()));
+  // Streak expires if more than 1 day has passed since the last activity
+  // This gives users a grace period of one full day after their last activity
+  const today = startOfDay(Date.now());
+  const streakExpired = !lastDay || addDays(lastDay, 1) < today;
 
   return { longestStreak, currentStreak: streakExpired ? 0 : currentStreak };
 };


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #64092

<!-- Feel free to add any additional description of changes below this line -->

---

# 🔧 Improve Streak Calculation Logic (Grace Period Fix)

## 📌 Summary

This PR fixes the issue where the **current streak resets to 0 immediately after the next day begins**, even before the user gets a chance to continue their progress.
A **1-day grace period** has now been added so streaks expire only when **more than one full day** has passed without activity.

---

## 🐞 Problem

The streak-widget previously used *exact date matching*:

* User completes challenge on **Jan 14**
* Day changes to **Jan 15**
* Streak resets instantly → **0** ❌
  (even though the user hasn't had a chance to play on Jan 15 yet)

This behavior feels unintuitive and inconsistent with common streak systems used across most apps.

---

## ✅ Solution

A streak is now retained if the user has activity from **within the last 2 days**.
It resets **only if** the last activity is **older than 1 full day** from today.

### New Logic:

* Activity on Jan 14
* Jan 15 → streak **continues** (within grace period)
* Jan 16 → streak **resets** (more than one full day without activity)

This makes streaks fairer, more user-friendly, and aligns with typical streak expectations.

---

## 🧠 Implementation Details

### `client/src/components/profile/components/stats.tsx`

* Updated `calculateStreaks` logic
* Implemented 1-day grace period using:

  ```ts
  const streakExpired = !lastDay || addDays(lastDay, 1) < today;
  ```
* Replaced previous day-equality check
* Added descriptive comments explaining the new behavior

### `client/src/components/profile/components/stats.test.tsx`

* Updated test titles and assertions to reflect grace period logic
* Added new test:

  * `"Should reset the current streak if more than 1 day has passed since the last activity"`
* Updated the previous expectation:

  * From `"Should return 0 for the current streak if the user has not made progress today"`
  * → To `"Should maintain the current streak if the user has made progress in the last 2 days"`

---

## 🧪 Test Results

All **11 tests** pass successfully.
<img width="1123" height="783" alt="Screenshot 2025-11-24 at 7 39 07 PM" src="https://github.com/user-attachments/assets/2f75a2b9-1b5c-4b30-8c72-04c890924399" />
The updated tests cover both grace-period cases and edge scenarios (multiple entries in a day, longest streak logic, etc.).

---

## 📂 Files Changed

- `client/src/components/profile/components/stats.tsx` — Updated grace period logic
- `client/src/components/profile/components/stats.test.tsx` — Updated and added tests

---

## 📊 Impact

* **User Experience:** Greatly improved — streaks don't suddenly drop to zero
* **Breaking Changes:** None
* **Performance:** Unaffected
* **Scope:** Only affects streak calculation and UI display logic

---

## 📝 Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

---

## ✅ PR Checklist

- [x] I have read the contributing guidelines
- [x] My code follows the style guidelines
- [x] I have tested my changes locally
- [x] All tests pass
- [x] I have not introduced breaking changes
- [x] My changes are properly documented with comments

---

## 🔗 Related Issue

Fixes the bug described in **"Calculate streaks correctly #64092"** and improves behavior for the upcoming navbar streak-widget.
