### PR TITLE
fix(curriculum): accept both multiplication orders in getRandomIndex test

### DIFF
--- a/curriculum/challenges/english/blocks/lab-random-background-color-changer/66b62d0ad68488dd76228d6c.md
+++ b/curriculum/challenges/english/blocks/lab-random-background-color-changer/66b62d0ad68488dd76228d6c.md
@@ -35,7 +35,7 @@ assert.isArray(darkColorsArr);
 You should fix the capitalization error in the `math.random()` line. 
 
 ```js
-assert.match(getRandomIndex.toString(), /\s*darkColorsArr\.length\s*\*\s*Math\.random\(\s*\)\s*/);
+assert.match(getRandomIndex.toString(), /\s*(darkColorsArr\.length\s*\*\s*Math\.random\(\s*\)|Math\.random\(\s*\)\s*\*\s*darkColorsArr\.length)\s*/);
 ```
 
 You should round `darkColorsArr.length * Math.random()` down to the nearest whole number.


### PR DESCRIPTION
This PR fixes issue #64220 by updating the test regex to accept both multiplication orders for the `getRandomIndex` function.

**Problem:** The test on line 48 only accepted `darkColorsArr.length * Math.random()` and failed when students wrote `Math.random() * darkColorsArr.length`.

**Solution:** Updated the regex pattern to use alternation `(A|B)` to accept both orders, matching the pattern already used in line 52 for the Math.floor test.

Since multiplication is commutative, both orders produce the same mathematical result and should be considered correct.

---

Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #64220