### PR TITLE
fix(curriculum): align getWeather error handling with expected behavior

### DIFF
--- a/curriculum/challenges/english/blocks/lab-weather-app/66f12a88741aeb16b9246c59.md
+++ b/curriculum/challenges/english/blocks/lab-weather-app/66f12a88741aeb16b9246c59.md
@@ -1041,14 +1041,17 @@ async function getWeather(city) {
       `https://weather-proxy.freecodecamp.rocks/api/city/${city}`
     );
 
-    if (!response.ok) {
-      alert('Something went wrong, please try again later');
-    }
+    if (!response.ok)
+      throw new Error(
+        `Weather information for city '${city}' not found.`
+      );
 
-    const json = await response.json();
-    return json;
+    let data = response.json();
+    return data;
   } catch (error) {
-    console.error(error.message);
+    console.log(error);
+    alert("Something went wrong, please try again later");
+    return 1;
   }
 }
 ```


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #65250 

<!-- Feel free to add any additional description of changes below this line -->
## Changes

This PR updates the `getWeather` function in the Weather App lab to make its error-handling behavior consistent with the example solution shared in the forum and discussed in issue #65250.

## Problem

Previously, failed API responses were handled inside the `if (!response.ok)` block using an `alert()`, while other errors were handled in the `catch` block.  
This created an inconsistent error-handling flow for learners and did not clearly demonstrate proper `async/await` error handling.

## Fix

Failed API responses now explicitly throw an error, and **all** error handling is centralized in the `catch` block.  
The function now:

- Logs the error using `console.log`
- Shows the alert message  
  **"Something went wrong, please try again later"**
- Returns `1` on failure

## Improvement

This makes the lab’s reference implementation:

- Clearer for learners  
- More consistent with the forum example  
- Aligned with the expected behavior discussed in the issue  