### PR TITLE
fix(curriculum): improve wording in input introductions

### DIFF
--- a/curriculum/challenges/english/blocks/zh-a1-learn-certification-introduction/691f071bd6a0ee105c5f571e.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-certification-introduction/691f071bd6a0ee105c5f571e.md
@@ -1,8 +1,8 @@
 ---
 id: 691f071bd6a0ee105c5f571e
-title: Pinyin-Hanzi Input
+title: Pinyin-to-Hanzi Input
 challengeType: 22
-dashedName: pinyin-hanzi-input
+dashedName: pinyin-to-hanzi-input
 lang: zh-CN
 inputType: pinyin-to-hanzi
 ---
@@ -11,7 +11,7 @@ inputType: pinyin-to-hanzi
 
 # --description--
 
-You've already learned how to input correct Pinyin. Now you're ready to input Chinese characters. This is where the Pinyin-Hanzi Input comes in. Try typing `ni3 hao3` and `shi4 jie4` to see how to say "Hello, world" in Chinese!
+You've already learned how to input correct Pinyin. Now you're ready to input Chinese characters. This is where the Pinyin-to-Hanzi input comes in. Try typing `ni3 hao3` and `shi4 jie4` again to see how "Hello, world" is written in Chinese!
 
 Again, if you make a mistake, just delete the incorrect part and re-enter it.
 
@@ -31,7 +31,7 @@ Listen to the audio and complete the sentence below.
 
 ### --feedback--
 
-This two-character word means "hello". You can type it using the Pinyin–Hanzi Input by entering `ni3 hao3`.
+This two-character word means "hello", created by typing `ni3 hao3`.
 
 ---
 
@@ -39,13 +39,13 @@ This two-character word means "hello". You can type it using the Pinyin–Hanzi 
 
 ### --feedback--
 
-This two-character word means "world". You can type it using the Pinyin–Hanzi Input by entering `shi4 jie4`.
+This two-character word means "world", created by typing `shi4 jie4`.
 
 # --explanation--
 
-With the Pinyin-Hanzi input, you can type the letters plus a tone number to automatically convert them into characters. For example, here, `ni3 hao3` becomes `你好`, and `shi4 jie4` becomes `世界`.
+With the Pinyin-to-Hanzi input, you can type the letters plus a tone number to automatically convert them into characters. For example, here, `ni3 hao3` becomes `你好`, and `shi4 jie4` becomes `世界`.
 
-*Note: Both the Pinyin-Tone Input and the Pinyin-Hanzi Input convert your letter and number input into either Pinyin or Chinese characters. The system automatically decides which conversion to apply, so you don't need to worry about the process.*
+*Note: Both the Pinyin Tone input and the Pinyin-to-Hanzi input convert your letter and number input into either Pinyin or Chinese characters. The system automatically decides which conversion to apply, so you don't need to worry about the process.*
 
 # --scene--
 

--- a/curriculum/challenges/english/blocks/zh-a1-learn-certification-introduction/691fd70b91fd33630effdf6e.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-certification-introduction/691fd70b91fd33630effdf6e.md
@@ -33,11 +33,11 @@ Listen to the audio and complete the sentence below.
 
 ## --sentence--
 
-`BLANK，BLANK。`
+`BLANK, BLANK.`
 
 ## --blanks--
 
-`nǐ hǎo`
+`Nǐ hǎo`
 
 ### --feedback--
 

--- a/curriculum/challenges/english/blocks/zh-a1-learn-certification-introduction/691fd70b91fd33630effdf6e.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-certification-introduction/691fd70b91fd33630effdf6e.md
@@ -19,7 +19,7 @@ Since Chinese characters are not phonetic, a system called **Pinyin**​ is used
 
 You're about to input your first two Chinese words, each made of two characters. Sounds unbelievable, right? freeCodeCamp has developed the **Pinyin Tone input** and **Pinyin-to-Hanzi input** to help you do this easily.
 
-This task has you writing Pinyin using the Pinyin Tone input.
+In this task, you'll practice writing Pinyin using the Pinyin Tone input.
 
 In the audio, Wang Hua is saying "Hello, world." in Chinese. Try typing `ni3 hao3` and `shi4 jie4` to see what happens. If you make a mistake, just delete the incorrect part and type again.
 

