### PR TITLE
fix(curriculum): disallow flex usage in Colored Boxes lab

### DIFF
--- a/curriculum/challenges/english/blocks/lab-colored-boxes/66f3f6eb66ea9dc41cdc30df.md
+++ b/curriculum/challenges/english/blocks/lab-colored-boxes/66f3f6eb66ea9dc41cdc30df.md
@@ -23,7 +23,8 @@ In this lab, you'll practice using CSS colors by designing boxes.
 7. The `.color2` element should have a `background-color` that uses an RGB color value.
 8. The `.color3` element should have a `background-color` that uses a predefined (word) color value.
 9. The `.color4` element should have a `background-color` that uses a HSL color value.
-10. The `.color5` element should have a `background-color` set.
+10. The `.color5` element should have a background color set.
+11. You should not use `display: flex` in this lab.
 
 **Note:** Be sure to link your stylesheet in your HTML and apply your CSS.
 
@@ -115,6 +116,21 @@ The `.color5` element should have a background color set.
 assert.isNotEmpty(new __helpers.CSSHelp(document).getStyle('.color5')?.getPropVal('background-color', true));
 ```
 
+You should not use `display: flex` in this lab.
+
+```js
+const testRoot = document.querySelector('.color-grid').parentElement;
+const elements = [testRoot, ...testRoot.querySelectorAll('*')];
+
+elements.forEach(el => {
+  assert.notMatch(
+    getComputedStyle(el).display,
+    /flex/,
+    'You should not use display: flex in this lab.'
+  );
+});
+```
+
 # --seed--
 
 ## --seed-contents--
@@ -164,15 +180,13 @@ assert.isNotEmpty(new __helpers.CSSHelp(document).getStyle('.color5')?.getPropVa
 ```css
 body {
     font-family: Arial, sans-serif;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
     margin: 0;
     padding: 20px;
     background-color: #f4f4f4;
 }
 
 h1 {
+    text-align: center;
     margin-bottom: 20px;
 }
 
@@ -182,12 +196,10 @@ h1 {
     gap: 10px;
     width: 100%;
     max-width: 800px;
+    margin: 0 auto;
 }
 
 .color-box {
-    display: flex;
-    justify-content: center;
-    align-items: center;
     font-weight: bold;
     border-radius: 8px;
     text-align: center;


### PR DESCRIPTION
### Checklist

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #65150


<!-- Feel free to add any additional description of changes below this line -->

This PR adds a final test and clarification to prevent the use of display: flex in the Design a Set of Colored Boxes lab.
While flexbox can technically work, it frequently causes width and height inconsistencies that confuse beginners and lead to unexpected test failures. This change helps learners stay aligned with the intended solution path and reduces friction in the lab.