### PR TITLE
fix(curriculum): correct CSS Animations quiz answer 16 wording

### DIFF
--- a/curriculum/challenges/english/blocks/quiz-css-animations/66ed8fc9f45ce3ece4053eae.md
+++ b/curriculum/challenges/english/blocks/quiz-css-animations/66ed8fc9f45ce3ece4053eae.md
@@ -849,7 +849,7 @@ It changes the text color to black.
 
 #### --answer--
 
-It makes the element fade in by gradually increasing its transparency.
+It makes the element fade in by gradually decreasing its transparency.
 
 ### --question--
 


### PR DESCRIPTION
This PR fixes the incorrect wording in **CSS Animations Quiz – Question 16**.

The current answer says the element fades in by **“increasing its transparency”**, which is incorrect.  
A fade-in animation goes from `opacity: 0` to `opacity: 1`, meaning the element becomes **less transparent**, not more.

Updated the answer text to:

**“It makes the element fade in by gradually decreasing its transparency.”**

This wording correctly reflects how opacity works and aligns with the fade-in behavior.

Closes **#64181**


## Checklist

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes locally on my machine.

