### PR TITLE
fix(curriculum): typo in CSS typography review

### DIFF
--- a/curriculum/challenges/english/blocks/review-css-typography/671a9528fc4f1487cf265444.md
+++ b/curriculum/challenges/english/blocks/review-css-typography/671a9528fc4f1487cf265444.md
@@ -86,7 +86,7 @@ font-family: Arial, Lato;
 
 ## Working With External Fonts
 
-- **Definition**: An external font is a font file that is not included directly within your project files.They're usually hosted on a separate server. To include these external fonts inside your project, you can use a `link` element or `@import` statement inside your CSS. 
+- **Definition**: An external font is a font file that is not included directly within your project files. They're usually hosted on a separate server. To include these external fonts inside your project, you can use a `link` element or `@import` statement inside your CSS. 
 - **Google Fonts**: This is a Google service that offers a collection of fonts, many of which are designed specifically for web development. 
 
 Here is an example using the `link` element:


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->

Added a single space before the first word in a sentence (there was no space previously).

Affected page: https://www.freecodecamp.org/learn/responsive-web-design-v9/review-css-typography/review-css-typography