### PR TITLE
fix(curriculum): dispatch bubbling event in Theme Switcher tests

### DIFF
--- a/curriculum/challenges/english/blocks/lab-theme-switcher/687ad7be1ff45032ccf1d92f.md
+++ b/curriculum/challenges/english/blocks/lab-theme-switcher/687ad7be1ff45032ccf1d92f.md
@@ -273,10 +273,10 @@ const listItems = document.querySelectorAll("#theme-dropdown li");
 
 themeDropdownBtn.dispatchEvent(new Event("click"));
 
-const clickedItem = listItems[1]; 
-clickedItem?.dispatchEvent(new Event("click"), {bubbles: true});
+const clickedItem = listItems[1];
+clickedItem?.dispatchEvent(new Event("click", {bubbles: true}));
 
-const expectedClass = clickedItem?.id; 
+const expectedClass = clickedItem?.id;
 const actualClass = document.body.className;
 
 assert.equal(actualClass, expectedClass);
@@ -291,7 +291,7 @@ const themeDropdownBtn = document.getElementById("theme-switcher-button");
 const listItems = document.querySelectorAll("ul li");
 
 themeDropdownBtn?.dispatchEvent(new Event("click"));
-listItems[1]?.dispatchEvent(new Event("click"), {bubbles: true});
+listItems[1]?.dispatchEvent(new Event("click", {bubbles: true}));
 
 const selectedThemeName = listItems[1]?.textContent.toLowerCase().trim();
 const selectedTheme = themes?.find(theme => theme.name === selectedThemeName);


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

- - -

- `Event` constructor accepts object with event options, `dispatchEvent` method does not, causing event in test to not bubble.
- Context https://forum.freecodecamp.org/t/build-a-theme-switcher-build-a-theme-switcher/768351