### PR TITLE
fix(curriculum): add reminder for neutral tone syllables in FITB feedback

### DIFF
--- a/curriculum/challenges/english/blocks/zh-a1-learn-understanding-questions-and-answers/6911adab1df9af571f600863.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-understanding-questions-and-answers/6911adab1df9af571f600863.md
@@ -31,7 +31,7 @@ Listen to the audio and complete the sentence below.
 
 ### --feedback--
 
-This is a question particle used at the end of a sentence.
+This is a question particle used at the end of a sentence. Don't forget to type 5 at the end for neutral tone syllables.
 
 # --explanation--
 

--- a/curriculum/challenges/english/blocks/zh-a1-learn-understanding-questions-and-answers/6911bcdd1ef7e704c8137b2c.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-understanding-questions-and-answers/6911bcdd1ef7e704c8137b2c.md
@@ -31,7 +31,7 @@ Listen to the audio and complete the sentence below.
 
 ### --feedback--
 
-These two characters means "How about you?" or "And you?"
+These two characters means "How about you?" or "And you?" Don't forget to type 5 at the end for neutral tone syllables.
 
 # --explanation--
 

--- a/curriculum/challenges/english/blocks/zh-a1-learn-understanding-questions-and-answers/69144f69e6621e83cc306401.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-understanding-questions-and-answers/69144f69e6621e83cc306401.md
@@ -29,7 +29,7 @@ Listen to the audio and complete the sentence below.
 
 ### --feedback--
 
-This means "yes" or "that's right", often used to give a positive answer.
+This means "yes" or "that's right", often used to give a positive answer. Don't forget to type 5 at the end for neutral tone syllables.
 
 # --explanation--
 

--- a/curriculum/challenges/english/blocks/zh-a1-practice-exchanging-basic-information/691740419e56e024c83ad7c9.md
+++ b/curriculum/challenges/english/blocks/zh-a1-practice-exchanging-basic-information/691740419e56e024c83ad7c9.md
@@ -43,7 +43,7 @@ This phrase means "you are" and is used before a profession to ask about someone
 
 ### --feedback--
 
-This word means "yes" and is used to confirm a statement.
+This word means "yes" and is used to confirm a statement. Don't forget to type 5 at the end for neutral tone syllables.
 
 ---
 
@@ -51,7 +51,7 @@ This word means "yes" and is used to confirm a statement.
 
 ### --feedback--
 
-This phrase means "and you?" and is used to return a question back to the other person.
+This phrase means "and you?" and is used to return a question back to the other person. Don't forget to type 5 at the end for neutral tone syllables.
 
 # --scene--
 

--- a/curriculum/challenges/english/blocks/zh-a1-practice-exchanging-basic-information/69182f75cc96e43363541510.md
+++ b/curriculum/challenges/english/blocks/zh-a1-practice-exchanging-basic-information/69182f75cc96e43363541510.md
@@ -49,7 +49,7 @@ This is used at the beginning of a question to make it more polite.
 
 ### --feedback--
 
-This phrase is used when asking for someone's name.
+This phrase is used when asking for someone's name. Don't forget to type 5 at the end for neutral tone syllables.
 
 ---
 
@@ -57,7 +57,7 @@ This phrase is used when asking for someone's name.
 
 ### --feedback--
 
-This is used to ask about the same information from the other person.
+This is used to ask about the same information from the other person. Don't forget to type 5 at the end for neutral tone syllables.
 
 ---
 

--- a/curriculum/challenges/english/blocks/zh-a1-warm-up-meeting-new-teammates/68fe27f120a1443005dfa6ef.md
+++ b/curriculum/challenges/english/blocks/zh-a1-warm-up-meeting-new-teammates/68fe27f120a1443005dfa6ef.md
@@ -29,7 +29,7 @@ Listen to the audio and complete the sentence below.
 
 ### --feedback--
 
-This word means "what" and is used to ask questions in Chinese.
+This word means "what" and is used to ask questions in Chinese. Don't forget to type 5 at the end for neutral tone syllables.
 
 # --explanation--
 

--- a/curriculum/challenges/english/blocks/zh-a1-warm-up-meeting-new-teammates/68ff2a79deb01d26232dd443.md
+++ b/curriculum/challenges/english/blocks/zh-a1-warm-up-meeting-new-teammates/68ff2a79deb01d26232dd443.md
@@ -29,7 +29,7 @@ Listen to the audio and complete the sentence below.
 
 ### --feedback--
 
-This word means "name".
+This word means "name". Don't forget to type 5 at the end for neutral tone syllables.
 
 # --explanation--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR:
- Adds a reminder in the feedback of FITB tasks that involve syllables with neutral tone
- Is related to https://github.com/freeCodeCamp/language-curricula/issues/44#issuecomment-3657863174

<details>
<summary>Screenshot</summary>

<img width="836" height="462" alt="Screenshot 2025-12-18 at 04 50 46" src="https://github.com/user-attachments/assets/c66fb741-dd6b-4bc9-863b-f593761671db" />

</details>

<!-- Feel free to add any additional description of changes below this line -->
