### PR TITLE
fix(curriculum): corrected dict() example value types

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-common-data-structures/6895d06b5968736797c408e7.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-common-data-structures/6895d06b5968736797c408e7.md
@@ -55,16 +55,16 @@ To create a Python dictionary, you just need to write the key-value pairs within
 
 ```python
 my_dictionary = {
-  "A": 1,
-  "B": 2, 
-  "C": 3
+  'A': 1,
+  'B': 2, 
+  'C': 3
 }
 ```
 
-In this code, `"A"` is the key and `1` is the value:
+In this code, `'A'` is the key and `1` is the value:
 
 ```python
-"A": 1
+'A': 1
 ```
 
 Alternatively, you can use `dict()`:
@@ -76,25 +76,25 @@ my_dictionary = dict(A=1, B=2, C=3)
 You can get the value through its corresponding key:
 
 ```python
-my_dictionary["A"]  # 1
+my_dictionary['A']  # 1
 ```
 
 You can also update the value associated with a key:
 
 ```python
-my_dictionary["A"] = 4
+my_dictionary['A'] = 4
 ```
 
 And you can remove a key-value pair:
 
 ```python
-del my_dictionary["A"]  
+del my_dictionary['A']  
 ```
 
 You can also check if a key is in the dictionary (or not):
 
 ```python
-"C" in my_dictionary
+'C' in my_dictionary
 ```
 
 And you can call these methods to get the keys, values, and items of the dictionary, respectively.

--- a/curriculum/challenges/english/blocks/lecture-working-with-common-data-structures/6895d06b5968736797c408e7.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-common-data-structures/6895d06b5968736797c408e7.md
@@ -70,7 +70,7 @@ In this code, `"A"` is the key and `1` is the value:
 Alternatively, you can use `dict()`:
 
 ```python
-my_dictionary = dict(A="1", B="2", C="3")
+my_dictionary = dict(A=1, B=2, C=3)
 ```
 
 You can get the value through its corresponding key:


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #65254 

<!-- Feel free to add any additional description of changes below this line -->

## Description

The `dict()` example used string values for numbers, which was inconsistent with the surrounding examples that use integers.

## Changes

- Updated the example to use integer values instead of strings.

## Affected Lesson
How do maps, hash maps, and sets work.