### PR TITLE
fix(learn): corrected variable reference to remainders array

### DIFF
--- a/curriculum/challenges/english/blocks/learn-recursion-by-building-a-decimal-to-binary-converter/645c81683d816b7b3a044143.md
+++ b/curriculum/challenges/english/blocks/learn-recursion-by-building-a-decimal-to-binary-converter/645c81683d816b7b3a044143.md
@@ -7,7 +7,7 @@ dashedName: step-40
 
 # --description--
 
-In the previous version of this function, you pushed the remainder of `input` divided by `2` to `binaryArray`. Then later you reversed and joined the entries into a binary number string.
+In the previous version of this function, you pushed the remainder of `input` divided by `2` to `remainders` array. Then later you reversed and joined the entries into a binary number string.
 
 But it would be easier to use string concatenation within the loop to build the binary string from right to left, so you won't need to reverse it later.
 

--- a/curriculum/challenges/english/blocks/learn-recursion-by-building-a-decimal-to-binary-converter/645c81683d816b7b3a044143.md
+++ b/curriculum/challenges/english/blocks/learn-recursion-by-building-a-decimal-to-binary-converter/645c81683d816b7b3a044143.md
@@ -7,7 +7,7 @@ dashedName: step-40
 
 # --description--
 
-In the previous version of this function, you pushed the remainder of `input` divided by `2` to `remainders` array. Then later you reversed and joined the entries into a binary number string.
+In the previous version of this function, you pushed the remainder of `input` divided by `2` to the `remainders` array. Then later you reversed and joined the entries into a binary number string.
 
 But it would be easier to use string concatenation within the loop to build the binary string from right to left, so you won't need to reverse it later.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #64444

<!-- Feel free to add any additional description of changes below this line -->
After analyzing the previous lectures I noticed that the remainder were pushed to `remainders` array
I changed the variable reference from `binaryArray` to `remainders` array.

