### PR TITLE
fix(curriculum): typos in parent teacher conference form workshop

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68ea8e6a87a2816b0bb2eb7d.md
+++ b/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68ea8e6a87a2816b0bb2eb7d.md
@@ -7,7 +7,7 @@ dashedName: step-8
 
 # --description--
 
-The next step is to section in the form for the parent information. 
+The next step is the section in the form for the parent information. 
 
 Start by adding another `fieldset` element. Inside that `fieldset` element, add a `legend` element with the text `Parent/Guardian Information`. 
 

--- a/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68ea9f01c51b66b937793611.md
+++ b/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68ea9f01c51b66b937793611.md
@@ -7,7 +7,7 @@ dashedName: step-12
 
 # --description--
 
-Next, add another label with a class of `"contact-method"` and a `for` attribute set to `"phone"`. The label should text should be `Phone: `.
+Next, add another label with a class of `"contact-method"` and a `for` attribute set to `"phone"`. The label text should be `Phone: `.
 
 Below your `label` element, add a radio button with `id` and `value` attributes set to `"phone"`. The `name` attribute should be set to `"contact-method"` and the class should be set to `"contact-method-radio-btn"`.
 

--- a/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eb323ff5a6dc1cc19fa300.md
+++ b/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eb323ff5a6dc1cc19fa300.md
@@ -9,7 +9,7 @@ dashedName: step-32
 
 Now, you should create the inner circle that will appear when the radio button is checked. You will use the `::before` pseudo-element for this.
 
-A pseudo-element like `:before` lets you insert extra content before the actual element. This is often used for decorative purposes.
+A pseudo-element like `::before` lets you insert extra content before the actual element. This is often used for decorative purposes.
 
 Targeting `.contact-method-radio-btn::before` pseudo-element, set a `display` of `block`, `content` of `" "`, `width` of `10px`, `height` of `10px`, and `border-radius` of `50%`.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->

Affected pages:

https://www.freecodecamp.org/learn/responsive-web-design-v9/workshop-parent-teacher-conference-form/step-8
https://www.freecodecamp.org/learn/responsive-web-design-v9/workshop-parent-teacher-conference-form/step-12
https://www.freecodecamp.org/learn/responsive-web-design-v9/workshop-parent-teacher-conference-form/step-32


