### PR TITLE
fix(Flappy Penguin Step 103):correct transition-property validation.

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-flappy-penguin/619d36103839c82efa95dd34.md
+++ b/curriculum/challenges/english/blocks/workshop-flappy-penguin/619d36103839c82efa95dd34.md
@@ -28,6 +28,11 @@ You should give `.penguin` a `transition-delay` of `--fcc-expected--`, but found
 ```js
 assert.equal(new __helpers.CSSHelp(document).getStyle('.penguin')?.transitionDelay, '0ms');
 ```
+You should give `.penguin` a `transition-property` of `--fcc-expected--`, but found `--fcc-actual--`.
+
+```js
+assert.include(new __helpers.CSSHelp(document).getStyle('.penguin')?.getPropVal('transition', true),'transform');
+
 
 # --seed--
 


### PR DESCRIPTION
Thank you for the contribution!

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #65492 

<!-- Feel free to add any additional description of changes below this line -->
Description:
Fixes incorrect validation in Flappy Penguin Step 103 where an invalid
`transition-property` value (`active`) was accepted.  

