### PR TITLE
fix(curriculum): correct symmetric difference wording and examples

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-dictionaries-and-sets/683ec8fd8b21827317388a45.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-dictionaries-and-sets/683ec8fd8b21827317388a45.md
@@ -103,7 +103,7 @@ The difference operator `-` returns a new set with the elements of the first set
 my_set - your_set # {1, 5}
 ```
 
-The symmetric difference operator `^` returns a new set with the elements that are either on the first or the second set, but not both. In this case, 1 and 5 are in `my_set` but not in `your_set`, so they are included. And the number 6 is in `your_set` but not in `my_set`, so it's included as well:
+The symmetric difference operator `^` returns a new set with the elements that are either in the first or the second set, but not both. In this case, 1 and 5 are in `my_set` but not in `your_set`, so they are included. And the number 6 is in `your_set` but not in `my_set`, so it's included as well:
 
 ```python
 my_set ^ your_set # {1, 5, 6}

--- a/curriculum/challenges/english/blocks/quiz-dictionaries-and-sets/67f412ac59601c4151b763da.md
+++ b/curriculum/challenges/english/blocks/quiz-dictionaries-and-sets/67f412ac59601c4151b763da.md
@@ -466,7 +466,7 @@ It returns a new set with the elements of the first set that are not in the othe
 
 #### --answer--
 
-It returns a new set with the elements that are either on the first or the second set, but not both.
+It returns a new set with the elements that are either in the first or the second set, but not both.
 
 ### --question--
 

--- a/curriculum/challenges/english/blocks/review-dictionaries-and-sets/67f39babe1e2ec1fb6eea32a.md
+++ b/curriculum/challenges/english/blocks/review-dictionaries-and-sets/67f39babe1e2ec1fb6eea32a.md
@@ -241,9 +241,8 @@ my_set.clear()
 - **`issubset()` and `issuperset()` Methods**: The `issubset()` and the `issuperset()` methods check if a set is a subset or superset of another set, respectively.
 
 ```python
-# Example sets for subset/superset
 my_set = {1, 2, 3, 4, 5}
-your_set = {2, 3, 4, 6}
+your_set = {2, 3, 4, 5}
 
 print(your_set.issubset(my_set)) # True
 print(my_set.issuperset(your_set)) # True
@@ -252,7 +251,6 @@ print(my_set.issuperset(your_set)) # True
 - **`isdisjoint()` Method**: The `isdisjoint()` method checks if two sets are disjoint, if they don't have elements in common.
 
 ```python
-# Example sets for disjoint
 my_set = {1, 2, 3}
 your_set = {4, 5, 6}
 
@@ -262,7 +260,6 @@ print(my_set.isdisjoint(your_set)) # True
 - **Union Operator (`|`)**: The union operator `|` returns a new set with all the elements from both sets.
 
 ```python
-# Example sets for union
 my_set = {1, 2, 3}
 your_set = {4, 5, 6}
 
@@ -272,7 +269,6 @@ my_set | your_set # {1, 2, 3, 4, 5, 6}
 - **Intersection Operator (`&`)**: The intersection operator `&` returns a new set with only the elements that the sets have in common.
 
 ```python
-# Example sets for intersection
 my_set = {1, 2, 3, 4, 5}
 your_set = {2, 3, 4, 6}
 
@@ -282,7 +278,6 @@ my_set & your_set # {2, 3, 4}
 - **Difference Operator (`-`)**: The difference operator `-` returns a new set with the elements of the first set that are not in the other sets.
 
 ```python
-# Example sets for difference
 my_set = {1, 2, 3, 4, 5}
 your_set = {2, 3, 4, 6}
 
@@ -292,7 +287,6 @@ my_set - your_set # {1, 5}
 - **Symmetric Difference Operator (`^`)**: The symmetric difference operator `^` returns a new set with the elements that are either in the first or the second set, but not both.
 
 ```python
