### PR TITLE
fix: correct grammar in CSS backgrounds and borders quiz

### DIFF
--- a/curriculum/challenges/english/blocks/quiz-css-backgrounds-and-borders/66ed8fd7f45ce3ece4053eb0.md
+++ b/curriculum/challenges/english/blocks/quiz-css-backgrounds-and-borders/66ed8fd7f45ce3ece4053eb0.md
@@ -69,7 +69,7 @@ It is used to set the background size for an element.
 
 ---
 
-It is used to style links that have not be visited by the user.
+It is used to style links that have not been visited by the user.
 
 ---
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ x ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ x ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ x ] My pull request targets the `main` branch of freeCodeCamp.
- [ x ] I have tested these changes either locally on my machine, or GitHub Codespaces.

This PR fixes a grammatical error in the CSS backgrounds and borders quiz by replacing "have not be" with "have not been".

Related to issue #65115


<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #65115

<!-- Feel free to add any additional description of changes below this line -->
