### PR TITLE
fix: correct grammar in CSS backgrounds and borders review

### DIFF
--- a/curriculum/challenges/english/blocks/review-css-backgrounds-and-borders/671a88d636cebc5fbd407b78.md
+++ b/curriculum/challenges/english/blocks/review-css-backgrounds-and-borders/671a88d636cebc5fbd407b78.md
@@ -23,7 +23,7 @@ dashedName: review-css-backgrounds-and-borders
 ## Styling Links
 
 - **`pseudo-class`**: This is a keyword added to a selector that allows you to select elements based on a particular state. Common states would include the `:hover`, `:visited` and `:focus` states.
-- **`:link pseudo-class`**: This pseudo-class is used to style links that have not be visited by the user.
+- **`:link pseudo-class`**: This pseudo-class is used to style links that have not been visited by the user.
 - **`:visited pseudo-class`**: This pseudo-class is used to style links where a user has already visited.
 - **`:hover pseudo-class`**: This pseudo-class is used to style elements where a user is actively hovering over them.
 - **`:focus pseudo-class`**: This pseudo-class is used to style an element when it receives focus. Examples would include `input` or `select` elements where the clicks or tabs on the element to focus it.


### PR DESCRIPTION


- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine or GitHub Codespaces.

Closes #65115

<!-- Description -->

This PR fixes a grammatical error in the
“Lists, Links, CSS Background and Borders Review”
section of the Responsive Web Design curriculum.

Changed:
- “have not be visited” → “have not been visited”
