### PR TITLE
fix: replace asset with assert in project euler hints

### DIFF
--- a/curriculum/challenges/english/blocks/project-euler-problems-301-to-400/5900f4b51000cf542c50ffc8.md
+++ b/curriculum/challenges/english/blocks/project-euler-problems-301-to-400/5900f4b51000cf542c50ffc8.md
@@ -25,7 +25,7 @@ Give your answer as a string as a fraction `p/q` in reduced form.
 `primeFrog()` should return a string.
 
 ```js
-asset.isString(primeFrog());
+assert.isString(primeFrog());
 ```
 
 `primeFrog()` should return the string `199740353/29386561536000`.

--- a/curriculum/challenges/english/blocks/project-euler-problems-301-to-400/5900f4bd1000cf542c50ffcf.md
+++ b/curriculum/challenges/english/blocks/project-euler-problems-301-to-400/5900f4bd1000cf542c50ffcf.md
@@ -29,7 +29,7 @@ Find the ${2011}^{\text{th}}$ lexicographic maximix arrangement for eleven carri
 `maximixArrangements()` should return a string.
 
 ```js
-asset.isString(maximixArrangements());
+assert.isString(maximixArrangements());
 ```
 
 `maximixArrangements()` should return the string `CAGBIHEFJDK`.

--- a/curriculum/challenges/english/blocks/project-euler-problems-301-to-400/5900f4e81000cf542c50fffb.md
+++ b/curriculum/challenges/english/blocks/project-euler-problems-301-to-400/5900f4e81000cf542c50fffb.md
@@ -25,7 +25,7 @@ When giving your answer, use a lowercase e to separate mantissa and exponent. E.
 `amazingMazes()` should return a string.
 
 ```js
-asset.isString(amazingMazes());
+assert.isString(amazingMazes());
 ```
 
 `amazingMazes()` should return the string `6.3202e25093`.

--- a/curriculum/challenges/english/blocks/project-euler-problems-301-to-400/5900f4fc1000cf542c51000e.md
+++ b/curriculum/challenges/english/blocks/project-euler-problems-301-to-400/5900f4fc1000cf542c51000e.md
@@ -31,7 +31,7 @@ If it happens that the conjecture is false, then the accepted answer to this pro
 `squarefreeFibonacciNumbers()` should return a string.
 
 ```js
-asset.isString(squarefreeFibonacciNumbers());
+assert.isString(squarefreeFibonacciNumbers());
 ```
 
 `squarefreeFibonacciNumbers()` should return the string `1508395636674243,6.5e27330467`.


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the contribution guidelines.
- [x] I have read and followed the how to open a pull request guide.
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Description of changes:

Fixed typos in multiple Project Euler challenge hint tests where `asset` was incorrectly used instead of `assert`.

Closes #65018