--- a/curriculum/challenges/english/blocks/zh-a1-learn-certification-introduction/691fd70b91fd33630effdf6e.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-certification-introduction/691fd70b91fd33630effdf6e.md
@@ -1,6 +1,6 @@
 ---
 id: 691fd70b91fd33630effdf6e
-title: Pinyin-Tone Input
+title: Pinyin Tone Input
 challengeType: 22
 dashedName: pinyin-tone-input
 lang: zh-CN
@@ -17,9 +17,11 @@ Chinese is written in two major forms: Simplified and Traditional Chinese. This 
 
 Since Chinese characters are not phonetic, a system called **Pinyin**​ is used to represent their sounds. Pinyin is a romanization system that uses the Latin alphabet to indicate how Chinese characters are pronounced. It serves as an essential tool for beginners to learn the pronunciation of the language and to type Chinese on digital devices.
 
-In the audio, Wang Hua is saying "Hello, world." in Chinese. You're about to input your first two Chinese words, each made of two characters. Sounds unbelievable, right? freeCodeCamp has customized the **Pinyin-Tone Input** and **Pinyin-Hanzi Input** to help you do this easily.
+You're about to input your first two Chinese words, each made of two characters. Sounds unbelievable, right? freeCodeCamp has developed the **Pinyin Tone input** and **Pinyin-to-Hanzi input** to help you do this easily.
 
-Try typing `ni3 hao3` and `shi4 jie4` to see what happens. If you make a mistake, just delete the incorrect part and type again.
+This task has you writing Pinyin using the Pinyin Tone input.
+
+In the audio, Wang Hua is saying "Hello, world." in Chinese. Try typing `ni3 hao3` and `shi4 jie4` to see what happens. If you make a mistake, just delete the incorrect part and type again.
 
 Remember to expand the explanation section below to see what's happening behind the scenes.
 
@@ -39,7 +41,7 @@ Listen to the audio and complete the sentence below.
 
 ### --feedback--
 
-This is the Pinyin for the greeting meaning "hello", typed `ni3 hao3` with freeCodeCamp's Pinyin-tone Input.
+This is the Pinyin for the greeting meaning "hello", created by typing `ni3 hao3`.
 
 ---
 
@@ -47,7 +49,7 @@ This is the Pinyin for the greeting meaning "hello", typed `ni3 hao3` with freeC
 
 ### --feedback--
 
-This is the Pinyin for "world", typed `shi4 jie4` with freeCodeCamp's Pinyin-tone Input.
+This is the Pinyin for "world", created by typing `shi4 jie4`.
 
 # --explanation--
   
@@ -57,7 +59,7 @@ In most built-in Chinese input methods on computers or mobile devices, as well a
 
 However, typing and seeing tone marks helps beginners build and strengthen the memory of Chinese characters.
 
-With the Pinyin-Tone input, you can type the letters plus a tone number to automatically convert them into tone-marked Pinyin. For example, here, `ni3 hao3` becomes `nǐ hǎo`, and `shi4 jie4` becomes `shì jiè`.
+With the Pinyin Tone input, you can type the letters plus a tone number to automatically convert them into tone-marked Pinyin. For example, here, `ni3 hao3` becomes `nǐ hǎo`, and `shi4 jie4` becomes `shì jiè`.
 
 You will use this input frequently when learning Pinyin in Chapter 2 of this curriculum.
 

--- a/curriculum/structure/blocks/zh-a1-learn-certification-introduction.json
+++ b/curriculum/structure/blocks/zh-a1-learn-certification-introduction.json
@@ -11,11 +11,11 @@
     },
     {
       "id": "691fd70b91fd33630effdf6e",
-      "title": "Pinyin-Tone Input"
+      "title": "Pinyin Tone Input"
     },
     {
       "id": "691f071bd6a0ee105c5f571e",
-      "title": "Pinyin-Hanzi Input"
+      "title": "Pinyin-to-Hanzi Input"
     },
     {
       "id": "691ecaaed19d057a2870c77b",


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Now that we have both inputs available, I reviewed chapter 1 again and thought we could improve the wording in the lessons a little.

<!-- Feel free to add any additional description of changes below this line -->
