### PR TITLE
fix(curriculum): remove invalid radial-gradient size keywords

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-backgrounds-and-borders/672b98be592cfb451f651451.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-backgrounds-and-borders/672b98be592cfb451f651451.md
@@ -59,7 +59,7 @@ background: radial-gradient(shape size at position, color-stop1, color-stop2, ..
 
 On the syntax, the `shape` specifies the shape of gradient which could be `circle` or `ellipse`.
 
-The `size` determines the size of the gradient's ending shape which could be `closest-side`, `closest-corner`, `farthest-side`, `farthest-corner`, `contain`, or `cover`.
+The `size` determines the size of the gradient's ending shape which could be `closest-side`, `closest-corner`, `farthest-side`, or `farthest-corner`.
 
 `position` determines the position of the gradient's center which could be specified using keywords (such as `center`, `top left`, `bottom right`) or precise values (such as `50% 50%`, `10px 20px`).
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-strings-in-javascript/673263df0eb568a7b450f2fc.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-strings-in-javascript/673263df0eb568a7b450f2fc.md
@@ -144,7 +144,7 @@ Consider how JavaScript misinterprets special characters without escaping them.
 
 ## --text--
 
-How would you correctly include quotes within a string that is already wrapped in quotes?
+How would you correctly include single quotes within a string that is already wrapped in single quotes?
 
 ## --answers--
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the contribution guidelines.
- [x] I have read and followed the how to open a pull request guide.
- [x] My pull request targets the main branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #64981

This PR removes invalid size keywords from the `radial-gradient()` lesson
to ensure the explanation aligns with the CSS specification.

