### PR TITLE
Fix formatting / typo (missing backtick) of total line in Category de…

### DIFF
--- a/curriculum/challenges/english/blocks/lab-budget-app/5e44413e903586ffb414c94e.md
+++ b/curriculum/challenges/english/blocks/lab-budget-app/5e44413e903586ffb414c94e.md
@@ -27,7 +27,7 @@ In this lab, you will build a simple budget app that tracks spending in differen
 1. When a `Category` object is printed, it should:  
    - Display a title line of 30 characters with the category name centered between `*` characters.  
    - List each `ledger` entry with up to 23 characters of its description left-aligned and the amount right-aligned (two decimal places, max 7 characters).  
-   - Show a final line `Total: [balance], where `[balance]` should be replaced by the category total.
+   - Show a final line `Total: [balance]`, where `[balance]` should be replaced by the category total.
    
    Here is an example usage:
    


### PR DESCRIPTION
…scription

Fixes missing backtick after 'Total:[balance]' in the line that describes how Category needs to be printed

Before:

<img width="1028" height="165" alt="image" src="https://github.com/user-attachments/assets/9fdf4c43-1f2c-4daa-a20a-3a3a708fe202" />

After:

<img width="1002" height="157" alt="image" src="https://github.com/user-attachments/assets/1288fbb9-f025-4559-b7d5-44de9865e838" />


Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
