### PR TITLE
test: more robust signed out detection

### DIFF
--- a/e2e/delete-modal.spec.ts
+++ b/e2e/delete-modal.spec.ts
@@ -151,6 +151,8 @@ test.describe('Delete Modal component', () => {
     // The user is signed out after their account is deleted. Don't check the
     // number of occurrences of the 'Sign in' link as it may vary depending on AB
     // tests and Gatsby develop mode flakiness.
-    await expect(page.getByRole('link', { name: 'Sign in' })).toBeVisible();
+    await expect(
+      page.getByRole('link', { name: 'Sign in' }).first()
+    ).toBeVisible();
   });
 });


### PR DESCRIPTION
toBeVisible() expects there to be at exactly one element

https://github.com/freeCodeCamp/freeCodeCamp/pull/64648 did not do what I intended.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->
