### PR TITLE
fix(curriculum): missing b1 cert from settings page

### DIFF
--- a/api/src/routes/protected/certificate.test.ts
+++ b/api/src/routes/protected/certificate.test.ts
@@ -127,6 +127,7 @@ describe('certificate routes', () => {
           isCertMap: {
             is2018DataVisCert: false,
             isA2EnglishCert: false,
+            isB1EnglishCert: false,
             isApisMicroservicesCert: false,
             isBackEndCert: false,
             isCollegeAlgebraPyCertV8: false,

--- a/api/src/routes/protected/certificate.test.ts
+++ b/api/src/routes/protected/certificate.test.ts
@@ -224,6 +224,7 @@ describe('certificate routes', () => {
             ],
             is2018DataVisCert: true,
             isA2EnglishCert: true,
+            isB1EnglishCert: true,
             isApisMicroservicesCert: true,
             isCollegeAlgebraPyCertV8: true,
             isDataAnalysisPyCertV7: true,

--- a/api/src/routes/protected/user.test.ts
+++ b/api/src/routes/protected/user.test.ts
@@ -337,6 +337,7 @@ const sessionUserData = {
 const baseProgressData = {
   currentChallengeId: '',
   isA2EnglishCert: false,
+  isB1EnglishCert: false,
   isRespWebDesignCert: false,
   is2018DataVisCert: false,
   isFrontEndLibsCert: false,

--- a/api/src/routes/public/user.test.ts
+++ b/api/src/routes/public/user.test.ts
@@ -188,6 +188,7 @@ const publicUserData = {
   is2018DataVisCert: testUserData.is2018DataVisCert,
   is2018FullStackCert: testUserData.is2018FullStackCert, // TODO: should this be returned? The client doesn't use it at the moment.
   isA2EnglishCert: testUserData.isA2EnglishCert,
+  isB1EnglishCert: testUserData.isB1EnglishCert,
   isApisMicroservicesCert: testUserData.isApisMicroservicesCert,
   isBackEndCert: testUserData.isBackEndCert,
   isCheater: testUserData.isCheater,

--- a/api/src/schemas/users/get-public-profile.ts
+++ b/api/src/schemas/users/get-public-profile.ts
@@ -53,6 +53,7 @@ export const getPublicProfile = {
               is2018DataVisCert: Type.Boolean(),
               is2018FullStackCert: Type.Boolean(),
               isA2EnglishCert: Type.Boolean(),
+              isB1EnglishCert: Type.Boolean(),
               isApisMicroservicesCert: Type.Boolean(),
               isBackEndCert: Type.Boolean(),
               isCheater: Type.Boolean(),

--- a/client/src/components/profile/components/utils/certification.ts
+++ b/client/src/components/profile/components/utils/certification.ts
@@ -4,6 +4,7 @@ import { User } from '../../../../redux/prop-types';
 export const getCertifications = (user: User) => {
   const {
     isA2EnglishCert,
+    isB1EnglishCert,
     isRespWebDesignCert,
     isRespWebDesignCertV9,
     is2018DataVisCert,
@@ -32,6 +33,7 @@ export const getCertifications = (user: User) => {
   return {
     hasModernCert:
       isA2EnglishCert ||
+      isB1EnglishCert ||
       isRespWebDesignCertV9 ||
       isJavascriptCertV9 ||
       isFoundationalCSharpCertV8 ||
@@ -62,6 +64,11 @@ export const getCertifications = (user: User) => {
         show: isA2EnglishCert,
         title: 'A2 English for Developers Certification (Beta)',
         certSlug: Certification.A2English
+      },
+      {
+        show: isB1EnglishCert,
+        title: 'B1 English for Developers Certification (Beta)',
+        certSlug: Certification.B1English
       },
       {
         show: isRespWebDesignCertV9,

--- a/client/src/components/profile/profile.test.tsx
+++ b/client/src/components/profile/profile.test.tsx
@@ -55,6 +55,7 @@ const userProps = {
     isDonating: false,
     is2018DataVisCert: true,
     isA2EnglishCert: true,
+    isB1EnglishCert: true,
     isApisMicroservicesCert: true,
     isBackEndCert: true,
     isDataVisCert: true,

--- a/e2e/cert-username-case-navigation.spec.ts
+++ b/e2e/cert-username-case-navigation.spec.ts
@@ -16,7 +16,7 @@ test.describe('Public profile certifications', () => {
 
     await expect(
       page.getByRole('link', { name: /View.+Certification/ })
-    ).toHaveCount(24);
+    ).toHaveCount(25);
   });
 
   test('Should show claimed certifications if the username includes uppercase characters', async ({
@@ -48,7 +48,7 @@ test.describe('Public profile certifications', () => {
     await page.waitForURL('/certifiedboozer');
     await expect(
       page.getByRole('link', { name: /View.+Certification/ })
-    ).toHaveCount(24);
+    ).toHaveCount(25);
   });
 
   test.afterAll(() => {

--- a/shared/config/certification-settings.ts
+++ b/shared/config/certification-settings.ts
@@ -55,6 +55,7 @@ export function isCertification(x: string): x is Certification {
 // live and not legacy.
 export const currentCertifications = [
   Certification.A2English,
+  Certification.B1English,
   Certification.FoundationalCSharp,
   Certification.JsV9,
   Certification.PythonV9,
@@ -96,7 +97,6 @@ export const upcomingCertifications = [
   Certification.FrontEndDevLibsV9,
   Certification.BackEndDevApisV9,
   Certification.FullStackDeveloperV9,
-  Certification.B1English,
   Certification.A2Spanish,
   Certification.A2Chinese,
   Certification.A1Chinese

--- a/tools/scripts/seed/user-data.js
+++ b/tools/scripts/seed/user-data.js
@@ -221,6 +221,7 @@ module.exports.fullyCertifiedUser = {
   currentChallengeId: '',
   isHonest: true,
   isA2EnglishCert: true,
+  isB1EnglishCert: true,
   isFrontEndCert: true,
   isDataVisCert: true,
   isBackEndCert: true,


### PR DESCRIPTION
Right now campers can take the B1 english exam but are not able to claim the certification because it is not listed in the settings page. 

So this PR adds that missing cert to the settings page. 

## Before

<img width="1512" height="576" alt="Screenshot 2025-12-30 at 10 08 01 PM" src="https://github.com/user-attachments/assets/8f6a86ab-e24f-441d-9dd1-90c34ecc1fd2" />


## After


<img width="1509" height="389" alt="Screenshot 2025-12-30 at 10 08 37 PM" src="https://github.com/user-attachments/assets/293a1bfe-5490-45a4-91e2-02932a6bf7df" />



Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes https://github.com/freeCodeCamp/freeCodeCamp/issues/64895

<!-- Feel free to add any additional description of changes below this line -->
