### PR TITLE
fix(client): increase font size and spacing for Chinese text

### DIFF
--- a/client/src/components/layouts/global.css
+++ b/client/src/components/layouts/global.css
@@ -39,8 +39,17 @@ blockquote .small:before {
   content: '\2014 \00A0';
 }
 
+p:has(ruby),
+li:has(> ruby) {
+  padding: 0.5rem 0;
+}
+
+ruby {
+  font-size: 1.3rem;
+}
+
 rt {
-  font-size: 0.8rem;
+  font-size: 0.9rem;
 }
 
 #___gatsby {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR:
- Increases the size of Hanzi and Pinyin, as well as adding vertical padding to paragraphs that contain Hanzi-Pinyin pairs
- Closes https://github.com/freeCodeCamp/language-curricula/issues/19.

<details>
<summary>Screenshots</summary>

<img width="792" height="507" alt="Screenshot 2025-12-09 at 05 05 59" src="https://github.com/user-attachments/assets/8fbab22d-a0f0-429b-9f8f-0d8fcb2591fa" />

<img width="856" height="791" alt="Screenshot 2025-12-09 at 05 04 05" src="https://github.com/user-attachments/assets/78d6f1ae-195d-4dcc-a469-6d22eec88458" />

</details>

<!-- Feel free to add any additional description of changes below this line -->
