### PR TITLE
test(e2e): stop checking no. of sign-in buttons

### DIFF
--- a/e2e/delete-modal.spec.ts
+++ b/e2e/delete-modal.spec.ts
@@ -148,7 +148,9 @@ test.describe('Delete Modal component', () => {
 
     await expect(page).toHaveURL(allowTrailingSlash('/learn'));
     await alertToBeVisible(page, translations.flash['account-deleted']);
-    // The user is signed out after their account is deleted
-    await expect(page.getByRole('link', { name: 'Sign in' })).toHaveCount(2);
+    // The user is signed out after their account is deleted. Don't check the
+    // number of occurrences of the 'Sign in' link as it may vary depending on AB
+    // tests and Gatsby develop mode flakiness.
+    await expect(page.getByRole('link', { name: 'Sign in' })).toBeVisible();
   });
 });


### PR DESCRIPTION
If there's at least one, we're signed out.

This should also make it possible to test in development where Gatsby's development mode messes up navigation. For some reason I can't fathom it thinks that /learn does not exist if it tries to `navigate` to it. However, the development page includes the signout button so we can check for that.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->
