### PR TITLE
fix(curriculum): correct brightness() baseline value question in CSS Layout quiz

### DIFF
--- a/curriculum/challenges/english/blocks/quiz-css-layout-and-effects/66ed8ff4f45ce3ece4053eb4.md
+++ b/curriculum/challenges/english/blocks/quiz-css-layout-and-effects/66ed8ff4f45ce3ece4053eb4.md
@@ -613,7 +613,7 @@ It will make the element appear completely grey.
 
 #### --text--
 
-What is the minimum value for the `brightness()` CSS function to brighten an element?
+What is the baseline value of the `brightness()` CSS function from which increasing brightness starts?
 
 #### --distractors--
 


### PR DESCRIPTION
## Description

This PR fixes an incorrect question in the CSS Layout and Effects Quiz regarding the `brightness()` CSS function.

**Issue:** The question previously asked "What is the minimum value for the brightness() CSS function to brighten an element?" with the answer "100%". This is misleading because 100% is the default/baseline value, not the minimum value needed to brighten an element (which would be anything greater than 100%).

**Fix:** Updated the question to "What is the baseline value of the brightness() CSS function from which increasing brightness starts?" The answer remains 100%, but now the question accurately describes this value as the baseline rather than the minimum to brighten.

Closes #64969

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [contributing guidelines](https://contribute.freecodecamp.org/#/how-to-contribute-to-open-source)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (N/A for curriculum content)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules (N/A)