### PR TITLE
fix(curriculum): remove extraneous punctuation in task 48

### DIFF
--- a/curriculum/challenges/english/blocks/learn-how-to-use-modal-verbs/67d5681f7a8dd6346ff23196.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-modal-verbs/67d5681f7a8dd6346ff23196.md
@@ -54,12 +54,12 @@ Remember:
 
 `Must` expresses strong necessity or obligation. For example:
 
-`You must wear a seatbelt.`.
+`You must wear a seatbelt.`
 
 `Have to` also expresses obligation but is sometimes less strict than must. For example:
 
-`You have to submit the report by Friday.`.
+`You have to submit the report by Friday.`
 
 `Should` is used for recommendations or advice. For example:
 
-`You should review your notes before the test.`.
+`You should review your notes before the test.`


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes locally.

Closes #65383

This PR removes extraneous punctuation marks appearing after closing quotation marks
in the B1 English for Developers modal verbs lesson (task 48), following standard
English punctuation rules.