### PR TITLE
fix: correct placement of Interactive Editor button 

### DIFF
--- a/client/src/templates/Challenges/classic/classic.css
+++ b/client/src/templates/Challenges/classic/classic.css
@@ -83,6 +83,7 @@
 .tabs-row-right {
   display: flex;
   justify-content: flex-end;
+  margin-inline-start: auto;
 }
 
 .monaco-editor-tabs button + button {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the 64349 below with the issue number.-->

Closes #64349

<!-- Feel free to add any additional description of changes below this line -->

## Description
Fixed the placement of the Interactive Editor button to be pinned at the end of the action row instead of sitting at the start.

## Changes Made
- Added `margin-inline-start: auto` to `.tabs-row-right` in `classic.css`

## Result
The Interactive Editor button is now correctly positioned at the end of the tabs row.
