### PR TITLE
fix(api): always use the same logic when saving challenges

### DIFF
--- a/api/src/routes/protected/challenge.test.ts
+++ b/api/src/routes/protected/challenge.test.ts
@@ -901,7 +901,13 @@ describe('challengeRoutes', () => {
             alreadyCompleted: false,
             points: 1,
             completedDate,
-            savedChallenges: []
+            savedChallenges: [
+              {
+                files: jsFiles,
+                id: JsProjectId,
+                lastSavedDate: expect.any(Number)
+              }
+            ]
           });
           expect(response.statusCode).toBe(200);
         });
@@ -1089,7 +1095,13 @@ describe('challengeRoutes', () => {
           alreadyCompleted: false,
           points: 1,
           completedDate,
-          savedChallenges: []
+          savedChallenges: [
+            {
+              files: jsFiles,
+              id: JsProjectId,
+              lastSavedDate: expect.any(Number)
+            }
+          ]
         });
         expect(response.statusCode).toBe(200);
       });

--- a/api/src/routes/protected/challenge.ts
+++ b/api/src/routes/protected/challenge.ts
@@ -22,7 +22,7 @@ import {
   formatCoderoadChallengeCompletedValidation,
   formatProjectCompletedValidation
 } from '../../utils/error-formatting.js';
-import { challenges } from '../../utils/get-challenges.js';
+import { challenges, savableChallenges } from '../../utils/get-challenges.js';
 import { ProgressTimestamp, getPoints } from '../../utils/progress.js';
 import {
   validateExamFromDbSchema,
@@ -1128,10 +1128,7 @@ async function postSaveChallenge(
     files
   };
 
-  if (
-    !multifileCertProjectIds.includes(challengeId) &&
-    !multifilePythonCertProjectIds.includes(challengeId)
-  ) {
+  if (!savableChallenges.has(challengeId)) {
     logger.warn(
       {
         challengeId

--- a/api/src/utils/common-challenge-functions.ts
+++ b/api/src/utils/common-challenge-functions.ts
@@ -194,10 +194,7 @@ export async function updateUserChallengeData(
       ? [...progressTimestamps, newProgressTimeStamp]
       : progressTimestamps;
 
-  if (
-    multifileCertProjectIds.includes(challengeId) ||
-    multifilePythonCertProjectIds.includes(challengeId)
-  ) {
+  if (savableChallenges.has(challengeId)) {
     const challengeToSave: SavedChallenge = {
       id: challengeId,
       lastSavedDate: newProgressTimeStamp,


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

I missed this when reviewing https://github.com/freeCodeCamp/freeCodeCamp/pull/64450/

<!-- Feel free to add any additional description of changes below this line -->
