### PR TITLE
fix(curriculum): change compound finals task scenes background

### DIFF
--- a/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/60593b49f060b40d28eb6c66.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/60593b49f060b40d28eb6c66.md
@@ -38,7 +38,7 @@ The syllable is pronounced with the first tone, which is a high-level tone.
 ```json
 {
   "setup": {
-    "background": "company2-lydia-cubicle.png",
+    "background": "company2-center.png",
     "characters": [
       {
         "character": "Lin Yating",

--- a/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/606b36601bd5d45cc8f17f74.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/606b36601bd5d45cc8f17f74.md
@@ -40,7 +40,7 @@ The speaker pronounces the syllable `liù`, which consists of the initial `l` an
 ```json
 {
   "setup": {
-    "background": "company2-lydia-cubicle.png",
+    "background": "company2-center.png",
     "characters": [
       {
         "character": "Lin Yating",

--- a/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/612cb090cb85f408182d42f8.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/612cb090cb85f408182d42f8.md
@@ -31,7 +31,7 @@ I've listened to the audio and pronounce the compound final and syllables.
 ```json
 {
   "setup": {
-    "background": "company2-lydia-cubicle.png",
+    "background": "company2-center.png",
     "characters": [
       {
         "character": "Lin Yating",

--- a/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/614ef01193b1140ee8bf5a44.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/614ef01193b1140ee8bf5a44.md
@@ -32,7 +32,7 @@ I've listened to the audio and pronounce the compound final and syllables.
 ```json
 {
   "setup": {
-    "background": "company2-lydia-cubicle.png",
+    "background": "company2-center.png",
     "characters": [
       {
         "character": "Lin Yating",

--- a/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/61641413ec99c49f9b67db7d.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/61641413ec99c49f9b67db7d.md
@@ -33,7 +33,7 @@ I've listened to the audio and pronounce the compound final and syllables.
 ```json
 {
   "setup": {
-    "background": "company2-lydia-cubicle.png",
+    "background": "company2-center.png",
     "characters": [
       {
         "character": "Lin Yating",

--- a/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/6197879f7a4594087b71cf09.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/6197879f7a4594087b71cf09.md
@@ -36,7 +36,7 @@ The audio pronounces the syllable `jià`, which consists of the initial `j` and 
 ```json
 {
   "setup": {
-    "background": "company2-lydia-cubicle.png",
+    "background": "company2-center.png",
     "characters": [
       {
         "character": "Lin Yating",

--- a/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/61ae50ecd635f47eaaaa489e.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/61ae50ecd635f47eaaaa489e.md
@@ -23,7 +23,7 @@ I've listened to the audio and practiced pronouncing the compound finals.
 ```json
 {
   "setup": {
-    "background": "company2-lydia-cubicle.png",
+    "background": "company2-center.png",
     "characters": [
       {
         "character": "Lin Yating",

--- a/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/6216709db347445868fb6ecc.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/6216709db347445868fb6ecc.md
@@ -32,7 +32,7 @@ I've listened to the audio and pronounce the compound final and syllables.
 ```json
 {
   "setup": {
-    "background": "company2-lydia-cubicle.png",
+    "background": "company2-center.png",
     "characters": [
       {
         "character": "Lin Yating",

--- a/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/628f0a002b0b54a778cfe2ea.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/628f0a002b0b54a778cfe2ea.md
@@ -42,7 +42,7 @@ The first syllable combines the initial `x` with the compound final `ue`, and us
 ```json
 {
   "setup": {
-    "background": "company2-lydia-cubicle.png",
+    "background": "company2-center.png",
     "characters": [
       {
         "character": "Lin Yating",

--- a/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/62d30cb99976f4663be90526.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/62d30cb99976f4663be90526.md
@@ -38,7 +38,7 @@ The syllable uses the third tone, which is a falling tone.
 ```json
 {
   "setup": {
-    "background": "company2-lydia-cubicle.png",
+    "background": "company2-center.png",
     "characters": [
       {
         "character": "Lin Yating",

--- a/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/6361841663e06404b93f76d2.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/6361841663e06404b93f76d2.md
@@ -42,7 +42,7 @@ The first syllable combines the initial `d` with the compound final `ie`, and us
 ```json
 {
   "setup": {
-    "background": "company2-lydia-cubicle.png",
+    "background": "company2-center.png",
     "characters": [
       {
         "character": "Lin Yating",

--- a/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/640786bb95f9743a1a45c4c7.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/640786bb95f9743a1a45c4c7.md
@@ -44,7 +44,7 @@ The first syllable combines the initial `j` with the compound final `ao`, and us
 ```json
 {
   "setup": {
-    "background": "company2-lydia-cubicle.png",
+    "background": "company2-center.png",
     "characters": [
       {
         "character": "Lin Yating",

--- a/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/64809712c232d44b290fe7d8.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/64809712c232d44b290fe7d8.md
@@ -38,7 +38,7 @@ Note that the two dots above `ü` is removed when `üe` follows the initial `x`.
 ```json
 {
   "setup": {
-    "background": "company2-lydia-cubicle.png",
+    "background": "company2-center.png",
     "characters": [
       {
         "character": "Lin Yating",

--- a/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/657db9efc496d4cf1821cf6a.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/657db9efc496d4cf1821cf6a.md
@@ -40,7 +40,7 @@ The speaker pronounces the syllable `jiāo`, which consists of the initial `j` a
 ```json
 {
   "setup": {
-    "background": "company2-lydia-cubicle.png",
+    "background": "company2-center.png",
     "characters": [
       {
         "character": "Lin Yating",

--- a/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/658dd82eeed6c4c828bdc617.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/658dd82eeed6c4c828bdc617.md
@@ -36,7 +36,7 @@ The speaker pronounces the syllable `kuà`, which consists of the initial `k` an
 ```json
 {
   "setup": {
-    "background": "company2-lydia-cubicle.png",
+    "background": "company2-center.png",
     "characters": [
       {
         "character": "Lin Yating",

--- a/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/65ea544013180471cac4b114.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/65ea544013180471cac4b114.md
@@ -36,7 +36,7 @@ The audio pronounces the syllable `dié`, which consists of the initial `d` and 
 ```json
 {
   "setup": {
-    "background": "company2-lydia-cubicle.png",
+    "background": "company2-center.png",
     "characters": [
       {
         "character": "Lin Yating",

--- a/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/6621a7b1a89964984aa2fa6b.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/6621a7b1a89964984aa2fa6b.md
@@ -50,7 +50,7 @@ The syllable uses the third tone, which starts in the middle, falls to a low poi
 ```json
 {
   "setup": {
-    "background": "company2-lydia-cubicle.png",
+    "background": "company2-center.png",
     "characters": [
       {
         "character": "Lin Yating",

--- a/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/66cb17a9180424ae6a09847a.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/66cb17a9180424ae6a09847a.md
@@ -32,7 +32,7 @@ I've listened to the audio and pronounce the compound final and syllables.
 ```json
 {
   "setup": {
-    "background": "company2-lydia-cubicle.png",
+    "background": "company2-center.png",
     "characters": [
       {
         "character": "Lin Yating",

--- a/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/67507a7199776477bbf39384.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/67507a7199776477bbf39384.md
@@ -34,7 +34,7 @@ I've listened to the audio and pronounce the compound final and syllables.
 ```json
 {
   "setup": {
-    "background": "company2-lydia-cubicle.png",
+    "background": "company2-center.png",
     "characters": [
       {
         "character": "Lin Yating",

--- a/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/675b98e3e66bb4c998781552.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/675b98e3e66bb4c998781552.md
@@ -59,7 +59,7 @@ The speaker pronounces the syllable `ér`, which consists of the special final `
 ```json
 {
   "setup": {
-    "background": "company2-lydia-cubicle.png",
+    "background": "company2-center.png",
     "characters": [
       {
         "character": "Lin Yating",

--- a/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/68705554ed9eb4337be6bb4d.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/68705554ed9eb4337be6bb4d.md
@@ -36,7 +36,7 @@ The speaker pronounces the syllable `tuǐ`, which consists of the initial `t` an
 ```json
 {
   "setup": {
-    "background": "company2-lydia-cubicle.png",
+    "background": "company2-center.png",
     "characters": [
       {
         "character": "Lin Yating",

--- a/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/68aed38abc5814eaa95a610f.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/68aed38abc5814eaa95a610f.md
@@ -38,7 +38,7 @@ I've listened to the audio and pronounce the compound final and syllables.
 ```json
 {
   "setup": {
-    "background": "company2-lydia-cubicle.png",
+    "background": "company2-center.png",
     "characters": [
       {
         "character": "Lin Yating",

--- a/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/68cb3503cacae44f68ff5659.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/68cb3503cacae44f68ff5659.md
@@ -36,7 +36,7 @@ The speaker pronounces the syllable `shuāi`, which consists of the initial `sh`
 ```json
 {
   "setup": {
-    "background": "company2-lydia-cubicle.png",
+    "background": "company2-center.png",
     "characters": [
       {
         "character": "Lin Yating",

--- a/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/68e74be40fa844d1c85b99c7.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/68e74be40fa844d1c85b99c7.md
@@ -32,7 +32,7 @@ I've listened to the audio and pronounce the compound final and syllables.
 ```json
 {
   "setup": {
-    "background": "company2-lydia-cubicle.png",
+    "background": "company2-center.png",
     "characters": [
       {
         "character": "Lin Yating",

--- a/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/68f032f89141b4e9b8815d0e.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/68f032f89141b4e9b8815d0e.md
@@ -36,7 +36,7 @@ The speaker pronounces the syllable `ruò`, which consists of the initial `r` an
 ```json
 {
   "setup": {
-    "background": "company2-lydia-cubicle.png",
+    "background": "company2-center.png",
     "characters": [
       {
         "character": "Lin Yating",

--- a/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/6905006d14b4843c3a0d7d2e.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/6905006d14b4843c3a0d7d2e.md
@@ -36,7 +36,7 @@ The speaker pronounces `èr`. It is a special final being a syllable on its own,
 ```json
 {
   "setup": {
-    "background": "company2-lydia-cubicle.png",
+    "background": "company2-center.png",
     "characters": [
       {
         "character": "Lin Yating",

--- a/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/690ae7f2e19334043aea0cb9.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/690ae7f2e19334043aea0cb9.md
@@ -31,7 +31,7 @@ I've listened to the audio and pronounced the special final and syllables.
 ```json
 {
   "setup": {
-    "background": "company2-lydia-cubicle.png",
+    "background": "company2-center.png",
     "characters": [
       {
         "character": "Lin Yating",

--- a/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/69414c07e0275598cd67d57b.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/69414c07e0275598cd67d57b.md
@@ -59,7 +59,7 @@ The speaker is pronouncing the syllable with the initial `sh`, the final `ao`, a
 ```json
 {
   "setup": {
-    "background": "company2-lydia-cubicle.png",
+    "background": "company2-center.png",
     "characters": [
       {
         "character": "Lin Yating",

--- a/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/69414c745a9c5fdd92bf07e6.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/69414c745a9c5fdd92bf07e6.md
@@ -59,7 +59,7 @@ The speaker is pronouncing the syllable with the initial `h`, the final `ua`, an
 ```json
 {
   "setup": {
-    "background": "company2-lydia-cubicle.png",
+    "background": "company2-center.png",
     "characters": [
       {
         "character": "Lin Yating",

--- a/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/69414ce8f460cc9baf4cff25.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/69414ce8f460cc9baf4cff25.md
@@ -59,7 +59,7 @@ The speaker is pronouncing the syllable with the initial `sh`, the final `uei` (
 ```json
 {
   "setup": {
-    "background": "company2-lydia-cubicle.png",
+    "background": "company2-center.png",
     "characters": [
       {
         "character": "Lin Yating",

--- a/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/6a5704d2e302e4b839f3c615.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/6a5704d2e302e4b839f3c615.md
@@ -44,7 +44,7 @@ The first syllable combines the initial `h` with the compound final `ei`, and us
 ```json
 {
   "setup": {
-    "background": "company2-lydia-cubicle.png",
+    "background": "company2-center.png",
     "characters": [
       {
         "character": "Lin Yating",

--- a/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/6a753a1ac417349fd88b3622.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/6a753a1ac417349fd88b3622.md
@@ -33,7 +33,7 @@ I've listened to the audio and pronounce the compound final and syllables.
 ```json
 {
   "setup": {
-    "background": "company2-lydia-cubicle.png",
+    "background": "company2-center.png",
     "characters": [
       {
         "character": "Lin Yating",

--- a/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/6aca3e7a5da3248da8ba95a7.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/6aca3e7a5da3248da8ba95a7.md
@@ -44,7 +44,7 @@ The first syllable combines the initial `sh` with the compound final `uai`, and 
 ```json
 {
   "setup": {
-    "background": "company2-lydia-cubicle.png",
+    "background": "company2-center.png",
     "characters": [
       {
         "character": "Lin Yating",

--- a/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/6bf22f1f6430040b78818d21.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/6bf22f1f6430040b78818d21.md
@@ -36,7 +36,7 @@ The audio pronounces the syllable `gǎo`, which consists of the initial `g` and 
 ```json
 {
   "setup": {
-    "background": "company2-lydia-cubicle.png",
+    "background": "company2-center.png",
     "characters": [
       {
         "character": "Lin Yating",

--- a/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/6c2294cc9b36b4bf2ba83d74.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/6c2294cc9b36b4bf2ba83d74.md
@@ -32,7 +32,7 @@ I've listened to the audio and pronounce the compound final and syllables.
 ```json
 {
   "setup": {
-    "background": "company2-lydia-cubicle.png",
+    "background": "company2-center.png",
     "characters": [
       {
         "character": "Lin Yating",

--- a/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/6c5b920a78761459abac94de.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/6c5b920a78761459abac94de.md
@@ -34,7 +34,7 @@ I've listened to the audio and pronounce the compound final and syllables.
 ```json
 {
   "setup": {
-    "background": "company2-lydia-cubicle.png",
+    "background": "company2-center.png",
     "characters": [
       {
         "character": "Lin Yating",

--- a/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/6ca764a717aa84bc69922867.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/6ca764a717aa84bc69922867.md
@@ -42,7 +42,7 @@ The first syllable combines the initial `g` with the compound final `ao`, and us
 ```json
 {
   "setup": {
-    "background": "company2-lydia-cubicle.png",
+    "background": "company2-center.png",
     "characters": [
       {
         "character": "Lin Yating",

--- a/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/6e83c1cf6325c491f80cc0cc.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/6e83c1cf6325c491f80cc0cc.md
@@ -32,7 +32,7 @@ I've listened to the audio and pronounce the compound final and syllables.
 ```json
 {
   "setup": {
-    "background": "company2-lydia-cubicle.png",
+    "background": "company2-center.png",
     "characters": [
       {
         "character": "Lin Yating",

--- a/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/6f1daab071e44400ca692d3b.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-compound-finals/6f1daab071e44400ca692d3b.md
@@ -32,7 +32,7 @@ I've listened to the audio and pronounce the compound final and syllables.
 ```json
 {
   "setup": {
-    "background": "company2-lydia-cubicle.png",
+    "background": "company2-center.png",
     "characters": [
       {
         "character": "Lin Yating",


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->

This PR changes the change task scenes background of the A1 Professional Chinese "Compound Finals" block from "company2-lydia-cubicle.png" to "company2-center.png". 