### PR TITLE
fix(curriculum): explain props.children

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-data-in-react/6734e3ceee2da4b0301719b7.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-data-in-react/6734e3ceee2da4b0301719b7.md
@@ -77,6 +77,34 @@ function Greeting({ name }) {
 
 This code achieves the same result but makes it clearer which props the component is expecting to receive.
 
+React also provides a special prop called `children`. Any JSX you place between a component's opening and closing tags is passed to the component as `children`.
+
+For example:
+
+```jsx
+function Card({ children }) {
+  return <div className="card">{children}</div>;
+}
+
+function App() {
+  return (
+    <Card>
+      <h2>Hello</h2>
+    </Card>
+  );
+}
+```
+
+In this case, the JSX inside `<Card>...</Card>` becomes the `children` prop. The rendered output in the DOM will be:
+
+```html
+<div class="card">
+  <h2>Hello</h2>
+</div>
+```
+
+This pattern is often used for component composition, where a component wraps other UI elements.
+
 Sometimes, you can have a lot of properties that you have to pass as props. Instead of passing them one by one, you can use the spread operator (`...`), after converting them to an object. 
 
 Here is an example of a new child component called `DeveloperCard`:
@@ -228,3 +256,5 @@ Remember the special syntax used to spread object properties as individual props
 ## --video-solution--
 
 2
+
+

--- a/curriculum/challenges/english/blocks/lecture-working-with-data-in-react/6734e3ceee2da4b0301719b7.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-data-in-react/6734e3ceee2da4b0301719b7.md
@@ -256,5 +256,3 @@ Remember the special syntax used to spread object properties as individual props
 ## --video-solution--
 
 2
-
-


### PR DESCRIPTION
## Description
Added explanation of the `children` prop to the React props lesson to help learners.

## Changes
- Added a new section explaining the special `children` prop in React
- Included a practical code example showing how to use `children` for wrapping UI elements
- Demonstrated the rendered output to clarify how the pattern works

## Motivation and Context
The lesson covered props well but didn't explain the `children` prop, which is a fundamental React pattern for component composition. This addition addresses issue #64645 by providing learners with information about the `children` prop.

## How Has This Been Tested?
- Tested locally by running `pnpm run develop` at `http://localhost:8000`
- Verified the markdown renders correctly
- Confirmed code examples display properly
- Checked that the new content flows naturally with existing lesson material

## Screenshots:
<img width="1083" height="679" alt="Screenshot 2025-12-27 at 9 19 23 PM" src="https://github.com/user-attachments/assets/8d534f52-eda4-4a39-bc3b-d75b59f55105" />
<img width="1093" height="693" alt="Screenshot 2025-12-27 at 9 19 46 PM" src="https://github.com/user-attachments/assets/d1d1fcff-4961-4182-9b8e-b88642f01608" />


Checklist:
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #64645