### PR TITLE
fix: update challenge link and test for #65057

### DIFF
--- a/client/src/templates/Challenges/components/challenge-title.test.tsx
+++ b/client/src/templates/Challenges/components/challenge-title.test.tsx
@@ -5,9 +5,10 @@ import { describe, it, expect } from 'vitest';
 import ChallengeTitle from './challenge-title';
 
 const baseProps = {
-  children: 'title text',
+  children: 'What is HTML?',
   isCompleted: true,
-  translationPending: false
+  translationPending: false,
+  link: 'learn/responsive-web-design-v9/lecture-understanding-html-attributes/what-is-html'
 };
 
 describe('<ChallengeTitle/>', () => {


### PR DESCRIPTION
Closes #65057

- Replaced challenge link in `challenge-title.test.tsx` with:
  learn/responsive-web-design-v9/lecture-understanding-html-attributes/what-is-html
- Updated test interactions and title text to match new challenge