### PR TITLE
Fix step 103

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -715,7 +715,7 @@
     },
     "archive": {
       "title": "Archived Coursework",
-      "content-not-updated": "<0>Warning:</0> The content in this section is not being updated, but is still available for you to further your learning. We recommend trying <1>our current curriculum</1>."
+      "content-not-updated": "The content in this section is not being updated, but is still available for you to further your learning. We recommend trying <0>our current curriculum</0>."
     }
   },
   "donate": {

--- a/curriculum/challenges/english/blocks/workshop-flappy-penguin/619d36103839c82efa95dd34.md
+++ b/curriculum/challenges/english/blocks/workshop-flappy-penguin/619d36103839c82efa95dd34.md
@@ -29,6 +29,12 @@ You should give `.penguin` a `transition-delay` of `--fcc-expected--`, but found
 assert.equal(new __helpers.CSSHelp(document).getStyle('.penguin')?.transitionDelay, '0ms');
 ```
 
+You should give `.penguin` a `transition-property` of `--fcc-expected--`, but found `--fcc-actual--`.
+
+```js
+assert.include(new __helpers.CSSHelp(document).getStyle('.penguin')?.getPropVal('transition', true),
+'transform');
+
 # --seed--
 
 ## --seed-contents--


### PR DESCRIPTION
### Description
Fixes incorrect validation in Flappy Penguin Step 103 where an invalid
`transition-property` value (`active`) was accepted.

### Affected challenge
- Responsive Web Design → Flappy Penguin → Step 103

### Checklist
- [x] Tested locally
- [x] Follows freeCodeCamp curriculum style
- [x] No breaking changes
