### PR TITLE
fix(curriculum): require non-white body background in blog post card lab

### DIFF
--- a/curriculum/challenges/english/blocks/lab-blog-post-card/66eaddd04a9e533fba689001.md
+++ b/curriculum/challenges/english/blocks/lab-blog-post-card/66eaddd04a9e533fba689001.md
@@ -20,7 +20,7 @@ In this lab, you'll practice how to style backgrounds and borders by creating a 
     - An `h2` element with a class of `post-title` and text for the title of your blog post.
     - A `p` element with a class of `post-excerpt` and text to summarize your blog post.
     - An `a` element with a class of `read-more` with the text `Read More`.
-4. You should set the `body` element’s background color to a value other than white.
+4. You should set the `body` element's background color to a value other than white.
 5. You should apply the following styles to the `.blog-post-card` element:
     - A white background.
     - Rounded corners.

--- a/curriculum/challenges/english/blocks/lab-blog-post-card/66eaddd04a9e533fba689001.md
+++ b/curriculum/challenges/english/blocks/lab-blog-post-card/66eaddd04a9e533fba689001.md
@@ -142,6 +142,15 @@ const whiteColors = ['rgb(255, 255, 255)', 'rgba(255, 255, 255, 1)', '#ffffff', 
 assert.oneOf(backgroundColor.toLowerCase(), whiteColors);
 ```
 
+Your `body` element should have a background color other than white.
+
+```js
+const bodyBg = getComputedStyle(document.body).backgroundColor;
+const whiteColors = ['rgb(255, 255, 255)', 'rgba(255, 255, 255, 1)', '#ffffff', '#fff', 'white'];
+
+assert.notOneOf(bodyBg.toLowerCase(), whiteColors);
+```
+
 You should target `.blog-post-card` and set its `width` property.
 
 ```js

--- a/curriculum/challenges/english/blocks/lab-blog-post-card/66eaddd04a9e533fba689001.md
+++ b/curriculum/challenges/english/blocks/lab-blog-post-card/66eaddd04a9e533fba689001.md
@@ -14,21 +14,22 @@ In this lab, you'll practice how to style backgrounds and borders by creating a 
 
 **User Stories:**
 
-1. You should have a `div` element with a class of `blog-post-card` to hold all of your card elements.
-2. Within the `.blog-post-card` element, you should have an image element with a valid `alt` attribute and text, and a class of `post-img`. You can use `https://cdn.freecodecamp.org/curriculum/labs/cover-photo.jpg` for the `src` attribute of the image.
-3. You should have a `div` with a class of `post-content` within the `.blog-post-card` element with the following:
+1. You should set the `body` element’s background color to a value other than white.
+2. You should have a `div` element with a class of `blog-post-card` to hold all of your card elements.
+3. Within the `.blog-post-card` element, you should have an image element with a valid `alt` attribute and text, and a class of `post-img`. You can use `https://cdn.freecodecamp.org/curriculum/labs/cover-photo.jpg` for the `src` attribute of the image.
+4. You should have a `div` with a class of `post-content` within the `.blog-post-card` element with the following:
     - An `h2` element with a class of `post-title` and text for the title of your blog post.
     - A `p` element with a class of `post-excerpt` and text to summarize your blog post.
     - An `a` element with a class of `read-more` with the text `Read More`.
-4. You should apply the following styles to the `.blog-post-card` element:
+5. You should apply the following styles to the `.blog-post-card` element:
     - A white background.
     - Rounded corners.
     - A width of your choice.
     - The text alignment of your choice.
-5. The `.post-img` element should be styled so that the image fills the card's entire width and has a bottom border.
-6. The `.post-content` element should be styled so that there is padding inside the card.
-7. The `.post-title` and `.post-excerpt` elements should have a text color other than the default and margins on all sides.
-8. The `.read-more` element should be styled like a button and have:
+6. The `.post-img` element should be styled so that the image fills the card's entire width and has a bottom border.
+7. The `.post-content` element should be styled so that there is padding inside the card.
+8. The `.post-title` and `.post-excerpt` elements should have a text color other than the default and margins on all sides.
+9. The `.read-more` element should be styled like a button and have:
     - A text color other than the default.
     - A background color.
     - Margins on all sides.

--- a/curriculum/challenges/english/blocks/lab-blog-post-card/66eaddd04a9e533fba689001.md
+++ b/curriculum/challenges/english/blocks/lab-blog-post-card/66eaddd04a9e533fba689001.md
@@ -14,13 +14,13 @@ In this lab, you'll practice how to style backgrounds and borders by creating a 
 
 **User Stories:**
 
-1. You should set the `body` element’s background color to a value other than white.
-2. You should have a `div` element with a class of `blog-post-card` to hold all of your card elements.
-3. Within the `.blog-post-card` element, you should have an image element with a valid `alt` attribute and text, and a class of `post-img`. You can use `https://cdn.freecodecamp.org/curriculum/labs/cover-photo.jpg` for the `src` attribute of the image.
-4. You should have a `div` with a class of `post-content` within the `.blog-post-card` element with the following:
+1. You should have a `div` element with a class of `blog-post-card` to hold all of your card elements.
+2. Within the `.blog-post-card` element, you should have an image element with a valid `alt` attribute and text, and a class of `post-img`. You can use `https://cdn.freecodecamp.org/curriculum/labs/cover-photo.jpg` for the `src` attribute of the image.
+3. You should have a `div` with a class of `post-content` within the `.blog-post-card` element with the following:
     - An `h2` element with a class of `post-title` and text for the title of your blog post.
     - A `p` element with a class of `post-excerpt` and text to summarize your blog post.
     - An `a` element with a class of `read-more` with the text `Read More`.
+4. You should set the `body` element’s background color to a value other than white.
 5. You should apply the following styles to the `.blog-post-card` element:
     - A white background.
     - Rounded corners.
@@ -148,7 +148,7 @@ Your `body` element should have a background color other than white.
 const bodyBg = getComputedStyle(document.body).backgroundColor;
 const whiteColors = ['rgb(255, 255, 255)', 'rgba(255, 255, 255, 1)', '#ffffff', '#fff', 'white'];
 
-assert.notOneOf(bodyBg.toLowerCase(), whiteColors);
+assert.isFalse(whiteColors.includes(bodyBg.toLowerCase()));
 ```
 
 You should target `.blog-post-card` and set its `width` property.


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #64971

This PR updates the blog post card lab requirements to explicitly require a non-white background on the `body` element, ensuring that the white background requirement for the `.blog-post-card` element can be meaningfully tested.