### PR TITLE
fix(curriculum): clarify descendant combinator symbol in css review

### DIFF
--- a/curriculum/challenges/english/blocks/review-css/671a9a0a140c2b9d6a75629f.md
+++ b/curriculum/challenges/english/blocks/review-css/671a9a0a140c2b9d6a75629f.md
@@ -33,7 +33,7 @@ Review the concepts below to prepare for the upcoming exam.
 
 ## Different Types of CSS Combinators
 
-- **Descendant Combinator**: This combinator is used to target elements that are descendants of a specified parent element.
+- **Descendant Combinator ( )**: This combinator is used to target elements that are descendants of a specified parent element.
 - **Child Combinator (`>`)**: This combinator is used to select elements that are direct children of a specified parent element. 
 - **Next-sibling Combinator (`+`)**: This combinator selects an element that immediately follows a specified sibling element. 
 

--- a/curriculum/challenges/english/blocks/review-css/671a9a0a140c2b9d6a75629f.md
+++ b/curriculum/challenges/english/blocks/review-css/671a9a0a140c2b9d6a75629f.md
@@ -33,7 +33,7 @@ Review the concepts below to prepare for the upcoming exam.
 
 ## Different Types of CSS Combinators
 
-- **Descendant Combinator ( )**: This combinator is used to target elements that are descendants of a specified parent element.
+- **Descendant Combinator (` `)**: This combinator is used to target elements that are descendants of a specified parent element.
 - **Child Combinator (`>`)**: This combinator is used to select elements that are direct children of a specified parent element. 
 - **Next-sibling Combinator (`+`)**: This combinator selects an element that immediately follows a specified sibling element. 
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #64255

<!-- Feel free to add any additional description of changes below this line -->

### Description
Updated the "Descendant Combinator" description in the CSS Review lesson to explicitly show the space character `( )` as the combinator symbol, consistent with how other combinators (like `>` and `+`) are presented. This clarifies that a single space is used to target descendant elements.

### Files Changed
- `curriculum/challenges/english/blocks/review-css/671a9a0a140c2b9d6a75629f.md`