### PR TITLE
fix: capitalize 'Character' in 'Build an RPG Character' title

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -4507,7 +4507,7 @@
         ]
       },
       "lab-rpg-character": {
-        "title": "Build an RPG Character",
+        "title": "Build an RPG character",
         "intro": [
           "In this lab you will practice basic python by building an RPG character."
         ]
@@ -6752,7 +6752,8 @@
         ]
       },
       "lab-rpg-character": {
-    "title": "Build an RPG Character",        "intro": [
+    "title": "Build an RPG Character",
+              "intro": [
           "In this lab you will practice basic python by building an RPG character."
         ]
       },

--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -4507,7 +4507,7 @@
         ]
       },
       "lab-rpg-character": {
-        "title": "Build an RPG character",
+        "title": "Build an RPG Character",
         "intro": [
           "In this lab you will practice basic python by building an RPG character."
         ]
@@ -6752,8 +6752,7 @@
         ]
       },
       "lab-rpg-character": {
-        "title": "Build an RPG character",
-        "intro": [
+    "title": "Build an RPG Character",        "intro": [
           "In this lab you will practice basic python by building an RPG character."
         ]
       },


### PR DESCRIPTION
Fixes #64103

Changed 'character' to 'Character' in line 6755 of intro.json to follow proper title capitalization for the 'Build an RPG Character' lesson.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org/).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #64103