### PR TITLE
fix(curriculum): refer to + as a quantifier in step 32 of Calorie Counter

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-calorie-counter/63bf5adfe2981b332eb007b6.md
+++ b/curriculum/challenges/english/blocks/workshop-calorie-counter/63bf5adfe2981b332eb007b6.md
@@ -7,7 +7,7 @@ dashedName: step-32
 
 # --description--
 
-The `+` quantifier in a regular expression matches the preceding pattern one or more times. To match your digit pattern one or more times, add a plus after each of the digit character classes. For example: `[0-9]+`.
+The `+` quantifier in a regular expression allows you to match a pattern that occurs one or more times. To match your digit pattern one or more times, add a plus after each of the digit character classes. For example: `[0-9]+`.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/workshop-calorie-counter/63bf5adfe2981b332eb007b6.md
+++ b/curriculum/challenges/english/blocks/workshop-calorie-counter/63bf5adfe2981b332eb007b6.md
@@ -7,17 +7,17 @@ dashedName: step-32
 
 # --description--
 
-The `+` modifier in a regex allows you to match a pattern that occurs one or more times. To match your digit pattern one or more times, add a plus after each of the digit character classes. For example: `[0-9]+`.
+The `+` quantifier in a regular expression matches the preceding pattern one or more times. To match your digit pattern one or more times, add a plus after each of the digit character classes. For example: `[0-9]+`.
 
 # --hints--
 
-You should add the `+` modifier to the character class before `e` in your regular expression.
+You should add the `+` quantifier to the character class before `e` in your regular expression.
 
 ```js
 assert.match(isInvalidInput.toString(), /regex\s*=\s*\/\[0-9\]\+e/);
 ```
 
-You should add the `+` modifier to the character class after `e` in your regular expression.
+You should add the `+` quantifier to the character class after `e` in your regular expression.
 
 ```js
 assert.match(isInvalidInput.toString(), /regex\s*=\s*\/\[0-9\]\+e\[0-9\]\+\//);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.
<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #64910 

<!-- Feel free to add any additional description of changes below this line -->
## Fix:
This change updates the challenge wording to refer to + as a regular expression quantifier instead of a modifier.
- The term modifier is commonly used to describe regex flags such as i, g, and m, while + belongs to the category of quantifiers that control repetition of the preceding token (one or more matches). 
- This is a documentation-only change — no logic, tests, or curriculum behaviour is affected.