### PR TITLE
fix(curriculum): update misleading python list method quiz wording

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-loops-and-sequences/6839e38cdf93ee5a00c79676.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-loops-and-sequences/6839e38cdf93ee5a00c79676.md
@@ -234,12 +234,12 @@ Review the last part of the lesson for the answer.
 Review the last part of the lesson for the answer.
 
 ## --video-solution--
-
+  
 1
 
 ## --text--
 
-Which of the following is **NOT** a commonly used method for lists?
+Which of the following is NOT a list method?
 
 ## --answers--
 
@@ -247,7 +247,7 @@ Which of the following is **NOT** a commonly used method for lists?
 
 ### --feedback--
 
-One of these methods is used in JavaScript. Not Python.
+This is a built-in method for Python lists. Review the lesson to find which one is not.
 
 ---
 
@@ -255,7 +255,7 @@ One of these methods is used in JavaScript. Not Python.
 
 ### --feedback--
 
-One of these methods is used in JavaScript. Not Python.
+This is a built-in method for Python lists. Review the lesson to find which one is not.
 
 ---
 
@@ -267,7 +267,7 @@ One of these methods is used in JavaScript. Not Python.
 
 ### --feedback--
 
-One of these methods is used in JavaScript. Not Python.
+This is a built-in method for Python lists. Review the lesson to find which one is not.
 
 ## --video-solution--
 


### PR DESCRIPTION
This PR addresses #64864.

Changes:

Updated the quiz question in the "Working with Loops and Sequences" lesson.

Changed "not a commonly used method" to "is NOT a list method" to remove ambiguity.

Updated feedback for incorrect answers to confirm they are valid Python methods.

Closes #64864
