### PR TITLE
fix(curriculum): Updated field label for better readability

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68ea8fdf2c9b167307e7f671.md
+++ b/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68ea8fdf2c9b167307e7f671.md
@@ -9,7 +9,7 @@ dashedName: step-9
 
 Now it is time to add the form elements to collect the parent's information.
 
-Start by adding a `label` element with the text `Parent/Guardian Information: ` and `for` attribute set to `"parent-name"`.
+Start by adding a `label` element with the text `Parent/Guardian Name: ` and `for` attribute set to `"parent-name"`.
 
 Then, below your `label` element, add an `input` element with the `type` attribute set to `"text"`. The `name` and `id` attributes should be set to `"parent-name"`. The `placeholder` attribute should be set to `"E.g., Nancy Doe"`. Lastly, your `input` should be required. 
 
@@ -21,10 +21,10 @@ You should have a total of three `label` elements on the page.
 assert.lengthOf(document.querySelectorAll("label"), 3);
 ```
 
-Your third `label` element should have the text `Parent/Guardian Information: `. Don't forget the space after the colon.
+Your third `label` element should have the text `Parent/Guardian Name: `. Don't forget the space after the colon.
 
 ```js
-assert.match(code, /Parent\/Guardian\s+Information:\s+<\/label>/);
+assert.match(code, /Parent\/Guardian\s+Name:\s+<\/label>/);
 ```
 
 Your third `label` element should have a `for` attribute.

--- a/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68ea95c833f0518ae6e366cd.md
+++ b/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68ea95c833f0518ae6e366cd.md
@@ -76,7 +76,7 @@ assert.strictEqual(document.querySelector("fieldset:last-of-type legend")?.inner
 
       <fieldset>
         <legend>Parent/Guardian Information</legend>
-        <label for="parent-name">Parent/Guardian Information: </label>
+        <label for="parent-name">Parent/Guardian Name: </label>
         <input
             type="text"
             name="parent-name"

--- a/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68ea975c7cbbb894a386e402.md
+++ b/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68ea975c7cbbb894a386e402.md
@@ -136,7 +136,7 @@ assert.isTrue(input?.hasAttribute("checked"));
 
       <fieldset>
         <legend>Parent/Guardian Information</legend>
-        <label for="parent-name">Parent/Guardian Information: </label>
+        <label for="parent-name">Parent/Guardian Name: </label>
         <input
             type="text"
             name="parent-name"

--- a/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68ea9f01c51b66b937793611.md
+++ b/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68ea9f01c51b66b937793611.md
@@ -123,7 +123,7 @@ assert.exists(document.querySelector("fieldset:last-of-type input[id='phone'].co
 
       <fieldset>
         <legend>Parent/Guardian Information</legend>
-        <label for="parent-name">Parent/Guardian Information: </label>
+        <label for="parent-name">Parent/Guardian Name: </label>
         <input
             type="text"
             name="parent-name"

--- a/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eaa310c153c0d0c5c9b78e.md
+++ b/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eaa310c153c0d0c5c9b78e.md
@@ -87,7 +87,7 @@ assert.equal(legend?.innerText?.trim(), 'Additional Notes');
 
       <fieldset>
         <legend>Parent/Guardian Information</legend>
-        <label for="parent-name">Parent/Guardian Information: </label>
+        <label for="parent-name">Parent/Guardian Name: </label>
         <input
             type="text"
             name="parent-name"

--- a/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eaa668d4d9fbe529a0e16b.md
+++ b/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eaa668d4d9fbe529a0e16b.md
@@ -119,7 +119,7 @@ assert.strictEqual(textarea?.getAttribute("cols"), "50");
 
       <fieldset>
         <legend>Parent/Guardian Information</legend>
-        <label for="parent-name">Parent/Guardian Information: </label>
+        <label for="parent-name">Parent/Guardian Name: </label>
         <input
             type="text"
             name="parent-name"

--- a/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eafe1bae175f3b2a87a90d.md
+++ b/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eafe1bae175f3b2a87a90d.md
@@ -85,7 +85,7 @@ assert.strictEqual(button?.innerText, "Submit Form");
 
       <fieldset>
         <legend>Parent/Guardian Information</legend>
-        <label for="parent-name">Parent/Guardian Information: </label>
+        <label for="parent-name">Parent/Guardian Name: </label>
         <input
             type="text"
             name="parent-name"

--- a/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eb01876d31f24efecb0475.md
+++ b/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eb01876d31f24efecb0475.md
@@ -79,7 +79,7 @@ assert.equal(style?.color, 'whitesmoke');
 
       <fieldset>
         <legend>Parent/Guardian Information</legend>
-        <label for="parent-name">Parent/Guardian Information: </label>
+        <label for="parent-name">Parent/Guardian Name: </label>
         <input
             type="text"
             name="parent-name"

--- a/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eb058081504963447bfa60.md
+++ b/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eb058081504963447bfa60.md
@@ -78,7 +78,7 @@ assert.strictEqual(style?.backgroundColor, 'rgba(255, 255, 255, 0.1)')
 
       <fieldset>
         <legend>Parent/Guardian Information</legend>
-        <label for="parent-name">Parent/Guardian Information: </label>
+        <label for="parent-name">Parent/Guardian Name: </label>
         <input
             type="text"
             name="parent-name"

--- a/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eb07a965e83b6ef95f488a.md
+++ b/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eb07a965e83b6ef95f488a.md
@@ -89,7 +89,7 @@ assert.strictEqual(style?.margin, '20px auto')
 
       <fieldset>
         <legend>Parent/Guardian Information</legend>
-        <label for="parent-name">Parent/Guardian Information: </label>
+        <label for="parent-name">Parent/Guardian Name: </label>
         <input
             type="text"
             name="parent-name"

--- a/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eb0d455ea45b89bbddd375.md
+++ b/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eb0d455ea45b89bbddd375.md
@@ -68,7 +68,7 @@ assert.strictEqual(style?.padding, '10px 20px')
 
       <fieldset>
         <legend>Parent/Guardian Information</legend>
-        <label for="parent-name">Parent/Guardian Information: </label>
+        <label for="parent-name">Parent/Guardian Name: </label>
         <input
             type="text"
             name="parent-name"

--- a/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eb0f604d821894a88d07d8.md
+++ b/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eb0f604d821894a88d07d8.md
@@ -70,7 +70,7 @@ assert.strictEqual(style?.getPropVal('box-shadow'), 'black 0px 5px 15px');
 
       <fieldset>
         <legend>Parent/Guardian Information</legend>
-        <label for="parent-name">Parent/Guardian Information: </label>
+        <label for="parent-name">Parent/Guardian Name: </label>
         <input
             type="text"
             name="parent-name"

--- a/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eb1089f079099d400162eb.md
+++ b/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eb1089f079099d400162eb.md
@@ -70,7 +70,7 @@ assert.strictEqual(style?.textAlign, 'center')
 
       <fieldset>
         <legend>Parent/Guardian Information</legend>
-        <label for="parent-name">Parent/Guardian Information: </label>
+        <label for="parent-name">Parent/Guardian Name: </label>
         <input
             type="text"
             name="parent-name"

--- a/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eb1f4e8ccb1cb263b81efe.md
+++ b/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eb1f4e8ccb1cb263b81efe.md
@@ -68,7 +68,7 @@ assert.strictEqual(style?.fontSize, '1.2rem')
 
       <fieldset>
         <legend>Parent/Guardian Information</legend>
-        <label for="parent-name">Parent/Guardian Information: </label>
+        <label for="parent-name">Parent/Guardian Name: </label>
         <input
             type="text"
             name="parent-name"

--- a/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eb206a76e5d0b9c0b40eb7.md
+++ b/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eb206a76e5d0b9c0b40eb7.md
@@ -91,7 +91,7 @@ assert.strictEqual(style?.padding, '20px');
 
       <fieldset>
         <legend>Parent/Guardian Information</legend>
-        <label for="parent-name">Parent/Guardian Information: </label>
+        <label for="parent-name">Parent/Guardian Name: </label>
         <input
             type="text"
             name="parent-name"

--- a/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eb2161d02d00c013fc44f9.md
+++ b/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eb2161d02d00c013fc44f9.md
@@ -91,7 +91,7 @@ assert.strictEqual(style?.fontWeight, '600');
 
       <fieldset>
         <legend>Parent/Guardian Information</legend>
-        <label for="parent-name">Parent/Guardian Information: </label>
+        <label for="parent-name">Parent/Guardian Name: </label>
         <input
             type="text"
             name="parent-name"

--- a/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eb2430ac339ace4d2cd0e5.md
+++ b/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eb2430ac339ace4d2cd0e5.md
@@ -70,7 +70,7 @@ assert.strictEqual(style?.fontSize, '1.2rem');
 
       <fieldset>
         <legend>Parent/Guardian Information</legend>
-        <label for="parent-name">Parent/Guardian Information: </label>
+        <label for="parent-name">Parent/Guardian Name: </label>
         <input
             type="text"
             name="parent-name"

--- a/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eb25b53c450ed6fc47e37a.md
+++ b/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eb25b53c450ed6fc47e37a.md
@@ -80,7 +80,7 @@ assert.strictEqual(style?.margin, '10px 0px');
 
       <fieldset>
         <legend>Parent/Guardian Information</legend>
-        <label for="parent-name">Parent/Guardian Information: </label>
+        <label for="parent-name">Parent/Guardian Name: </label>
         <input
             type="text"
             name="parent-name"

--- a/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eb288f63d818e6e2ff246b.md
+++ b/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eb288f63d818e6e2ff246b.md
@@ -102,7 +102,7 @@ assert.strictEqual(style?.padding, '10px');
 
       <fieldset>
         <legend>Parent/Guardian Information</legend>
-        <label for="parent-name">Parent/Guardian Information: </label>
+        <label for="parent-name">Parent/Guardian Name: </label>
         <input
             type="text"
             name="parent-name"

--- a/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eb29fa879c7deef9806a04.md
+++ b/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eb29fa879c7deef9806a04.md
@@ -70,7 +70,7 @@ assert.strictEqual(style?.color, 'whitesmoke');
 
       <fieldset>
         <legend>Parent/Guardian Information</legend>
-        <label for="parent-name">Parent/Guardian Information: </label>
+        <label for="parent-name">Parent/Guardian Name: </label>
         <input
             type="text"
             name="parent-name"

--- a/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eb2d6986a77e004f583091.md
+++ b/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eb2d6986a77e004f583091.md
@@ -70,7 +70,7 @@ assert.strictEqual(style?.appearance, 'none');
 
       <fieldset>
         <legend>Parent/Guardian Information</legend>
-        <label for="parent-name">Parent/Guardian Information: </label>
+        <label for="parent-name">Parent/Guardian Name: </label>
         <input
             type="text"
             name="parent-name"

--- a/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eb2ec44a4c4108988f2d7c.md
+++ b/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eb2ec44a4c4108988f2d7c.md
@@ -91,7 +91,7 @@ assert.oneOf(style?.border, ['2px solid gray', '2px solid grey']);
 
       <fieldset>
         <legend>Parent/Guardian Information</legend>
-        <label for="parent-name">Parent/Guardian Information: </label>
+        <label for="parent-name">Parent/Guardian Name: </label>
         <input
             type="text"
             name="parent-name"

--- a/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eb30a907dc8813531084df.md
+++ b/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eb30a907dc8813531084df.md
@@ -72,7 +72,7 @@ assert.strictEqual(style?.verticalAlign, 'bottom');
 
       <fieldset>
         <legend>Parent/Guardian Information</legend>
-        <label for="parent-name">Parent/Guardian Information: </label>
+        <label for="parent-name">Parent/Guardian Name: </label>
         <input
             type="text"
             name="parent-name"

--- a/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eb323ff5a6dc1cc19fa300.md
+++ b/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eb323ff5a6dc1cc19fa300.md
@@ -100,7 +100,7 @@ assert.strictEqual(style?.borderRadius, '50%');
 
       <fieldset>
         <legend>Parent/Guardian Information</legend>
-        <label for="parent-name">Parent/Guardian Information: </label>
+        <label for="parent-name">Parent/Guardian Name: </label>
         <input
             type="text"
             name="parent-name"

--- a/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eb33a0e109d026cf545b43.md
+++ b/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eb33a0e109d026cf545b43.md
@@ -79,7 +79,7 @@ assert.oneOf(style?.transition, ['0.3s ease-in', 'all 0.3s ease-in 0s'])
 
       <fieldset>
         <legend>Parent/Guardian Information</legend>
-        <label for="parent-name">Parent/Guardian Information: </label>
+        <label for="parent-name">Parent/Guardian Name: </label>
         <input
             type="text"
             name="parent-name"

--- a/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eb372f9b470238bf60577d.md
+++ b/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eb372f9b470238bf60577d.md
@@ -81,7 +81,7 @@ assert.strictEqual(style?.backgroundColor, 'lightgreen');
 
       <fieldset>
         <legend>Parent/Guardian Information</legend>
-        <label for="parent-name">Parent/Guardian Information: </label>
+        <label for="parent-name">Parent/Guardian Name: </label>
         <input
             type="text"
             name="parent-name"

--- a/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eb3a06c6adde47584e2721.md
+++ b/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eb3a06c6adde47584e2721.md
@@ -105,7 +105,7 @@ assert.strictEqual(style?.padding, '12px 20px');
 
       <fieldset>
         <legend>Parent/Guardian Information</legend>
-        <label for="parent-name">Parent/Guardian Information: </label>
+        <label for="parent-name">Parent/Guardian Name: </label>
         <input
             type="text"
             name="parent-name"

--- a/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eb3acbc5d86e4d53b58d91.md
+++ b/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eb3acbc5d86e4d53b58d91.md
@@ -82,7 +82,7 @@ assert.strictEqual(style?.margin, 'auto');
 
       <fieldset>
         <legend>Parent/Guardian Information</legend>
-        <label for="parent-name">Parent/Guardian Information: </label>
+        <label for="parent-name">Parent/Guardian Name: </label>
         <input
             type="text"
             name="parent-name"

--- a/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eb3bdd830d4e552f0bb24a.md
+++ b/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eb3bdd830d4e552f0bb24a.md
@@ -70,7 +70,7 @@ assert.strictEqual(style?.backgroundColor, 'midnightblue');
         
         <fieldset>
           <legend>Parent/Guardian Information</legend>
-          <label for="parent-name">Parent/Guardian Information: </label>
+          <label for="parent-name">Parent/Guardian Name: </label>
           <input
             type="text"
             name="parent-name"
@@ -260,7 +260,7 @@ textarea {
         
         <fieldset>
           <legend>Parent/Guardian Information</legend>
-          <label for="parent-name">Parent/Guardian Information: </label>
+          <label for="parent-name">Parent/Guardian Name: </label>
           <input
             type="text"
             name="parent-name"


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #65057 

<!-- Feel free to add any additional description of changes below this line -->

Updated steps in Responsive Web Design Certification to have the label with the name `Parent/Guardian Name` instead of `Parent/Guardian Information` for better readability. I have also updated the respective test as well to capture the new field. 
