### PR TITLE
docs(curriculum): clarify use of source element with video

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-audio-and-video-elements/67168278ac6df6a799555db5.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-audio-and-video-elements/67168278ac6df6a799555db5.md
@@ -81,6 +81,8 @@ When it comes to audio file types, there are differences in which browsers suppo
 
 The browser will first start with the ogg type, and if it can't play the audio, then it'll move down to the next type in the list.
 
+The same `source` element approach can also be used with the `video` element. While the examples above use the `src` attribute directly on the `video` tag, it is common practice to include one or more `source` elements inside `video`, which you will use in the upcoming lab.
+
 All the attributes we have learned so far are also supported in the `video` element. Here's an example of using a `video` element with the `loop`, `controls`, and `muted` attributes. 
 
 Add the `autoplay` attribute to the opening `video` tag so the video plays automatically. To interact with the example, you will need to enable the interactive editor.


### PR DESCRIPTION
This PR adds a brief clarification to the audio and video lesson explaining that the source element can also be used with video, aligning the lesson with the requirements of the following lab and reducing beginner confusion.

fixes #64989
