### PR TITLE
fix(curriculum): update ambiguous answer in Task 54

### DIFF
--- a/curriculum/challenges/english/blocks/learn-present-perfect-while-talking-about-accessibility/671f9e83b440da8486fdf76e.md
+++ b/curriculum/challenges/english/blocks/learn-present-perfect-while-talking-about-accessibility/671f9e83b440da8486fdf76e.md
@@ -20,7 +20,7 @@ What is the current status of the issue according to James?
 
 ## --answers--
 
-The development team is still working on it and narrowing down the possible solutions.
+The quality assurance team is still working on it and narrowing down the possible solutions.
 
 ### --feedback--
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #65118

I updated the first option in the "answers" section for Task 54 (B1 English for Developers).
Previously, the first and third answers were semantically identical ("development team is still working on it").
I changed the first answer to refer to the "quality assurance team" instead, making it clearly incorrect compared to the dialogue, as requested in the issue.