### PR TITLE
fix(curriculum): correct validation example in encapsulation lesson

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-understanding-object-oriented-programming-and-encapsulation/68420be9af9d89620af7944a.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-object-oriented-programming-and-encapsulation/68420be9af9d89620af7944a.md
@@ -144,11 +144,11 @@ class Wallet:
        return self.__balance
 
 acct_one = Wallet()
-acct_one.deposit(4) # ValueError('Amount must be positive')
-print(acct_one.get_balance()) # 0
+acct_one.deposit(3)
+print(acct_one.get_balance()) # 3
 
 acct_one.deposit(50)
-print(acct_one.get_balance()) # 50
+print(acct_one.get_balance()) # 53
 acct_one.withdraw(-8) # ValueError('Amount must be positive')
 acct_one.withdraw(58) # ValueError('Insufficient funds')
 ```

--- a/curriculum/challenges/english/blocks/lecture-understanding-object-oriented-programming-and-encapsulation/68420be9af9d89620af7944a.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-object-oriented-programming-and-encapsulation/68420be9af9d89620af7944a.md
@@ -146,10 +146,11 @@ class Wallet:
 acct_one = Wallet()
 acct_one.deposit(3)
 print(acct_one.get_balance()) # 3
-acct_one.deposit(-4) # ValueError: Amount must be positive
 
 acct_one.deposit(50)
 print(acct_one.get_balance()) # 53
+
+acct_one.deposit(-4)  # ValueError: Amount must be positive
 acct_one.withdraw(-8) # ValueError: Amount must be positive
 acct_one.withdraw(58) # ValueError: Insufficient funds
 ```

--- a/curriculum/challenges/english/blocks/lecture-understanding-object-oriented-programming-and-encapsulation/68420be9af9d89620af7944a.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-object-oriented-programming-and-encapsulation/68420be9af9d89620af7944a.md
@@ -146,11 +146,12 @@ class Wallet:
 acct_one = Wallet()
 acct_one.deposit(3)
 print(acct_one.get_balance()) # 3
+acct_one.deposit(-4) # ValueError('Amount must be positive')
 
 acct_one.deposit(50)
 print(acct_one.get_balance()) # 53
-acct_one.withdraw(-8) # ValueError('Amount must be positive')
-acct_one.withdraw(58) # ValueError('Insufficient funds')
+acct_one.withdraw(-8) # ValueError: Amount must be positive
+acct_one.withdraw(58) # ValueError: Insufficient funds
 ```
 
 As you can see, the `__validate` method is private, and runs behind the scenes in the `deposit()` and `withdraw()` public methods to make sure the amount is always valid.

--- a/curriculum/challenges/english/blocks/lecture-understanding-object-oriented-programming-and-encapsulation/68420be9af9d89620af7944a.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-object-oriented-programming-and-encapsulation/68420be9af9d89620af7944a.md
@@ -146,7 +146,7 @@ class Wallet:
 acct_one = Wallet()
 acct_one.deposit(3)
 print(acct_one.get_balance()) # 3
-acct_one.deposit(-4) # ValueError('Amount must be positive')
+acct_one.deposit(-4) # ValueError: Amount must be positive
 
 acct_one.deposit(50)
 print(acct_one.get_balance()) # 53


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #64905

This PR fixes an incorrect example in the Python OOP encapsulation lesson.

- Corrected the deposit example to reflect actual validation behavior
- Ensured ValueError is only raised for negative amounts
- Updated outputs to match real execution
- Content-only change, no logic modifications
