### PR TITLE
fix(curriculum): clarify discount percentage in step 17 instruction

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-discount-calculator/68e5293bd00d2fe134f58988.md
+++ b/curriculum/challenges/english/blocks/workshop-discount-calculator/68e5293bd00d2fe134f58988.md
@@ -9,7 +9,7 @@ dashedName: step-17
 
 Implement the `is_applicable` method for your `FixedAmountDiscount` class. A fixed amount discount should only be applied if it makes sense economically.
 
-Return `True` if `product.price * 0.9` is greater than `self.amount`, otherwise return `False`. This ensures the discount doesn't exceed 10% of the original price, which would be unrealistic.
+Return `True` if `product.price * 0.9` is greater than `self.amount`, otherwise return `False`. This ensures the discount is less than 90% of the original price, so it's not unrealistic.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:


- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #65111

This PR updates the Step 17 instruction text to correctly describe the discount logic.
The original wording mentioned a 10% limit, while the actual condition enforces a 90% threshold.