### PR TITLE
fix(curriculum): add HTML element syntax for better clarification

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-bookstore-page/68eca6364c5616d393389a30.md
+++ b/curriculum/challenges/english/blocks/workshop-bookstore-page/68eca6364c5616d393389a30.md
@@ -7,7 +7,7 @@ dashedName: step-18
 
 # --description--
 
-Remember, a HTML element looks like this:
+Remember, an HTML element looks like this:
 
 ```html
 <element attribute="value">

--- a/curriculum/challenges/english/blocks/workshop-bookstore-page/68eca6364c5616d393389a30.md
+++ b/curriculum/challenges/english/blocks/workshop-bookstore-page/68eca6364c5616d393389a30.md
@@ -15,6 +15,14 @@ Review your selections and continue to checkout.
 
 Below the `p` element, create a `div` element with the `class` attribute set to `btn-container`. This container will group your navigation button elements.
 
+Remember, a HTML element looks like this:
+
+```html
+<element attribute="value">
+    inner text
+</element>
+```
+
 # --hints--
 
 The newly added `p` element should be below the element with a class of `card-container`.

--- a/curriculum/challenges/english/blocks/workshop-bookstore-page/68eca6364c5616d393389a30.md
+++ b/curriculum/challenges/english/blocks/workshop-bookstore-page/68eca6364c5616d393389a30.md
@@ -7,14 +7,6 @@ dashedName: step-18
 
 # --description--
 
-Below the element with the class `card-container`, add a new `p` element with this text:
-
-```md
-Review your selections and continue to checkout.
-```
-
-Below the `p` element, create a `div` element with the `class` attribute set to `btn-container`. This container will group your navigation button elements.
-
 Remember, a HTML element looks like this:
 
 ```html
@@ -22,6 +14,14 @@ Remember, a HTML element looks like this:
     inner text
 </element>
 ```
+
+Below the element with the class `card-container`, add a new `p` element with this text:
+
+```md
+Review your selections and continue to checkout.
+```
+
+Below the `p` element, create a `div` element with the `class` attribute set to `btn-container`. This container will group your navigation button elements.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #65027

<!-- Feel free to add any additional description of changes below this line -->

This PR adds an HTML element syntax reminder to prevent placement confusion in the build bookstore workshop.

Changes:

-Added a reminder of HTML element syntax to clarify that new element should be added below the closing tag.