### PR TITLE
refactor(tools): simplify turbo tasks, include outputs

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -143,6 +143,7 @@
     "@babel/plugin-syntax-dynamic-import": "7.8.3",
     "@freecodecamp/eslint-config": "workspace:*",
     "@freecodecamp/shared": "workspace:*",
+    "@freecodecamp/curriculum": "workspace:*",
     "@testing-library/jest-dom": "^6.8.0",
     "@testing-library/react": "12.1.5",
     "@testing-library/react-hooks": "^8.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -550,6 +550,9 @@ importers:
       '@babel/plugin-syntax-dynamic-import':
         specifier: 7.8.3
         version: 7.8.3(@babel/core@7.28.5)
+      '@freecodecamp/curriculum':
+        specifier: workspace:*
+        version: link:../curriculum
       '@freecodecamp/eslint-config':
         specifier: workspace:*
         version: link:../packages/eslint-config
@@ -1185,6 +1188,9 @@ importers:
 
   tools/client-plugins/gatsby-source-challenges:
     devDependencies:
+      '@freecodecamp/curriculum':
+        specifier: workspace:*
+        version: link:../../../curriculum
       '@freecodecamp/eslint-config':
         specifier: workspace:*
         version: link:../../../packages/eslint-config
@@ -24053,7 +24059,7 @@ snapshots:
       confusing-browser-globals: 1.0.11
       eslint: 7.32.0
       eslint-plugin-flowtype: 5.10.0(eslint@7.32.0)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@4.33.0(eslint@7.32.0)(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@4.33.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.4(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react-hooks: 4.6.0(eslint@9.39.2(jiti@2.6.1))
@@ -24083,7 +24089,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@4.33.0(eslint@7.32.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@4.33.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -24137,7 +24143,7 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@4.33.0(eslint@7.32.0)(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@4.33.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -24148,7 +24154,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@4.33.0(eslint@7.32.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@4.33.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.2(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -25386,7 +25392,7 @@ snapshots:
       eslint-config-react-app: 6.0.0(@typescript-eslint/eslint-plugin@4.33.0(@typescript-eslint/parser@4.33.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)(typescript@5.9.3))(@typescript-eslint/parser@4.33.0(eslint@7.32.0)(typescript@5.9.3))(babel-eslint@10.1.0(eslint@9.39.2(jiti@2.6.1)))(eslint-plugin-flowtype@5.10.0(eslint@7.32.0))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@4.33.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0))(eslint-plugin-jsx-a11y@6.10.2(eslint@7.32.0))(eslint-plugin-react-hooks@4.6.0(eslint@7.32.0))(eslint-plugin-react@7.37.4(eslint@7.32.0))(eslint@7.32.0)(typescript@5.9.3)
       eslint-plugin-flowtype: 5.10.0(eslint@7.32.0)
       eslint-plugin-graphql: 4.0.0(@types/node@24.10.9)(graphql@15.8.0)(typescript@5.9.3)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@4.33.0(eslint@7.32.0)(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@4.33.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.4(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react-hooks: 4.6.0(eslint@9.39.2(jiti@2.6.1))

--- a/tools/client-plugins/gatsby-source-challenges/gatsby-node.js
+++ b/tools/client-plugins/gatsby-source-challenges/gatsby-node.js
@@ -1,10 +1,10 @@
 const chokidar = require('chokidar');
 const {
   getSuperblockStructure
-} = require('../../../curriculum/dist/file-handler');
+} = require('@freecodecamp/curriculum/dist/file-handler');
 const {
   superBlockToFilename
-} = require('../../../curriculum/dist/build-curriculum');
+} = require('@freecodecamp/curriculum/dist/build-curriculum');
 
 const { createChallengeNode } = require('./create-challenge-nodes');
 

--- a/tools/client-plugins/gatsby-source-challenges/package.json
+++ b/tools/client-plugins/gatsby-source-challenges/package.json
@@ -23,6 +23,7 @@
   "main": "gatsby-node.js",
   "devDependencies": {
     "@freecodecamp/eslint-config": "workspace:*",
+    "@freecodecamp/curriculum": "workspace:*",
     "chokidar": "3.6.0",
     "eslint": "^9.39.1"
   }

--- a/turbo.json
+++ b/turbo.json
@@ -4,16 +4,10 @@
     "lint": { "dependsOn": ["compile"] },
     "type-check": { "dependsOn": ["compile"] },
     "@freecodecamp/client#lint": {
-      "dependsOn": [
-        "compile",
-        "create:env"
-      ]
+      "dependsOn": ["compile", "create:env"]
     },
     "@freecodecamp/client#type-check": {
-      "dependsOn": [
-        "compile",
-        "create:env"
-      ]
+      "dependsOn": ["compile", "create:env"]
     },
     "@freecodecamp/scripts-lint#lint": {
       "dependsOn": ["@freecodecamp/client#create:trending"],

--- a/turbo.json
+++ b/turbo.json
@@ -5,21 +5,15 @@
     "type-check": { "dependsOn": ["compile"] },
     "@freecodecamp/client#lint": {
       "dependsOn": [
-        "@freecodecamp/curriculum#compile",
-        "create:env",
-        "build:scripts"
+        "compile",
+        "create:env"
       ]
     },
     "@freecodecamp/client#type-check": {
       "dependsOn": [
-        "@freecodecamp/curriculum#compile",
-        "create:env",
-        "@freecodecamp/curriculum#build",
-        "build:scripts"
+        "compile",
+        "create:env"
       ]
-    },
-    "@freecodecamp/gatsby-source-challenges#lint": {
-      "dependsOn": ["@freecodecamp/curriculum#compile"]
     },
     "@freecodecamp/scripts-lint#lint": {
       "dependsOn": ["@freecodecamp/client#create:trending"],
@@ -29,15 +23,15 @@
       ]
     },
     "//#lint-root": {
-      "dependsOn": [
-        "@freecodecamp/shared#compile",
-        "@freecodecamp/curriculum#build"
-      ]
+      "dependsOn": ["@freecodecamp/shared#compile"]
     },
-    "compile": { "dependsOn": ["^compile"] },
+    "compile": { "dependsOn": ["^compile"], "outputs": ["dist/**"] },
     "create:trending": { "cache": false },
-    "create:env": { "dependsOn": ["@freecodecamp/curriculum#compile"] },
-    "build": { "dependsOn": ["compile"] },
+    "create:env": {
+      "dependsOn": ["@freecodecamp/curriculum#compile"],
+      "outputs": ["config/env.json"]
+    },
+    "build": { "dependsOn": ["compile"], "outputs": ["generated/**"] },
     "build:scripts": {},
     "build:external-curriculum": {
       "dependsOn": ["@freecodecamp/curriculum#build"]


### PR DESCRIPTION
Some task dependencies weren't necessary (or could be handled via workspace dependencies).

outputs should ensure that turbo regenerates the outputs if you, say, revert a change.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->
