### PR TITLE
fix: issue with getStyleAny - enforce strict selectors in Book Inventory Lab

### DIFF
--- a/curriculum/challenges/english/blocks/lab-book-inventory-app/66a207974c806a19d6607073.md
+++ b/curriculum/challenges/english/blocks/lab-book-inventory-app/66a207974c806a19d6607073.md
@@ -367,134 +367,31 @@ You should use an attribute selector to target the `span` elements which are dir
 assert.isNotEmpty(new __helpers.CSSHelp(document).getStyle('span[class^="rate"] > span')?.getPropVal('background-color'));
 ```
 
-You should have an attribute selector to target the first descendant of `span` elements that have the word `one` as a part of their `class` value.
-
-```js
-const selectors = [
-  'span[class~="one"] :first-child',
-  'span[class~="one"] :nth-child(1)',
-  'span[class~="one"] :first-of-type',
-  'span[class~="one"] span:first-child',
-  'span[class~="one"] span:nth-child(1)',
-  'span[class~="one"] span:first-of-type',
-  'span[class~="one"] > :first-child',
-  'span[class~="one"] > :nth-child(1)',
-  'span[class~="one"] > :first-of-type',
-  'span[class~="one"] > span:first-child',
-  'span[class~="one"] > span:nth-child(1)',
-  'span[class~="one"] > span:first-of-type'
-]
-assert.isNotNull(new __helpers.CSSHelp(document).getStyleAny(selectors));
-```
-
 You should use an attribute selector to target the first descendant of `span` elements that have the word `one` as a part of their `class` value and set its `background-image` property to use a `linear-gradient`.
 
 ```js
