### PR TITLE
fix(curriculum): modify the grammar of a question's choice in the updated python curriculum

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-loops-and-sequences/6839e4b003571c149bcda122.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-loops-and-sequences/6839e4b003571c149bcda122.md
@@ -141,7 +141,7 @@ Review the beginning of the lesson for the answer.
 
 ---
 
-It is used to track of the index for an iterable and return an `enumerate` object.
+It is used to keep track of the index of an iterable and return an `enumerate` object.
 
 ---
 


### PR DESCRIPTION
I have modified the text of one of the questions choices in lecture "lecture-working-with-loops-and-sequences" specifically the lesson "What Are the Enumerate and Zip Functions and How Do They Work?" as the grammar of the sentence needed some modification to make the sentence clearer.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.
