### PR TITLE
fix(curriculum): A1 Spanish simplify review heading structure

### DIFF
--- a/curriculum/challenges/english/blocks/es-a1-review-first-questions/6910a23b05a7eb4386e6e730.md
+++ b/curriculum/challenges/english/blocks/es-a1-review-first-questions/6910a23b05a7eb4386e6e730.md
@@ -14,9 +14,7 @@ Congratulations! You're almost done with this module.
 
 The article below will help you review some key grammar points covered in the tasks, so you can feel confident before taking the Module Quiz.
 
-## Grammar Highlights
-
-### Talking about Origin
+## Talking about Origin
 
 To say where you are from, you should use: **`Soy` + `de` + [country]**. For example:
 
@@ -28,7 +26,7 @@ To know where someone is from, ask `¿De dónde eres?`.
 
 <br>
 
-### Talking About Nationality
+## Talking About Nationality
 
 To say your nationality, you should use: **`Soy` + [nationality]**.
 
@@ -57,7 +55,7 @@ Nationalities that end in `-e` or `-í` are usually the same for both genders. F
 
 <br>
 
-### Talking About Profession
+## Talking About Profession
 
 To say your profession, you should use: **`Soy` + [profession]**. For example:
 
@@ -69,7 +67,7 @@ Use this question to ask someone about their profession: `¿A qué te dedicas?`.
 
 <br>
 
-### Talking About Age
+## Talking About Age
 
 To say your age in Spanish, you should use: **`Tengo` + [number] + `años`**. For example:
 
@@ -81,7 +79,7 @@ You can use this question to ask someone's age: `¿Cuántos años tienes?`.
 
 <br>
 
-### Being Politely During Introductions
+## Being Politely During Introductions
 
 There are three important courtesy expressions in Spanish.
 

--- a/curriculum/challenges/english/blocks/es-a1-review-first-questions/6910a2da60b9e944f13240a0.md
+++ b/curriculum/challenges/english/blocks/es-a1-review-first-questions/6910a2da60b9e944f13240a0.md
@@ -10,11 +10,9 @@ lang: es
 
 # --description--
 
-## Glossary
-
 This Glossary is a quick reference for the most important words and phrases from the content you've worked with in this module. The words are organized by category and in alphabetical order.
 
-### Greetings and Introductions
+## Greetings and Introductions
 
 - `Buenas tardes` - Good afternoon
 
@@ -34,7 +32,7 @@ This Glossary is a quick reference for the most important words and phrases from
 
 <br>
 
-### Questions
+## Questions
 
 - `¿A qué te dedicas?` - What is your profession?
 
@@ -50,7 +48,7 @@ This Glossary is a quick reference for the most important words and phrases from
 
 <br>
 
-### People and Identity
+## People and Identity
 
 - `Eres` - You are
 
@@ -58,7 +56,7 @@ This Glossary is a quick reference for the most important words and phrases from
 
 <br>
 
-### Professions and Work
+## Professions and Work
 
 - `Analista` - Analyst
 
@@ -76,7 +74,7 @@ This Glossary is a quick reference for the most important words and phrases from
 
 <br>
 
-### Location and Origin
+## Location and Origin
 
 - `Colombia` - Colombia
 
@@ -98,7 +96,7 @@ This Glossary is a quick reference for the most important words and phrases from
 
 <br>
 
-### Numbers
+## Numbers
 
 - `Treinta` - Thirty
 

--- a/curriculum/challenges/english/blocks/es-a1-review-greetings-and-farewells/68c850ed23d494c9be5cb22a.md
+++ b/curriculum/challenges/english/blocks/es-a1-review-greetings-and-farewells/68c850ed23d494c9be5cb22a.md
@@ -16,9 +16,7 @@ The article below will help you review some key grammar points covered in the ta
 
 Once you've read it, just mark the task as complete and move on to the next part of the review.
 
