### PR TITLE
fix(curriculum): move checkbox input before label text

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-best-practices-for-styling-forms/672bc9d9eecb65cdf63491de.md
+++ b/curriculum/challenges/english/blocks/lecture-best-practices-for-styling-forms/672bc9d9eecb65cdf63491de.md
@@ -21,7 +21,7 @@ Here is an example of a custom checkbox:
 <link rel="stylesheet" href="styles.css" />
 <form>
   <label>
-  Agree <input class="checkbox" type="checkbox" />
+    <input class="checkbox" type="checkbox" /> Agree
   </label>
 </form>
 ```


### PR DESCRIPTION
Placed the <input> before the label text so the example follows proper accessibility practices.

Closes #64374

Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.