### PR TITLE
fix(curriculum): correct typo in step 12

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/64007367d54d2a7efbf44fcf.md
+++ b/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/64007367d54d2a7efbf44fcf.md
@@ -19,7 +19,7 @@ isNaN("3.5"); // false
 
 Update the second condition in your `if` statement to use the `isNaN()` function to check if the value returned by `parseInt()` is `NaN`.
 
-Also,as we mentioned in step 1 that we are considering only positive numbers, we should add a third condition in `if` statement to check whether the number is less than 0 (i.e negative numbers)
+Also, as we mentioned in step 1 that we are considering only positive numbers, we should add a third condition in `if` statement to check whether the number is less than 0 (i.e negative numbers)
 
 ```js
  6 < 0; // false

--- a/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/64007367d54d2a7efbf44fcf.md
+++ b/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/64007367d54d2a7efbf44fcf.md
@@ -19,7 +19,7 @@ isNaN("3.5"); // false
 
 Update the second condition in your `if` statement to use the `isNaN()` function to check if the value returned by `parseInt()` is `NaN`.
 
-Also, as we mentioned in step 1 that we are considering only positive numbers, we should add a third condition in `if` statement to check whether the number is less than 0 (i.e negative numbers)
+Also, as we mentioned in step 1, we are considering only positive numbers, so we should add a third condition to the `if` statement to check whether the number is less than 0 (i.e., negative numbers).
 
 ```js
  6 < 0; // false


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #64443

<!-- Feel free to add any additional description of changes below this line -->

This PR fixes a small typo in Step 12 of the "Decimal to Binary Converter" workshop.

The phrase:
"Also,as we mentioned"
was corrected to:
"Also, as we mentioned"

This change affects text content only and does not modify any JavaScript, HTML, or UI behavior.
