### PR TITLE
fix(curriculum): add hint for feature selection labels

### DIFF
--- a/curriculum/challenges/english/blocks/lab-feature-selection/68ce56d54d3cad1149a1c4cf.md
+++ b/curriculum/challenges/english/blocks/lab-feature-selection/68ce56d54d3cad1149a1c4cf.md
@@ -61,7 +61,6 @@ assert.isNotEmpty(labels);
 labels.forEach(label => assert.isTrue(label.classList.contains('feature-card')));
 ```
 
-
 Inside each `label` element you should have label text.
 
 ```js

--- a/curriculum/challenges/english/blocks/lab-feature-selection/68ce56d54d3cad1149a1c4cf.md
+++ b/curriculum/challenges/english/blocks/lab-feature-selection/68ce56d54d3cad1149a1c4cf.md
@@ -45,12 +45,22 @@ You should have a `div` element with the class `feature-card-container`.
 assert.exists(document.querySelector('div.feature-card-container'));
 ```
 
-You should have at least two `label` elements with the class `feature-card` inside `.feature-card-container`.
+You should have at least two `label` elements inside `.feature-card-container`.
 
 ```js
 const labels = document.querySelectorAll('.feature-card-container label');
 assert.isAtLeast(labels.length, 2);
 ```
+
+Each `label` element inside `.feature-card-container` should have the class `feature-card`.
+
+```js
+const labels = document.querySelectorAll('.feature-card-container label');
+assert.isNotEmpty(labels);
+
+labels.forEach(label => assert.isTrue(label.classList.contains('feature-card')));
+```
+
 
 Inside each `label` element you should have label text.
 


### PR DESCRIPTION
This PR adds a missing hint and test for User Story 3 in the "Design a Feature Selection Page" lab.

User Story 3 expects at least two `label` elements with the `feature-card` class inside `.feature-card-container`. Currently, the challenge does not include a specific hint or test for this, so learners may miss the requirement and fail later tests without clear feedback.

I added a new hint and the appropriate test block to ensure this requirement is explicitly checked.

Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces (or verified correctness based on similar curriculum tests).

Closes #64148

