### PR TITLE
fix grammatical typo ticket #64586

### DIFF
--- a/curriculum/challenges/english/blocks/review-front-end-libraries/6724e2dbf723fe1c8883cc69.md
+++ b/curriculum/challenges/english/blocks/review-front-end-libraries/6724e2dbf723fe1c8883cc69.md
@@ -315,7 +315,7 @@ function handleDelete(id) {
 ## Working with State and the `useState` Hook
 
 - **Definition for state**: In React, state is an object that contains data for a component. When the state updates the component will re-render. React treats state as immutable, meaning you should not modify it directly.  
-- **`useState()` Hook**: The `useState` hook is a function that lets you declare state variables in functional components.  Here is a basic syntax:
+- **`useState()` Hook**: The `useState` hook is a function that lets you declare state variables in functional components. Here is the basic syntax:
 
 ```js
 const [stateVariable, setStateFunction] = useState(initialValue);


### PR DESCRIPTION
Checklist:
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.


Closes #64586

This pull request fixes a minor grammatical issue in the documentation by correcting article usage in the `useState()` Hook syntax description. The change improves clarity and aligns with standard technical writing conventions, without altering the meaning or functionality of the content.
