### PR TITLE
fix(tools): let prettier ignore dirs starting with `.`

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
+.*/*
 **/.cache
 **/*fixtures*
 client/**/trending.json


### PR DESCRIPTION
It annoys the heck out of me when prettier tries to lint dirs, we do not care about.