### PR TITLE
fix(.github): correct curriculum structure path in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -35,7 +35,7 @@ pnpm-lock.yaml
 # -------------------------------------------------
 
 /curriculum/challenges/english/* @freecodecamp/curriculum
-/curriculum/challenges/structure/* @freecodecamp/dev-team @freecodecamp/curriculum
+/curriculum/structure/* @freecodecamp/dev-team @freecodecamp/curriculum
 /client/i18n/locales/english/* @freecodecamp/dev-team @freecodecamp/curriculum
 /client/src/pages/learn/* @freecodecamp/dev-team @freecodecamp/curriculum
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

#64562 is not effective because the path to the curriculum structure is incorrect (sorry!). The Curriculum team now should be able to merge changes to the structure files.

<!-- Feel free to add any additional description of changes below this line -->
