### PR TITLE
feat(client): show helpful warning when sourcing style.css

### DIFF
--- a/client/src/templates/Challenges/utils/frame.ts
+++ b/client/src/templates/Challenges/utils/frame.ts
@@ -113,6 +113,15 @@ const createHeader = (id = mainPreviewId) =>
   </style>
   <script>
     window.__frameId = '${id}';
+    window.addEventListener('error', function (e) {
+      if (e.target && (e.target.nodeName === 'LINK' || e.target.nodeName === 'SCRIPT')) {
+        // @ts-expect-error - e.target is an Element
+        var src = e.target.getAttribute('href') || e.target.getAttribute('src');
+        if (src && src.includes('style.css')) {
+           console.warn('You have tried to source style.css, but that does not exist. The only files that can be sourced are styles.css and script.js.');
+        }
+      }
+    }, true);
     window.onerror = function(msg) {
       const string = msg.toLowerCase();
       if (string.includes('script error')) {
@@ -491,3 +500,4 @@ const createFramer = ({
     restoreScrollPosition,
     init(frameReady, proxyLogger)
   ) as (args: Context) => void;
+


### PR DESCRIPTION
Checklist:
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the \main\ branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Closes #49492

#### Description
This PR adds an event listener to the practice iframe that captures 404 errors for linked resources.
Specifically, if a user tries to link \style.css\ instead of \styles.css\ (a common typo), it logs a helpful warning to the console as requested in the issue.

I added this to the \createHeader\ string so it is present in the challenge preview frame.