### PR TITLE
fix: correct pronoun typo in modal verbs task feedback

### DIFF
--- a/curriculum/challenges/english/blocks/learn-how-to-use-modal-verbs/67d58d55a85963454795b33b.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-modal-verbs/67d58d55a85963454795b33b.md
@@ -44,7 +44,7 @@ Because she wants to delay the deployment.
 
 ### --feedback--
 
-Ahe doesn't say she wants to delay the process.
+She doesn't say she wants to delay the process.
 
 ## --video-solution--
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the contribution guidelines.
- [x] I have read and followed the how to open a pull request guide.
- [x] My pull request targets the main branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #65441

This PR fixes a small pronoun typo in the task feedback by replacing "Ahe" with "She".
