### PR TITLE
fix(curriculum): add assert to prevent empty editor pass in todo list

### DIFF
--- a/curriculum/challenges/english/blocks/lab-stylized-to-do-list/66c051d13a6a20255a963695.md
+++ b/curriculum/challenges/english/blocks/lab-stylized-to-do-list/66c051d13a6a20255a963695.md
@@ -100,6 +100,7 @@ The `id` and `for` attributes of the `input` and `label` elements pairs, should 
 
 ```js
 const labels = document.querySelectorAll("label");
+assert.isNotEmpty(labels);
 
 document.querySelectorAll("input").forEach((input, index) => {
   assert.equal(input.id, labels[index].htmlFor);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #64191

<!-- Feel free to add any additional description of changes below this line -->
## Description of Changes
I added `assert.isNotEmpty(labels)` after line 102 in the todo list challenge test to ensure the test doesn't pass when the code editor is empty. This prevents learners from accidentally passing the test without actually implementing the required functionality.

This is my first contribution to freeCodeCamp. Thank you for the opportunity!