-# Example sets for symmetric difference
 my_set = {1, 2, 3, 4, 5}
 your_set = {2, 3, 4, 6}
 
@@ -302,7 +296,7 @@ my_set ^ your_set # {1, 5, 6}
 - **`in` Operator**: You can check if an element is in a set or not with the `in` operator.
 
 ```python
-print(5 in my_set)
+print(5 in my_set) # True
 ```
 
 ## Python Standard Library

--- a/curriculum/challenges/english/blocks/review-dictionaries-and-sets/67f39babe1e2ec1fb6eea32a.md
+++ b/curriculum/challenges/english/blocks/review-dictionaries-and-sets/67f39babe1e2ec1fb6eea32a.md
@@ -241,7 +241,8 @@ my_set.clear()
 - **`issubset()` and `issuperset()` Methods**: The `issubset()` and the `issuperset()` methods check if a set is a subset or superset of another set, respectively.
 
 ```python
-my_set = {1, 2, 3, 4, 5} 
+# Example sets for subset/superset
+my_set = {1, 2, 3, 4, 5}
 your_set = {2, 3, 4, 6}
 
 print(your_set.issubset(my_set)) # True
@@ -251,30 +252,50 @@ print(my_set.issuperset(your_set)) # True
 - **`isdisjoint()` Method**: The `isdisjoint()` method checks if two sets are disjoint, if they don't have elements in common.
 
 ```python
-print(my_set.isdisjoint(your_set)) # False
+# Example sets for disjoint
+my_set = {1, 2, 3}
+your_set = {4, 5, 6}
+
+print(my_set.isdisjoint(your_set)) # True
 ```
 
 - **Union Operator (`|`)**: The union operator `|` returns a new set with all the elements from both sets.
 
 ```python
+# Example sets for union
+my_set = {1, 2, 3}
+your_set = {4, 5, 6}
+
 my_set | your_set # {1, 2, 3, 4, 5, 6}
 ```
 
 - **Intersection Operator (`&`)**: The intersection operator `&` returns a new set with only the elements that the sets have in common.
 
 ```python
+# Example sets for intersection
+my_set = {1, 2, 3, 4, 5}
+your_set = {2, 3, 4, 6}
+
 my_set & your_set # {2, 3, 4}
 ```
 
 - **Difference Operator (`-`)**: The difference operator `-` returns a new set with the elements of the first set that are not in the other sets.
 
 ```python
+# Example sets for difference
+my_set = {1, 2, 3, 4, 5}
+your_set = {2, 3, 4, 6}
+
 my_set - your_set # {1, 5}
 ```
 
 - **Symmetric Difference Operator (`^`)**: The symmetric difference operator `^` returns a new set with the elements that are either in the first or the second set, but not both.
 
 ```python
+# Example sets for symmetric difference
+my_set = {1, 2, 3, 4, 5}
+your_set = {2, 3, 4, 6}
+
 my_set ^ your_set # {1, 5, 6}
 ```
 

--- a/curriculum/challenges/english/blocks/review-dictionaries-and-sets/67f39babe1e2ec1fb6eea32a.md
+++ b/curriculum/challenges/english/blocks/review-dictionaries-and-sets/67f39babe1e2ec1fb6eea32a.md
@@ -242,7 +242,7 @@ my_set.clear()
 
 ```python
 my_set = {1, 2, 3, 4, 5} 
-your_set = {2, 3, 4, 5}
+your_set = {2, 3, 4, 6}
 
 print(your_set.issubset(my_set)) # True
 print(my_set.issuperset(your_set)) # True
@@ -272,7 +272,7 @@ my_set & your_set # {2, 3, 4}
 my_set - your_set # {1, 5}
 ```
 
-- **Symmetric Difference Operator (`^`)**: The symmetric difference operator `^` returns a new set with the elements that are either on the first or the second set, but not both.
+- **Symmetric Difference Operator (`^`)**: The symmetric difference operator `^` returns a new set with the elements that are either in the first or the second set, but not both.
 
 ```python
 my_set ^ your_set # {1, 5, 6}

