### PR TITLE
fix(curriculum): add length check to Media Catalogue step 40

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-media-catalogue/68b9999b6cfccc74e268c0f1.md
+++ b/curriculum/challenges/english/blocks/workshop-media-catalogue/68b9999b6cfccc74e268c0f1.md
@@ -17,7 +17,7 @@ You should have an `if` statement in your `__str__` method that checks if the `m
 ({
   test: () => runPython(`
   cond = _Node(_code).find_class("MediaCatalogue").find_function("__str__").find_ifs()[1].find_conditions()[0]
-  conds = ["movies", "len(movies)"]
+  conds = ["movies", "len(movies)", "len(movies) > 0"]
   assert any(cond.is_equivalent(c) for c in conds)  
   `)
 })


### PR DESCRIPTION
Checklist:

- [x ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x ] My pull request targets the `main` branch of freeCodeCamp.
- [ x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #64404
This PR updates the validation logic for Python v9 Workshop Step 40 to accept the explicit condition `if len(movies) > 0:`.