### PR TITLE
fix(curriculum): explain props.children with example

### DIFF
--- a/curriculum/challenges/english/blocks/react/5a24c314108439a4d403616f.md
+++ b/curriculum/challenges/english/blocks/react/5a24c314108439a4d403616f.md
@@ -14,6 +14,21 @@ A *stateless functional component* is any function you write which accepts props
 
 A common pattern is to try to minimize statefulness and to create stateless functional components wherever possible. This helps contain your state management to a specific area of your application. In turn, this improves development and maintenance of your app by making it easier to follow how changes to state affect its behavior.
 
+In React, components can also receive content nested between their opening and closing tags. This content is passed to the component as a special prop called `children`. Accessing `props.children` allows a component to render or work with whatever elements are placed inside it by its parent.
+
+For example, a component can render any elements passed between its tags using `props.children`:
+
+```jsx
+const Card = (props) => {
+  return <div>{props.children}</div>;
+};
+
+<Card>
+  <h2>Hello!</h2>
+</Card>
+
+
+
 # --instructions--
 
 The code editor has a `CampSite` component that renders a `Camper` component as a child. Define the `Camper` component and assign it default props of `{ name: 'CamperBot' }`. Inside the `Camper` component, render any code that you want, but make sure to have one `p` element that includes only the `name` value that is passed in as a `prop`. Finally, define `propTypes` on the `Camper` component to require `name` to be provided as a prop and verify that it is of type `string`.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #64645 

<!-- Feel free to add any additional description of changes below this line -->

This PR adds a short explanation and a simple JSX example for the special
React prop `children` in the "Review Using Props with Stateless Functional Components"
lesson to improve clarity for beginners.

