### PR TITLE
fix:Streak Calculation Logic by add 1-day grace period 

### DIFF
--- a/client/src/components/profile/components/stats.test.tsx
+++ b/client/src/components/profile/components/stats.test.tsx
@@ -74,7 +74,18 @@ vi.useFakeTimers();
 
 describe('calculateStreaks', () => {
   beforeEach(() => vi.setSystemTime(new Date(2025, 0, 15)));
-  test('Should return 0 for the current streak if the user has not made progress today', () => {
+  test('Should maintain current streak if last activity was yesterday (grace period)', () => {
+    // Last activity on Jan 14, testing on Jan 15 (1 day grace period)
+    const { longestStreak, currentStreak } =
+      calculateStreaks(oldStreakCalendar);
+
+    expect(longestStreak).toBe(5);
+    expect(currentStreak).toBe(5);
+  });
+
+  test('Should reset current streak after grace period expires (2+ days without activity)', () => {
+    // Last activity on Jan 14, testing on Jan 16 (grace period expired)
+    vi.setSystemTime(new Date(2025, 0, 16));
     const { longestStreak, currentStreak } =
       calculateStreaks(oldStreakCalendar);
 

--- a/client/src/components/profile/components/stats.tsx
+++ b/client/src/components/profile/components/stats.tsx
@@ -1,5 +1,10 @@
 import React, { useState, useEffect } from 'react';
-import { startOfDay, addDays, isEqual } from 'date-fns';
+import {
+  startOfDay,
+  addDays,
+  isEqual,
+  differenceInCalendarDays
+} from 'date-fns';
 import { useTranslation } from 'react-i18next';
 import { Spacer } from '@freecodecamp/ui';
 import { last } from 'lodash-es';
@@ -42,7 +47,11 @@ export const calculateStreaks = (calendar: Record<string, number>) => {
   );
 
   const lastDay = last(days);
-  const streakExpired = !lastDay || !isEqual(lastDay, startOfDay(Date.now()));
+  const today = startOfDay(Date.now());
+
+  // Grace period: streak remains active if last activity was today or yesterday
+  const streakExpired =
+    !lastDay || differenceInCalendarDays(today, lastDay) > 1;
 
   return { longestStreak, currentStreak: streakExpired ? 0 : currentStreak };
 };


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the 64092 below with the issue number.-->

Closes  #64092

<!-- Feel free to add any additional description of changes below this line -->
## Description
This PR implements a 1-day grace period for the streak calculation to prevent immediate streak resets when users don't complete challenges today.

## Changes Made
- Added grace period logic: streak remains active if last activity was today **or** yesterday
- Refactored `calculateStreaks()` to use `differenceInCalendarDays` for clearer date comparison
- Updated existing test to verify grace period behavior (yesterday = streak active)
- Added new test case to verify streak resets after grace period expires (2+ days = streak reset to 0)

## Technical Implementation
- Used `differenceInCalendarDays(today, lastDay) > 1` to check if more than 1 day has passed
- Streak expires only when 2+ calendar days have passed since last activity
- Maintains backward compatibility with all existing tests

## Testing
- ✅ All 11 tests pass locally
- ✅ New test verifies grace period behavior
- ✅ Edge cases covered: no activity, today's activity, yesterday's activity, 2+ days gap

### Test Results Screenshot:
<img width="1412" height="986" alt="image" src="https://github.com/user-attachments/assets/4d20005d-ca83-4d32-afa6-6cae9c8604db" />


## Behavior
| Days Since Last Activity | Streak Status |
|-------------------------|---------------|
| 0 days (today) | ✅ Active |
| 1 day (yesterday) | ✅ Active (grace period) |
| 2+ days | ❌ Reset to 0 |
