### PR TITLE
fix(client): increase chapter icon size

### DIFF
--- a/client/src/assets/chapter-icon.tsx
+++ b/client/src/assets/chapter-icon.tsx
@@ -63,7 +63,7 @@ export function ChapterIcon(props: ChapterIconProps): JSX.Element {
   const Icon = iconMap[chapter] ?? ResponsiveDesign;
 
   if (typeof Icon === 'object') {
-    return <FontAwesomeIcon icon={Icon} />;
+    return <FontAwesomeIcon icon={Icon} size='lg' />;
   }
 
   return <Icon {...iconProps} />;


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #64308

Increased the chapter icon size by adding the size='lg' prop as requested in the issue.
