### PR TITLE
fix(responsive-web-design): update checkbox color tests to use CSS rule inspection

### DIFF
--- a/curriculum/challenges/english/blocks/lab-feature-selection/68ce56d54d3cad1149a1c4cf.md
+++ b/curriculum/challenges/english/blocks/lab-feature-selection/68ce56d54d3cad1149a1c4cf.md
@@ -167,33 +167,45 @@ checkboxes.forEach((checkbox) => {
 When the checkbox is checked, the background color of the checkbox should change to a color of your choosing.
 
 ```js
-const checkboxes = document.querySelectorAll('.feature-card input[type="checkbox"]');
-assert.isNotEmpty(checkboxes);
+const css = new __helpers.CSSHelp(document);
 
-checkboxes.forEach((checkbox) => { 
-    checkbox.checked = false;
-    const uncheckedBG = window.getComputedStyle(checkbox).backgroundColor;
-    checkbox.checked = true;
-    const checkedBG = window.getComputedStyle(checkbox).backgroundColor;
+const normal = css.getStyleAny([
+  'input[type="checkbox"]',
+  '.feature-card input[type="checkbox"]'
+]);
 
-    assert.notEqual(checkedBG, uncheckedBG);
-});
+const checked = css.getStyleAny([
+  'input[type="checkbox"]:checked',
+  '.feature-card input[type="checkbox"]:checked'
+]);
+
+assert.isNotEmpty(checked.getPropVal('background-color'));
+assert.notEqual(
+  checked.getPropVal('background-color'),
+  normal.getPropVal('background-color')
+);
 ```
 
 When the checkbox is checked, the border color of the checkbox should change to a color of your choosing.
 
 ```js
-const checkboxes = document.querySelectorAll('.feature-card input[type="checkbox"]');
-assert.isNotEmpty(checkboxes);
+const css = new __helpers.CSSHelp(document);
 
-checkboxes.forEach((checkbox) => { 
-    checkbox.checked = false;
-    const uncheckedBC = window.getComputedStyle(checkbox).borderColor;
-    checkbox.checked = true;
-    const checkedBC = window.getComputedStyle(checkbox).borderColor;
+const normal = css.getStyleAny([
+  'input[type="checkbox"]',
+  '.feature-card input[type="checkbox"]'
+]);
 
-    assert.notEqual(checkedBC, uncheckedBC);
-});
+const checked = css.getStyleAny([
+  'input[type="checkbox"]:checked',
+  '.feature-card input[type="checkbox"]:checked'
+]);
+
+assert.isNotEmpty(checked.getPropVal('border-color'));
+assert.notEqual(
+  checked.getPropVal('border-color'),
+  normal.getPropVal('border-color')
+);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/lab-feature-selection/68ce56d54d3cad1149a1c4cf.md
+++ b/curriculum/challenges/english/blocks/lab-feature-selection/68ce56d54d3cad1149a1c4cf.md
@@ -171,12 +171,18 @@ const css = new __helpers.CSSHelp(document);
 
 const normal = css.getStyleAny([
   'input[type="checkbox"]',
-  '.feature-card input[type="checkbox"]'
+  '.feature-card input[type="checkbox"]',
+  '.feature-card input',          
+  'input',                   
+  '[type="checkbox"]' 
 ]);
 
 const checked = css.getStyleAny([
   'input[type="checkbox"]:checked',
-  '.feature-card input[type="checkbox"]:checked'
+  '.feature-card input[type="checkbox"]:checked',
+  '.feature-card input:checked',  
+  'input:checked',                
+  '[type="checkbox"]:checked' 
 ]);
 
 assert.isNotEmpty(checked.getPropVal('background-color'));
@@ -193,12 +199,18 @@ const css = new __helpers.CSSHelp(document);
 
 const normal = css.getStyleAny([
   'input[type="checkbox"]',
-  '.feature-card input[type="checkbox"]'
+  '.feature-card input[type="checkbox"]',
+  '.feature-card input',          
+  'input',                   
+  '[type="checkbox"]'    
 ]);
 
 const checked = css.getStyleAny([
   'input[type="checkbox"]:checked',
-  '.feature-card input[type="checkbox"]:checked'
+  '.feature-card input[type="checkbox"]:checked',
+  '.feature-card input:checked',  
+  'input:checked',                
+  '[type="checkbox"]:checked'    
 ]);
 
 assert.isNotEmpty(checked.getPropVal('border-color'));


### PR DESCRIPTION
…le inspection

The previous checkbox background-color and border-color tests relied on window.getComputedStyle() immediately after toggling checkbox.checked. This caused false negatives when learners applied CSS transitions, because the rendered styles were still in a mid-transition state at the moment the tests were executed.

This update replaces computed-style inspection with CSS rule inspection using __helpers.CSSHelp. By comparing the author-defined CSS rules for the unchecked and :checked states, the tests now accurately evaluate the intended styling without depending on animation timing or browser paint cycles.

Why This Fix:

- Computed styles are not reliable when transitions or delays are applied.
- Learners who used `transition:` on checkboxes were penalized despite having correct CSS.
- FCC’s testing philosophy favors deterministic rule-based validation over timing-dependent DOM state.
- CSS rule inspection is stable, animation-safe, and used across other FCC challenges.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #64377

<!-- Feel free to add any additional description of changes below this line -->
