### PR TITLE
fix: add missing quote in checkbox selector

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-game-settings-panel/68e9a6bf1a74721a4e43e217.md
+++ b/curriculum/challenges/english/blocks/workshop-game-settings-panel/68e9a6bf1a74721a4e43e217.md
@@ -27,7 +27,7 @@ You should have an `appearance` property with a value of `none`.
 assert.strictEqual(new __helpers.CSSHelp(document).getStyle('input[type="checkbox"]')?.appearance, "none");
 ```
 
-You should add a `border` property to your `input[type="checkbox"]` selector.
+You should add a `border` property to your `input[type="checkbox]` selector.
 
 ```js
 assert.isNotEmpty(new __helpers.CSSHelp(document).getStyle('input[type="checkbox"]')?.border);

--- a/curriculum/challenges/english/blocks/workshop-game-settings-panel/68e9a6bf1a74721a4e43e217.md
+++ b/curriculum/challenges/english/blocks/workshop-game-settings-panel/68e9a6bf1a74721a4e43e217.md
@@ -15,7 +15,7 @@ After doing so, since the checkbox won't be visible anymore, set a `border` with
 
 # --hints--
 
-You should add an `appearance` property to your `input[type="checkbox]` selector.
+You should add an `appearance` property to your `input[type="checkbox"]` selector.
 
 ```js
 assert.isNotEmpty(new __helpers.CSSHelp(document).getStyle('input[type="checkbox"]')?.appearance);

--- a/curriculum/challenges/english/blocks/workshop-game-settings-panel/68e9a6bf1a74721a4e43e217.md
+++ b/curriculum/challenges/english/blocks/workshop-game-settings-panel/68e9a6bf1a74721a4e43e217.md
@@ -27,7 +27,7 @@ You should have an `appearance` property with a value of `none`.
 assert.strictEqual(new __helpers.CSSHelp(document).getStyle('input[type="checkbox"]')?.appearance, "none");
 ```
 
-You should add a `border` property to your `input[type="checkbox]` selector.
+You should add a `border` property to your `input[type="checkbox"]` selector.
 
 ```js
 assert.isNotEmpty(new __helpers.CSSHelp(document).getStyle('input[type="checkbox"]')?.border);


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #64582

Adds the missing closing quote to the checkbox input selector in step 10 of the workshop game settings panel.