### PR TITLE
fix(curriculum): correct numbers in selection sort example

### DIFF
--- a/curriculum/challenges/english/blocks/lab-selection-sort/680b3ef395479b0e449ecb6e.md
+++ b/curriculum/challenges/english/blocks/lab-selection-sort/680b3ef395479b0e449ecb6e.md
@@ -168,7 +168,7 @@ Your `selection_sort` should follow the selection sort algorithm, swapping the m
 )
 ```
 
-`selection_sort([33, 1, 89, 2, 67, 245])` should return `[1, 2, 33, 89, 67, 245]`.
+`selection_sort([33, 1, 89, 2, 67, 245])` should return `[1, 2, 33, 67, 89, 245]`.
 
 ```js
 (


### PR DESCRIPTION
## Checklist:
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

## Description:
Fixed transposed numbers in the [selection sort](https://www.freecodecamp.org/learn/python-v9/lab-selection-sort/implement-selection-sort-algorithm) example. The expected output for `selection_sort([33, 1, 89, 2, 67, 245])` incorrectly showed `[1, 2, 33, 89, 67, 245]` with 89 and 67 swapped. Corrected it to `[1, 2, 33, 67, 89, 245]`.