### PR TITLE
fix(curriculum): clarify displayResults output formatting

### DIFF
--- a/curriculum/challenges/english/blocks/lab-voting-system/673b567e3ba535dda140d278.md
+++ b/curriculum/challenges/english/blocks/lab-voting-system/673b567e3ba535dda140d278.md
@@ -44,21 +44,26 @@ In this lab, you will build a voting system that uses `Map` to create a poll and
 
 8. You should have a function `displayResults` that returns the poll results in the following format:
 
-```js
-Poll Results:
-OptionA: N votes
-OptionB: N votes
-.
-.
+    ```js
+    Poll Results:
+    OptionA: N votes
+    OptionB: N votes
+    ```
 
-/*
-sample output
+    Example output (exact formatting):
+    ```js
+    Poll Results:
+    Turkey: 2 votes
+    Morocco: 1 votes
+    Spain: 0 votes
+    ```
 
-Poll Results:
-Turkey: 2 votes
-Morocco: 1 votes
-*/
-```
+    This corresponds to the string:
+    ```js
+    "Poll Results:\nTurkey: 2 votes\nMorocco: 1 votes\nSpain: 0 votes"
+    ```
+
+    The output must match this format exactly, including line breaks. Do not include extra spaces or trailing newlines. Options with zero votes should also be included in the output.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #65004

<!-- Feel free to add any additional description of changes below this line -->

This PR adds a brief clarification to the challenge description about the exact output formatting expected from displayResults().
No tests or solution logic were changed.
