### PR TITLE
fix: add test for feature-card class on label elements

### DIFF
--- a/curriculum/challenges/english/blocks/lab-feature-selection/68ce56d54d3cad1149a1c4cf.md
+++ b/curriculum/challenges/english/blocks/lab-feature-selection/68ce56d54d3cad1149a1c4cf.md
@@ -48,7 +48,7 @@ assert.exists(document.querySelector('div.feature-card-container'));
 You should have at least two `label` elements with the class `feature-card` inside `.feature-card-container`.
 
 ```js
-const labels = document.querySelectorAll('.feature-card-container label');
+const labels = document.querySelectorAll('.feature-card-container label.feature-card');
 assert.isAtLeast(labels.length, 2);
 ```
 


### PR DESCRIPTION
Updated test selector to specifically check for the feature-card class on label elements. The previous test only checked for label elements inside the container but didn't verify they had the required class.

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org/).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Fixes #64148