### PR TITLE
test: enforce rel="stylesheet" in flexbox photo gallery step 1

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-flexbox-photo-gallery/61537bb9b1a29430ac15ad38.md
+++ b/curriculum/challenges/english/blocks/workshop-flexbox-photo-gallery/61537bb9b1a29430ac15ad38.md
@@ -14,10 +14,30 @@ Start this project by linking your `styles.css` file to the page.
 
 Your `link` element should have an `href` attribute with the value `styles.css`.
 
-```js
-assert.match(code, /<link[\s\S]*?href=('|"|`)(\.\/)?styles\.css\1/)
-```
+To actually apply the stylesheet, remember to set the `rel` attribute to `stylesheet`.
 
+```js
+const link = document.querySelector("head > link");
+
+assert.exists(
+  link,
+  "You should add a link element inside the head element."
+);
+
+assert.equal(
+  link.getAttribute("rel"),
+  "stylesheet",
+  'Your link element should have rel="stylesheet".'
+);
+
+const href = link.getAttribute("href");
+
+assert.oneOf(
+  href,
+  ["styles.css", "./styles.css"],
+  'Your link element should have href="styles.css".'
+);
+```
 # --seed--
 
 ## --seed-contents--


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

This pull request completes **Step 1** of the Photo Gallery project by linking the external stylesheet `styles.css` to the HTML page.  

**Changes Made:**  
Tests if the <link> element contains an rel attribute;
Tests if the rel attribute contains a valid value.

