### PR TITLE
fix(curriculum): remove incorrect article in RWD curriculum

### DIFF
--- a/curriculum/challenges/english/blocks/review-css-backgrounds-and-borders/671a88d636cebc5fbd407b78.md
+++ b/curriculum/challenges/english/blocks/review-css-backgrounds-and-borders/671a88d636cebc5fbd407b78.md
@@ -25,7 +25,7 @@ dashedName: review-css-backgrounds-and-borders
 - **`pseudo-class`**: This is a keyword added to a selector that allows you to select elements based on a particular state. Common states would include the `:hover`, `:visited` and `:focus` states.
 - **`:link pseudo-class`**: This pseudo-class is used to style links that have not be visited by the user.
 - **`:visited pseudo-class`**: This pseudo-class is used to style links where a user has already visited.
-- **`:hover pseudo-class`**: This pseudo-class is used to style an elements where a user is actively hovering over them.
+- **`:hover pseudo-class`**: This pseudo-class is used to style elements where a user is actively hovering over them.
 - **`:focus pseudo-class`**: This pseudo-class is used to style an element when it receives focus. Examples would include `input` or `select` elements where the clicks or tabs on the element to focus it.
 - **`:active pseudo-class`**: This pseudo-class is used to style an element that was activated by the user. A common example would be when the user clicks on a button.
 


### PR DESCRIPTION
**Summary**
Fixed a grammatical error in the Responsive Web Design curriculum.

**Description**
The sentence "This pseudo-class is used to style an elements where a user is actively hovering over them" contained an incorrect article ("an") before the plural noun "elements." I have removed "an" to ensure the sentence is grammatically correct.

**Affected Page**
https://www.freecodecamp.org/learn/responsive-web-design-v9/review-css-backgrounds-and-borders/review-css-backgrounds-and-borders

Checklist:
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitHub Codespaces.

Additional note:
Since this was a small change, I opened the PR directly without opening an issue first.