### PR TITLE
fix(curriculum): change A1 Chinese introducing yourself audio timestamp

### DIFF
--- a/curriculum/challenges/english/blocks/zh-a1-practice-introducing-yourself/68f5f636fff053375f4fbd71.md
+++ b/curriculum/challenges/english/blocks/zh-a1-practice-introducing-yourself/68f5f636fff053375f4fbd71.md
@@ -89,7 +89,7 @@ Liu Ming first greets politely with `您好 (nín hǎo)`, then uses `我是 (wǒ
     "audio": {
       "filename": "ZH_A1_greetings_and_introductions_liuming.mp3",
       "startTime": 1,
-      "startTimestamp": 0.78,
+      "startTimestamp": 0.1,
       "finishTimestamp": 5.44
     }
   },


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #64681

<!-- Feel free to add any additional description of changes below this line -->

This PR fixes the start timestamp of Task 4 in the practice "Introducing Yourself" block of the A1 Professional Chinese curriculum. 
