### PR TITLE
fix(curriculum): clarify error when inserting without columns

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-relational-databases/687ea8a88c9e9419af7cd8c3.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-relational-databases/687ea8a88c9e9419af7cd8c3.md
@@ -47,7 +47,13 @@ INSERT INTO dogs
 VALUES ('Gino', 3);
 ```
 
-This is valid too, but it's more prone to errors because the values are assigned to the columns based on their order.
+This syntax is valid SQL, but it is error-prone.
+
+Since values are assigned based on column order, PostgreSQL will try to insert `'Gino'`
+into the `id` column, which expects an integer. This results in an error such as
+`invalid input syntax for type integer`.
+
+For this reason, it is safer to explicitly specify the column names when inserting data.
 
 You can also insert multiple records in the same SQL command by separating them with a comma.
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-relational-databases/687ea8a88c9e9419af7cd8c3.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-relational-databases/687ea8a88c9e9419af7cd8c3.md
@@ -49,9 +49,7 @@ VALUES ('Gino', 3);
 
 This syntax is valid SQL, but it is error-prone.
 
-Since values are assigned based on column order, PostgreSQL will try to insert `'Gino'`
-into the `id` column, which expects an integer. This results in an error such as
-`invalid input syntax for type integer`.
+Since values are assigned based on column order, PostgreSQL will try to insert `'Gino'` into the `id` column, which expects an integer. This results in an error such as `invalid input syntax for type integer`.
 
 For this reason, it is safer to explicitly specify the column names when inserting data.
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #64893

I’ve added an explanation clarifying what “error-prone” means in this context,
including the PostgreSQL error message and why it occurs when values are assigned
by column order.