### PR TITLE
fix(curriculum): Fix incorrect test assertion in SCREAMING_SNAKE_CASE challenge

### DIFF
--- a/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/69272dcf1c24b44fd79137c3.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/69272dcf1c24b44fd79137c3.md
@@ -40,7 +40,7 @@ assert.equal(toScreamingSnakeCase("UserPassword"), "USER_PASSWORD");
 `toScreamingSnakeCase("user_id")` should return `"USER_ID"`.
 
 ```js
-assert.equal(toScreamingSnakeCase("userEmail"), "USER_EMAIL");
+assert.equal(toScreamingSnakeCase("user_id"), "USER_ID");
 ```
 
 `toScreamingSnakeCase("user-address")` should return `"USER_ADDRESS"`.


### PR DESCRIPTION
…SE challenge

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #64924 

<!-- Feel free to add any additional description of changes below this line -->

This PR fixes an incorrect test case in the SCREAMING_SNAKE_CASE challenge. 

The hint for the user_id input was asserting toScreamingSnakeCase("userEmail") instead of testing "user_id". Because of this, implementations that failed to correctly handle snake_case inputs could still pass the test suite. 

The assertion has been corrected to properly test toScreamingSnakeCase("user_id"), ensuring the challenge validates underscore-separated variable names as intended.