### PR TITLE
feat(curriculum): add Pinyin Practice block with placeholder task

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -8967,6 +8967,10 @@
       "zh-a1-warm-up-meeting-new-teammates": {
         "title": "Meeting New Teammates",
         "intro": ["", ""]
+      },
+      "zh-a1-practice-pinyin": {
+        "title": "Pinyin Practice",
+        "intro": ["", ""]
       }
     }
   },

--- a/client/src/pages/learn/a1-professional-chinese/zh-a1-practice-pinyin/index.md
+++ b/client/src/pages/learn/a1-professional-chinese/zh-a1-practice-pinyin/index.md
@@ -1,0 +1,9 @@
+---
+title: Introduction to the Pinyin Practice
+block: zh-a1-practice-pinyin
+superBlock: a1-professional-chinese
+---
+
+## Introduction to the Pinyin Practice
+
+This page is for the Pinyin Practice

--- a/curriculum/challenges/english/blocks/zh-a1-practice-pinyin/6940554db3c6d9578a853ecf.md
+++ b/curriculum/challenges/english/blocks/zh-a1-practice-pinyin/6940554db3c6d9578a853ecf.md
@@ -1,0 +1,59 @@
+---
+id: 6940554db3c6d9578a853ecf
+title: "Dialogue 1: I'm Tom"
+challengeType: 21
+dashedName: dialogue-1-im-tom
+lang: zh-CN
+---
+
+# --description--
+
+Watch the video below to understand the context of the upcoming lessons.
+
+# --assignment--
+
+Watch the video.
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "chaos.png",
+    "characters": [
+      {
+        "character": "David",
+        "position": {"x":50,"y":80,"z":8},
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-1.mp3",
+      "startTime": 1,
+      "startTimestamp": 5.7,
+      "finishTimestamp": 6.48
+    }
+  },
+  "commands": [
+    {
+      "character": "David",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "David",
+      "startTime": 1,
+      "finishTime": 0.78,
+      "dialogue": {
+        "text": "I'm Tom.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Tom",
+      "opacity": 0,
+      "startTime": 1.28
+    }
+  ]
+}
+```

--- a/curriculum/structure/blocks/zh-a1-practice-pinyin.json
+++ b/curriculum/structure/blocks/zh-a1-practice-pinyin.json
@@ -1,0 +1,11 @@
+{
+  "name": "Pinyin Practice",
+  "isUpcomingChange": true,
+  "dashedName": "zh-a1-practice-pinyin",
+  "helpCategory": "Chinese Curriculum",
+  "blockLayout": "challenge-grid",
+  "challengeOrder": [
+    { "id": "6940554db3c6d9578a853ecf", "title": "Dialogue 1: I'm Tom" }
+  ],
+  "blockLabel": "practice"
+}

--- a/curriculum/structure/superblocks/a1-professional-chinese.json
+++ b/curriculum/structure/superblocks/a1-professional-chinese.json
@@ -19,6 +19,7 @@
             "zh-a1-learn-initials",
             "zh-a1-learn-compound-finals",
             "zh-a1-learn-nasal-finals",
+            "zh-a1-practice-pinyin",
             "zh-a1-review-pinyin",
             "zh-a1-quiz-pinyin"
           ]


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR:
- Adds Pinyin Practice block to chapter 2 (the Review and Quiz blocks will be removed from this module. I'll make this change separately)
- Closes https://github.com/freeCodeCamp/language-curricula/issues/47

<img width="771" height="449" alt="Screenshot 2025-12-16 at 01 54 31" src="https://github.com/user-attachments/assets/f9af0e7f-53f1-4a90-bcc1-be8e4d2448b1" />

<!-- Feel free to add any additional description of changes below this line -->
