### PR TITLE
fix(client): better architecture detection for exam downloads

### DIFF
--- a/client/src/templates/Challenges/exam-download/show.test.tsx
+++ b/client/src/templates/Challenges/exam-download/show.test.tsx
@@ -1,0 +1,146 @@
+import { describe, test, expect } from 'vitest';
+import { handleDownloadLink } from './show';
+import type { UserOSState } from '../utils/use-detect-os';
+
+describe('handleDownloadLink', () => {
+  // handleDownloadLink only cares about the architecture and extension, so we
+  // can use simplified sample links for testing.
+  const sampleDownloadLinks = [
+    'url_x64.exe',
+    'url_x86.exe',
+    'url_aarch64.dmg',
+    'url_x64.dmg',
+    'url_x86_64.AppImage',
+    'url_aarch64.AppImage',
+    'url_x64.app.tar.gz',
+    'url_aarch64.tar.gz',
+    'url.sig',
+    'url.json'
+  ];
+
+  test('ignores irrelevant extensions', () => {
+    const links = ['url.deb', 'url.rpm', 'url.zip', 'url.sig', 'url.json'];
+    const osState: UserOSState = { os: 'WIN', architecture: '' };
+    const result = handleDownloadLink(osState, links);
+    expect(result).toBe('');
+  });
+
+  describe('Windows OS', () => {
+    test('returns x64 exe for Windows with x86_64 architecture', () => {
+      const osState: UserOSState = { os: 'WIN', architecture: 'x86_64' };
+      const result = handleDownloadLink(osState, sampleDownloadLinks);
+      expect(result).toBe('url_x64.exe');
+    });
+
+    test('returns x86 exe for Windows with x86 architecture', () => {
+      const osState: UserOSState = { os: 'WIN', architecture: 'x86' };
+      const result = handleDownloadLink(osState, sampleDownloadLinks);
+      expect(result).toBe('url_x86.exe');
+    });
+
+    test('returns any exe when architecture is not specified', () => {
+      const osState: UserOSState = { os: 'WIN', architecture: '' };
+      const result = handleDownloadLink(osState, sampleDownloadLinks);
+      expect(result).toMatch(/\.exe$/);
+    });
+  });
+
+  describe('Mac OS', () => {
+    test('returns x64 dmg for Mac with x86_64 architecture', () => {
+      const osState: UserOSState = { os: 'MAC', architecture: 'x86_64' };
+      const result = handleDownloadLink(osState, sampleDownloadLinks);
+      expect(result).toBe('url_x64.dmg');
+    });
+
+    test('returns aarch64 dmg for Mac with arm64 architecture', () => {
+      const osState: UserOSState = { os: 'MAC', architecture: 'arm64' };
+      const result = handleDownloadLink(osState, sampleDownloadLinks);
+      expect(result).toBe('url_aarch64.dmg');
+    });
+
+    test('returns any dmg when architecture is not specified', () => {
+      const osState: UserOSState = { os: 'MAC', architecture: '' };
+      const result = handleDownloadLink(osState, sampleDownloadLinks);
+      expect(result).toMatch(/\.dmg$/);
+    });
+  });
+
+  describe('Linux OS', () => {
+    test('returns x86_64 AppImage for Linux with x86_64 architecture', () => {
+      const osState: UserOSState = { os: 'LINUX', architecture: 'x86_64' };
+      const result = handleDownloadLink(osState, sampleDownloadLinks);
+      expect(result).toBe('url_x86_64.AppImage');
+    });
+
+    test('returns aarch64 AppImage for Linux with arm64 architecture', () => {
+      const osState: UserOSState = { os: 'LINUX', architecture: 'arm64' };
+      const result = handleDownloadLink(osState, sampleDownloadLinks);
+      expect(result).toBe('url_aarch64.AppImage');
+    });
+
+    test('prefers AppImage over tar.gz', () => {
+      const links = ['url_x64.tar.gz', 'url_x64.AppImage'];
+      const osState: UserOSState = { os: 'LINUX', architecture: 'x86_64' };
+      const result = handleDownloadLink(osState, links);
+      expect(result).toBe('url_x64.AppImage');
+    });
+
+    test('prefers app.tar.gz over tar.gz', () => {
+      const links = ['url_x64.tar.gz', 'url_x64.app.tar.gz'];
+      const osState: UserOSState = { os: 'LINUX', architecture: 'x86_64' };
+      const result = handleDownloadLink(osState, links);
+      expect(result).toBe('url_x64.app.tar.gz');
+    });
+  });
+
+  describe('Unknown OSes', () => {
+    test('returns empty string for unknown OS', () => {
+      const osState: UserOSState = { os: 'OTHER', architecture: 'x86_64' };
+      const result = handleDownloadLink(osState, sampleDownloadLinks);
+      expect(result).toBe('');
+    });
+
+    test('returns empty string for LOADING OS state', () => {
+      const osState: UserOSState = { os: 'LOADING', architecture: '' };
+      const result = handleDownloadLink(osState, sampleDownloadLinks);
+      expect(result).toBe('');
+    });
+  });
+
+  describe('Architecture normalization', () => {
+    test('picks the first link if two normalize to the same arch', () => {
+      const links = ['url_x64.exe', 'url_amd64.exe'];
+      const osState: UserOSState = { os: 'WIN', architecture: 'amd64' };
+      const result = handleDownloadLink(osState, links);
+      expect(result).toBe('url_x64.exe');
+    });
+
+    test('normalizes amd64 to x64', () => {
+      const links = ['url_fake.exe', 'url_x64.exe'];
+      const osState: UserOSState = { os: 'WIN', architecture: 'amd64' };
+      const result = handleDownloadLink(osState, links);
+      expect(result).toBe('url_x64.exe');
+    });
+
+    test('normalizes arm64 to arm', () => {
+      const links = ['url_fake.dmg', 'url_arm.dmg'];
+      const osState: UserOSState = { os: 'MAC', architecture: 'arm64' };
+      const result = handleDownloadLink(osState, links);
+      expect(result).toBe('url_arm.dmg');
+    });
+
+    test('normalizes i386 to x86', () => {
+      const links = ['url_fake.exe', 'url_x86.exe'];
+      const osState: UserOSState = { os: 'WIN', architecture: 'i386' };
+      const result = handleDownloadLink(osState, links);
+      expect(result).toBe('url_x86.exe');
+    });
+
+    test('normalizes i686 to x86', () => {
+      const links = ['url_fake.exe', 'url_x86.exe'];
+      const osState: UserOSState = { os: 'WIN', architecture: 'i686' };
+      const result = handleDownloadLink(osState, links);
+      expect(result).toBe('url_x86.exe');
+    });
+  });
+});

