### PR TITLE
fix(curriculum): replace ambiguous CSS variables quiz question

### DIFF
--- a/curriculum/challenges/english/blocks/quiz-css-variables/66ed9018f45ce3ece4053eb9.md
+++ b/curriculum/challenges/english/blocks/quiz-css-variables/66ed9018f45ce3ece4053eb9.md
@@ -759,7 +759,7 @@ white
 
 ---
 
-transparent
+`transparent`
 
 ---
 

--- a/curriculum/challenges/english/blocks/quiz-css-variables/66ed9018f45ce3ece4053eb9.md
+++ b/curriculum/challenges/english/blocks/quiz-css-variables/66ed9018f45ce3ece4053eb9.md
@@ -755,19 +755,19 @@ Consider the following HTML and CSS. What background color will be applied to th
 
 #### --distractors--
 
-`white` (the `:root` value)
+white
 
 ---
 
-`#333` (the `.dark-theme` value)
+transparent
 
 ---
 
-`transparent` (CSS default)
+inherit
 
 #### --answer--
 
-`#333` (the `.dark-theme` value)
+`#333`
 
 ### --question--
 

--- a/curriculum/challenges/english/blocks/quiz-css-variables/66ed9018f45ce3ece4053eb9.md
+++ b/curriculum/challenges/english/blocks/quiz-css-variables/66ed9018f45ce3ece4053eb9.md
@@ -755,7 +755,7 @@ Consider the following HTML and CSS. What background color will be applied to th
 
 #### --distractors--
 
-white
+`white`
 
 ---
 

--- a/curriculum/challenges/english/blocks/quiz-css-variables/66ed9018f45ce3ece4053eb9.md
+++ b/curriculum/challenges/english/blocks/quiz-css-variables/66ed9018f45ce3ece4053eb9.md
@@ -731,29 +731,43 @@ It assigns a default value for the property if none is set.
 
 #### --text--
 
-In the following CSS, which selector provides the value for the custom property `--bg-color` that will be used by elements inside `.dark-theme`?
+Consider the following HTML and CSS. What background color will be applied to the `.card` element?
+
+```html
+<div class="dark-theme">
+  <div class="card">Content</div>
+</div>
+```
 
 ```css
+:root {
+  --bg-color: white;
+}
+
 .dark-theme {
   --bg-color: #333;
+}
+
+.card {
+  background: var(--bg-color);
 }
 ```
 
 #### --distractors--
 
-The `:root` selector.
+`white` (the `:root` value)
 
 ---
 
-All elements on the page.
+`#333` (the `.dark-theme` value)
 
 ---
 
-Any parent element regardless of class.
+`transparent` (CSS default)
 
 #### --answer--
 
-The `.dark-theme` selector.
+`#333` (the `.dark-theme` value)
 
 ### --question--
 

--- a/curriculum/challenges/english/blocks/quiz-css-variables/66ed9018f45ce3ece4053eb9.md
+++ b/curriculum/challenges/english/blocks/quiz-css-variables/66ed9018f45ce3ece4053eb9.md
@@ -763,7 +763,7 @@ transparent
 
 ---
 
-inherit
+`inherit`
 
 #### --answer--
 

--- a/curriculum/challenges/english/blocks/quiz-css-variables/66ed9018f45ce3ece4053eb9.md
+++ b/curriculum/challenges/english/blocks/quiz-css-variables/66ed9018f45ce3ece4053eb9.md
@@ -731,13 +731,9 @@ It assigns a default value for the property if none is set.
 
 #### --text--
 
-In the following CSS, how does the custom property `--bg-color` behave?
+In the following CSS, which selector provides the value for the custom property `--bg-color` that will be used by elements inside `.dark-theme`?
 
 ```css
-:root {
-  --bg-color: white;
-}
-
 .dark-theme {
   --bg-color: #333;
 }
@@ -745,19 +741,19 @@ In the following CSS, how does the custom property `--bg-color` behave?
 
 #### --distractors--
 
-Overrides the root value globally.
+The `:root` selector.
 
 ---
 
-Applies to all elements by default.
+All elements on the page.
 
 ---
 
-Is inherited automatically by all children.
+Any parent element regardless of class.
 
 #### --answer--
 
-Only applies within `.dark-theme` scope.
+The `.dark-theme` selector.
 
 ### --question--
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #64432

This PR replaces an ambiguous CSS Variables quiz question that previously showed both a `:root` and `.dark-theme` variable definition, which made the correct answer unclear.

The updated question now uses only the `.dark-theme` definition, making the expected answer accurate and unambiguous.