### PR TITLE
fix(curriculum): discourage using flex in colored boxes lab

### DIFF
--- a/curriculum/challenges/english/blocks/lab-colored-boxes/66f3f6eb66ea9dc41cdc30df.md
+++ b/curriculum/challenges/english/blocks/lab-colored-boxes/66f3f6eb66ea9dc41cdc30df.md
@@ -115,14 +115,14 @@ The `.color5` element should have a background color set.
 assert.isNotEmpty(new __helpers.CSSHelp(document).getStyle('.color5')?.getPropVal('background-color', true));
 ```
 
-You should not use `display: flex` for this lab.
+The .color-grid element should not use flexbox for layout.
 
 ```js
-assert.notMatch(
-  code,
-  /display\s*:\s*flex/i,
-  "You should not use display: flex for this lab"
-);
+const colorGridDisplay = getComputedStyle(
+  document.querySelector('.color-grid')
+).display;
+
+assert.notStrictEqual(colorGridDisplay, 'flex');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/lab-colored-boxes/66f3f6eb66ea9dc41cdc30df.md
+++ b/curriculum/challenges/english/blocks/lab-colored-boxes/66f3f6eb66ea9dc41cdc30df.md
@@ -115,7 +115,7 @@ The `.color5` element should have a background color set.
 assert.isNotEmpty(new __helpers.CSSHelp(document).getStyle('.color5')?.getPropVal('background-color', true));
 ```
 
-The .color-grid element should not use flexbox for layout.
+The `.color-grid` element should not use flexbox for the layout.
 
 ```js
 const colorGridDisplay = getComputedStyle(

--- a/curriculum/challenges/english/blocks/lab-colored-boxes/66f3f6eb66ea9dc41cdc30df.md
+++ b/curriculum/challenges/english/blocks/lab-colored-boxes/66f3f6eb66ea9dc41cdc30df.md
@@ -115,6 +115,16 @@ The `.color5` element should have a background color set.
 assert.isNotEmpty(new __helpers.CSSHelp(document).getStyle('.color5')?.getPropVal('background-color', true));
 ```
 
+You should not use `display: flex` for this lab.
+
+```js
+assert.notMatch(
+  code,
+  /display\s*:\s*flex/i,
+  "You should not use display: flex for this lab"
+);
+```
+
 # --seed--
 
 ## --seed-contents--


### PR DESCRIPTION
Checklist:
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #65150

### Description

This PR adds a final hint test to discourage using display: flex in the Set of Colored Boxes lab.

Learners often try flexbox here and run into layout issues, so this helps guide them toward simpler approaches that match the lab’s intent. The change only affects the hints section and does not modify any existing tests, seeds, or solutions.
