### PR TITLE
fix(curriculum): add missing space before required attribute

### DIFF
--- a/curriculum/challenges/english/blocks/lab-debug-donation-form/690ddb5e6ee94eb73ed172b0.md
+++ b/curriculum/challenges/english/blocks/lab-debug-donation-form/690ddb5e6ee94eb73ed172b0.md
@@ -75,7 +75,7 @@ const labels = document.querySelectorAll("label");
 assert.match(labels[2]?.textContent, /Donation\s*Amount\s*\(\$\)\s*:/i);
 ```
 
-Your third `input` should have a`required` attribute.
+Your third `input` should have a `required` attribute.
 
 ```js
 const thirdInput = document.querySelector("input[name='amount']");


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Fixes #65107

<!-- Feel free to add any additional description of changes below this line -->

Adds a missing space between `a` and `required` in the donation form lab instructions.
