### PR TITLE
feat: allow multiline declaration in Build a Sentence Maker

### DIFF
--- a/curriculum/challenges/english/blocks/lab-sentence-maker/66c057041df6394ca796bf33.md
+++ b/curriculum/challenges/english/blocks/lab-sentence-maker/66c057041df6394ca796bf33.md
@@ -138,7 +138,7 @@ You should assemble your first story using the variables you declared in the cor
 ```js
 assert.match(
   __helpers.removeJSComments(code),
-  /firstStory\s*=\s*.*?adjective.*?noun.*?noun2.*?noun.*?place.*?adjective2.*?verb/
+  /firstStory\s*=\s*.*?adjective.*?noun.*?noun2.*?noun.*?place.*?adjective2.*?verb/s
 );
 ```
 
@@ -204,7 +204,7 @@ You should assemble your second story using the variables you declared in the co
 ```js
 assert.match(
   __helpers.removeJSComments(code),
-  /secondStory\s*=\s*.*?adjective.*?noun.*?noun2.*?noun.*?place.*?adjective2.*?verb/
+  /secondStory\s*=\s*.*?adjective.*?noun.*?noun2.*?noun.*?place.*?adjective2.*?verb/s
 );
 ```
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes https://github.com/freeCodeCamp/freeCodeCamp/issues/64583

<!-- Feel free to add any additional description of changes below this line -->

I don't know if this is something we want, but this would allow code like the below (to have an exageration)
```js
let firstStory = "Once upon a time, there was a(n) "
+  
adjective 
+ 
" " 
+ 
noun 
+ 
" who loved to eat " 
+  
noun2 
+ 
". The " 
+ 
noun 
+ 
" lived in a " 
+ 
place 
+ 
" and had " 
+
adjective2 
+ 
" nostrils that blew fire when it was " 
+ 
verb 
+ 
".";
```

Having the string concatenation broken on multiple lines is a common reason campers ask for help on the forum for this project

the issue could be that if `firstStory` does not have all the variables, then it could match the variable declarations below, or the variables used in `secondStory`