### PR TITLE
fix(tools/scripts): improve validation for editable region markers

### DIFF
--- a/tools/challenge-parser/parser/plugins/add-seed.js
+++ b/tools/challenge-parser/parser/plugins/add-seed.js
@@ -13,7 +13,10 @@ function findRegionMarkers(challengeFile) {
     .filter(id => id >= 0);
 
   if (editableLines.length > 2) {
-    throw Error('Editable region has too many markers. Only two are allowed.');
+    throw Error(
+      'Editable region has too many markers. Only two are allowed: ' +
+        editableLines.join(', ')
+    );
   }
 
   if (editableLines.length === 0) {

--- a/tools/challenge-parser/parser/plugins/add-seed.js
+++ b/tools/challenge-parser/parser/plugins/add-seed.js
@@ -13,16 +13,20 @@ function findRegionMarkers(challengeFile) {
     .filter(id => id >= 0);
 
   if (editableLines.length > 2) {
-    throw Error('Editable region has too many markers: ' + editableLines);
+    throw Error('Editable region has too many markers. Only two are allowed.');
   }
 
   if (editableLines.length === 0) {
     return null;
-  } else if (editableLines.length === 1) {
-    throw Error(`Editable region not closed`);
-  } else {
-    return editableLines;
   }
+
+  if (editableLines.length === 1) {
+    throw Error(
+      'Editable region not closed. You must add a second --fcc-editable-region-- marker.'
+    );
+  }
+
+  return editableLines;
 }
 
 function removeLines(contents, toRemove) {
@@ -67,9 +71,12 @@ function addSeeds() {
       if (editRegionMarkers) {
         seed.contents = removeLines(seed.contents, editRegionMarkers);
 
-        if (editRegionMarkers[1] <= editRegionMarkers[0]) {
-          throw Error('Editable region must be non zero');
+        if (editRegionMarkers[1] - editRegionMarkers[0] <= 1) {
+          throw Error(
+            'Editable region must contain at least one editable line.'
+          );
         }
+
         seed.editableRegionBoundaries = editRegionMarkers;
       } else {
         seed.editableRegionBoundaries = [];

--- a/tools/challenge-parser/parser/plugins/add-seed.js
+++ b/tools/challenge-parser/parser/plugins/add-seed.js
@@ -71,10 +71,8 @@ function addSeeds() {
       if (editRegionMarkers) {
         seed.contents = removeLines(seed.contents, editRegionMarkers);
 
-        if (editRegionMarkers[1] - editRegionMarkers[0] <= 1) {
-          throw Error(
-            'Editable region must contain at least one editable line.'
-          );
+        if (editRegionMarkers[1] <= editRegionMarkers[0]) {
+          throw Error('Editable region must be non zero');
         }
 
         seed.editableRegionBoundaries = editRegionMarkers;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related to https://github.com/freeCodeCamp/freeCodeCamp/issues/62366

<!-- Feel free to add any additional description of changes below this line -->
## Summary
This PR improves validation for `--fcc-editable-region--` markers in challenge seed files.

## What was fixed
- Added an error when more than two editable region markers are used.
- Improved the error message when only one marker is present.
- Ensured editable regions contain at least one editable line.
- Prevented malformed marker formats from being accepted.

## Why this change is needed
Incorrect editable region markers can break the editor experience and cause issues in challenges.  
These changes make the parser stricter and provide clearer feedback for content authors.

## Testing
I ran the challenge-parser test suite:
```
cd tools/challenge-parser  
npm test  
```

All tests passed.


