### PR TITLE
feat(client): redirect from /settings + /update-email after sign out

### DIFF
--- a/client/src/components/signout-modal/signout-modal.test.ts
+++ b/client/src/components/signout-modal/signout-modal.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+
+import { pathAfterSignout } from '.';
+
+describe('pathAfterSignout', () => {
+  it('should default to the supplied path', () => {
+    const unexceptionalPath = 'a/normal/path/';
+    expect(pathAfterSignout(unexceptionalPath)).toBe(unexceptionalPath);
+  });
+
+  it('should redirect paths that automatically sign in back to /learn', () => {
+    const pathsThatAttemptToSignIn = ['/settings', '/update-email'];
+    const newPaths = pathsThatAttemptToSignIn.map(pathAfterSignout);
+
+    expect(newPaths).toEqual(['/learn', '/learn']);
+  });
+
+  it('should redirect paths with trailing slashes', () => {
+    const pathsThatAttemptToSignIn = ['/settings/', '/update-email/'];
+    const newPaths = pathsThatAttemptToSignIn.map(pathAfterSignout);
+
+    expect(newPaths).toEqual(['/learn', '/learn']);
+  });
+
+  it('should only redirect exact matches', () => {
+    const similarPaths = ['/settingss', '/update-emails/', '/settings/2'];
+    const newPaths = similarPaths.map(pathAfterSignout);
+
+    expect(newPaths).toEqual(similarPaths);
+  });
+});


### PR DESCRIPTION
These pages try to sign in and it's bad UX for a user to immediately be signed back in after signing out.

Also, this improves the separation of concerns. Now a developer only needs to consider the client when deciding how it signs out.

Finally, the catch is necessary because the api is still attempting to redirect and this isn't allowed by CORS. This should be fine, but it's worth checking on .dev. Once we've updated the api we can do something more useful with the catch like trigger a flash message.

https://github.com/freeCodeCamp/freeCodeCamp/pull/64398 should work properly once this is in.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->
