### PR TITLE
feat(curriculum): add auto-save with timestamp indicator for lab challenges

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -551,7 +551,8 @@
       "preview": "Preview",
       "terminal": "Terminal",
       "editor": "Editor",
-      "interactive-editor": "Interactive Editor"
+      "interactive-editor": "Interactive Editor",
+      "saved": "Saved {{timeAgo}}"
     },
     "editor-alerts": {
       "tab-trapped": "Pressing tab will now insert the tab character",

--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -552,7 +552,8 @@
       "terminal": "Terminal",
       "editor": "Editor",
       "interactive-editor": "Interactive Editor",
-      "saved": "Saved {{timeAgo}}"
+      "saved": "Saved {{timeAgo}}",
+      "download-code": "Download Code"
     },
     "editor-alerts": {
       "tab-trapped": "Pressing tab will now insert the tab character",

--- a/client/src/templates/Challenges/classic/action-row.tsx
+++ b/client/src/templates/Challenges/classic/action-row.tsx
@@ -1,7 +1,11 @@
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 import { lastSavedTimeSelector } from '../redux/selectors';
-import { faCheck, faWindowRestore } from '@fortawesome/free-solid-svg-icons';
+import {
+  faCheck,
+  faDownload,
+  faWindowRestore
+} from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -9,6 +13,7 @@ import store from 'store';
 import { DailyCodingChallengeLanguages } from '../../../redux/prop-types';
 import { challengeTypes } from '@freecodecamp/shared/config/challenge-types';
 import EditorTabs from './editor-tabs';
+import { useDownloadChallenge } from '../hooks';
 
 interface ClassicLayoutProps {
   dailyCodingChallengeLanguage: DailyCodingChallengeLanguages;
@@ -40,6 +45,7 @@ type ActionRowProps = ClassicLayoutProps | InteractiveEditorProps;
 
 const ActionRow = (props: ActionRowProps): JSX.Element => {
   const { t } = useTranslation();
+  const { downloadChallenge } = useDownloadChallenge();
 
   const [currentTime, setCurrentTime] = useState<number>(Date.now());
 
@@ -209,8 +215,23 @@ const ActionRow = (props: ActionRowProps): JSX.Element => {
               </button>
             </>
           )}
-          <span className='save-status' aria-live='polite'>
-            <FontAwesomeIcon icon={faCheck} />
+          <button
+            className='download-code'
+            onClick={downloadChallenge}
+            aria-label={t('learn.editor-tabs.download-code')}
+          >
+            <FontAwesomeIcon
+              icon={faDownload}
+              aria-hidden='true'
+              focusable='false'
+            />
+          </button>
+          <span className='save-status' aria-live='off'>
+            <FontAwesomeIcon
+              icon={faCheck}
+              aria-hidden='true'
+              focusable='false'
+            />
             {t('learn.editor-tabs.saved', {
               timeAgo: formatTimeAgo(lastSavedTime)
             })}

--- a/client/src/templates/Challenges/classic/action-row.tsx
+++ b/client/src/templates/Challenges/classic/action-row.tsx
@@ -32,7 +32,6 @@ interface ClassicLayoutProps {
   challengeType: number;
   togglePane: (pane: string) => void;
   hasInteractiveEditor?: never;
-  lastSavedTime: number | null;
 }
 
 interface InteractiveEditorProps {
@@ -41,7 +40,12 @@ interface InteractiveEditorProps {
   toggleInteractiveEditor: () => void;
 }
 
-type ActionRowProps = ClassicLayoutProps | InteractiveEditorProps;
+interface ReduxProps {
+  lastSavedTime: number | null;
+}
+
+type ActionRowProps = (ClassicLayoutProps | InteractiveEditorProps) &
+  ReduxProps;
 
 const ActionRow = (props: ActionRowProps): JSX.Element => {
   const { t } = useTranslation();

--- a/client/src/templates/Challenges/classic/action-row.tsx
+++ b/client/src/templates/Challenges/classic/action-row.tsx
@@ -52,7 +52,7 @@ const ActionRow = (props: ActionRowProps): JSX.Element => {
   useEffect(() => {
     const interval = setInterval(() => {
       setCurrentTime(Date.now());
-    }, 10000);
+    }, 5000);
 
     return () => clearInterval(interval);
   }, []);
@@ -134,15 +134,26 @@ const ActionRow = (props: ActionRowProps): JSX.Element => {
     setDailyCodingChallengeLanguage(language);
   };
 
-  const formatTimeAgo = (timestamp: number | null): string => {
-    if (!timestamp) return 'just now';
+  const formatTimeAgo = (): JSX.Element | null => {
+    if (!lastSavedTime) return null;
 
-    const seconds = Math.floor((currentTime - timestamp) / 1000);
+    const seconds = Math.floor((currentTime - lastSavedTime) / 1000);
 
-    if (seconds < 10) return 'just now';
-    if (seconds < 60) return `${seconds}s ago`;
-    if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`;
-    return `${Math.floor(seconds / 3600)}h ago`;
+    const timeAgo =
+      seconds < 5
+        ? 'just now'
+        : seconds < 60
+          ? `${seconds}s ago`
+          : seconds < 3600
+            ? `${Math.floor(seconds / 60)}m ago`
+            : `${Math.floor(seconds / 3600)}h ago`;
+
+    return (
+      <span className='save-status' aria-live='off'>
+        <FontAwesomeIcon icon={faCheck} aria-hidden='true' focusable='false' />
+        {t('learn.editor-tabs.saved', { timeAgo })}
+      </span>
+    );
   };
 
   return (
@@ -182,6 +193,7 @@ const ActionRow = (props: ActionRowProps): JSX.Element => {
         )}
         {/* right */}
         <div className='tabs-row-right panel-display-tabs'>
+          {formatTimeAgo()}
           <button
             aria-expanded={!!showConsole}
             onClick={() => togglePane('showConsole')}
@@ -202,6 +214,7 @@ const ActionRow = (props: ActionRowProps): JSX.Element => {
                 data-playwright-test-label='preview-pane-button'
                 aria-expanded={!!showPreviewPane}
                 onClick={() => togglePane('showPreviewPane')}
+                className='preview-pane'
               >
                 <span className='sr-only'>{getPreviewBtnsSrText().pane}</span>
                 <span aria-hidden='true'>{previewButtonText}</span>
@@ -216,7 +229,6 @@ const ActionRow = (props: ActionRowProps): JSX.Element => {
             </>
           )}
           <button
-            className='download-code'
             onClick={downloadChallenge}
             aria-label={t('learn.editor-tabs.download-code')}
           >
@@ -226,16 +238,6 @@ const ActionRow = (props: ActionRowProps): JSX.Element => {
               focusable='false'
             />
           </button>
-          <span className='save-status' aria-live='off'>
-            <FontAwesomeIcon
-              icon={faCheck}
-              aria-hidden='true'
-              focusable='false'
-            />
-            {t('learn.editor-tabs.saved', {
-              timeAgo: formatTimeAgo(lastSavedTime)
-            })}
-          </span>
         </div>
       </div>
     </div>

--- a/client/src/templates/Challenges/classic/classic.css
+++ b/client/src/templates/Challenges/classic/classic.css
@@ -116,24 +116,12 @@
   margin-inline-end: auto;
 }
 
-.panel-display-tabs button:first-child {
-  margin: 0 10px 0 0;
-}
-
 .panel-display-tabs button:last-child {
   margin: 0;
 }
 
-.panel-display-tabs button:last-of-type {
-  border-inline-start-width: 1px;
-}
-
 .panel-display-tabs button:last-of-type:first-of-type {
   border-inline-start-width: 3px;
-}
-
-.panel-display-tabs button:nth-last-child(2) {
-  border-inline-end-width: 1px;
 }
 
 .interactive-editor-tab {
@@ -320,30 +308,6 @@
 
   #mobile-layout .monaco-editor-tabs {
     padding: 5px;
-  }
-
-  #mobile-layout .save-status {
-    font-size: 12px;
-    padding: 4px 8px;
-    margin-right: 8px;
-  }
-
-  @media screen and (max-width: 480px) {
-    #mobile-layout .save-status {
-      font-size: 11px;
-      padding: 2px 6px;
-      gap: 4px;
-    }
-  }
-
-  @media screen and (max-width: 360px) {
-    #mobile-layout .save-status {
-      font-size: 0;
-    }
-
-    #mobile-layout .save-status svg {
-      font-size: 14px;
-    }
   }
 
   .monaco-editor-tabs button {

--- a/client/src/templates/Challenges/classic/classic.css
+++ b/client/src/templates/Challenges/classic/classic.css
@@ -87,6 +87,24 @@
 .tabs-row-right {
   display: flex;
   justify-content: flex-end;
+  gap: 8px;
+
+  & .save-status {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    color: var(--gray-45);
+    font-size: 14px;
+    padding: 6px;
+
+    & svg {
+      color: var(--primary-color);
+    }
+  }
+
+  & .preview-pane {
+    margin-right: -8px;
+  }
 }
 
 .monaco-editor-tabs button + button {
@@ -302,6 +320,30 @@
 
   #mobile-layout .monaco-editor-tabs {
     padding: 5px;
+  }
+
+  #mobile-layout .save-status {
+    font-size: 12px;
+    padding: 4px 8px;
+    margin-right: 8px;
+  }
+
+  @media screen and (max-width: 480px) {
+    #mobile-layout .save-status {
+      font-size: 11px;
+      padding: 2px 6px;
+      gap: 4px;
+    }
+  }
+
+  @media screen and (max-width: 360px) {
+    #mobile-layout .save-status {
+      font-size: 0;
+    }
+
+    #mobile-layout .save-status svg {
+      font-size: 14px;
+    }
   }
 
   .monaco-editor-tabs button {

--- a/client/src/templates/Challenges/classic/desktop-layout.tsx
+++ b/client/src/templates/Challenges/classic/desktop-layout.tsx
@@ -289,6 +289,7 @@ const DesktopLayout = (props: DesktopLayoutProps): JSX.Element => {
           togglePane={togglePane}
           challengeType={challengeType}
           data-playwright-test-label='action-row'
+          lastSavedTime={null}
         />
       )}
       <ReflexContainer

--- a/client/src/templates/Challenges/classic/desktop-layout.tsx
+++ b/client/src/templates/Challenges/classic/desktop-layout.tsx
@@ -289,7 +289,6 @@ const DesktopLayout = (props: DesktopLayoutProps): JSX.Element => {
           togglePane={togglePane}
           challengeType={challengeType}
           data-playwright-test-label='action-row'
-          lastSavedTime={null}
         />
       )}
       <ReflexContainer

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -1346,7 +1346,7 @@ const Editor = (props: EditorProps): JSX.Element => {
       const currentContent = editorRef.current?.getValue();
       if (currentContent && currentContent.trim().length > 0) {
         autoSaveDebounceRef.current.cancel();
-        saveEditorContent();
+        saveEditorContent({ isSilent: true });
       }
     };
 

--- a/client/src/templates/Challenges/components/completion-modal.test.tsx
+++ b/client/src/templates/Challenges/components/completion-modal.test.tsx
@@ -16,8 +16,11 @@ import {
   isBuildEnabledSelector,
   isBlockNewlyCompletedSelector
 } from '../redux/selectors';
+
 import { getTestRunner } from '../utils/build';
-import CompletionModal, { combineFileData } from './completion-modal';
+import CompletionModal from './completion-modal';
+import { combineFileData } from '../utils/download-helpers';
+
 vi.mock('../../../analytics');
 vi.mock('../../../utils/fire-confetti');
 vi.mock('../../../components/Progress');
@@ -156,18 +159,33 @@ describe('<CompletionModal />', () => {
     it('Should label each section appropriately', () => {
       const indexHtml = {
         name: 'index',
-        ext: 'html',
-        contents: 'some html elements'
+        ext: 'html' as const,
+        contents: 'some html elements',
+        head: '',
+        tail: '',
+        path: 'index.html',
+        history: ['index.html'],
+        fileKey: 'indexhtml'
       };
       const stylesCSS = {
         name: 'styles',
-        ext: 'css',
-        contents: 'some css styles'
+        ext: 'css' as const,
+        contents: 'some css styles',
+        head: '',
+        tail: '',
+        path: 'styles.css',
+        history: ['styles.css'],
+        fileKey: 'stylescss'
       };
       const scriptJS = {
         name: 'script',
-        ext: 'js',
-        contents: 'some javascript'
+        ext: 'js' as const,
+        contents: 'some javascript',
+        head: '',
+        tail: '',
+        path: 'script.js',
+        history: ['script.js'],
+        fileKey: 'scriptjs'
       };
       const result = combineFileData([indexHtml, stylesCSS, scriptJS]);
       expect(result).toContain('** start of index.html **');

--- a/client/src/templates/Challenges/components/completion-modal.tsx
+++ b/client/src/templates/Challenges/components/completion-modal.tsx
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { combineFileData } from '../utils/download-helpers';
 import type { TFunction } from 'i18next';
 import { withTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
@@ -69,13 +70,6 @@ interface CompletionModalsProps extends StateProps {
 interface CompletionModalState {
   downloadURL: null | string;
 }
-
-interface DownloadableChallengeFile {
-  name: string;
-  ext: string;
-  contents: string;
-}
-
 class CompletionModal extends Component<
   CompletionModalsProps,
   CompletionModalState
@@ -237,18 +231,3 @@ export default connect(
   mapStateToProps,
   mapDispatchToProps
 )(withTranslation()(CompletionModal));
-
-export function combineFileData(challengeFiles: DownloadableChallengeFile[]) {
-  return challengeFiles.reduce<string>(function (
-    allFiles: string,
-    currentFile: DownloadableChallengeFile
-  ) {
-    const beforeText = `** start of ${currentFile.name + '.' + currentFile.ext} **\n\n`;
-    const afterText = `\n\n** end of ${currentFile.name + '.' + currentFile.ext} **\n\n`;
-    allFiles +=
-      challengeFiles.length > 0
-        ? `${beforeText}${currentFile.contents}${afterText}`
-        : currentFile.contents;
-    return allFiles;
-  }, '');
-}

--- a/client/src/templates/Challenges/hooks/index.ts
+++ b/client/src/templates/Challenges/hooks/index.ts
@@ -1,1 +1,2 @@
 export { usePageLeave } from './use-page-leave';
+export { useDownloadChallenge } from './use-download-challenge';

--- a/client/src/templates/Challenges/hooks/use-download-challenge.ts
+++ b/client/src/templates/Challenges/hooks/use-download-challenge.ts
@@ -1,0 +1,34 @@
+import { useSelector } from 'react-redux';
+import {
+  challengeFilesSelector,
+  challengeMetaSelector
+} from '../redux/selectors';
+import { combineFileData } from '../utils/download-helpers';
+import { ChallengeFiles } from '../../../redux/prop-types';
+
+export const useDownloadChallenge = () => {
+  const challengeFiles = useSelector<unknown, ChallengeFiles>(
+    challengeFilesSelector
+  );
+  const { dashedName } = useSelector<
+    unknown,
+    { dashedName: string; id: string }
+  >(challengeMetaSelector);
+
+  const downloadChallenge = () => {
+    if (!challengeFiles || challengeFiles.length === 0) return;
+
+    const combinedContent = combineFileData(challengeFiles);
+    const blob = new Blob([combinedContent], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `${dashedName || 'challenge'}-code.txt`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  };
+
+  return { downloadChallenge };
+};

--- a/client/src/templates/Challenges/redux/action-types.js
+++ b/client/src/templates/Challenges/redux/action-types.js
@@ -25,6 +25,7 @@ export const actionTypes = createTypes(
     'disableBuildOnError',
     'noStoredCodeFound',
     'saveEditorContent',
+    'setLastSavedTime',
     'setShowPreviewPane',
     'setShowPreviewPortal',
     'closeModal',

--- a/client/src/templates/Challenges/redux/actions.js
+++ b/client/src/templates/Challenges/redux/actions.js
@@ -36,6 +36,7 @@ export const disableBuildOnError = createAction(
 );
 export const noStoredCodeFound = createAction(actionTypes.noStoredCodeFound);
 export const saveEditorContent = createAction(actionTypes.saveEditorContent);
+export const setLastSavedTime = createAction(actionTypes.setLastSavedTime);
 export const setIsAdvancing = createAction(actionTypes.setIsAdvancing);
 export const setChapterSlug = createAction(actionTypes.setChapterSlug);
 export const setUserCompletedExam = createAction(

--- a/client/src/templates/Challenges/redux/code-storage-epic.js
+++ b/client/src/templates/Challenges/redux/code-storage-epic.js
@@ -13,7 +13,7 @@ import {
   getDailyCodingChallengeLanguage
 } from '@freecodecamp/shared/config/challenge-types';
 import { actionTypes } from './action-types';
-import { noStoredCodeFound, updateFile } from './actions';
+import { noStoredCodeFound, updateFile, setLastSavedTime } from './actions';
 import { challengeFilesSelector, challengeMetaSelector } from './selectors';
 
 const legacyPrefixes = [
@@ -127,7 +127,8 @@ function saveCodeEpic(action$, state$) {
           message: error
             ? FlashMessages.LocalCodeSaveError
             : FlashMessages.LocalCodeSaved
-        })
+        }),
+        ...(!error ? [setLastSavedTime(Date.now())] : [])
       )
     )
   );

--- a/client/src/templates/Challenges/redux/code-storage-epic.js
+++ b/client/src/templates/Challenges/redux/code-storage-epic.js
@@ -120,17 +120,30 @@ function saveCodeEpic(action$, state$) {
       }
     }),
     ofType(actionTypes.saveEditorContent),
-    switchMap(({ error }) =>
-      of(
-        createFlashMessage({
-          type: error ? 'warning' : 'success',
-          message: error
-            ? FlashMessages.LocalCodeSaveError
-            : FlashMessages.LocalCodeSaved
-        }),
-        ...(!error ? [setLastSavedTime(Date.now())] : [])
-      )
-    )
+    switchMap(action => {
+      const actions = [];
+
+      // Show flash message unless explicitly silenced
+      if (
+        action.type === actionTypes.executeChallenge ||
+        !action.payload?.isSilent
+      ) {
+        actions.push(
+          createFlashMessage({
+            type: action.error ? 'warning' : 'success',
+            message: action.error
+              ? FlashMessages.LocalCodeSaveError
+              : FlashMessages.LocalCodeSaved
+          })
+        );
+      }
+
+      if (!action.error) {
+        actions.push(setLastSavedTime(Date.now()));
+      }
+
+      return of(...actions);
+    })
   );
 }
 

--- a/client/src/templates/Challenges/redux/index.js
+++ b/client/src/templates/Challenges/redux/index.js
@@ -282,6 +282,10 @@ export const reducer = handleActions(
       ...state,
       canFocusEditor: payload
     }),
+    [actionTypes.challengeMounted]: state => ({
+      ...state,
+      lastSavedTime: null
+    }),
     [actionTypes.setLastSavedTime]: (state, { payload }) => ({
       ...state,
       lastSavedTime: payload

--- a/client/src/templates/Challenges/redux/index.js
+++ b/client/src/templates/Challenges/redux/index.js
@@ -58,7 +58,8 @@ const initialState = {
   successMessage: 'Happy Coding!',
   isAdvancing: false,
   chapterSlug: '',
-  isSubmitting: false
+  isSubmitting: false,
+  lastSavedTime: null
 };
 
 export const epics = [completionEpic, createQuestionEpic, codeStorageEpic];
@@ -280,6 +281,10 @@ export const reducer = handleActions(
     [actionTypes.setEditorFocusability]: (state, { payload }) => ({
       ...state,
       canFocusEditor: payload
+    }),
+    [actionTypes.setLastSavedTime]: (state, { payload }) => ({
+      ...state,
+      lastSavedTime: payload
     }),
     [actionTypes.toggleVisibleEditor]: (state, { payload }) => {
       return {

--- a/client/src/templates/Challenges/redux/selectors.js
+++ b/client/src/templates/Challenges/redux/selectors.js
@@ -191,3 +191,4 @@ export const canFocusEditorSelector = state => state[ns].canFocusEditor;
 export const visibleEditorsSelector = state => state[ns].visibleEditors;
 export const showPreviewPortalSelector = state => state[ns].showPreviewPortal;
 export const showPreviewPaneSelector = state => state[ns].showPreviewPane;
+export const lastSavedTimeSelector = state => state[ns].lastSavedTime;

--- a/client/src/templates/Challenges/utils/download-helpers.ts
+++ b/client/src/templates/Challenges/utils/download-helpers.ts
@@ -1,0 +1,14 @@
+import { ChallengeFiles } from '../../../redux/prop-types';
+
+export const combineFileData = (challengeFiles: ChallengeFiles): string => {
+  if (!challengeFiles || challengeFiles.length === 0) {
+    return '';
+  }
+
+  return challengeFiles.reduce<string>((allFiles, currentFile) => {
+    const beforeText = `** start of ${currentFile.name}.${currentFile.ext} **\n\n`;
+    const afterText = `\n\n** end of ${currentFile.name}.${currentFile.ext} **\n\n`;
+    allFiles += `${beforeText}${currentFile.contents}${afterText}`;
+    return allFiles;
+  }, '');
+};


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #57818

<!-- Feel free to add any additional description of changes below this line -->

## Description
This PR adds auto-save functionality with a live timestamp indicator for lab challenges, improving the user experience by automatically saving work and providing visual feedback. The download button is now prominently visible in the action row for easy access.

## Changes
- **Auto-save implementation**: Added debounced auto-save (2 seconds after typing stops) in the Monaco editor for onChange event.
- **Multiple save triggers**: Code saves on editor blur, editor unmount, and browser beforeunload events
- **Timestamp indicator**: Added live "Saved X ago" status in the action row that updates every 5 seconds
- **Download functionality**: Implemented download button to export challenge code as a text file, now prominently displayed in the action row
- **Redux state management**: 
  - Added `lastSavedTime` state to track when code was last saved
  - Added `setLastSavedTime` action and reducer
  - Timestamp resets when navigating between challenges
- **Utility functions**: Created `combineFileData` helper to format multi-file downloads with proper separators.
- **Custom hook**: Built `useDownloadChallenge` hook for adding download functionality in the ActionRow component.
- **Refactoring**: Updated CompletionModal to use shared `combineFileData` utility (DRY)
- **Translations**: Added "saved" translation entry for timestamp display
- **Styling**: Updated classic.css for save status and download button layout, removed unnecessary first-child button margin

## Image:

- "Saved Xs ago"
<img width="1440" height="148" alt="Saved 24s ago" src="https://github.com/user-attachments/assets/ced8053f-46cf-485c-be3f-8440bf843c6a" />



## Videos Sample:

Navigate away and come back to the page, content is retained.

https://github.com/user-attachments/assets/9596022c-fd71-4726-9071-9b8709231f32



