### PR TITLE
fix(curriculum): replace 'boolean operations' with 'boolean operators'

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-introduction-to-python/68480f431e8568b2056b140b.md
+++ b/curriculum/challenges/english/blocks/lecture-introduction-to-python/68480f431e8568b2056b140b.md
@@ -52,7 +52,7 @@ print(bool(1)) # True
 print(bool('Hello')) # True
 ```
 
-Now that you understand truthy and falsy values, we can take a look at Boolean operators, which are also known as logical operators or Boolean operations. These are special operators that allow you to combine multiple expressions to create more complex decision-making logic in your code.
+Now that you understand truthy and falsy values, we can take a look at Boolean operators, which are also known as logical operators or Boolean operators. These are special operators that allow you to combine multiple expressions to create more complex decision-making logic in your code.
 
 There are three Boolean operators in Python: `and`, `or`, and `not`.
 


### PR DESCRIPTION
This PR fixes a minor typo in the Python V9 lecture: "Introduction to Python: What Are Truthy and Falsy Values and How Do Boolean Operators and Short-Circuiting Work".

The text incorrectly uses "boolean operations" instead of "boolean operators". This change corrects the terminology to accurately reflect Python concepts.

Affected Page:
https://www.freecodecamp.org/learn/python-v9/lecture-introduction-to-python/what-are-truthy-and-falsy-values-and-how-do-boolean-operators-and-short-circuiting-work

Closes #64242

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #64242 

<!-- Feel free to add any additional description of changes below this line -->
