### PR TITLE
fix(curriculum,schema): allow A2 and B1 English to have block label

### DIFF
--- a/client/src/redux/prop-types.ts
+++ b/client/src/redux/prop-types.ts
@@ -207,7 +207,7 @@ type InteractiveEditorNodule = {
 export type ChallengeNode = {
   challenge: {
     block: string;
-    blockLabel: BlockLabel;
+    blockLabel?: BlockLabel;
     blockLayout: BlockLayouts;
     certification: string;
     challengeOrder: number;

--- a/client/src/templates/Introduction/components/super-block-accordion.tsx
+++ b/client/src/templates/Introduction/components/super-block-accordion.tsx
@@ -49,7 +49,7 @@ interface ModuleProps {
 interface Challenge {
   id: string;
   block: string;
-  blockLabel: BlockLabel;
+  blockLabel?: BlockLabel;
   title: string;
   fields: { slug: string };
   dashedName: string;
@@ -236,7 +236,7 @@ const LinkModule = ({
     <li className='link-block'>
       <Block
         block={challenges[0].block}
-        blockLabel={label}
+        blockLabel={label || null}
         challenges={challenges}
         superBlock={superBlock}
         accordion={accordion}

--- a/client/src/templates/Introduction/components/super-block-map.tsx
+++ b/client/src/templates/Introduction/components/super-block-map.tsx
@@ -32,7 +32,7 @@ import './super-block-accordion.css';
 
 type Challenge = {
   block: string;
-  blockLabel: BlockLabel;
+  blockLabel?: BlockLabel;
   blockLayout: BlockLayouts;
   challengeType: number;
   dashedName: string;

--- a/client/src/templates/Introduction/super-block-intro.test.tsx
+++ b/client/src/templates/Introduction/super-block-intro.test.tsx
@@ -156,7 +156,7 @@ type ChallengeNode = {
     id: string;
     fields: { slug: string; blockName: string };
     block: string;
-    blockLabel: BlockLabel;
+    blockLabel?: BlockLabel;
     challengeType: number;
     title: string;
     order: number;

--- a/client/src/templates/Introduction/super-block-intro.tsx
+++ b/client/src/templates/Introduction/super-block-intro.tsx
@@ -58,7 +58,7 @@ type ChallengeNode = {
     fields: { slug: string };
     id: string;
     block: string;
-    blockLabel: BlockLabel;
+    blockLabel?: BlockLabel;
     challengeType: number;
     title: string;
     order: number;

--- a/curriculum/schema/challenge-schema.js
+++ b/curriculum/schema/challenge-schema.js
@@ -133,13 +133,7 @@ const schema = Joi.object().keys({
   block: Joi.string().regex(slugRE).required(),
   blockId: Joi.objectId(),
   blockLabel: Joi.when('superBlock', {
-    is: [
-      ...chapterBasedSuperBlocks,
-      ...catalogSuperBlocks,
-      // This is temporary in order to allow A2 and B1 English to have block label.
-      // This won't be needed once we convert those super blocks to chapter-based.
-      ...languageSuperBlocks
-    ],
+    is: [...chapterBasedSuperBlocks, ...catalogSuperBlocks],
     then: Joi.valid(
       'workshop',
       'lab',
@@ -151,7 +145,7 @@ const schema = Joi.object().keys({
       'learn',
       'practice'
     ).required(),
-    otherwise: Joi.valid(null)
+    otherwise: Joi.optional()
   }),
   blockLayout: Joi.valid(
     'challenge-list',

--- a/curriculum/schema/challenge-schema.js
+++ b/curriculum/schema/challenge-schema.js
@@ -133,7 +133,13 @@ const schema = Joi.object().keys({
   block: Joi.string().regex(slugRE).required(),
   blockId: Joi.objectId(),
   blockLabel: Joi.when('superBlock', {
-    is: [...chapterBasedSuperBlocks, ...catalogSuperBlocks],
+    is: [
+      ...chapterBasedSuperBlocks,
+      ...catalogSuperBlocks,
+      // This is temporary in order to allow A2 and B1 English to have block label.
+      // This won't be needed once we convert those super blocks to chapter-based.
+      ...languageSuperBlocks
+    ],
     then: Joi.valid(
       'workshop',
       'lab',

--- a/curriculum/src/file-handler.ts
+++ b/curriculum/src/file-handler.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url';
 import debug from 'debug';
 
 import type { Chapter } from '../../shared-dist/config/chapters.js';
+import type { BlockLabel } from '../../shared-dist/config/blocks.js';
 import type {
   SuperBlocks,
   ChallengeLang
@@ -169,7 +170,7 @@ export interface BlockStructure {
   disableLoopProtectTests?: boolean;
   disableLoopProtectPreview?: boolean;
   blockLayout: string;
-  blockLabel: string;
+  blockLabel?: BlockLabel;
   challengeOrder: Challenge[];
   dashedName: string;
   isUpcomingChange?: boolean;

--- a/tools/challenge-helper-scripts/helpers/project-metadata.ts
+++ b/tools/challenge-helper-scripts/helpers/project-metadata.ts
@@ -3,12 +3,13 @@ import {
   getBlockStructure,
   writeBlockStructure
 } from '../../../curriculum/src/file-handler.js';
+import type { BlockLabel } from '../../../shared-dist/config/blocks.js';
 import { getProjectPath } from './get-project-info.js';
 
 export type Meta = {
   name: string;
   blockLayout: string;
-  blockLabel: string;
+  blockLabel?: BlockLabel;
   isUpcomingChange: boolean;
   dashedName: string;
   helpCategory: string;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

We're adding quiz blocks to A2 and B1 English (#65049 and #65050), which requires setting `blockLabel: quiz` to the block structure files, and the validation doesn't allow this as the super blocks aren't chapter-based. 

I'm updating the schema to allow these two to have `blockLabel`. I don't think this change will break anything.

Also a side note: This is a temporary change, we're adding quiz blocks to these super blocks so that the LC team can start writing questions immediately, and we're going to work on the chapter-based conversion in parallel.

<!-- Feel free to add any additional description of changes below this line -->
