### PR TITLE
fix(curriculum): correct grammar in JavaScript review comment

### DIFF
--- a/curriculum/challenges/english/blocks/review-javascript-math/6723c463e51a2d9b747d7529.md
+++ b/curriculum/challenges/english/blocks/review-javascript-math/6723c463e51a2d9b747d7529.md
@@ -181,7 +181,7 @@ const score = 87;
 if (score >= 90) {
  console.log('You got an A'); 
 } else if (score >= 80) {
- console.log('You got a B'); // You got an B
+ console.log('You got a B'); // You got a B
 } else if (score >= 70) {
  console.log('You got a C');
 } else {


### PR DESCRIPTION
### Description

This pull request fixes a small grammatical error in a JavaScript review example.

The inline comment incorrectly used “an B” instead of the grammatically correct “a B”.  
Correcting this improves clarity and content quality for learners reviewing the JavaScript V9 certification material.

### Changes Made
- Fixed grammar in an inline comment in the JavaScript math review block

### Checklist
- [x] I have read and followed the contribution guidelines.
- [x] I have read and followed the how to open a pull request guide.
- [x] My pull request targets the main branch of freeCodeCamp.
- [x] I have tested these changes locally or via GitHub Codespaces (documentation-only change).

### Related Issue
Closes #65288
