### PR TITLE
fix(curriculum): add missing first-word test

### DIFF
--- a/curriculum/challenges/english/blocks/lab-longest-word-in-a-string/a26cbbe9ad8655a977e1ceb5.md
+++ b/curriculum/challenges/english/blocks/lab-longest-word-in-a-string/a26cbbe9ad8655a977e1ceb5.md
@@ -83,6 +83,12 @@ assert.strictEqual(
 );
 ```
 
+`findLongestWordLength("Philanthropy is great")` should return `12`.
+
+```js
+assert.strictEqual(findLongestWordLength('Philanthropy is great'), 12);
+```
+
 # --seed--
 
 ## --seed-contents--


### PR DESCRIPTION
Checklist:

- [x]  I have read and followed the contribution guidelines.
- [x]  I have read and followed the how to open a pull request guide.
- [x]  My pull request targets the main branch of freeCodeCamp.
- [ ]  I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #65028

This PR adds a missing edge case test to the "Build a Longest Word Finder App" challenge to prevent buggy code that skips the first word from passing.

Changes:

- Added a new test case where the first word is uniquely the longest word in the string.
- `findLongestWordLength("Philanthropy is great")` should return `12`.