### PR TITLE
fix(curriculum): remove hash symbol from authorContainer

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-fcc-authors-page/641da5abaac81844a54adb03.md
+++ b/curriculum/challenges/english/blocks/workshop-fcc-authors-page/641da5abaac81844a54adb03.md
@@ -9,7 +9,7 @@ dashedName: step-8
 
 Now, it is time to create the function that will be responsible for displaying the authors on the page. 
 
-Start by creating a function called `displayAuthors` that takes an `authors` parameter. Your function should then loop through the `authors` array and add a card for each author to the `#authorContainer` element. 
+Start by creating a function called `displayAuthors` that takes an `authors` parameter. Your function should then loop through the `authors` array and add a card for each author to the `authorContainer` element. 
 
 The card should have the following structure:
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #65031

<!-- Feel free to add any additional description of changes below this line -->

This PR fixes the confusion in Step 8 instructions regarding the authorContainer reference in fcc author page workshop.


Changes:

- Changed #authorContainer to authorContainer in the instruction text to clarify it refers to the JavaScript variable, not a CSS selector