### PR TITLE
fix(tools): wrong throw causes test to pass

### DIFF
--- a/tools/challenge-parser/parser/plugins/add-video-question.js
+++ b/tools/challenge-parser/parser/plugins/add-video-question.js
@@ -110,6 +110,8 @@ function plugin() {
           questionNode.children?.[0]?.value === '--text--';
         if (isStartOfQuestion) {
           questionTrees.push([questionNode]);
+        } else if (questionTrees.length === 0) {
+          throw Error('question text is missing in questions section');
         } else {
           questionTrees[questionTrees.length - 1].push(questionNode);
         }

--- a/tools/challenge-parser/parser/plugins/add-video-question.test.js
+++ b/tools/challenge-parser/parser/plugins/add-video-question.test.js
@@ -104,7 +104,9 @@ describe('add-video-question plugin', () => {
   // 'The md is missing "x"', so it's obvious how to fix things.
   it('should throw if the subheadings are outside the question heading', () => {
     expect.assertions(1);
-    expect(() => plugin(videoOutOfOrderAST, file)).toThrow();
+    expect(() => plugin(videoOutOfOrderAST, file)).toThrow(
+      'question text is missing in questions section'
+    );
   });
 
   it('should NOT throw if there is no question', () => {

--- a/tools/challenge-parser/parser/plugins/add-video-question.test.js
+++ b/tools/challenge-parser/parser/plugins/add-video-question.test.js
@@ -104,7 +104,7 @@ describe('add-video-question plugin', () => {
   // 'The md is missing "x"', so it's obvious how to fix things.
   it('should throw if the subheadings are outside the question heading', () => {
     expect.assertions(1);
-    expect(() => plugin(videoOutOfOrderAST)).toThrow();
+    expect(() => plugin(videoOutOfOrderAST, file)).toThrow();
   });
 
   it('should NOT throw if there is no question', () => {


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

- - -
- Missing `file` argument caused test to not really test what was wanted.
- Test still passed, because there was error thrown (`"TypeError: Cannot read properties of undefined (reading 'data')"`), but that could have been obtained also by passing any valid AST, if second argument was omitted, ie.:
    ```ts
    expect(() => plugin(simpleAST)).not.toThrow();
    ```
    would fail.
- With the `file` argument, test passes due to `"TypeError: Cannot read properties of undefined (reading 'push')"` being thrown.