### PR TITLE
fix: remove ellipsis from Pinyin in zh-a1 task

### DIFF
--- a/curriculum/challenges/english/blocks/zh-a1-learn-understanding-the-questions-and-answers/6909747cd7497056dc7618ef.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-understanding-the-questions-and-answers/6909747cd7497056dc7618ef.md
@@ -56,7 +56,7 @@ This reverses the order of the speaker's name.
 
 # --explanation--
 
-`我叫 (wǒ jiào...)` means "I am called..." or "My name is...". `叫 (jiào)` means "to be called". Here it's used to show identity. For example:
+`我叫 (wǒ jiào)` means "I am called..." or "My name is...". `叫 (jiào)` means "to be called". Here it's used to show identity. For example:
 
 `我叫王华 (wǒ jiào wáng huá)` — I am called Wang Hua, or, my name is Wang Hua.
 


### PR DESCRIPTION
- [x] I have read and followed the contribution guidelines.
- [x] I have read and followed the how to open a pull request guide.
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #64595

This PR removes the ellipsis from the Pinyin example in the explanation section to match the intended usage.
