### PR TITLE
fix(curriculum): correct docstring example in Python V9 Step 24

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-media-catalogue/68b816815f13eca63a588b45.md
+++ b/curriculum/challenges/english/blocks/workshop-media-catalogue/68b816815f13eca63a588b45.md
@@ -10,8 +10,8 @@ dashedName: step-24
 A docstring is a string placed as the first statement in a class or function, and it's used to provide documentation for that class or function. Docstrings are typically enclosed by triple double quotes:
 
 ```py
-def add(x):
-    """A function that returns the square of a number."""
+def add(x, y):
+    """A function that returns the sum of two numbers."""
     return x + y
 ```
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #65091

Fixes an incorrect docstring example in Step 24 to ensure the function and explanation match.
