### PR TITLE
fix: update shopping list step 6 instructions (issue #64923)

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-shopping-list/66cbe2319d3845545a293a0b.md
+++ b/curriculum/challenges/english/blocks/workshop-shopping-list/66cbe2319d3845545a293a0b.md
@@ -9,7 +9,7 @@ dashedName: step-6
 
 Now it is time to see the message logged to the console.
 
-Add a `console.log` and call the `getShoppingListMsg` function inside of the `console.log` to see the message logged to the console.
+Add a `console.log` and call the `getShoppingListMsg` function with the `shoppingList` variable as an argument inside of the `console.log` to see the message logged to the console.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:
[x]I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org/).

[x]I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).

[x] My pull request targets the main branch of freeCodeCamp.

[x] I have tested these changes either locally on my machine, or GitHub Codespaces.
Closes #64923
Description
Clarifies Step 6 of the Build a Shopping List workshop by explicitly instructing learners to pass the shoppingList variable as an argument to getShoppingListMsg when logging the result.

Verification
Verified the updated markdown content.
No tests were run since this is a documentation-only change.
