### PR TITLE
fix: correct typo 'Finialy' to 'Finally' in recipe tracker step 6

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-recipe-tracker/670e4f45f7116c0f216a5177.md
+++ b/curriculum/challenges/english/blocks/workshop-recipe-tracker/670e4f45f7116c0f216a5177.md
@@ -26,7 +26,7 @@ Access the `name` property of `recipe1`, and assign it to the variable `recipe1N
 
 Next, access the `cookingTime` property of `recipe2` and assign it to the variable `recipe2CookingTime`.
 
-Finialy, access the `ingredients` property of `recipe3` and assign it to the variable `recipe3Ingredients`.
+Finally, access the `ingredients` property of `recipe3` and assign it to the variable `recipe3Ingredients`.
 
 Make sure all the variables you created are logged to the console.
 


### PR DESCRIPTION
## Description
Fixed typo in Build a Recipe Tracker - Step 6 instructions.

## Changes
- Changed "Finialy" to "Finally" in line 29

## Related Issue
Closes #65094

## Testing
Verified the markdown renders correctly with the corrected spelling.