### PR TITLE
fix(curriculum): ensure setters run during object initialization

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-understanding-object-oriented-programming-and-encapsulation/68c128cbd77e4ba9ed671937.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-object-oriented-programming-and-encapsulation/68c128cbd77e4ba9ed671937.md
@@ -50,6 +50,8 @@ Notice how we used `_radius` instead of radius inside the class. The underscore 
 
 To make a setter to create the radius, for example, you have to define another method with the same name and use `@<property_name>.setter` above it:
 
+Using `self.radius` inside `__init__` ensures the setter runs during object creation, so invalid radius values are caught immediately.
+
 ```py
 class Circle:
     def __init__(self, radius):

--- a/curriculum/challenges/english/blocks/lecture-understanding-object-oriented-programming-and-encapsulation/68c128cbd77e4ba9ed671937.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-object-oriented-programming-and-encapsulation/68c128cbd77e4ba9ed671937.md
@@ -53,7 +53,7 @@ To make a setter to create the radius, for example, you have to define another m
 ```py
 class Circle:
     def __init__(self, radius):
-        self._radius = radius
+        self.radius = radius
 
     @property
     def radius(self):  # A getter to get the radius
@@ -90,7 +90,7 @@ A deleter runs custom logic when you use the del statement on a property. To cre
 ```py
 class Circle:
     def __init__(self, radius):
-        self._radius = radius
+        self.radius = radius
 
     # Getter
     @property

--- a/curriculum/challenges/english/blocks/lecture-understanding-object-oriented-programming-and-encapsulation/68c128cbd77e4ba9ed671937.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-object-oriented-programming-and-encapsulation/68c128cbd77e4ba9ed671937.md
@@ -55,7 +55,7 @@ Using `self.radius` inside `__init__` ensures the setter runs during object crea
 ```py
 class Circle:
     def __init__(self, radius):
-        self.radius = radius
+        self.radius = radius # Calling the setter
 
     @property
     def radius(self):  # A getter to get the radius


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #65075 

<!-- Feel free to add any additional description of changes below this line -->

### Summary

This PR updates the **"What are Getters and Setters"** lesson to ensure that setters are triggered during object initialization.

Previously, the examples assigned values directly to the private attribute (`_radius`) inside `__init__`, which bypassed the setter logic. This meant validation (like checking for positive values) did not run when creating a new object.

### What Changed

- Updated `__init__` to use the property:
```
  self.radius = radius
```
instead of:
 ```
  self._radius = radius
```

- This ensures that the setter is executed during initialization.
- Keeps the behavior consistent with how the properties are intended to be used.

## Why This Matters

- Prevents invalid values from being assigned at object creation.
- Makes the examples more accurate and educational.
- Aligns the lesson with best practices for using setters in Python.
