### PR TITLE
fix(curriculum): reworded explanation to resolve common misunderstanding (Issue #64814)

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-caesar-cipher/680a549f60f5a3fedfc0edd9.md
+++ b/curriculum/challenges/english/blocks/workshop-caesar-cipher/680a549f60f5a3fedfc0edd9.md
@@ -17,7 +17,7 @@ print(greeting) # Hello World
 
 ```
 
-Use the slicing syntax to extract the missing first portion of `alphabet` and concatenate it to `alphabet[shift:]`.
+Use the slicing syntax to extract the missing first portion of `alphabet` and concatenate it to `alphabet[shift:]` by updating the value of `shifted_alphabet`.
 
 As a reminder, `sentence[start:stop]` returns the characters of `sentence` from position `start` (included) to `stop` (excluded).
 


### PR DESCRIPTION
…ting print, rather than creating a new one.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #64814 

<!-- Feel free to add any additional description of changes below this line -->
