### PR TITLE
fix(curriculum): extend selection sort algorithm tests

### DIFF
--- a/curriculum/challenges/english/blocks/lab-selection-sort/680b3ef395479b0e449ecb6e.md
+++ b/curriculum/challenges/english/blocks/lab-selection-sort/680b3ef395479b0e449ecb6e.md
@@ -112,7 +112,7 @@ Your `selection_sort` should modify input list in-place. You should not use any 
 
             list_to_sort = CustomList([32, 0, 88, 1, 203])
 
-            _ = selection_sort(list_to_sort)
+            selection_sort(list_to_sort)
             assert all(
                 'Setting item' in record
                 for record in list_to_sort._record
@@ -149,7 +149,7 @@ Your `selection_sort` should follow selection sort algorithm, swapping the minim
                 ((3, 67, 89), (4, 89, 67)),
             ]
 
-            _ = selection_sort(list_to_sort)
+            selection_sort(list_to_sort)
             record = list_to_sort._record
 
             actual_pairs = [

--- a/curriculum/challenges/english/blocks/lab-selection-sort/680b3ef395479b0e449ecb6e.md
+++ b/curriculum/challenges/english/blocks/lab-selection-sort/680b3ef395479b0e449ecb6e.md
@@ -20,8 +20,8 @@ Selection sort results in a quadratic time complexity in the best, average, and 
 1. You should define a function named `selection_sort`.
 1. Your `selection_sort` function should have one parameter that represents the list of items.
 1. Your `selection_sort` function should take a list and sort the items in place from smallest to largest.
-1. Your `selection_sort` function should modify input list in-place, and return it once it's sorted.
-1. Your `selection_sor` function should follow selection sort algorithm, swapping the smallest element from unsorted portion of list, with the first unsorted element.
+1. Your `selection_sort` function should modify the input list in-place, and return it once it's sorted.
+1. Your `selection_sort` function should follow the selection sort algorithm, swapping the smallest element from the unsorted portion of the list, with the first unsorted element.
 1. Your `selection_sort` function should not use either the built-in `sort()` method or `sorted()` function.
 
 # --hints--
@@ -76,7 +76,7 @@ Your `selection_sort` should return the same list as the input list.
 )
 ```
 
-Your `selection_sort` should modify input list in-place. You should not use any method adding, or removing items from the list.
+Your `selection_sort` should modify the input list in-place. You should not use any method adding, or removing items from the list.
 
 ```js
 (
@@ -122,7 +122,7 @@ Your `selection_sort` should modify input list in-place. You should not use any 
 )
 ```
 
-Your `selection_sort` should follow selection sort algorithm, swapping the minimum value in unsorted part of list with first unsorted element.
+Your `selection_sort` should follow the selection sort algorithm, swapping the minimum value in unsorted part of the list with first the unsorted element.
 
 ```js
 (

--- a/curriculum/challenges/english/blocks/lab-selection-sort/680b3ef395479b0e449ecb6e.md
+++ b/curriculum/challenges/english/blocks/lab-selection-sort/680b3ef395479b0e449ecb6e.md
@@ -20,6 +20,8 @@ Selection sort results in a quadratic time complexity in the best, average, and 
 1. You should define a function named `selection_sort`.
 1. Your `selection_sort` function should have one parameter that represents the list of items.
 1. Your `selection_sort` function should take a list and sort the items in place from smallest to largest.
+1. Your `selection_sort` function should modify input list in-place, and return it once it's sorted.
+1. Your `selection_sor` function should follow selection sort algorithm, swapping the smallest element from unsorted portion of list, with the first unsorted element.
 1. Your `selection_sort` function should not use either the built-in `sort()` method or `sorted()` function.
 
 # --hints--
@@ -56,6 +58,111 @@ You should not use the built-in `sort()` method or `sorted()` function in your c
         test: () => runPython(`
             assert not _Node(_code).block_has_call("sort")
             assert not _Node(_code).block_has_call("sorted")
+        `)
+    }
+)
+```
+
+Your `selection_sort` should return the same list as the input list.
+
+```js
+(
+    {
+        test: () => runPython(`
+            input_list = [32, 0, 88, 1, 203]
+            assert selection_sort(input_list) is input_list
+        `)
+    }
+)
+```
+
+Your `selection_sort` should modify input list in-place. You should not use any method adding, or removing items from the list.
+
+```js
+(
+    {
+        test: () => runPython(`
+            from collections import UserList
+
+            class CustomList(UserList):
+                def __init__(self, *args, **kwargs):
+                    self._record = []
+                    super().__init__(*args, **kwargs)
+
+                def __setitem__(self, key, value):
+                    self._record.append(f'Setting item {key} to {value}. Previous value: {self[key]}')
+                    super().__setitem__(key, value)
+
+                def append(self, *args, **kwargs):
+                    self._record.append(f'Appending to list: {args}, {kwargs}')
+                    super().append(*args, **kwargs)
+
+                def insert(self, *args, **kwargs):
+                    self._record.append(f'Inserting to list: {args}, {kwargs}')
+                    super().insert(*args, **kwargs)
+
+                def pop(self, *args, **kwargs):
+                    self._record.append(f'Popping from list: {args}, {kwargs}')
+                    super().pop(*args, **kwargs)
+
+                def remove(self, *args, **kwargs):
+                    self._record.append(f'Removing from list: {args}, {kwargs}')
+                    super().remove(*args, **kwargs)
+
+
+            list_to_sort = CustomList([32, 0, 88, 1, 203])
+
+            _ = selection_sort(list_to_sort)
+            assert all(
+                'Setting item' in record
+                for record in list_to_sort._record
+            )
+        `)
+    }
+)
+```
+
+Your `selection_sort` should follow selection sort algorithm, swapping the minimum value in unsorted part of list with first unsorted element.
+
+```js
+(
+    {
+        test: () => runPython(`
+            from collections import UserList
+
+            class CustomList(UserList):
+                def __init__(self, *args, **kwargs):
+                    self._record = []
+                    super().__init__(*args, **kwargs)
+
+                def __setitem__(self, key, value):
+                    self._record.append(f'Setting item {key} to {value}. Previous value: {self[key]}')
+                    super().__setitem__(key, value)
+
+
+            list_to_sort = CustomList([33, 1, 89, 2, 67, 245])
+
+            swap_pairs = [
+                ((0, 1, 33), (1, 33, 1)),
+                ((1, 2, 33), (3, 33, 2)),
+                ((2, 33, 89), (3, 89, 33)),
+                ((3, 67, 89), (4, 89, 67)),
+            ]
+
+            _ = selection_sort(list_to_sort)
+            record = list_to_sort._record
+
+            actual_pairs = [
+                (record[offset * 2], record[offset * 2 + 1])
+                for offset, _ in enumerate(record[::2])
+            ]
+            assert len(swap_pairs) == len(actual_pairs)
+
+            for expected_pair, actual_pair in zip(swap_pairs, actual_pairs):
+                assert (
+                    set(f'Setting item {key} to {value}. Previous value: {old}' for key, value, old in expected_pair)
+                    == set(actual_pair)
+                )
         `)
     }
 )


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #64360

- - -
- Three new tests.
- Checking if returned list is the same as the input list.
- Checking if no methods changing size of list are used. So, ie. using `pop` and `append` to add items in the right order won't work.
- Checking if swapping follows selection sort. Each swapping pair is allowed in any order. Ie. both `l[0], l[3] = l[3], l[0]` and `l[3], l[0] = l[0], l[3]` will be fine. Note that _one line_ swapping is not mandatory.