### PR TITLE
fix: remove extra period in step 15 description

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-email-simulator/68b9366fae8b13c1278761b1.md
+++ b/curriculum/challenges/english/blocks/workshop-email-simulator/68b9366fae8b13c1278761b1.md
@@ -9,7 +9,7 @@ dashedName: step-15
 
 Your inbox needs a way to receive new emails. When someone sends an email to a user, it should be added to their inbox.
 
-Add a method called `receive_email` to your `Inbox` class. that takes `self` and an email object `email` as a parameter. Within the method body, add the `email` to the `emails` list using the `append` method.
+Add a method called `receive_email` to your `Inbox` class that takes `self` and an email object `email` as a parameter. Within the method body, add the `email` to the `emails` list using the `append` method.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


Closes #64403
#### Description
This PR removes an extra period (typo) in the description of **Step 15** in the *Learn Python with an Email Simulator* workshop.
**Changes:**
- Removed extra `.` after `Inbox class` in the description text.
