### PR TITLE
fix(curriculum): typo in Game Settings Panel workshop

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-game-settings-panel/68e9a6201e2efa142d62bfe1.md
+++ b/curriculum/challenges/english/blocks/workshop-game-settings-panel/68e9a6201e2efa142d62bfe1.md
@@ -13,7 +13,7 @@ Begin by setting up a selector for `input`, but specifically targetting your `[t
 
 Within your selector, set the `width` and the `height` to `20px`. This makes it larger than it was before.
 
-And to conform with your `cursor` setting that was set on the labels, add `cursor` and assign the value of `pointer` to it. After that, when you hover over the labels it will display a pointer.
+And to conform with your `cursor` setting that was set on the labels, add `cursor` and assign the value of `pointer` to it. After that, when you hover over the checkboxes it will display a pointer.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->

Affected page: https://www.freecodecamp.org/learn/responsive-web-design-v9/workshop-game-settings-panel/step-9
