### PR TITLE
fix: clarify remove() examples in Python list methods lesson

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-loops-and-sequences/6839e38cdf93ee5a00c79676.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-loops-and-sequences/6839e38cdf93ee5a00c79676.md
@@ -56,22 +56,22 @@ print(numbers) # [1, 2, 2.5, 3, 4, 5]
 
 The following code will insert the number `2.5` at index `2` in the `numbers` list.
 
-If you want to remove an element from a list, you can use the `remove()` method. Here is an example of using the `remove()` method to remove a duplicate number from a `numbers` list:
+If you want to remove an element from a list, you can use the `remove()` method. The `remove()` method takes the *value* of the element to remove as an argument:
 
 ```py
-numbers = [1, 2, 3, 4, 5, 5]
-numbers.remove(5)
+numbers = [10, 20, 30, 40, 50, 50]
+numbers.remove(50)
 
-print(numbers) # [1, 2, 3, 4, 5]
+print(numbers)  # [10, 20, 30, 40, 50]
 ```
 
 It is important to note that this method will only remove the first occurrence of an item. Not all of them:
 
 ```py
-numbers = [1, 2, 3, 4, 5, 5, 5]
-numbers.remove(5)
+numbers = [10, 20, 30, 40, 50, 50, 50]
+numbers.remove(50)
 
-print(numbers) # [1, 2, 3, 4, 5, 5]
+print(numbers)  # [10, 20, 30, 40, 50, 50]
 ```
 
 To remove an element at a specific index in the list, you can use the `pop()` method like this:


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #64364

<!-- Feel free to add any additional description of changes below this line -->

Updated the `remove()` method examples to avoid confusion between index/value.
Replaced ambiguous examples using `5` with clearer list values like `[10, 20, 30, 40, 50, 50]`.