### PR TITLE
fix(curriculum): distractors and answer are changed to inline code blocks

### DIFF
--- a/curriculum/challenges/english/blocks/quiz-javascript-classes/67358ac128957c865dcf3ddf.md
+++ b/curriculum/challenges/english/blocks/quiz-javascript-classes/67358ac128957c865dcf3ddf.md
@@ -153,27 +153,19 @@ Which of the following is an example of how to create a `Car` class that inherit
 
 #### --distractors--
 
-```javascript
-class Car uses Vehicle {}
-```
+`class Car uses Vehicle {}`
 
 ---
 
-```javascript
-class Car = Vehicle {}
-```
+`class Car = Vehicle {}`
 
 ---
 
-```javascript
-class Car inherits Vehicle {}
-```
+`class Car inherits Vehicle {}`
 
 #### --answer--
 
-```javascript
-class Car extends Vehicle {}
-```
+`class Car extends Vehicle {}`
 
 ### --question--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #64447

<!-- Feel free to add any additional description of changes below this line -->
### Description
-  The three distractors and the answer are changed to inline code blocks.
-  Now they are not highlighted anymore to give away the answer.
