### PR TITLE
feat(client): remove broken signout button from /update-email

### DIFF
--- a/client/src/client-only-routes/show-update-email.tsx
+++ b/client/src/client-only-routes/show-update-email.tsx
@@ -21,8 +21,7 @@ import {
 } from '@freecodecamp/ui';
 
 import envData from '../../config/env.json';
-import { Loader, Link } from '../components/helpers';
-import './show-update-email.css';
+import { Loader } from '../components/helpers';
 import { isSignedInSelector, userSelector } from '../redux/selectors';
 import { hardGoTo as navigate } from '../redux/actions';
 import { updateMyEmail } from '../redux/settings/actions';
@@ -122,9 +121,7 @@ function ShowUpdateEmail({
                     : t('buttons.verify-email')}
                 </Button>
               </form>
-              <p className='text-center'>
-                <Link to='/signout'>{t('buttons.sign-out')}</Link>
-              </p>
+              <Spacer size='s' />
             </Row>
           </Col>
         </Row>

--- a/e2e/update-email.spec.ts
+++ b/e2e/update-email.spec.ts
@@ -38,11 +38,6 @@ test.describe('The update-email page when the user is signed in', () => {
     );
     await expect(submitButton).toBeVisible();
     await expect(submitButton).toHaveAttribute('type', 'submit');
-
-    const signOutButton = page.getByRole('link', { name: 'Sign out' });
-
-    await expect(signOutButton).toBeVisible();
-    await expect(signOutButton).toHaveAttribute('href', '/signout');
   });
 
   test('should enable the submit button if the email input is valid', async ({


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

It was redirecting to /signout on the client, which does nothing. It doesn't seem necessary, though, since you can easily sign out via the menu.

<!-- Feel free to add any additional description of changes below this line -->
