### PR TITLE
fix(curriculum): remove redundant form attribute denitions in html review

### DIFF
--- a/curriculum/challenges/english/blocks/review-html/671a883163d5ab5d47145880.md
+++ b/curriculum/challenges/english/blocks/review-html/671a883163d5ab5d47145880.md
@@ -98,8 +98,6 @@ Review the concepts below to prepare for the upcoming prep exam.
 ### Forms
 
 - **`form` element**: Used to create an HTML form for user input.
-- **`action` attribute**: Defines where to send form data.
-- **`method` attribute**: Determines how form data is sent (`GET` or `POST`).
 - **Common Input Types**: 
   - `text`, `email`, `password`, `radio`, `checkbox`, `number`, `date`.
 - **`action` attribute**: used to specify the URL where the form data should be sent.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #64250

<!-- Feel free to add any additional description of changes below this line -->

### Description
Removed redundant definitions for `action` and `method` attributes in the HTML Review lesson. The lesson previously defined these attributes twice in the "Forms" section. I kept the more detailed definitions and removed the duplicate, less specific ones to improve clarity and reduce repetition.

### Files Changed
- `curriculum/challenges/english/blocks/review-html/671a883163d5ab5d47145880.md`