### PR TITLE
fix: rename A1 Chinese chapter to greetings and introductions

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -8749,7 +8749,7 @@
     "chapters": {
       "zh-a1-chapter-welcome-to-a1-professional-chinese": "Welcome to A1 Professional Chinese",
       "zh-a1-chapter-pinyin": "Pinyin",
-      "zh-a1-chapter-greeting-and-self-introduction": "Greeting and Self-introduction",
+      "zh-a1-chapter-greetings-and-introductions": "Greetings and Introductions",
       "zh-a1-chapter-introducing-colleagues-and-family": "Introducing Colleagues and Family",
       "zh-a1-chapter-expressing-what-you-can-and-cant-do": "Expressing What You Can and Can't Do"
     },

--- a/curriculum/structure/superblocks/a1-professional-chinese.json
+++ b/curriculum/structure/superblocks/a1-professional-chinese.json
@@ -25,7 +25,7 @@
       ]
     },
     {
-      "dashedName": "zh-a1-chapter-greeting-and-self-introduction",
+      "dashedName": "zh-a1-chapter-greetings-and-introductions",
       "modules": [
         {
           "dashedName": "zh-a1-module-greetings-and-basic-introductions",


### PR DESCRIPTION
Renames the A1 Professional Chinese chapter identifier to
"zh-a1-chapter-greetings-and-introductions" and updates the
English locale entry accordingly.

Closes #64649
