### PR TITLE
feat(client): Added tests for per-module progress in client

### DIFF
--- a/client/src/templates/Introduction/components/super-block-accordion.test.tsx
+++ b/client/src/templates/Introduction/components/super-block-accordion.test.tsx
@@ -3,6 +3,10 @@ import { render, screen, within } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 import { SuperBlocks } from '../../../../../shared-dist/config/curriculum';
 import { SuperBlockAccordion } from './super-block-accordion';
+import {
+  BlockLabel,
+  BlockLayouts
+} from '../../../../../shared-dist/config/blocks';
 
 const mockStructure = {
   superBlock: SuperBlocks.RespWebDesign,
@@ -17,6 +21,19 @@ const mockStructure = {
       ]
     }
   ]
+};
+
+// Representative challenge used to populate module content.
+const mockChallenge = {
+  id: 'test-challenge-id',
+  block: 'test-block',
+  blockLabel: BlockLabel.lecture,
+  title: 'Test Challenge',
+  fields: { slug: '/test-slug' },
+  dashedName: 'test-challenge',
+  challengeType: 0,
+  blockLayout: BlockLayouts.ChallengeList,
+  superBlock: SuperBlocks.RespWebDesign
 };
 
 describe('SuperBlockAccordion', () => {
@@ -39,5 +56,126 @@ describe('SuperBlockAccordion', () => {
     const chapterButton = chapterButtons[0];
     const checkmark = within(chapterButton).getByTestId('green-not-completed');
     expect(checkmark).toBeInTheDocument();
+  });
+
+  // With progress data present, the module button should render the steps label.
+  it('shows module progress when totalSteps > 0 and not comingSoon', () => {
+    const structureWithProgress = {
+      superBlock: SuperBlocks.RespWebDesign,
+      chapters: [
+        {
+          dashedName: 'test-chapter',
+          modules: [
+            {
+              dashedName: 'test-module',
+              blocks: ['test-block'],
+              comingSoon: false,
+              totalSteps: 10,
+              completedSteps: 5
+            }
+          ]
+        }
+      ]
+    };
+
+    render(
+      <SuperBlockAccordion
+        challenges={[mockChallenge]}
+        superBlock={SuperBlocks.RespWebDesign}
+        structure={structureWithProgress}
+        chosenBlock={''}
+        completedChallengeIds={[]}
+      />
+    );
+
+    const moduleButtons = screen.getAllByRole('button', {
+      name: /test-module/i
+    });
+    const moduleButton = moduleButtons[0];
+
+    const moduleRight = within(moduleButton).getByTestId('module-button-right');
+    const moduleSteps = within(moduleRight).getByText(
+      /learn\.steps-completed/i
+    );
+    expect(moduleSteps).toBeInTheDocument();
+    expect(moduleSteps).toHaveClass('module-steps');
+  });
+
+  // A coming-soon module should hide the steps summary even if progress exists.
+  it('does not show module progress when comingSoon is true', () => {
+    const structureComingSoon = {
+      superBlock: SuperBlocks.RespWebDesign,
+      chapters: [
+        {
+          dashedName: 'test-chapter',
+          modules: [
+            {
+              dashedName: 'test-module',
+              blocks: ['test-block'],
+              comingSoon: true,
+              totalSteps: 10,
+              completedSteps: 5
+            }
+          ]
+        }
+      ]
+    };
+
+    render(
+      <SuperBlockAccordion
+        challenges={[mockChallenge]}
+        superBlock={SuperBlocks.RespWebDesign}
+        structure={structureComingSoon}
+        chosenBlock={''}
+        completedChallengeIds={[]}
+      />
+    );
+
+    const moduleButtons = screen.getAllByRole('button', {
+      name: /test-module/i
+    });
+    const moduleButton = moduleButtons[0];
+
+    const moduleRight = within(moduleButton).getByTestId('module-button-right');
+    expect(within(moduleRight).queryByText(/steps/i)).not.toBeInTheDocument();
+  });
+
+  // Modules with zero total steps should not display any progress text.
+  it('does not show module progress when totalSteps is zero', () => {
+    const structureZeroSteps = {
+      superBlock: SuperBlocks.RespWebDesign,
+      chapters: [
+        {
+          dashedName: 'test-chapter',
+          modules: [
+            {
+              dashedName: 'test-module',
+              blocks: ['test-block'],
+              comingSoon: false,
+              totalSteps: 0,
+              completedSteps: 0
+            }
+          ]
+        }
+      ]
+    };
+
+    render(
+      <SuperBlockAccordion
+        challenges={[]}
+        superBlock={SuperBlocks.RespWebDesign}
+        structure={structureZeroSteps}
+        chosenBlock={''}
+        completedChallengeIds={[]}
+      />
+    );
+
+    const moduleButtons = screen.getAllByRole('button', {
+      name: /test-module/i
+    });
+    const moduleButton = moduleButtons[0];
+
+    const moduleRight = within(moduleButton).getByTestId('module-button-right');
+    expect(within(moduleRight).queryByText(/steps/i)).not.toBeInTheDocument();
   });
 });

--- a/client/src/templates/Introduction/components/super-block-accordion.tsx
+++ b/client/src/templates/Introduction/components/super-block-accordion.tsx
@@ -189,7 +189,7 @@ const Module = ({
           </span>
           {t(`intro:${superBlock}.modules.${dashedName}`)}
         </div>
-        <div className='module-button-right'>
+        <div className='module-button-right' data-testid='module-button-right'>
           {!comingSoon && !!totalSteps && (
             <span className='module-steps'>
               {t('learn.steps-completed', {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #63994

<!-- Feel free to add any additional description of changes below this line -->

Included a set of unit tests for the per-module progress display introduced in PR #63966.

**Added three tests to super-block-accordion.test.tsx to cover:**
- rendering module-level progress when totalSteps > 0 and comingSoon === false
- hiding module progress when the module is marked comingSoon
- hiding module progress when totalSteps === 0

**Implementation details**
- To reliably target the module-level progress container, I added:
`<div className="module-button-right" data-testid="module-button-right">`

- The tests assert against the untranslated i18n key (learn.steps-completed) rather than a fully rendered string, since the client test environment does not initialize i18n providers.
- The test setup avoids rendering deeper Redux-connected components and focuses only on the UI behavior required by #63994.