--- a/client/src/templates/Challenges/utils/use-detect-os.test.ts
+++ b/client/src/templates/Challenges/utils/use-detect-os.test.ts
@@ -1,0 +1,31 @@
+import { describe, test, expect } from 'vitest';
+
+import { userAgentDataToArchitecture } from './use-detect-os';
+
+describe('userAgentDataToArchitecture', () => {
+  test('defaults to x86 when architecture is empty and bitness is 32', () => {
+    const data = { architecture: '', bitness: '32' } as const;
+    const result = userAgentDataToArchitecture(data);
+    expect(result).toBe('x86');
+  });
+
+  test('defaults to x86_64 when architecture is empty and bitness is 64', () => {
+    const data = { architecture: '', bitness: '64' } as const;
+    const result = userAgentDataToArchitecture(data);
+    expect(result).toBe('x86_64');
+  });
+
+  test('defaults to 32bit when bitness is empty', () => {
+    const empty = { architecture: '', bitness: '' } as const;
+    const emptyResult = userAgentDataToArchitecture(empty);
+    expect(emptyResult).toBe('x86');
+
+    const x86 = { architecture: 'x86', bitness: '' } as const;
+    const x86Result = userAgentDataToArchitecture(x86);
+    expect(x86Result).toBe('x86');
+
+    const arm = { architecture: 'arm', bitness: '' } as const;
+    const armResult = userAgentDataToArchitecture(arm);
+    expect(armResult).toBe('arm');
+  });
+});

--- a/client/src/templates/Challenges/utils/use-detect-os.ts
+++ b/client/src/templates/Challenges/utils/use-detect-os.ts
@@ -1,8 +1,8 @@
 import { useEffect, useState } from 'react';
 
