### PR TITLE
fix(curriculum): refine editable regions in html video player

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f18724d71db1dda8d6fec7.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f18724d71db1dda8d6fec7.md
@@ -35,9 +35,9 @@ assert.strictEqual(h1?.textContent.trim(), 'Working with the HTML Video Element'
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Working with the HTML Video Element</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Working with the HTML Video Element</title>
 </head>
 <body>
 --fcc-editable-region--

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f18724d71db1dda8d6fec7.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f18724d71db1dda8d6fec7.md
@@ -41,7 +41,7 @@ assert.strictEqual(h1?.textContent.trim(), 'Working with the HTML Video Element'
 </head>
   <body>
 --fcc-editable-region--
-
+    
 --fcc-editable-region--
   </body>
 </html>

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f18724d71db1dda8d6fec7.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f18724d71db1dda8d6fec7.md
@@ -39,10 +39,10 @@ assert.strictEqual(h1?.textContent.trim(), 'Working with the HTML Video Element'
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Working with the HTML Video Element</title>
 </head>
-  <body>
+<body>
 --fcc-editable-region--
-    
+  
 --fcc-editable-region--
-  </body>
+</body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f1eb9ad0a7575e4dbc31d5.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f1eb9ad0a7575e4dbc31d5.md
@@ -38,7 +38,7 @@ assert.exists(document.querySelector('h1 + video'));
 <body>
   <h1>Working with the HTML Video Element</h1>
 --fcc-editable-region--
-    
+  
 --fcc-editable-region--
 </body>
 </html>

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f1eb9ad0a7575e4dbc31d5.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f1eb9ad0a7575e4dbc31d5.md
@@ -38,7 +38,7 @@ assert.exists(document.querySelector('h1 + video'));
   <body>
     <h1>Working with the HTML Video Element</h1>
 --fcc-editable-region--
-    
+      
 --fcc-editable-region--
   </body>
 </html>

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f1eb9ad0a7575e4dbc31d5.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f1eb9ad0a7575e4dbc31d5.md
@@ -35,11 +35,11 @@ assert.exists(document.querySelector('h1 + video'));
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Working with the HTML Video Element</title>
 </head>
-  <body>
-    <h1>Working with the HTML Video Element</h1>
+<body>
+  <h1>Working with the HTML Video Element</h1>
 --fcc-editable-region--
-      
+    
 --fcc-editable-region--
-  </body>
+</body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f1eb9ad0a7575e4dbc31d5.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f1eb9ad0a7575e4dbc31d5.md
@@ -31,9 +31,9 @@ assert.exists(document.querySelector('h1 + video'));
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Working with the HTML Video Element</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Working with the HTML Video Element</title>
 </head>
 <body>
   <h1>Working with the HTML Video Element</h1>

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f1eb9ad0a7575e4dbc31d5.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f1eb9ad0a7575e4dbc31d5.md
@@ -35,11 +35,11 @@ assert.exists(document.querySelector('h1 + video'));
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Working with the HTML Video Element</title>
 </head>
-<body>
-  <h1>Working with the HTML Video Element</h1>
+  <body>
+    <h1>Working with the HTML Video Element</h1>
 --fcc-editable-region--
-
+    
 --fcc-editable-region--
-</body>
+  </body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f371fefd448b4f70b898.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f371fefd448b4f70b898.md
@@ -35,9 +35,9 @@ assert.strictEqual(video?.getAttribute('width'), '640');
 <body>
   <h1>Working with the HTML Video Element</h1>
 --fcc-editable-region--
-    <video>
+  <video>
 --fcc-editable-region--
-    </video>
+  </video>
 </body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f371fefd448b4f70b898.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f371fefd448b4f70b898.md
@@ -32,12 +32,12 @@ assert.strictEqual(video?.getAttribute('width'), '640');
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Working with the HTML Video Element</title>
 </head>
-<body>
-  <h1>Working with the HTML Video Element</h1>
+  <body>
+    <h1>Working with the HTML Video Element</h1>
 --fcc-editable-region--
-  <video>
+      <video>
 --fcc-editable-region--
-  </video>
+      </video>
   </body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f371fefd448b4f70b898.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f371fefd448b4f70b898.md
@@ -28,9 +28,9 @@ assert.strictEqual(video?.getAttribute('width'), '640');
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Working with the HTML Video Element</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Working with the HTML Video Element</title>
 </head>
 <body>
   <h1>Working with the HTML Video Element</h1>

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f371fefd448b4f70b898.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f371fefd448b4f70b898.md
@@ -32,12 +32,12 @@ assert.strictEqual(video?.getAttribute('width'), '640');
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Working with the HTML Video Element</title>
 </head>
-  <body>
-    <h1>Working with the HTML Video Element</h1>
+<body>
+  <h1>Working with the HTML Video Element</h1>
 --fcc-editable-region--
-      <video>
+    <video>
 --fcc-editable-region--
-      </video>
-  </body>
+    </video>
+</body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f57723debf9383c75947.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f57723debf9383c75947.md
@@ -37,9 +37,9 @@ assert.isTrue(video?.hasAttribute('loop'));
 <body>
   <h1>Working with the HTML Video Element</h1>
 --fcc-editable-region--
-    <video width="640">
+  <video width="640">
 --fcc-editable-region--
-    </video>
+  </video>
 </body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f57723debf9383c75947.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f57723debf9383c75947.md
@@ -34,12 +34,12 @@ assert.isTrue(video?.hasAttribute('loop'));
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Working with the HTML Video Element</title>
 </head>
-  <body>
-    <h1>Working with the HTML Video Element</h1>
+<body>
+  <h1>Working with the HTML Video Element</h1>
 --fcc-editable-region--
-      <video width="640">
+    <video width="640">
 --fcc-editable-region--
-      </video>
-  </body>
+    </video>
+</body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f57723debf9383c75947.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f57723debf9383c75947.md
@@ -34,12 +34,12 @@ assert.isTrue(video?.hasAttribute('loop'));
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Working with the HTML Video Element</title>
 </head>
-<body>
-  <h1>Working with the HTML Video Element</h1>
+  <body>
+    <h1>Working with the HTML Video Element</h1>
 --fcc-editable-region--
-  <video width="640">
+      <video width="640">
 --fcc-editable-region--
-  </video>
+      </video>
   </body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f57723debf9383c75947.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f57723debf9383c75947.md
@@ -30,9 +30,9 @@ assert.isTrue(video?.hasAttribute('loop'));
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Working with the HTML Video Element</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Working with the HTML Video Element</title>
 </head>
 <body>
   <h1>Working with the HTML Video Element</h1>

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f6f97af9749a42260a43.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f6f97af9749a42260a43.md
@@ -39,9 +39,9 @@ assert.isTrue(video?.hasAttribute('controls'));
 <body>
   <h1>Working with the HTML Video Element</h1>
 --fcc-editable-region--
-    <video width="640" loop>
+  <video width="640" loop>
 --fcc-editable-region--
-    </video>
+  </video>
 </body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f6f97af9749a42260a43.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f6f97af9749a42260a43.md
@@ -36,12 +36,12 @@ assert.isTrue(video?.hasAttribute('controls'));
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Working with the HTML Video Element</title>
 </head>
-  <body>
-    <h1>Working with the HTML Video Element</h1>
+<body>
+  <h1>Working with the HTML Video Element</h1>
 --fcc-editable-region--
-      <video width="640" loop>
+    <video width="640" loop>
 --fcc-editable-region--
-      </video>
-  </body>
+    </video>
+</body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f6f97af9749a42260a43.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f6f97af9749a42260a43.md
@@ -36,12 +36,12 @@ assert.isTrue(video?.hasAttribute('controls'));
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Working with the HTML Video Element</title>
 </head>
-<body>
-  <h1>Working with the HTML Video Element</h1>
+  <body>
+    <h1>Working with the HTML Video Element</h1>
 --fcc-editable-region--
-  <video width="640" loop>
+      <video width="640" loop>
 --fcc-editable-region--
-  </video>
+      </video>
   </body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f6f97af9749a42260a43.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f6f97af9749a42260a43.md
@@ -32,9 +32,9 @@ assert.isTrue(video?.hasAttribute('controls'));
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Working with the HTML Video Element</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Working with the HTML Video Element</title>
 </head>
 <body>
   <h1>Working with the HTML Video Element</h1>

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f8c248306da204655117.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f8c248306da204655117.md
@@ -37,9 +37,9 @@ assert.isTrue(video?.hasAttribute('muted'));
 <body>
   <h1>Working with the HTML Video Element</h1>
 --fcc-editable-region--
-    <video width="640" loop controls>
+  <video width="640" loop controls>
 --fcc-editable-region--
-    </video>
+  </video>
 </body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f8c248306da204655117.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f8c248306da204655117.md
@@ -30,9 +30,9 @@ assert.isTrue(video?.hasAttribute('muted'));
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Working with the HTML Video Element</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Working with the HTML Video Element</title>
 </head>
 <body>
   <h1>Working with the HTML Video Element</h1>

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f8c248306da204655117.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f8c248306da204655117.md
@@ -34,12 +34,12 @@ assert.isTrue(video?.hasAttribute('muted'));
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Working with the HTML Video Element</title>
 </head>
-<body>
-  <h1>Working with the HTML Video Element</h1>
+  <body>
+    <h1>Working with the HTML Video Element</h1>
 --fcc-editable-region--
-  <video width="640" loop controls>
+      <video width="640" loop controls>
 --fcc-editable-region--
-  </video>
+      </video>
   </body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f8c248306da204655117.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f8c248306da204655117.md
@@ -34,12 +34,12 @@ assert.isTrue(video?.hasAttribute('muted'));
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Working with the HTML Video Element</title>
 </head>
-  <body>
-    <h1>Working with the HTML Video Element</h1>
+<body>
+  <h1>Working with the HTML Video Element</h1>
 --fcc-editable-region--
-      <video width="640" loop controls>
+    <video width="640" loop controls>
 --fcc-editable-region--
-      </video>
-  </body>
+    </video>
+</body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f993460f06a64c033061.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f993460f06a64c033061.md
@@ -34,16 +34,16 @@ assert.strictEqual(video?.getAttribute('poster'), 'https://cdn.freecodecamp.org/
 </head>
 <body>
   <h1>Working with the HTML Video Element</h1>
-    <video
-      width="640"
-      loop
-      controls
-      muted
+  <video
+    width="640"
+    loop
+    controls
+    muted
 --fcc-editable-region--
-      
+    
 --fcc-editable-region--
-    >
-    </video>
+  >
+  </video>
 </body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f993460f06a64c033061.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f993460f06a64c033061.md
@@ -32,17 +32,18 @@ assert.strictEqual(video?.getAttribute('poster'), 'https://cdn.freecodecamp.org/
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Working with the HTML Video Element</title>
 </head>
-<body>
-  <h1>Working with the HTML Video Element</h1>
+  <body>
+    <h1>Working with the HTML Video Element</h1>
+      <video
+        width="640"
+        loop
+        controls
+        muted
 --fcc-editable-region--
-  <video
-    width="640"
-    loop
-    controls
-    muted
-  >
+
 --fcc-editable-region--
-  </video>
+      >
+      </video>
   </body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f993460f06a64c033061.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f993460f06a64c033061.md
@@ -28,9 +28,9 @@ assert.strictEqual(video?.getAttribute('poster'), 'https://cdn.freecodecamp.org/
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Working with the HTML Video Element</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Working with the HTML Video Element</title>
 </head>
 <body>
   <h1>Working with the HTML Video Element</h1>

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f993460f06a64c033061.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f993460f06a64c033061.md
@@ -40,7 +40,7 @@ assert.strictEqual(video?.getAttribute('poster'), 'https://cdn.freecodecamp.org/
         controls
         muted
 --fcc-editable-region--
-
+        
 --fcc-editable-region--
       >
       </video>

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f993460f06a64c033061.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f993460f06a64c033061.md
@@ -32,18 +32,18 @@ assert.strictEqual(video?.getAttribute('poster'), 'https://cdn.freecodecamp.org/
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Working with the HTML Video Element</title>
 </head>
-  <body>
-    <h1>Working with the HTML Video Element</h1>
-      <video
-        width="640"
-        loop
-        controls
-        muted
+<body>
+  <h1>Working with the HTML Video Element</h1>
+    <video
+      width="640"
+      loop
+      controls
+      muted
 --fcc-editable-region--
-        
+      
 --fcc-editable-region--
-      >
-      </video>
-  </body>
+    >
+    </video>
+</body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f1fac259a4afabb478b960.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f1fac259a4afabb478b960.md
@@ -44,17 +44,17 @@ assert.exists(document.querySelector('video > source'));
 </head>
 <body>
   <h1>Working with the HTML Video Element</h1>
-    <video
-      width="640"
-      loop
-      controls
-      muted
-      poster="https://cdn.freecodecamp.org/curriculum/labs/past-event2.jpg"
-    >
+  <video
+    width="640"
+    loop
+    controls
+    muted
+    poster="https://cdn.freecodecamp.org/curriculum/labs/past-event2.jpg"
+  >
 --fcc-editable-region--
-      
+    
 --fcc-editable-region--
-    </video>
+  </video>
 </body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f1fac259a4afabb478b960.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f1fac259a4afabb478b960.md
@@ -42,19 +42,19 @@ assert.exists(document.querySelector('video > source'));
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Working with the HTML Video Element</title>
 </head>
-<body>
-  <h1>Working with the HTML Video Element</h1>
-  <video
-    width="640"
-    loop
-    controls
-    muted
-    poster="https://cdn.freecodecamp.org/curriculum/labs/past-event2.jpg"
-  >
---fcc-editable-region--
-
---fcc-editable-region--
-  </video>
+  <body>
+    <h1>Working with the HTML Video Element</h1>
+      <video
+        width="640"
+        loop
+        controls
+        muted
+        poster="https://cdn.freecodecamp.org/curriculum/labs/past-event2.jpg"
+      >
+  --fcc-editable-region--
+        
+  --fcc-editable-region--
+      </video>
   </body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f1fac259a4afabb478b960.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f1fac259a4afabb478b960.md
@@ -42,19 +42,19 @@ assert.exists(document.querySelector('video > source'));
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Working with the HTML Video Element</title>
 </head>
-  <body>
-    <h1>Working with the HTML Video Element</h1>
-      <video
-        width="640"
-        loop
-        controls
-        muted
-        poster="https://cdn.freecodecamp.org/curriculum/labs/past-event2.jpg"
-      >
-  --fcc-editable-region--
-        
-  --fcc-editable-region--
-      </video>
-  </body>
+<body>
+  <h1>Working with the HTML Video Element</h1>
+    <video
+      width="640"
+      loop
+      controls
+      muted
+      poster="https://cdn.freecodecamp.org/curriculum/labs/past-event2.jpg"
+    >
+--fcc-editable-region--
+      
+--fcc-editable-region--
+    </video>
+</body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f1fac259a4afabb478b960.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f1fac259a4afabb478b960.md
@@ -38,9 +38,9 @@ assert.exists(document.querySelector('video > source'));
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Working with the HTML Video Element</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Working with the HTML Video Element</title>
 </head>
 <body>
   <h1>Working with the HTML Video Element</h1>

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f268880219c2485bd71d2a.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f268880219c2485bd71d2a.md
@@ -42,17 +42,17 @@ assert.strictEqual(source?.getAttribute('src'),
 </head>
 <body>
   <h1>Working with the HTML Video Element</h1>
-    <video
-      width="640"
-      loop
-      controls
-      muted
-      poster="https://cdn.freecodecamp.org/curriculum/labs/past-event2.jpg"
-    >
+  <video
+    width="640"
+    loop
+    controls
+    muted
+    poster="https://cdn.freecodecamp.org/curriculum/labs/past-event2.jpg"
+  >
 --fcc-editable-region--
-      <source>
+    <source>
 --fcc-editable-region--
-    </video>
+  </video>
 </body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f268880219c2485bd71d2a.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f268880219c2485bd71d2a.md
@@ -40,19 +40,19 @@ assert.strictEqual(source?.getAttribute('src'),
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Working with the HTML Video Element</title>
 </head>
-<body>
-  <h1>Working with the HTML Video Element</h1>
-  <video
-    width="640"
-    loop
-    controls
-    muted
-    poster="https://cdn.freecodecamp.org/curriculum/labs/past-event2.jpg"
-  >
---fcc-editable-region--
-  <source>
---fcc-editable-region--
-  </video>
+  <body>
+    <h1>Working with the HTML Video Element</h1>
+      <video
+        width="640"
+        loop
+        controls
+        muted
+        poster="https://cdn.freecodecamp.org/curriculum/labs/past-event2.jpg"
+      >
+  --fcc-editable-region--
+        <source>
+  --fcc-editable-region--
+      </video>
   </body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f268880219c2485bd71d2a.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f268880219c2485bd71d2a.md
@@ -36,9 +36,9 @@ assert.strictEqual(source?.getAttribute('src'),
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Working with the HTML Video Element</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Working with the HTML Video Element</title>
 </head>
 <body>
   <h1>Working with the HTML Video Element</h1>

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f268880219c2485bd71d2a.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f268880219c2485bd71d2a.md
@@ -40,19 +40,19 @@ assert.strictEqual(source?.getAttribute('src'),
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Working with the HTML Video Element</title>
 </head>
-  <body>
-    <h1>Working with the HTML Video Element</h1>
-      <video
-        width="640"
-        loop
-        controls
-        muted
-        poster="https://cdn.freecodecamp.org/curriculum/labs/past-event2.jpg"
-      >
-  --fcc-editable-region--
-        <source>
-  --fcc-editable-region--
-      </video>
-  </body>
+<body>
+  <h1>Working with the HTML Video Element</h1>
+    <video
+      width="640"
+      loop
+      controls
+      muted
+      poster="https://cdn.freecodecamp.org/curriculum/labs/past-event2.jpg"
+    >
+--fcc-editable-region--
+      <source>
+--fcc-editable-region--
+    </video>
+</body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f26a5f79e97c5032c10642.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f26a5f79e97c5032c10642.md
@@ -47,20 +47,20 @@ assert.strictEqual(source?.getAttribute('type'), 'video/mp4');
 </head>
 <body>
   <h1>Working with the HTML Video Element</h1>
-    <video
-      width="640"
-      loop
-      controls
-      muted
-      poster="https://cdn.freecodecamp.org/curriculum/labs/past-event2.jpg"
+  <video
+    width="640"
+    loop
+    controls
+    muted
+    poster="https://cdn.freecodecamp.org/curriculum/labs/past-event2.jpg"
+  >
+    <source
+      src="https://cdn.freecodecamp.org/curriculum/labs/what-is-the-map-method-and-how-does-it-work.mp4"
+--fcc-editable-region--
+      
+--fcc-editable-region--
     >
-      <source
-        src="https://cdn.freecodecamp.org/curriculum/labs/what-is-the-map-method-and-how-does-it-work.mp4"
-  --fcc-editable-region--
-        
-  --fcc-editable-region--
-      >
-    </video>
+  </video>
 </body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f26a5f79e97c5032c10642.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f26a5f79e97c5032c10642.md
@@ -41,9 +41,9 @@ assert.strictEqual(source?.getAttribute('type'), 'video/mp4');
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Working with the HTML Video Element</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Working with the HTML Video Element</title>
 </head>
 <body>
   <h1>Working with the HTML Video Element</h1>

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f26a5f79e97c5032c10642.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f26a5f79e97c5032c10642.md
@@ -45,22 +45,22 @@ assert.strictEqual(source?.getAttribute('type'), 'video/mp4');
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Working with the HTML Video Element</title>
 </head>
-  <body>
-    <h1>Working with the HTML Video Element</h1>
-      <video
-        width="640"
-        loop
-        controls
-        muted
-        poster="https://cdn.freecodecamp.org/curriculum/labs/past-event2.jpg"
+<body>
+  <h1>Working with the HTML Video Element</h1>
+    <video
+      width="640"
+      loop
+      controls
+      muted
+      poster="https://cdn.freecodecamp.org/curriculum/labs/past-event2.jpg"
+    >
+      <source
+        src="https://cdn.freecodecamp.org/curriculum/labs/what-is-the-map-method-and-how-does-it-work.mp4"
+  --fcc-editable-region--
+        
+  --fcc-editable-region--
       >
-        <source
-          src="https://cdn.freecodecamp.org/curriculum/labs/what-is-the-map-method-and-how-does-it-work.mp4"
-    --fcc-editable-region--
-          
-    --fcc-editable-region--
-        >
-      </video>
-  </body>
+    </video>
+</body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f26a5f79e97c5032c10642.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f26a5f79e97c5032c10642.md
@@ -45,22 +45,22 @@ assert.strictEqual(source?.getAttribute('type'), 'video/mp4');
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Working with the HTML Video Element</title>
 </head>
-<body>
-  <h1>Working with the HTML Video Element</h1>
-  <video
-    width="640"
-    loop
-    controls
-    muted
-    poster="https://cdn.freecodecamp.org/curriculum/labs/past-event2.jpg"
-  >
---fcc-editable-region--
-  <source
-    src="https://cdn.freecodecamp.org/curriculum/labs/what-is-the-map-method-and-how-does-it-work.mp4"
-
-  >
---fcc-editable-region--
-  </video>
-</body>
+  <body>
+    <h1>Working with the HTML Video Element</h1>
+      <video
+        width="640"
+        loop
+        controls
+        muted
+        poster="https://cdn.freecodecamp.org/curriculum/labs/past-event2.jpg"
+      >
+        <source
+          src="https://cdn.freecodecamp.org/curriculum/labs/what-is-the-map-method-and-how-does-it-work.mp4"
+    --fcc-editable-region--
+          
+    --fcc-editable-region--
+        >
+      </video>
+  </body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f26d52b13e0f5b6e2d2e09.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f26d52b13e0f5b6e2d2e09.md
@@ -63,21 +63,21 @@ assert.strictEqual(source?.getAttribute('type'), 'video/webm');
 </head>
 <body>
   <h1>Working with the HTML Video Element</h1>
-    <video
-      width="640"
-      loop
-      controls
-      muted
-      poster="https://cdn.freecodecamp.org/curriculum/labs/past-event2.jpg"
+  <video
+    width="640"
+    loop
+    controls
+    muted
+    poster="https://cdn.freecodecamp.org/curriculum/labs/past-event2.jpg"
+  >
+    <source
+      src="https://cdn.freecodecamp.org/curriculum/labs/what-is-the-map-method-and-how-does-it-work.mp4"
+      type="video/mp4"
     >
-      <source
-        src="https://cdn.freecodecamp.org/curriculum/labs/what-is-the-map-method-and-how-does-it-work.mp4"
-        type="video/mp4"
-      >
-  --fcc-editable-region--
-      
-  --fcc-editable-region--
-    </video>
+--fcc-editable-region--
+    
+--fcc-editable-region--
+  </video>
 </body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f26d52b13e0f5b6e2d2e09.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f26d52b13e0f5b6e2d2e09.md
@@ -61,23 +61,23 @@ assert.strictEqual(source?.getAttribute('type'), 'video/webm');
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Working with the HTML Video Element</title>
 </head>
-<body>
-  <h1>Working with the HTML Video Element</h1>
-  <video
-    width="640"
-    loop
-    controls
-    muted
-    poster="https://cdn.freecodecamp.org/curriculum/labs/past-event2.jpg"
-  >
-  <source
-    src="https://cdn.freecodecamp.org/curriculum/labs/what-is-the-map-method-and-how-does-it-work.mp4"
-    type="video/mp4"
-  >
---fcc-editable-region--
-
---fcc-editable-region--
-  </video>
+  <body>
+    <h1>Working with the HTML Video Element</h1>
+      <video
+        width="640"
+        loop
+        controls
+        muted
+        poster="https://cdn.freecodecamp.org/curriculum/labs/past-event2.jpg"
+      >
+        <source
+          src="https://cdn.freecodecamp.org/curriculum/labs/what-is-the-map-method-and-how-does-it-work.mp4"
+          type="video/mp4"
+        >
+    --fcc-editable-region--
+        
+    --fcc-editable-region--
+      </video>
   </body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f26d52b13e0f5b6e2d2e09.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f26d52b13e0f5b6e2d2e09.md
@@ -61,23 +61,23 @@ assert.strictEqual(source?.getAttribute('type'), 'video/webm');
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Working with the HTML Video Element</title>
 </head>
-  <body>
-    <h1>Working with the HTML Video Element</h1>
-      <video
-        width="640"
-        loop
-        controls
-        muted
-        poster="https://cdn.freecodecamp.org/curriculum/labs/past-event2.jpg"
+<body>
+  <h1>Working with the HTML Video Element</h1>
+    <video
+      width="640"
+      loop
+      controls
+      muted
+      poster="https://cdn.freecodecamp.org/curriculum/labs/past-event2.jpg"
+    >
+      <source
+        src="https://cdn.freecodecamp.org/curriculum/labs/what-is-the-map-method-and-how-does-it-work.mp4"
+        type="video/mp4"
       >
-        <source
-          src="https://cdn.freecodecamp.org/curriculum/labs/what-is-the-map-method-and-how-does-it-work.mp4"
-          type="video/mp4"
-        >
-    --fcc-editable-region--
-        
-    --fcc-editable-region--
-      </video>
-  </body>
+  --fcc-editable-region--
+      
+  --fcc-editable-region--
+    </video>
+</body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f26d52b13e0f5b6e2d2e09.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f26d52b13e0f5b6e2d2e09.md
@@ -57,9 +57,9 @@ assert.strictEqual(source?.getAttribute('type'), 'video/webm');
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Working with the HTML Video Element</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Working with the HTML Video Element</title>
 </head>
 <body>
   <h1>Working with the HTML Video Element</h1>

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f2701b2160c765f23b60f8.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f2701b2160c765f23b60f8.md
@@ -61,27 +61,27 @@ assert.strictEqual(source?.getAttribute('type'), 'video/ogg');
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Working with the HTML Video Element</title>
 </head>
-  <body>
-    <h1>Working with the HTML Video Element</h1>
-      <video
-        width="640"
-        loop
-        controls
-        muted
-        poster="https://cdn.freecodecamp.org/curriculum/labs/past-event2.jpg"
-      >
-        <source
-          src="https://cdn.freecodecamp.org/curriculum/labs/what-is-the-map-method-and-how-does-it-work.mp4"
-          type="video/mp4"
-        >
-        <source
-          src="https://cdn.freecodecamp.org/curriculum/labs/mapmethod.webm"
-          type="video/webm"
-        >
-  --fcc-editable-region--
-        
-  --fcc-editable-region--
-      </video>
-  </body>
+<body>
+  <h1>Working with the HTML Video Element</h1>
+  <video
+    width="640"
+    loop
+    controls
+    muted
+    poster="https://cdn.freecodecamp.org/curriculum/labs/past-event2.jpg"
+  >
+    <source
+      src="https://cdn.freecodecamp.org/curriculum/labs/what-is-the-map-method-and-how-does-it-work.mp4"
+      type="video/mp4"
+    >
+    <source
+      src="https://cdn.freecodecamp.org/curriculum/labs/mapmethod.webm"
+      type="video/webm"
+    >
+--fcc-editable-region--
+    
+--fcc-editable-region--
+  </video>
+</body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f2701b2160c765f23b60f8.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f2701b2160c765f23b60f8.md
@@ -61,27 +61,27 @@ assert.strictEqual(source?.getAttribute('type'), 'video/ogg');
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Working with the HTML Video Element</title>
 </head>
-<body>
-  <h1>Working with the HTML Video Element</h1>
-  <video
-    width="640"
-    loop
-    controls
-    muted
-    poster="https://cdn.freecodecamp.org/curriculum/labs/past-event2.jpg"
-  >
-  <source
-    src="https://cdn.freecodecamp.org/curriculum/labs/what-is-the-map-method-and-how-does-it-work.mp4"
-    type="video/mp4"
-  >
-  <source
-    src="https://cdn.freecodecamp.org/curriculum/labs/mapmethod.webm"
-    type="video/webm"
-  >
---fcc-editable-region--
-
---fcc-editable-region--
-  </video>
+  <body>
+    <h1>Working with the HTML Video Element</h1>
+      <video
+        width="640"
+        loop
+        controls
+        muted
+        poster="https://cdn.freecodecamp.org/curriculum/labs/past-event2.jpg"
+      >
+        <source
+          src="https://cdn.freecodecamp.org/curriculum/labs/what-is-the-map-method-and-how-does-it-work.mp4"
+          type="video/mp4"
+        >
+        <source
+          src="https://cdn.freecodecamp.org/curriculum/labs/mapmethod.webm"
+          type="video/webm"
+        >
+  --fcc-editable-region--
+        
+  --fcc-editable-region--
+      </video>
   </body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f2701b2160c765f23b60f8.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f2701b2160c765f23b60f8.md
@@ -57,9 +57,9 @@ assert.strictEqual(source?.getAttribute('type'), 'video/ogg');
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Working with the HTML Video Element</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Working with the HTML Video Element</title>
 </head>
   <body>
     <h1>Working with the HTML Video Element</h1>

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f27139bddf9f6bf2821acf.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f27139bddf9f6bf2821acf.md
@@ -63,32 +63,32 @@ assert.strictEqual(source?.getAttribute('type'), 'video/quicktime');
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Working with the HTML Video Element</title>
 </head>
-  <body>
-    <h1>Working with the HTML Video Element</h1>
-      <video
-        width="640"
-        loop
-        controls
-        muted
-        poster="https://cdn.freecodecamp.org/curriculum/labs/past-event2.jpg"
-      >
-        <source
-          src="https://cdn.freecodecamp.org/curriculum/labs/what-is-the-map-method-and-how-does-it-work.mp4"
-          type="video/mp4"
-        >
-        <source
-          src="https://cdn.freecodecamp.org/curriculum/labs/mapmethod.webm"
-          type="video/webm"
-        >
-        <source
-          src="https://cdn.freecodecamp.org/curriculum/labs/mapmethod.ogg"
-          type="video/ogg"
-        >
-  --fcc-editable-region--
-        
-  --fcc-editable-region--
-    </video>
-  </body>
+<body>
+  <h1>Working with the HTML Video Element</h1>
+  <video
+    width="640"
+    loop
+    controls
+    muted
+    poster="https://cdn.freecodecamp.org/curriculum/labs/past-event2.jpg"
+  >
+    <source
+      src="https://cdn.freecodecamp.org/curriculum/labs/what-is-the-map-method-and-how-does-it-work.mp4"
+      type="video/mp4"
+    >
+    <source
+      src="https://cdn.freecodecamp.org/curriculum/labs/mapmethod.webm"
+      type="video/webm"
+    >
+    <source
+      src="https://cdn.freecodecamp.org/curriculum/labs/mapmethod.ogg"
+      type="video/ogg"
+    >
+--fcc-editable-region--
+    
+--fcc-editable-region--
+  </video>
+</body>
 </html>
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f27139bddf9f6bf2821acf.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f27139bddf9f6bf2821acf.md
@@ -63,31 +63,31 @@ assert.strictEqual(source?.getAttribute('type'), 'video/quicktime');
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Working with the HTML Video Element</title>
 </head>
-<body>
-  <h1>Working with the HTML Video Element</h1>
-  <video
-    width="640"
-    loop
-    controls
-    muted
-    poster="https://cdn.freecodecamp.org/curriculum/labs/past-event2.jpg"
-  >
-  <source
-    src="https://cdn.freecodecamp.org/curriculum/labs/what-is-the-map-method-and-how-does-it-work.mp4"
-    type="video/mp4"
-  >
-  <source
-    src="https://cdn.freecodecamp.org/curriculum/labs/mapmethod.webm"
-    type="video/webm"
-  >
-  <source
-    src="https://cdn.freecodecamp.org/curriculum/labs/mapmethod.ogg"
-    type="video/ogg"
-  >
---fcc-editable-region--
-
---fcc-editable-region--
-  </video>
+  <body>
+    <h1>Working with the HTML Video Element</h1>
+      <video
+        width="640"
+        loop
+        controls
+        muted
+        poster="https://cdn.freecodecamp.org/curriculum/labs/past-event2.jpg"
+      >
+        <source
+          src="https://cdn.freecodecamp.org/curriculum/labs/what-is-the-map-method-and-how-does-it-work.mp4"
+          type="video/mp4"
+        >
+        <source
+          src="https://cdn.freecodecamp.org/curriculum/labs/mapmethod.webm"
+          type="video/webm"
+        >
+        <source
+          src="https://cdn.freecodecamp.org/curriculum/labs/mapmethod.ogg"
+          type="video/ogg"
+        >
+  --fcc-editable-region--
+        
+  --fcc-editable-region--
+    </video>
   </body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f27139bddf9f6bf2821acf.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f27139bddf9f6bf2821acf.md
@@ -59,9 +59,9 @@ assert.strictEqual(source?.getAttribute('type'), 'video/quicktime');
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Working with the HTML Video Element</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Working with the HTML Video Element</title>
 </head>
   <body>
     <h1>Working with the HTML Video Element</h1>


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.


Related #65268


Refines the editable-region markers in the workshop-html-video-player challenge.