### PR TITLE
fix(curriculum): correct CSS specificity lesson example to use ID selector

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-css-specificity-the-cascade-algorithm-and-inheritance/672aa62178d5ff57fe4f98e0.md
+++ b/curriculum/challenges/english/blocks/lecture-css-specificity-the-cascade-algorithm-and-inheritance/672aa62178d5ff57fe4f98e0.md
@@ -192,13 +192,13 @@ The specificity value for internal styles is determined by the selectors used. F
 ```html
 <head>
   <style>
-    .text {
+    #text {
       color: blue;
     }
   </style>
 </head>
 <body>
-  <div class="text">This text is blue.</div>
+  <div id="text">This text is blue.</div>
 </body>
 ```
 


### PR DESCRIPTION
## Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org/)
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/)
- [x] My pull request targets the main branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

## Closes #64488

This PR fixes a mismatch between the explanation and code example in the CSS Specificity lesson. The explanation explicitly states that "an ID selector within internal CSS has a specificity value of (0, 1, 0, 0)", but the code example was using a class selector (.text) instead of an ID selector.

## Changes:

Updated the example from a class selector to an ID selector to match the explanation.

Ensured the code example correctly demonstrates the specificity value mentioned in the text.