### PR TITLE
fix(curriculum): sintax issue in intro to javascript

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-introduction-to-javascript-objects-and-their-properties/67329f737126b75bcb949e13.md
+++ b/curriculum/challenges/english/blocks/lecture-introduction-to-javascript-objects-and-their-properties/67329f737126b75bcb949e13.md
@@ -15,7 +15,7 @@ These pieces of information are called properties, and they consist of a name (o
 
 ```js
 const exampleObject = {
-  propertyName: value;
+  propertyName: value,
 }
 ```
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #64988

Description:
As requested in the issue, the semicolon in the example has been changed with a comma in "curriculum/challenges/english/blocks/lecture-introduction-to-javascript-objects-and-their-properties/67329f737126b75bcb949e13.md".
