### PR TITLE
fix(curriculum): update coordinates of tall characters

### DIFF
--- a/curriculum/challenges/english/blocks/es-a1-learn-consonants-and-special-characters/68efe5645c5ef92f345cce87.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-consonants-and-special-characters/68efe5645c5ef92f345cce87.md
@@ -27,8 +27,8 @@ I've listened to the audio and practiced pronouncing each letter.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-learn-consonants-and-special-characters/68efeeee917f9037c483e8c4.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-consonants-and-special-characters/68efeeee917f9037c483e8c4.md
@@ -45,8 +45,8 @@ This is the second letter in the alphabet.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-learn-consonants-and-special-characters/68eff2d1dd230e3c432e8ea8.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-consonants-and-special-characters/68eff2d1dd230e3c432e8ea8.md
@@ -47,8 +47,8 @@ This is the third letter in the alphabet.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-learn-consonants-and-special-characters/68eff70d0ade1c408ecbfeb4.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-consonants-and-special-characters/68eff70d0ade1c408ecbfeb4.md
@@ -45,8 +45,8 @@ This is the fourth letter in the alphabet.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-learn-consonants-and-special-characters/68effaf6e380504611559905.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-consonants-and-special-characters/68effaf6e380504611559905.md
@@ -45,8 +45,8 @@ This is the sixth letter in the alphabet.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-learn-consonants-and-special-characters/68effd205eebbd49d532538e.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-consonants-and-special-characters/68effd205eebbd49d532538e.md
@@ -65,8 +65,8 @@ The sound in the audio corresponds to the vowel `e`.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-learn-consonants-and-special-characters/68f0033275987f5d4fb8a7d6.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-consonants-and-special-characters/68f0033275987f5d4fb8a7d6.md
@@ -47,8 +47,8 @@ This is the seventh letter in the alphabet.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-learn-consonants-and-special-characters/68f005b907771b61fecbe573.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-consonants-and-special-characters/68f005b907771b61fecbe573.md
@@ -48,8 +48,8 @@ This is the eighth letter in the alphabet.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-learn-consonants-and-special-characters/68f00b0eaaef1f69c4036e7e.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-consonants-and-special-characters/68f00b0eaaef1f69c4036e7e.md
@@ -65,8 +65,8 @@ The sound in the audio corresponds to the vowel `i`.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-learn-consonants-and-special-characters/68f00e8fb25b23734da65b17.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-consonants-and-special-characters/68f00e8fb25b23734da65b17.md
@@ -65,8 +65,8 @@ The sound that you can hear in the audio is the vowel `a`.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-learn-consonants-and-special-characters/68f013c4ea4d437b8e1aff98.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-consonants-and-special-characters/68f013c4ea4d437b8e1aff98.md
@@ -43,8 +43,8 @@ This is the tenth letter in the alphabet.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-learn-consonants-and-special-characters/68f14e18661a6b11c80fb151.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-consonants-and-special-characters/68f14e18661a6b11c80fb151.md
@@ -45,8 +45,8 @@ This is the 11th letter in the alphabet.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-learn-consonants-and-special-characters/68f14fe3f4d64113fc1ff216.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-consonants-and-special-characters/68f14fe3f4d64113fc1ff216.md
@@ -45,8 +45,8 @@ This is the 12th letter in the alphabet.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-learn-consonants-and-special-characters/68f151561e931f16a1e02e6c.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-consonants-and-special-characters/68f151561e931f16a1e02e6c.md
@@ -43,8 +43,8 @@ This is the 13th letter in the alphabet.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-learn-consonants-and-special-characters/68f152c617ec3b1954b9eb04.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-consonants-and-special-characters/68f152c617ec3b1954b9eb04.md
@@ -45,8 +45,8 @@ This is the 14th letter in the alphabet.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-learn-consonants-and-special-characters/68f1550f645e741d2710ddf1.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-consonants-and-special-characters/68f1550f645e741d2710ddf1.md
@@ -45,8 +45,8 @@ This is the 14th letter in the alphabet.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-learn-consonants-and-special-characters/68f15a2e37cb9024598a8ecb.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-consonants-and-special-characters/68f15a2e37cb9024598a8ecb.md
@@ -43,8 +43,8 @@ This is the 15th letter in the alphabet.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-learn-consonants-and-special-characters/68f1604d9780b72979573743.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-consonants-and-special-characters/68f1604d9780b72979573743.md
@@ -43,8 +43,8 @@ This is the 17th letter in the alphabet.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-learn-consonants-and-special-characters/68f162336c7f322d12c98d1c.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-consonants-and-special-characters/68f162336c7f322d12c98d1c.md
@@ -47,8 +47,8 @@ This is the 18th letter in the alphabet.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-learn-consonants-and-special-characters/68f1654b7fe81e31b21cdc9b.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-consonants-and-special-characters/68f1654b7fe81e31b21cdc9b.md
@@ -47,8 +47,8 @@ This is the 19th letter in the alphabet.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-learn-consonants-and-special-characters/68f168ca08a2403598529d7c.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-consonants-and-special-characters/68f168ca08a2403598529d7c.md
@@ -43,8 +43,8 @@ This is the 20th letter in the alphabet.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-learn-consonants-and-special-characters/68f16a6fe3e82b37f5f28d06.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-consonants-and-special-characters/68f16a6fe3e82b37f5f28d06.md
@@ -41,8 +41,8 @@ This is the 21st letter in the alphabet.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-learn-consonants-and-special-characters/68f16e4132b9113ff2999bd7.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-consonants-and-special-characters/68f16e4132b9113ff2999bd7.md
@@ -65,8 +65,8 @@ The sound that you can hear in the audio is the vowel `u`.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-learn-consonants-and-special-characters/68f16ecc9c45df418fe2f836.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-consonants-and-special-characters/68f16ecc9c45df418fe2f836.md
@@ -43,8 +43,8 @@ This is the 23rd letter in the alphabet.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-learn-consonants-and-special-characters/68f171a7245612468fc69f63.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-consonants-and-special-characters/68f171a7245612468fc69f63.md
@@ -47,8 +47,8 @@ This is the 24th letter in the alphabet.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-learn-consonants-and-special-characters/68f17437c466594bc1267a30.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-consonants-and-special-characters/68f17437c466594bc1267a30.md
@@ -47,8 +47,8 @@ This is the 25th letter in the alphabet.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-learn-consonants-and-special-characters/68f175d4ab10784f2d6c13f2.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-consonants-and-special-characters/68f175d4ab10784f2d6c13f2.md
@@ -43,8 +43,8 @@ This is the 26th letter in the alphabet.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-learn-consonants-and-special-characters/68f177f744693a522c10138a.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-consonants-and-special-characters/68f177f744693a522c10138a.md
@@ -45,8 +45,8 @@ This is the 27th letter in the alphabet.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-learn-greetings-during-the-day/68c896d45893e91d602f0373.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-greetings-during-the-day/68c896d45893e91d602f0373.md
@@ -70,7 +70,7 @@ Camila is not saying "good night".
         "character": "Camila",
         "position": {
           "x": 50,
-          "y": 0,
+          "y": 18,
           "z": 1.5
         },
         "opacity": 0

