### PR TITLE
fix(tools): allow quizzes for block-based super blocks

### DIFF
--- a/tools/challenge-helper-scripts/create-language-block.ts
+++ b/tools/challenge-helper-scripts/create-language-block.ts
@@ -293,9 +293,7 @@ void getAllBlocks()
         message: 'Choose a block label',
         default: BlockLabel.learn,
         type: 'list',
-        choices: Object.values(BlockLabel),
-        when: (answers: CreateBlockArgs) =>
-          chapterBasedSuperBlocks.includes(answers.superBlock)
+        choices: Object.values(BlockLabel)
       },
       {
         name: 'block',


### PR DESCRIPTION
Checklist:

- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.



Closes #65043

This removes the `when` condition that restricted quiz block creation
to chapter-based super blocks, allowing block-based super blocks
(such as A2 and B1 English) to include quizzes.

