### PR TITLE
test: prevent use of flexbox in colored boxes lab

### DIFF
--- a/curriculum/challenges/english/blocks/lab-colored-boxes/66f3f6eb66ea9dc41cdc30df.md
+++ b/curriculum/challenges/english/blocks/lab-colored-boxes/66f3f6eb66ea9dc41cdc30df.md
@@ -24,6 +24,7 @@ In this lab, you'll practice using CSS colors by designing boxes.
 8. The `.color3` element should have a `background-color` that uses a predefined (word) color value.
 9. The `.color4` element should have a `background-color` that uses a HSL color value.
 10. The `.color5` element should have a `background-color` set.
+11. You should not use flexbox to lay out the `.color-grid` element.
 
 **Note:** Be sure to link your stylesheet in your HTML and apply your CSS.
 
@@ -113,6 +114,16 @@ The `.color5` element should have a background color set.
 
 ```js
 assert.isNotEmpty(new __helpers.CSSHelp(document).getStyle('.color5')?.getPropVal('background-color', true));
+```
+
+The .color-grid element should not use flexbox for layout.
+
+```js
+const colorGridDisplay = getComputedStyle(
+  document.querySelector('.color-grid')
+).display;
+
+assert.notStrictEqual(colorGridDisplay, 'flex');
 ```
 
 # --seed--


### PR DESCRIPTION
## Desscription
This PR adds a test to the “Set of Colored Boxes” lab to prevent the use of flexbox
for the `.color-grid` layout.

Campers often attempt to solve the lab using `display: flex`, which leads to
unexpected sizing issues and confusion. Adding this test helps guide learners
toward the intended solution approach.

### Testing
- Ran the Responsive Web Design curriculum locally
- Verified the new test fails when `.color-grid` uses `display: flex`
- Verified the provided solution passes all tests


Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #65150 

<!-- Feel free to add any additional description of changes below this line -->
