### PR TITLE
fix(curriculum): clarify pronunciation wording in Chinese glossary

### DIFF
--- a/curriculum/challenges/english/blocks/zh-a1-review-introduction-questions/69183626c350253a6a4a05e1.md
+++ b/curriculum/challenges/english/blocks/zh-a1-review-introduction-questions/69183626c350253a6a4a05e1.md
@@ -58,7 +58,7 @@ There's also a summary of important Pinyin rules involved in this module.
 
 When `不 (bù)` is followed by a syllable in the first, second, or third tone, it remains in the fourth tone. However, when `不 (bù)` is followed by a syllable in the fourth tone, it changes to the second tone. For example:
 
-`不是 (bù shì)` pronounced as `bú shì`
+`不是 (bù shì)` is pronounced as `bú shì`.
 
 # --assignment--
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #64683

Additional description:

This PR fixes a small typo in the Chinese A1 introduction questions glossary.

Changes:
- Updated wording to "is pronounced as" for clarity and grammatical correctness.
