### PR TITLE
fix: clarify brightness() CSS quiz question

### DIFF
--- a/curriculum/challenges/english/blocks/quiz-css-layout-and-effects/66ed8ff4f45ce3ece4053eb4.md
+++ b/curriculum/challenges/english/blocks/quiz-css-layout-and-effects/66ed8ff4f45ce3ece4053eb4.md
@@ -613,7 +613,7 @@ It will make the element appear completely grey.
 
 #### --text--
 
-What is the minimum value for the `brightness()` CSS function to brighten an element?
+What is the baseline value of the `brightness()` CSS function from which increasing brightness starts?
 
 #### --distractors--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #64908

<!-- Feel free to add any additional description of changes below this line -->
This PR fixes a misleading quiz question about the CSS brightness() function.

Previously, the question implied that 100% brightens an element, but 100% is actually the default value and does not increase brightness. Brightening only occurs with values greater than 100%.

The question has been reworded to accurately reflect this behavior.