### PR TITLE
Fix: correct brightness() baseline value question in CSS Layout quiz

### DIFF
--- a/curriculum/challenges/english/blocks/quiz-css-layout-and-effects/66ed8ff4f45ce3ece4053eb4.md
+++ b/curriculum/challenges/english/blocks/quiz-css-layout-and-effects/66ed8ff4f45ce3ece4053eb4.md
@@ -613,7 +613,7 @@ It will make the element appear completely grey.
 
 #### --text--
 
-What is the minimum value for the `brightness()` CSS function to brighten an element?
+What is the default baseline value of the `brightness()` CSS function before any brightening or darkening is applied?
 
 #### --distractors--
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the contribution guidelines.
- [x] I have read and followed the how to open a pull request guide.
- [x] My pull request targets the main branch of freeCodeCamp.
- [x] I have tested these changes locally on my machine.

Closes #64908

## Description

Fixed an incorrect question in the CSS Layout and Effects Quiz regarding the `brightness()` CSS function. The original question incorrectly asked for the "minimum value to brighten" with the answer being `100%`, which is technically incorrect because `100%` is the baseline/default value and does not brighten the element.

## Changes Made

Changed the question from:
- "What is the minimum value for the `brightness()` CSS function to brighten an element?"

To:
- "What is the default baseline value of the `brightness()` CSS function before any brightening or darkening is applied?"

The answer `100%` is now correct, as it represents the baseline value. Values above `100%` brighten the element, while values below `100%` darken it.

## Technical Context

According to CSS specifications:
- `brightness(100%)` = baseline (no change)
- `brightness(>100%)` = brightens (e.g., 150%, 200%)  
- `brightness(<100%)` = darkens (e.g., 50%, 75%)
- `brightness(0%)` = completely black

## Testing

- [x] Verified the question is technically accurate per CSS specifications
- [x] Confirmed the answer `100%` correctly represents the baseline value
- [x] All linting and formatting checks passed locally