### PR TITLE
fix(i18n): Capitalize title for RPG character lab in English locale

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -4507,7 +4507,7 @@
         ]
       },
       "lab-rpg-character": {
-        "title": "Build an RPG character",
+        "title": "Build an RPG Character",
         "intro": [
           "In this lab you will practice basic python by building an RPG character."
         ]


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #64103

<!-- Feel free to add any additional description of changes below this line -->
capitalized the word Character in [freeCodeCamp/client/i18n/locales/english/intro.json](https://github.com/freeCodeCamp/freeCodeCamp/blob/981d0c301c70bb7d06dfd423b5529f55922ab665/client/i18n/locales/english/intro.json#L6755)