### PR TITLE
Update challenge-reset-modal.spec.ts to use v9 lesson URLs

### DIFF
--- a/e2e/challenge-reset-modal.spec.ts
+++ b/e2e/challenge-reset-modal.spec.ts
@@ -29,7 +29,7 @@ const expectToRenderResetModal = async (page: Page) => {
 
 test('should render the modal content correctly', async ({ page }) => {
   await page.goto(
-    '/learn/2022/responsive-web-design/learn-html-by-building-a-cat-photo-app/step-3'
+    '/learn/responsive-web-design-v9/workshop-cat-photo-app/step-3'
   );
 
   await page.getByRole('button', { name: translations.buttons.reset }).click();
@@ -61,7 +61,7 @@ test('User can reset challenge', async ({ page, isMobile, browserName }) => {
     .getByText(updatedText);
 
   await page.goto(
-    '/learn/2022/responsive-web-design/learn-html-by-building-a-cat-photo-app/step-3'
+    '/learn/responsive-web-design-v9/workshop-cat-photo-app/step-3'
   );
 
   // Building the preview can take a while
@@ -105,7 +105,7 @@ test.describe('When the user is not logged in', () => {
   test.use({ storageState: { cookies: [], origins: [] } });
   test('User can reset classic challenge', async ({ page, isMobile }) => {
     await page.goto(
-      '/learn/javascript-algorithms-and-data-structures/basic-javascript/comment-your-javascript-code'
+      '/learn/rosetta-code/rosetta-code-challenges/100-doors'
     );
 
     const challengeSolution = '// This is in-line comment';
@@ -167,7 +167,7 @@ test.describe('When the user is not logged in', () => {
 
 test('should close when the user clicks the close button', async ({ page }) => {
   await page.goto(
-    '/learn/2022/responsive-web-design/learn-html-by-building-a-cat-photo-app/step-3'
+    '/learn/responsive-web-design-v9/workshop-cat-photo-app/step-3'
   );
 
   await page.getByRole('button', { name: translations.buttons.reset }).click();
@@ -195,7 +195,7 @@ test('User can reset on a multi-file project', async ({
   const sampleText = 'function palindrome() { return true; }';
 
   await page.goto(
-    '/learn/javascript-algorithms-and-data-structures-v8/build-a-palindrome-checker-project/build-a-palindrome-checker'
+    '/learn/javascript-v9/lab-palindrome-checker/build-a-palindrome-checker'
   );
 
   await focusEditor({ page, isMobile });
@@ -245,7 +245,7 @@ test.describe('Signed in user', () => {
     const updatedText = 'function palindrome() { return false; }';
 
     await page.goto(
-      '/learn/javascript-algorithms-and-data-structures-v8/build-a-palindrome-checker-project/build-a-palindrome-checker'
+      '/learn/javascript-v9/lab-palindrome-checker/build-a-palindrome-checker'
     );
 
     // This first edit should reappear after the reset
@@ -286,7 +286,7 @@ test.describe('Signed in user', () => {
     const updatedText = 'function palindrome() { return false; }';
 
     await page.goto(
-      '/learn/javascript-algorithms-and-data-structures-v8/build-a-palindrome-checker-project/build-a-palindrome-checker'
+      '/learn/javascript-v9/lab-palindrome-checker/build-a-palindrome-checker'
     );
 
     // This first edit should reappear after the reset


### PR DESCRIPTION
Checklist:

 I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org/).
 I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
 My pull request targets the main branch of freeCodeCamp.
 I have tested these changes either locally on my machine, or GitHub Codespaces.

This PR updates the lesson URLs in `e2e/challenge-reset-modal.spec.ts` to point to the new v9 versions of the lessons:

- Cat Photo App: step-3 → /learn/responsive-web-design-v9/workshop-cat-photo-app/step-3
- 100 Doors challenge → /learn/rosetta-code/rosetta-code-challenges/100-doors
- Palindrome Checker project → /learn/javascript-v9/lab-palindrome-checker/build-a-palindrome-checker

I have verified in the browser that the selectors and content match these lessons


Closes #64848