### PR TITLE
fix(curriculum): convert user output to string to improve test comparision

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-plant-nursery-catalog/673521668be7905059b2d555.md
+++ b/curriculum/challenges/english/blocks/workshop-plant-nursery-catalog/673521668be7905059b2d555.md
@@ -56,7 +56,7 @@ const displayCatalogTest = () => {
 `   })
     return catalogString
 }
-let actualOutput = String(displayCatalog())
+const actualOutput = String(displayCatalog())
 assert.equal(actualOutput, displayCatalogTest())
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-plant-nursery-catalog/673521668be7905059b2d555.md
+++ b/curriculum/challenges/english/blocks/workshop-plant-nursery-catalog/673521668be7905059b2d555.md
@@ -56,7 +56,8 @@ const displayCatalogTest = () => {
 `   })
     return catalogString
 }
-assert.equal(displayCatalog(), displayCatalogTest())
+let actualOutput = String(displayCatalog())
+assert.equal(actualOutput, displayCatalogTest())
 ```
 
 # --seed--


### PR DESCRIPTION
…ison accuracy

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #64229

<!-- Feel free to add any additional description of changes below this line -->
* Handling falsey values by converting the user output to string before assertion.
* Objects would still appear as `[object Object]` (same as before). Can handle this edge case by converting objects to string using `JSON.stringify`, but we will have to introduce some extra logic into the tests. I don't think it is necessary at this stage.
