### PR TITLE
Removed aria label from icons in shareTemplate component

### DIFF
--- a/client/src/components/share/share-template.tsx
+++ b/client/src/components/share/share-template.tsx
@@ -23,12 +23,7 @@ export const ShareTemplate: React.ComponentType<ShareRedirectProps> = ({
         target='_blank'
         rel='noreferrer'
       >
-        <FontAwesomeIcon
-          icon={faXTwitter}
-          size='1x'
-          aria-label='xIcon'
-          aria-hidden='true'
-        />
+        <FontAwesomeIcon icon={faXTwitter} size='1x' aria-hidden='true' />
         {t('buttons.share-on-x')}
         <span className='sr-only'>{t('aria.opens-new-window')}</span>
       </a>
@@ -39,12 +34,7 @@ export const ShareTemplate: React.ComponentType<ShareRedirectProps> = ({
         target='_blank'
         rel='noreferrer'
       >
-        <FontAwesomeIcon
-          icon={faBluesky}
-          size='1x'
-          aria-label='blueSkyIcon'
-          aria-hidden='true'
-        />
+        <FontAwesomeIcon icon={faBluesky} size='1x' aria-hidden='true' />
         {t('buttons.share-on-bluesky')}
         <span className='sr-only'>{t('aria.opens-new-window')}</span>
       </a>
@@ -55,12 +45,7 @@ export const ShareTemplate: React.ComponentType<ShareRedirectProps> = ({
         target='_blank'
         rel='noreferrer'
       >
-        <FontAwesomeIcon
-          icon={faInstagram}
-          size='1x'
-          aria-label='instagramIcon'
-          aria-hidden='true'
-        />
+        <FontAwesomeIcon icon={faInstagram} size='1x' aria-hidden='true' />
         {t('buttons.share-on-threads')}
         <span className='sr-only'>{t('aria.opens-new-window')}</span>
       </a>


### PR DESCRIPTION
I have removed aria label from icons in shareTemplate component as required.

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #64372 