### PR TITLE
fix(curriculum): clarify email confirmation message

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-email-simulator/685d53b5e4f5784562a12d1b.md
+++ b/curriculum/challenges/english/blocks/workshop-email-simulator/685d53b5e4f5784562a12d1b.md
@@ -9,7 +9,7 @@ dashedName: step-45
 
 Users should get confirmation when they successfully send an email. Let's improve the user experience by adding feedback to the `send_email` method.
 
-In the `send_email` method of the `User` class, add a print statement after the email is sent that shows confirmation. The message should include both the sender's name and the receiver's name in this format: `Email sent from [sender_name] to [receiver_name]!\n`
+The message should be `Email sent from [sender_name] to [receiver_name]!\n`, where `[sender_name]` is replaced by the sender's name and `[receiver_name]` is replaced by the receiver's name.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/workshop-email-simulator/685d53b5e4f5784562a12d1b.md
+++ b/curriculum/challenges/english/blocks/workshop-email-simulator/685d53b5e4f5784562a12d1b.md
@@ -9,7 +9,7 @@ dashedName: step-45
 
 Users should get confirmation when they successfully send an email. Let's improve the user experience by adding feedback to the `send_email` method.
 
-The message should be `Email sent from [sender_name] to [receiver_name]!\n`, where `[sender_name]` is replaced by the sender's name and `[receiver_name]` is replaced by the receiver's name.
+In the `send_email` method of the `User` class, add a `print` statement after the email is sent that shows confirmation. The message should be `Email sent from [sender_name] to [receiver_name]!\n`, where `[sender_name]` is replaced by the sender's name and `[receiver_name]` is replaced by the receiver's name.
 
 # --hints--
 


### PR DESCRIPTION
Clarifies the expected confirmation print message in step 45 of the workshop email simulator to reduce learner confusion.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #64858