### PR TITLE
Fix/my bufix(python): correct set operation examples in Review Dictionaries and Setsg fix

### DIFF
--- a/curriculum/challenges/english/blocks/review-dictionaries-and-sets/67f39babe1e2ec1fb6eea32a.md
+++ b/curriculum/challenges/english/blocks/review-dictionaries-and-sets/67f39babe1e2ec1fb6eea32a.md
@@ -240,7 +240,7 @@ my_set.clear()
 
 ```python
 my_set = {1, 2, 3, 4, 5} 
-your_set = {2, 3, 4, 5}
+your_set = {2, 3, 4, 7}
 
 print(your_set.issubset(my_set)) # False
 print(my_set.issuperset(your_set)) # False

--- a/curriculum/challenges/english/blocks/review-dictionaries-and-sets/67f39babe1e2ec1fb6eea32a.md
+++ b/curriculum/challenges/english/blocks/review-dictionaries-and-sets/67f39babe1e2ec1fb6eea32a.md
@@ -242,8 +242,8 @@ my_set.clear()
 my_set = {1, 2, 3, 4, 5} 
 your_set = {2, 3, 4, 5}
 
-print(your_set.issubset(my_set)) # True
-print(my_set.issuperset(your_set)) # True
+print(your_set.issubset(my_set)) # False
+print(my_set.issuperset(your_set)) # False
 ```
 
 - **`isdisjoint()` Method**: The `isdisjoint()` method checks if two sets are disjoint, if they don't have elements in common.
@@ -255,7 +255,7 @@ print(my_set.isdisjoint(your_set)) # False
 - **Union Operator (`|`)**: The union operator `|` returns a new set with all the elements from both sets.
 
 ```python
-my_set | your_set # {1, 2, 3, 4, 5, 6}
+my_set | your_set # {1, 2, 3, 4, 5, 7}
 ```
 
 - **Intersection Operator (`&`)**: The intersection operator `&` returns a new set with only the elements that the sets have in common.
@@ -273,13 +273,13 @@ my_set - your_set # {1, 5}
 - **Symmetric Difference Operator (`^`)**: The symmetric difference operator `^` returns a new set with the elements that are either on the first or the second set, but not both.
 
 ```python
-my_set ^ your_set # {1, 5, 6}
+my_set ^ your_set # {1, 5, 7}
 ```
 
 - **`in` Operator**: You can check if an element is in a set or not with the `in` operator.
 
 ```python
-print(5 in my_set)
+print(5 in my_set) # True
 ```
 
 ## Python Standard Library


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ x] My pull request targets the `main` branch of freeCodeCamp.
- [ x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
Updated 'my_set' and 'your_set' examples to correct outputs for union, intersection, difference, and symmetric difference.
Replaced your_set = {2, 3, 4, 5} with your_set = {2, 3, 4, 7} to match the corrected example.

