### PR TITLE
fix(curriculum): correct typo in  Lists, Links, CSS backgrounds and borders lesson

### DIFF
--- a/curriculum/challenges/english/blocks/quiz-css-backgrounds-and-borders/66ed8fd7f45ce3ece4053eb0.md
+++ b/curriculum/challenges/english/blocks/quiz-css-backgrounds-and-borders/66ed8fd7f45ce3ece4053eb0.md
@@ -69,7 +69,7 @@ It is used to set the background size for an element.
 
 ---
 
-It is used to style links that have not be visited by the user.
+It is used to style links that have not been visited by the user.
 
 ---
 

--- a/curriculum/challenges/english/blocks/review-css-backgrounds-and-borders/671a88d636cebc5fbd407b78.md
+++ b/curriculum/challenges/english/blocks/review-css-backgrounds-and-borders/671a88d636cebc5fbd407b78.md
@@ -23,7 +23,7 @@ dashedName: review-css-backgrounds-and-borders
 ## Styling Links
 
 - **`pseudo-class`**: This is a keyword added to a selector that allows you to select elements based on a particular state. Common states would include the `:hover`, `:visited` and `:focus` states.
-- **`:link pseudo-class`**: This pseudo-class is used to style links that have not be visited by the user.
+- **`:link pseudo-class`**: This pseudo-class is used to style links that have not been visited by the user.
 - **`:visited pseudo-class`**: This pseudo-class is used to style links where a user has already visited.
 - **`:hover pseudo-class`**: This pseudo-class is used to style an elements where a user is actively hovering over them.
 - **`:focus pseudo-class`**: This pseudo-class is used to style an element when it receives focus. Examples would include `input` or `select` elements where the clicks or tabs on the element to focus it.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #65115

<!-- Feel free to add any additional description of changes below this line -->
### Description
Corrects a grammatical typo in the Responsive Web Design curriculum.
The same sentence appeared in both the quiz and review content, and the typo was fixed in both locations:
"have not be" → "have not been".

### Testing
- Verified the correction directly in the curriculum markdown files.
- Text-only change; no functional impact.

