### PR TITLE
fix(curriculum): correct grammar in Big O notation lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-common-data-structures/68420c314cdf5c6863ca8330.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-common-data-structures/68420c314cdf5c6863ca8330.md
@@ -64,7 +64,7 @@ In Big O notation, we usually denote input size with the letter `n`. For example
 
 Constant factors and lower-order terms are not taken into account to find the time complexity of an algorithm based on the number of operations. That's because as the size of `n` grows, the impact of these smaller terms in the total number of operations performed will become smaller and smaller.
 
-The term that will dominate the overall behavior of the algorithm will the term with `n`, the input size.
+The term that will dominate the overall behavior of the algorithm will be the highest order term with `n`, the input size.
 
 For example, if an algorithm performs `7n + 20` operations to be completed, the impact of the constant `20` on the final result will be smaller and smaller as `n` grows. The term `7n` will tend to dominate and this will define the overall behavior and efficiency of the algorithm.
 


### PR DESCRIPTION
Checklist:

- [x ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x ] My pull request targets the `main` branch of freeCodeCamp.
- [x ] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #64707

Fixes a grammar issue in the Python lecture
"What is an algorithm and how does Big O notation work".

Clarifies the sentence describing the dominant term in Big O notation.

