### PR TITLE
fix(learn): correct capitalization in RPG character title

### DIFF
--- a/client/i18n/locales/chinese/intro.json
+++ b/client/i18n/locales/chinese/intro.json
@@ -6739,7 +6739,7 @@
         ]
       },
       "lab-rpg-character": {
-        "title": "Build an RPG Character",
+        "title": "Build an RPG character",
         "intro": [
           "In this lab you will practice basic python by building an RPG character."
         ]

--- a/client/i18n/locales/chinese/intro.json
+++ b/client/i18n/locales/chinese/intro.json
@@ -6739,7 +6739,7 @@
         ]
       },
       "lab-rpg-character": {
-        "title": "Build an RPG character",
+        "title": "Build an RPG Character",
         "intro": [
           "In this lab you will practice basic python by building an RPG character."
         ]

--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -6711,7 +6711,7 @@
         ]
       },
       "lab-rpg-character": {
-        "title": "Build an RPG character",
+        "title": "Build an RPG Character",
         "intro": [
           "In this lab you will practice basic python by building an RPG character."
         ]


### PR DESCRIPTION
…ocale

Checklist:

- [x ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x ] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #64816

Fixes capitalization of "Character" in the "Build an RPG Character" title in the Chinese locale.

