### PR TITLE
fix(curriculum): add missing section titles in JavaScript review

### DIFF
--- a/curriculum/challenges/english/blocks/review-javascript/6723d3cfdd0717d3f1bf27e3.md
+++ b/curriculum/challenges/english/blocks/review-javascript/6723d3cfdd0717d3f1bf27e3.md
@@ -2729,6 +2729,7 @@ class Car {
 console.log(Car.numberOfWheels); 
 ```
 
+## Recursion
 
 - Recursion is programming concept that allows you to call a function repeatedly until a base-case is reached.
 
@@ -2798,6 +2799,8 @@ const curriedAverage = a => b => c => (a + b + c) / 3;
 ```
 
 - While currying can lead to more flexible and reusable code, it can also make code harder to read if overused. 
+
+## Asynchronous JavaScript
 
 - **Synchronous JavaScript** is executed sequentially and waits for the previous operation to finish before moving on to the next one.
 - **Asynchronous JavaScript** allows multiple operations to be executed in the background without blocking the main thread.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ x] My pull request targets the `main` branch of freeCodeCamp.
- [ x] I have tested these changes either locally on my machine, or GitHub Codespaces.


Closes #64576

<!-- Feel free to add any additional description of changes below this line -->

This PR adds missing section titles in the JavaScript review to clearly separate:
- Static methods/properties and recursion
- Currying and asynchronous JavaScript