--- a/curriculum/challenges/english/blocks/es-a1-learn-greetings-during-the-day/68c8974b9d5ddd2334b965c0.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-greetings-during-the-day/68c8974b9d5ddd2334b965c0.md
@@ -44,7 +44,7 @@ In Spanish, `tardes` is a **feminine plural noun**, so the word `buenas` (good) 
         "character": "Camila",
         "position": {
           "x": 50,
-          "y": 0,
+          "y": 18,
           "z": 1.5
         },
         "opacity": 0

--- a/curriculum/challenges/english/blocks/es-a1-learn-greetings-during-the-day/68c897a539d3dd283ffa3713.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-greetings-during-the-day/68c897a539d3dd283ffa3713.md
@@ -80,7 +80,7 @@ This is a common name, but not the one spoken.
         "character": "Camila",
         "position": {
           "x": 50,
-          "y": 0,
+          "y": 18,
           "z": 1.5
         },
         "opacity": 0

--- a/curriculum/challenges/english/blocks/es-a1-learn-greetings-during-the-day/68c897fe7948d82ccadf1f3b.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-greetings-during-the-day/68c897fe7948d82ccadf1f3b.md
@@ -76,7 +76,7 @@ This example sentence works for both male and female.
         "character": "Camila",
         "position": {
           "x": 50,
-          "y": 0,
+          "y": 18,
           "z": 1.5
         },
         "opacity": 0

--- a/curriculum/challenges/english/blocks/es-a1-learn-greetings-during-the-day/68c8989990f68b3450a32db9.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-greetings-during-the-day/68c8989990f68b3450a32db9.md
@@ -54,7 +54,7 @@ Even though the subject `yo` (I) is not written, it's understood from the verb f
         "character": "Camila",
         "position": {
           "x": 50,
-          "y": 0,
+          "y": 18,
           "z": 1.5
         },
         "opacity": 0

--- a/curriculum/challenges/english/blocks/es-a1-learn-greetings-during-the-day/68c8992767e7eb3ae4b4e5fe.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-greetings-during-the-day/68c8992767e7eb3ae4b4e5fe.md
@@ -44,7 +44,7 @@ In Spanish, many professions that end in `-a` don't change with gender. `Analist
         "character": "Camila",
         "position": {
           "x": 50,
-          "y": 0,
+          "y": 18,
           "z": 1.5
         },
         "opacity": 0

--- a/curriculum/challenges/english/blocks/es-a1-learn-greetings-during-the-day/68c89979e06c663f1b4fff0d.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-greetings-during-the-day/68c89979e06c663f1b4fff0d.md
@@ -68,7 +68,7 @@ This phrase has **two words** and means "See you soon". It's a friendly way to s
         "character": "Camila",
         "position": {
           "x": 50,
-          "y": 0,
+          "y": 18,
           "z": 1.5
         },
         "opacity": 0

