### PR TITLE
fix(curriculum): correct ambiguous python list question

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-loops-and-sequences/6839e38cdf93ee5a00c79676.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-loops-and-sequences/6839e38cdf93ee5a00c79676.md
@@ -239,7 +239,7 @@ Review the last part of the lesson for the answer.
 
 ## --text--
 
-Which of the following is **NOT** a commonly used method for lists?
+Which of the following is **NOT** a method for Python lists?
 
 ## --answers--
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #64864

### Description
The original question was confusing. It asked for a "commonly used" method, but the correct answer `splice()` is not a Python method at all. 

I changed the text to **"Which of the following is NOT a method for Python lists?"** to make the question clear and accurate.