### PR TITLE
fix: correct function name typo in Markdown Italic Parser tests

### DIFF
--- a/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/69272dcf1c24b44fd79137c6.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/69272dcf1c24b44fd79137c6.md
@@ -19,31 +19,31 @@ Note: The console may not display HTML tags in strings when logging messages. Ch
 
 # --hints--
 
-`parseItalic("*This is italic*")` should return `"<i>This is italic</i>"`.
+`parseItalics("*This is italic*")` should return `"<i>This is italic</i>"`.
 
 ```js
 assert.equal(parseItalics("*This is italic*"), "<i>This is italic</i>");
 ```
 
-`parseItalic("_This is also italic_")` should return `"<i>This is also italic</i>"`.
+`parseItalics("_This is also italic_")` should return `"<i>This is also italic</i>"`.
 
 ```js
 assert.equal(parseItalics("_This is also italic_"), "<i>This is also italic</i>");
 ```
 
-`parseItalic("*This is not italic *")` should return `"*This is not italic *"`.
+`parseItalics("*This is not italic *")` should return `"*This is not italic *"`.
 
 ```js
 assert.equal(parseItalics("*This is not italic *"), "*This is not italic *");
 ```
 
-`parseItalic("_ This is also not italic_")` should return `"_ This is also not italic_"`.
+`parseItalics("_ This is also not italic_")` should return `"_ This is also not italic_"`.
 
 ```js
 assert.equal(parseItalics("_ This is also not italic_"), "_ This is also not italic_");
 ```
 
-`parseItalic("The *quick* brown fox _jumps_ over the *lazy* dog.")` should return `"The <i>quick</i> brown fox <i>jumps</i> over the <i>lazy</i> dog."`.
+`parseItalics("The *quick* brown fox _jumps_ over the *lazy* dog.")` should return `"The <i>quick</i> brown fox <i>jumps</i> over the <i>lazy</i> dog."`.
 
 ```js
 assert.equal(parseItalics("The *quick* brown fox _jumps_ over the *lazy* dog."), "The <i>quick</i> brown fox <i>jumps</i> over the <i>lazy</i> dog.");


### PR DESCRIPTION
Checklist:

### Description
Fixes a typo in the test cases where `parseItalic` was used instead of the correct function name `parseItalics`.

### Reason
The editor function name is the source of truth for learners, and test cases should match it to avoid confusion and failing tests.

### Checklist
- [x] No logic changes
- [x] Tests updated only
- [x] First-time contributor

