### PR TITLE
fix(curriculum): correct typo in recipe tracker workshop

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-recipe-tracker/670e4f45f7116c0f216a5177.md
+++ b/curriculum/challenges/english/blocks/workshop-recipe-tracker/670e4f45f7116c0f216a5177.md
@@ -26,7 +26,7 @@ Access the `name` property of `recipe1`, and assign it to the variable `recipe1N
 
 Next, access the `cookingTime` property of `recipe2` and assign it to the variable `recipe2CookingTime`.
 
-Finialy, access the `ingredients` property of `recipe3` and assign it to the variable `recipe3Ingredients`.
+Finally, access the `ingredients` property of `recipe3` and assign it to the variable `recipe3Ingredients`.
 
 Make sure all the variables you created are logged to the console.
 


### PR DESCRIPTION
Fixes a typo in Step 6 of the Build a Recipe Tracker workshop.

Changed "Finialy" to "Finally".
