### PR TITLE
fix(curriculum): test that contacts array is not modified in lab profile lookup

### DIFF
--- a/curriculum/challenges/english/blocks/lab-profile-lookup/5688e62ea601b2482ff8422b.md
+++ b/curriculum/challenges/english/blocks/lab-profile-lookup/5688e62ea601b2482ff8422b.md
@@ -24,7 +24,7 @@ For this example imagine there is a contact named Akira Laine, the `lookUpProfil
 # --before-each--
 
 ```js
-let _contacts = [
+const _contacts = [
   {
     firstName: "Akira",
     lastName: "Laine",

--- a/curriculum/challenges/english/blocks/lab-profile-lookup/5688e62ea601b2482ff8422b.md
+++ b/curriculum/challenges/english/blocks/lab-profile-lookup/5688e62ea601b2482ff8422b.md
@@ -24,7 +24,7 @@ For this example imagine there is a contact named Akira Laine, the `lookUpProfil
 # --before-each--
 
 ```js
-contacts = [
+let _contacts = [
   {
     firstName: "Akira",
     lastName: "Laine",
@@ -50,6 +50,8 @@ contacts = [
     likes: ["JavaScript", "Gaming", "Foxes"],
   },
 ];
+
+contacts = structuredClone(_contacts); 
 ```
 
 # --hints--
@@ -109,6 +111,13 @@ assert.strictEqual(lookUpProfile('Bob', 'potato'), 'No such contact');
 
 ```js
 assert.strictEqual(lookUpProfile('Akira', 'address'), 'No such property');
+```
+
+The `contacts` array should remain unchanged after running `lookUpProfile` 
+
+```js
+lookUpProfile("Sherlock", "likes");
+assert.deepEqual(contacts,_contacts);
 ```
 
 # --seed--


### PR DESCRIPTION

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #65019

<!-- Feel free to add any additional description of changes below this line -->
I essentially duplicated the contacts array so I have something to compare it to after the `lookup` function is called. 