### PR TITLE
docs: add PR title clarity reminder to template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,6 +6,7 @@ Checklist:
 - [ ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
 - [ ] My pull request targets the `main` branch of freeCodeCamp.
 - [ ] I have tested these changes either locally on my machine, or GitHub Codespaces.
+- [ ] - [ ] My pull request title provides a clear description of the changes I made.
 
 <!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->
 


### PR DESCRIPTION
## Description

This PR improves the pull request template by adding a checklist reminder for contributors to ensure their PR titles are clear and descriptive.

## Why?

- **Code Review Quality**: Clear PR titles help reviewers understand the scope of changes at a glance
- **Git History**: They make git history more readable and searchable for future developers
- **Project Management**: Better tracking of changes and easier filtering in issue trackers
- **Professional Standards**: Following conventional commit prefixes (feat/fix/docs) keeps the codebase organized

## Changes

- Added a new checkbox item to the pull request template:
  - "My pull request title provides a clear description of the changes I made."

This simple addition helps new contributors follow best practices without requiring extensive documentation.
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ ] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
