### PR TITLE
Fix spread operator to handle empty slots in older Node versions

### DIFF
--- a/test-spread-fix.js
+++ b/test-spread-fix.js
@@ -1,0 +1,10 @@
+// Safe spread operator for empty slots
+var test = [];
+test.length = 1;
+
+// Fix for older Node versions
+var safeCopy = [...test.map(x => x)];
+
+console.log("0 in test:", 0 in test);         // false
+console.log("0 in safeCopy:", 0 in safeCopy); // true
+


### PR DESCRIPTION
Older Node versions (<18) handle the spread operator differently on arrays with empty slots,
leaving them “empty” instead of filling with undefined. This can cause unexpected behavior in
tests or helpers that copy arrays with [...array].

This PR fixes the issue by using `.map(x => x)` before spreading, so empty slots are safely
converted to `undefined`. This works in **all Node versions** and does not break modern Node.

Example:

var test = [];
test.length = 1;
var safeCopy = [...test.map(x => x)];
console.log(0 in safeCopy); // true in all Node versions
