### PR TITLE
fix: correct enumerate function description grammar

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-loops-and-sequences/6839e4b003571c149bcda122.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-loops-and-sequences/6839e4b003571c149bcda122.md
@@ -141,7 +141,7 @@ Review the beginning of the lesson for the answer.
 
 ---
 
-It is used to track of the index for an iterable and return an `enumerate` object.
+It is used to keep track of the index of an iterable and return an `enumerate` object.
 
 ---
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #64877

<!-- Feel free to add any additional description of changes below this line -->

## Description

Fixed grammar error in the `enumerate()` function description in the lecture challenge file.

**Changes made:**
- Changed "track of" to "keep track of" 
- Changed "for an iterable" to "of an iterable"

**File changed:**
- `curriculum/challenges/english/blocks/lecture-working-with-loops-and-sequences/6839e4b003571c149bcda122.md`

**Before:**
> It is used to track of the index for an iterable and return an `enumerate` object.

**After:**
> It is used to keep track of the index of an iterable and return an `enumerate` object.

This correction improves the clarity and grammatical correctness of the description while maintaining the same meaning.