### PR TITLE
fix(curriculum): simplify section headings in Chinese review pages

### DIFF
--- a/curriculum/challenges/english/blocks/zh-a1-review-greetings-and-introductions/69021947fa86ab50f9d3e287.md
+++ b/curriculum/challenges/english/blocks/zh-a1-review-greetings-and-introductions/69021947fa86ab50f9d3e287.md
@@ -16,9 +16,7 @@ The article below will help you review some key grammar points covered in the ta
 
 Once you've read it, just mark the task as complete and move on to the next part of the review.
 
-## Grammar Highlights
-
-### Three Types of Greetings
+## Three Types of Greetings
 
 In Chinese, there are different ways to say "hello" depending on who you're greeting:
 
@@ -30,7 +28,7 @@ In Chinese, there are different ways to say "hello" depending on who you're gree
 
 <br />
 
-### Using `我是 (wǒ shì)` to Introduce Yourself
+## Using `我是 (wǒ shì)` to Introduce Yourself
 
 The phrase `我是 (wǒ shì)` is the most basic way to describe who your are, like your name, nationality, and profession. Examples:
 

--- a/curriculum/challenges/english/blocks/zh-a1-review-introduction-questions/6918362cb49e2a3adf102413.md
+++ b/curriculum/challenges/english/blocks/zh-a1-review-introduction-questions/6918362cb49e2a3adf102413.md
@@ -16,11 +16,9 @@ The article below will help you review some key grammar points covered in the ta
 
 Once you've read it, just mark the task as complete and move on to the next part of the review.
 
-## Grammar Highlights
+## Ask Questions and Answers
 
-### Ask Questions and Answers
-
-#### Using `请问 (qǐng wèn)` to Ask Questions Politely
+### Using `请问 (qǐng wèn)` to Ask Questions Politely
 
 `请问 (qǐng wèn)` means "excuse me" or "may I ask". It's a polite way to start a question and is commonly used to show respect. Examples:
 
@@ -30,7 +28,7 @@ Once you've read it, just mark the task as complete and move on to the next part
 
 <br />
 
-#### Forming a Question with `吗 (ma)`
+### Forming a Question with `吗 (ma)`
 
 Adding the particle `吗 (ma)` to the end of a declarative sentence makes it a question. Examples:
 
@@ -40,7 +38,7 @@ Adding the particle `吗 (ma)` to the end of a declarative sentence makes it a q
 
 <br />
 
-#### Giving a Positive or Negative Answer
+### Giving a Positive or Negative Answer
 
 There're two ways to answer a question made with `吗 (ma)`. The positive answer is `是的 (shì de)`, which means "yes" or "that's right". The negative answer is `不是 (bù shì)`, which means "no" or "is not". Examples:
 
@@ -50,7 +48,7 @@ Speaker B: `是的 (shì de)，我是设计师 (wǒ shì shè jì shī)。` – 
 
 <br />
 
-#### Asking Follow-up Questions with `你呢 (nǐ ne)？`
+### Asking Follow-up Questions with `你呢 (nǐ ne)？`
 
 `你呢 (nǐ ne)` is a natural way to ask the person you're speaking to a question about a previously mentioned topic, meaning "How about you?" or "And you?". Examples:
 
@@ -60,13 +58,13 @@ Speaker B: `是的 (shì de)，我是设计师 (wǒ shì shè jì shī)。` – 
 
 <br />
 
-### Using `我叫 (wǒ jiào)` to Introduce Your Name
+## Using `我叫 (wǒ jiào)` to Introduce Your Name
 
 `我叫 (wǒ jiào)` + name is a commonly used structure to introduce someone's name, similar to `我是 (wǒ shì)` + name. It means "I am called..." or "My name is...".
 
 <br />
 
-### Using `你是 (nǐ shì)` to Talk About Someone you're Speaking to
+## Using `你是 (nǐ shì)` to Talk About Someone You're Speaking to
 
 Just as you use `我是 (wǒ shì)` to describe yourself, you can use `你是 (nǐ shì)` to talk about the person you are speaking to. This structure works with names, nationalities, and professions:
 
@@ -78,7 +76,7 @@ Just as you use `我是 (wǒ shì)` to describe yourself, you can use `你是 (n
 
 <br />
 
-### Other Useful Expressions
+## Other Useful Expressions
 
 `很高兴认识你 (hěn gāo xìng rèn shì nǐ)` is a common phrase used when meeting someone for the first time. It means "Nice to meet you." The natural response to this is `我也是 (wǒ yě shì)` which means "likewise".
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

These pages have "Grammar Highlights" as the title, so we don't need to repeat that in the subheadings.

Removing the Grammar Highlights h2 also helps simplify the heading hierarchy a little.

<!-- Feel free to add any additional description of changes below this line -->
