### PR TITLE
fix(curriculum): replace unicode minus with dash in challenge 165

### DIFF
--- a/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/694596b0585c11170ac7c7fd.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/694596b0585c11170ac7c7fd.md
@@ -13,7 +13,7 @@ Given an array of exam scores (numbers), return the average score in form of a l
 | - | - |
 | 97-100 | `"A+"` |
 | 93-96 | `"A"` |
-| 90-92 | `"A−"` |
+| 90-92 | `"A-"` |
 | 87-89 | `"B+"` |
 | 83-86 | `"B"` |
 | 80-82 | `"B-"` |

--- a/curriculum/challenges/english/blocks/daily-coding-challenges-python/694596b0585c11170ac7c7fd.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-python/694596b0585c11170ac7c7fd.md
@@ -13,7 +13,7 @@ Given an array of exam scores (numbers), return the average score in form of a l
 | - | - |
 | 97-100 | `"A+"` |
 | 93-96 | `"A"` |
-| 90-92 | `"A−"` |
+| 90-92 | `"A-"` |
 | 87-89 | `"B+"` |
 | 83-86 | `"B"` |
 | 80-82 | `"B-"` |


### PR DESCRIPTION
### Description
This code replaces a Unicode minus character with a standard ASCII dash in the
Daily Coding Challenge 165 descriptions.

This prevents copy-paste issues where users encounter failing tests
due to an invisible Unicode character.

### Related Issue
Closes #65418

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ x] My pull request targets the `main` branch of freeCodeCamp.
- [x ] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #65418

<!-- Feel free to add any additional description of changes below this line -->
