### PR TITLE
test: ignore url after deleting account

### DIFF
--- a/e2e/delete-modal.spec.ts
+++ b/e2e/delete-modal.spec.ts
@@ -4,8 +4,6 @@ import { promisify } from 'util';
 import { test, expect } from '@playwright/test';
 
 import translations from '../client/i18n/locales/english/translations.json';
-import { alertToBeVisible } from './utils/alerts';
-import { allowTrailingSlash } from './utils/url';
 
 const execP = promisify(exec);
 
@@ -116,7 +114,7 @@ test.describe('Delete Modal component', () => {
     ).toBeDisabled();
   });
 
-  test('should close the modal and redirect to /learn after the user fills the verify input text and clicks delete', async ({
+  test('should close the modal and sign the user out after they fill in the verify input text and click delete', async ({
     page
   }) => {
     await page
@@ -146,8 +144,9 @@ test.describe('Delete Modal component', () => {
       })
     ).not.toBeVisible();
 
-    await expect(page).toHaveURL(allowTrailingSlash('/learn'));
-    await alertToBeVisible(page, translations.flash['account-deleted']);
+    // TODO: Reinstate these checks when flakiness is resolved:
+    // await expect(page).toHaveURL(allowTrailingSlash('/learn'));
+    // await alertToBeVisible(page, translations.flash['account-deleted']);
     // The user is signed out after their account is deleted. Don't check the
     // number of occurrences of the 'Sign in' link as it may vary depending on AB
     // tests and Gatsby develop mode flakiness.


### PR DESCRIPTION
The test is still flaky, so this narrows the focus to the main concern: are they signed out?

https://github.com/freeCodeCamp/freeCodeCamp/pull/64654 helped a bit, but I'm still seeing test failures.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
