### PR TITLE
fix(curriclum): remove cite attribute from p tag quincys job tips worshop

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-quincys-job-tips/68eab45aceb7c00fd8de4fed.md
+++ b/curriculum/challenges/english/blocks/workshop-quincys-job-tips/68eab45aceb7c00fd8de4fed.md
@@ -77,7 +77,7 @@ assert.equal(blockquoteEl?.getAttribute('cite'), 'https://www.freecodecamp.org/n
         <blockquote cite="https://www.freecodecamp.org/news/learn-to-code-book/">
           Can you imagine what it would be like to be a successful developer? To have built software systems that people rely upon?
         </blockquote>
-        <p cite="https://www.freecodecamp.org/news/learn-to-code-book/">
+        <p>
           —Quincy Larson, <cite>How to Learn to Code and Get a Developer Job [Full Book]</cite>
         </p>
       </section>

--- a/curriculum/challenges/english/blocks/workshop-quincys-job-tips/68eab6a2b37d2f13602d0c3f.md
+++ b/curriculum/challenges/english/blocks/workshop-quincys-job-tips/68eab6a2b37d2f13602d0c3f.md
@@ -87,7 +87,7 @@ assert.equal(forthPEl?.innerText.trim(), 'Go to tech meetups and conferences. Tr
         <blockquote cite="https://www.freecodecamp.org/news/learn-to-code-book/">
           Can you imagine what it would be like to be a successful developer? To have built software systems that people rely upon?
         </blockquote>
-        <p cite="https://www.freecodecamp.org/news/learn-to-code-book/">
+        <p>
           —Quincy Larson, <cite>How to Learn to Code and Get a Developer Job [Full Book]</cite>
         </p>
       </section>

--- a/curriculum/challenges/english/blocks/workshop-quincys-job-tips/68ebe9cd7523d340c0b343d3.md
+++ b/curriculum/challenges/english/blocks/workshop-quincys-job-tips/68ebe9cd7523d340c0b343d3.md
@@ -115,7 +115,7 @@ assert.equal(thirdPEl?.innerText.trim(), 'Hang out at hackerspaces and help peop
         <blockquote cite="https://www.freecodecamp.org/news/learn-to-code-book/">
           Can you imagine what it would be like to be a successful developer? To have built software systems that people rely upon?
         </blockquote>
-        <p cite="https://www.freecodecamp.org/news/learn-to-code-book/">
+        <p>
           —Quincy Larson, <cite>How to Learn to Code and Get a Developer Job [Full Book]</cite>
         </p>
       </section>
@@ -161,7 +161,7 @@ assert.equal(thirdPEl?.innerText.trim(), 'Hang out at hackerspaces and help peop
         <blockquote cite="https://www.freecodecamp.org/news/learn-to-code-book/">
           Can you imagine what it would be like to be a successful developer? To have built software systems that people rely upon?
         </blockquote>
-        <p cite="https://www.freecodecamp.org/news/learn-to-code-book/">
+        <p>
           —Quincy Larson, <cite>How to Learn to Code and Get a Developer Job [Full Book]</cite>
         </p>
       </section>


### PR DESCRIPTION

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #65347

<!-- Feel free to add any additional description of changes below this line -->

This PR is to fix the unnecessary cite attribute in p element of Quincys job tips workshop.
