### PR TITLE
feat(client): add Chinese Curriculum and Spanish Curriculum to links.json

### DIFF
--- a/client/i18n/locales/english/links.json
+++ b/client/i18n/locales/english/links.json
@@ -33,6 +33,8 @@
     "Backend Development": "Backend Development",
     "C-Sharp": "C-Sharp",
     "English": "English",
+    "Spanish Curriculum": "Spanish Curriculum",
+    "Chinese Curriculum": "Chinese Curriculum",
     "Odin": "The Odin Project",
     "Euler": "Project Euler",
     "Rosetta": "Rosetta Code"


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This is actually a fix rather than a feat.

`Chinese Curriculum` and `Spanish Curriculum` need to be listed in `links.json`, so that camper posts via the help modal are sent to the right place.

<!-- Feel free to add any additional description of changes below this line -->
