### PR TITLE
refactor(client): simplify checks to see if a user has a certification

### DIFF
--- a/client/src/components/settings/certification.tsx
+++ b/client/src/components/settings/certification.tsx
@@ -18,6 +18,7 @@ import { SolutionDisplayWidget } from '../solution-display-widget';
 import {
   Certification,
   currentCertifications,
+  isCertified,
   legacyCertifications,
   upcomingCertifications,
   type CertificationFlags
@@ -41,69 +42,6 @@ const { showUpcomingChanges } = env;
 const mapDispatchToProps = {
   openModal
 };
-
-const createCertifiedMap = ({
-  is2018DataVisCert,
-  isA2EnglishCert,
-  isApisMicroservicesCert,
-  isJavascriptCertV9,
-  isJsAlgoDataStructCert,
-  isInfosecQaCert,
-  isPythonCertV9,
-  isQaCertV7,
-  isInfosecCertV7,
-  isFrontEndLibsCert,
-  isRespWebDesignCert,
-  isRespWebDesignCertV9,
-  isDataVisCert,
-  isFrontEndCert,
-  isBackEndCert,
-  isSciCompPyCertV7,
-  isDataAnalysisPyCertV7,
-  isMachineLearningPyCertV7,
-  isRelationalDatabaseCertV8,
-  isRelationalDatabaseCertV9,
-  isCollegeAlgebraPyCertV8,
-  isFoundationalCSharpCertV8,
-  isJsAlgoDataStructCertV8
-}: CertificationFlags): Record<
-  Exclude<Certification, Certification.LegacyFullStack>,
-  boolean
-> => ({
-  [Certification.RespWebDesign]: isRespWebDesignCert,
-  [Certification.JsAlgoDataStruct]: isJsAlgoDataStructCert,
-  [Certification.FrontEndDevLibs]: isFrontEndLibsCert,
-  [Certification.DataVis]: is2018DataVisCert,
-  [Certification.BackEndDevApis]: isApisMicroservicesCert,
-  [Certification.QualityAssurance]: isQaCertV7,
-  [Certification.InfoSec]: isInfosecCertV7,
-  [Certification.SciCompPy]: isSciCompPyCertV7,
-  [Certification.DataAnalysisPy]: isDataAnalysisPyCertV7,
-  [Certification.MachineLearningPy]: isMachineLearningPyCertV7,
-  [Certification.RelationalDb]: isRelationalDatabaseCertV8,
-  [Certification.CollegeAlgebraPy]: isCollegeAlgebraPyCertV8,
-  [Certification.FoundationalCSharp]: isFoundationalCSharpCertV8,
-  [Certification.LegacyFrontEnd]: isFrontEndCert,
-  [Certification.LegacyDataVis]: isDataVisCert,
-  [Certification.LegacyBackEnd]: isBackEndCert,
-  [Certification.LegacyInfoSecQa]: isInfosecQaCert,
-  // LegacyFullStack cannot be handled by this because there are no projects to
-  // be rendered. The new FullStackDeveloper certification is a normal
-  // certification with projects.
-  [Certification.RespWebDesignV9]: isRespWebDesignCertV9,
-  [Certification.JsV9]: isJavascriptCertV9,
-  [Certification.FrontEndDevLibsV9]: false,
-  [Certification.PythonV9]: isPythonCertV9,
-  [Certification.RelationalDbV9]: isRelationalDatabaseCertV9,
-  [Certification.BackEndDevApisV9]: false,
-  [Certification.FullStackDeveloperV9]: false,
-  [Certification.A2English]: isA2EnglishCert,
-  [Certification.B1English]: false,
-  [Certification.A2Spanish]: false,
-  [Certification.A2Chinese]: false,
-  [Certification.A1Chinese]: false,
-  [Certification.JsAlgoDataStructNew]: isJsAlgoDataStructCertV8
-});
 
 const honestyInfoMessage = {
   type: 'info',
@@ -239,7 +177,6 @@ function CertificationSettings(props: CertificationSettingsProps) {
 
   const handleSolutionModalHide = () => initialiseState();
 
-  const isCertifiedMap = createCertifiedMap(props);
   const getProjectSolution = (projectId: string, projectTitle: string) => {
     const { completedChallenges, openModal } = props;
     const completedProject = find(
@@ -317,7 +254,7 @@ function CertificationSettings(props: CertificationSettingsProps) {
               <tbody>
                 <ProjectsFor
                   certSlug={certSlug}
-                  isCert={isCertifiedMap[certSlug]}
+                  isCert={isCertified(props, certSlug)}
                 />
               </tbody>
             </Table>
@@ -334,6 +271,7 @@ function CertificationSettings(props: CertificationSettingsProps) {
     certSlug: Exclude<Certification, Certification.LegacyFullStack>;
     isCert: boolean;
   }) {
+    console.log({ certSlug, isCert });
     const { username, isHonest, createFlashMessage, t, verifyCert } = props;
     const certLocation = `/certification/${username}/${certSlug}`;
 

--- a/client/src/components/settings/certification.tsx
+++ b/client/src/components/settings/certification.tsx
@@ -271,7 +271,6 @@ function CertificationSettings(props: CertificationSettingsProps) {
     certSlug: Exclude<Certification, Certification.LegacyFullStack>;
     isCert: boolean;
   }) {
-    console.log({ certSlug, isCert });
     const { username, isHonest, createFlashMessage, t, verifyCert } = props;
     const certLocation = `/certification/${username}/${certSlug}`;
 

--- a/shared/config/certification-settings.test.ts
+++ b/shared/config/certification-settings.test.ts
@@ -4,7 +4,8 @@ import {
   linkedInCredentialIds,
   certToTitleMap,
   certToIdMap,
-  certSlugTypeMap
+  certSlugTypeMap,
+  isCertified
 } from './certification-settings';
 
 describe('linkedInCredentialIds', () => {
@@ -47,5 +48,34 @@ describe('certSlugTypeMap', () => {
     const uniqueTypes = Array.from(new Set(types)).sort();
 
     expect(uniqueTypes).toEqual(types);
+  });
+});
+
+describe('isCertified', () => {
+  it('should return true if a user has the specified certification', () => {
+    const cert = Certification.RespWebDesignV9;
+    const user = {
+      isRespWebDesignCertV9: true
+    };
+
+    expect(isCertified(user, cert)).toBe(true);
+  });
+
+  it('should return false if a user does not have the specified certification', () => {
+    const cert = Certification.JsAlgoDataStruct;
+    const user = {
+      isRespWebDesignCertV9: true
+    };
+
+    expect(isCertified(user, cert)).toBe(false);
+  });
+
+  it('should return false if the certification does not exist', () => {
+    const cert = 'NonExistentCert' as Certification;
+    const user = {
+      isRespWebDesignCertV9: true
+    };
+
+    expect(isCertified(user, cert)).toBe(false);
   });
 });

--- a/shared/config/certification-settings.ts
+++ b/shared/config/certification-settings.ts
@@ -251,6 +251,14 @@ export type CertificationFlags = {
   [key in UserCertFlag]: boolean;
 };
 
+export function isCertified(
+  user: Partial<CertificationFlags>,
+  cert: Certification
+): boolean {
+  const certFlag = certSlugTypeMap[cert];
+  return Boolean(user[certFlag]);
+}
+
 // TODO: use i18n keys instead of hardcoded titles
 export const certToTitleMap: Record<Certification, string> = {
   // Legacy certifications


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Now that there's a map from Certification to userCertFlag, checking if a user has a specific certification is trivial.

<!-- Feel free to add any additional description of changes below this line -->
