### PR TITLE
fix(curriculum): fix editable region in caesar cipher workshop

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-caesar-cipher/680a431692a5f863f726c438.md
+++ b/curriculum/challenges/english/blocks/workshop-caesar-cipher/680a431692a5f863f726c438.md
@@ -44,9 +44,9 @@ You should call the `print()` function passing in `shifted_alphabet` as an argum
 ## --seed-contents--
 
 ```py
---fcc-editable-region--
 alphabet = 'abcdefghijklmnopqrstuvwxyz'
 shift = 5
+--fcc-editable-region--
 
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-caesar-cipher/680a549f60f5a3fedfc0edd9.md
+++ b/curriculum/challenges/english/blocks/workshop-caesar-cipher/680a549f60f5a3fedfc0edd9.md
@@ -47,10 +47,10 @@ assert _first or _second
 ## --seed-contents--
 
 ```py
---fcc-editable-region--
 alphabet = 'abcdefghijklmnopqrstuvwxyz'
 shift = 5
-shifted_alphabet = alphabet[shift:]
-print(shifted_alphabet)
 --fcc-editable-region--
+shifted_alphabet = alphabet[shift:]
+--fcc-editable-region--
+print(shifted_alphabet)
 ```

--- a/curriculum/challenges/english/blocks/workshop-caesar-cipher/680a5e7f3d47715196b12ca0.md
+++ b/curriculum/challenges/english/blocks/workshop-caesar-cipher/680a5e7f3d47715196b12ca0.md
@@ -22,10 +22,10 @@ You should remove `print(shifted_alphabet)` from your code.
 ## --seed-contents--
 
 ```py
---fcc-editable-region--
 alphabet = 'abcdefghijklmnopqrstuvwxyz'
 shift = 5
 shifted_alphabet = alphabet[shift:] + alphabet[:shift]
+--fcc-editable-region--
 print(shifted_alphabet)
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-caesar-cipher/680a7e200400089967b8b1f4.md
+++ b/curriculum/challenges/english/blocks/workshop-caesar-cipher/680a7e200400089967b8b1f4.md
@@ -38,10 +38,10 @@ You should call `str.maketrans()` passing in `alphabet` and `shifted_alphabet` a
 ## --seed-contents--
 
 ```py
---fcc-editable-region--
 alphabet = 'abcdefghijklmnopqrstuvwxyz'
 shift = 5
 shifted_alphabet = alphabet[shift:] + alphabet[:shift]
+--fcc-editable-region--
 
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-caesar-cipher/680a82806c4c6bc3567f2708.md
+++ b/curriculum/challenges/english/blocks/workshop-caesar-cipher/680a82806c4c6bc3567f2708.md
@@ -28,11 +28,11 @@ You should assign the string `hello world` to `text`. Remember to enclose the st
 ## --seed-contents--
 
 ```py
---fcc-editable-region--
 alphabet = 'abcdefghijklmnopqrstuvwxyz'
 shift = 5
 shifted_alphabet = alphabet[shift:] + alphabet[:shift]
 translation_table = str.maketrans(alphabet, shifted_alphabet)
+--fcc-editable-region--
 
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-caesar-cipher/680a836235461fce1ff53b3f.md
+++ b/curriculum/challenges/english/blocks/workshop-caesar-cipher/680a836235461fce1ff53b3f.md
@@ -38,12 +38,12 @@ You should assign `text.translate(translation_table)` to `encrypted_text`.
 ## --seed-contents--
 
 ```py
---fcc-editable-region--
 alphabet = 'abcdefghijklmnopqrstuvwxyz'
 shift = 5
 shifted_alphabet = alphabet[shift:] + alphabet[:shift]
 translation_table = str.maketrans(alphabet, shifted_alphabet)
 text = 'hello world'
+--fcc-editable-region--
 
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-caesar-cipher/6810869355fa2468f9ebaf9c.md
+++ b/curriculum/challenges/english/blocks/workshop-caesar-cipher/6810869355fa2468f9ebaf9c.md
@@ -22,13 +22,13 @@ You should print `encrypted_text`.
 ## --seed-contents--
 
 ```py
---fcc-editable-region--
 alphabet = 'abcdefghijklmnopqrstuvwxyz'
 shift = 5
 shifted_alphabet = alphabet[shift:] + alphabet[:shift]
 translation_table = str.maketrans(alphabet, shifted_alphabet)
 text = 'hello world'
 encrypted_text = text.translate(translation_table)
