### PR TITLE
fix(curriculum): ensure solution passes when longest word is first in sentence

### DIFF
--- a/curriculum/challenges/english/blocks/lab-longest-word-in-a-string/a26cbbe9ad8655a977e1ceb5.md
+++ b/curriculum/challenges/english/blocks/lab-longest-word-in-a-string/a26cbbe9ad8655a977e1ceb5.md
@@ -61,6 +61,12 @@ assert.strictEqual(findLongestWordLength('May the force be with you'), 5);
 assert.strictEqual(findLongestWordLength('Google do a barrel roll'), 6);
 ```
 
+`findLongestWordLength("Googling do a barrel roll")` should return `8`.
+
+```js
+assert.strictEqual(findLongestWordLength('Googling do a barrel roll'), 8);
+```
+
 `findLongestWordLength("What is the average airspeed velocity of an unladen swallow")` should return `8`.
 
 ```js


### PR DESCRIPTION
Checklist:
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #65028

Description:
Added a test case to check that the code works even if the longest world is the first one. 
```
`findLongestWordLength("Googling do a barrel roll")` should return `8`.

```js
assert.strictEqual(findLongestWordLength('Googling do a barrel roll'), 8);
```
```
