### PR TITLE
fix: capitalize 'Character' in RPG challenge title

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -6752,7 +6752,7 @@
         ]
       },
       "lab-rpg-character": {
-        "title": "Build an RPG character",
+        "title": "Build an RPG Character",
         "intro": [
           "In this lab you will practice basic python by building an RPG character."
         ]


### PR DESCRIPTION
This pull request fixes the incorrect capitalization in the English intro.json file.

Issue reference: #64103

The current title reads:
"Build an RPG character"

According to the style guidelines for challenge titles, major words should be capitalized.   This PR updates the string to:

"Build an RPG Character"

This is a minor, first-timers-friendly correction aimed at improving consistency across the curriculum text.   No functional changes have been made, and this update only modifies the localized title field.

Thank you!

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the 64103 below with the issue number.-->

Closes #64103

<!-- Feel free to add any additional description of changes below this line -->