+--fcc-editable-region--
 
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-caesar-cipher/6810891bd6de8a87a833df42.md
+++ b/curriculum/challenges/english/blocks/workshop-caesar-cipher/6810891bd6de8a87a833df42.md
@@ -38,6 +38,7 @@ You should move all the code you wrote so far within the `caesar` function body.
 
 ```py
 --fcc-editable-region--
+
 alphabet = 'abcdefghijklmnopqrstuvwxyz'
 shift = 5
 shifted_alphabet = alphabet[shift:] + alphabet[:shift]

--- a/curriculum/challenges/english/blocks/workshop-caesar-cipher/6818b80519e6c6c47a8bb6e8.md
+++ b/curriculum/challenges/english/blocks/workshop-caesar-cipher/6818b80519e6c6c47a8bb6e8.md
@@ -43,6 +43,7 @@ You should not have a `shift` variable declared within the `caesar` function bod
 ```py
 --fcc-editable-region--
 def caesar():
+--fcc-editable-region--
     alphabet = 'abcdefghijklmnopqrstuvwxyz'
     shift = 5
     shifted_alphabet = alphabet[shift:] + alphabet[:shift]
@@ -50,5 +51,4 @@ def caesar():
     text = 'hello world'
     encrypted_text = text.translate(translation_table)
     print(encrypted_text)
---fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-caesar-cipher/6818b80519e6c6c47a8bb6e8.md
+++ b/curriculum/challenges/english/blocks/workshop-caesar-cipher/6818b80519e6c6c47a8bb6e8.md
@@ -43,9 +43,9 @@ You should not have a `shift` variable declared within the `caesar` function bod
 ```py
 --fcc-editable-region--
 def caesar():
---fcc-editable-region--
     alphabet = 'abcdefghijklmnopqrstuvwxyz'
     shift = 5
+--fcc-editable-region--
     shifted_alphabet = alphabet[shift:] + alphabet[:shift]
     translation_table = str.maketrans(alphabet, shifted_alphabet)
     text = 'hello world'

--- a/curriculum/challenges/english/blocks/workshop-caesar-cipher/6818b80519e6c6c47a8bb6e8.md
+++ b/curriculum/challenges/english/blocks/workshop-caesar-cipher/6818b80519e6c6c47a8bb6e8.md
@@ -45,10 +45,10 @@ You should not have a `shift` variable declared within the `caesar` function bod
 def caesar():
     alphabet = 'abcdefghijklmnopqrstuvwxyz'
     shift = 5
---fcc-editable-region--
     shifted_alphabet = alphabet[shift:] + alphabet[:shift]
     translation_table = str.maketrans(alphabet, shifted_alphabet)
     text = 'hello world'
+--fcc-editable-region--
     encrypted_text = text.translate(translation_table)
     print(encrypted_text)
 ```

--- a/curriculum/challenges/english/blocks/workshop-caesar-cipher/6818e9c7c8dc5694e8f64fc3.md
+++ b/curriculum/challenges/english/blocks/workshop-caesar-cipher/6818e9c7c8dc5694e8f64fc3.md
@@ -34,8 +34,8 @@ def caesar(text, shift):
     translation_table = str.maketrans(alphabet, shifted_alphabet)
     encrypted_text = text.translate(translation_table)
     print(encrypted_text)
---fcc-editable-region--
 
+--fcc-editable-region--
 
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-caesar-cipher/6818eb3f98c0bca5af7c8d03.md
+++ b/curriculum/challenges/english/blocks/workshop-caesar-cipher/6818eb3f98c0bca5af7c8d03.md
@@ -29,8 +29,8 @@ def caesar(text, shift):
     encrypted_text = text.translate(translation_table)
     print(encrypted_text)
 
---fcc-editable-region--
 encrypted_text = caesar('freeCodeCamp', 3)
+--fcc-editable-region--
 
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-caesar-cipher/6818ed1adc249bb91d373729.md
+++ b/curriculum/challenges/english/blocks/workshop-caesar-cipher/6818ed1adc249bb91d373729.md
@@ -41,16 +41,15 @@ Your `caesar` function should return `text.translate(translation_table)`.
 ## --seed-contents--
 
 ```py
---fcc-editable-region--
 def caesar(text, shift):
     alphabet = 'abcdefghijklmnopqrstuvwxyz'
     shifted_alphabet = alphabet[shift:] + alphabet[:shift]
     translation_table = str.maketrans(alphabet, shifted_alphabet)
+--fcc-editable-region--
     encrypted_text = text.translate(translation_table)
     print(encrypted_text)
 --fcc-editable-region--
 
 encrypted_text = caesar('freeCodeCamp', 3)
 print(encrypted_text)
-
 ```

