### PR TITLE
fix: replace archived responsive web design links in breadcrumb test

### DIFF
--- a/e2e/bread-crumb.spec.ts
+++ b/e2e/bread-crumb.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test';
 
 test.beforeEach(async ({ page }) => {
   await page.goto(
-    '/learn/2022/responsive-web-design/learn-html-by-building-a-cat-photo-app/step-2'
+    '/learn/responsive-web-design-v9/workshop-cat-photo-app/step-2'
   );
 });
 
@@ -18,7 +18,7 @@ test.describe('Challenge Breadcrumb Tests', () => {
       await expect(superBlockLink).toBeVisible();
       await expect(superBlockLink).toHaveAttribute(
         'href',
-        '/learn/2022/responsive-web-design'
+        '/learn/responsive-web-design-v9'
       );
 
       const block = page.getByTestId(testId).getByRole('listitem').last();
@@ -30,7 +30,7 @@ test.describe('Challenge Breadcrumb Tests', () => {
       await expect(blockLink).toBeVisible();
       await expect(blockLink).toHaveAttribute(
         'href',
-        '/learn/2022/responsive-web-design/#learn-html-by-building-a-cat-photo-app'
+        '/learn/responsive-web-design-v9/#workshop-cat-photo-app'
       );
     };
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.


Closes #64838

- Updated archived Responsive Web Design v2022 links
- Replaced with Responsive Web Design v9 paths in bread-crumb Playwright test
