### PR TITLE
refactor: skip curriculum import to save compile time

### DIFF
--- a/client/tools/external-curriculum/build.ts
+++ b/client/tools/external-curriculum/build.ts
@@ -1,4 +1,13 @@
-import curriculum from '../../../shared-dist/config/curriculum.json';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const CURRICULUM_PATH = '../../../shared-dist/config/curriculum.json';
+// const __dirname = dirname(fileURLToPath(import.meta.url));
+// Curriculum is read using fs, because it is too large for VSCode's LSP to handle type inference which causes annoying behavior.
+const curriculum = JSON.parse(
+  readFileSync(join(__dirname, CURRICULUM_PATH), 'utf-8')
+);
+
 import {
   buildExtCurriculumDataV1,
   Curriculum as CurriculumV1,
@@ -20,10 +29,6 @@ if (isSelectiveBuild) {
     'Skipping external curriculum build (selective build mode active)'
   );
 } else {
-  buildExtCurriculumDataV1(
-    curriculum as unknown as CurriculumV1<CurriculumPropsV1>
-  );
-  buildExtCurriculumDataV2(
-    curriculum as unknown as CurriculumV2<CurriculumPropsV2>
-  );
+  buildExtCurriculumDataV1(curriculum as CurriculumV1<CurriculumPropsV1>);
+  buildExtCurriculumDataV2(curriculum as CurriculumV2<CurriculumPropsV2>);
 }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

The majority of `tsc`s time was spent parsing curriculum.json, only for it to be cast as unknown.

<!-- Feel free to add any additional description of changes below this line -->
