### PR TITLE
fix(client): correct placement of Interactive Editor button

### DIFF
--- a/client/src/templates/Challenges/classic/classic.css
+++ b/client/src/templates/Challenges/classic/classic.css
@@ -83,6 +83,7 @@
 .tabs-row-right {
   display: flex;
   justify-content: flex-end;
+  margin-inline-start: auto;
 }
 
 .monaco-editor-tabs button + button {

--- a/client/src/templates/Challenges/classic/classic.css
+++ b/client/src/templates/Challenges/classic/classic.css
@@ -83,6 +83,7 @@
 .tabs-row-right {
   display: flex;
   justify-content: flex-end;
+  /* Ensure the right group pins to the end even when no left/middle items exist */
   margin-inline-start: auto;
 }
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #64349
<img width="1916" height="905" alt="fix_InteractiveEditor_button" src="https://github.com/user-attachments/assets/daa2cf5c-543d-4bc0-b6cc-644f6601af96" />


<!-- Feel free to add any additional description of changes below this line -->
