### PR TITLE
fix(curriculum): add validation test for filteredBooks release year

### DIFF
--- a/curriculum/challenges/english/blocks/lab-book-organizer/67172b43f84bcd2dec238a3d.md
+++ b/curriculum/challenges/english/blocks/lab-book-organizer/67172b43f84bcd2dec238a3d.md
@@ -89,6 +89,28 @@ assert.isBelow(filteredBooks.length, books.length)
 assert.isNotEmpty(filteredBooks)
 ```
 
+The `filteredBooks` array should only contain books from the original `books` array.
+
+```js
+filteredBooks.forEach(book => {
+  assert.isTrue(
+    books.some(original => 
+      original.title === book.title &&
+      original.authorName === book.authorName &&
+      original.releaseYear === book.releaseYear
+    )
+  );
+});
+```
+
+The `filteredBooks` array should include only books released on or before a specified year.
+
+```js
+const maxYear = Math.max(...filteredBooks.map(book => book.releaseYear));
+const removedYears = books.filter(book => !filteredBooks.includes(book)).map(book => book.releaseYear);
+assert.isTrue(removedYears.every(year => year > maxYear));
+```
+
 You should call the `sort` higher order function by passing the `sortByYear` callback function on the `filteredBooks` array.
 
 ```js


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #63631

<!-- Feel free to add any additional description of changes below this line -->

Added a new test to verify that `filteredBooks` only includes books from the original `books` array and excludes books released after the specified year.
