### PR TITLE
fix(curriculum): correct caret name

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-regular-expressions/6733c5ba834ded4bb067e67c.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-regular-expressions/6733c5ba834ded4bb067e67c.md
@@ -143,7 +143,7 @@ Looking at this example, you can see how the state of the regular expression cha
 
 The global flag is great when you need to get multiple matches from a single string. But if you're testing multiple strings with the same regular expression it's best to leave the `g` flag off.
 
-Before learning about the next flag, you need to learn about anchors. The carrot (`^`) anchor, at the beginning of the regular expression, says "match the start of the string":
+Before learning about the next flag, you need to learn about anchors. The caret (`^`) anchor, at the beginning of the regular expression, says "match the start of the string":
 
 ```js
 const start = /^freecodecamp/i;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #64441 

<!-- Feel free to add any additional description of changes below this line -->
I have changed the spelling of '^' from "carrot" to "caret"
