### PR TITLE
fix(curriculum): use textContent instead of innerText in Book Inventory App tests

### DIFF
--- a/curriculum/challenges/english/blocks/lab-book-inventory-app/66a207974c806a19d6607073.md
+++ b/curriculum/challenges/english/blocks/lab-book-inventory-app/66a207974c806a19d6607073.md
@@ -36,7 +36,7 @@ saveSubmissionToDB: true
 You should have an `h1` element with the text `Book Inventory`.
 
 ```js
-assert.equal(document.querySelector('h1')?.innerText.trim(), 'Book Inventory');
+assert.equal(document.querySelector('h1')?.textContent.trim(), 'Book Inventory');
 ```
 
 You should have only one `h1` element.
@@ -64,31 +64,31 @@ for (const row of rows) {
 Your first column should have the text `Title` as the heading.
 
 ```js
-assert.equal(document.querySelectorAll('th')[0]?.innerText.trim(), 'Title');
+assert.equal(document.querySelectorAll('th')[0]?.textContent.trim(), 'Title');
 ```
 
 Your second column should have the text `Author` as the heading.
 
 ```js
-assert.equal(document.querySelectorAll('th')[1]?.innerText.trim(), 'Author');
+assert.equal(document.querySelectorAll('th')[1]?.textContent.trim(), 'Author');
 ```
 
 Your third column should have the text `Category` as the heading.
 
 ```js
-assert.equal(document.querySelectorAll('th')[2]?.innerText.trim(), 'Category');
+assert.equal(document.querySelectorAll('th')[2]?.textContent.trim(), 'Category');
 ```
 
 Your fourth column should have the text `Status` as the heading.
 
 ```js
-assert.equal(document.querySelectorAll('th')[3]?.innerText.trim(), 'Status');
+assert.equal(document.querySelectorAll('th')[3]?.textContent.trim(), 'Status');
 ```
 
 Your fifth column should have the text `Rate` as the heading.
 
 ```js
-assert.equal(document.querySelectorAll('th')[4]?.innerText.trim(), 'Rate');
+assert.equal(document.querySelectorAll('th')[4]?.textContent.trim(), 'Rate');
 ```
 
 Your table should have at least four rows.
@@ -137,7 +137,7 @@ const statusSpans = document.querySelectorAll('tr td:nth-child(4) :first-child')
 const rows = Array.from(document.querySelectorAll('tr')).slice(1);
 assert.isAbove(statusSpans.length, 0);
 for (let i = 0; i < rows.length; i++) {
-  switch (statusSpans[i]?.innerText.trim()) {
+  switch (statusSpans[i]?.textContent.trim()) {
         case 'Read':
             assert.isTrue(rows[i].classList.contains('read'));
             break;
@@ -182,7 +182,7 @@ for (let e of rateSpans) {
     assert.equal(e.children.length, 3);
     for (let child of e.children) {
         assert.equal(child.tagName, 'SPAN');
-        assert.equal(child.innerText.length, 0);
+        assert.equal(child.textContent.length, 0);
     }
 }
 ```


### PR DESCRIPTION
## Summary
- Replace `innerText` with `textContent` in Book Inventory App tests to fix issues when users apply `text-transform: uppercase` CSS

## Details
When users apply CSS `text-transform: uppercase` to elements, `innerText` returns the visually rendered text (e.g., "TITLE") instead of the original text. This causes tests checking for "Title", "Author", etc. to fail unexpectedly.

Changing to `textContent` ensures tests validate the source text regardless of CSS styling applied.

## Changes
Updated 8 occurrences of `innerText` to `textContent` in the test assertions.

Closes #65059