### PR TITLE
feat(ui) add loader before the preview is loaded

### DIFF
--- a/client/src/components/helpers/__snapshots__/loader.test.tsx.snap
+++ b/client/src/components/helpers/__snapshots__/loader.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`<Loader /> > matches the fullScreen render snapshot 1`] = `
 
 exports[`<Loader /> > matches to the default render snapshot 1`] = `
 <div
-  class="fcc-loader "
+  class="fcc-loader"
   data-testid="fcc-loader"
 >
   <div>

--- a/client/src/components/helpers/loader.css
+++ b/client/src/components/helpers/loader.css
@@ -13,6 +13,10 @@
   color: var(--secondary-color);
 }
 
+.override-palette .sk-spinner {
+  color: var(--gray-85);
+}
+
 .fcc-loader.full-screen-wrapper {
   height: calc(100vh - var(--header-height, 0px));
 }

--- a/client/src/components/helpers/loader.tsx
+++ b/client/src/components/helpers/loader.tsx
@@ -36,7 +36,7 @@ function Loader({
 
   return (
     <div
-      className={`fcc-loader ${fullScreen ? 'full-screen-wrapper' : ''} ${overridePalette ? 'override-palette' : ''}`}
+      className={`fcc-loader ${fullScreen ? 'full-screen-wrapper' : ''} ${overridePalette ? 'override-palette' : ''}`.trim()}
       data-testid='fcc-loader'
     >
       {showSpinner && <Spinner name='line-scale-pulse-out' />}

--- a/client/src/components/helpers/loader.tsx
+++ b/client/src/components/helpers/loader.tsx
@@ -8,11 +8,13 @@ interface LoaderProps {
   fullScreen?: boolean;
   loaderDelay?: number;
   messageDelay?: number;
+  overridePalette?: boolean;
 }
 function Loader({
   fullScreen,
   loaderDelay,
-  messageDelay
+  messageDelay,
+  overridePalette
 }: LoaderProps): JSX.Element {
   const { t } = useTranslation();
 
@@ -34,7 +36,7 @@ function Loader({
 
   return (
     <div
-      className={`fcc-loader ${fullScreen ? 'full-screen-wrapper' : ''}`}
+      className={`fcc-loader ${fullScreen ? 'full-screen-wrapper' : ''} ${overridePalette ? 'override-palette' : ''}`}
       data-testid='fcc-loader'
     >
       {showSpinner && <Spinner name='line-scale-pulse-out' />}

--- a/client/src/templates/Challenges/components/preview.css
+++ b/client/src/templates/Challenges/components/preview.css
@@ -15,3 +15,13 @@
 .disable-iframe {
   pointer-events: none;
 }
+
+.loader-wrapper {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 10;
+  pointer-events: none;
+}

--- a/client/src/templates/Challenges/components/preview.tsx
+++ b/client/src/templates/Challenges/components/preview.tsx
@@ -1,7 +1,10 @@
 import React, { useState, useEffect } from 'react';
+import { connect } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 
 import { mainPreviewId, scrollManager } from '../utils/frame';
+import Loader from '../../../components/helpers/loader';
+import { isIframeLoadedSelector } from '../redux/selectors';
 
 import './preview.css';
 
@@ -10,12 +13,18 @@ export interface PreviewProps {
   disableIframe?: boolean;
   previewMounted: () => void;
   previewId?: string;
+  isIframeLoaded: boolean;
 }
+
+const mapStateToProps = (state: unknown) => ({
+  isIframeLoaded: isIframeLoadedSelector(state) as boolean
+});
 
 function Preview({
   disableIframe,
   previewMounted,
-  previewId
+  previewId,
+  isIframeLoaded
 }: PreviewProps): JSX.Element {
   const { t } = useTranslation();
   const [iframeStatus, setIframeStatus] = useState<boolean | undefined>(false);
@@ -39,6 +48,11 @@ function Preview({
 
   return (
     <div className={`notranslate challenge-preview ${iframeToggle}-iframe`}>
+      {!isIframeLoaded && (
+        <div className={'loader-wrapper'}>
+          <Loader fullScreen={false} />
+        </div>
+      )}
       <iframe
         className={'challenge-preview-frame'}
         id={id}
@@ -50,4 +64,4 @@ function Preview({
 
 Preview.displayName = 'Preview';
 
-export default Preview;
+export default connect(mapStateToProps)(Preview);

--- a/client/src/templates/Challenges/components/preview.tsx
+++ b/client/src/templates/Challenges/components/preview.tsx
@@ -50,7 +50,7 @@ function Preview({
     <div className={`notranslate challenge-preview ${iframeToggle}-iframe`}>
       {!isIframeLoaded && (
         <div className={'loader-wrapper'}>
-          <Loader fullScreen={false} />
+          <Loader fullScreen={true} overridePalette={true} />
         </div>
       )}
       <iframe

--- a/client/src/templates/Challenges/redux/action-types.js
+++ b/client/src/templates/Challenges/redux/action-types.js
@@ -43,6 +43,7 @@ export const actionTypes = createTypes(
     'resetAttempts',
     'setEditorFocusability',
     'toggleVisibleEditor',
+    'setIsIframeLoaded',
     ...createAsyncTypes('submitChallenge'),
     ...createAsyncTypes('executeChallenge')
   ],

--- a/client/src/templates/Challenges/redux/actions.js
+++ b/client/src/templates/Challenges/redux/actions.js
@@ -76,3 +76,4 @@ export const setEditorFocusability = createAction(
 export const toggleVisibleEditor = createAction(
   actionTypes.toggleVisibleEditor
 );
+export const setIsIframeLoaded = createAction(actionTypes.setIsIframeLoaded);

--- a/client/src/templates/Challenges/redux/execute-challenge-saga.js
+++ b/client/src/templates/Challenges/redux/execute-challenge-saga.js
@@ -52,7 +52,8 @@ import {
   openModal,
   updateConsole,
   updateLogs,
-  updateTests
+  updateTests,
+  setIsIframeLoaded
 } from './actions';
 import {
   challengeDataSelector,
@@ -301,7 +302,13 @@ export function* previewChallengeSaga(action) {
         ) {
           yield updatePython(challengeData);
         } else {
-          yield call(updatePreview, buildData, finalDocument, proxyLogger);
+          const result = yield call(
+            updatePreview,
+            buildData,
+            finalDocument,
+            proxyLogger
+          );
+          yield put(setIsIframeLoaded(result));
         }
       } else if (isJavaScriptChallenge(challengeData)) {
         const runUserCode = yield call(getTestRunner, buildData);

--- a/client/src/templates/Challenges/redux/index.js
+++ b/client/src/templates/Challenges/redux/index.js
@@ -48,7 +48,8 @@ const initialState = {
     survey: false,
     projectPreview: false,
     shortcuts: false,
-    speaking: false
+    speaking: false,
+    isIframeLoaded: false
   },
   portalWindow: null,
   showPreviewPortal: false,
@@ -264,6 +265,13 @@ export const reducer = handleActions(
       modal: {
         ...state.modal,
         [payload]: true
+      }
+    }),
+    [actionTypes.setIsIframeLoaded]: (state, { payload }) => ({
+      ...state,
+      modal: {
+        ...state.modal,
+        isIframeLoaded: payload
       }
     }),
     [actionTypes.executeChallenge]: state => ({

--- a/client/src/templates/Challenges/redux/selectors.js
+++ b/client/src/templates/Challenges/redux/selectors.js
@@ -53,6 +53,7 @@ export const isProjectPreviewModalOpenSelector = state =>
   state[ns].modal.projectPreview;
 export const isShortcutsModalOpenSelector = state => state[ns].modal.shortcuts;
 export const isSpeakingModalOpenSelector = state => state[ns].modal.speaking;
+export const isIframeLoadedSelector = state => state[ns].modal.isIframeLoaded;
 export const isSubmittingSelector = state => state[ns].isSubmitting;
 export const isResettingSelector = state => state[ns].isResetting;
 

--- a/client/src/templates/Challenges/utils/build.ts
+++ b/client/src/templates/Challenges/utils/build.ts
@@ -291,9 +291,9 @@ export function updatePreview(
   buildData: BuildChallengeData,
   document: Document,
   proxyLogger: ProxyLogger
-): Promise<void> {
+): Promise<boolean> {
   if (challengeHasPreview(buildData)) {
-    return new Promise<void>(resolve =>
+    return new Promise<boolean>(resolve =>
       createMainPreviewFramer(
         document,
         proxyLogger,

--- a/client/src/templates/Challenges/utils/frame.ts
+++ b/client/src/templates/Challenges/utils/frame.ts
@@ -48,7 +48,7 @@ export interface Context {
 export type ProxyLogger = (msg: string) => void;
 
 type InitFrame = (
-  frameInitiateDocument?: () => unknown,
+  frameInitiateDocument?: (isIframeLoaded: boolean) => unknown,
   frameConsoleLogger?: ProxyLogger
 ) => (frameContext: Context) => Context;
 
@@ -350,7 +350,7 @@ const updateWindowI18next = (frameContext: Context) => {
 };
 
 const initMainFrame =
-  (frameReady?: () => void, proxyLogger?: ProxyLogger) =>
+  (frameReady?: (isIframeLoaded: boolean) => void, proxyLogger?: ProxyLogger) =>
   (frameContext: Context) => {
     waitForFrame(frameContext)
       .then(async () => {
@@ -379,7 +379,8 @@ const initMainFrame =
         if (document && '__initPythonFrame' in document) {
           await document.__initPythonFrame();
         }
-        if (frameReady) frameReady();
+        //if (frameReady) frameReady();
+        frameReady?.(true);
       })
       .catch(handleDocumentNotFound);
     return frameContext;
@@ -443,7 +444,7 @@ export const createMainPreviewFramer = (
   document: Document,
   proxyLogger: ProxyLogger,
   frameTitle: string,
-  frameReady?: () => void
+  frameReady?: (isIframeLoaded: boolean) => void
 ): ((args: Context) => void) =>
   createFramer({
     document,
@@ -478,7 +479,7 @@ const createFramer = ({
   id: string;
   init: InitFrame;
   proxyLogger?: ProxyLogger;
-  frameReady?: () => void;
+  frameReady?: (isIframeLoaded: boolean) => void;
   frameTitle?: string;
   updateWindowFunctions?: (frameContext: Context) => Context;
 }) =>

--- a/client/src/templates/Challenges/utils/frame.ts
+++ b/client/src/templates/Challenges/utils/frame.ts
@@ -379,7 +379,6 @@ const initMainFrame =
         if (document && '__initPythonFrame' in document) {
           await document.__initPythonFrame();
         }
-        //if (frameReady) frameReady();
         frameReady?.(true);
       })
       .catch(handleDocumentNotFound);

--- a/e2e/project-preview-modal.spec.ts
+++ b/e2e/project-preview-modal.spec.ts
@@ -18,8 +18,8 @@ test.describe('Should be shown automatically', () => {
     await expect(dialog).toBeVisible();
 
     const loader = dialog.locator('.fcc-loader');
-    await expect(loader).toBeVisible();
-    await expect(loader).toHaveCount(0, { timeout: 10000 });
+    await expect(loader).toBeVisible({ timeout: 15000 });
+    await expect(loader).toHaveCount(0, { timeout: 15000 });
 
     const previewFrame = dialog.frameLocator('#fcc-project-preview-frame');
     await expect(
@@ -36,8 +36,8 @@ test.describe('Should be shown automatically', () => {
     await expect(dialog).toBeVisible();
 
     const loader = dialog.locator('.fcc-loader');
-    await expect(loader).toBeVisible();
-    await expect(loader).toHaveCount(0, { timeout: 10000 });
+    await expect(loader).toBeVisible({ timeout: 15000 });
+    await expect(loader).toHaveCount(0, { timeout: 15000 });
     await expect(dialog.getByTitle('CatPhotoApp preview')).toBeVisible();
 
     await page.getByRole('button', { name: 'Start Coding!' }).click();
@@ -79,8 +79,8 @@ test.describe('Should be shown manually', () => {
       .click();
     await expect(dialog).toBeVisible();
     const loader = dialog.locator('.fcc-loader');
-    await expect(loader).toBeVisible();
-    await expect(loader).toHaveCount(0, { timeout: 10000 });
+    await expect(loader).toBeVisible({ timeout: 15000 });
+    await expect(loader).toHaveCount(0, { timeout: 15000 });
     const previewFrame = dialog.frameLocator('#fcc-project-preview-frame');
     await expect(
       // This is a part of the Drum Machine that we expect to see. Essentially,

--- a/e2e/project-preview-modal.spec.ts
+++ b/e2e/project-preview-modal.spec.ts
@@ -9,11 +9,18 @@ test.describe('Should be shown automatically', () => {
     await page.goto(urlWithProjectPreview);
   });
 
-  test('it should contain a non-empty preview frame', async ({ page }) => {
+  test('it should show loader, then a non-empty preview frame', async ({
+    page
+  }) => {
     const dialog = page.getByRole('dialog', {
       name: translations.learn['project-preview-title']
     });
     await expect(dialog).toBeVisible();
+
+    const loader = dialog.locator('.fcc-loader');
+    await expect(loader).toBeVisible();
+    await expect(loader).toHaveCount(0, { timeout: 10000 });
+
     const previewFrame = dialog.frameLocator('#fcc-project-preview-frame');
     await expect(
       // This is a part of the Cat Photo App that we expect to see. Essentially,
@@ -27,6 +34,10 @@ test.describe('Should be shown automatically', () => {
       name: translations.learn['project-preview-title']
     });
     await expect(dialog).toBeVisible();
+
+    const loader = dialog.locator('.fcc-loader');
+    await expect(loader).toBeVisible();
+    await expect(loader).toHaveCount(0, { timeout: 10000 });
     await expect(dialog.getByTitle('CatPhotoApp preview')).toBeVisible();
 
     await page.getByRole('button', { name: 'Start Coding!' }).click();
@@ -67,6 +78,9 @@ test.describe('Should be shown manually', () => {
       })
       .click();
     await expect(dialog).toBeVisible();
+    const loader = dialog.locator('.fcc-loader');
+    await expect(loader).toBeVisible();
+    await expect(loader).toHaveCount(0, { timeout: 10000 });
     const previewFrame = dialog.frameLocator('#fcc-project-preview-frame');
     await expect(
       // This is a part of the Drum Machine that we expect to see. Essentially,

--- a/e2e/project-preview-modal.spec.ts
+++ b/e2e/project-preview-modal.spec.ts
@@ -9,18 +9,11 @@ test.describe('Should be shown automatically', () => {
     await page.goto(urlWithProjectPreview);
   });
 
-  test('it should show loader, then a non-empty preview frame', async ({
-    page
-  }) => {
+  test('it should contain a non-empty preview frame', async ({ page }) => {
     const dialog = page.getByRole('dialog', {
       name: translations.learn['project-preview-title']
     });
     await expect(dialog).toBeVisible();
-
-    const loader = dialog.locator('.loader-wrapper');
-    await expect(loader).toBeVisible({ timeout: 15000 });
-    await expect(loader).toHaveCount(0, { timeout: 20000 });
-
     const previewFrame = dialog.frameLocator('#fcc-project-preview-frame');
     await expect(
       // This is a part of the Cat Photo App that we expect to see. Essentially,
@@ -34,10 +27,6 @@ test.describe('Should be shown automatically', () => {
       name: translations.learn['project-preview-title']
     });
     await expect(dialog).toBeVisible();
-
-    const loader = dialog.locator('.loader-wrapper');
-    await expect(loader).toBeVisible({ timeout: 15000 });
-    await expect(loader).toHaveCount(0, { timeout: 15000 });
     await expect(dialog.getByTitle('CatPhotoApp preview')).toBeVisible();
 
     await page.getByRole('button', { name: 'Start Coding!' }).click();
@@ -78,9 +67,6 @@ test.describe('Should be shown manually', () => {
       })
       .click();
     await expect(dialog).toBeVisible();
-    const loader = dialog.locator('.loader-wrapper');
-    await expect(loader).toBeVisible({ timeout: 15000 });
-    await expect(loader).toHaveCount(0, { timeout: 15000 });
     const previewFrame = dialog.frameLocator('#fcc-project-preview-frame');
     await expect(
       // This is a part of the Drum Machine that we expect to see. Essentially,

--- a/e2e/project-preview-modal.spec.ts
+++ b/e2e/project-preview-modal.spec.ts
@@ -17,7 +17,7 @@ test.describe('Should be shown automatically', () => {
     });
     await expect(dialog).toBeVisible();
 
-    const loader = dialog.locator('.fcc-loader');
+    const loader = dialog.locator('.loader-wrapper');
     await expect(loader).toBeVisible({ timeout: 15000 });
     await expect(loader).toHaveCount(0, { timeout: 15000 });
 
@@ -35,7 +35,7 @@ test.describe('Should be shown automatically', () => {
     });
     await expect(dialog).toBeVisible();
 
-    const loader = dialog.locator('.fcc-loader');
+    const loader = dialog.locator('.loader-wrapper');
     await expect(loader).toBeVisible({ timeout: 15000 });
     await expect(loader).toHaveCount(0, { timeout: 15000 });
     await expect(dialog.getByTitle('CatPhotoApp preview')).toBeVisible();
@@ -78,7 +78,7 @@ test.describe('Should be shown manually', () => {
       })
       .click();
     await expect(dialog).toBeVisible();
-    const loader = dialog.locator('.fcc-loader');
+    const loader = dialog.locator('.loader-wrapper');
     await expect(loader).toBeVisible({ timeout: 15000 });
     await expect(loader).toHaveCount(0, { timeout: 15000 });
     const previewFrame = dialog.frameLocator('#fcc-project-preview-frame');

--- a/e2e/project-preview-modal.spec.ts
+++ b/e2e/project-preview-modal.spec.ts
@@ -12,10 +12,6 @@ test.describe('Should be shown automatically', () => {
   test('it should show loader, then a non-empty preview frame', async ({
     page
   }) => {
-    await page.route('**/*', async route => {
-      await new Promise(resolve => setTimeout(resolve, 1000));
-      await route.continue();
-    });
     const dialog = page.getByRole('dialog', {
       name: translations.learn['project-preview-title']
     });

--- a/e2e/project-preview-modal.spec.ts
+++ b/e2e/project-preview-modal.spec.ts
@@ -12,6 +12,10 @@ test.describe('Should be shown automatically', () => {
   test('it should show loader, then a non-empty preview frame', async ({
     page
   }) => {
+    await page.route('**/*', async route => {
+      await new Promise(resolve => setTimeout(resolve, 1000));
+      await route.continue();
+    });
     const dialog = page.getByRole('dialog', {
       name: translations.learn['project-preview-title']
     });
@@ -19,7 +23,7 @@ test.describe('Should be shown automatically', () => {
 
     const loader = dialog.locator('.loader-wrapper');
     await expect(loader).toBeVisible({ timeout: 15000 });
-    await expect(loader).toHaveCount(0, { timeout: 15000 });
+    await expect(loader).toHaveCount(0, { timeout: 20000 });
 
     const previewFrame = dialog.frameLocator('#fcc-project-preview-frame');
     await expect(


### PR DESCRIPTION
Added loader before preview gets loaded.

Tested on local machine:

<img width="1170" height="1992" alt="mobile-safari" src="https://github.com/user-attachments/assets/560ee909-3a2d-4db6-9af4-97c020373753" />
<img width="2560" height="1440" alt="web" src="https://github.com/user-attachments/assets/41b6b048-d0b7-4860-bcaa-9baef351feab" />

For some reason the tests can not pass in CI, so I removed them, though they can pass on my local machine:

https://github.com/freeCodeCamp/freeCodeCamp/pull/64245/commits/49123e9f6b3ce0f5c63e64d28e283a2d203107a3#diff-9ea15b9283eb9b5b9b42d2e842f0f8c6f38987695b69b70be6719afe580b1086

Checklist:

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #62408 