--- a/curriculum/challenges/english/blocks/es-a1-learn-meet-julieta/68dc74dc55e05b6ee15b743d.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-meet-julieta/68dc74dc55e05b6ee15b743d.md
@@ -61,8 +61,8 @@ Spanish greetings vary depending on the time of day. For example:
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 15,
-          "z": 1.2
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-learn-meet-julieta/69050330908fe2245936bf21.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-meet-julieta/69050330908fe2245936bf21.md
@@ -73,8 +73,8 @@ This profession involves designing buildings, which is unrelated to what Julieta
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 15,
-          "z": 1.2
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-learn-meet-julieta/690a2aca25b9d771e2dd1101.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-meet-julieta/690a2aca25b9d771e2dd1101.md
@@ -67,8 +67,8 @@ This nationality refers to Colombia.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 15,
-          "z": 1.2
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-learn-meet-julieta/690a2ca5e5cfb078be515fc7.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-meet-julieta/690a2ca5e5cfb078be515fc7.md
@@ -82,8 +82,8 @@ The word `años` has a tilde (~) over the "n".
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 15,
-          "z": 1.2
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-learn-meet-julieta/69165d13fdec0a457abf861d.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-meet-julieta/69165d13fdec0a457abf861d.md
@@ -69,8 +69,8 @@ The phrase `hasta mañana` literally means *"until tomorrow",* but its everyday 
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 15,
-          "z": 1.2
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-learn-meet-julieta/6916658d16916957c1a318a9.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-meet-julieta/6916658d16916957c1a318a9.md
@@ -43,8 +43,8 @@ The phrase `Hasta mañana` means **"see you tomorrow."** The word `chao` is an i
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 15,
-          "z": 1.2
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-learn-meet-mateo/68dc74a6f1c8c46cfd4af3f4.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-meet-mateo/68dc74a6f1c8c46cfd4af3f4.md
@@ -81,8 +81,8 @@ It literally means **“Good afternoon”** or **“Good evening”**, depending
         "character": "Mateo",
         "position": {
           "x": 50,
-          "y": 15,
-          "z": 1.2
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-learn-meet-mateo/6903d068b5495af23a7df214.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-meet-mateo/6903d068b5495af23a7df214.md
@@ -67,7 +67,6 @@ Use `soy` when describing who you are or what you do. For example:
 
 # --scene--
 
-
 ```json
 {
   "setup": {
@@ -77,8 +76,8 @@ Use `soy` when describing who you are or what you do. For example:
         "character": "Mateo",
         "position": {
           "x": 50,
-          "y": 15,
-          "z": 1.2
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-learn-meet-mateo/6903d3c4ccae5fffec5f3cbc.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-meet-mateo/6903d3c4ccae5fffec5f3cbc.md
@@ -66,7 +66,6 @@ This refers to a woman from Colombia, and the ending `-a` indicates the feminine
 
 # --scene--
 
-
 ```json
 {
   "setup": {
@@ -76,8 +75,8 @@ This refers to a woman from Colombia, and the ending `-a` indicates the feminine
         "character": "Mateo",
         "position": {
           "x": 50,
-          "y": 15,
-          "z": 1.2
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-learn-meet-mateo/6903d8144e306313835959e6.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-meet-mateo/6903d8144e306313835959e6.md
@@ -76,7 +76,6 @@ As a reminder, the letter `ñ` in `años` has a tilde (`˜`), giving it a distin
 
 # --scene--
 
-
 ```json
 {
   "setup": {
@@ -86,8 +85,8 @@ As a reminder, the letter `ñ` in `años` has a tilde (`˜`), giving it a distin
         "character": "Mateo",
         "position": {
           "x": 50,
-          "y": 15,
-          "z": 1.2
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-learn-meet-mateo/6914d94cee63aa7cbcafab2c.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-meet-mateo/6914d94cee63aa7cbcafab2c.md
@@ -58,8 +58,8 @@ This verb form comes from `ser` and is used to describe who you are or what you 
         "character": "Mateo",
         "position": {
           "x": 50,
-          "y": 15,
-          "z": 1.2
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-learn-meet-mateo/691629d2fd3b84528356dfcb.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-meet-mateo/691629d2fd3b84528356dfcb.md
@@ -45,8 +45,8 @@ Think about which farewell means "See you soon", often used when you expect to s
         "character": "Mateo",
         "position": {
           "x": 50,
-          "y": 15,
-          "z": 1.2
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-learn-numbers-10-to-29/692322e4deeb92161eddbcb9.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-numbers-10-to-29/692322e4deeb92161eddbcb9.md
@@ -77,7 +77,7 @@ Camila mentions three numbers:
         "character": "Camila",
         "position": {
           "x": 50,
-          "y": 0,
+          "y": 18,
           "z": 1.5
         },
         "opacity": 0

--- a/curriculum/challenges/english/blocks/es-a1-learn-numbers-10-to-29/692325cde805a91e7d973d6f.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-numbers-10-to-29/692325cde805a91e7d973d6f.md
@@ -69,7 +69,7 @@ Camila pronounces the word `Once`, which corresponds to the number 11.
         "character": "Camila",
         "position": {
           "x": 50,
-          "y": 0,
+          "y": 18,
           "z": 1.5
         },
         "opacity": 0

--- a/curriculum/challenges/english/blocks/es-a1-learn-numbers-10-to-29/692327940e4aa020e97c3151.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-numbers-10-to-29/692327940e4aa020e97c3151.md
@@ -77,7 +77,7 @@ Camila mentions three numbers:
         "character": "Camila",
         "position": {
           "x": 50,
-          "y": 0,
+          "y": 18,
           "z": 1.5
         },
         "opacity": 0

--- a/curriculum/challenges/english/blocks/es-a1-learn-numbers-10-to-29/692328943fc4ec22f3f644ca.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-numbers-10-to-29/692328943fc4ec22f3f644ca.md
@@ -69,7 +69,7 @@ Camila mentions the word `Trece`, which corresponds to the number 13.
         "character": "Camila",
         "position": {
           "x": 50,
-          "y": 0,
+          "y": 18,
           "z": 1.5
         },
         "opacity": 0

--- a/curriculum/challenges/english/blocks/es-a1-learn-numbers-10-to-29/692329f211c3d9256f1c8372.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-numbers-10-to-29/692329f211c3d9256f1c8372.md
@@ -66,7 +66,7 @@ Camila mentions two numbers:
         "character": "Camila",
         "position": {
           "x": 50,
-          "y": 0,
+          "y": 18,
           "z": 1.5
         },
         "opacity": 0

--- a/curriculum/challenges/english/blocks/es-a1-learn-numbers-10-to-29/69232bde8391ec28781fdd2d.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-numbers-10-to-29/69232bde8391ec28781fdd2d.md
@@ -69,7 +69,7 @@ Camila pronounces the word `Diecisiete`, which corresponds to the number 17.
         "character": "Camila",
         "position": {
           "x": 50,
-          "y": 0,
+          "y": 18,
           "z": 1.5
         },
         "opacity": 0

--- a/curriculum/challenges/english/blocks/es-a1-learn-numbers-10-to-29/69232e147dc8972bd5bb92a9.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-numbers-10-to-29/69232e147dc8972bd5bb92a9.md
@@ -66,7 +66,7 @@ Camila mentions two numbers:
         "character": "Camila",
         "position": {
           "x": 50,
-          "y": 0,
+          "y": 18,
           "z": 1.5
         },
         "opacity": 0

--- a/curriculum/challenges/english/blocks/es-a1-learn-numbers-10-to-29/69232f2b8ee0472da4c63f76.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-numbers-10-to-29/69232f2b8ee0472da4c63f76.md
@@ -69,7 +69,7 @@ Camila pronounces the number `Dieciocho`, which corresponds to the number 18.
         "character": "Camila",
         "position": {
           "x": 50,
-          "y": 0,
+          "y": 18,
           "z": 1.5
         },
         "opacity": 0

--- a/curriculum/challenges/english/blocks/es-a1-learn-numbers-10-to-29/692330428792892f803d82f2.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-numbers-10-to-29/692330428792892f803d82f2.md
@@ -49,7 +49,7 @@ Camila mentions the number `Veinte`, which corresponds to 20.
         "character": "Camila",
         "position": {
           "x": 50,
-          "y": 0,
+          "y": 18,
           "z": 1.5
         },
         "opacity": 0

--- a/curriculum/challenges/english/blocks/es-a1-learn-numbers-10-to-29/69234011db1dd3390bbe798d.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-numbers-10-to-29/69234011db1dd3390bbe798d.md
@@ -79,7 +79,7 @@ Camila mentions three numbers:
         "character": "Camila",
         "position": {
           "x": 50,
-          "y": 0,
+          "y": 18,
           "z": 1.5
         },
         "opacity": 0

--- a/curriculum/challenges/english/blocks/es-a1-learn-numbers-10-to-29/692344d67fb48a3d632f0996.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-numbers-10-to-29/692344d67fb48a3d632f0996.md
@@ -69,7 +69,7 @@ Camila mentions the number `Veintidós`, which corresponds to 22.
         "character": "Camila",
         "position": {
           "x": 50,
-          "y": 0,
+          "y": 18,
           "z": 1.5
         },
         "opacity": 0

--- a/curriculum/challenges/english/blocks/es-a1-learn-numbers-10-to-29/6923467f09211340886b82b7.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-numbers-10-to-29/6923467f09211340886b82b7.md
@@ -77,7 +77,7 @@ Camila mentions three numbers:
         "character": "Camila",
         "position": {
           "x": 50,
-          "y": 0,
+          "y": 18,
           "z": 1.5
         },
         "opacity": 0

--- a/curriculum/challenges/english/blocks/es-a1-learn-numbers-10-to-29/6923485ec3611f43d1c4d3e2.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-numbers-10-to-29/6923485ec3611f43d1c4d3e2.md
@@ -69,7 +69,7 @@ Camila mentions the number `Veinticuatro`, which corresponds to 24.
         "character": "Camila",
         "position": {
           "x": 50,
-          "y": 0,
+          "y": 18,
           "z": 1.5
         },
         "opacity": 0

--- a/curriculum/challenges/english/blocks/es-a1-learn-numbers-10-to-29/692349d239ccd645a6147f68.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-numbers-10-to-29/692349d239ccd645a6147f68.md
@@ -79,7 +79,7 @@ Camila mentions three numbers:
         "character": "Camila",
         "position": {
           "x": 50,
-          "y": 0,
+          "y": 18,
           "z": 1.5
         },
         "opacity": 0

--- a/curriculum/challenges/english/blocks/es-a1-learn-numbers-10-to-29/69234b22f3779e47a34c71ff.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-numbers-10-to-29/69234b22f3779e47a34c71ff.md
@@ -67,7 +67,7 @@ Camila mentions the number `Veintiocho`, which corresponds to the number 28.
         "character": "Camila",
         "position": {
           "x": 50,
-          "y": 0,
+          "y": 18,
           "z": 1.5
         },
         "opacity": 0

--- a/curriculum/challenges/english/blocks/es-a1-learn-the-first-ten-numbers/691dd85d8f84be17adbac86e.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-the-first-ten-numbers/691dd85d8f84be17adbac86e.md
@@ -33,8 +33,8 @@ I've listened to the audio and practiced how to pronounce these numbers.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-learn-the-first-ten-numbers/691de4643cfa17239f3f63dc.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-the-first-ten-numbers/691de4643cfa17239f3f63dc.md
@@ -43,8 +43,8 @@ This is the number 0 in Spanish.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-learn-the-first-ten-numbers/691e0644af6d3a35040b3cfd.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-the-first-ten-numbers/691e0644af6d3a35040b3cfd.md
@@ -49,8 +49,8 @@ This is the number 1 in Spanish.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-learn-the-first-ten-numbers/691e087cf197283819e6a63d.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-the-first-ten-numbers/691e087cf197283819e6a63d.md
@@ -43,8 +43,8 @@ This is the number 2 in Spanish.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-learn-the-first-ten-numbers/691e0ac57367e53acf30751f.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-the-first-ten-numbers/691e0ac57367e53acf30751f.md
@@ -43,8 +43,8 @@ This is the number 3 in Spanish.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-learn-the-first-ten-numbers/691e0c17d551d93dba095daa.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-the-first-ten-numbers/691e0c17d551d93dba095daa.md
@@ -43,8 +43,8 @@ This is the number 4 in Spanish.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-learn-the-first-ten-numbers/691e0d81718641411ba24e0c.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-the-first-ten-numbers/691e0d81718641411ba24e0c.md
@@ -43,8 +43,8 @@ This is the number 5 in Spanish.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-learn-the-first-ten-numbers/691e1152c55f46443b285022.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-the-first-ten-numbers/691e1152c55f46443b285022.md
@@ -43,8 +43,8 @@ This is the number 6 in Spanish.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-learn-the-first-ten-numbers/691e13e13f0d4946618340fd.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-the-first-ten-numbers/691e13e13f0d4946618340fd.md
@@ -43,8 +43,8 @@ This is the number 7 in Spanish.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-learn-the-first-ten-numbers/691e15ba76672548922802b2.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-the-first-ten-numbers/691e15ba76672548922802b2.md
@@ -43,8 +43,8 @@ This is the number 8 in Spanish.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-learn-the-first-ten-numbers/691e16648483544a25ffc6c6.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-the-first-ten-numbers/691e16648483544a25ffc6c6.md
@@ -43,8 +43,8 @@ This is the number 9 in Spanish.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-learn-vowels/68e6f57272e3a55b84653033.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-vowels/68e6f57272e3a55b84653033.md
@@ -37,8 +37,8 @@ I've listened to the vowels and practiced repeating them.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-learn-vowels/68e6f7070ff3315e22638f7a.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-vowels/68e6f7070ff3315e22638f7a.md
@@ -67,8 +67,8 @@ The vowel that you can hear in the audio is `i`.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-learn-vowels/68e6fa5e79210663511af8e8.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-vowels/68e6fa5e79210663511af8e8.md
@@ -67,8 +67,8 @@ The vowel that you can hear in the audio is `e`.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-learn-vowels/68e6fb109cd658656e70b535.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-vowels/68e6fb109cd658656e70b535.md
@@ -67,8 +67,8 @@ The vowel that you can hear in the audio is `a`.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-learn-vowels/68e6fb98b9549d66fe846579.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-vowels/68e6fb98b9549d66fe846579.md
@@ -55,8 +55,8 @@ This vowel is found in the word `Hola`, which is a common greeting in Spanish.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-learn-vowels/68e6fbefe999d06833f54c47.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-vowels/68e6fbefe999d06833f54c47.md
@@ -67,8 +67,8 @@ The audio contains this sequence of three vowels: **`a`**, **`i`**, **`u`**.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-learn-vowels/68e6ffbf8c385a6d5f7f87e7.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-vowels/68e6ffbf8c385a6d5f7f87e7.md
@@ -51,8 +51,8 @@ The sequence of vowels that you can hear in the audio is **`u`**, **`a`**, **`e`
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-learn-vowels/68e7058a10380e7bf750c58a.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-vowels/68e7058a10380e7bf750c58a.md
@@ -53,8 +53,8 @@ The vowel **`a`** is not part of this sequence. Therefore, the answer is No.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-learn-vowels/68e7064f26de457d959ce43a.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-vowels/68e7064f26de457d959ce43a.md
@@ -49,8 +49,8 @@ Therefore, the correct sequence is **`aei`**.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-practice-first-questions/69108ccea9363f23b3aacb49.md
+++ b/curriculum/challenges/english/blocks/es-a1-practice-first-questions/69108ccea9363f23b3aacb49.md
@@ -102,7 +102,7 @@ In Spanish, most professions change based on gender. However, some professions t
         "character": "Camila",
         "position": {
           "x": 50,
-          "y": 0,
+          "y": 18,
           "z": 1.5
         },
         "opacity": 0
@@ -111,7 +111,7 @@ In Spanish, most professions change based on gender. However, some professions t
         "character": "Mateo",
         "position": {
           "x": 50,
-          "y": 0,
+          "y": 18,
           "z": 1.5
         },
         "opacity": 0

--- a/curriculum/challenges/english/blocks/es-a1-practice-first-questions/691090f4e43e61297523d064.md
+++ b/curriculum/challenges/english/blocks/es-a1-practice-first-questions/691090f4e43e61297523d064.md
@@ -77,7 +77,7 @@ This dialogue between Mateo and Camila focuses on age.
         "character": "Camila",
         "position": {
           "x": 50,
-          "y": 0,
+          "y": 18,
           "z": 1.5
         },
         "opacity": 0
@@ -86,7 +86,7 @@ This dialogue between Mateo and Camila focuses on age.
         "character": "Mateo",
         "position": {
           "x": 50,
-          "y": 0,
+          "y": 18,
           "z": 1.5
         },
         "opacity": 0

--- a/curriculum/challenges/english/blocks/es-a1-practice-greetings-and-farewells/68c9881715d314368f261622.md
+++ b/curriculum/challenges/english/blocks/es-a1-practice-greetings-and-farewells/68c9881715d314368f261622.md
@@ -70,7 +70,7 @@ Camila does mention the time of the day.
         "character": "Camila",
         "position": {
           "x": 50,
-          "y": 0,
+          "y": 18,
           "z": 1.5
         },
         "opacity": 0

--- a/curriculum/challenges/english/blocks/es-a1-practice-introducing-yourself/68dc7500da504f7042474b20.md
+++ b/curriculum/challenges/english/blocks/es-a1-practice-introducing-yourself/68dc7500da504f7042474b20.md
@@ -75,8 +75,8 @@ This is a general greeting, but Mateo uses a more specific one for nighttime.
         "character": "Mateo",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-practice-introducing-yourself/691b4fcd528ad6fa5c9d92d8.md
+++ b/curriculum/challenges/english/blocks/es-a1-practice-introducing-yourself/691b4fcd528ad6fa5c9d92d8.md
@@ -71,8 +71,8 @@ Other valid options are `Soy Mateo` and `Mi nombre es Mateo`, but Mateo uses the
         "character": "Mateo",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-practice-introducing-yourself/69389800ad6b2ca59892ca90.md
+++ b/curriculum/challenges/english/blocks/es-a1-practice-introducing-yourself/69389800ad6b2ca59892ca90.md
@@ -66,8 +66,8 @@ The phrase `Hasta mañana` is a common way to say that she plans to see you tomo
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 15,
-          "z": 1.2
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-practice-the-alphabet/68fa88e167c0503ec7cd58e6.md
+++ b/curriculum/challenges/english/blocks/es-a1-practice-the-alphabet/68fa88e167c0503ec7cd58e6.md
@@ -49,8 +49,8 @@ The letter `e` is the third one. Therefore, this is true.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-practice-the-alphabet/68fa8b4ecf2cf649ff55f7fd.md
+++ b/curriculum/challenges/english/blocks/es-a1-practice-the-alphabet/68fa8b4ecf2cf649ff55f7fd.md
@@ -65,8 +65,8 @@ The letter `x` is the second one. Therefore, `x` is the correct answer.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-practice-the-alphabet/68fa8c06a9cb054b5b1fe121.md
+++ b/curriculum/challenges/english/blocks/es-a1-practice-the-alphabet/68fa8c06a9cb054b5b1fe121.md
@@ -39,8 +39,8 @@ The sequence of letters in the audio is **`c`**, **`h`**, **`l`**. Therefore, th
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-practice-the-alphabet/68fa8d4751c7604d01de5197.md
+++ b/curriculum/challenges/english/blocks/es-a1-practice-the-alphabet/68fa8d4751c7604d01de5197.md
@@ -51,8 +51,8 @@ Therefore, the answer is false because the letter `n` is not pronounced in the a
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-practice-the-alphabet/68fa8eedb588aa4fb0d3f603.md
+++ b/curriculum/challenges/english/blocks/es-a1-practice-the-alphabet/68fa8eedb588aa4fb0d3f603.md
@@ -47,8 +47,8 @@ The sequence of letters in the audio is **`f`**, **`q`**, **`r`**.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-practice-the-alphabet/68fa91c242eb5956da637831.md
+++ b/curriculum/challenges/english/blocks/es-a1-practice-the-alphabet/68fa91c242eb5956da637831.md
@@ -39,8 +39,8 @@ The sequence of letters in the audio is **`i`**, **`ñ`**, **`p`**.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-practice-the-alphabet/68fa921d0e5d785813d00773.md
+++ b/curriculum/challenges/english/blocks/es-a1-practice-the-alphabet/68fa921d0e5d785813d00773.md
@@ -65,8 +65,8 @@ The first letter is **`o`**. Therefore, this is the correct answer.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-practice-the-alphabet/68fa92e5cf564859a1fa89e7.md
+++ b/curriculum/challenges/english/blocks/es-a1-practice-the-alphabet/68fa92e5cf564859a1fa89e7.md
@@ -47,8 +47,8 @@ The sequence of letters in the audio is **`k`**, **`v`**, **`u`**.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-practice-the-alphabet/68fa938257d3055aea0cb298.md
+++ b/curriculum/challenges/english/blocks/es-a1-practice-the-alphabet/68fa938257d3055aea0cb298.md
@@ -55,8 +55,8 @@ The sequence of letters in the audio is **`s`**, **`w`**, **`y`**.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-practice-the-first-ten-numbers/691e2602b9559564dc8883b4.md
+++ b/curriculum/challenges/english/blocks/es-a1-practice-the-first-ten-numbers/691e2602b9559564dc8883b4.md
@@ -69,8 +69,8 @@ Julieta mentions the number `dos` (2).
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-practice-the-first-ten-numbers/691e2804e0eda3682d6da6da.md
+++ b/curriculum/challenges/english/blocks/es-a1-practice-the-first-ten-numbers/691e2804e0eda3682d6da6da.md
@@ -69,8 +69,8 @@ Julieta mentions the number `cuatro` (4).
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-practice-the-first-ten-numbers/691e3a8551b50974a59d93ae.md
+++ b/curriculum/challenges/english/blocks/es-a1-practice-the-first-ten-numbers/691e3a8551b50974a59d93ae.md
@@ -45,8 +45,8 @@ Julieta mentions this sequence of numbers: `Cuatro - Dos - Cero`.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-practice-the-first-ten-numbers/691f1d842d52c8142d0c67bd.md
+++ b/curriculum/challenges/english/blocks/es-a1-practice-the-first-ten-numbers/691f1d842d52c8142d0c67bd.md
@@ -69,8 +69,8 @@ Julieta mentions the number `nueve` (9).
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-practice-the-first-ten-numbers/691f20b1c95dc123fa0d7493.md
+++ b/curriculum/challenges/english/blocks/es-a1-practice-the-first-ten-numbers/691f20b1c95dc123fa0d7493.md
@@ -45,8 +45,8 @@ Julieta mentions this sequence of numbers: `Siete - Nueve - Tres`.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-practice-the-first-ten-numbers/691f218124e5d72585095275.md
+++ b/curriculum/challenges/english/blocks/es-a1-practice-the-first-ten-numbers/691f218124e5d72585095275.md
@@ -45,8 +45,8 @@ Julieta mentions this sequence of numbers: `Ocho - Cero - Uno`.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-practice-the-first-ten-numbers/691f2524eb0b572be243cae8.md
+++ b/curriculum/challenges/english/blocks/es-a1-practice-the-first-ten-numbers/691f2524eb0b572be243cae8.md
@@ -41,8 +41,8 @@ Julieta mentions the number `Siete` (7) in the audio.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-practice-the-first-ten-numbers/691f27bbe3eead3076f3f49f.md
+++ b/curriculum/challenges/english/blocks/es-a1-practice-the-first-ten-numbers/691f27bbe3eead3076f3f49f.md
@@ -53,8 +53,8 @@ Julieta mentions this sequence of numbers: `Ocho - Seis - Cuatro`.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-practice-using-numbers-10-to-29/692362e117d7be7f2ec621b7.md
+++ b/curriculum/challenges/english/blocks/es-a1-practice-using-numbers-10-to-29/692362e117d7be7f2ec621b7.md
@@ -69,7 +69,7 @@ The sequence mentioned by Camila is `Diez - Trece - Quince`.
         "character": "Camila",
         "position": {
           "x": 50,
-          "y": 0,
+          "y": 18,
           "z": 1.5
         },
         "opacity": 0

--- a/curriculum/challenges/english/blocks/es-a1-practice-using-numbers-10-to-29/6923631d11905882a334aa74.md
+++ b/curriculum/challenges/english/blocks/es-a1-practice-using-numbers-10-to-29/6923631d11905882a334aa74.md
@@ -53,7 +53,7 @@ This statement is true because Camila mentions `Catorce`, which is the number 14
         "character": "Camila",
         "position": {
           "x": 50,
-          "y": 0,
+          "y": 18,
           "z": 1.5
         },
         "opacity": 0

--- a/curriculum/challenges/english/blocks/es-a1-practice-using-numbers-10-to-29/692363aa62c77f88dd893665.md
+++ b/curriculum/challenges/english/blocks/es-a1-practice-using-numbers-10-to-29/692363aa62c77f88dd893665.md
@@ -65,7 +65,7 @@ Camila says the word `Veintinueve`, which corresponds to the number 29.
         "character": "Camila",
         "position": {
           "x": 50,
-          "y": 0,
+          "y": 18,
           "z": 1.5
         },
         "opacity": 0

--- a/curriculum/challenges/english/blocks/es-a1-practice-using-numbers-10-to-29/692364152d35bb8df0c73274.md
+++ b/curriculum/challenges/english/blocks/es-a1-practice-using-numbers-10-to-29/692364152d35bb8df0c73274.md
@@ -65,7 +65,7 @@ Camila mentions the word `Diecisiete`, which corresponds to the number 17.
         "character": "Camila",
         "position": {
           "x": 50,
-          "y": 0,
+          "y": 18,
           "z": 1.5
         },
         "opacity": 0

--- a/curriculum/challenges/english/blocks/es-a1-practice-using-numbers-10-to-29/6923644f41365a8fe354d904.md
+++ b/curriculum/challenges/english/blocks/es-a1-practice-using-numbers-10-to-29/6923644f41365a8fe354d904.md
@@ -53,7 +53,7 @@ The sequence of numbers in the audio is: `Doce - Once - Dieciocho - Veinte`.
         "character": "Camila",
         "position": {
           "x": 50,
-          "y": 0,
+          "y": 18,
           "z": 1.5
         },
         "opacity": 0

--- a/curriculum/challenges/english/blocks/es-a1-practice-using-numbers-10-to-29/6923646cdc997590ee04f838.md
+++ b/curriculum/challenges/english/blocks/es-a1-practice-using-numbers-10-to-29/6923646cdc997590ee04f838.md
@@ -65,7 +65,7 @@ Camila mentions the number `Diecinueve`, which corresponds to number 19.
         "character": "Camila",
         "position": {
           "x": 50,
-          "y": 0,
+          "y": 18,
           "z": 1.5
         },
         "opacity": 0

--- a/curriculum/challenges/english/blocks/es-a1-review-numbers-10-to-29/6923745a0f2505b360e96660.md
+++ b/curriculum/challenges/english/blocks/es-a1-review-numbers-10-to-29/6923745a0f2505b360e96660.md
@@ -25,7 +25,7 @@ I've reviewed and practiced how to pronounce these numbers.
         "character": "Camila",
         "position": {
           "x": 50,
-          "y": 0,
+          "y": 18,
           "z": 1.5
         },
         "opacity": 0

--- a/curriculum/challenges/english/blocks/es-a1-review-spanish-fundamentals/68f245ba618d531136b99a19.md
+++ b/curriculum/challenges/english/blocks/es-a1-review-spanish-fundamentals/68f245ba618d531136b99a19.md
@@ -27,8 +27,8 @@ I've reviewed the pronunciation of the Spanish alphabet.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-review-spanish-fundamentals/69206e4d7c0cfd1935d08ae4.md
+++ b/curriculum/challenges/english/blocks/es-a1-review-spanish-fundamentals/69206e4d7c0cfd1935d08ae4.md
@@ -27,8 +27,8 @@ I've reviewed and practiced how to pronounce these numbers.
         "character": "Julieta",
         "position": {
           "x": 50,
-          "y": 0,
-          "z": 1.4
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-warm-up-greetings-and-farewells-basics/68c586973237a2ae8b8a9dcb.md
+++ b/curriculum/challenges/english/blocks/es-a1-warm-up-greetings-and-farewells-basics/68c586973237a2ae8b8a9dcb.md
@@ -70,7 +70,7 @@ This is a more specific morning greeting, not the phrase used in the audio.
         "character": "Camila",
         "position": {
           "x": 50,
-          "y": 0,
+          "y": 18,
           "z": 1.5
         },
         "opacity": 0
@@ -79,7 +79,7 @@ This is a more specific morning greeting, not the phrase used in the audio.
     "audio": {
       "filename": "ES_A1_1.2.mp3",
       "startTime": 1,
-      "startTimestamp": 1.0,
+      "startTimestamp": 1,
       "finishTimestamp": 2.13
     }
   },

--- a/curriculum/challenges/english/blocks/es-a1-warm-up-greetings-and-farewells-basics/68c58ac706597fe1f643837d.md
+++ b/curriculum/challenges/english/blocks/es-a1-warm-up-greetings-and-farewells-basics/68c58ac706597fe1f643837d.md
@@ -72,7 +72,7 @@ It's similar to `Hasta luego` ("See you later"), but `hasta pronto` suggests a s
         "character": "Camila",
         "position": {
           "x": 50,
-          "y": 0,
+          "y": 18,
           "z": 1.5
         },
         "opacity": 0

--- a/curriculum/challenges/english/blocks/es-a1-warm-up-greetings-and-farewells-basics/68c58b85c5a2e0ed307f24d4.md
+++ b/curriculum/challenges/english/blocks/es-a1-warm-up-greetings-and-farewells-basics/68c58b85c5a2e0ed307f24d4.md
@@ -70,7 +70,7 @@ This means "designer", not the word you hear.
         "character": "Camila",
         "position": {
           "x": 50,
-          "y": 0,
+          "y": 18,
           "z": 1.5
         },
         "opacity": 0

--- a/curriculum/challenges/english/blocks/es-a1-warm-up-introducing-yourself-basics/68deada768199f7410bda165.md
+++ b/curriculum/challenges/english/blocks/es-a1-warm-up-introducing-yourself-basics/68deada768199f7410bda165.md
@@ -86,8 +86,8 @@ In Spanish, many professions change their ending depending on whether the speake
         "character": "Mateo",
         "position": {
           "x": 50,
-          "y": 15,
-          "z": 1.2
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-warm-up-introducing-yourself-basics/68dec33d726ba397789a62ec.md
+++ b/curriculum/challenges/english/blocks/es-a1-warm-up-introducing-yourself-basics/68dec33d726ba397789a62ec.md
@@ -70,8 +70,8 @@ Mateo did not mention a male architect.
         "character": "Mateo",
         "position": {
           "x": 50,
-          "y": 15,
-          "z": 1.2
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-warm-up-introducing-yourself-basics/68dec93b79d995a4449c63a4.md
+++ b/curriculum/challenges/english/blocks/es-a1-warm-up-introducing-yourself-basics/68dec93b79d995a4449c63a4.md
@@ -73,8 +73,8 @@ This is a male or female police officer, which is not what Mateo said.
         "character": "Mateo",
         "position": {
           "x": 50,
-          "y": 15,
-          "z": 1.2
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-warm-up-introducing-yourself-basics/68df28fd4c9350f60d677e77.md
+++ b/curriculum/challenges/english/blocks/es-a1-warm-up-introducing-yourself-basics/68df28fd4c9350f60d677e77.md
@@ -84,8 +84,8 @@ This refers to a man from Colombia.
         "character": "Mateo",
         "position": {
           "x": 50,
-          "y": 15,
-          "z": 1.2
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-warm-up-introducing-yourself-basics/68df2d0bfdc47c0438a86747.md
+++ b/curriculum/challenges/english/blocks/es-a1-warm-up-introducing-yourself-basics/68df2d0bfdc47c0438a86747.md
@@ -69,8 +69,8 @@ This refers to a man from Colombia.
         "character": "Mateo",
         "position": {
           "x": 50,
-          "y": 15,
-          "z": 1.2
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-warm-up-introducing-yourself-basics/68df2eb089231308d5addb91.md
+++ b/curriculum/challenges/english/blocks/es-a1-warm-up-introducing-yourself-basics/68df2eb089231308d5addb91.md
@@ -65,8 +65,8 @@ This refers to a woman from Brazil.
         "character": "Mateo",
         "position": {
           "x": 50,
-          "y": 15,
-          "z": 1.2
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-warm-up-introducing-yourself-basics/68e53795c299ac48cf6e12f9.md
+++ b/curriculum/challenges/english/blocks/es-a1-warm-up-introducing-yourself-basics/68e53795c299ac48cf6e12f9.md
@@ -81,8 +81,8 @@ Notice the special character `ñ` in `años`.
         "character": "Mateo",
         "position": {
           "x": 50,
-          "y": 15,
-          "z": 1.2
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }
@@ -90,7 +90,7 @@ Notice the special character `ñ` in `años`.
     "audio": {
       "filename": "ES_A1_2_vocabulary.mp3",
       "startTime": 1,
-      "startTimestamp": 23.60,
+      "startTimestamp": 23.6,
       "finishTimestamp": 25.69
     }
   },

--- a/curriculum/challenges/english/blocks/es-a1-warm-up-introducing-yourself-basics/68e53e2526414c56ac61f4e5.md
+++ b/curriculum/challenges/english/blocks/es-a1-warm-up-introducing-yourself-basics/68e53e2526414c56ac61f4e5.md
@@ -75,8 +75,8 @@ This means "twenty two years old". The number Mateo says is higher.
         "character": "Mateo",
         "position": {
           "x": 50,
-          "y": 15,
-          "z": 1.2
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-warm-up-introducing-yourself-basics/68e54b639461636cb65a87ee.md
+++ b/curriculum/challenges/english/blocks/es-a1-warm-up-introducing-yourself-basics/68e54b639461636cb65a87ee.md
@@ -77,8 +77,8 @@ The number he says is lower than thirty-eight.
         "character": "Mateo",
         "position": {
           "x": 50,
-          "y": 15,
-          "z": 1.2
+          "y": 18,
+          "z": 1.5
         },
         "opacity": 0
       }

--- a/curriculum/challenges/english/blocks/es-a1-warm-up-remember-first-numbers/6920da549e860c1d800bab97.md
+++ b/curriculum/challenges/english/blocks/es-a1-warm-up-remember-first-numbers/6920da549e860c1d800bab97.md
@@ -25,7 +25,7 @@ I've reviewed and practiced pronouncing the numbers from 0 to 9.
         "character": "Camila",
         "position": {
           "x": 50,
-          "y": 0,
+          "y": 18,
           "z": 1.5
         },
         "opacity": 0

--- a/curriculum/challenges/english/blocks/es-a1-warm-up-remember-first-numbers/6920df47b620d52875b2a2ce.md
+++ b/curriculum/challenges/english/blocks/es-a1-warm-up-remember-first-numbers/6920df47b620d52875b2a2ce.md
@@ -69,7 +69,7 @@ Camila mentions this sequence of numbers: `Cuatro - Dos - Cero`.
         "character": "Camila",
         "position": {
           "x": 50,
-          "y": 0,
+          "y": 18,
           "z": 1.5
         },
         "opacity": 0

--- a/curriculum/challenges/english/blocks/es-a1-warm-up-remember-first-numbers/6920e2f27a1bb92fdc6ac723.md
+++ b/curriculum/challenges/english/blocks/es-a1-warm-up-remember-first-numbers/6920e2f27a1bb92fdc6ac723.md
@@ -51,7 +51,7 @@ Camila mentions the sequence: `Cinco - Seis - Siete - Ocho`.
         "character": "Camila",
         "position": {
           "x": 50,
-          "y": 0,
+          "y": 18,
           "z": 1.5
         },
         "opacity": 0

--- a/curriculum/challenges/english/blocks/es-a1-warm-up-remember-first-numbers/6920e3d96a1fb331b9814b50.md
+++ b/curriculum/challenges/english/blocks/es-a1-warm-up-remember-first-numbers/6920e3d96a1fb331b9814b50.md
@@ -49,7 +49,7 @@ Camila pronounces the number `Nueve` (9). The number 0 is called `Cero` in Spani
         "character": "Camila",
         "position": {
           "x": 50,
-          "y": 0,
+          "y": 18,
           "z": 1.5
         },
         "opacity": 0


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR:
- Updates the coordinates of tall characters (Camila, Julieta, and Mateo) to:
  - x: 50 
  - y: 18
  - z: 1.5
- Is related to https://github.com/freeCodeCamp/language-curricula/issues/39

<details>
<summary>Screenshot</summary>

<img width="995" height="630" alt="Screenshot 2025-12-11 at 18 15 01" src="https://github.com/user-attachments/assets/56f1b04d-bc43-4fff-bc0e-3b0a246acbfb" />

</details>

<!-- Feel free to add any additional description of changes below this line -->
