### PR TITLE
fix(client): Increased line height of quiz labels containing ruby

### DIFF
--- a/client/src/templates/Challenges/quiz/show.css
+++ b/client/src/templates/Challenges/quiz/show.css
@@ -21,3 +21,7 @@
   font-size: 1rem;
   margin: 0 0 1.2rem;
 }
+
+.quiz-answer-label:has(ruby) {
+  line-height: 1.7rem;
+}


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #64622 

<!-- Feel free to add any additional description of changes below this line -->
Increased the line height as mentioned in the issue description.
