### PR TITLE
fix(curriculum): fix editable region in workshop quincys job tips

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-quincys-job-tips/68e4c81577243e4db1676491.md
+++ b/curriculum/challenges/english/blocks/workshop-quincys-job-tips/68e4c81577243e4db1676491.md
@@ -40,7 +40,7 @@ assert.equal(document.querySelector('h1')?.textContent.trim(), "Quincy's Tips fo
   </head>
   <body>
 --fcc-editable-region--
-   
+    
 --fcc-editable-region--
   </body>
 </html>

--- a/curriculum/challenges/english/blocks/workshop-quincys-job-tips/68e65ec5348e40a739903e6d.md
+++ b/curriculum/challenges/english/blocks/workshop-quincys-job-tips/68e65ec5348e40a739903e6d.md
@@ -44,7 +44,7 @@ assert.exists(document.querySelector('h1 + p'));
   <body>
     <h1>Quincy's Tips for Getting a Developer Job</h1>
 --fcc-editable-region--
-   
+    
 --fcc-editable-region--
   </body>
 </html>

--- a/curriculum/challenges/english/blocks/workshop-quincys-job-tips/68e96ce52087043b0e999296.md
+++ b/curriculum/challenges/english/blocks/workshop-quincys-job-tips/68e96ce52087043b0e999296.md
@@ -45,7 +45,7 @@ assert.lengthOf(sections, 3);
     </p>
 
 --fcc-editable-region--
-
+    
 --fcc-editable-region--
   </body>
 </html>

--- a/curriculum/challenges/english/blocks/workshop-quincys-job-tips/68ea5ccc1229b85eca38a3e8.md
+++ b/curriculum/challenges/english/blocks/workshop-quincys-job-tips/68ea5ccc1229b85eca38a3e8.md
@@ -44,11 +44,11 @@ assert.equal(firstH2El?.innerText.trim(), `Envisioning Success`);
     </p>
 
     <main>
---fcc-editable-region--
       <section>
-
+      --fcc-editable-region--
+        
+      --fcc-editable-region--
       </section>
---fcc-editable-region--
       <section>
 
       </section>

--- a/curriculum/challenges/english/blocks/workshop-quincys-job-tips/68ea7e7b916e8270483689b6.md
+++ b/curriculum/challenges/english/blocks/workshop-quincys-job-tips/68ea7e7b916e8270483689b6.md
@@ -54,12 +54,12 @@ assert.equal(firstBlockquoteEl?.innerText.trim(), 'Can you imagine what it would
     </p>
 
     <main>
---fcc-editable-region--
       <section>
         <h2>Envisioning Success</h2>
-
+        --fcc-editable-region--
+        
+        --fcc-editable-region--
       </section>
---fcc-editable-region--
       <section>
 
       </section>

--- a/curriculum/challenges/english/blocks/workshop-quincys-job-tips/68ea9d23318b6481ac3de777.md
+++ b/curriculum/challenges/english/blocks/workshop-quincys-job-tips/68ea9d23318b6481ac3de777.md
@@ -57,11 +57,11 @@ assert.equal(firstBlockquoteEl?.getAttribute('cite'), 'https://www.freecodecamp.
     <main>
       <section>
         <h2>Envisioning Success</h2>
---fcc-editable-region--
+      --fcc-editable-region--
         <blockquote>
+      --fcc-editable-region--
           Can you imagine what it would be like to be a successful developer? To have built software systems that people rely upon?
         </blockquote>
---fcc-editable-region--
       </section>
       <section>
 

--- a/curriculum/challenges/english/blocks/workshop-quincys-job-tips/68eaa3593b6ffd019d772a1f.md
+++ b/curriculum/challenges/english/blocks/workshop-quincys-job-tips/68eaa3593b6ffd019d772a1f.md
@@ -56,7 +56,7 @@ assert.oneOf(html, [
           Can you imagine what it would be like to be a successful developer? To have built software systems that people rely upon?
         </blockquote>
 --fcc-editable-region--
-
+        
 --fcc-editable-region--
       </section>
       <section>

--- a/curriculum/challenges/english/blocks/workshop-quincys-job-tips/68eaa9ef8a0867071f195f59.md
+++ b/curriculum/challenges/english/blocks/workshop-quincys-job-tips/68eaa9ef8a0867071f195f59.md
@@ -71,11 +71,11 @@ assert.equal(pElCleanedText, '—Quincy Larson, How to Learn to Code and Get a D
         <blockquote cite="https://www.freecodecamp.org/news/learn-to-code-book/">
           Can you imagine what it would be like to be a successful developer? To have built software systems that people rely upon?
         </blockquote>
---fcc-editable-region--
         <p>
+      --fcc-editable-region--
           —Quincy Larson, How to Learn to Code and Get a Developer Job [Full Book]
+      --fcc-editable-region--
         </p>
---fcc-editable-region--
       </section>
       <section>
 

--- a/curriculum/challenges/english/blocks/workshop-quincys-job-tips/68eab45aceb7c00fd8de4fed.md
+++ b/curriculum/challenges/english/blocks/workshop-quincys-job-tips/68eab45aceb7c00fd8de4fed.md
@@ -83,7 +83,7 @@ assert.equal(blockquoteEl?.getAttribute('cite'), 'https://www.freecodecamp.org/n
       </section>
       <section>
 --fcc-editable-region--
-
+        
 --fcc-editable-region--
       </section>
       <section>

--- a/curriculum/challenges/english/blocks/workshop-quincys-job-tips/68eab6a2b37d2f13602d0c3f.md
+++ b/curriculum/challenges/english/blocks/workshop-quincys-job-tips/68eab6a2b37d2f13602d0c3f.md
@@ -93,11 +93,11 @@ assert.equal(forthPEl?.innerText.trim(), 'Go to tech meetups and conferences. Tr
       </section>
       <section>
         <h2>Importance of Networking</h2>
---fcc-editable-region--
         <blockquote cite="https://www.freecodecamp.org/news/learn-to-code-book/">
-
+        --fcc-editable-region--
+          
+        --fcc-editable-region--
         </blockquote>
---fcc-editable-region--
       </section>
       <section>
 

--- a/curriculum/challenges/english/blocks/workshop-quincys-job-tips/68ebe9cd7523d340c0b343d3.md
+++ b/curriculum/challenges/english/blocks/workshop-quincys-job-tips/68ebe9cd7523d340c0b343d3.md
@@ -128,11 +128,11 @@ assert.equal(thirdPEl?.innerText.trim(), 'Hang out at hackerspaces and help peop
           <p>Go to tech meetups and conferences. Travel if you have to.</p>
         </blockquote>
       </section>
---fcc-editable-region--
       <section>
-
+      --fcc-editable-region--
+        
+      --fcc-editable-region--
       </section>
---fcc-editable-region--
     </main>
   </body>
 </html>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related to #65268 

<!-- Feel free to add any additional description of changes below this line -->

This PR is to fix the editable regions to contain only exactly the lines to edit in quincys job tips workshop as with the new editor, campers don't loose the context of the code.