--- a/curriculum/challenges/english/blocks/workshop-caesar-cipher/6818fcb250f34e62cab32c39.md
+++ b/curriculum/challenges/english/blocks/workshop-caesar-cipher/6818fcb250f34e62cab32c39.md
@@ -39,7 +39,6 @@ def caesar(text, shift):
 --fcc-editable-region--
     return text.translate(translation_table)
 
-
 encrypted_text = caesar('freeCodeCamp', 3)
 print(encrypted_text)
 ```

--- a/curriculum/challenges/english/blocks/workshop-caesar-cipher/6819bc0637b80256a33adccc.md
+++ b/curriculum/challenges/english/blocks/workshop-caesar-cipher/6819bc0637b80256a33adccc.md
@@ -41,15 +41,16 @@ You should return the string `Shift must be an integer value.` from your `if` st
 ## --seed-contents--
 
 ```py
---fcc-editable-region--
 def caesar(text, shift):
     
 --fcc-editable-region--
+    
+--fcc-editable-region--
+
     alphabet = 'abcdefghijklmnopqrstuvwxyz'
     shifted_alphabet = alphabet[shift:] + alphabet[:shift]
     translation_table = str.maketrans(alphabet + alphabet.upper(), shifted_alphabet + shifted_alphabet.upper())
     return text.translate(translation_table)
-
 
 encrypted_text = caesar('freeCodeCamp', 3)
 print(encrypted_text)

--- a/curriculum/challenges/english/blocks/workshop-caesar-cipher/6819be9055828d65c813eec5.md
+++ b/curriculum/challenges/english/blocks/workshop-caesar-cipher/6819be9055828d65c813eec5.md
@@ -29,16 +29,17 @@ Your `if` statement should use `isinstance(shift, int)` as its condition.
 ## --seed-contents--
 
 ```py
---fcc-editable-region--
 def caesar(text, shift):
-    if True:
-        return 'Shift must be an integer value.'
+
 --fcc-editable-region--
+    if True:
+--fcc-editable-region--
+        return 'Shift must be an integer value.'
+
     alphabet = 'abcdefghijklmnopqrstuvwxyz'
     shifted_alphabet = alphabet[shift:] + alphabet[:shift]
     translation_table = str.maketrans(alphabet + alphabet.upper(), shifted_alphabet + shifted_alphabet.upper())
     return text.translate(translation_table)
-
 
 encrypted_text = caesar('freeCodeCamp', 3)
 print(encrypted_text)

--- a/curriculum/challenges/english/blocks/workshop-caesar-cipher/6819c5c9faf2548e556163d5.md
+++ b/curriculum/challenges/english/blocks/workshop-caesar-cipher/6819c5c9faf2548e556163d5.md
@@ -29,16 +29,17 @@ You should use the `not` operator to negate `isinstance(shift, int)` in your `if
 ## --seed-contents--
 
 ```py
---fcc-editable-region--
 def caesar(text, shift):
-    if isinstance(shift, int):
-        return 'Shift must be an integer value.'
+
 --fcc-editable-region--
+    if isinstance(shift, int):
+--fcc-editable-region--
+        return 'Shift must be an integer value.'
+    
     alphabet = 'abcdefghijklmnopqrstuvwxyz'
     shifted_alphabet = alphabet[shift:] + alphabet[:shift]
     translation_table = str.maketrans(alphabet + alphabet.upper(), shifted_alphabet + shifted_alphabet.upper())
     return text.translate(translation_table)
-
 
 encrypted_text = caesar('freeCodeCamp', 3)
 print(encrypted_text)

--- a/curriculum/challenges/english/blocks/workshop-caesar-cipher/6819c7beb4a8289c2b4f24d5.md
+++ b/curriculum/challenges/english/blocks/workshop-caesar-cipher/6819c7beb4a8289c2b4f24d5.md
@@ -32,17 +32,18 @@ Your second `if` statement should return `Shift must be a positive integer.`.
 ## --seed-contents--
 
 ```py
---fcc-editable-region--
 def caesar(text, shift):
     if not isinstance(shift, int):
         return 'Shift must be an integer value.'
-
+    
 --fcc-editable-region--
+    
+--fcc-editable-region--
+
     alphabet = 'abcdefghijklmnopqrstuvwxyz'
     shifted_alphabet = alphabet[shift:] + alphabet[:shift]
     translation_table = str.maketrans(alphabet + alphabet.upper(), shifted_alphabet + shifted_alphabet.upper())
     return text.translate(translation_table)
