### PR TITLE
fix(curriculum): correct verb agreement in comparison lesson

### DIFF
--- a/curriculum/challenges/english/blocks/learn-how-to-express-decisions-based-on-comparisons/67d43411dc590273489277b6.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-express-decisions-based-on-comparisons/67d43411dc590273489277b6.md
@@ -42,7 +42,7 @@ This two-word phrase means to consider something carefully.
 
 `Think about` means to consider something carefully. For example:  
 
-`I need to think about my options before making a decision.` - This means you needs time to decide.  
+`I need to think about my options before making a decision.` - This means you need time to decide.  
 
 # --scene--
 


### PR DESCRIPTION
Checklist
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #65079

Description
Corrects a minor verb agreement issue in the explanatory text for the
"Learn How to Express Decisions Based on Comparisons" lesson.
Changes "needs" to "need" in the explanatory text.
Affected Page
https://www.freecodecamp.org/learn/b1-english-for-developers/learn-how-to-express-decisions-based-on-comparisons/task-90