### PR TITLE
docs(curriculum): add reminder for user story hints and tests

### DIFF
--- a/curriculum/structure/blocks/lab-feature-selection.json
+++ b/curriculum/structure/blocks/lab-feature-selection.json
@@ -12,4 +12,5 @@
   ],
   "blockLabel": "lab",
   "usesMultifileEditor": true
+   // Note: Ensure all user stories (1-3) have corresponding hints and tests in the challenge files
 }


### PR DESCRIPTION
Add a comment note to remind developers that all user stories (1-3) in the feature selection lab must have corresponding hints and tests.

Addresses issue #64148 by documenting the requirement for complete hints and tests for all user stories in the feature selection page challenge.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ ] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
