### PR TITLE
fix(curriculum): correct CSS fade-in animation answer wording  Fix is…

### DIFF
--- a/curriculum/challenges/english/blocks/quiz-css-animations/66ed8fc9f45ce3ece4053eae.md
+++ b/curriculum/challenges/english/blocks/quiz-css-animations/66ed8fc9f45ce3ece4053eae.md
@@ -849,7 +849,7 @@ It changes the text color to black.
 
 #### --answer--
 
-It makes the element fade in by gradually increasing its transparency.
+It makes the element fade in by gradually decreasing its transparency.
 
 ### --question--
 


### PR DESCRIPTION
…sue #64181: Changed the incorrect answer for question 16 in the CSS Animations Quiz.  The answer previously stated 'increasing its transparency' which was technically incorrect. As opacity increases from 0 to 1, transparency actually decreases (not increases).  Changed: 'It makes the element fade in by gradually increasing its transparency.' To: 'It makes the element fade in by gradually decreasing its transparency.'  This makes the answer scientifically accurate and aligns with CSS opacity semantics.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ ] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #64181
<!-- Feel free to add any additional description of changes below this line -->
