### PR TITLE
fix: clarify callback explanation (#64439)

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-higher-order-functions-and-callbacks/67329ffd75010f5ddeb4ea13.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-higher-order-functions-and-callbacks/67329ffd75010f5ddeb4ea13.md
@@ -7,7 +7,8 @@ dashedName: what-is-a-callback-function-and-how-does-it-work-with-the-foreach-me
 
 # --interactive--
 
-Imagine you have a function that performs a task, and you want to make its behavior more flexible. Instead of writing everything inside one function, you can pass another function (a callback) as an argument. The function that receives the callback decides when to run it — this might happen immediately, later, or even asynchronously. This makes your code more modular and easier to customize.
+Imagine you have a function that performs a task, and you want to make that task more flexible. Instead of hard-coding extra behavior inside the function, you can pass another function (a callback) as an argument. The receiving function chooses when to run the callback — it may run before, during, after, or even asynchronously.
+This makes your code more modular and easier to customize.
 
 This concept is fundamental to understanding many aspects of JavaScript, including how the `forEach` method works.
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-higher-order-functions-and-callbacks/67329ffd75010f5ddeb4ea13.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-higher-order-functions-and-callbacks/67329ffd75010f5ddeb4ea13.md
@@ -7,8 +7,7 @@ dashedName: what-is-a-callback-function-and-how-does-it-work-with-the-foreach-me
 
 # --interactive--
 
-Imagine you have a function that performs a task, and you want to make that task more flexible. Instead of hard-coding extra behavior inside the function, you can pass another function (a callback) as an argument. The receiving function chooses when to run the callback — it may run before, during, after, or even asynchronously.
-This makes your code more modular and easier to customize.
+Imagine you have a function that performs a task, and you want to make its behavior more flexible. Instead of writing everything inside one function, you can pass another function (a callback) as an argument. The function that receives the callback decides when to run it — this might happen immediately, later, or even asynchronously. This makes your code more modular and easier to customize.
 
 This concept is fundamental to understanding many aspects of JavaScript, including how the `forEach` method works.
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-higher-order-functions-and-callbacks/67329ffd75010f5ddeb4ea13.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-higher-order-functions-and-callbacks/67329ffd75010f5ddeb4ea13.md
@@ -7,7 +7,7 @@ dashedName: what-is-a-callback-function-and-how-does-it-work-with-the-foreach-me
 
 # --interactive--
 
-In JavaScript, a callback function is a function that is passed as an argument to another function, so that the outer function can invoke it at a specific point.
+Imagine you have a function that performs a task, and you want to make its behavior more flexible. Instead of writing everything inside one function, you can pass another function (a callback) as an argument. The function that receives the callback decides when to run it — this might happen immediately, later, or even asynchronously. This makes your code more modular and easier to customize.
 
 This concept is fundamental to understanding many aspects of JavaScript, including how the `forEach` method works.
 

--- a/curriculum/challenges/english/blocks/review-javascript-higher-order-functions/6723ca6c6db3deb21cb1bf19.md
+++ b/curriculum/challenges/english/blocks/review-javascript-higher-order-functions/6723ca6c6db3deb21cb1bf19.md
@@ -9,7 +9,7 @@ dashedName: review-javascript-higher-order-functions
 
 ## Callback Functions and the `forEach` Method
 
-- **Definition**: In JavaScript, a callback function is a function that is passed as an argument to another function. The receiving function chooses when to execute it — this may happen before, during, or after the outer function’s main operations.
+- **Definition**: In JavaScript, a callback function is a function that is passed as an argument to another function. The receiving function chooses when to execute it — this may happen before, during, or after the outer function's main operations.
 - **`forEach()` Method**: This method is used to iterate over each element in an array and perform an operation on each element. The callback function in `forEach` can take up to three arguments: the current element, the index of the current element, and the array that `forEach` was called upon. 
 
 ```js

--- a/curriculum/challenges/english/blocks/review-javascript-higher-order-functions/6723ca6c6db3deb21cb1bf19.md
+++ b/curriculum/challenges/english/blocks/review-javascript-higher-order-functions/6723ca6c6db3deb21cb1bf19.md
@@ -9,7 +9,7 @@ dashedName: review-javascript-higher-order-functions
 
 ## Callback Functions and the `forEach` Method
 
-- **Definition**: In JavaScript, a callback function is a function that is passed as an argument to another function and is executed after the main function has finished its execution.
+- **Definition**: In JavaScript, a callback function is a function that is passed as an argument to another function. The receiving function chooses when to execute it — this may happen before, during, or after the outer function’s main operations.
 - **`forEach()` Method**: This method is used to iterate over each element in an array and perform an operation on each element. The callback function in `forEach` can take up to three arguments: the current element, the index of the current element, and the array that `forEach` was called upon. 
 
 ```js


### PR DESCRIPTION
Fixes #64439

This PR updates the callback explanations in two curriculum files to make the definition more accurate. 
The previous text implied that a callback always runs after the outer function finishes, which is not always true. 
The updated explanation clarifies that the receiving function decides when to execute the callback — before, during, or after its main operations.

Checklist:

- [ ] I have read and followed the contribution guidelines.
- [ ] I have read and followed the how to open a pull request guide.
- [ ] My pull request targets the main branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #64439
