### PR TITLE
fix(curriculum): clarify difference between absolute paths and absolute URLs

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-links/671682dd88e461a8e2620f38.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-links/671682dd88e461a8e2620f38.md
@@ -11,7 +11,9 @@ A path is a string that specifies the location of a file or directory in a file 
 
 An absolute path is a complete link to a resource. It starts from the root directory, includes every other directory, and finally the filename and extension. The "root directory" refers to the top-level directory or folder in a hierarchy.
 
-An absolute path also includes the protocol - which could be `http`, `https`, and `file` and the domain name if the resource is on the web. Here's an example of an absolute path that links to the freeCodeCamp logo:
+An absolute path starts from the root of a file system and includes the full directory structure to a resource.
+
+When a resource is on the web, the full address is called an **absolute URL**, which includes the protocol (such as `http`, `https`, or `file`) and the domain name. Here's an example of an absolute path that links to the freeCodeCamp logo:
 
 ```html
 <a href="https://design-style-guide.freecodecamp.org/img/fcc_secondary_small.svg">


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #64885 

<!-- Feel free to add any additional description of changes below this line -->

## Summary

This PR clarifies the explanation of **absolute paths** in the
“Working with Links” lecture to avoid confusion with **absolute URLs**.

The previous text implied that an absolute path always includes the
protocol and domain, which is not accurate for file system paths.

---

## What Changed

- Updated the definition of an **absolute path** to focus on file system usage  
- Clarified that a **URL** (with protocol + domain) is an **absolute URL**, not an absolute path  
- Improved wording to reduce learner confusion  

---

## Why This Is Needed

Some learners were confused because:
- Absolute paths and absolute URLs are treated as the same thing  
- Quiz questions did not match the lesson explanation  

This update aligns the lesson with standard web terminology.

---

## Testing

- Curriculum build ran successfully  
- No code or logic changes were made  
- Only the curriculum content was updated  


