### PR TITLE
refactor: standardize server error responses across routes

### DIFF
--- a/api/src/daily-coding-challenge/routes/daily-coding-challenge.ts
+++ b/api/src/daily-coding-challenge/routes/daily-coding-challenge.ts
@@ -4,7 +4,8 @@ import * as schemas from '../schemas/index.js';
 import {
   getNowUsCentral,
   getUtcMidnight,
-  dateStringToUtcMidnight
+  dateStringToUtcMidnight,
+  sendServerError
 } from '../utils/helpers.js';
 
 /**
@@ -16,6 +17,8 @@ import {
  * @param _options Options passed to the plugin via `fastify.register(plugin, options)`.
  * @param done Callback to signal that the logic has completed.
  */
+
+
 export const dailyCodingChallengeRoutes: FastifyPluginCallbackTypebox = (
   fastify,
   _options,
@@ -66,9 +69,7 @@ export const dailyCodingChallengeRoutes: FastifyPluginCallbackTypebox = (
         });
       } catch (error) {
         logger.error(error, 'Failed to get daily coding challenge.');
-        await reply
-          .status(500)
-          .send({ type: 'error', message: 'Internal server error.' });
+        return sendServerError(reply);
       }
     }
   );
@@ -105,11 +106,9 @@ export const dailyCodingChallengeRoutes: FastifyPluginCallbackTypebox = (
         });
       } catch (error) {
         logger.error(error, "Failed to get today's daily coding challenge.");
-        await reply
-          .status(500)
-          .send({ type: 'error', message: 'Internal server error.' });
-      }
+        return sendServerError(reply);
     }
+  }
   );
 
   fastify.get(
@@ -179,9 +178,7 @@ export const dailyCodingChallengeRoutes: FastifyPluginCallbackTypebox = (
         return reply.send(response);
       } catch (error) {
         logger.error(error, 'Failed to get monthly daily coding challenges.');
-        await reply
-          .status(500)
-          .send({ type: 'error', message: 'Internal server error.' });
+        return sendServerError(reply);
       }
     }
   );
@@ -232,9 +229,7 @@ export const dailyCodingChallengeRoutes: FastifyPluginCallbackTypebox = (
         return reply.send(response);
       } catch (error) {
         logger.error(error, 'Failed to get all daily coding challenges.');
-        await reply
-          .status(500)
-          .send({ type: 'error', message: 'Internal server error.' });
+        return sendServerError(reply);
       }
     }
   );
@@ -269,9 +264,7 @@ export const dailyCodingChallengeRoutes: FastifyPluginCallbackTypebox = (
         return reply.send({ date: newestChallenge.date.toISOString() });
       } catch (error) {
         logger.error(error, 'Failed to get newest daily coding challenge.');
-        await reply
-          .status(500)
-          .send({ type: 'error', message: 'Internal server error.' });
+        return sendServerError(reply);
       }
     }
   );

--- a/api/src/daily-coding-challenge/utils/helpers.ts
+++ b/api/src/daily-coding-challenge/utils/helpers.ts
@@ -1,4 +1,5 @@
 import { getTimezoneOffset } from 'date-fns-tz';
+import { FastifyReply } from 'fastify';
 
 /**
  * @returns Now US Central time.
@@ -37,4 +38,26 @@ export function dateStringToUtcMidnight(dateStr: string): Date | null {
   ];
 
   return new Date(Date.UTC(year, month - 1, day));
+}
+
+/**
+ * Sends a standardized server error response.
+ *
+ * @param reply The Fastify reply instance.
+ * @param replyStatus HTTP status code to send (default is 500).
+ * @param message Error message to return.
+ * @param type Error type identifier.
+ * @returns The Fastify reply instance.
+ */
+
+export function sendServerError(
+  reply: FastifyReply,
+  replyStatus = 500,
+  message = 'Internal server error.',
+  type = 'error'
+) {
+  return reply.status(replyStatus).send({
+    type,
+    message
+  });
 }


### PR DESCRIPTION
Checklists:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #64979 

### Summary
- Introducing a reusable helper for sending standardized server error responses.
- This replaces repeated server error reply logic in daily coding challenge routes which was breaking DRY rule and also redundant.

### What it does
- Improves consistency across API error responses
- Reduces duplication and improves readability
- Keeps behavior unchanged

### Scope
- Affects daily coding challenge API routes only
- No breaking changes
