### PR TITLE
fix: Correct typo for parseItalic in markdown

### DIFF
--- a/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/69272dcf1c24b44fd79137c6.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/69272dcf1c24b44fd79137c6.md
@@ -19,31 +19,31 @@ Note: The console may not display HTML tags in strings when logging messages. Ch
 
 # --hints--
 
-`parseItalic("*This is italic*")` should return `"<i>This is italic</i>"`.
+`parseItalics("*This is italic*")` should return `"<i>This is italic</i>"`.
 
 ```js
 assert.equal(parseItalics("*This is italic*"), "<i>This is italic</i>");
 ```
 
-`parseItalic("_This is also italic_")` should return `"<i>This is also italic</i>"`.
+`parseItalics("_This is also italic_")` should return `"<i>This is also italic</i>"`.
 
 ```js
 assert.equal(parseItalics("_This is also italic_"), "<i>This is also italic</i>");
 ```
 
-`parseItalic("*This is not italic *")` should return `"*This is not italic *"`.
+`parseItalics("*This is not italic *")` should return `"*This is not italic *"`.
 
 ```js
 assert.equal(parseItalics("*This is not italic *"), "*This is not italic *");
 ```
 
-`parseItalic("_ This is also not italic_")` should return `"_ This is also not italic_"`.
+`parseItalics("_ This is also not italic_")` should return `"_ This is also not italic_"`.
 
 ```js
 assert.equal(parseItalics("_ This is also not italic_"), "_ This is also not italic_");
 ```
 
-`parseItalic("The *quick* brown fox _jumps_ over the *lazy* dog.")` should return `"The <i>quick</i> brown fox <i>jumps</i> over the <i>lazy</i> dog."`.
+`parseItalics("The *quick* brown fox _jumps_ over the *lazy* dog.")` should return `"The <i>quick</i> brown fox <i>jumps</i> over the <i>lazy</i> dog."`.
 
 ```js
 assert.equal(parseItalics("The *quick* brown fox _jumps_ over the *lazy* dog."), "The <i>quick</i> brown fox <i>jumps</i> over the <i>lazy</i> dog.");


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #64941

<!-- Feel free to add any additional description of changes below this line -->
**Description:** Changes the function names of test cases from  `parseItalic( )` to `parseItalics( )` to match the function name in javaScript page . (Python page is correct , dont need to change).