--- a/curriculum/challenges/english/blocks/review-python/67f39e391c9b373069def02c.md
+++ b/curriculum/challenges/english/blocks/review-python/67f39e391c9b373069def02c.md
@@ -1838,7 +1838,6 @@ my_set | your_set # {1, 2, 3, 4, 5, 6}
 - **Intersection Operator (`&`)**: The intersection operator `&` returns a new set with only the elements that the sets have in common.
 
 ```python
-# Example sets for intersection
 my_set = {1, 2, 3, 4, 5}
 your_set = {2, 3, 4, 6}
 

--- a/curriculum/challenges/english/blocks/review-python/67f39e391c9b373069def02c.md
+++ b/curriculum/challenges/english/blocks/review-python/67f39e391c9b373069def02c.md
@@ -1808,7 +1808,7 @@ my_set.clear()
 
 ```python
 my_set = {1, 2, 3, 4, 5} 
-your_set = {2, 3, 4, 5}
+your_set = {2, 3, 4, 6}
 
 print(your_set.issubset(my_set)) # True
 print(my_set.issuperset(your_set)) # True
@@ -1838,7 +1838,7 @@ my_set & your_set # {2, 3, 4}
 my_set - your_set # {1, 5}
 ```
 
-- **Symmetric Difference Operator (`^`)**: The symmetric difference operator `^` returns a new set with the elements that are either on the first or the second set, but not both.
+- **Symmetric Difference Operator (`^`)**: The symmetric difference operator `^` returns a new set with the elements that are either in the first or the second set, but not both.
 
 ```python
 my_set ^ your_set # {1, 5, 6}

--- a/curriculum/challenges/english/blocks/review-python/67f39e391c9b373069def02c.md
+++ b/curriculum/challenges/english/blocks/review-python/67f39e391c9b373069def02c.md
@@ -1857,7 +1857,6 @@ my_set - your_set # {1, 5}
 - **Symmetric Difference Operator (`^`)**: The symmetric difference operator `^` returns a new set with the elements that are either in the first or the second set, but not both.
 
 ```python
-# Example sets for symmetric difference
 my_set = {1, 2, 3, 4, 5}
 your_set = {2, 3, 4, 6}
 

--- a/curriculum/challenges/english/blocks/review-python/67f39e391c9b373069def02c.md
+++ b/curriculum/challenges/english/blocks/review-python/67f39e391c9b373069def02c.md
@@ -1807,7 +1807,6 @@ my_set.clear()
 - **`issubset()` and `issuperset()` Methods**: The `issubset()` and the `issuperset()` methods check if a set is a subset or superset of another set, respectively.
 
 ```python
-# Example sets for subset/superset
 my_set = {1, 2, 3, 4, 5}
 your_set = {2, 3, 4, 5}
 

--- a/curriculum/challenges/english/blocks/review-python/67f39e391c9b373069def02c.md
+++ b/curriculum/challenges/english/blocks/review-python/67f39e391c9b373069def02c.md
@@ -1809,7 +1809,7 @@ my_set.clear()
 ```python
 # Example sets for subset/superset
 my_set = {1, 2, 3, 4, 5}
-your_set = {2, 3, 4, 6}
+your_set = {2, 3, 4, 5}
 
 print(your_set.issubset(my_set)) # True
 print(my_set.issuperset(your_set)) # True

--- a/curriculum/challenges/english/blocks/review-python/67f39e391c9b373069def02c.md
+++ b/curriculum/challenges/english/blocks/review-python/67f39e391c9b373069def02c.md
@@ -1818,7 +1818,6 @@ print(my_set.issuperset(your_set)) # True
 - **`isdisjoint()` Method**: The `isdisjoint()` method checks if two sets are disjoint, if they don't have elements in common.
 
 ```python
