### PR TITLE
fix: standardize button text capitalization to "Show Rules" and "Hide Rules" in dice game

### DIFF
--- a/curriculum/challenges/english/blocks/review-algorithmic-thinking-by-building-a-dice-game/657a19e477dc04e36a86dffc.md
+++ b/curriculum/challenges/english/blocks/review-algorithmic-thinking-by-building-a-dice-game/657a19e477dc04e36a86dffc.md
@@ -7,16 +7,16 @@ dashedName: step-2
 
 # --description--
 
-When the user clicks on the `Show rules` button, the rules for the game should display on the screen. When they click on the button again, the rules should be hidden.
+When the user clicks on the `Show Rules` button, the rules for the game should display on the screen. When they click on the button again, the rules should be hidden.
 
-Use an event listener to invert the value of the `isModalShowing` variable, toggle the visibility of the `rulesContainer`, and change the text of the `rulesBtn` to `Show rules` or `Hide rules`.
+Use an event listener to invert the value of the `isModalShowing` variable, toggle the visibility of the `rulesContainer`, and change the text of the `rulesBtn` to `Show Rules` or `Hide Rules`.
 
 # --before-all--
 
 ```js
 function resetState() {
   isModalShowing = false;
-  rulesBtn.textContent = 'Show rules';
+  rulesBtn.textContent = 'Show Rules';
   rulesContainer.style.display = 'none';
 }
 ```
@@ -45,11 +45,11 @@ assert.isTrue(rulesContainer.checkVisibility());
 resetState();
 ```
 
-When your `rulesBtn` is clicked, your `rulesBtn` should say `Hide rules`.
+When your `rulesBtn` is clicked, your `rulesBtn` should say `Hide Rules`.
 
 ```js
 rulesBtn.click();
-assert.strictEqual(rulesBtn.innerText.trim(), "Hide rules");
+assert.strictEqual(rulesBtn.innerText.trim(), "Hide Rules");
 resetState();
 ```
 
@@ -73,13 +73,13 @@ assert.isFalse(rulesContainer.checkVisibility());
 resetState();
 ```
 
-When your `rulesBtn` is clicked twice, your `rulesBtn` should say `Show rules`.
+When your `rulesBtn` is clicked twice, your `rulesBtn` should say `Show Rules`.
 
 ```js
 rulesBtn.click();
-assert.strictEqual(rulesBtn.innerText.trim(), "Hide rules");
+assert.strictEqual(rulesBtn.innerText.trim(), "Hide Rules");
 rulesBtn.click();
-assert.strictEqual(rulesBtn.innerText.trim(), "Show rules");
+assert.strictEqual(rulesBtn.innerText.trim(), "Show Rules");
 resetState();
 ```
 
@@ -101,7 +101,7 @@ resetState();
 <body>
   <header>
     <h1>Advanced Dice Game</h1>
-    <button class="btn" id="rules-btn" type="button">Show rules</button>
+    <button class="btn" id="rules-btn" type="button">Show Rules</button>
     <div class="rules-container">
       <h2>Rules</h2>
       <ul>


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the contribution guidelines.  
- [x] I have read and followed the how to open a pull request guide.  
- [x] My pull request targets the `main` branch of freeCodeCamp.  
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

The Dice Game project had inconsistent capitalization for the rules toggle button (`Show rules` / `Hide rules` vs `Show Rules` / `Hide Rules`).  
This caused mismatches between the instructions, tests, and starter HTML.  
This PR standardizes all occurrences to **"Show Rules"** and **"Hide Rules"** for consistency across the curriculum.

Context: https://forum.freecodecamp.org/
