### PR TITLE
fix(curriculum): change spinal case converter lab example in user story

### DIFF
--- a/curriculum/challenges/english/blocks/lab-spinal-case-converter/a103376db3ba46b2d50db289.md
+++ b/curriculum/challenges/english/blocks/lab-spinal-case-converter/a103376db3ba46b2d50db289.md
@@ -17,7 +17,7 @@ In this lab, you will create a function that converts a given string to spinal c
 
 1. You should create a function named `spinalCase`.
 2. The `spinalCase` function should take a single argument, a string.
-3. The `spinalCase` function should return the string in spinal case format. For example, if the argument is `JavaScript is awesome`, the function should return `javascript-is-awesome`.
+3. The `spinalCase` function should return the string in spinal case format. For example, if the argument is `ProductLanding page`, the function should return `product-landing-page`.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #64987

<!-- Feel free to add any additional description of changes below this line -->

This PR updates the example in the Spinal Case Converter user story to resolve an inconsistency with the provided tests.

Previously, the example stated that “JavaScript is awesome” converts to javascript-is-awesome, while the tests expect behavior consistent with inputs like “AllThe-small Things” converting to all-the-small-things. This mismatch caused confusion for learners.

The example has now been replaced with one that accurately reflects the test cases and expected behavior, ensuring clarity and consistency across the challenge.