### PR TITLE
fix(curriculum): clarify moon phase day numbering in Daily Coding Challenge 60

### DIFF
--- a/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/68c497f3aaefc9fd9f1b0e24.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/68c497f3aaefc9fd9f1b0e24.md
@@ -22,7 +22,7 @@ After day 28, the cycle repeats with day 1, a new moon.
 - You will not be given any dates before the reference date.
 - Return the correct phase as a string.
 
-**Note:** Day 1 represents the day of the new moon, meaning 0 days have passed since the last new moon. This avoids off-by-one confusion.
+**Note:** Day 1 represents the day of the new moon, meaning 0 days have passed since the last new moon.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/68c497f3aaefc9fd9f1b0e24.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/68c497f3aaefc9fd9f1b0e24.md
@@ -22,6 +22,8 @@ After day 28, the cycle repeats with day 1, a new moon.
 - You will not be given any dates before the reference date.
 - Return the correct phase as a string.
 
+**Note:** Day 1 represents the day of the new moon, meaning 0 days have passed since the last new moon. This avoids off-by-one confusion.
+
 # --hints--
 
 `moonPhase("2000-01-12")` should return `"New"`.

--- a/curriculum/challenges/english/blocks/daily-coding-challenges-python/68c497f3aaefc9fd9f1b0e24.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-python/68c497f3aaefc9fd9f1b0e24.md
@@ -21,6 +21,7 @@ After day 28, the cycle repeats with day 1, a new moon.
 - Use `"2000-01-06"` as a reference new moon (day 1 of the cycle) to determine the phase of the given day.
 - You will not be given any dates before the reference date.
 - Return the correct phase as a string.
+
 **Note:** Day 1 represents the day of the new moon, meaning 0 days have passed since the last new moon.
 
 # --hints--

--- a/curriculum/challenges/english/blocks/daily-coding-challenges-python/68c497f3aaefc9fd9f1b0e24.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-python/68c497f3aaefc9fd9f1b0e24.md
@@ -21,6 +21,7 @@ After day 28, the cycle repeats with day 1, a new moon.
 - Use `"2000-01-06"` as a reference new moon (day 1 of the cycle) to determine the phase of the given day.
 - You will not be given any dates before the reference date.
 - Return the correct phase as a string.
+**Note:** Day 1 represents the day of the new moon, meaning 0 days have passed since the last new moon.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #62663 

<!-- Feel free to add any additional description of changes below this line -->

### Summary

This challenge description can lead to off-by-one confusion. Learners often
misinterpret the lunar cycle because Day 1 represents the new moon (0 days since
the last new moon), while the chart starts at Day 1. This causes incorrect
interpretations such as treating `days % 28 === 0` as "day 28".

### Fix

Added a clarification note:

> **Day 1 represents the day of the new moon, meaning 0 days have passed since
> the last new moon. This avoids off-by-one confusion.**

### Why

This improves clarity for learners and aligns the written description with the
intended logic of the challenge. The change is documentation-only, with no
impact on tests or solution logic.

