### PR TITLE
fix(curriculum): add feature-card class selector to test for user sto…

### DIFF
--- a/curriculum/challenges/english/blocks/lab-feature-selection/68ce56d54d3cad1149a1c4cf.md
+++ b/curriculum/challenges/english/blocks/lab-feature-selection/68ce56d54d3cad1149a1c4cf.md
@@ -48,7 +48,7 @@ assert.exists(document.querySelector('div.feature-card-container'));
 You should have at least two `label` elements with the class `feature-card` inside `.feature-card-container`.
 
 ```js
-const labels = document.querySelectorAll('.feature-card-container label');
+const labels = document.querySelectorAll('.feature-card-container label.feature-card');
 assert.isAtLeast(labels.length, 2);
 ```
 


### PR DESCRIPTION
…ry 3 (#64148)

Updated the test selector in the feature selection challenge to specifically check for label elements with the 'feature-card' class. This ensures that the test properly validates that user story 3 is correctly implemented, catching the case where labels don't have the required 'feature-card' class.

The change was made from:
  .feature-card-container label

To:
  .feature-card-container label.feature-card

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ ] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #64148

<!-- Feel free to add any additional description of changes below this line -->
