### PR TITLE
fix(curriculum): change spelling from travelling to to traveling

### DIFF
--- a/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/691b559495c5cb5a37b9b487.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/691b559495c5cb5a37b9b487.md
@@ -10,9 +10,9 @@ dashedName: challenge-127
 Given the speed you are traveling in miles per hour (MPH), and a speed limit in kilometers per hour (KPH), determine whether you are speeding and if you will get a warning or a ticket.
 
 - 1 mile equals 1.60934 kilometers.
-- If you are travelling less than or equal to the speed limit, return `"Not Speeding"`.
-- If you are travelling 5 KPH or less over the speed limit, return `"Warning"`.
-- If you are travelling more than 5 KPH over the speed limit, return `"Ticket"`.
+- If you are traveling less than or equal to the speed limit, return `"Not Speeding"`.
+- If you are traveling 5 KPH or less over the speed limit, return `"Warning"`.
+- If you are traveling more than 5 KPH over the speed limit, return `"Ticket"`.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/daily-coding-challenges-python/691b559495c5cb5a37b9b487.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-python/691b559495c5cb5a37b9b487.md
@@ -10,9 +10,9 @@ dashedName: challenge-127
 Given the speed you are traveling in miles per hour (MPH), and a speed limit in kilometers per hour (KPH), determine whether you are speeding and if you will get a warning or a ticket.
 
 - 1 mile equals 1.60934 kilometers.
-- If you are travelling less than or equal to the speed limit, return `"Not Speeding"`.
-- If you are travelling 5 KPH or less over the speed limit, return `"Warning"`.
-- If you are travelling more than 5 KPH over the speed limit, return `"Ticket"`.
+- If you are traveling less than or equal to the speed limit, return `"Not Speeding"`.
+- If you are traveling 5 KPH or less over the speed limit, return `"Warning"`.
+- If you are traveling more than 5 KPH over the speed limit, return `"Ticket"`.
 
 # --hints--
 


### PR DESCRIPTION
Update the spelling of "travelling" from British spelling to American Standard spelling.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
