### PR TITLE
fix(curriculum): add explicit test for feature-card class in feature …

### DIFF
--- a/curriculum/challenges/english/blocks/lab-feature-selection/68ce56d54d3cad1149a1c4cf.md
+++ b/curriculum/challenges/english/blocks/lab-feature-selection/68ce56d54d3cad1149a1c4cf.md
@@ -48,8 +48,7 @@ assert.exists(document.querySelector('div.feature-card-container'));
 You should have at least two `label` elements with the class `feature-card` inside `.feature-card-container`.
 
 ```js
-const labels = document.querySelectorAll('.feature-card-container label');
-assert.isAtLeast(labels.length, 2);
+const labels = document.querySelectorAll('.feature-card-container label.feature-card');assert.isAtLeast(labels.length, 2);
 ```
 
 Inside each `label` element you should have label text.


### PR DESCRIPTION
…selection challenge (closes #64148)

The test selector for label elements was not checking for the 'feature-card' class. This change ensures that the test specifically targets label elements with the 'feature-card' class, making the hint and test requirement clearer for learners.

Modified: curriculum/challenges/english/blocks/lab-feature-selection/68ce56d54d3cad1149a1c4cf.md
- Updated CSS selector from '.feature-card-container label' to '.feature-card-container label.feature-card'
- This ensures learners receive proper feedback when they miss adding the required class to label elements

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ ] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
