### PR TITLE
fix(curriculum): Resolved grammar error in Email Simulator

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-email-simulator/68b9366fae8b13c1278761b1.md
+++ b/curriculum/challenges/english/blocks/workshop-email-simulator/68b9366fae8b13c1278761b1.md
@@ -9,7 +9,7 @@ dashedName: step-15
 
 Your inbox needs a way to receive new emails. When someone sends an email to a user, it should be added to their inbox.
 
-Add a method called `receive_email` to your `Inbox` class. that takes `self` and an email object `email` as a parameter. Within the method body, add the `email` to the `emails` list using the `append` method.
+Add a method called `receive_email` to your `Inbox` class that takes `self` and an email object `email` as parameters. Within the method body, add the `email` to the `emails` list using the `append` method.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #64403

<!-- Feel free to add any additional description of changes below this line -->
### Description
- This PR fixes the grammar issue in Line 12 of [freeCodeCamp/curriculum/challenges/english/blocks/workshop-email-simulator/68b9366fae8b13c1278761b1.md](https://github.com/freeCodeCamp/freeCodeCamp/blob/7b88efe5c5d9f18604b5de6ad6cdb04cf81875ef/curriculum/challenges/english/blocks/workshop-email-simulator/68b9366fae8b13c1278761b1.md#L12)
 
