### PR TITLE
fix(curriculum): change amd to and in task 62

### DIFF
--- a/curriculum/challenges/english/blocks/learn-how-to-express-concerns/67c7171a70134feaf2f75a55.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-express-concerns/67c7171a70134feaf2f75a55.md
@@ -52,7 +52,7 @@ How the team members will react to the deadline change.
 
 # --explanation--
 
-In this sentence, Maria uses `they` to refer to the **members of the team**. Earlier in the conversation, she mentioned `the team` amd used a singular verb when she said `I need to understand how the team feels about the new project deadline`. Now, she refers to the people individually, so she switches to `they`. Another example:
+In this sentence, Maria uses `they` to refer to the **members of the team**. Earlier in the conversation, she mentioned `the team` and used a singular verb when she said `I need to understand how the team feels about the new project deadline`. Now, she refers to the people individually, so she switches to `they`. Another example:
 
 - `The committee decides on the rules.` - Notice the usage of the verb in the singular to refer to the group as a whole. 
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the contribution guidelines.
- [x] I have read and followed the how to open a pull request guide.
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #64881

This PR fixes a typo in task 62 of the "Learn How to Express Concerns"
lesson by correcting "amd" to "and".
