### PR TITLE
fix(curriculum): added information about the missing children prop

### DIFF
--- a/client/src/templates/Challenges/quiz/show.css
+++ b/client/src/templates/Challenges/quiz/show.css
@@ -21,3 +21,7 @@
   font-size: 1rem;
   margin: 0 0 1.2rem;
 }
+
+.quiz-answer-label:has(ruby) {
+  line-height: 1.7rem;
+}

--- a/curriculum/challenges/english/blocks/lecture-working-with-data-in-react/6734e3ceee2da4b0301719b7.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-data-in-react/6734e3ceee2da4b0301719b7.md
@@ -117,6 +117,8 @@ This is particularly useful when working with arrays of objects and passing mult
 
 You will learn more about how to render lists in arrays in future lessons.
 
+Note: In React, any content nested between a component’s opening and closing tags is automatically passed to that component as a special prop called `children`. This allows components to render nested JSX passed to them by their parent.
+
 Using props in React makes your components more flexible and reusable, allowing you to build more complex UIs. However, it's important to note that props are immutable, meaning they cannot be changed once passed to a component. If you need to handle user input and modify data, you should use state instead. You'll learn more about managing state in future lessons.
 
 # --questions--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #64645

<!-- Feel free to add any additional description of changes below this line -->
Added a concise clarification about props.children without a code example to avoid expanding the lesson scope. The lesson remains focused on explicit prop passing, while addressing a common point of confusion. 
I haven't added an example to keep the lesson’s scope focused, but one could be added in this section if further clarification feels necessary.
