### PR TITLE
fix(curriculum): remove unintended line break in Tower of Hanoi expec…

### DIFF
--- a/curriculum/challenges/english/blocks/lab-tower-of-hanoi/68773ee26f332a80bc0295db.md
+++ b/curriculum/challenges/english/blocks/lab-tower-of-hanoi/68773ee26f332a80bc0295db.md
@@ -67,8 +67,7 @@ assert isinstance(hanoi_solver(11), str)
 `) })
 ```
 
-`hanoi_solver(2)` should return `[2, 1] [] []\n[2] [1] []\n[] [1] [2]\n
-[] [] [2, 1]`.
+`hanoi_solver(2)` should return `[2, 1] [] []\n[2] [1] []\n[] [1] [2]\n[] [] [2, 1]`.
 
 ```js
 ({ test: () => runPython(`


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the contribution guidelines.
- [x] I have read and followed the how to open a pull request guide.
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes locally.

Closes #65334 

<!--
This PR removes an unintended line break in the expected output for the
Tower of Hanoi lab, which was causing an extra space in the displayed value.
-->