### PR TITLE
fix: create quiz project challenges in correct folder

### DIFF
--- a/curriculum/src/file-handler.ts
+++ b/curriculum/src/file-handler.ts
@@ -1,7 +1,7 @@
 import { dirname, resolve } from 'node:path';
 import assert from 'node:assert';
 import { existsSync, readFileSync } from 'node:fs';
-import { writeFile } from 'node:fs/promises';
+import { mkdir, writeFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import debug from 'debug';
 
@@ -171,6 +171,16 @@ export interface BlockStructure {
   isUpcomingChange?: boolean;
   chapter?: string;
   module?: string;
+}
+
+export async function createBlockFolder(block: string) {
+  const { blockContentDir } = getContentConfig('english') as {
+    blockContentDir: string;
+  };
+
+  const newBlockDir = resolve(blockContentDir, block);
+  await mkdir(newBlockDir, { recursive: true });
+  return newBlockDir + '/';
 }
 
 export function getBlockStructure(block: string) {

--- a/tools/challenge-helper-scripts/create-language-block.ts
+++ b/tools/challenge-helper-scripts/create-language-block.ts
@@ -1,5 +1,4 @@
 import fs from 'fs/promises';
-import { existsSync } from 'fs';
 import path from 'path';
 import { prompt } from 'inquirer';
 import { format } from 'prettier';
@@ -15,7 +14,8 @@ import { BlockLayouts, BlockLabel } from '../../shared/config/blocks';
 import {
   getContentConfig,
   writeBlockStructure,
-  getSuperblockStructure
+  getSuperblockStructure,
+  createBlockFolder
 } from '../../curriculum/src/file-handler';
 import { superBlockToFilename } from '../../curriculum/src/build-curriculum';
 import { getBaseMeta } from './helpers/get-base-meta';
@@ -211,16 +211,8 @@ async function createQuizChallenge(
   questionCount: number,
   challengeLang: string
 ): Promise<ObjectID> {
-  const { blockContentDir } = getContentConfig('english') as {
-    blockContentDir: string;
-  };
-
-  const newChallengeDir = path.resolve(blockContentDir, block);
-  if (!existsSync(newChallengeDir)) {
-    await withTrace(fs.mkdir, newChallengeDir);
-  }
   return createQuizFile({
-    projectPath: newChallengeDir + '/',
+    projectPath: await createBlockFolder(block),
     title: title,
     dashedName: block,
     questionCount: questionCount,

--- a/tools/challenge-helper-scripts/create-project.ts
+++ b/tools/challenge-helper-scripts/create-project.ts
@@ -1,4 +1,3 @@
-import { existsSync } from 'fs';
 import fs from 'fs/promises';
 import path from 'path';
 import { prompt } from 'inquirer';
@@ -11,7 +10,7 @@ import {
 } from '../../shared/config/curriculum';
 import { BlockLayouts, BlockLabel } from '../../shared/config/blocks';
 import {
-  getContentConfig,
+  createBlockFolder,
   writeBlockStructure
 } from '../../curriculum/src/file-handler';
 import { superBlockToFilename } from '../../curriculum/src/build-curriculum';
@@ -209,13 +208,6 @@ async function createMetaJson(
 }
 
 async function createFirstChallenge(block: string): Promise<ObjectID> {
-  const { blockContentDir } = getContentConfig('english') as {
-    blockContentDir: string;
-  };
-
-  const newChallengeDir = path.resolve(blockContentDir, block);
-  await fs.mkdir(newChallengeDir, { recursive: true });
-
   // TODO: would be nice if the extension made sense for the challenge, but, at
   // least until react I think they're all going to be html anyway.
   const challengeSeeds = [
@@ -227,7 +219,7 @@ async function createFirstChallenge(block: string): Promise<ObjectID> {
   ];
   // including trailing slash for compatibility with createStepFile
   return createStepFile({
-    projectPath: newChallengeDir + '/',
+    projectPath: await createBlockFolder(block),
     stepNum: 1,
     challengeType: 0,
     challengeSeeds,
@@ -240,15 +232,8 @@ async function createQuizChallenge(
   title: string,
   questionCount: number
 ): Promise<ObjectID> {
-  const newChallengeDir = path.resolve(
-    __dirname,
-    `../../curriculum/challenges/english/${block}`
-  );
-  if (!existsSync(newChallengeDir)) {
-    await withTrace(fs.mkdir, newChallengeDir);
-  }
   return createQuizFile({
-    projectPath: newChallengeDir + '/',
+    projectPath: await createBlockFolder(block),
     title: title,
     dashedName: block,
     questionCount: questionCount

--- a/tools/challenge-helper-scripts/create-quiz.ts
+++ b/tools/challenge-helper-scripts/create-quiz.ts
@@ -6,7 +6,7 @@ import ObjectID from 'bson-objectid';
 
 import { SuperBlocks } from '../../shared/config/curriculum';
 import {
-  getContentConfig,
+  createBlockFolder,
   writeBlockStructure
 } from '../../curriculum/src/file-handler';
 import { superBlockToFilename } from '../../curriculum/src/build-curriculum';
@@ -111,15 +111,8 @@ async function createQuizChallenge(
   title: string,
   questionCount: number
 ): Promise<ObjectID> {
-  const { blockContentDir } = getContentConfig('english') as {
-    blockContentDir: string;
-  };
-
-  const newChallengeDir = path.resolve(blockContentDir, block);
-  await fs.mkdir(newChallengeDir, { recursive: true });
-
   return createQuizFile({
-    projectPath: newChallengeDir + '/',
+    projectPath: await createBlockFolder(block),
     title: title,
     dashedName: block,
     questionCount: questionCount


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Fixes a bug where `create-new-project` would put the first challenge in the wrong folder if you created a quiz.

<!-- Feel free to add any additional description of changes below this line -->
