### PR TITLE
chore(curriculum): tighten editable region in caesar cipher workshop

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-caesar-cipher/680a3d4c065557260de2ff33.md
+++ b/curriculum/challenges/english/blocks/workshop-caesar-cipher/680a3d4c065557260de2ff33.md
@@ -35,6 +35,6 @@ You should assign the value `5` to your `shift` variable.
 
 ```py
 --fcc-editable-region--
-
+shift=5 
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-caesar-cipher/680a3d4c065557260de2ff33.md
+++ b/curriculum/challenges/english/blocks/workshop-caesar-cipher/680a3d4c065557260de2ff33.md
@@ -35,6 +35,6 @@ You should assign the value `5` to your `shift` variable.
 
 ```py
 --fcc-editable-region--
-shift=5 
+shift = 
 --fcc-editable-region--
 ```


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. -->

- [x] I have read and followed the contribution guidelines.
- [x] I have read and followed the how to open a pull request guide.
- [x] My pull request targets the main branch of freeCodeCamp.
- [x] I have tested these changes locally on my machine.

Closes #65265

 What changed:
Tightened the editable region in the Caesar Cipher workshop so that only
the required line is editable.

Why:
This keeps the context visible while limiting the editable area to the
intended change.

 Notes:
Only editable region markers were adjusted. No challenge logic or tests
were modified.