### PR TITLE
feat(client): add locale date to attempt

### DIFF
--- a/client/src/templates/Challenges/exam-download/attempts.tsx
+++ b/client/src/templates/Challenges/exam-download/attempts.tsx
@@ -93,7 +93,7 @@ export function Attempts({ examChallengeId }: AttemptsProps) {
       <tbody>
         {attempts.map(attempt => (
           <tr key={attempt.startTime}>
-            <td>{new Date(attempt.startTime).toTimeString()}</td>
+            <td>{new Date(attempt.startTime).toLocaleString('en-GB')}</td>
             <td>{renderScore(attempt)}</td>
             <td>{renderStatus(attempt)}</td>
           </tr>

--- a/client/src/templates/Challenges/exam-download/attempts.tsx
+++ b/client/src/templates/Challenges/exam-download/attempts.tsx
@@ -93,7 +93,7 @@ export function Attempts({ examChallengeId }: AttemptsProps) {
       <tbody>
         {attempts.map(attempt => (
           <tr key={attempt.startTime}>
-            <td>{new Date(attempt.startTime).toLocaleString('en-GB')}</td>
+            <td>{new Date(attempt.startTime).toLocaleString()}</td>
             <td>{renderScore(attempt)}</td>
             <td>{renderStatus(attempt)}</td>
           </tr>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Ref: https://forum.freecodecamp.org/t/exam-attempt-shows-only-time-not-date/770699
Someone brought up the attempts not showing the date part of the Date.