### PR TITLE
fix(tools): display blocks despite of missing superblock title/intro

### DIFF
--- a/tools/challenge-editor/api/utils/get-blocks.ts
+++ b/tools/challenge-editor/api/utils/get-blocks.ts
@@ -65,5 +65,5 @@ export const getBlocks = async (sup: string): Promise<BlockLocation> => {
     );
   }
 
-  return { blocks: blocks, currentSuperBlock: introData[sup].title };
+  return { blocks: blocks, currentSuperBlock: introData[sup]?.title };
 };

--- a/tools/challenge-editor/api/utils/get-steps.ts
+++ b/tools/challenge-editor/api/utils/get-steps.ts
@@ -76,6 +76,6 @@ export const getSteps = async (
   return {
     steps: steps,
     currentBlock: blockMetaData.name,
-    currentSuperBlock: introData[sup].title
+    currentSuperBlock: introData[sup]?.title
   };
 };


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

- - -
- Challenge-editor seems to have troubles with displaying blocks from old (renamed?) superblocks, for which name in `/client/i18n/locales/english/intro.json` is differing from the name of superblock structure file in `/curriculum/structure/superblocks/`.
  1. Superblocks in challenge editor are loaded from `/tools/challenge-editor/api/configs/super-block-list.ts`.
  2. Navigating in editor client to one of the affected superblocks, ie. _Responsive Web Design_: `responsive-web-design-22`.
  3. Name corresponds to names of structure files, so blocks in the superblock are available.
  4. Then editor tries to find relevant superblock in `/client/i18n/locales/english/intro.json`, but it does not exist there with such name (dashed-name).
  5. Error.
- This optional chaining these blocks display, without the superblock title, instead of showing error about invalid JSON.