### PR TITLE
feat(curriculum): add A1 Spanish audio for numbers 30 to 100 practice

### DIFF
--- a/curriculum/schema/scene-assets.js
+++ b/curriculum/schema/scene-assets.js
@@ -288,6 +288,7 @@ const availableAudios = [
   'ES_A1_basic_personal_details_numbers_10_29.mp3',
   'ES_A1_basic_personal_details_numbers_mixed.mp3',
   'ES_A1_basti_personal_details.mp3',
+  'ES_A1_describing_company_and_people_numbers_practice.mp3',
   'ES_A1_esteban_personal_records_dialogue_with_angela.mp3',
   'ES_A1_describing_company_and_people_numbers_21_100.mp3',
   'ES_A1_julieta_personal_details.mp3',


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->

This PR adds an audio file for the "Chapter Describing a Company and Its People" > "Module 1 Numbers from 30 to 100" > Practice block to the scene assets of the schema.

- ES_A1_describing_company_and_people_numbers_practice.mp3
