### PR TITLE
fix(curriculum): clarify absolute path vs absolute URL in links lesson

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-links/671682dd88e461a8e2620f38.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-links/671682dd88e461a8e2620f38.md
@@ -11,7 +11,8 @@ A path is a string that specifies the location of a file or directory in a file 
 
 An absolute path is a complete link to a resource. It starts from the root directory, includes every other directory, and finally the filename and extension. The "root directory" refers to the top-level directory or folder in a hierarchy.
 
-An absolute path also includes the protocol - which could be `http`, `https`, and `file` and the domain name if the resource is on the web. Here's an example of an absolute path that links to the freeCodeCamp logo:
+An absolute path starts from the root directory of a file system or website. When a protocol and domain name are included (such as `https://example.com`), it is more accurately called an absolute URL. While both are often used interchangeably in casual discussion, distinguishing between absolute paths and absolute URLs helps avoid confusion.
+
 
 ```html
 <a href="https://design-style-guide.freecodecamp.org/img/fcc_secondary_small.svg">
@@ -20,6 +21,8 @@ An absolute path also includes the protocol - which could be `http`, `https`, an
 ```
 
 In this example, the protocol is `https`, the domain name is `design-style-guide.freecodecamp.org`, and the filename is `fcc_secondary_small.svg`.
+In this lesson, examples that include a protocol and domain name are technically absolute URLs, which also contain an absolute path.
+
 
 Now, what if the resource you want to link to using an absolute path is on your local machine? Here's how to link to the `about.html` file with an absolute path:
 

--- a/curriculum/challenges/english/blocks/quiz-css-backgrounds-and-borders/66ed8fd7f45ce3ece4053eb0.md
+++ b/curriculum/challenges/english/blocks/quiz-css-backgrounds-and-borders/66ed8fd7f45ce3ece4053eb0.md
@@ -69,7 +69,7 @@ It is used to set the background size for an element.
 
 ---
 
-It is used to style links that have not be visited by the user.
+It is used to style links that have not been visited by the user.
 
 ---
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ x ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ x ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ x ] My pull request targets the `main` branch of freeCodeCamp.
- [ x ] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #65481

This PR clarifies the conceptual difference between an absolute path and an absolute URL in the links lesson to avoid confusion for learners.

It improves technical accuracy while keeping the explanation beginner-friendly.


<!-- Feel free to add any additional description of changes below this line -->
