### PR TITLE
fix(curriculum): typo in react forms, data fetching and routing review

### DIFF
--- a/curriculum/challenges/english/blocks/review-front-end-libraries/6724e2dbf723fe1c8883cc69.md
+++ b/curriculum/challenges/english/blocks/review-front-end-libraries/6724e2dbf723fe1c8883cc69.md
@@ -944,7 +944,7 @@ export default function Page() {
 
 ## State Management
 
-- **Context API**: Context refers to when a parent component makes information available to child components without needing to pass it explicitly through props. `createContext` is used to create a context object which represent the context that other components will read. The `Provider` is used to supply context values to the child components.
+- **Context API**: Context refers to when a parent component makes information available to child components without needing to pass it explicitly through props. `createContext` is used to create a context object which represents the context that other components will read. The `Provider` is used to supply context values to the child components.
 
 ```js
 import { useState, createContext } from "react";

--- a/curriculum/challenges/english/blocks/review-react-forms-data-fetching-and-routing/67c9e932c6c4234532d46394.md
+++ b/curriculum/challenges/english/blocks/review-react-forms-data-fetching-and-routing/67c9e932c6c4234532d46394.md
@@ -458,7 +458,7 @@ export default function Page() {
 
 ## State Management
 
-- **Context API**: Context refers to when a parent component makes information available to child components without needing to pass it explicitly through props. `createContext` is used to create a context object which represent the context that other components will read. The `Provider` is used to supply context values to the child components.
+- **Context API**: Context refers to when a parent component makes information available to child components without needing to pass it explicitly through props. `createContext` is used to create a context object which represents the context that other components will read. The `Provider` is used to supply context values to the child components.
 
 ```jsx
 import { useState, createContext } from "react";


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->

Affected pages : https://www.freecodecamp.org/learn/front-end-development-libraries-v9/review-react-forms-data-fetching-and-routing/review-react-forms-data-fetching-and-routing#:~:text=startTransition

Also I made the same change on the review for the Front End Development Libraries certificate. But this webpage does not seem to be available at the moment since the curriculum is still a work in progress. So I was not able to include a link here. 
