### PR TITLE
feat: add custom Spanish input for fill-in-the-blank tasks

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -970,7 +970,8 @@
     "not-available": "Not available",
     "interactive-editor-desc": "Turn static code examples into interactive editors. This allows you to edit and run the code directly on the page.",
     "pinyin-to-hanzi-input-desc": "This task uses Pinyin-to-Hanzi inputs. Type pinyin with tone numbers (1 to 5). When you enter a correct syllable, it will turn into a Chinese character. If you press backspace after a Chinese character, it will change back to pinyin and remove the last thing you typed: if it's a tone number, the tone is removed; if it's a letter, the letter is removed.",
-    "pinyin-tone-input-desc": "This task uses Pinyin Tone inputs. Type pinyin with tone numbers (1 to 5). When you enter a tone number, it will be converted to a tone mark. If you press backspace, the last thing you typed is removed: if it's a tone number, the tone is removed; if it's a letter, the letter is removed."
+    "pinyin-tone-input-desc": "This task uses Pinyin Tone inputs. Type pinyin with tone numbers (1 to 5). When you enter a tone number, it will be converted to a tone mark. If you press backspace, the last thing you typed is removed: if it's a tone number, the tone is removed; if it's a letter, the letter is removed.",
+    "spanish-input-desc": "This task uses Spanish inputs. Type using US International keyboard layout: type an apostrophe (') followed by a vowel (a, e, i, o, u) to create accented vowels (á, é, í, ó, ú), or type a tilde (~) followed by n to create ñ."
   },
   "flash": {
     "no-email-in-userinfo": "We could not retrieve an email from your chosen provider. Please try another provider or use the 'Continue with Email' option.",

--- a/client/src/redux/prop-types.ts
+++ b/client/src/redux/prop-types.ts
@@ -53,7 +53,7 @@ export type Question = {
 export type FillInTheBlank = {
   sentence: string;
   blanks: MultipleChoiceAnswer[];
-  inputType?: 'pinyin-tone' | 'pinyin-to-hanzi';
+  inputType?: 'pinyin-tone' | 'pinyin-to-hanzi' | 'spanish';
 };
 
 export type Fields = {

--- a/client/src/templates/Challenges/components/fill-in-the-blanks.tsx
+++ b/client/src/templates/Challenges/components/fill-in-the-blanks.tsx
@@ -8,6 +8,8 @@ import { FillInTheBlank } from '../../../redux/prop-types';
 import ChallengeHeading from './challenge-heading';
 import PinyinToHanziInput from './pinyin-to-hanzi-input';
 import PinyinToneInput from './pinyin-tone-input';
+import SpanishInput from './spanish-input';
+import { ChallengeLang } from '../../../../../shared-dist/config/curriculum';
 
 type FillInTheBlankProps = {
   fillInTheBlank: FillInTheBlank;
@@ -16,6 +18,7 @@ type FillInTheBlankProps = {
   feedback: string | null;
   showWrong: boolean;
   handleInputChange: (inputIndex: number, value: string) => void;
+  lang?: ChallengeLang;
 };
 
 const AnswerText = ({ answer }: { answer: string }) => {
@@ -42,7 +45,7 @@ type BlankInputProps = {
   className: string;
   onChange: (index: number, value: string) => void;
   ariaLabel: string;
-  inputType?: 'pinyin-to-hanzi' | 'pinyin-tone';
+  inputType?: 'pinyin-to-hanzi' | 'pinyin-tone' | 'spanish';
 };
 
 const BlankInput = ({
@@ -85,9 +88,20 @@ const BlankInput = ({
         ariaLabel={ariaLabel}
       />
     );
+  } else if (inputType === 'spanish' && typeof parsedAnswer === 'string') {
+    return (
+      <SpanishInput
+        index={blankIndex}
+        isCorrect={isCorrect}
+        onChange={onChange}
+        className={className}
+        maxLength={answerLength + 3}
+        size={answerLength}
+        ariaLabel={ariaLabel}
+      />
+    );
   }
 
-  // Default text input
   return (
     <input
       type='text'
@@ -108,7 +122,8 @@ function FillInTheBlanks({
   showFeedback,
   feedback,
   showWrong,
-  handleInputChange
+  handleInputChange,
+  lang
 }: FillInTheBlankProps): JSX.Element {
   const { t } = useTranslation();
 
@@ -125,12 +140,17 @@ function FillInTheBlanks({
   const paragraphs = parseBlanks(sentence);
   const blankAnswers = blanks.map(b => b.answer);
 
+  const effectiveInputType =
+    inputType || (lang === ChallengeLang.Spanish ? 'spanish' : undefined);
+
   const ariaInputDescription =
-    inputType === 'pinyin-to-hanzi'
+    effectiveInputType === 'pinyin-to-hanzi'
       ? t('aria.pinyin-to-hanzi-input-desc')
-      : inputType === 'pinyin-tone'
+      : effectiveInputType === 'pinyin-tone'
         ? t('aria.pinyin-tone-input-desc')
-        : '';
+        : effectiveInputType === 'spanish'
+          ? t('aria.spanish-input-desc')
+          : '';
 
   return (
     <>
@@ -175,7 +195,7 @@ function FillInTheBlanks({
                   className={getInputClass(value)}
                   onChange={handleInputChange}
                   ariaLabel={t('learn.fill-in-the-blank.blank')}
-                  inputType={inputType}
+                  inputType={effectiveInputType}
                 />
               );
             })}

--- a/client/src/templates/Challenges/components/spanish-input.tsx
+++ b/client/src/templates/Challenges/components/spanish-input.tsx
@@ -1,0 +1,242 @@
+import React, { useState } from 'react';
+
+export function convertToSpanishWithAccents(raw: string): string {
+  if (!raw) return raw;
+
+  let result = '';
+  let i = 0;
+
+  while (i < raw.length) {
+    const char = raw[i];
+
+    if (char === "'" && i + 1 < raw.length) {
+      const nextChar = raw[i + 1].toLowerCase();
+      if (nextChar === 'a') {
+        result += 'á';
+        i += 2;
+        continue;
+      } else if (nextChar === 'e') {
+        result += 'é';
+        i += 2;
+        continue;
+      } else if (nextChar === 'i') {
+        result += 'í';
+        i += 2;
+        continue;
+      } else if (nextChar === 'o') {
+        result += 'ó';
+        i += 2;
+        continue;
+      } else if (nextChar === 'u') {
+        result += 'ú';
+        i += 2;
+        continue;
+      }
+      result += "'";
+      i++;
+    } else if (char === '~' && i + 1 < raw.length) {
+      const nextChar = raw[i + 1].toLowerCase();
+      if (nextChar === 'n') {
+        result += 'ñ';
+        i += 2;
+        continue;
+      } else if (nextChar === 'a') {
+        result += 'ã';
+        i += 2;
+        continue;
+      } else if (nextChar === 'o') {
+        result += 'õ';
+        i += 2;
+        continue;
+      }
+      result += '~';
+      i++;
+    } else if (char === '`' && i + 1 < raw.length) {
+      const nextChar = raw[i + 1].toLowerCase();
+      if (nextChar === 'a') {
+        result += 'à';
+        i += 2;
+        continue;
+      } else if (nextChar === 'e') {
+        result += 'è';
+        i += 2;
+        continue;
+      } else if (nextChar === 'i') {
+        result += 'ì';
+        i += 2;
+        continue;
+      } else if (nextChar === 'o') {
+        result += 'ò';
+        i += 2;
+        continue;
+      } else if (nextChar === 'u') {
+        result += 'ù';
+        i += 2;
+        continue;
+      }
+      result += '`';
+      i++;
+    } else if (char === '"' && i + 1 < raw.length) {
+      const nextChar = raw[i + 1].toLowerCase();
+      if (nextChar === 'a') {
+        result += 'ä';
+        i += 2;
+        continue;
+      } else if (nextChar === 'e') {
+        result += 'ë';
+        i += 2;
+        continue;
+      } else if (nextChar === 'i') {
+        result += 'ï';
+        i += 2;
+        continue;
+      } else if (nextChar === 'o') {
+        result += 'ö';
+        i += 2;
+        continue;
+      } else if (nextChar === 'u') {
+        result += 'ü';
+        i += 2;
+        continue;
+      }
+      result += '"';
+      i++;
+    } else if (char === '^' && i + 1 < raw.length) {
+      const nextChar = raw[i + 1].toLowerCase();
+      if (nextChar === 'a') {
+        result += 'â';
+        i += 2;
+        continue;
+      } else if (nextChar === 'e') {
+        result += 'ê';
+        i += 2;
+        continue;
+      } else if (nextChar === 'i') {
+        result += 'î';
+        i += 2;
+        continue;
+      } else if (nextChar === 'o') {
+        result += 'ô';
+        i += 2;
+        continue;
+      } else if (nextChar === 'u') {
+        result += 'û';
+        i += 2;
+        continue;
+      }
+      result += '^';
+      i++;
+    } else {
+      result += char;
+      i++;
+    }
+  }
+
+  return result;
+}
+
+interface SpanishInputProps {
+  index: number;
+  isCorrect: boolean | null;
+  onChange: (index: number, value: string) => void;
+  className?: string;
+  maxLength: number;
+  size: number;
+  ariaLabel: string;
+}
+
+function SpanishInput({
+  index,
+  isCorrect,
+  onChange,
+  className,
+  maxLength,
+  size,
+  ariaLabel
+}: SpanishInputProps): JSX.Element {
+  const [rawInput, setRawInput] = useState('');
+  const [displayValue, setDisplayValue] = useState('');
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const inputValue = e.target.value;
+    const prevDisplayLength = displayValue.length;
+    const inputLength = inputValue.length;
+
+    const isAppendingAtEnd =
+      inputLength > prevDisplayLength &&
+      inputValue.startsWith(displayValue);
+    const isDeletingFromEnd =
+      inputLength < prevDisplayLength && displayValue.startsWith(inputValue);
+
+    let newRawInput: string;
+
+    if (isAppendingAtEnd) {
+      const added = inputValue.substring(prevDisplayLength);
+
+      const accentedToSequence: Record<string, string> = {
+        á: "'a",
+        é: "'e",
+        í: "'i",
+        ó: "'o",
+        ú: "'u",
+        ñ: '~n',
+        à: '`a',
+        è: '`e',
+        ì: '`i',
+        ò: '`o',
+        ù: '`u',
+        ä: '"a',
+        ë: '"e',
+        ï: '"i',
+        ö: '"o',
+        ü: '"u',
+        â: '^a',
+        ê: '^e',
+        î: '^i',
+        ô: '^o',
+        û: '^u',
+        ã: '~a',
+        õ: '~o'
+      };
+
+      if (added.length === 1 && accentedToSequence[added]) {
+        newRawInput = rawInput + accentedToSequence[added];
+      } else {
+        newRawInput = rawInput + added;
+      }
+    } else if (isDeletingFromEnd) {
+      if (inputLength === 0) {
+        newRawInput = '';
+      } else {
+        const charsToRemove = prevDisplayLength - inputLength;
+        newRawInput = rawInput.slice(0, -charsToRemove);
+      }
+    } else {
+      newRawInput = inputValue;
+    }
+
+    setRawInput(newRawInput);
+    const newDisplayValue = convertToSpanishWithAccents(newRawInput);
+    setDisplayValue(newDisplayValue);
+    onChange(index, newDisplayValue);
+  };
+
+  return (
+    <input
+      type='text'
+      value={displayValue}
+      onChange={handleChange}
+      className={className}
+      maxLength={maxLength}
+      size={size}
+      autoComplete='off'
+      aria-label={ariaLabel}
+      {...(isCorrect === false ? { 'aria-invalid': 'true' } : {})}
+    />
+  );
+}
+
+SpanishInput.displayName = 'SpanishInput';
+
+export default SpanishInput;
+

--- a/client/src/templates/Challenges/fill-in-the-blank/show.tsx
+++ b/client/src/templates/Challenges/fill-in-the-blank/show.tsx
@@ -303,6 +303,7 @@ const ShowFillInTheBlank = ({
                   feedback={feedback}
                   showWrong={showWrong}
                   handleInputChange={handleInputChange}
+                  lang={lang}
                 />
               </ObserveKeys>
 


### PR DESCRIPTION
Implement US International keyboard behavior for Spanish FITB challenges:
- Typing ' + vowel gives accented vowels (á, é, í, ó, ú)
- Typing ~ + n gives ñ
- Supports other dead key combinations (grave, diaeresis, circumflex)

Closes freeCodeCamp/language-curricula#84

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes freeCodeCamp/language-curricula#84

<!-- Feel free to add any additional description of changes below this line -->

 Description

This PR adds a custom input component for Spanish fill-in-the-blank tasks, similar to the existing Chinese input implementation.

 Problem
Previously, users completing Spanish fill-in-the-blank challenges had to switch keyboards or configure a Spanish keyboard on their device to type accented characters like `á`, `é`, `í`, `ó`, `ú`, and `ñ`. This created a barrier for learners who don't have Spanish keyboard layouts set up.

 Solution
Implemented a custom Spanish input component that emulates the US International keyboard layout behavior:
- Typing an apostrophe (`'`) followed by a vowel (`a`, `e`, `i`, `o`, `u`) automatically converts to accented vowels (`á`, `é`, `í`, `ó`, `ú`)
- Typing a tilde (`~`) followed by `n` automatically converts to `ñ`
- Supports additional dead key combinations (grave accents, diaeresis, circumflex) for comprehensive Spanish character support

Changes Made
1. Created `spanish-input.tsx` component with US International keyboard behavior
2. Integrated Spanish input into `fill-in-the-blanks.tsx` component
3. Updated type definitions to include `'spanish'` as a valid `inputType`
4. Added accessibility support with aria labels and descriptions
5. Updated `show.tsx` to pass language prop for automatic Spanish input detection

The implementation automatically detects Spanish challenges (`lang === ChallengeLang.Spanish`) and uses the custom input, allowing users to type Spanish characters without switching keyboards.