-## Grammar Highlights
-
-### Subject Pronoun Omission
+## Subject Pronoun Omission
 
 In Spanish, it's common to omit the subject pronoun (like `yo`) because the verb form already tells who the subject is. For example:
 
@@ -28,7 +26,7 @@ In Spanish, it's common to omit the subject pronoun (like `yo`) because the verb
 
 <br />
 
-### Using `soy` to Talk About Identity
+## Using `soy` to Talk About Identity
 
 The verb `ser` (to be) is used to describe who you are, like your name or profession.
 
@@ -40,7 +38,7 @@ The verb `ser` (to be) is used to describe who you are, like your name or profes
 
 <br />
 
-### No Articles Before Professions
+## No Articles Before Professions
 
 In Spanish, you **don't use** an article (`un` or `una`) before a profession.
 
@@ -50,7 +48,7 @@ For example: `Soy analista`.
 
 <br />
 
-### Greeting with Time of Day
+## Greeting with Time of Day
 
 Spanish greetings change depending on the time of day. For example:
 
@@ -64,7 +62,7 @@ Spanish greetings change depending on the time of day. For example:
 
 <br />
 
-### Combined Farewells
+## Combined Farewells
 
 In Spanish, farewells don’t always have to be combined, but it's common to see them used together. For example:
 
@@ -74,7 +72,7 @@ In Spanish, farewells don’t always have to be combined, but it's common to see
 
 <br />
 
-### Accents Marks and Pronunciation
+## Accents Marks and Pronunciation
 
 Accent marks in Spanish show where to put the stress and sometimes change the meaning of a word. These are some examples from this lesson:
 
@@ -84,7 +82,7 @@ Accent marks in Spanish show where to put the stress and sometimes change the me
 
 <br />
 
-### Special Letters in Spanish
+## Special Letters in Spanish
 
 `Ñ` is a separate letter in the Spanish alphabet. Its lowercase version is `ñ`. For example: 
 

--- a/curriculum/challenges/english/blocks/es-a1-review-introducing-yourself/68dc753010b6b271ac564e93.md
+++ b/curriculum/challenges/english/blocks/es-a1-review-introducing-yourself/68dc753010b6b271ac564e93.md
@@ -10,9 +10,7 @@ lang: es
 
 # --description--
 
-## Grammar Highlights
-
-### Conjugation of the Verb `tener` in Present Indicative Tense
+## Conjugation of the Verb `tener` in Present Indicative Tense
 
 The verb `tener` (to have) is commonly used to talk about age in Spanish.
 
@@ -33,7 +31,7 @@ For example:
 
 <br>
 
-### Nationalities and Gender Agreement
+## Nationalities and Gender Agreement
 
 In Spanish, nationalities must agree in gender with the person they're describing:
 
@@ -50,7 +48,7 @@ Examples:
 
 <br>
 
-### Greetings by Time of Day
+## Greetings by Time of Day
 
 Spanish greetings change depending on the time of day:
 
@@ -64,7 +62,7 @@ These are polite and time-sensitive ways to start a conversation.
 
 ---
 
-### Farewells
+## Farewells
 
 Here are some common ways to say goodbye in Spanish:
 

--- a/curriculum/challenges/english/blocks/es-a1-review-introducing-yourself/691e2de9727ca24425272790.md
+++ b/curriculum/challenges/english/blocks/es-a1-review-introducing-yourself/691e2de9727ca24425272790.md
@@ -10,9 +10,7 @@ lang: es
 
 # --description--
 
-## Glossary
-
-Review this glossary as a quick reference of the most important words and phrases in the content you've worked with in this module. 
+Review this glossary as a quick reference of the most important words and phrases in the content you've worked with in this module.
 
 The words are organized by category and in alphabetical order.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #64720

<!-- Feel free to add any additional description of changes below this line -->

This PR flattens the heading structure of the review section of the "Greetings and Farewells", "First Questions", and "Introducing Yourself" blocks of the A1 Professional Spanish curriculum by removing the section heading.