### PR TITLE
docs: update copyright year to 2026 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ Recent Contributions:
 
 ### License
 
-Copyright © 2025 freeCodeCamp.org
+Copyright © 2026 freeCodeCamp.org
 
 The content of this repository is bound by the following licenses:
 
 - The computer software is licensed under the [BSD-3-Clause](LICENSE.md) license.
-- The learning resources in the [`/curriculum`](/curriculum) directory including their subdirectories therein are copyright © 2025 freeCodeCamp.org
+- The learning resources in the [`/curriculum`](/curriculum) directory including their subdirectories therein are copyright © 2026 freeCodeCamp.org


### PR DESCRIPTION
### Description
This PR updates the copyright year in the main `README.md` from 2025 to 2026 to ensure the documentation reflects the current year.

### Type of Change
- Documentation update (non-breaking change)

### Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own changes

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
