### PR TITLE
refactor(client): speed up client updates

### DIFF
--- a/client/gatsby-node.js
+++ b/client/gatsby-node.js
@@ -8,7 +8,6 @@ const webpack = require('webpack');
 const { SuperBlocks } = require('../shared-dist/config/curriculum');
 const env = require('./config/env.json');
 const {
-  createChallengePages,
   createBlockIntroPages,
   createSuperBlockIntroPages
 } = require('./utils/gatsby');
@@ -60,62 +59,11 @@ exports.createPages = async function createPages({
 
   const result = await graphql(`
     {
-      allChallengeNode(
-        sort: {
-          fields: [
-            challenge___superOrder
-            challenge___order
-            challenge___challengeOrder
-          ]
-        }
-      ) {
+      allChallengeNode {
         edges {
           node {
-            id
             challenge {
               block
-              blockLabel
-              blockLayout
-              certification
-              challengeType
-              dashedName
-              demoType
-              disableLoopProtectTests
-              disableLoopProtectPreview
-              fields {
-                slug
-                blockHashSlug
-              }
-              id
-              isLastChallengeInBlock
-              order
-              required {
-                link
-                src
-              }
-              challengeOrder
-              challengeFiles {
-                name
-                ext
-                contents
-                head
-                tail
-                history
-                fileKey
-              }
-              saveSubmissionToDB
-              solutions {
-                contents
-                ext
-                history
-                fileKey
-              }
-              superBlock
-              superOrder
-              template
-              usesMultifileEditor
-              chapter
-              module
             }
           }
         }
@@ -139,40 +87,6 @@ exports.createPages = async function createPages({
       }
     }
   `);
-
-  const allChallengeNodes = result.data.allChallengeNode.edges.map(
-    ({ node }) => node
-  );
-
-  const createIdToNextPathMap = nodes =>
-    nodes.reduce((map, node, index) => {
-      const nextNode = nodes[index + 1];
-      const nextPath = nextNode ? nextNode.challenge.fields.slug : null;
-      if (nextPath) map[node.id] = nextPath;
-      return map;
-    }, {});
-
-  const createIdToPrevPathMap = nodes =>
-    nodes.reduce((map, node, index) => {
-      const prevNode = nodes[index - 1];
-      const prevPath = prevNode ? prevNode.challenge.fields.slug : null;
-      if (prevPath) map[node.id] = prevPath;
-      return map;
-    }, {});
-
-  const idToNextPathCurrentCurriculum =
-    createIdToNextPathMap(allChallengeNodes);
-
-  const idToPrevPathCurrentCurriculum =
-    createIdToPrevPathMap(allChallengeNodes);
-
-  // Create challenge pages.
-  result.data.allChallengeNode.edges.forEach(
-    createChallengePages(createPage, {
-      idToNextPathCurrentCurriculum,
-      idToPrevPathCurrentCurriculum
-    })
-  );
 
   const blocks = uniq(
     result.data.allChallengeNode.edges.map(

--- a/client/utils/build-challenges.js
+++ b/client/utils/build-challenges.js
@@ -51,7 +51,6 @@ exports.replaceChallengeNodes = () => {
     const block = path.basename(parentDir);
     const filename = path.basename(filePath);
 
-    console.log(`Replacing challenge nodes for ${filePath}`);
     const meta = getBlockStructure(block);
     const superblocks = getSuperblocks(block);
 

--- a/client/utils/gatsby/challenge-page-creator.js
+++ b/client/utils/gatsby/challenge-page-creator.js
@@ -69,12 +69,12 @@ const views = {
   examDownload
 };
 
-function getIsFirstStepInBlock(id, edges) {
-  const current = edges[id];
-  const previous = edges[id - 1];
+function getIsFirstStepInBlock(id, nodes) {
+  const current = nodes[id];
+  const previous = nodes[id - 1];
 
   if (!previous) return true;
-  return previous.node.challenge.block !== current.node.challenge.block;
+  return previous.challenge.block !== current.challenge.block;
 }
 
 function getTemplateComponent(challengeType) {
@@ -85,7 +85,7 @@ exports.createChallengePages = function (
   createPage,
   { idToNextPathCurrentCurriculum, idToPrevPathCurrentCurriculum }
 ) {
-  return function ({ node }, index, allChallengeEdges) {
+  return function (node, index, allChallengeNodes) {
     const {
       dashedName,
       disableLoopProtectTests,
@@ -118,7 +118,7 @@ exports.createChallengePages = function (
           chapter,
           module,
           block,
-          isFirstStep: getIsFirstStepInBlock(index, allChallengeEdges),
+          isFirstStep: getIsFirstStepInBlock(index, allChallengeNodes),
           template,
           required,
           isLastChallengeInBlock: isLastChallengeInBlock,
@@ -129,7 +129,7 @@ exports.createChallengePages = function (
         },
         projectPreview: getProjectPreviewConfig(
           node.challenge,
-          allChallengeEdges
+          allChallengeNodes
         ),
         id: node.id
       }
@@ -140,12 +140,12 @@ exports.createChallengePages = function (
 // TODO: figure out a cleaner way to get the last challenge in a block. Create
 // it during the curriculum build process and attach it to the first challenge?
 // That would remove the need to analyse allChallengeEdges.
-function getProjectPreviewConfig(challenge, allChallengeEdges) {
+function getProjectPreviewConfig(challenge, allChallengeNodes) {
   const { block } = challenge;
 
-  const challengesInBlock = allChallengeEdges
-    .filter(({ node: { challenge } }) => challenge.block === block)
-    .map(({ node: { challenge } }) => challenge);
+  const challengesInBlock = allChallengeNodes
+    .filter(({ challenge }) => challenge.block === block)
+    .map(({ challenge }) => challenge);
   const lastChallenge = challengesInBlock[challengesInBlock.length - 1];
   const solutionFiles = lastChallenge.solutions[0] ?? [];
   const lastChallengeFiles = lastChallenge.challengeFiles ?? [];

--- a/client/utils/gatsby/challenge-page-creator.js
+++ b/client/utils/gatsby/challenge-page-creator.js
@@ -81,6 +81,8 @@ function getTemplateComponent(challengeType) {
   return views[viewTypes[challengeType]];
 }
 
+exports.getTemplateComponent = getTemplateComponent;
+
 exports.createChallengePages = function (
   createPage,
   { idToNextPathCurrentCurriculum, idToPrevPathCurrentCurriculum }

--- a/curriculum/schema/challenge-schema.js
+++ b/curriculum/schema/challenge-schema.js
@@ -339,6 +339,8 @@ const schema = Joi.object().keys({
       })
   }),
   showSpeakingButton: Joi.bool(),
+  // This is only to be used for dynamic client updates.
+  sourceLocation: Joi.string(),
   solutions: Joi.array().items(Joi.array().items(fileJoi).min(1)),
   superBlock: Joi.string().regex(slugWithSlashRE),
   superOrder: Joi.number(),

--- a/curriculum/src/build-superblock.ts
+++ b/curriculum/src/build-superblock.ts
@@ -1,5 +1,5 @@
 import { existsSync, readdirSync } from 'fs';
-import { resolve } from 'path';
+import { join, resolve, basename } from 'path';
 import { isEmpty } from 'lodash';
 import debug from 'debug';
 
@@ -336,6 +336,13 @@ export class BlockCreator {
     );
 
     challenge.translationPending = this.lang !== 'english' && !isAudited;
+    // Add source location to allow tracing back to original file (necessary to
+    // update the client when files change)
+    challenge.sourceLocation = join(
+      basename(this.blockContentDir),
+      block,
+      filename
+    );
 
     return finalizeChallenge(challenge, meta);
   }

--- a/tools/client-plugins/gatsby-source-challenges/gatsby-node.js
+++ b/tools/client-plugins/gatsby-source-challenges/gatsby-node.js
@@ -109,7 +109,7 @@ exports.sourceNodes = function sourceChallengesSourceNodes(
     if (action === 'deleted') {
       // We have to return before calling onSourceChange, since the file is
       // gone.
-      tryToDeletePages(filePath);
+      return tryToDeletePages(filePath);
     }
 
     return onSourceChange(filePath)

--- a/tools/client-plugins/gatsby-source-challenges/gatsby-node.js
+++ b/tools/client-plugins/gatsby-source-challenges/gatsby-node.js
@@ -39,7 +39,7 @@ exports.sourceNodes = function sourceChallengesSourceNodes(
     a path to a curriculum directory
     `);
   }
-  const { createNode } = actions;
+  const { createNode, deleteNode } = actions;
   const watcher = chokidar.watch(curriculumPath, {
     ignored: /(^|[/\\])\../,
     ignoreInitial: true,
@@ -47,7 +47,13 @@ exports.sourceNodes = function sourceChallengesSourceNodes(
     cwd: curriculumPath
   });
 
+  function cleanUpOldNodes(filePath) {
+    createdFileNodes.get(filePath)?.forEach(node => deleteNode(node));
+  }
+
   function handleChallengeUpdate(filePath, action = 'changed') {
+    cleanUpOldNodes(filePath, actions.deleteNode);
+
     return onSourceChange(filePath)
       .then(challenges => {
         const actionText = action === 'added' ? 'creating' : 'replacing';

--- a/tools/client-plugins/gatsby-source-challenges/gatsby-node.js
+++ b/tools/client-plugins/gatsby-source-challenges/gatsby-node.js
@@ -62,6 +62,14 @@ exports.sourceNodes = function sourceChallengesSourceNodes(
           if (action === 'added') {
             updatedFileNodes.set(filePath, newNode);
           }
+          if (action === 'changed') {
+            const existingFileNode = updatedFileNodes.get(filePath);
+            // If a file has been created since boot and then changed, the store
+            // has to be updated or the page won't reflect the latest changes.
+            if (existingFileNode) {
+              updatedFileNodes.set(filePath, newNode);
+            }
+          }
         });
       })
       .catch(e =>

--- a/tools/client-plugins/gatsby-source-challenges/gatsby-node.js
+++ b/tools/client-plugins/gatsby-source-challenges/gatsby-node.js
@@ -56,15 +56,22 @@ exports.sourceNodes = function sourceChallengesSourceNodes(
   }
 
   function deletePages(filePath) {
-    const nodesToDelete = statefullyCreatedNodes.get(filePath) || [];
-    nodesToDelete.forEach(node => {
+    const statefulNodes = statefullyCreatedNodes.get(filePath) || [];
+    statefulNodes.forEach(node => {
       deleteNode(node);
       deletePage({
         path: node.challenge.fields.slug,
         component: getTemplateComponent(node.challenge.challengeType)
       });
     });
+
+    const createdNodes = createdFileNodes.get(filePath) || [];
+    createdNodes.forEach(node => {
+      deleteNode(node);
+    });
+
     statefullyCreatedNodes.delete(filePath);
+    createdFileNodes.delete(filePath);
   }
 
   function handleChallengeUpdate(filePath, action = 'changed') {

--- a/tools/client-plugins/gatsby-source-challenges/gatsby-node.js
+++ b/tools/client-plugins/gatsby-source-challenges/gatsby-node.js
@@ -14,7 +14,7 @@ const { createChallengePages } = require('../../../client/utils/gatsby');
 let allChallengeNodes;
 let idToNextPathCurrentCurriculum;
 let idToPrevPathCurrentCurriculum;
-let createdNodes = [];
+const updatedFileNodes = new Map();
 
 exports.sourceNodes = function sourceChallengesSourceNodes(
   { actions, reporter, createNodeId, createContentDigest },
@@ -60,7 +60,7 @@ exports.sourceNodes = function sourceChallengesSourceNodes(
             isReloading: true
           });
           if (action === 'added') {
-            createdNodes.push(newNode);
+            updatedFileNodes.set(filePath, newNode);
           }
         });
       })
@@ -245,7 +245,7 @@ exports.createPagesStatefully = async function ({ graphql, actions }) {
 
 exports.createPages = function ({ actions }) {
   // actions.createPage has to be called in the createPages hook
-  for (const node of createdNodes) {
+  for (const node of updatedFileNodes.values()) {
     const nodeToPage = createChallengePages(actions.createPage, {
       idToNextPathCurrentCurriculum,
       idToPrevPathCurrentCurriculum

--- a/tools/client-plugins/gatsby-source-challenges/gatsby-node.js
+++ b/tools/client-plugins/gatsby-source-challenges/gatsby-node.js
@@ -14,7 +14,7 @@ const { createChallengePages } = require('../../../client/utils/gatsby');
 let allChallengeNodes;
 let idToNextPathCurrentCurriculum;
 let idToPrevPathCurrentCurriculum;
-const updatedFileNodes = new Map();
+const createdFileNodes = new Map();
 
 exports.sourceNodes = function sourceChallengesSourceNodes(
   { actions, reporter, createNodeId, createContentDigest },
@@ -60,14 +60,14 @@ exports.sourceNodes = function sourceChallengesSourceNodes(
             isReloading: true
           });
           if (action === 'added') {
-            updatedFileNodes.set(filePath, newNode);
+            createdFileNodes.set(filePath, newNode);
           }
           if (action === 'changed') {
-            const existingFileNode = updatedFileNodes.get(filePath);
+            const existingFileNode = createdFileNodes.get(filePath);
             // If a file has been created since boot and then changed, the store
             // has to be updated or the page won't reflect the latest changes.
             if (existingFileNode) {
-              updatedFileNodes.set(filePath, newNode);
+              createdFileNodes.set(filePath, newNode);
             }
           }
         });
@@ -253,7 +253,7 @@ exports.createPagesStatefully = async function ({ graphql, actions }) {
 
 exports.createPages = function ({ actions }) {
   // actions.createPage has to be called in the createPages hook
-  for (const node of updatedFileNodes.values()) {
+  for (const node of createdFileNodes.values()) {
     const nodeToPage = createChallengePages(actions.createPage, {
       idToNextPathCurrentCurriculum,
       idToPrevPathCurrentCurriculum

--- a/tools/client-plugins/gatsby-source-challenges/gatsby-node.js
+++ b/tools/client-plugins/gatsby-source-challenges/gatsby-node.js
@@ -254,5 +254,6 @@ exports.createPages = function ({ actions }) {
     nodeToPage(node, 0, allChallengeNodes);
   }
 
-  createdNodes = [];
+  // It's important NOT to clear the createdNodes, since Gatsby deletes any
+  // pages that are not recreated each time createPages is called.
 };


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This should make the DX when working on challenges much smoother. Prior to this PR the client would take an excessive amount of time (sometimes more than a minute) to update whenever a challenge was changed. The reason for this was that Gatsby's default approach is to try to create every page, do a diff against the existing pages and then render each page in the diff. This was quite expensive and does not scale well with our growing number of challenges. 

As of this PR we tell Gatsby precisely which pages to create and render, sidestepping the scaling issue.

~It's still draft because sometimes creating a new page simply fails, but it's not clear why.~

To persist the created pages we need to recreate them on every update.

Update:

Now files can be deleted or renamed.

<!-- Feel free to add any additional description of changes below this line -->
