### PR TITLE
fix(curriculum): correct test for SCREAMING_SNAKE_CASE challenge

### DIFF
--- a/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/69272dcf1c24b44fd79137c3.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/69272dcf1c24b44fd79137c3.md
@@ -28,7 +28,7 @@ To convert to SCREAMING_SNAKE_CASE:
 `toScreamingSnakeCase("userEmail")` should return `"USER_EMAIL"`.
 
 ```js
-assert.equal(toScreamingSnakeCase("userEmail"), "USER_EMAIL");
+assert.equal(toScreamingSnakeCase("user_id"), "USER_ID");
 ```
 
 `toScreamingSnakeCase("UserPassword")` should return `"USER_PASSWORD"`.

--- a/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/69272dcf1c24b44fd79137c3.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/69272dcf1c24b44fd79137c3.md
@@ -28,7 +28,7 @@ To convert to SCREAMING_SNAKE_CASE:
 `toScreamingSnakeCase("userEmail")` should return `"USER_EMAIL"`.
 
 ```js
-assert.equal(toScreamingSnakeCase("user_id"), "USER_ID");
+assert.equal(toScreamingSnakeCase("userEmail"), "USER_EMAIL");
 ```
 
 `toScreamingSnakeCase("UserPassword")` should return `"USER_PASSWORD"`.
@@ -40,7 +40,7 @@ assert.equal(toScreamingSnakeCase("UserPassword"), "USER_PASSWORD");
 `toScreamingSnakeCase("user_id")` should return `"USER_ID"`.
 
 ```js
-assert.equal(toScreamingSnakeCase("userEmail"), "USER_EMAIL");
+assert.equal(toScreamingSnakeCase("user_id"), "USER_ID");
 ```
 
 `toScreamingSnakeCase("user-address")` should return `"USER_ADDRESS"`.


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #64932

This PR fixes an incorrect test case in the SCREAMING_SNAKE_CASE daily coding challenge.

### What was happening
The hint and description for `toScreamingSnakeCase("user_id")` expect the output `"USER_ID"`, but the associated assertion was incorrectly testing `"userEmail"` instead.  
This caused the test to pass even when the underscore was missing in the returned value, resulting in a false positive.

### What this change does
- Updates the assertion to correctly test `toScreamingSnakeCase("user_id")`
- Aligns the test with the challenge description and expected behavior
- Prevents false positives in the challenge validation

### Scope
- Curriculum only
- No changes to challenge logic, seed code, or solution

