### PR TITLE
fix(curriculum): clarify instructions for step 44

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-medical-data-validator/68529fb26c581f13e901de3a.md
+++ b/curriculum/challenges/english/blocks/workshop-medical-data-validator/68529fb26c581f13e901de3a.md
@@ -7,20 +7,13 @@ dashedName: step-44
 
 # --description--
 
-Right after the `invalid_records` variable, create a `for` loop to iterate over it.
+Right after the `invalid_records` variable, create a `for` loop to iterate over it. For each invalid record, print `Unexpected format '<key>: <val>' at position <index>.`. Replace `<key>`, `<val>`, and `<index>` with the current key, value, and index.
 
-`invalid_records` is a list of keys that refer to invalid records in the current `dictionary`.
-You will need to take the key from `invalid_records` and look up the value in `dictionary`.
+Remember that `invalid_records` is a list of keys that refer to invalid records in the current `dictionary`. You will need to take the key from `invalid_records` and look up the value in `dictionary`.
 
 Position or `index` refers to the current dictionary in `medical_records`, defined by the outer `for` loop in the function.
 
 Review your code so far if you need to remind yourself of the loops and variables already created.
-
-For each invalid record, print:
-
-Unexpected format '<key>: <val>' at position <index>.
-
-Replace `<key>`, `<val>`, and `<index>` with the current key, value, and index.
 
 Then, set `is_invalid` to `True`.
 

--- a/curriculum/challenges/english/blocks/workshop-medical-data-validator/68529fb26c581f13e901de3a.md
+++ b/curriculum/challenges/english/blocks/workshop-medical-data-validator/68529fb26c581f13e901de3a.md
@@ -12,7 +12,7 @@ Right after the `invalid_records` variable, create a `for` loop to iterate over 
 `invalid_records` is a list of keys that refer to invalid records in the current `dictionary`.
 You will need to take the key from `invalid_records` and look up the value in `dictionary`.
 
-`position` or `index` refers to the current dictionary in `medical_records`, defined by the first `for` loop in the function.
+Position or `index` refers to the current dictionary in `medical_records`, defined by the outer `for` loop in the function.
 
 Review your code so far if you need to remind yourself of the loops and variables already created.
 

--- a/curriculum/challenges/english/blocks/workshop-medical-data-validator/68529fb26c581f13e901de3a.md
+++ b/curriculum/challenges/english/blocks/workshop-medical-data-validator/68529fb26c581f13e901de3a.md
@@ -7,7 +7,22 @@ dashedName: step-44
 
 # --description--
 
-Right after the `invalid_records` variable, create a `for` loop to iterate over it. For each invalid record, print `Unexpected format '<key>: <val>' at position <index>.` (where `<key>`, `<val>`, and `<index>` should be replaced by the current key, value and index). Then, set `is_invalid` to `True`.
+Right after the `invalid_records` variable, create a `for` loop to iterate over it.
+
+`invalid_records` is a list of keys that refer to invalid records in the current `dictionary`.
+You will need to take the key from `invalid_records` and look up the value in `dictionary`.
+
+`position` or `index` refers to the current dictionary in `medical_records`, defined by the first `for` loop in the function.
+
+Review your code so far if you need to remind yourself of the loops and variables already created.
+
+For each invalid record, print:
+
+Unexpected format '<key>: <val>' at position <index>.
+
+Replace `<key>`, `<val>`, and `<index>` with the current key, value, and index.
+
+Then, set `is_invalid` to `True`.
 
 Feel free to test the `validate` function with invalid data to see the validation messages. 
 


### PR DESCRIPTION
Checklist:
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #65476

This PR clarifies the instructions for Step 44 of the Medical Data Validator workshop.

It explains what `invalid_records` contains, where the `index` value comes from, and how to format the expected output. This helps reduce confusion and repeated forum questions while keeping the step logic unchanged.
