### PR TITLE
fix(challenge-helper-scripts): add stub module intro when creating a new module

### DIFF
--- a/tools/challenge-helper-scripts/create-language-block.ts
+++ b/tools/challenge-helper-scripts/create-language-block.ts
@@ -47,6 +47,7 @@ type SuperBlockInfo = {
   blocks: Record<string, BlockInfo>;
   chapters?: Record<string, string>;
   modules?: Record<string, string>;
+  'module-intros'?: Record<string, { intro: string[]; note: string }>;
 };
 
 type IntroJson = Record<SuperBlocks, SuperBlockInfo>;
@@ -191,6 +192,16 @@ async function updateIntroJson({
     }
     if (!newIntro[superBlock].modules[module]) {
       newIntro[superBlock].modules[module] = moduleTitle;
+    }
+
+    if (!newIntro[superBlock]['module-intros']) {
+      newIntro[superBlock]['module-intros'] = {};
+    }
+    if (!newIntro[superBlock]['module-intros'][module]) {
+      newIntro[superBlock]['module-intros'][module] = {
+        note: '',
+        intro: ['']
+      };
     }
   }
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR:
- Updates the `create-language-block` script to add the newly created module to the `module-intros` object in `intro.json`. We missed this when we updated the script to handle chapter/module creation.
- Is related to https://github.com/freeCodeCamp/freeCodeCamp/pull/65340#issuecomment-3774032950.

<!-- Feel free to add any additional description of changes below this line -->
