### PR TITLE
Fix(curriculum): correct Bingo challenge test 5 description

### DIFF
--- a/curriculum/challenges/english/blocks/daily-coding-challenges-python/696655d24b614176d4c9b78a.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-python/696655d24b614176d4c9b78a.md
@@ -55,7 +55,7 @@ TestCase().assertEqual(get_bingo_letter(38), "N")`)
 }})
 ```
 
-`get_bingo_letter(11)` should return `"11"`.
+`get_bingo_letter(11)` should return `"B"`.
 
 ```js
 ({test: () => { runPython(`


### PR DESCRIPTION
 Description
Fixes a typo in the Test 5 description of the Bingo daily coding challenge.

## Issue
The description incorrectly states that `get_bingo_letter(11)` should return `"11"`.

#Fix
Updated the description to correctly state that it should return `"B"`.

Closes #65470

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X ] My pull request targets the `main` branch of freeCodeCamp.
- [X ] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #65470

<!-- Feel free to add any additional description of changes below this line -->
