### PR TITLE
fix(client,curriculum): add lang property to Challenge type

### DIFF
--- a/client/gatsby-node.js
+++ b/client/gatsby-node.js
@@ -326,6 +326,7 @@ exports.createSchemaCustomization = ({ actions }) => {
       instructions: String
       isLastChallengeInBlock: Boolean
       isPrivate: Boolean
+      lang: String
       module: String
       msTrophyId: String
       nodules: [Nodule]

--- a/curriculum/src/file-handler.ts
+++ b/curriculum/src/file-handler.ts
@@ -153,6 +153,7 @@ export type Challenge = {
   missing?: boolean;
   challengeFiles?: ChallengeFile[];
   solutions?: ChallengeFile[][];
+  lang?: string;
 };
 
 export interface BlockStructure {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Only language challenges (English, Spanish, Chinese) have the `lang` property. When building the curriculum selectively and language challenges aren't included, Gatsby will throw "Cannot query lang on type Challenge". 

This is because the property isn't defined in the GraphQL schema. So this PR adds the property in.

To test the change, run `FCC_BLOCK=write-your-first-code-using-c-sharp pnpm develop` or `FCC_SUPERBLOCK=javascript-v9 pnpm develop`.

<!-- Feel free to add any additional description of changes below this line -->
