### PR TITLE
fix(curriculum): update regex terminology from modifier to quantifier    

### DIFF
--- a/curriculum/challenges/english/blocks/learn-form-validation-by-building-a-calorie-counter/63bf5adfe2981b332eb007b6.md
+++ b/curriculum/challenges/english/blocks/learn-form-validation-by-building-a-calorie-counter/63bf5adfe2981b332eb007b6.md
@@ -7,7 +7,7 @@ dashedName: step-32
 
 # --description--
 
-The `+` modifier in a regex allows you to match a pattern that occurs one or more times. To match your digit pattern one or more times, add a plus after each of the digit character classes. For example: `[0-9]+`.
+The `+` quantifier in a regex allows you to match a pattern that occurs one or more times. To match your digit pattern one or more times, add a plus after each of the digit character classes. For example: `[0-9]+`.
 
 # --hints--
 


### PR DESCRIPTION
### Checklist:
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #64910

### Description of changes:
This PR updates the terminology in Step 32 of the Calorie Counter project, changing "+ modifier" to the technically correct "+ quantifier" as discussed in the linked issue.  
