### PR TITLE
fix(curriculum): simplify heading structure in Spanish review pages

### DIFF
--- a/curriculum/challenges/english/blocks/es-a1-review-first-questions/6910a23b05a7eb4386e6e730.md
+++ b/curriculum/challenges/english/blocks/es-a1-review-first-questions/6910a23b05a7eb4386e6e730.md
@@ -14,8 +14,6 @@ Congratulations! You're almost done with this module.
 
 The article below will help you review some key grammar points covered in the tasks, so you can feel confident before taking the Module Quiz.
 
-## Grammar Highlights
-
 ### Talking about Origin
 
 To say where you are from, you should use: **`Soy` + `de` + [country]**. For example:

--- a/curriculum/challenges/english/blocks/es-a1-review-first-questions/6910a2da60b9e944f13240a0.md
+++ b/curriculum/challenges/english/blocks/es-a1-review-first-questions/6910a2da60b9e944f13240a0.md
@@ -10,8 +10,6 @@ lang: es
 
 # --description--
 
-## Glossary
-
 This Glossary is a quick reference for the most important words and phrases from the content you've worked with in this module. The words are organized by category and in alphabetical order.
 
 ### Greetings and Introductions

--- a/curriculum/challenges/english/blocks/es-a1-review-greetings-and-farewells/68c850ed23d494c9be5cb22a.md
+++ b/curriculum/challenges/english/blocks/es-a1-review-greetings-and-farewells/68c850ed23d494c9be5cb22a.md
@@ -16,8 +16,6 @@ The article below will help you review some key grammar points covered in the ta
 
 Once you've read it, just mark the task as complete and move on to the next part of the review.
 
-## Grammar Highlights
-
 ### Subject Pronoun Omission
 
 In Spanish, it's common to omit the subject pronoun (like `yo`) because the verb form already tells who the subject is. For example:

--- a/curriculum/challenges/english/blocks/es-a1-review-introducing-yourself/68dc753010b6b271ac564e93.md
+++ b/curriculum/challenges/english/blocks/es-a1-review-introducing-yourself/68dc753010b6b271ac564e93.md
@@ -10,8 +10,6 @@ lang: es
 
 # --description--
 
-## Grammar Highlights
-
 ### Conjugation of the Verb `tener` in Present Indicative Tense
 
 The verb `tener` (to have) is commonly used to talk about age in Spanish.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x ] My pull request targets the `main` branch of freeCodeCamp.
- [ x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #64720

This pull request removes duplicate headings from the affected Spanish review pages.
The page titles already provide the main heading, so the redundant section headings were removed to improve clarity and accessibility.
