### PR TITLE
fix(curriculum): correct grammar in React state and hooks review

### DIFF
--- a/curriculum/challenges/english/blocks/review-react-state-and-hooks/67c2bbd476f6e540b4c0b0d4.md
+++ b/curriculum/challenges/english/blocks/review-react-state-and-hooks/67c2bbd476f6e540b4c0b0d4.md
@@ -52,7 +52,7 @@ function handleDelete(id) {
 ## Working with State and the `useState` Hook
 
 - **Definition for state**: In React, state is an object that contains data for a component. When the state updates the component will re-render. React treats state as immutable, meaning you should not modify it directly.  
-- **`useState()` Hook**: The `useState` hook is a function that lets you declare state variables in functional components.  Here is the basic syntax:
+- **`useState()` Hook**: The `useState` hook is a function that lets you declare state variables in functional components. Here is the basic syntax:
 
 ```js
 const [stateVariable, setStateFunction] = useState(initialValue);

--- a/curriculum/challenges/english/blocks/review-react-state-and-hooks/67c2bbd476f6e540b4c0b0d4.md
+++ b/curriculum/challenges/english/blocks/review-react-state-and-hooks/67c2bbd476f6e540b4c0b0d4.md
@@ -51,8 +51,8 @@ function handleDelete(id) {
 
 ## Working with State and the `useState` Hook
 
-- **Definition for state**: In React, state is a object that contains data for a component. When the state updates the component will re-render. React treats state as immutable, meaning you should not modify it directly.  
-- **`useState()` Hook**: The `useState` hook is a function that lets you declare state variables in functional components.  Here is an basic syntax:
+- **Definition for state**: In React, state is an object that contains data for a component. When the state updates the component will re-render. React treats state as immutable, meaning you should not modify it directly.  
+- **`useState()` Hook**: The `useState` hook is a function that lets you declare state variables in functional components.  Here is the basic syntax:
 
 ```js
 const [stateVariable, setStateFunction] = useState(initialValue);


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #64586

<!-- Feel free to add any additional description of changes below this line -->

### Summary
This PR fixes minor grammatical errors in the React State and Hooks review lesson.

### Changes
- Corrected "state is a object" to "state is an object"
- Corrected "Here is an basic syntax" to "Here is the basic syntax"
