### PR TITLE
fix(curriculum): fix double space in React forms description

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-forms-in-react/67d1a928ae86929a85c1bb6b.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-forms-in-react/67d1a928ae86929a85c1bb6b.md
@@ -9,7 +9,7 @@ dashedName: how-do-forms-work-in-react
 
 Forms are fundamental to every web application because they let you handle user input, collect data, and trigger actions.
 
-In React, forms are managed using state or refs, giving you full control over their behavior and validation. These two ways to manage forms are called "controlled"  and "uncontrolled" input.
+In React, forms are managed using state or refs, giving you full control over their behavior and validation. These two ways to manage forms are called "controlled" and "uncontrolled" input.
 
 Let's look at what controlled and uncontrolled inputs are.
 


### PR DESCRIPTION
Checklist:

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitHub Codespaces.

Found a double space in "curriculum/challenges/english/blocks/lecture-working-with-forms-in-react/67d1a928ae86929a85c1bb6b.md".
