### PR TITLE
fix(curriculum): remove ellipsis from Pinyin in zh-a1 challenge

### DIFF
--- a/curriculum/challenges/english/blocks/zh-a1-learn-understanding-the-questions-and-answers/6909747cd7497056dc7618ef.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-understanding-the-questions-and-answers/6909747cd7497056dc7618ef.md
@@ -56,7 +56,7 @@ This reverses the order of the speaker's name.
 
 # --explanation--
 
-`我叫 (wǒ jiào...)` means "I am called..." or "My name is...". `叫 (jiào)` means "to be called". Here it's used to show identity. For example:
+`我叫 (wǒ jiào)` means "I am called..." or "My name is...". `叫 (jiào)` means "to be called". Here it's used to show identity. For example:
 
 `我叫王华 (wǒ jiào wáng huá)` — I am called Wang Hua, or, my name is Wang Hua.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #64595

<!-- Feel free to add any additional description of changes below this line -->
Removed ellipsis from Pinyin `我叫 (wǒ jiào...)` to `我叫 (wǒ jiào)` in the explanation section of the Chinese A1 challenge.
