### PR TITLE
fix(curriculum): two correct answers web response quiz

### DIFF
--- a/curriculum/challenges/english/blocks/quiz-responsive-web-design/66ed9034f45ce3ece4053ebd.md
+++ b/curriculum/challenges/english/blocks/quiz-responsive-web-design/66ed9034f45ce3ece4053ebd.md
@@ -691,7 +691,7 @@ Which of the following is a valid way to target devices with a portrait orientat
 
 ---
 
-`@media (orientation: portrait) { ... }`
+`@media (portrait: orientation) { ... }`
 
 ---
 


### PR DESCRIPTION
Checklist:
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #64862

Description: 
Changed one of the distractor of the question: "Which of the following is a valid way to target devices with a portrait orientation using a media query?" because two answers were correct. 
The correct distractor: `@media (orientation: portrait) { ... }`
has been changed to `@media (portrait: orientation) { ... }`, which is actually not correct
