### PR TITLE
feat: add DSA modules in js cert

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -5303,11 +5303,41 @@
       "classes-and-the-this-keyword": "Classes",
       "lab-bank-account-manager": "Build a Bank Account Management Program",
       "recursion": "Recursion",
+      "data-structures": "Data Structures",
+      "algorithms": "Algorithms",
+      "graphs-and-trees": "Graphs and Trees",
+      "dynamic-programming": "Dynamic Programming",
       "functional-programming": "Functional Programming",
       "asynchronous-javascript": "Asynchronous JavaScript",
       "lab-weather-app": "Build a Weather App",
       "review-javascript": "JavaScript Review",
       "javascript-certification-exam": "JavaScript Certification Exam"
+    },
+    "module-intros": {
+      "data-structures": {
+        "note": "Coming Spring 2026",
+        "intro": [
+          "In this module, you will learn about linked lists, stacks, queues and more."
+        ]
+      },
+      "algorithms": {
+        "note": "Coming Spring 2026",
+        "intro": [
+          "In this module, you will learn about common sorting and searching algorithms including bubble sort, binary search and more."
+        ]
+      },
+      "graphs-and-trees": {
+        "note": "Coming Spring 2026",
+        "intro": [
+          "In this module, you will learn about graphs, trees and tries."
+        ]
+      },
+      "dynamic-programming": {
+        "note": "Coming Spring 2026",
+        "intro": [
+          "In this module, you will learn how dynamic programming works."
+        ]
+      }
     },
     "blocks": {
       "lecture-introduction-to-javascript": {

--- a/curriculum/structure/superblocks/javascript-v9.json
+++ b/curriculum/structure/superblocks/javascript-v9.json
@@ -294,6 +294,26 @@
           ]
         },
         {
+          "dashedName": "data-structures",
+          "comingSoon": true,
+          "blocks": []
+        },
+        {
+          "dashedName": "algorithms",
+          "comingSoon": true,
+          "blocks": []
+        },
+        {
+          "dashedName": "graphs-and-trees",
+          "comingSoon": true,
+          "blocks": []
+        },
+        {
+          "dashedName": "dynamic-programming",
+          "comingSoon": true,
+          "blocks": []
+        },
+        {
           "dashedName": "functional-programming",
           "blocks": [
             "lecture-understanding-functional-programming",


### PR DESCRIPTION
Originally we just had the one full stack cert where DSA was taught in the Python chapter. However, now that we have smaller certs, DSA should be taught in the JS chapter too. There will be separate issues to add that content. But this PR is to setup the modules. 

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

