### PR TITLE
fix: replace innerText with textContent in book inventory lab tests

### DIFF
--- a/curriculum/challenges/english/blocks/lab-book-inventory-app/66a207974c806a19d6607073.md
+++ b/curriculum/challenges/english/blocks/lab-book-inventory-app/66a207974c806a19d6607073.md
@@ -64,31 +64,31 @@ for (const row of rows) {
 Your first column should have the text `Title` as the heading.
 
 ```js
-assert.equal(document.querySelectorAll('th')[0]?.innerText.trim(), 'Title');
+assert.equal(document.querySelectorAll('th')[0]?.textContent.trim(), 'Title');
 ```
 
 Your second column should have the text `Author` as the heading.
 
 ```js
-assert.equal(document.querySelectorAll('th')[1]?.innerText.trim(), 'Author');
+assert.equal(document.querySelectorAll('th')[1]?.textContent.trim(), 'Author');
 ```
 
 Your third column should have the text `Category` as the heading.
 
 ```js
-assert.equal(document.querySelectorAll('th')[2]?.innerText.trim(), 'Category');
+assert.equal(document.querySelectorAll('th')[2]?.textContent.trim(), 'Category');
 ```
 
 Your fourth column should have the text `Status` as the heading.
 
 ```js
-assert.equal(document.querySelectorAll('th')[3]?.innerText.trim(), 'Status');
+assert.equal(document.querySelectorAll('th')[3]?.textContent.trim(), 'Status');
 ```
 
 Your fifth column should have the text `Rate` as the heading.
 
 ```js
-assert.equal(document.querySelectorAll('th')[4]?.innerText.trim(), 'Rate');
+assert.equal(document.querySelectorAll('th')[4]?.textContent.trim(), 'Rate');
 ```
 
 Your table should have at least four rows.


### PR DESCRIPTION

Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #65059 

Updated several test assertions in the Book Inventory App lab to use `textContent` instead of `innerText`.  
This prevents false negatives when learners apply CSS (e.g., `text-transform: uppercase`) and improves test reliability.