### PR TITLE
fix(client): remove redundant warning text from archive content notice

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -715,7 +715,7 @@
     },
     "archive": {
       "title": "Archived Coursework",
-      "content-not-updated": "<0>Warning:</0> The content in this section is not being updated, but is still available for you to further your learning. We recommend trying <1>our current curriculum</1>."
+      "content-not-updated": "The content in this section is not being updated, but is still available for you to further your learning. We recommend trying <1>our current curriculum</1>."
     }
   },
   "donate": {

--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -715,7 +715,8 @@
     },
     "archive": {
       "title": "Archived Coursework",
-      "content-not-updated": "The content in this section is not being updated, but is still available for you to further your learning. We recommend trying <1>our current curriculum</1>."
+      "content-not-updated": "This content is no longer actively maintained, but remains available for reference. We recommend exploring <1>our current curriculum</1>."
+
     }
   },
   "donate": {

--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -715,7 +715,7 @@
     },
     "archive": {
       "title": "Archived Coursework",
-      "content-not-updated": "This content is no longer actively maintained, but remains available for reference. We recommend exploring <0>our current curriculum</0>."
+      "content-not-updated": "The content in this section is not being updated, but is still available for you to further your learning. We recommend trying <0>our current curriculum</0>."
     }
   },
   "donate": {

--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -715,8 +715,7 @@
     },
     "archive": {
       "title": "Archived Coursework",
-      "content-not-updated": "This content is no longer actively maintained, but remains available for reference. We recommend exploring <1>our current curriculum</1>."
-
+      "content-not-updated": "This content is no longer actively maintained, but remains available for reference. We recommend exploring <0>our current curriculum</0>."
     }
   },
   "donate": {

--- a/client/src/components/archived-warning/index.tsx
+++ b/client/src/components/archived-warning/index.tsx
@@ -10,9 +10,8 @@ const ArchivedWarning = () => {
   const { t } = useTranslation();
   return (
     <Callout variant='note' label={t('misc.note')}>
-      <p className='text-center archived-warning'>
+      <p className='archived-warning'>
         <Trans i18nKey='learn.archive.content-not-updated'>
-          <strong>placeholder</strong>
           <Link to={'/learn/full-stack-developer'}>placeholder</Link>
         </Trans>
       </p>


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or in GitHub Codespaces.

<!-- If your pull request closes a GitHub issue, replace the xxxxx below with the issue number. -->

Closes #65439

<!-- Feel free to add any additional description of changes below this line -->

Removes the redundant "Warning:" text from the archive content notice so the message is not duplicated.
