### PR TITLE
fix(curriculum): Change comma to full stop in explanation

### DIFF
--- a/curriculum/challenges/english/blocks/zh-a1-warm-up-greeting-new-colleagues/68ece776dbb09b63b4ab41b4.md
+++ b/curriculum/challenges/english/blocks/zh-a1-warm-up-greeting-new-colleagues/68ece776dbb09b63b4ab41b4.md
@@ -52,7 +52,7 @@ The first syllable in the audio begins with the initial `zh`, not `z`.
 
 # --explanation--
 
-Wang Hua is saying `zhōng guó rén`, The tones for the three syllables are first tone, second tone, and second tone, respectively.
+Wang Hua is saying `zhōng guó rén`. The tones for the three syllables are first tone, second tone, and second tone, respectively.
 
 Pay attention to the initial of the first syllable. The tongue tip should be curled up to pronounce the `zh` sound.
 


### PR DESCRIPTION
Change comma to full stop in explanation in Greeting New Colleagues Warm Up

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #64688

<!-- Feel free to add any additional description of changes below this line -->
