### PR TITLE
fix(curriculum): fix wording in Todo App Step 6

### DIFF
--- a/curriculum/challenges/english/blocks/learn-localstorage-by-building-a-todo-app/64e4e78a7ea4a168de4e6a38.md
+++ b/curriculum/challenges/english/blocks/learn-localstorage-by-building-a-todo-app/64e4e78a7ea4a168de4e6a38.md
@@ -9,7 +9,7 @@ dashedName: step-6
 
 Now, you will work on opening and closing the form modal.
 
-In earlier projects, you learned how to add and remove classes from an element with `el.classList.add()` and `el.classList.remove()`. Another method to use with the `classList` property is the `toggle` method.
+In earlier lessons, you learned how to add and remove classes from an element with `el.classList.add()` and `el.classList.remove()`. Another method to use with the `classList` property is the `toggle` method.
 
 The `toggle` method will add the class if it is not present on the element, and remove the class if it is present on the element.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #64449

<!-- Feel free to add any additional description of changes below this line -->

Step 6 in the Todo App lesson currently says "In earlier projects". It should say "In earlier lessons". This pull request updates the wording accordingly.
