### PR TITLE
fix(curriculum): replace meta.json with proper filename

### DIFF
--- a/curriculum/src/test/test-challenges.js
+++ b/curriculum/src/test/test-challenges.js
@@ -175,7 +175,7 @@ async function populateTestsForLang({ lang, challenges, meta }) {
           describe(`ID: ${challenge.id}`, function () {
             // Note: the title in meta.json are purely for human readability and
             // do not include translations, so we do not validate against them.
-            it(`Matches an ID ${challenge.block}.json`, function () {
+            it(`Matches an ID in ${challenge.block}.json`, function () {
               const index = meta[dashedBlockName]?.challengeOrder?.findIndex(
                 ({ id }) => id === challenge.id
               );

--- a/curriculum/src/test/test-challenges.js
+++ b/curriculum/src/test/test-challenges.js
@@ -175,13 +175,13 @@ async function populateTestsForLang({ lang, challenges, meta }) {
           describe(`ID: ${challenge.id}`, function () {
             // Note: the title in meta.json are purely for human readability and
             // do not include translations, so we do not validate against them.
-            it('Matches an ID in meta.json', function () {
+            it(`Matches an ID ${challenge.block}.json`, function () {
               const index = meta[dashedBlockName]?.challengeOrder?.findIndex(
                 ({ id }) => id === challenge.id
               );
               expect(
                 index,
-                `Cannot find ID "${challenge.id}" in meta.json file for block "${dashedBlockName}"`
+                `Cannot find ID "${challenge.id}" in ${challenge.block}.json file for block "${dashedBlockName}"`
               ).toBeGreaterThanOrEqual(0);
             });
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

These messages appear when testing with `test:curriculum:content`, `meta.json` does not exist anymore so this is a better message. Edit: actually the second message does not appear, there are other tests that fail first

should I use `dashedBlockName` instead of `challenge.block`? they are both used in these lines and I am unsure what would be best