### PR TITLE
fix: Capitalize character in RPG character title (#64103)

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -4507,7 +4507,7 @@
         ]
       },
       "lab-rpg-character": {
-        "title": "Build an RPG character",
+        "title": "Build an RPG Character",
         "intro": [
           "In this lab you will practice basic python by building an RPG character."
         ]
@@ -6752,7 +6752,7 @@
         ]
       },
       "lab-rpg-character": {
-        "title": "Build an RPG character",
+        "title": "Build an RPG Character",
         "intro": [
           "In this lab you will practice basic python by building an RPG character."
         ]


### PR DESCRIPTION
## Description

This PR addresses issue #64103 by fixing the incorrect capitalization of "character" in the RPG character title within the curriculum content.

## Changes Made

- Changed "Build an RPG character" to "Build an RPG Character" in `client/i18n/locales/english/intro.json`
- The letter 'c' in "character" is now properly capitalized to maintain consistent title capitalization throughout the curriculum
- Single-character change at line 4510

## Files Modified

- `client/i18n/locales/english/intro.json` (line 4510)