### PR TITLE
fix(curriculum): correct SQL code block language in relation databases lesson

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-relational-databases/687ea8a88c9e9419af7cd8c3.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-relational-databases/687ea8a88c9e9419af7cd8c3.md
@@ -210,7 +210,7 @@ Think about the basic actions you perform on data. Which SQL keyword corresponds
 
 Given the following query:
 
-```bash
+```sql
 SELECT price FROM products WHERE category = 'Laptops';
 ```
 


### PR DESCRIPTION
## Description
This PR corrects the language identifier for a SQL code block in the "How Do You Insert and View Data in a Table?" lesson. 

## Motivation
In the questions section, one of the SQL examples was incorrectly labeled as `bash`. This prevented proper syntax highlighting and was inconsistent with the other SQL examples in the curriculum.

## Changes
- Changed ` ```bash ` to ` ```sql ` for the query: `SELECT price FROM products WHERE category = 'Laptops';`

## Linked Issues
Closes #64893