### PR TITLE
fix(curriculum): Python sets typo

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-dictionaries-and-sets/683ec8fd8b21827317388a45.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-dictionaries-and-sets/683ec8fd8b21827317388a45.md
@@ -103,7 +103,7 @@ The difference operator `-` returns a new set with the elements of the first set
 my_set - your_set # {1, 5}
 ```
 
-The symmetric difference operator `^` returns a new set with the elements that are either on the first or the second set, but not both. In this case, 1 and 5 are in `my_set` but not in `your_set`, so they are included. And the number 6 is in `your_set` but not in `my_set`, so it's included as well:
+The symmetric difference operator `^` returns a new set with the elements that are either in the first or the second set, but not both. In this case, 1 and 5 are in `my_set` but not in `your_set`, so they are included. And the number 6 is in `your_set` but not in `my_set`, so it's included as well:
 
 ```python
 my_set ^ your_set # {1, 5, 6}

--- a/curriculum/challenges/english/blocks/quiz-dictionaries-and-sets/67f412ac59601c4151b763da.md
+++ b/curriculum/challenges/english/blocks/quiz-dictionaries-and-sets/67f412ac59601c4151b763da.md
@@ -466,7 +466,7 @@ It returns a new set with the elements of the first set that are not in the othe
 
 #### --answer--
 
-It returns a new set with the elements that are either on the first or the second set, but not both.
+It returns a new set with the elements that are either in the first or the second set, but not both.
 
 ### --question--
 

--- a/curriculum/challenges/english/blocks/review-dictionaries-and-sets/67f39babe1e2ec1fb6eea32a.md
+++ b/curriculum/challenges/english/blocks/review-dictionaries-and-sets/67f39babe1e2ec1fb6eea32a.md
@@ -242,7 +242,7 @@ my_set.clear()
 
 ```python
 my_set = {1, 2, 3, 4, 5} 
-your_set = {2, 3, 4, 5}
+your_set = {2, 3, 4, 5, 6}
 
 print(your_set.issubset(my_set)) # True
 print(my_set.issuperset(your_set)) # True
@@ -272,7 +272,7 @@ my_set & your_set # {2, 3, 4}
 my_set - your_set # {1, 5}
 ```
 
-- **Symmetric Difference Operator (`^`)**: The symmetric difference operator `^` returns a new set with the elements that are either on the first or the second set, but not both.
+- **Symmetric Difference Operator (`^`)**: The symmetric difference operator `^` returns a new set with the elements that are either in the first or the second set, but not both.
 
 ```python
 my_set ^ your_set # {1, 5, 6}

--- a/curriculum/challenges/english/blocks/review-python/67f39e391c9b373069def02c.md
+++ b/curriculum/challenges/english/blocks/review-python/67f39e391c9b373069def02c.md
@@ -1808,7 +1808,7 @@ my_set.clear()
 
 ```python
 my_set = {1, 2, 3, 4, 5} 
-your_set = {2, 3, 4, 5}
+your_set = {2, 3, 4, 5, 6}
 
 print(your_set.issubset(my_set)) # True
 print(my_set.issuperset(your_set)) # True
@@ -1838,7 +1838,7 @@ my_set & your_set # {2, 3, 4}
 my_set - your_set # {1, 5}
 ```
 
-- **Symmetric Difference Operator (`^`)**: The symmetric difference operator `^` returns a new set with the elements that are either on the first or the second set, but not both.
+- **Symmetric Difference Operator (`^`)**: The symmetric difference operator `^` returns a new set with the elements that are either in the first or the second set, but not both.
 
 ```python
 my_set ^ your_set # {1, 5, 6}


### PR DESCRIPTION

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #64486


<!-- Feel free to add any additional description of changes below this line -->

This pull request fixes a typo in four Python curriculum files and updates the example set in two files for the Dictionaries and Sets review and quiz challenges. Verified locally using the freeCodeCamp development environment (localhost:8000). All affected pages render correctly with updated text and example sets.

Files updated:
- lecture-working-with-dictionaries-and-sets/683ec8fd8b21827317388a45.md
- quiz-dictionaries-and-sets/67f412ac59601c4151b763da.md
- review-dictionaries-and-sets/67f39babe1e2ec1fb6eea32a.md
- review-python/67f39e391c9b373069def02c.md