-const selectors = [
-  'span[class~="one"] :first-child',
-  'span[class~="one"] :nth-child(1)',
-  'span[class~="one"] :first-of-type',
-  'span[class~="one"] span:first-child',
-  'span[class~="one"] span:nth-child(1)',
-  'span[class~="one"] span:first-of-type',
-  'span[class~="one"] > :first-child',
-  'span[class~="one"] > :nth-child(1)',
-  'span[class~="one"] > :first-of-type',
-  'span[class~="one"] > span:first-child',
-  'span[class~="one"] > span:nth-child(1)',
-  'span[class~="one"] > span:first-of-type'
-]
-assert.isTrue(new __helpers.CSSHelp(document).getStyleAny(selectors)?.getPropVal('background-image').includes('linear-gradient('));
-```
-
-You should have an attribute selector to target the first two descendants of `span` elements that have the word `two` as a part of their `class` value.
-
-```js
-
-const selectors = [
-  'span[class~="two"] :nth-child(1), span[class~="two"] :nth-child(2)',
-  'span[class~="two"] :nth-child(2), span[class~="two"] :nth-child(1)',
-  'span[class~="two"] :first-child, span[class~="two"] :nth-child(2)',
-  'span[class~="two"] :nth-child(2), span[class~="two"] :first-child',
-  'span[class~="two"] :nth-of-type(-n+2)',
-  'span[class~="two"] :nth-child(-n+2)',
-  'span[class~="two"] span:nth-child(1), span[class~="two"] span:nth-child(2)',
-  'span[class~="two"] span:nth-child(2), span[class~="two"] span:nth-child(1)',
-  'span[class~="two"] span:first-child, span[class~="two"] span:nth-child(2)',
-  'span[class~="two"] span:nth-child(2), span[class~="two"] span:first-child',
-  'span[class~="two"] span:nth-of-type(-n+2)',
-  'span[class~="two"] span:nth-child(-n+2)',
-  'span[class~="two"] > :nth-child(1), span[class~="two"] > :nth-child(2)',
-  'span[class~="two"] > :nth-child(2), span[class~="two"] > :nth-child(1)',
-  'span[class~="two"] > :first-child, span[class~="two"] > :nth-child(2)',
-  'span[class~="two"] > :nth-child(2), span[class~="two"] > :first-child',
-  'span[class~="two"] > :nth-of-type(-n+2)',
-  'span[class~="two"] > :first-child, span[class~="two"] > :nth-of-type(2)',
-  'span[class~="two"] > :nth-of-type(2), span[class~="two"] > :first-child',
-  'span[class~="two"] > :nth-child(-n+2)',
-  'span[class~="two"] > span:nth-child(1), span[class~="two"] > span:nth-child(2)',
-  'span[class~="two"] > span:nth-child(2), span[class~="two"] > span:nth-child(1)',
-  'span[class~="two"] > span:first-child, span[class~="two"] > span:nth-child(2)',
-  'span[class~="two"] > span:nth-child(2), span[class~="two"] > span:first-child',
-  'span[class~="two"] > span:nth-of-type(-n+2)',
-  'span[class~="two"] > span:nth-child(-n+2)'
-  ]
-assert.isNotNull(new __helpers.CSSHelp(document).getStyleAny(selectors));
+const style = new __helpers.CSSHelp(document).getStyle('span[class~="one"] span:first-of-type');
+assert.exists(style);
+assert.include(style.backgroundImage, 'linear-gradient(');
+assert.match(code, /span\[class~=('|")one\1\]\s+span:first-of-type/);
 ```
 
 You should use an attribute selector to target the first two descendants of `span` elements that have the word `two` as a part of their `class` value and set their `background-image` property to use a `linear-gradient`.
 
 ```js
-const selectors = [
-  'span[class~="two"] :nth-child(1), span[class~="two"] :nth-child(2)',
-  'span[class~="two"] :nth-child(2), span[class~="two"] :nth-child(1)',
-  'span[class~="two"] :first-child, span[class~="two"] :nth-child(2)',
-  'span[class~="two"] :nth-child(2), span[class~="two"] :first-child',
-  'span[class~="two"] :nth-of-type(-n+2)',
-  'span[class~="two"] :nth-child(-n+2)',
-  'span[class~="two"] span:nth-child(1), span[class~="two"] span:nth-child(2)',
-  'span[class~="two"] span:nth-child(2), span[class~="two"] span:nth-child(1)',
-  'span[class~="two"] span:first-child, span[class~="two"] span:nth-child(2)',
-  'span[class~="two"] span:nth-child(2), span[class~="two"] span:first-child',
-  'span[class~="two"] span:nth-of-type(-n+2)',
-  'span[class~="two"] span:nth-child(-n+2)',
-  'span[class~="two"] > :nth-child(1), span[class~="two"] > :nth-child(2)',
-  'span[class~="two"] > :nth-child(2), span[class~="two"] > :nth-child(1)',
-  'span[class~="two"] > :first-child, span[class~="two"] > :nth-child(2)',
-  'span[class~="two"] > :nth-child(2), span[class~="two"] > :first-child',
-  'span[class~="two"] > :first-child, span[class~="two"] > :nth-of-type(2)',
-  'span[class~="two"] > :nth-of-type(2), span[class~="two"] > :first-child',
-  'span[class~="two"] > :nth-of-type(-n+2)',
-  'span[class~="two"] > :nth-child(-n+2)',
-  'span[class~="two"] > span:nth-child(1), span[class~="two"] > span:nth-child(2)',
-  'span[class~="two"] > span:nth-child(2), span[class~="two"] > span:nth-child(1)',
-  'span[class~="two"] > span:first-child, span[class~="two"] > span:nth-child(2)',
-  'span[class~="two"] > span:nth-child(2), span[class~="two"] > span:first-child',
-  'span[class~="two"] > span:nth-of-type(-n+2)',
-  'span[class~="two"] > span:nth-child(-n+2)'
-  ]
-
-assert.isTrue(new __helpers.CSSHelp(document).getStyleAny(selectors)?.backgroundImage.includes('linear-gradient(')) 
-```
-
-You should have an attribute selector to target the `span` elements that are descendants of `span` elements that have the word `three` as a part of their `class` value.
-
-```js
-const selectors = [
-  'span[class~="three"] span',
-  'span[class~="three"] > span'
-]
-assert.exists(new __helpers.CSSHelp(document).getStyleAny(selectors));
+const style = new __helpers.CSSHelp(document).getStyle('span[class~="two"] span:nth-of-type(-n + 2)');
+assert.exists(style);
+assert.include(style.backgroundImage, 'linear-gradient(');
+assert.match(code, /span\[class~=('|")two\1\]\s+span:nth-of-type\(\s*-n\s*\+\s*2\s*\)/);
 ```
 
 You should use an attribute selector to target the `span` elements that are descendants of `span` elements that have the word `three` as a part of their `class` value and set their `background-image` property to use a `linear-gradient`.
 
 ```js
-const selectors = [
-  'span[class~="three"] span',
-  'span[class~="three"] > span'
-]
-assert.include(new __helpers.CSSHelp(document).getStyleAny(selectors)?.getPropVal('background-image'), 'linear-gradient(');
+const style = new __helpers.CSSHelp(document).getStyle('span[class~="three"] span');
+assert.exists(style);
+assert.include(style.backgroundImage, 'linear-gradient(');
+assert.match(code, /span\[class~=('|")three\1\]\s+span/);
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #64218 

## Issue:
- The tests for the "Build a Book Inventory App" lab were too lenient. They allowed the use of the universal selector * (e.g., span[class~="one"] *:first-of-type) where specific span selectors were expected. This permitted solutions that did not strictly follow the instructions or best practices regarding specificity.

## Solution: 
- Updated the tests for the one, two, and three class selectors to enforce strict selector matching:

- Replaced getStyleAny with getStyle to target a specific expected selector.
- Added assert.match with a regular expression to verify that the user's code explicitly uses span in the selector (e.g., span[class~="one"] span:first-of-type).
- Consolidated redundant existence checks into the property checks for cleaner testing logic.

This solution resolves getStyleAny issue. 
it is tested locally and works perfectly fine.
Please, i request the maintainer to review it and suggest changes if any, and if everything seems good, hopes this PR gets merged!

