### PR TITLE
fix(curriculum): move lang attribute to step1 in bookstore page workshop

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-bookstore-page/69134b6cb43aa5f254950a10.md
+++ b/curriculum/challenges/english/blocks/workshop-bookstore-page/69134b6cb43aa5f254950a10.md
@@ -33,7 +33,7 @@ assert.match(code,/<html\b[^>]*>[\s\S]*<\/html>/i);
 Your `html` element should have a `lang` attribute set to `"en"`.
 
 ```js
-assert.match(code, /<html[^>]*\blang=["']en["'][^>]*>/i);
+assert.match(code, /<html[^>]*\blang\s*=\s*["']en["'][^>]*>/i);
 ```
 
 Your code should include both opening and closing `<head>` tags.

--- a/curriculum/challenges/english/blocks/workshop-bookstore-page/69134b6cb43aa5f254950a10.md
+++ b/curriculum/challenges/english/blocks/workshop-bookstore-page/69134b6cb43aa5f254950a10.md
@@ -14,6 +14,8 @@ Start your bookstore page by creating the HTML boilerplate.
 
 Add the `<!DOCTYPE html>` declaration and `html` and `head` elements.
 
+Add a `lang` attribute to the `html` element and set it to `"en"`.
+
 # --hints--
 
 Your code should include a `<!DOCTYPE html>` declaration.
@@ -26,6 +28,12 @@ Your code should include both opening and closing `<html>` tags.
 
 ```js
 assert.match(code,/<html>[\s\S]*<\/html>/i);
+```
+
+Your `html` element should have a `lang` attribute set to `"en"`.
+
+```js
+assert.match(code, /<html[^>]*\blang=["']en["'][^>]*>/i);
 ```
 
 Your code should include both opening and closing `<head>` tags.

--- a/curriculum/challenges/english/blocks/workshop-bookstore-page/69134b6cb43aa5f254950a10.md
+++ b/curriculum/challenges/english/blocks/workshop-bookstore-page/69134b6cb43aa5f254950a10.md
@@ -27,7 +27,7 @@ assert.match(code, /<!DOCTYPE html>/i);
 Your code should include both opening and closing `<html>` tags.
 
 ```js
-assert.match(code,/<html>[\s\S]*<\/html>/i);
+assert.match(code,/<html\b[^>]*>[\s\S]*<\/html>/i);
 ```
 
 Your `html` element should have a `lang` attribute set to `"en"`.

--- a/curriculum/challenges/english/blocks/workshop-bookstore-page/69134d14150d51f8066a3246.md
+++ b/curriculum/challenges/english/blocks/workshop-bookstore-page/69134d14150d51f8066a3246.md
@@ -9,17 +9,11 @@ dashedName: step-3
 
 Now, improve the structure of your HTML document to ensure your page is encoded correctly.
 
-Add a `lang` attribute to the `html` element and set it to `"en"`. Then, inside the `head` element add the `<meta charset="UTF-8">` element.
+Inside the `head` element, add the `<meta charset="UTF-8">` element.
 
 Lastly, add a `body` element below the `head` section. This is where all of your visible page content will go.
 
 # --hints--
-
-Your `html` element should have a `lang` attribute set to `"en"`.
-
-```js
-assert.match(code, /<html[^>]*\blang=["']en["'][^>]*>/i);
-```
 
 Your code should include a `<meta charset="UTF-8">` element.
 
@@ -45,7 +39,7 @@ assert.match(code, /<\/head>[\s\S]*<body>[\s\S]*<\/body>[\s\S]*<\/html>/i);
 ```html
 <!DOCTYPE html>
 --fcc-editable-region--
-<html>
+<html lang="en">
 <head>
   <title>XYZ Bookstore Page</title>
 </head>

--- a/curriculum/challenges/english/blocks/workshop-bookstore-page/691f85085787a8c4ca589fbb.md
+++ b/curriculum/challenges/english/blocks/workshop-bookstore-page/691f85085787a8c4ca589fbb.md
@@ -38,7 +38,7 @@ assert.match(code, /<head>[\s\S]*<title>[\s\S]*<\/title>[\s\S]*<\/head>/i);
 ```html
   --fcc-editable-region--
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 
 </head>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #65163

<!-- Feel free to add any additional description of changes below this line -->

This PR is to move the step of adding `lang` attribute to Step1 of Bookstore Page workshop.

Changes:

- Added instruction and assertion to add `lang` attribute to Step1 of the workshop.
- Added `lang="en"` to the `html` tag in Step2 and Step3 seeded code.
- Removed instruction and assertion for adding `lang` attribute in Step3.
