### PR TITLE
fix(curriculum): remove redundant 'each' in Lab - Feature selection

### DIFF
--- a/curriculum/challenges/english/blocks/lab-feature-selection/68ce56d54d3cad1149a1c4cf.md
+++ b/curriculum/challenges/english/blocks/lab-feature-selection/68ce56d54d3cad1149a1c4cf.md
@@ -15,7 +15,7 @@ demoType: onClick
 1. Your page should have an `h1` element with the text `Feature Selection`.
 2. Your page should have a `div` element with the class `feature-card-container`.
 3. Your page should have at least two `label` elements each with the class `feature-card` inside the `div`.
-4. Each of your `label` elements should each have label text and an `input` element of type `checkbox` in them.
+4. Each of your `label` elements should have label text and an `input` element of type `checkbox` in them.
 5. Create a selector that targets the checkboxes, and apply the following styling:
     - All of your checkbox elements should be set to `appearance: none;` in your CSS.
     - All of your checkbox elements should have a border width, color and style of your choosing.


### PR DESCRIPTION
…page

Removes the second, redundant use of "each" from "instruction 4." text for the "Design a Feature Selection Page" lab.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

It does not closes any issue. 

<!-- Feel free to add any additional description of changes below this line -->
