### PR TITLE
Fix: correct TPGi Colour Contrast Analyzer description in CSS accessibility quiz

### DIFF
--- a/curriculum/challenges/english/blocks/quiz-css-accessibility/66ed8fc1f45ce3ece4053ead.md
+++ b/curriculum/challenges/english/blocks/quiz-css-accessibility/66ed8fc1f45ce3ece4053ead.md
@@ -61,7 +61,7 @@ WebAIM's Color Contrast Checker
 
 #### --text--
 
-Which of the following tools allows you to pick background and foreground colors from a live webpage and check for their contrast ratio?
+Which of the following is a desktop application that allows you to pick background and foreground colors from your screen and check for their contrast ratio?
 
 #### --distractors--
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the contribution guidelines.
- [x] I have read and followed the how to open a pull request guide.
- [x] My pull request targets the main branch of freeCodeCamp.
- [x] I have tested these changes locally on my machine.

Closes #64961

## Description

Updated the CSS Accessibility Quiz question to accurately describe TPGi Colour Contrast Analyzer as a desktop application that picks colors from the screen, rather than incorrectly stating it picks colors from "live webpages."

## Changes Made

Changed the quiz question from:
- "Which of the following tools allows you to pick background and foreground colors from a **live webpage** and check for their contrast ratio?"

To:
- "Which of the following is a **desktop application** that allows you to pick background and foreground colors from **your screen** and check for their contrast ratio?"

This accurately reflects that TPGi Colour Contrast Analyzer is a desktop application (Windows/Mac) that samples colors from anywhere on the screen, not just web pages.

## Testing

- [x] Verified the question text is grammatically correct
- [x] Confirmed TPGi Colour Contrast Analyzer is indeed a desktop application
- [x] All linting and formatting checks passed locally