### PR TITLE
fix(curriculum): removes redundancy and solved issue #64224

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-conditional-logic-and-math-methods/67327217e70ee0db7913b255.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-conditional-logic-and-math-methods/67327217e70ee0db7913b255.md
@@ -79,7 +79,7 @@ So, if the decimal point is less than `5`, the number is rounded down. And if th
 ```js
 const max = 10;
 const min = 5;
-const randomNum = Math.floor(Math.random() * (max - min)) + min;
+const randomNum = Math.floor(Math.random() * (max - min + 1)) + min;
 console.log(randomNum);
 ```
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-text-and-time-semantic-elements/672995d673bd3237200b9e7c.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-text-and-time-semantic-elements/672995d673bd3237200b9e7c.md
@@ -51,7 +51,7 @@ Let's take the same example as before, but add the `title` attribute. It will be
 
 :::
 
-Usually, the style of the abbreviation element will change when you add this attribute. The specific style will depend on the browser. Some browsers may display a dotted underline, while others may convert the contents to small caps, or even assign certain default styles, such as a dotted underline. When the user hovers over the abbreviation with the mouse, the full form is displayed as a tooltip.
+Usually, the style of the abbreviation element will change when you add this attribute. The specific style will depend on the browser. Some browsers may display a dotted underline, while others may convert the contents to small caps. When the user hovers over the abbreviation, the full form is displayed as a tooltip.
 
 While you don't necessarily need to use the abbreviation element for every abbreviation on your web page, it's recommended for those that might be unclear and those that might need additional context.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #64224

<!-- Feel free to add any additional description of changes below this line -->

(fix): Removed redundant text in the HTML abbreviation lesson explanation:
1. Removed duplicate mention of "display a dotted underline"
2. Removed unnecessary phrase "with the mouse" since hovering already implies pointer interaction

This makes the text more concise and eliminates repetition.