### PR TITLE
fix: correct typo in grid-auto-flow description

### DIFF
--- a/curriculum/challenges/english/blocks/review-css-grid/671a99394bedfb9a5bc687c4.md
+++ b/curriculum/challenges/english/blocks/review-css-grid/671a99394bedfb9a5bc687c4.md
@@ -30,7 +30,7 @@ dashedName: review-css-grid
 ```
 
 - **`grid-template-rows`**: This is used to set lines names and sizing for the grid track rows.
-- **`grid-auto-flow`**: The determines how auto placed items fit in the grid.
+- **`grid-auto-flow`**: This determines how auto placed items fit in the grid.
 
 ```css
 .container {


### PR DESCRIPTION
This PR fixes a small typo in the CSS Grid Review challenge.
The text currently says:
"The determines how auto placed items fit in the grid."
It has been corrected to:
"This determines how auto-placed items fit in the grid."

Fixes #64436