### PR TITLE
fix(curriculum): add test for number input min value in lab event RSVP

### DIFF
--- a/curriculum/challenges/english/blocks/lab-event-rsvp/67d936de7055982b02baf186.md
+++ b/curriculum/challenges/english/blocks/lab-event-rsvp/67d936de7055982b02baf186.md
@@ -127,6 +127,19 @@ try {
 }
 ```
 
+The `input[type="number"]` element should not accept values less than 1.
+
+```js
+try {
+  const input = document.querySelector('form input[type="number"]');
+  assert.exists(input);
+  assert.equal(input.min, '1');
+} catch (e) {
+  console.log(e);
+  throw e;
+}
+```
+
 Changing the value of the `input[type="text"]` elements should update component state.
 
 ```js


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
[User story #4](https://www.freecodecamp.org/learn/front-end-development-libraries-v9/lab-event-rsvp/build-an-event-rsvp) explicitly requires  "the number should not be less than one", but there is no test case validating this constraint.  Campers can currently pass all tests without implementing the `min` attribute.