### PR TITLE
fix(curriculum): add missing Chinese full stop in greetings lesson

### DIFF
--- a/curriculum/challenges/english/blocks/zh-a1-learn-understanding-greetings-and-introductions/6929b43bc9d6c580f1db8050.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-understanding-greetings-and-introductions/6929b43bc9d6c580f1db8050.md
@@ -17,7 +17,7 @@ Listen to the audio and complete the sentence below.
 
 ## --sentence--
 
-`我是数据 (wǒ shì shù jù) BLANK`
+`我是数据 (wǒ shì shù jù) BLANK。`
 
 ## --blanks--
 


### PR DESCRIPTION
### Description
Add a missing Chinese full stop in the Understanding Greetings lesson.

### Checklist

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes locally.

### Issue
Fixes #64658
