### PR TITLE
fix(curriculum): clarify quotes question to remove ambiguity

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-strings-in-javascript/673263df0eb568a7b450f2fc.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-strings-in-javascript/673263df0eb568a7b450f2fc.md
@@ -144,7 +144,7 @@ Consider how JavaScript misinterprets special characters without escaping them.
 
 ## --text--
 
-How would you correctly include quotes within a string that is already wrapped in quotes?
+How would you correctly include single quotes within a string that is already wrapped in single quotes?
 
 ## --answers--
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #64809

---

### What was happening
The question *“How would you correctly include quotes within a string that is already wrapped in quotes?”* was ambiguous, as more than one answer could be considered correct based on the wording.

### What this change does
- Clarifies the question to explicitly refer to **single quotes inside a string wrapped in single quotes**
- Aligns the wording with the intended correct answer
- Improves learner clarity without changing answers or validation logic

### Scope
- Curriculum text only
- No changes to tests, logic, or challenge structure

