### PR TITLE
fix(curriculum): replace scene background by company center

### DIFF
--- a/curriculum/challenges/english/blocks/es-a1-warm-up-first-questions-basics/68dc7578ad62ca74e21c23e0.md
+++ b/curriculum/challenges/english/blocks/es-a1-warm-up-first-questions-basics/68dc7578ad62ca74e21c23e0.md
@@ -65,7 +65,7 @@ This is the most common way to introduce yourself in Spanish, using the verb `ll
 ```json
 {
   "setup": {
-    "background": "company3-breakroom.png",
+    "background": "company3-center.png",
     "characters": [
       {
         "character": "Ángela",

--- a/curriculum/challenges/english/blocks/es-a1-warm-up-first-questions-basics/690e399dcbcca11f0f171613.md
+++ b/curriculum/challenges/english/blocks/es-a1-warm-up-first-questions-basics/690e399dcbcca11f0f171613.md
@@ -67,7 +67,7 @@ In Spanish, when the word `cómo` is used to ask a question, it carries an accen
 ```json
 {
   "setup": {
-    "background": "company3-breakroom.png",
+    "background": "company3-center.png",
     "characters": [
       {
         "character": "Ángela",

--- a/curriculum/challenges/english/blocks/es-a1-warm-up-first-questions-basics/690e3b36537bbb20f7c1d62f.md
+++ b/curriculum/challenges/english/blocks/es-a1-warm-up-first-questions-basics/690e3b36537bbb20f7c1d62f.md
@@ -65,7 +65,7 @@ This is a common way to say where you are from in Spanish.
 ```json
 {
   "setup": {
-    "background": "company3-breakroom.png",
+    "background": "company3-center.png",
     "characters": [
       {
         "character": "Ángela",

--- a/curriculum/challenges/english/blocks/es-a1-warm-up-first-questions-basics/690e3d643e0cf5269fc248dc.md
+++ b/curriculum/challenges/english/blocks/es-a1-warm-up-first-questions-basics/690e3d643e0cf5269fc248dc.md
@@ -70,7 +70,7 @@ Nationalities must agree in gender with the person they describe. For example:
 ```json
 {
   "setup": {
-    "background": "company3-breakroom.png",
+    "background": "company3-center.png",
     "characters": [
       {
         "character": "Ángela",

--- a/curriculum/challenges/english/blocks/es-a1-warm-up-first-questions-basics/690e428065f59a2b48813c79.md
+++ b/curriculum/challenges/english/blocks/es-a1-warm-up-first-questions-basics/690e428065f59a2b48813c79.md
@@ -70,7 +70,7 @@ Nationalities must agree in gender with the person they describe.
 ```json
 {
   "setup": {
-    "background": "company3-breakroom.png",
+    "background": "company3-center.png",
     "characters": [
       {
         "character": "Ángela",

--- a/curriculum/challenges/english/blocks/es-a1-warm-up-first-questions-basics/690e44b76dc8f52d638e82b7.md
+++ b/curriculum/challenges/english/blocks/es-a1-warm-up-first-questions-basics/690e44b76dc8f52d638e82b7.md
@@ -65,7 +65,7 @@ The preposition `de` ("from") is very important because omitting it changes the 
 ```json
 {
   "setup": {
-    "background": "company3-breakroom.png",
+    "background": "company3-center.png",
     "characters": [
       {
         "character": "Ángela",

--- a/curriculum/challenges/english/blocks/es-a1-warm-up-first-questions-basics/690e4698c0492430e49c3705.md
+++ b/curriculum/challenges/english/blocks/es-a1-warm-up-first-questions-basics/690e4698c0492430e49c3705.md
@@ -63,7 +63,7 @@ The question starter `¿A qué…?` (specifically in the phrase `¿A qué te ded
 ```json
 {
   "setup": {
-    "background": "company3-breakroom.png",
+    "background": "company3-center.png",
     "characters": [
       {
         "character": "Ángela",

--- a/curriculum/challenges/english/blocks/es-a1-warm-up-first-questions-basics/690e48893869863487c9d8af.md
+++ b/curriculum/challenges/english/blocks/es-a1-warm-up-first-questions-basics/690e48893869863487c9d8af.md
@@ -65,7 +65,7 @@ It should have an accent mark in the letter `a` when it's part of a question.
 ```json
 {
   "setup": {
-    "background": "company3-breakroom.png",
+    "background": "company3-center.png",
     "characters": [
       {
         "character": "Ángela",

--- a/curriculum/challenges/english/blocks/es-a1-warm-up-first-questions-basics/690e4ae1ec236137adc148a1.md
+++ b/curriculum/challenges/english/blocks/es-a1-warm-up-first-questions-basics/690e4ae1ec236137adc148a1.md
@@ -67,7 +67,7 @@ It's used in both formal and informal settings.
 ```json
 {
   "setup": {
-    "background": "company3-breakroom.png",
+    "background": "company3-center.png",
     "characters": [
       {
         "character": "Ángela",

--- a/curriculum/challenges/english/blocks/es-a1-warm-up-first-questions-basics/690e4ce4d95c5c3ab09f2700.md
+++ b/curriculum/challenges/english/blocks/es-a1-warm-up-first-questions-basics/690e4ce4d95c5c3ab09f2700.md
@@ -70,7 +70,7 @@ It means "charmed" or "delighted".
 ```json
 {
   "setup": {
-    "background": "company3-breakroom.png",
+    "background": "company3-center.png",
     "characters": [
       {
         "character": "Ángela",

--- a/curriculum/challenges/english/blocks/es-a1-warm-up-first-questions-basics/690e4e299e38f83d039e4811.md
+++ b/curriculum/challenges/english/blocks/es-a1-warm-up-first-questions-basics/690e4e299e38f83d039e4811.md
@@ -65,7 +65,7 @@ You can use it as a quick reply to give a nice greeting or compliment back to th
 ```json
 {
   "setup": {
-    "background": "company3-breakroom.png",
+    "background": "company3-center.png",
     "characters": [
       {
         "character": "Ángela",

--- a/curriculum/challenges/english/blocks/es-a1-warm-up-first-questions-basics/690e50f994b82a40ab8664b8.md
+++ b/curriculum/challenges/english/blocks/es-a1-warm-up-first-questions-basics/690e50f994b82a40ab8664b8.md
@@ -65,7 +65,7 @@ The `representante de recursos humanos` ("Human Resources Representative") is th
 ```json
 {
   "setup": {
-    "background": "company3-breakroom.png",
+    "background": "company3-center.png",
     "characters": [
       {
         "character": "Ángela",

--- a/curriculum/challenges/english/blocks/es-a1-warm-up-first-questions-basics/690e52572154034292be27f5.md
+++ b/curriculum/challenges/english/blocks/es-a1-warm-up-first-questions-basics/690e52572154034292be27f5.md
@@ -65,7 +65,7 @@ The word `junior` ("Junior") is used to indicate an entry-level role.
 ```json
 {
   "setup": {
-    "background": "company3-breakroom.png",
+    "background": "company3-center.png",
     "characters": [
       {
         "character": "Ángela",

--- a/curriculum/challenges/english/blocks/es-a1-warm-up-first-questions-basics/6914e14b15579d2610af5c54.md
+++ b/curriculum/challenges/english/blocks/es-a1-warm-up-first-questions-basics/6914e14b15579d2610af5c54.md
@@ -61,7 +61,7 @@ This word means 25. Ángela is mentioning a different number.
 ```json
 {
   "setup": {
-    "background": "company3-breakroom.png",
+    "background": "company3-center.png",
     "characters": [
       {
         "character": "Ángela",

--- a/curriculum/challenges/english/blocks/es-a1-warm-up-first-questions-basics/6914e158fc489627068929d5.md
+++ b/curriculum/challenges/english/blocks/es-a1-warm-up-first-questions-basics/6914e158fc489627068929d5.md
@@ -61,7 +61,7 @@ This word means 23. Ángela is mentioning a different number.
 ```json
 {
   "setup": {
-    "background": "company3-breakroom.png",
+    "background": "company3-center.png",
     "characters": [
       {
         "character": "Ángela",

--- a/curriculum/challenges/english/blocks/es-a1-warm-up-first-questions-basics/6914e7f76afe9430861af32c.md
+++ b/curriculum/challenges/english/blocks/es-a1-warm-up-first-questions-basics/6914e7f76afe9430861af32c.md
@@ -61,7 +61,7 @@ This word means 32. Ángela is mentioning a different number.
 ```json
 {
   "setup": {
-    "background": "company3-breakroom.png",
+    "background": "company3-center.png",
     "characters": [
       {
         "character": "Ángela",

--- a/curriculum/challenges/english/blocks/es-a1-warm-up-first-questions-basics/6914e870b77341326df3f70e.md
+++ b/curriculum/challenges/english/blocks/es-a1-warm-up-first-questions-basics/6914e870b77341326df3f70e.md
@@ -61,7 +61,7 @@ This word means 34. Ángela is mentioning a different number.
 ```json
 {
   "setup": {
-    "background": "company3-breakroom.png",
+    "background": "company3-center.png",
     "characters": [
       {
         "character": "Ángela",

--- a/curriculum/challenges/english/blocks/es-a1-warm-up-first-questions-basics/6914e8d79ff89933f84f8ddf.md
+++ b/curriculum/challenges/english/blocks/es-a1-warm-up-first-questions-basics/6914e8d79ff89933f84f8ddf.md
@@ -61,7 +61,7 @@ This word means 29. Ángela is mentioning a different number.
 ```json
 {
   "setup": {
-    "background": "company3-breakroom.png",
+    "background": "company3-center.png",
     "characters": [
       {
         "character": "Ángela",

--- a/curriculum/challenges/english/blocks/es-a1-warm-up-first-questions-basics/6914e966155354366f418a2d.md
+++ b/curriculum/challenges/english/blocks/es-a1-warm-up-first-questions-basics/6914e966155354366f418a2d.md
@@ -61,7 +61,7 @@ This word means 25. Ángela is mentioning a different number.
 ```json
 {
   "setup": {
-    "background": "company3-breakroom.png",
+    "background": "company3-center.png",
     "characters": [
       {
         "character": "Ángela",


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->

This PR changes the background of the scenes of the Spanish Curriculum that had the `company3-breakroom.png` background to `company3-center.png`