### PR TITLE
fix(Header): Improve mobile responsiveness and touch-friendly navigat…

### DIFF
--- a/client/src/components/Header/header.css
+++ b/client/src/components/Header/header.css
@@ -25,3 +25,55 @@
     left: 5px;
   }
 }
+
+
+/* Mobile-first responsive improvements for issue #64189 */
+/* Enhanced touch-friendly navigation for mobile devices */
+
+@media screen and (max-width: 576px) {
+  .site-header {
+    position: sticky;
+    width: 100%;
+    padding: 8px 0;
+    background-color: #fff;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  }
+
+  .skip-to-content-button {
+    position: fixed;
+    left: 50%;
+    transform: translateX(-50%);
+    top: 5px;
+    font-size: 14px;
+    padding: 8px 16px;
+    z-index: 1000;
+  }
+
+  .skip-to-content-button:focus {
+    left: 50%;
+    transform: translateX(-50%);
+    top: 5px;
+  }
+}
+
+/* Tablet responsiveness improvements */
+@media screen and (min-width: 577px) and (max-width: 768px) {
+  .site-header {
+    padding: 10px 8px;
+  }
+
+  .skip-to-content-button {
+    font-size: 15px;
+    padding: 10px 18px;
+  }
+}
+
+/* Large screen optimizations */
+@media screen and (min-width: 769px) {
+  .site-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 12px 16px;
+  }
+}


### PR DESCRIPTION
…ion - Resolves #64189  This commit enhances the header component's mobile user experience by: - Adding sticky positioning for header on mobile devices - Implementing touch-friendly button sizing and spacing - Creating responsive media queries for small (max-width: 576px), medium (577-768px), and large (769px+) screens - Fixing skip-to-content button positioning for better accessibility - Adding box-shadow and background optimizations for mobile view - Improving visual hierarchy across different viewport sizes

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ ] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #64189
<!-- Feel free to add any additional description of changes below this line -->
