### PR TITLE
Fix incorrect test for Screaming Snake Case challenge

### DIFF
--- a/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/69272dcf1c24b44fd79137c3.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/69272dcf1c24b44fd79137c3.md
@@ -41,6 +41,8 @@ assert.equal(toScreamingSnakeCase("UserPassword"), "USER_PASSWORD");
 
 ```js
 assert.equal(toScreamingSnakeCase("userEmail"), "USER_EMAIL");
+assert.equal(toScreamingSnakeCase("user_id"), "USER_ID");
+
 ```
 
 `toScreamingSnakeCase("user-address")` should return `"USER_ADDRESS"`.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->



<!-- Feel free to add any additional description of changes below this line -->
The Screaming Snake Case challenge test was asserting a camelCase input while describing a snake_case example.

This PR updates the assertion to correctly test "user_id" → "USER_ID", preventing incorrect implementations from passing.

Closes #64924

