### PR TITLE
fix(curriculum): add missing Chinese full stop in Task 22

### DIFF
--- a/curriculum/challenges/english/blocks/zh-a1-learn-understanding-greetings-and-introductions/6929b43bc9d6c580f1db8050.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-understanding-greetings-and-introductions/6929b43bc9d6c580f1db8050.md
@@ -17,7 +17,7 @@ Listen to the audio and complete the sentence below.
 
 ## --sentence--
 
-`我是数据 (wǒ shì shù jù) BLANK`
+`我是数据 (wǒ shì shù jù) BLANK。`
 
 ## --blanks--
 


### PR DESCRIPTION
Adds the missing Chinese full stop (。) at the end of the sentence in the
fill-in-the-blank section for Task 22, as described in #64658.
