### PR TITLE
fix(curriculum): change 'is agreeing' to 'agree' in Task 75

### DIFF
--- a/curriculum/challenges/english/blocks/learn-how-to-express-agreement/67b2f6ded80a5349b4cdb55f.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-express-agreement/67b2f6ded80a5349b4cdb55f.md
@@ -38,7 +38,7 @@ This three-word phrase means to inform someone or provide them with information.
 
 `Got it` is an informal way of acknowledging that you've understood something. It's a quick response showing comprehension and agreement. For example:
 
-`Got it, I'll handle it.` - This means you understand the request and is agreeing to take care of it.
+`Got it, I'll handle it.` - This means you understand the request and agree to take care of it.
 
 `Let you know` means to tell someone about something in the future. It shows that you will keep someone informed. For example:
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #64302

<!-- Feel free to add any additional description of changes below this line -->

Grammar fix in Task 75
Replaced “is agreeing” with “agree” in the explanation text to correct the tense usage and improve readability.
