### PR TITLE
fix(curriculum): refine editable regions in iframe video display work

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-build-a-video-display-using-iframe/68b94f23f7b3ee14078c89c5.md
+++ b/curriculum/challenges/english/blocks/workshop-build-a-video-display-using-iframe/68b94f23f7b3ee14078c89c5.md
@@ -40,7 +40,7 @@ assert.equal(document.querySelector('h1')?.textContent.trim(), 'iframe Video Dis
   </head>
   <body>
 --fcc-editable-region--
-   
+    
 --fcc-editable-region--
   </body>
 </html>

--- a/curriculum/challenges/english/blocks/workshop-build-a-video-display-using-iframe/68ba9c4f1688914d72876093.md
+++ b/curriculum/challenges/english/blocks/workshop-build-a-video-display-using-iframe/68ba9c4f1688914d72876093.md
@@ -38,7 +38,7 @@ assert.equal(document.querySelector('iframe')?.innerHTML.trim(), '')
   <body>
     <h1>iframe Video Display</h1>
 --fcc-editable-region--
-   
+    
 --fcc-editable-region--
   </body>
 </html>

--- a/curriculum/challenges/english/blocks/workshop-build-a-video-display-using-iframe/68ba9c4f1688914d72876094.md
+++ b/curriculum/challenges/english/blocks/workshop-build-a-video-display-using-iframe/68ba9c4f1688914d72876094.md
@@ -44,7 +44,7 @@ assert.equal(iframeEl?.getAttribute('height'), '315')
 
     <iframe
 --fcc-editable-region--
-   
+      
 --fcc-editable-region--
     >
 

--- a/curriculum/challenges/english/blocks/workshop-build-a-video-display-using-iframe/68ba9c4f1688914d72876094.md
+++ b/curriculum/challenges/english/blocks/workshop-build-a-video-display-using-iframe/68ba9c4f1688914d72876094.md
@@ -44,7 +44,7 @@ assert.equal(iframeEl?.getAttribute('height'), '315')
 
     <iframe
 --fcc-editable-region--
-
+   
 --fcc-editable-region--
     >
 

--- a/curriculum/challenges/english/blocks/workshop-build-a-video-display-using-iframe/68ba9c4f1688914d72876094.md
+++ b/curriculum/challenges/english/blocks/workshop-build-a-video-display-using-iframe/68ba9c4f1688914d72876094.md
@@ -41,11 +41,14 @@ assert.equal(iframeEl?.getAttribute('height'), '315')
   </head>
   <body>
     <h1>iframe Video Display</h1>
+
+    <iframe
 --fcc-editable-region--
-    <iframe>
+
+--fcc-editable-region--
+    >
 
     </iframe>
---fcc-editable-region--
   </body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-build-a-video-display-using-iframe/68ba9c4f1688914d72876095.md
+++ b/curriculum/challenges/english/blocks/workshop-build-a-video-display-using-iframe/68ba9c4f1688914d72876095.md
@@ -36,15 +36,15 @@ assert.equal(iframeEl?.getAttribute('src'), 'https://www.youtube.com/embed/I0_95
   </head>
   <body>
     <h1>iframe Video Display</h1>
---fcc-editable-region--
     <iframe
       width="560"
       height="315"
+--fcc-editable-region--
 
+--fcc-editable-region--
     >
 
     </iframe>
---fcc-editable-region--
   </body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-build-a-video-display-using-iframe/68ba9c4f1688914d72876095.md
+++ b/curriculum/challenges/english/blocks/workshop-build-a-video-display-using-iframe/68ba9c4f1688914d72876095.md
@@ -40,7 +40,7 @@ assert.equal(iframeEl?.getAttribute('src'), 'https://www.youtube.com/embed/I0_95
       width="560"
       height="315"
 --fcc-editable-region--
-   
+      
 --fcc-editable-region--
     >
 

--- a/curriculum/challenges/english/blocks/workshop-build-a-video-display-using-iframe/68ba9c4f1688914d72876095.md
+++ b/curriculum/challenges/english/blocks/workshop-build-a-video-display-using-iframe/68ba9c4f1688914d72876095.md
@@ -40,7 +40,7 @@ assert.equal(iframeEl?.getAttribute('src'), 'https://www.youtube.com/embed/I0_95
       width="560"
       height="315"
 --fcc-editable-region--
-
+   
 --fcc-editable-region--
     >
 

--- a/curriculum/challenges/english/blocks/workshop-build-a-video-display-using-iframe/68ba9c4f1688914d72876096.md
+++ b/curriculum/challenges/english/blocks/workshop-build-a-video-display-using-iframe/68ba9c4f1688914d72876096.md
@@ -66,7 +66,7 @@ assert.match(iframeElAllowAttr, /clipboard-write/)
       height="315"
       src="https://www.youtube.com/embed/I0_951_MPE0"
 --fcc-editable-region--
-
+   
 --fcc-editable-region--
     >
 

--- a/curriculum/challenges/english/blocks/workshop-build-a-video-display-using-iframe/68ba9c4f1688914d72876096.md
+++ b/curriculum/challenges/english/blocks/workshop-build-a-video-display-using-iframe/68ba9c4f1688914d72876096.md
@@ -66,7 +66,7 @@ assert.match(iframeElAllowAttr, /clipboard-write/)
       height="315"
       src="https://www.youtube.com/embed/I0_951_MPE0"
 --fcc-editable-region--
-   
+      
 --fcc-editable-region--
     >
 

--- a/curriculum/challenges/english/blocks/workshop-build-a-video-display-using-iframe/68ba9c4f1688914d72876096.md
+++ b/curriculum/challenges/english/blocks/workshop-build-a-video-display-using-iframe/68ba9c4f1688914d72876096.md
@@ -61,16 +61,16 @@ assert.match(iframeElAllowAttr, /clipboard-write/)
   </head>
   <body>
     <h1>iframe Video Display</h1>
---fcc-editable-region--
     <iframe
       width="560"
       height="315"
       src="https://www.youtube.com/embed/I0_951_MPE0"
+--fcc-editable-region--
 
+--fcc-editable-region--
     >
 
     </iframe>
---fcc-editable-region--
   </body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-build-a-video-display-using-iframe/68ba9c4f1688914d72876097.md
+++ b/curriculum/challenges/english/blocks/workshop-build-a-video-display-using-iframe/68ba9c4f1688914d72876097.md
@@ -51,16 +51,16 @@ assert.match(iframeElAllowAttr, /web-share/)
   </head>
   <body>
     <h1>iframe Video Display</h1>
---fcc-editable-region--
     <iframe
       width="560"
       height="315"
       src="https://www.youtube.com/embed/I0_951_MPE0"
+--fcc-editable-region--
       allow="accelerometer autoplay clipboard-write"
+--fcc-editable-region--
     >
 
     </iframe>
---fcc-editable-region--
   </body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-build-a-video-display-using-iframe/68ba9c4f1688914d72876098.md
+++ b/curriculum/challenges/english/blocks/workshop-build-a-video-display-using-iframe/68ba9c4f1688914d72876098.md
@@ -40,7 +40,7 @@ assert.equal(iframeEl?.getAttribute('referrerpolicy'), 'strict-origin-when-cross
       src="https://www.youtube.com/embed/I0_951_MPE0"
       allow="accelerometer autoplay clipboard-write encrypted-media gyroscope web-share"
 --fcc-editable-region--
-
+   
 --fcc-editable-region--
     >
 

--- a/curriculum/challenges/english/blocks/workshop-build-a-video-display-using-iframe/68ba9c4f1688914d72876098.md
+++ b/curriculum/challenges/english/blocks/workshop-build-a-video-display-using-iframe/68ba9c4f1688914d72876098.md
@@ -34,16 +34,17 @@ assert.equal(iframeEl?.getAttribute('referrerpolicy'), 'strict-origin-when-cross
   </head>
   <body>
     <h1>iframe Video Display</h1>
---fcc-editable-region--
     <iframe
       width="560"
       height="315"
       src="https://www.youtube.com/embed/I0_951_MPE0"
       allow="accelerometer autoplay clipboard-write encrypted-media gyroscope web-share"
+--fcc-editable-region--
+
+--fcc-editable-region--
     >
 
     </iframe>
---fcc-editable-region--
   </body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-build-a-video-display-using-iframe/68ba9c4f1688914d72876098.md
+++ b/curriculum/challenges/english/blocks/workshop-build-a-video-display-using-iframe/68ba9c4f1688914d72876098.md
@@ -40,7 +40,7 @@ assert.equal(iframeEl?.getAttribute('referrerpolicy'), 'strict-origin-when-cross
       src="https://www.youtube.com/embed/I0_951_MPE0"
       allow="accelerometer autoplay clipboard-write encrypted-media gyroscope web-share"
 --fcc-editable-region--
-   
+      
 --fcc-editable-region--
     >
 

--- a/curriculum/challenges/english/blocks/workshop-build-a-video-display-using-iframe/68ba9c4f1688914d72876099.md
+++ b/curriculum/challenges/english/blocks/workshop-build-a-video-display-using-iframe/68ba9c4f1688914d72876099.md
@@ -34,18 +34,18 @@ assert.exists(iframeEl?.getAttribute('allowfullscreen'))
   </head>
   <body>
     <h1>iframe Video Display</h1>
---fcc-editable-region--
     <iframe
       width="560"
       height="315"
       src="https://www.youtube.com/embed/I0_951_MPE0"
       allow="accelerometer autoplay clipboard-write encrypted-media gyroscope web-share"
       referrerpolicy="strict-origin-when-cross-origin"
+--fcc-editable-region--
 
+--fcc-editable-region--
     >
 
     </iframe>
---fcc-editable-region--
   </body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-build-a-video-display-using-iframe/68ba9c4f1688914d72876099.md
+++ b/curriculum/challenges/english/blocks/workshop-build-a-video-display-using-iframe/68ba9c4f1688914d72876099.md
@@ -41,7 +41,7 @@ assert.exists(iframeEl?.getAttribute('allowfullscreen'))
       allow="accelerometer autoplay clipboard-write encrypted-media gyroscope web-share"
       referrerpolicy="strict-origin-when-cross-origin"
 --fcc-editable-region--
-   
+      
 --fcc-editable-region--
     >
 

--- a/curriculum/challenges/english/blocks/workshop-build-a-video-display-using-iframe/68ba9c4f1688914d72876099.md
+++ b/curriculum/challenges/english/blocks/workshop-build-a-video-display-using-iframe/68ba9c4f1688914d72876099.md
@@ -41,7 +41,7 @@ assert.exists(iframeEl?.getAttribute('allowfullscreen'))
       allow="accelerometer autoplay clipboard-write encrypted-media gyroscope web-share"
       referrerpolicy="strict-origin-when-cross-origin"
 --fcc-editable-region--
-
+   
 --fcc-editable-region--
     >
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.



Related #65268

Audited workshop-build-a-video-display-using-iframe to ensure editable regions only include the lines campers must modify.