-type UserOS = 'MAC' | 'WIN' | 'LINUX' | 'AIX' | 'OTHER' | 'LOADING';
+type UserOS = 'MAC' | 'WIN' | 'LINUX' | 'OTHER' | 'LOADING';
 
-type UserOSState = {
+export type UserOSState = {
   os: UserOS;
   architecture: string;
 };
@@ -46,12 +46,12 @@ const getArchitecture = async (): Promise<string> => {
   return 'Unknown';
 };
 
-export const detectOsInUserAgent = (userAgent: string | undefined): UserOS => {
+const detectOsInUserAgent = (userAgent: string | undefined): UserOS => {
   const osMatch = userAgent?.match(/(Win|Mac|Linux)/);
   return osMatch ? (osMatch[1].toUpperCase() as UserOS) : 'OTHER';
 };
 
-export const detectOS = (): UserOS => detectOsInUserAgent(navigator?.userAgent);
+const detectOS = (): UserOS => detectOsInUserAgent(navigator?.userAgent);
 
 const useDetectOS = () => {
   const [userOS, setUserOS] = useState<UserOSState>({

--- a/client/src/templates/Challenges/utils/use-detect-os.ts
+++ b/client/src/templates/Challenges/utils/use-detect-os.ts
@@ -1,30 +1,50 @@
 import { useEffect, useState } from 'react';
 
 type UserOS = 'MAC' | 'WIN' | 'LINUX' | 'OTHER' | 'LOADING';
+type Architecture = 'x86' | 'x86_64' | 'arm' | 'arm64' | 'Unknown' | 'LOADING';
 
 export type UserOSState = {
   os: UserOS;
   architecture: string;
 };
 
+// There are other hints, such as "model", that we're not using, so it's not
+// exhaustive. This covers our use cases.
+type HighEntropyValues = {
+  architecture: 'x86' | 'arm' | '';
+  bitness: '32' | '64' | '';
+};
+
 interface NavigatorUAData {
-  getHighEntropyValues(hints: string[]): Promise<Record<string, string>>;
+  getHighEntropyValues(hints: string[]): Promise<HighEntropyValues>;
 }
 
-interface Navigator {
-  userAgentData?: NavigatorUAData;
-}
+export const userAgentDataToArchitecture = ({
+  architecture,
+  bitness
+}: HighEntropyValues) => {
+  if (architecture === 'arm') {
+    return bitness === '64' ? 'arm64' : 'arm';
+  } else {
+    return bitness === '64' ? 'x86_64' : 'x86';
+  }
+};
 
-const getArchitecture = async (): Promise<string> => {
-  if ((navigator as Navigator).userAgentData?.getHighEntropyValues) {
+const hasUserAgentData = (
+  nav: globalThis.Navigator
+): nav is globalThis.Navigator & { userAgentData: NavigatorUAData } => {
+  return 'userAgentData' in nav && nav.userAgentData !== undefined;
+};
+
+const getArchitecture = async (): Promise<Architecture> => {
+  if (hasUserAgentData(navigator)) {
     try {
-      const { architecture } =
-        (await (navigator as Navigator).userAgentData?.getHighEntropyValues([
-          'architecture'
-        ])) ?? {};
-      if (architecture) {
-        return architecture;
-      }
+      const uAData = await navigator.userAgentData.getHighEntropyValues([
+        'architecture',
+        'bitness'
+      ]);
+
+      return userAgentDataToArchitecture(uAData);
     } catch (error) {
       console.error(
         'Error fetching architecture via User-Agent Client Hints:',
@@ -40,7 +60,7 @@ const getArchitecture = async (): Promise<string> => {
   } else if (/i686|x86|Win32/.test(userAgent)) {
     return 'x86';
   } else if (/arm|aarch64/.test(userAgent)) {
-    return /aarch64/.test(userAgent) ? 'ARM64' : 'ARM';
+    return /aarch64/.test(userAgent) ? 'arm64' : 'arm';
   }
 
   return 'Unknown';


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

The main changes are 

* use `bitness` to better specify the architecture
* use the order of exts to determine the preferred download links
* match a few more possible user agent strings 

Fixes https://github.com/freeCodeCamp/freeCodeCamp/issues/65003

<!-- Feel free to add any additional description of changes below this line -->
