### PR TITLE
fix(curriculum): update ambiguous distractor in responsive web design quiz

### DIFF
--- a/curriculum/challenges/english/blocks/quiz-responsive-web-design/66ed9034f45ce3ece4053ebd.md
+++ b/curriculum/challenges/english/blocks/quiz-responsive-web-design/66ed9034f45ce3ece4053ebd.md
@@ -691,7 +691,7 @@ Which of the following is a valid way to target devices with a portrait orientat
 
 ---
 
-`@media (orientation: portrait) { ... }`
+`@media (portrait: orientation) { ... }`
 
 ---
 


### PR DESCRIPTION
## Description
This PR modifies a distractor in the Responsive Web Design quiz that was technically a valid CSS statement.

## Motivation
As noted in #64862, `@media (orientation: portrait)` is a valid media query, making it a second correct answer for the question. I have updated it to `@media (portrait: orientation) { ... }` which is syntactically invalid, ensuring there is only one correct answer.

## Linked Issues
Closes #64862