### PR TITLE
fix(curriculum): clarify absolute path vs url definition

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-links/671682dd88e461a8e2620f38.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-links/671682dd88e461a8e2620f38.md
@@ -56,7 +56,7 @@ So imagine you are on the `contact.html` page, and because the `about.html` page
 
 So, which should you use and when; an absolute path or a relative path? Here are the rules you should follow:
 
-- Use absolute paths when linking to a resource hosted on an external website.
+- Use absolute URLs when linking to a resource hosted on an external website.
 
 - Use absolute paths when you need the link to a page or resource to work consistently regardless of the document location within the site.
 
@@ -110,7 +110,7 @@ How do you link to a resource available only on the internet?
 
 ## --answers--
 
-Absolute path.
+Absolute URL.
 
 ---
 

--- a/curriculum/challenges/english/blocks/review-basic-html/67072fc183c7ca6c588feb4d.md
+++ b/curriculum/challenges/english/blocks/review-basic-html/67072fc183c7ca6c588feb4d.md
@@ -441,7 +441,7 @@ public/index.html
 ../src/index.css
 ```
 
-- **Absolute Path**: An absolute path is a complete link to a resource. It starts from the root directory, includes every other directory, and finally the filename and extension. The "root directory" refers to the top-level directory or folder in a hierarchy. An absolute path also includes the protocol - which could be `http`, `https`, and `file` and the domain name if the resource is on the web. Here's an example of an absolute path that links to the freeCodeCamp logo:
+- **Absolute Path vs. Absolute URL**: An absolute path is the full file system path to a resource, starting from the root directory and including every subdirectory and the filename. The "root directory" refers to the top-level directory or folder in a hierarchy. An absolute URL is a complete web address that includes the protocol (such as `http`, `https`, or `file`) and the domain name. Here's an example of an absolute URL that links to the freeCodeCamp logo:
 
 ```html
 <a href="https://design-style-guide.freecodecamp.org/img/fcc_secondary_small.svg">


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #64885

## Description
This PR corrects a terminology error where "Absolute Path" was defined including a protocol and domain. This actually describes an **Absolute URL**.

**Changes:**
1. Updated definitions in both the Link Lecture and Basic HTML Review blocks to distinguish between Absolute URLs and Absolute Paths.
2. Updated the "Rules" list to correctly use "Absolute URL" for external resources.
3. Updated quiz questions and answers in the Markdown files to ensure they test for the correct terminology.