-
 
 encrypted_text = caesar('freeCodeCamp', 3)
 print(encrypted_text)

--- a/curriculum/challenges/english/blocks/workshop-caesar-cipher/6819ca464db219ab86f37dc4.md
+++ b/curriculum/challenges/english/blocks/workshop-caesar-cipher/6819ca464db219ab86f37dc4.md
@@ -37,17 +37,19 @@ Your second `if` statement should return `Shift must be an integer between 1 and
 
 ```py
 def caesar(text, shift):
+
     if not isinstance(shift, int):
         return 'Shift must be an integer value.'
+    
 --fcc-editable-region--
     if shift < 1:
         return 'Shift must be a positive integer.'
 --fcc-editable-region--
+
     alphabet = 'abcdefghijklmnopqrstuvwxyz'
     shifted_alphabet = alphabet[shift:] + alphabet[:shift]
     translation_table = str.maketrans(alphabet + alphabet.upper(), shifted_alphabet + shifted_alphabet.upper())
     return text.translate(translation_table)
-
 
 encrypted_text = caesar('freeCodeCamp', 3)
 print(encrypted_text)

--- a/curriculum/challenges/english/blocks/workshop-caesar-cipher/6819cf38880d8cc9b9f6af7a.md
+++ b/curriculum/challenges/english/blocks/workshop-caesar-cipher/6819cf38880d8cc9b9f6af7a.md
@@ -34,6 +34,7 @@ You should add a third parameter named `encrypt` with a default value of `True` 
 --fcc-editable-region--
 def caesar(text, shift):
 --fcc-editable-region--
+
     if not isinstance(shift, int):
         return 'Shift must be an integer value.'
 
@@ -44,7 +45,6 @@ def caesar(text, shift):
     shifted_alphabet = alphabet[shift:] + alphabet[:shift]
     translation_table = str.maketrans(alphabet + alphabet.upper(), shifted_alphabet + shifted_alphabet.upper())
     return text.translate(translation_table)
-
 
 encrypted_text = caesar('freeCodeCamp', 3)
 print(encrypted_text)

--- a/curriculum/challenges/english/blocks/workshop-caesar-cipher/681a1d60e037127e7c8e0230.md
+++ b/curriculum/challenges/english/blocks/workshop-caesar-cipher/681a1d60e037127e7c8e0230.md
@@ -43,7 +43,6 @@ def caesar(text, shift, encrypt=True):
     encrypted_text = text.translate(translation_table)
     return encrypted_text
 
-
 encrypted_text = caesar('freeCodeCamp', 3)
 print(encrypted_text)
 ```

--- a/curriculum/challenges/english/blocks/workshop-caesar-cipher/681a2e35c406ade2f0a5f9b2.md
+++ b/curriculum/challenges/english/blocks/workshop-caesar-cipher/681a2e35c406ade2f0a5f9b2.md
@@ -47,6 +47,6 @@ def decrypt(text, shift):
     return caesar(text, shift, encrypt=False)
 --fcc-editable-region--
 encrypted_text = caesar('freeCodeCamp', 3)
-print(encrypted_text)
 --fcc-editable-region--
+print(encrypted_text)
 ```

--- a/curriculum/challenges/english/blocks/workshop-caesar-cipher/681a2e35c406ade2f0a5f9b2.md
+++ b/curriculum/challenges/english/blocks/workshop-caesar-cipher/681a2e35c406ade2f0a5f9b2.md
@@ -45,6 +45,7 @@ def encrypt(text, shift):
     
 def decrypt(text, shift):
     return caesar(text, shift, encrypt=False)
+
 --fcc-editable-region--
 encrypted_text = caesar('freeCodeCamp', 3)
 --fcc-editable-region--

--- a/curriculum/challenges/english/blocks/workshop-caesar-cipher/681a44f4c3235f7d8f428545.md
+++ b/curriculum/challenges/english/blocks/workshop-caesar-cipher/681a44f4c3235f7d8f428545.md
@@ -67,6 +67,7 @@ def encrypt(text, shift):
     
 def decrypt(text, shift):
     return caesar(text, shift, encrypt=False)
+
 --fcc-editable-region--
 encrypted_text = encrypt('freeCodeCamp', 3)
 print(encrypted_text)


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #65265

<!-- Feel free to add any additional description of changes below this line -->

This PR is to fix the editable region to contain only exactly the lines to edit in Caesar Cipher workshop as with the new editor, campers don't loose the context of the code.