### PR TITLE
fix(curriculum): add explanation for double curlies syntax in React inline styles

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-data-in-react/673500bfe1f41601c1ddb1a2.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-data-in-react/673500bfe1f41601c1ddb1a2.md
@@ -50,6 +50,8 @@ function Button({ buttonText }) {
 }
 ```
 
+Notice the double curly braces `{{}}` in the `style` attribute. The outer curly braces `{}` tell JSX that you're embedding a JavaScript expression. The inner curly braces `{}` create a JavaScript object literal. So `style={{}}` means you're passing a JavaScript object to the `style` attribute. This is why you need both sets of curly braces - the outer ones for JSX and the inner ones for the object.
+
 Sometimes you might want to pass in an object directly if there are only a few properties like shown here. Otherwise, passing in a name to an object would be better like in the first example.
 
 It's important to note that while CSS property names are typically written in kebab case, like `font-size`, in React's inline styles, we use camel case, like `fontSize`. This is because the style object is a JavaScript object, and kebab case names are not valid as object keys in JavaScript without using quotes.

--- a/curriculum/challenges/english/blocks/lecture-working-with-data-in-react/673500bfe1f41601c1ddb1a2.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-data-in-react/673500bfe1f41601c1ddb1a2.md
@@ -50,7 +50,7 @@ function Button({ buttonText }) {
 }
 ```
 
-Notice the double curly braces `{{}}` in the `style` attribute. The outer curly braces `{}` tell JSX that you're embedding a JavaScript expression. The inner curly braces `{}` create a JavaScript object literal. So `style={{}}` means you're passing a JavaScript object to the `style` attribute. This is why you need both sets of curly braces - the outer ones for JSX and the inner ones for the object.
+Notice the double curly braces `{{}}` in the `style` attribute. The outer braces indicate a JavaScript expression in JSX, while the inner braces define a JavaScript object literal. This syntax allows you to embed JavaScript objects directly in JSX attributes.
 
 Sometimes you might want to pass in an object directly if there are only a few properties like shown here. Otherwise, passing in a name to an object would be better like in the first example.
 


### PR DESCRIPTION
…inline styles

- Add clarification about why style={{}} uses double curly braces
- Explain that outer braces are for JSX expressions and inner braces are for object literals
- This helps learners understand the syntax better and reduces confusion

Fixes #64002

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #64002

<!-- Feel free to add any additional description of changes below this line -->
