### PR TITLE
fix(curriculum): correct grammar in dictionaries lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-dictionaries-and-sets/683ec7a722bc7b67c1132bd3.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-dictionaries-and-sets/683ec7a722bc7b67c1132bd3.md
@@ -81,7 +81,7 @@ print(pizza['name']) # 'Margherita'
 
 Dictionaries also have helpful methods to perform common operations.
 
-The `.get()` method retrieves the value associated with a key. It's similar to the bracket notation that we just used, but its advantage is that you can set a default value, so you won't get an error is the key doesn't exist:
+The `.get()` method retrieves the value associated with a key. It's similar to the bracket notation that we just used, but its advantage is that you can set a default value, so you won't get an error if the key doesn't exist:
 
 ```python
 dictionary.get(key, default)


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #64391

<!-- Feel free to add any additional description of changes below this line -->
**What does this PR do?**
Fixes a grammatical error in the Python "Working with Dictionaries and Sets" lecture.


**Description of Changes**
Changed "you won't get an error is the key doesn't exist" to "you won't get an error if the key doesn't exist" on line 84 of the dictionaries lecture file to correct the grammar.

Before: "...so you won't get an error is the key doesn't exist" 
After: "...so you won't get an error if the key doesn't exist"

