### PR TITLE
fix(a11y): improve color contrast for Certification Project label

### DIFF
--- a/client/src/components/layouts/variables.css
+++ b/client/src/components/layouts/variables.css
@@ -26,8 +26,8 @@
   --green-dark: #00471b;
   --red-light: #ffadad;
   --red-dark: #850000;
-  --love-light: #f8577c;
-  --love-dark: #f82153;
+  --love-light: var(--red30);
+  --love-dark: var(--red70);
   --editor-background-light: #fffffe;
   --editor-background-dark: #2a2b40;
   --focus-outline-color: var(--blue-mid);


### PR DESCRIPTION
This PR updates the color variables used for the Certification Project label to improve contrast in light mode. It replaces hardcoded hex values with system theme variables.

Changes:
- `--love-light` changed from `#f8577c` to `var(--red30)`
- `--love-dark` changed from `#f82153` to `var(--red70)`

This improves readability and resolves the insufficient contrast reported in #64199.

Fixes #64199