### PR TITLE
fix(client): enable MathJax rendering for Python V9 lab

### DIFF
--- a/client/src/utils/math-jax.ts
+++ b/client/src/utils/math-jax.ts
@@ -13,6 +13,7 @@ const superBlocksWithMathJax = [
   SuperBlocks.ProjectEuler,
   SuperBlocks.RosettaCode,
   SuperBlocks.SciCompPy,
+  SuperBlocks.PythonV9,
   SuperBlocks.FullStackDeveloper
 ];
 


### PR DESCRIPTION
- Add PythonV9 superblock to superBlocksWithMathJax array
- This enables MathJax rendering in Python V9 lab challenges
- Fixes issue where mathematical expressions were not rendering

Fixes #64265

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #64265

<!-- Feel free to add any additional description of changes below this line -->
