### PR TITLE
docs(python): clarify that Python 2 is EOL and learners should use Python 3

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-introduction-to-python/67fe8567f141d632afaeb71b.md
+++ b/curriculum/challenges/english/blocks/lecture-introduction-to-python/67fe8567f141d632afaeb71b.md
@@ -28,7 +28,8 @@ You can also open the Python interpreter by running `python` or `python3` in the
 
 A <dfn>terminal</dfn> is a text-based interface that lets you interact with your computer by typing commands. Each operating system comes with a default terminal app. On macOS, you can use the Terminal app. On Windows, you can use Command Prompt or PowerShell. On Linux, each desktop environment has its own default terminal app, like GNOME Terminal or Konsole.
 
-Note that, on some older macOS and Linux systems, `python` can be reserved for Python 2, while `python3` is for Python 3 specifically. If you run `python --version` and see a version of Python 2 like `Python 2.7.18`, then it's possible that your OS relies on some software that was written in the older version of Python. If that's the case, you should use `python3` to run your Python code going forward.
+> **Note:** Python 2 reached its official end-of-life in January 2020 and is no longer maintained. On some older macOS and Linux systems, the `python` command may still point to Python 2. If `python --version` shows Python 2.x, **do not use it**. Install Python 3 and run your programs using the `python3` command (or configure your system so that `python` points to Python 3). All lessons and exercises in this course require Python 3.
+
 
 To install Python on Windows, follow these steps:
 


### PR DESCRIPTION
…thon 3

Checklist:

- [x] I have read and followed the contribution guidelines.
- [x] I have read and followed the how to open a pull request guide.
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #64531

This PR updates the lesson "How Do You Install, Configure and Use Python in Your Local Environment?" to clarify that Python 2 is end-of-life and should no longer be used.

The updated text explains that:
- Python 2 reached EOL in January 2020.
- On some systems `python` may still refer to Python 2.
- Learners should always use Python 3 for the curriculum.
- If `python` points to Python 2, they should use `python3` or configure the system accordingly.

This change improves clarity for beginners and aligns the curriculum with current Python best practices.

