### PR TITLE
fix(curriculum): correct grammar in zh A1 review questions

### DIFF
--- a/curriculum/challenges/english/blocks/zh-a1-review-introduction-questions/69183626c350253a6a4a05e1.md
+++ b/curriculum/challenges/english/blocks/zh-a1-review-introduction-questions/69183626c350253a6a4a05e1.md
@@ -62,4 +62,4 @@ When `不 (bù)` is followed by a syllable in the first, second, or third tone, 
 
 # --assignment--
 
-I confirm I read the glossary.
+I confirm I've read the glossary.

--- a/curriculum/challenges/english/blocks/zh-a1-review-introduction-questions/6918362cb49e2a3adf102413.md
+++ b/curriculum/challenges/english/blocks/zh-a1-review-introduction-questions/6918362cb49e2a3adf102413.md
@@ -40,7 +40,7 @@ Adding the particle `吗 (ma)` to the end of a declarative sentence makes it a q
 
 ### Giving a Positive or Negative Answer
 
-There're two ways to answer a question made with `吗 (ma)`. The positive answer is `是的 (shì de)`, which means "yes" or "that's right". The negative answer is `不是 (bù shì)`, which means "no" or "is not". Examples:
+There are two ways to answer a question made with `吗 (ma)`. The positive answer is `是的 (shì de)`, which means "yes" or "that's right". The negative answer is `不是 (bù shì)`, which means "no" or "is not". Examples:
 
 Speaker A: `你是设计师吗 (nǐ shì shè jì shī ma)？` – Are you a designer?
 
@@ -82,4 +82,4 @@ Just as you use `我是 (wǒ shì)` to describe yourself, you can use `你是 (n
 
 # --assignment--
 
-I confirm I read the grammar highlights.
+I confirm I've read the grammar highlights.


### PR DESCRIPTION
Fixes minor grammar issues in the Chinese A1 review introduction questions.

- Replaced informal contraction "There're" with "There are"
- Used consistent present perfect tense in confirmation statements
