### PR TITLE
fix(curriculum): typo in react basics review

### DIFF
--- a/curriculum/challenges/english/blocks/review-front-end-libraries/6724e2dbf723fe1c8883cc69.md
+++ b/curriculum/challenges/english/blocks/review-front-end-libraries/6724e2dbf723fe1c8883cc69.md
@@ -92,7 +92,7 @@ export default function City() {
 ## Setting up a React project using Vite
 
 - Project setup tools and CLIs provide a quick & easy way to start new projects, allowing developers to focus on writing code rather than dealing with configuration. 
-- Vite, a popular project setup tool and can be used with React.
+- Vite is a popular project setup tool and can be used with React.
 - To create a new project with Vite, you can use the following command in your terminal:
 
 ```bash

--- a/curriculum/challenges/english/blocks/review-react-basics/67487e141bb6a7140a352e12.md
+++ b/curriculum/challenges/english/blocks/review-react-basics/67487e141bb6a7140a352e12.md
@@ -92,7 +92,7 @@ export default function City() {
 ## Setting up a React project using Vite
 
 - Project setup tools and CLIs provide a quick & easy way to start new projects, allowing developers to focus on writing code rather than dealing with configuration. 
-- Vite, a popular project setup tool and can be used with React.
+- Vite is a popular project setup tool and can be used with React.
 - To create a new project with Vite, you can use the following command in your terminal:
 
 ```bash


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!-- Feel free to add any additional description of changes below this line -->

Affected page: https://www.freecodecamp.org/learn/front-end-development-libraries-v9/review-react-basics/review-react-basics

Also I made the same change to the Front End Libraries Review. I am not providing a link though because it does not seem that this review is currently available for viewing.
