### PR TITLE
fix: delete/reset modal - stop passing event payloads

### DIFF
--- a/client/src/components/settings/delete-modal.tsx
+++ b/client/src/components/settings/delete-modal.tsx
@@ -10,7 +10,7 @@ import {
 } from '@freecodecamp/ui';
 
 type DeleteModalProps = {
-  delete: () => void;
+  delete: (x?: never) => void;
   onHide: () => void;
   show: boolean;
 };
@@ -72,7 +72,7 @@ function DeleteModal(props: DeleteModalProps): JSX.Element {
           block={true}
           size='large'
           variant='danger'
-          onClick={props.delete}
+          onClick={() => props.delete()}
           disabled={verifyText !== t('settings.danger.verify-delete-text')}
           type='button'
         >

--- a/client/src/components/settings/reset-modal.tsx
+++ b/client/src/components/settings/reset-modal.tsx
@@ -11,7 +11,7 @@ import {
 
 type ResetModalProps = {
   onHide: () => void;
-  reset: () => void;
+  reset: (x?: never) => void;
   show: boolean;
 };
 
@@ -71,7 +71,7 @@ function ResetModal(props: ResetModalProps): JSX.Element {
           size='large'
           variant='danger'
           disabled={verifyText !== t('settings.danger.verify-reset-text')}
-          onClick={props.reset}
+          onClick={() => props.reset()}
           type='button'
         >
           {t('settings.danger.reset-confirm')}


### PR DESCRIPTION
These actions should not have payloads and definitely shouldn't have non-serializable ones.

I don't know of any bug that's caused by this, but they're noisy.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->
