### PR TITLE
feat(curriculum): allow use of transition property in Feature Selection page

### DIFF
--- a/curriculum/challenges/english/blocks/lab-feature-selection/68ce56d54d3cad1149a1c4cf.md
+++ b/curriculum/challenges/english/blocks/lab-feature-selection/68ce56d54d3cad1149a1c4cf.md
@@ -25,6 +25,12 @@ demoType: onClick
 
 **Note:** Be sure to link your CSS file in your HTML.
 
+# --before-all--
+
+```js
+const clock = __FakeTimers.install()
+```
+
 # --hints--
 
 You should have an `h1` element.
@@ -150,6 +156,7 @@ checkboxes.forEach((checkbox) => {
     checkbox.checked = false;
 
     checkbox.checked = true;
+    clock.tick(1000)
     const after = window.getComputedStyle(checkbox, ':after');
     assert.equal(after.content, '"✓"');
 });
@@ -165,6 +172,7 @@ checkboxes.forEach((checkbox) => {
     checkbox.checked = false;
     const uncheckedBG = window.getComputedStyle(checkbox).backgroundColor;
     checkbox.checked = true;
+    clock.tick(1000)
     const checkedBG = window.getComputedStyle(checkbox).backgroundColor;
 
     assert.notEqual(checkedBG, uncheckedBG);
@@ -181,6 +189,7 @@ checkboxes.forEach((checkbox) => {
     checkbox.checked = false;
     const uncheckedBC = window.getComputedStyle(checkbox).borderColor;
     checkbox.checked = true;
+    clock.tick(1000)
     const checkedBC = window.getComputedStyle(checkbox).borderColor;
 
     assert.notEqual(checkedBC, uncheckedBC);
@@ -312,6 +321,7 @@ body {
   border: 2px solid #ccc;
   border-radius: 4px;
   background-color: white;
+  transition: all 0.3s;
 }
 
 .feature-card input[type='checkbox']:checked {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes https://github.com/freeCodeCamp/freeCodeCamp/issues/63678

<!-- Feel free to add any additional description of changes below this line -->

If there are other projects affected we will find out looking at user reports, but this one seems the most hit, with this `transition` property should now be allowed. I have added it in the solution to check that it keeps being allowed.