### PR TITLE
fix(curriculum): clarify source element usage with video element

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-audio-and-video-elements/67168278ac6df6a799555db5.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-audio-and-video-elements/67168278ac6df6a799555db5.md
@@ -113,6 +113,7 @@ For the `src`, or source attribute, we are using a video called "Big Buck Bunny"
   width="400"
 ></video>
 ```
+
 You can also use the `source` element inside a `video` element, just like you did with the `audio` element. This lets you provide the same video in multiple formats, and the browser will choose the first one it can play.
 
 ```html

--- a/curriculum/challenges/english/blocks/lecture-working-with-audio-and-video-elements/67168278ac6df6a799555db5.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-audio-and-video-elements/67168278ac6df6a799555db5.md
@@ -131,7 +131,7 @@ You can also use the `source` element inside a `video` element, just like you di
   />
   Your browser does not support the video tag.
 </video>
-
+```
 
 # --questions--
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-audio-and-video-elements/67168278ac6df6a799555db5.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-audio-and-video-elements/67168278ac6df6a799555db5.md
@@ -113,6 +113,25 @@ For the `src`, or source attribute, we are using a video called "Big Buck Bunny"
   width="400"
 ></video>
 ```
+You can also use the `source` element inside a `video` element, just like you did with the `audio` element. This lets you provide the same video in multiple formats, and the browser will choose the first one it can play.
+
+```html
+<video
+  controls
+  width="400"
+  poster="https://peach.blender.org/wp-content/uploads/title_anouncement.jpg?x11217"
+>
+  <source
+    src="https://archive.org/download/BigBuckBunny_124/Content/big_buck_bunny_720p_surround.mp4"
+    type="video/mp4"
+  />
+  <source
+    src="https://archive.org/download/BigBuckBunny_124/Content/big_buck_bunny_720p_surround.webm"
+    type="video/webm"
+  />
+  Your browser does not support the video tag.
+</video>
+
 
 # --questions--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #64989

<!-- Feel free to add any additional description of changes below this line -->

Changes made:

Added a `video` element example using multiple `<source>` elements after the `poster` attribute explanation.