-# Example sets for disjoint
 my_set = {1, 2, 3}
 your_set = {4, 5, 6}
 

--- a/curriculum/challenges/english/blocks/review-python/67f39e391c9b373069def02c.md
+++ b/curriculum/challenges/english/blocks/review-python/67f39e391c9b373069def02c.md
@@ -1847,7 +1847,6 @@ my_set & your_set # {2, 3, 4}
 - **Difference Operator (`-`)**: The difference operator `-` returns a new set with the elements of the first set that are not in the other sets.
 
 ```python
-# Example sets for difference
 my_set = {1, 2, 3, 4, 5}
 your_set = {2, 3, 4, 6}
 

--- a/curriculum/challenges/english/blocks/review-python/67f39e391c9b373069def02c.md
+++ b/curriculum/challenges/english/blocks/review-python/67f39e391c9b373069def02c.md
@@ -1828,7 +1828,6 @@ print(my_set.isdisjoint(your_set)) # True
 - **Union Operator (`|`)**: The union operator `|` returns a new set with all the elements from both sets.
 
 ```python
-# Example sets for union
 my_set = {1, 2, 3}
 your_set = {4, 5, 6}
 

--- a/curriculum/challenges/english/blocks/review-python/67f39e391c9b373069def02c.md
+++ b/curriculum/challenges/english/blocks/review-python/67f39e391c9b373069def02c.md
@@ -1807,7 +1807,8 @@ my_set.clear()
 - **`issubset()` and `issuperset()` Methods**: The `issubset()` and the `issuperset()` methods check if a set is a subset or superset of another set, respectively.
 
 ```python
-my_set = {1, 2, 3, 4, 5} 
+# Example sets for subset/superset
+my_set = {1, 2, 3, 4, 5}
 your_set = {2, 3, 4, 6}
 
 print(your_set.issubset(my_set)) # True
@@ -1817,30 +1818,50 @@ print(my_set.issuperset(your_set)) # True
 - **`isdisjoint()` Method**: The `isdisjoint()` method checks if two sets are disjoint, if they don't have elements in common.
 
 ```python
-print(my_set.isdisjoint(your_set)) # False
+# Example sets for disjoint
+my_set = {1, 2, 3}
+your_set = {4, 5, 6}
+
+print(my_set.isdisjoint(your_set)) # True
 ```
 
 - **Union Operator (`|`)**: The union operator `|` returns a new set with all the elements from both sets.
 
 ```python
+# Example sets for union
+my_set = {1, 2, 3}
+your_set = {4, 5, 6}
+
 my_set | your_set # {1, 2, 3, 4, 5, 6}
 ```
 
 - **Intersection Operator (`&`)**: The intersection operator `&` returns a new set with only the elements that the sets have in common.
 
 ```python
+# Example sets for intersection
+my_set = {1, 2, 3, 4, 5}
+your_set = {2, 3, 4, 6}
+
 my_set & your_set # {2, 3, 4}
 ```
 
 - **Difference Operator (`-`)**: The difference operator `-` returns a new set with the elements of the first set that are not in the other sets.
 
 ```python
+# Example sets for difference
+my_set = {1, 2, 3, 4, 5}
+your_set = {2, 3, 4, 6}
+
 my_set - your_set # {1, 5}
 ```
 
 - **Symmetric Difference Operator (`^`)**: The symmetric difference operator `^` returns a new set with the elements that are either in the first or the second set, but not both.
 
 ```python
+# Example sets for symmetric difference
+my_set = {1, 2, 3, 4, 5}
+your_set = {2, 3, 4, 6}
+
 my_set ^ your_set # {1, 5, 6}
 ```
 


### PR DESCRIPTION
Updated symmetric difference wording from 'on' to 'in' across lecture, quiz, and review content. Adjusted set examples to include the missing element 6 and corrected resulting outputs and subset/superset expectations so the examples match the demonstrated results.

Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.


Closes #64486 