### PR TITLE
fix(tools): update error message for hints without tests

### DIFF
--- a/curriculum/challenges/english/blocks/lab-javascript-trivia-bot/66ed41f912d0bb1dc62da5dd.md
+++ b/curriculum/challenges/english/blocks/lab-javascript-trivia-bot/66ed41f912d0bb1dc62da5dd.md
@@ -34,9 +34,9 @@ const getLogs = () => spy.calls.map(call => call?.[0]);
 
 You should log `"Hello! I'm your coding fun fact guide!"` to the console.
 
-<!-- ```js
+```js
 assert.equal(getLogs()[0], "Hello! I'm your coding fun fact guide!")
-``` -->
+```
 
 You should declare a `botName` variable. Double check for any spelling or casing errors.
 

--- a/curriculum/challenges/english/blocks/lab-javascript-trivia-bot/66ed41f912d0bb1dc62da5dd.md
+++ b/curriculum/challenges/english/blocks/lab-javascript-trivia-bot/66ed41f912d0bb1dc62da5dd.md
@@ -34,9 +34,9 @@ const getLogs = () => spy.calls.map(call => call?.[0]);
 
 You should log `"Hello! I'm your coding fun fact guide!"` to the console.
 
-```js
+<!-- ```js
 assert.equal(getLogs()[0], "Hello! I'm your coding fun fact guide!")
-```
+``` -->
 
 You should declare a `botName` variable. Double check for any spelling or casing errors.
 

--- a/tools/challenge-parser/parser/plugins/add-tests.js
+++ b/tools/challenge-parser/parser/plugins/add-tests.js
@@ -8,7 +8,9 @@ function plugin() {
   function transformer(tree, file) {
     const hintNodes = getSection(tree, '--hints--');
     if (hintNodes.length % 2 !== 0)
-      throw Error('Hints must be in pairs: each hint text followed by a test code block');
+      throw Error(
+        'Hints must be in pairs: each hint text followed by a test code block'
+      );
 
     const tests = chunk(hintNodes, 2).map(getTest);
     file.data.tests = tests;

--- a/tools/challenge-parser/parser/plugins/add-tests.js
+++ b/tools/challenge-parser/parser/plugins/add-tests.js
@@ -8,7 +8,7 @@ function plugin() {
   function transformer(tree, file) {
     const hintNodes = getSection(tree, '--hints--');
     if (hintNodes.length % 2 !== 0)
-      throw Error('Tests must be in (text, ```testString```) order');
+      throw Error('Hints must be in pairs: each hint text followed by a test code block');
 
     const tests = chunk(hintNodes, 2).map(getTest);
     file.data.tests = tests;

--- a/tools/challenge-parser/parser/plugins/add-tests.test.js
+++ b/tools/challenge-parser/parser/plugins/add-tests.test.js
@@ -42,7 +42,7 @@ describe('add-tests plugin', () => {
   it('should throw if a test pair is out of order', () => {
     // TODO: update the markdown so it makes this error
     expect(() => plugin(brokenHintsAST, file)).toThrow(
-      'Tests must be in (text, ```testString```) order'
+      'Hints must be in pairs: each hint text followed by a test code block'
     );
   });
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitHub Codespaces. [**I was unable to reproduce the error message, but have indeed run these changes with GitHub Codespaces**]

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #63874

<!-- Feel free to add any additional description of changes below this line -->
**Requested changes:**
Update the error message in these two files:
https://github.com/freeCodeCamp/freeCodeCamp/blob/a28ff5d2cd0bc85d9b7f22eb452a33007845ce51/tools/challenge-parser/parser/plugins/add-tests.js#L11
and
https://github.com/freeCodeCamp/freeCodeCamp/blob/a28ff5d2cd0bc85d9b7f22eb452a33007845ce51/tools/challenge-parser/parser/plugins/add-tests.test.js#L45

The new error message is as follows: Hints must be in pairs: each hint text followed by a test code block

In the original issue #63874 discussion suggests the same new error message but with a period at the end. I removed this for consistency.

The requested changes were simple lines text for two errors. This change was easy enough. However, I must admit I do not know where these errors are outputted or what the challenge parser (directory for the files in question) does. I believe it has to do with dev tools. I attempted to verify the error message manually by tinkering with the --hints-- section of challenge id: 66ed41f912d0bb1dc62da5dd. However, this challenge does not seem to use this parser at all, it only uses tools/client_plugins/browser-scripts/test-runner.js. I hope that this addition can be accepted even with my inability to check the actual error message.
