### PR TITLE
fix: correct typo in step 12 of decimal-to-binary converter challenge 

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/64007367d54d2a7efbf44fcf.md
+++ b/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/64007367d54d2a7efbf44fcf.md
@@ -19,7 +19,7 @@ isNaN("3.5"); // false
 
 Update the second condition in your `if` statement to use the `isNaN()` function to check if the value returned by `parseInt()` is `NaN`.
 
-Also,as we mentioned in step 1 that we are considering only positive numbers, we should add a third condition in `if` statement to check whether the number is less than 0 (i.e negative numbers)
+Also, as we mentioned in step 1 that we are considering only positive numbers, we should add a third condition in `if` statement to check whether the number is less than 0 (i.e negative numbers)
 
 ```js
  6 < 0; // false


### PR DESCRIPTION
This pull request fixes a small typo in the workshop-decimal-to-binary-converter challenge.

In step 12, the text originally read : Also,as we mentioned

The missing space after the comma has been corrected to : Also, as we mentioned

This improves readability and keeps the curriculum content consistent.

Closes #64443
