### PR TITLE
docs: remove redundant wording in Certifications section

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Our full-stack web development and machine learning curriculum is completely fre
 
 freeCodeCamp.org offers several free developer certifications. Each of these certifications involves completing interactive lessons, workshops, labs and quizzes. Throughout the certification, you will need to complete 5 required projects to qualify for the exam. Once you pass the exam, then you can claim the certification.
 
-Once you've earned a certification, you will always have it. You will always be able to link to it from your LinkedIn or resume. And when your prospective employers or freelance clients click that link, they'll see a verified certification specific to you.
+Once you've earned a certification, you will always have it and can link to it from your LinkedIn or resume. And when your prospective employers or freelance clients click that link, they'll see a verified certification specific to you.
 
 The one exception to this is if we discover violations of our [Academic Honesty Policy](https://www.freecodecamp.org/news/academic-honesty-policy/). When we catch people unambiguously plagiarizing (submitting other people's code or projects as their own without citation), we do what all rigorous institutions of learning should do - we revoke their certifications and ban those people.
 


### PR DESCRIPTION
This PR removes redundant wording in the Certifications section of the README to improve clarity without changing meaning.

