### PR TITLE
fix(curriculum): refine editable regions in html video player

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-build-a-heart-icon/686daa7ed79ceacd0b264e7d.md
+++ b/curriculum/challenges/english/blocks/workshop-build-a-heart-icon/686daa7ed79ceacd0b264e7d.md
@@ -32,11 +32,11 @@ assert.exists(path);
     <title>Heart Icon</title>
   </head>
   <body>
-    --fcc-editable-region--
     <svg>
-      
-    </svg>
     --fcc-editable-region--
+      
+    --fcc-editable-region--
+    </svg>
   </body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-build-a-heart-icon/686daa7ed79ceacd0b264e7e.md
+++ b/curriculum/challenges/english/blocks/workshop-build-a-heart-icon/686daa7ed79ceacd0b264e7e.md
@@ -46,11 +46,13 @@ assert.strictEqual(
     <title>Heart Icon</title>
   </head>
   <body>
-    --fcc-editable-region--
     <svg>
-      <path></path>
+      <path
+      --fcc-editable-region--
+        
+      --fcc-editable-region--
+      ></path>
     </svg>
-    --fcc-editable-region--
   </body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-build-a-heart-icon/686daa7ed79ceacd0b264e7f.md
+++ b/curriculum/challenges/english/blocks/workshop-build-a-heart-icon/686daa7ed79ceacd0b264e7f.md
@@ -41,11 +41,11 @@ assert.strictEqual(svg.getAttribute('height'), '24');
   <body>
     --fcc-editable-region--
     <svg>
+    --fcc-editable-region--
       <path
         d="M12 21s-6-4.35-9.33-8.22C-.5 7.39 3.24 1 8.4 4.28 10.08 5.32 12 7.5 12 7.5s1.92-2.18 3.6-3.22C20.76 1 24.5 7.39 21.33 12.78 18 16.65 12 21 12 21z"
       ></path>
     </svg>
-    --fcc-editable-region--
   </body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-build-a-heart-icon/686daa7ed79ceacd0b264e80.md
+++ b/curriculum/challenges/english/blocks/workshop-build-a-heart-icon/686daa7ed79ceacd0b264e80.md
@@ -81,11 +81,11 @@ assert.strictEqual(height, '24');
   <body>
     --fcc-editable-region--
     <svg width="24" height="24">
+    --fcc-editable-region--
       <path
         d="M12 21s-6-4.35-9.33-8.22C-.5 7.39 3.24 1 8.4 4.28 10.08 5.32 12 7.5 12 7.5s1.92-2.18 3.6-3.22C20.76 1 24.5 7.39 21.33 12.78 18 16.65 12 21 12 21z"
       ></path>
     </svg>
-    --fcc-editable-region--
   </body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-build-a-heart-icon/686daa7ed79ceacd0b264e81.md
+++ b/curriculum/challenges/english/blocks/workshop-build-a-heart-icon/686daa7ed79ceacd0b264e81.md
@@ -44,11 +44,11 @@ assert.strictEqual(fill, "red");
   <body>
     --fcc-editable-region--
     <svg width="24" height="24" viewBox="0 0 24 24">
+    --fcc-editable-region--
       <path
         d="M12 21s-6-4.35-9.33-8.22C-.5 7.39 3.24 1 8.4 4.28 10.08 5.32 12 7.5 12 7.5s1.92-2.18 3.6-3.22C20.76 1 24.5 7.39 21.33 12.78 18 16.65 12 21 12 21z"
       ></path>
     </svg>
-    --fcc-editable-region--
   </body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f18724d71db1dda8d6fec7.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f18724d71db1dda8d6fec7.md
@@ -41,7 +41,7 @@ assert.strictEqual(h1?.textContent.trim(), 'Working with the HTML Video Element'
 </head>
   <body>
 --fcc-editable-region--
-
+    
 --fcc-editable-region--
   </body>
 </html>

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f1eb9ad0a7575e4dbc31d5.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f1eb9ad0a7575e4dbc31d5.md
@@ -38,7 +38,7 @@ assert.exists(document.querySelector('h1 + video'));
 <body>
   <h1>Working with the HTML Video Element</h1>
 --fcc-editable-region--
-
+    
 --fcc-editable-region--
 </body>
 </html>

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f371fefd448b4f70b898.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f371fefd448b4f70b898.md
@@ -35,9 +35,9 @@ assert.strictEqual(video?.getAttribute('width'), '640');
 <body>
   <h1>Working with the HTML Video Element</h1>
 --fcc-editable-region--
-  <video>
+    <video>
 --fcc-editable-region--
-  </video>
+    </video>
   </body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f57723debf9383c75947.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f57723debf9383c75947.md
@@ -37,9 +37,9 @@ assert.isTrue(video?.hasAttribute('loop'));
 <body>
   <h1>Working with the HTML Video Element</h1>
 --fcc-editable-region--
-  <video width="640">
+    <video width="640">
 --fcc-editable-region--
-  </video>
+    </video>
   </body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f6f97af9749a42260a43.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f6f97af9749a42260a43.md
@@ -39,9 +39,9 @@ assert.isTrue(video?.hasAttribute('controls'));
 <body>
   <h1>Working with the HTML Video Element</h1>
 --fcc-editable-region--
-  <video width="640" loop>
+    <video width="640" loop>
 --fcc-editable-region--
-  </video>
+    </video>
   </body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f8c248306da204655117.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f8c248306da204655117.md
@@ -37,9 +37,9 @@ assert.isTrue(video?.hasAttribute('muted'));
 <body>
   <h1>Working with the HTML Video Element</h1>
 --fcc-editable-region--
-  <video width="640" loop controls>
+    <video width="640" loop controls>
 --fcc-editable-region--
-  </video>
+    </video>
   </body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f993460f06a64c033061.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f993460f06a64c033061.md
@@ -34,15 +34,16 @@ assert.strictEqual(video?.getAttribute('poster'), 'https://cdn.freecodecamp.org/
 </head>
 <body>
   <h1>Working with the HTML Video Element</h1>
+    <video
+      width="640"
+      loop
+      controls
+      muted
 --fcc-editable-region--
-  <video
-    width="640"
-    loop
-    controls
-    muted
-  >
+      
 --fcc-editable-region--
-  </video>
+    >
+    </video>
   </body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f1fac259a4afabb478b960.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f1fac259a4afabb478b960.md
@@ -44,17 +44,17 @@ assert.exists(document.querySelector('video > source'));
 </head>
 <body>
   <h1>Working with the HTML Video Element</h1>
-  <video
-    width="640"
-    loop
-    controls
-    muted
-    poster="https://cdn.freecodecamp.org/curriculum/labs/past-event2.jpg"
-  >
+    <video
+      width="640"
+      loop
+      controls
+      muted
+      poster="https://cdn.freecodecamp.org/curriculum/labs/past-event2.jpg"
+    >
 --fcc-editable-region--
-
+      
 --fcc-editable-region--
-  </video>
+    </video>
   </body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f268880219c2485bd71d2a.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f268880219c2485bd71d2a.md
@@ -42,17 +42,17 @@ assert.strictEqual(source?.getAttribute('src'),
 </head>
 <body>
   <h1>Working with the HTML Video Element</h1>
-  <video
-    width="640"
-    loop
-    controls
-    muted
-    poster="https://cdn.freecodecamp.org/curriculum/labs/past-event2.jpg"
-  >
+    <video
+      width="640"
+      loop
+      controls
+      muted
+      poster="https://cdn.freecodecamp.org/curriculum/labs/past-event2.jpg"
+    >
 --fcc-editable-region--
-  <source>
+      <source>
 --fcc-editable-region--
-  </video>
+    </video>
   </body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f26a5f79e97c5032c10642.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f26a5f79e97c5032c10642.md
@@ -47,20 +47,20 @@ assert.strictEqual(source?.getAttribute('type'), 'video/mp4');
 </head>
 <body>
   <h1>Working with the HTML Video Element</h1>
-  <video
-    width="640"
-    loop
-    controls
-    muted
-    poster="https://cdn.freecodecamp.org/curriculum/labs/past-event2.jpg"
-  >
---fcc-editable-region--
-  <source
-    src="https://cdn.freecodecamp.org/curriculum/labs/what-is-the-map-method-and-how-does-it-work.mp4"
-
-  >
---fcc-editable-region--
-  </video>
+    <video
+      width="640"
+      loop
+      controls
+      muted
+      poster="https://cdn.freecodecamp.org/curriculum/labs/past-event2.jpg"
+    >
+      <source
+        src="https://cdn.freecodecamp.org/curriculum/labs/what-is-the-map-method-and-how-does-it-work.mp4"
+  --fcc-editable-region--
+        
+  --fcc-editable-region--
+      >
+    </video>
 </body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f26d52b13e0f5b6e2d2e09.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f26d52b13e0f5b6e2d2e09.md
@@ -63,21 +63,21 @@ assert.strictEqual(source?.getAttribute('type'), 'video/webm');
 </head>
 <body>
   <h1>Working with the HTML Video Element</h1>
-  <video
-    width="640"
-    loop
-    controls
-    muted
-    poster="https://cdn.freecodecamp.org/curriculum/labs/past-event2.jpg"
-  >
-  <source
-    src="https://cdn.freecodecamp.org/curriculum/labs/what-is-the-map-method-and-how-does-it-work.mp4"
-    type="video/mp4"
-  >
---fcc-editable-region--
-
---fcc-editable-region--
-  </video>
+    <video
+      width="640"
+      loop
+      controls
+      muted
+      poster="https://cdn.freecodecamp.org/curriculum/labs/past-event2.jpg"
+    >
+      <source
+        src="https://cdn.freecodecamp.org/curriculum/labs/what-is-the-map-method-and-how-does-it-work.mp4"
+        type="video/mp4"
+      >
+  --fcc-editable-region--
+      
+  --fcc-editable-region--
+    </video>
   </body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f2701b2160c765f23b60f8.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f2701b2160c765f23b60f8.md
@@ -63,25 +63,25 @@ assert.strictEqual(source?.getAttribute('type'), 'video/ogg');
 </head>
 <body>
   <h1>Working with the HTML Video Element</h1>
-  <video
-    width="640"
-    loop
-    controls
-    muted
-    poster="https://cdn.freecodecamp.org/curriculum/labs/past-event2.jpg"
-  >
-  <source
-    src="https://cdn.freecodecamp.org/curriculum/labs/what-is-the-map-method-and-how-does-it-work.mp4"
-    type="video/mp4"
-  >
-  <source
-    src="https://cdn.freecodecamp.org/curriculum/labs/mapmethod.webm"
-    type="video/webm"
-  >
+    <video
+      width="640"
+      loop
+      controls
+      muted
+      poster="https://cdn.freecodecamp.org/curriculum/labs/past-event2.jpg"
+    >
+      <source
+        src="https://cdn.freecodecamp.org/curriculum/labs/what-is-the-map-method-and-how-does-it-work.mp4"
+        type="video/mp4"
+      >
+      <source
+        src="https://cdn.freecodecamp.org/curriculum/labs/mapmethod.webm"
+        type="video/webm"
+      >
 --fcc-editable-region--
-
+      
 --fcc-editable-region--
-  </video>
+    </video>
   </body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f27139bddf9f6bf2821acf.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f27139bddf9f6bf2821acf.md
@@ -65,29 +65,29 @@ assert.strictEqual(source?.getAttribute('type'), 'video/quicktime');
 </head>
 <body>
   <h1>Working with the HTML Video Element</h1>
-  <video
-    width="640"
-    loop
-    controls
-    muted
-    poster="https://cdn.freecodecamp.org/curriculum/labs/past-event2.jpg"
-  >
-  <source
-    src="https://cdn.freecodecamp.org/curriculum/labs/what-is-the-map-method-and-how-does-it-work.mp4"
-    type="video/mp4"
-  >
-  <source
-    src="https://cdn.freecodecamp.org/curriculum/labs/mapmethod.webm"
-    type="video/webm"
-  >
-  <source
-    src="https://cdn.freecodecamp.org/curriculum/labs/mapmethod.ogg"
-    type="video/ogg"
-  >
+    <video
+      width="640"
+      loop
+      controls
+      muted
+      poster="https://cdn.freecodecamp.org/curriculum/labs/past-event2.jpg"
+    >
+      <source
+        src="https://cdn.freecodecamp.org/curriculum/labs/what-is-the-map-method-and-how-does-it-work.mp4"
+        type="video/mp4"
+      >
+      <source
+        src="https://cdn.freecodecamp.org/curriculum/labs/mapmethod.webm"
+        type="video/webm"
+      >
+      <source
+        src="https://cdn.freecodecamp.org/curriculum/labs/mapmethod.ogg"
+        type="video/ogg"
+      >
 --fcc-editable-region--
-
+      
 --fcc-editable-region--
-  </video>
+   </video>
   </body>
 </html>
 ```


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.


Related #65268

Refines the editable-region markers in the workshop-build-a-html-video-player challenge.
