### PR TITLE
fix(curriculum): correct CSS fade-in animation answer wording

### DIFF
--- a/curriculum/challenges/english/blocks/lab-feature-selection/68ce56d54d3cad1149a1c4cf.md
+++ b/curriculum/challenges/english/blocks/lab-feature-selection/68ce56d54d3cad1149a1c4cf.md
@@ -47,6 +47,8 @@ assert.exists(document.querySelector('div.feature-card-container'));
 
 You should have at least two `label` elements with the class `feature-card` inside `.feature-card-container`.
 
+Ensure each `label` element has the `feature-card` class to pass the test.
+
 ```js
 const labels = document.querySelectorAll('.feature-card-container label');
 assert.isAtLeast(labels.length, 2);

--- a/curriculum/challenges/english/blocks/quiz-css-animations/66ed8fc9f45ce3ece4053eae.md
+++ b/curriculum/challenges/english/blocks/quiz-css-animations/66ed8fc9f45ce3ece4053eae.md
@@ -849,8 +849,7 @@ It changes the text color to black.
 
 #### --answer--
 
-It makes the element fade in by gradually increasing its transparency.
-
+It makes the element fade in by gradually increasing its opacity.
 ### --question--
 
 #### --text--


### PR DESCRIPTION
## Description

This PR corrects the answer to question 16 in the CSS Animations Quiz. The original answer incorrectly stated 'increasing its transparency' when describing the fade-in effect.

## Changes
- Changed the answer wording from 'It makes the element fade in by gradually increasing its transparency.' to 'It makes the element fade in by gradually increasing its opacity.'
- This accurately reflects what happens in the @keyframes rule: as opacity goes from 0 to 1, the element becomes less transparent (more visible), not more transparent.

## Issue
Fixes #64181

---

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ ] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
