### PR TITLE
fix: allow optional parentheses in arrow function parameters for step 19

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-fruit-search-app/6813f4dc94d4a31c5702f594.md
+++ b/curriculum/challenges/english/blocks/workshop-fruit-search-app/6813f4dc94d4a31c5702f594.md
@@ -16,9 +16,7 @@ You should update `setResults` with `data.map(fruit => fruit.name)`.
 ```js
 assert.match(
   code,
- /setResults\\s*\\(\\s*data\\.map\\(\\s*(?:\\(\\w+\\)|\\w+)\\s*=>\\s*\\w+\\.name\\s*\\)\\s*\\)/s
-
-
+  /setResults\\s*\\(\\s*data\\.map\\(\\s*(?:\\(\\w+\\)|\\w+)\\s*=>\\s*\\w+\\.name\\s*\\)\\s*\\)/s
 );
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-fruit-search-app/6813f4dc94d4a31c5702f594.md
+++ b/curriculum/challenges/english/blocks/workshop-fruit-search-app/6813f4dc94d4a31c5702f594.md
@@ -16,7 +16,8 @@ You should update `setResults` with `data.map(fruit => fruit.name)`.
 ```js
 assert.match(
   code,
-  /setResults\s*\(\s*data\.map\(\s*\w+\s*=>\s*\w+\.name\s*\)\s*\)/s
+  /setResults\\s*\\(\\s*data\\.map\\(\\s*\\(?\\w+\\)?\\s*=>\\s*\\w+\\.name\\s*\\)\\s*\\)/s
+
 );
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-fruit-search-app/6813f4dc94d4a31c5702f594.md
+++ b/curriculum/challenges/english/blocks/workshop-fruit-search-app/6813f4dc94d4a31c5702f594.md
@@ -16,7 +16,7 @@ You should update `setResults` with `data.map(fruit => fruit.name)`.
 ```js
 assert.match(
   code,
-   /setResults\s*\(\s*data\.map\(\s*(?:\(\w+\)|\w+)\s*=>\s*\w+\.name\s*\)\s*\)/s
+  /setResults\s*\(\s*data\.map\(\s*(?:\(\w+\)|\w+)\s*=>\s*\w+\.name\s*\)\s*\)/s
 );
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-fruit-search-app/6813f4dc94d4a31c5702f594.md
+++ b/curriculum/challenges/english/blocks/workshop-fruit-search-app/6813f4dc94d4a31c5702f594.md
@@ -16,7 +16,7 @@ You should update `setResults` with `data.map(fruit => fruit.name)`.
 ```js
 assert.match(
   code,
-  /setResults\\s*\\(\\s*data\\.map\\(\\s*(?:\\(\\w+\\)|\\w+)\\s*=>\\s*\\w+\\.name\\s*\\)\\s*\\)/s
+   /setResults\s*\(\s*data\.map\(\s*(?:\(\w+\)|\w+)\s*=>\s*\w+\.name\s*\)\s*\)/s
 );
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-fruit-search-app/6813f4dc94d4a31c5702f594.md
+++ b/curriculum/challenges/english/blocks/workshop-fruit-search-app/6813f4dc94d4a31c5702f594.md
@@ -16,7 +16,8 @@ You should update `setResults` with `data.map(fruit => fruit.name)`.
 ```js
 assert.match(
   code,
-  /setResults\\s*\\(\\s*data\\.map\\(\\s*\\(?\\w+\\)?\\s*=>\\s*\\w+\\.name\\s*\\)\\s*\\)/s
+ /setResults\\s*\\(\\s*data\\.map\\(\\s*(?:\\(\\w+\\)|\\w+)\\s*=>\\s*\\w+\\.name\\s*\\)\\s*\\)/s
+
 
 );
 ```


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #64713

<!-- Feel free to add any additional description of changes below this line -->

## Summary
Fixed the regex pattern in Step 19 of the Fruit Search App workshop to accept optional parentheses around arrow function parameters.

## Problem
The test was failing when students used valid JavaScript syntax with parentheses around single arrow function parameters: `data.map((datum) => datum.name)`. The regex only accepted the syntax without parentheses: `data.map(datum => datum.name)`.

## Solution
Added \\(? and \\)? to make parentheses optional, allowing both valid JavaScript syntaxes to pass the test.

## Testing
Verified the regex accepts:

setResults(data.map(datum => datum.name)) ✅

setResults(data.map((datum) => datum.name)) ✅

setResults( data.map( (fruit) => fruit.name ) ) ✅