### PR TITLE
fix(curriculum): correct object property syntax example

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-introduction-to-javascript-objects-and-their-properties/67329f737126b75bcb949e13.md
+++ b/curriculum/challenges/english/blocks/lecture-introduction-to-javascript-objects-and-their-properties/67329f737126b75bcb949e13.md
@@ -15,7 +15,7 @@ These pieces of information are called properties, and they consist of a name (o
 
 ```js
 const exampleObject = {
-  propertyName: value;
+  propertyName: value,
 }
 ```
 


### PR DESCRIPTION
This fixes an incorrect JavaScript object example where a semicolon was used instead of a comma.

Fixes #64988
