### PR TITLE
fix: center align hero section text

### DIFF
--- a/client/src/components/landing/landing.css
+++ b/client/src/components/landing/landing.css
@@ -412,6 +412,7 @@ figcaption.caption {
     flex: 0 0 50%;
     max-width: 50%;
     z-index: 1;
+    text-align: center;
   }
 
   .landing-top-two-column .landing-top-right {


### PR DESCRIPTION
This PR centers the hero text on the landing page as requested in issue #63590.

- Updated the `.landing-top-two-column .landing-top-left` CSS rule.
- Added `text-align: center;` to improve layout and visual balance.
- This aligns the main heading, subtext, and call-to-action button to the center.



- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #63590
