### PR TITLE
fix(curriculum): correct enumerate description in loops lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-loops-and-sequences/6839e4b003571c149bcda122.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-loops-and-sequences/6839e4b003571c149bcda122.md
@@ -141,7 +141,7 @@ Review the beginning of the lesson for the answer.
 
 ---
 
-It is used to track of the index for an iterable and return an `enumerate` object.
+It is used to keep track of the index of an iterable and return an `enumerate` object.
 
 ---
 


### PR DESCRIPTION
This PR corrects the description of the enumerate function in the
"working with loops and sequences" lecture.

Resolves #64877
