### PR TITLE
fix(client): clarify “my location” wording

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -315,7 +315,7 @@
       "results-for": "Results for {{projectTitle}}",
       "my-profile": "My profile",
       "my-name": "My name",
-      "my-location": "My location",
+      "my-location": "My stated location (freeCodeCamp does not track your actual location)",
       "my-about": "My about",
       "my-points": "My points",
       "my-heatmap": "My heatmap",


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes locally on my machine.

Closes #64248

This PR updates the wording of the `my-location` translation string to:

“My stated location (freeCodeCamp does not track your actual location)”

This clarifies that the location displayed is the user’s stated location and not their real geolocation, improving privacy transparency as described in the issue.

Only the translation string was updated, and no other keys or files were modified.