### PR TITLE
fix(curriculum): correct float output comments in python challenges

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-introduction-to-python/67fe859a00971c34a23abd43.md
+++ b/curriculum/challenges/english/blocks/lecture-introduction-to-python/67fe859a00971c34a23abd43.md
@@ -38,7 +38,7 @@ print('Integer:', my_integer_var) # Integer: 10
 
 ```python
 my_float_var = 4.50
-print('Float:', my_float_var) # Float: 4.50
+print('Float:', my_float_var) # Float: 4.5
 ```
 
 - Complex: A number with a real and imaginary part, like `6 + 7j`.
@@ -146,7 +146,7 @@ my_integer_var = 10
 print('Integer:', my_integer_var, '| Type:', type(my_integer_var))  # Integer: 10 | Type: <class 'int'>
 
 my_float_var = 4.50
-print('Float:', my_float_var, '| Type:', type(my_float_var))  # Float: 4.50 | Type: <class 'float'>
+print('Float:', my_float_var, '| Type:', type(my_float_var))  # Float: 4.5 | Type: <class 'float'>
 
 my_complex_var = 3 + 4j
 print('Complex:', my_complex_var, '| Type:', type(my_complex_var))  # Complex: (3+4j) | Type: <class 'complex'>

--- a/curriculum/challenges/english/blocks/review-python-basics/67f39b40deaec81a3e40e0c5.md
+++ b/curriculum/challenges/english/blocks/review-python-basics/67f39b40deaec81a3e40e0c5.md
@@ -74,7 +74,7 @@ print('Integer:', my_integer_var) # Integer: 10
 
 ```py
 my_float_var = 4.50
-print('Float:', my_float_var) # Float: 4.50
+print('Float:', my_float_var) # Float: 4.5
 ```
 
 - **Complex**: A number with a real and imaginary part:

--- a/curriculum/challenges/english/blocks/review-python/67f39e391c9b373069def02c.md
+++ b/curriculum/challenges/english/blocks/review-python/67f39e391c9b373069def02c.md
@@ -74,7 +74,7 @@ print('Integer:', my_integer_var) # Integer: 10
 
 ```py
 my_float_var = 4.50
-print('Float:', my_float_var) # Float: 4.50
+print('Float:', my_float_var) # Float: 4.5
 ```
 
 - **Complex**: A number with a real and imaginary part:


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #64243

<!-- Feel free to add any additional description of changes below this line -->

### Description
Updated the comments in the Python curriculum files to accurately reflect Python's float output behavior. Specifically, changed the commented output `# Float: 4.50` to `# Float: 4.5` because Python removes trailing zeros when printing floats.

### Files Changed
- `curriculum/challenges/english/blocks/lecture-introduction-to-python/67fe859a00971c34a23abd43.md`
- `curriculum/challenges/english/blocks/review-python/67f39e391c9b373069def02c.md`
- `curriculum/challenges/english/blocks/review-python-basics/67f39b40deaec81a3e40e0c5.md`