### PR TITLE
chore: move challenge-auditor out of root

### DIFF
--- a/curriculum/package.json
+++ b/curriculum/package.json
@@ -18,6 +18,7 @@
   "homepage": "https://github.com/freeCodeCamp/freeCodeCamp#readme",
   "author": "freeCodeCamp <team@freecodecamp.org>",
   "scripts": {
+    "audit-challenges": "pnpm -w run compile:ts && tsx ./src/challenge-auditor/index.ts",
     "build": "tsx ./src/generate/build-curriculum",
     "compile": "tsc --build --clean && tsc --build",
     "create-empty-steps": "CALLING_DIR=$INIT_CWD tsx --tsconfig ../tsconfig.json ../tools/challenge-helper-scripts/create-empty-steps",

--- a/curriculum/src/challenge-auditor/index.ts
+++ b/curriculum/src/challenge-auditor/index.ts
@@ -1,5 +1,4 @@
-import { readdir } from 'fs/promises';
-import { join, resolve } from 'path';
+import { resolve } from 'path';
 
 import { flatten } from 'lodash/fp';
 import { config } from 'dotenv';
@@ -13,7 +12,6 @@ import {
   SuperBlocks,
   getAuditedSuperBlocks
 } from '../../../shared/config/curriculum';
-import { getContentDir } from '../file-handler';
 
 // TODO: re-organise the types to a common 'types' folder that can be shared
 // between the workspaces so we don't have to declare ChallengeNode here and in
@@ -49,20 +47,7 @@ const getChallenges = async (lang: string) => {
 
 void (async () => {
   let actionShouldFail = false;
-  const englishCurriculumDirectory = getContentDir('english');
-  const englishFilePaths: string[] = [];
-  const englishBlocks = await readdir(englishCurriculumDirectory);
-  for (const englishBlock of englishBlocks) {
-    if (englishBlock.endsWith('.txt')) {
-      continue;
-    }
-    const englishChallenges = await readdir(
-      join(englishCurriculumDirectory, englishBlock)
-    );
-    for (const englishChallenge of englishChallenges) {
-      englishFilePaths.push(join(englishBlock, englishChallenge));
-    }
-  }
+
   const langsToCheck = availableLangs.curriculum.filter(
     lang => String(lang) !== 'english'
   );

--- a/curriculum/src/challenge-auditor/index.ts
+++ b/curriculum/src/challenge-auditor/index.ts
@@ -1,10 +1,4 @@
-import { resolve } from 'path';
-
 import { flatten } from 'lodash/fp';
-import { config } from 'dotenv';
-
-const envPath = resolve(__dirname, '../../../.env');
-config({ path: envPath });
 
 import { availableLangs } from '../../../shared/config/i18n';
 import { getChallengesForLang } from '../get-challenges';

--- a/curriculum/src/challenge-auditor/index.ts
+++ b/curriculum/src/challenge-auditor/index.ts
@@ -4,15 +4,16 @@ import { join, resolve } from 'path';
 import { flatten } from 'lodash/fp';
 import { config } from 'dotenv';
 
-const envPath = resolve(__dirname, '../../.env');
+const envPath = resolve(__dirname, '../../../.env');
 config({ path: envPath });
 
-import { availableLangs } from '../../shared/config/i18n';
-import { getChallengesForLang } from '../../curriculum/src/get-challenges';
+import { availableLangs } from '../../../shared/config/i18n';
+import { getChallengesForLang } from '../get-challenges';
 import {
   SuperBlocks,
   getAuditedSuperBlocks
-} from '../../shared/config/curriculum';
+} from '../../../shared/config/curriculum';
+import { getContentDir } from '../file-handler';
 
 // TODO: re-organise the types to a common 'types' folder that can be shared
 // between the workspaces so we don't have to declare ChallengeNode here and in
@@ -30,10 +31,6 @@ type ChallengeNode = {
 
 // Adding types for getChallengesForLang is possible, but not worth the effort
 // at this time.
-/* eslint-disable @typescript-eslint/no-unsafe-return */
-/* eslint-disable @typescript-eslint/no-unsafe-argument */
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
 
 const getChallenges = async (lang: string) => {
   const curriculum = await getChallengesForLang(lang);
@@ -50,19 +47,9 @@ const getChallenges = async (lang: string) => {
   );
 };
 
-/* eslint-enable @typescript-eslint/no-unsafe-return */
-/* eslint-enable @typescript-eslint/no-unsafe-argument */
-/* eslint-enable @typescript-eslint/no-unsafe-assignment */
-/* eslint-enable @typescript-eslint/no-unsafe-member-access */
-
 void (async () => {
   let actionShouldFail = false;
-  const englishCurriculumDirectory = join(
-    process.cwd(),
-    'curriculum',
-    'challenges',
-    'english'
-  );
+  const englishCurriculumDirectory = getContentDir('english');
   const englishFilePaths: string[] = [];
   const englishBlocks = await readdir(englishCurriculumDirectory);
   for (const englishBlock of englishBlocks) {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "freeCodeCamp <team@freecodecamp.org>",
   "main": "none",
   "scripts": {
-    "audit-challenges": "pnpm run compile:ts && tsx tools/challenge-auditor/index.ts",
+    "audit-challenges": "cd curriculum && pnpm audit-challenges",
     "analyze-bundle": "webpack-bundle-analyzer",
     "prebuild": "npm-run-all compile:ts",
     "build": "npm-run-all -p build:*",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,6 @@
   "include": [
     "*.ts",
     "curriculum/*.test.ts",
-    "tools/challenge-auditor/index.ts",
     "tools/challenge-editor/**/*",
     "tools/scripts/**/*.ts",
     "tools/daily-challenges/**/*.ts"


### PR DESCRIPTION
- **refactor: move challenge auditing to curriculum**
- **refactor: remove dead code**
- **refactor: remove more dead code**

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Challenge auditing doesn't make sense as a root responsibility.  Challenges are part of the curriculum, so checking them should be the curriculum package's job. Grouping the curriculum validation with the rest of the curriculum is a little more coherent.

That said, this might be best in the i18n repo, since this only checks the i18n challenges. @moT01 maybe something for a follow up?

<!-- Feel free to add any additional description of changes below this line -->
