### PR TITLE
fix(curriculum): Update column count test in Book Inventory App

### DIFF
--- a/curriculum/challenges/english/blocks/lab-book-inventory-app/66a207974c806a19d6607073.md
+++ b/curriculum/challenges/english/blocks/lab-book-inventory-app/66a207974c806a19d6607073.md
@@ -54,7 +54,11 @@ assert.equal(document.querySelectorAll('table')?.length, 1);
 Your `table` element should have five columns.
 
 ```js
-assert.equal(document.querySelectorAll('th')?.length, 5);
+const rows = document.querySelectorAll('tr');
+assert.isAbove(rows.length, 0);
+for (const row of rows) {
+  assert.equal(row.children.length, 5);
+}
 ```
 
 Your first column should have the text `Title` as the heading.

--- a/curriculum/challenges/english/blocks/lab-book-inventory-app/66a207974c806a19d6607073.md
+++ b/curriculum/challenges/english/blocks/lab-book-inventory-app/66a207974c806a19d6607073.md
@@ -55,7 +55,7 @@ Your `table` element should have five columns.
 
 ```js
 const rows = document.querySelectorAll('tr');
-assert.isAbove(rows.length, 0);
+assert.isNotEmpty(rows);
 for (const row of rows) {
   assert.equal(row.children.length, 5);
 }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #64580

<!-- Feel free to add any additional description of changes below this line -->

**Changes:**
Updates the test logic for checking the number of columns in the "Build a Book Inventory App" project.

**Reason:**
The previous test `document.querySelectorAll('th').length` failed if a user added header cells inside rows or used a different table structure.
The new test iterates through all `tr` elements and asserts that each row has exactly 5 children, ensuring the table structure is correct regardless of the tag used (`th` or `td`).
