### PR TITLE
fix(curriculum): clarify Step 12 paragraph instructions

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-quincys-job-tips/68eab6a2b37d2f13602d0c3f.md
+++ b/curriculum/challenges/english/blocks/workshop-quincys-job-tips/68eab6a2b37d2f13602d0c3f.md
@@ -20,10 +20,10 @@ Here's an example with two paragraphs:
 
 In the second section, inside the existing block quotation element, add four `p` elements with the following texts, in order:
 
-1. `So much of getting a job is who you know.`
-2. `It's OK to be an introvert, but you do need to push your boundaries.`
-3. `Create GitHub, Twitter, LinkedIn, and Discord accounts.`
-4. `Go to tech meetups and conferences. Travel if you have to.`
+- `So much of getting a job is who you know.`
+- `It's OK to be an introvert, but you do need to push your boundaries.`
+- `Create GitHub, Twitter, LinkedIn, and Discord accounts.`
+- `Go to tech meetups and conferences. Travel if you have to.`
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

This PR clarifies the Step 12 instructions in the "Build Quincy's Job Tips Page" workshop.

The numbered list was causing confusion about whether the numbers were part of the required paragraph text. The instructions have been updated to make it explicit, improving clarity and accessibility for learners and screen reader users

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.


Closes #65429


