### PR TITLE
feat(client): nudge to complete the profile

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -284,6 +284,7 @@
     "private-name": "Your name will not appear on your certifications, if this is set to private.",
     "claim-legacy": "Once you've earned the following freeCodeCamp certifications, you'll be able to claim the {{cert}}:",
     "for": "Settings for {{username}}",
+    "profile-note": "You can go to <0>your profile</0> to update your personal information.",
     "sound-mode": "This adds the pleasant sound of acoustic guitar throughout the website. You'll get musical feedback as you type in the editor, complete challenges, claim certifications, and more.",
     "sound-volume": "Campfire Volume:",
     "scrollbar-width": "Editor Scrollbar Width",

--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -453,6 +453,16 @@
       "present": "Present",
       "date-format-error": "Please enter the date in MM/YYYY format.",
       "date-invalid": "Please enter a valid date."
+    },
+    "completeness": {
+      "heading": "Profile {{percentage}}% complete",
+      "name": "Add your name",
+      "location": "Add your location",
+      "picture": "Upload a profile picture",
+      "about": "Write an about section",
+      "social": "Add a social link",
+      "portfolio": "Add a portfolio project",
+      "experience": "Add your experience"
     }
   },
   "footer": {

--- a/client/src/client-only-routes/show-settings.test.tsx
+++ b/client/src/client-only-routes/show-settings.test.tsx
@@ -8,6 +8,8 @@ import ShowSettings from './show-settings';
 import { createStore } from '../redux/create-store';
 import { initialState } from '../redux';
 
+const testUsername = 'testuser';
+
 vi.mock('../utils/get-words');
 
 const { apiLocation } = envData;
@@ -51,5 +53,32 @@ describe('<ShowSettings />', () => {
     );
     expect(spy).toHaveBeenCalledTimes(1);
     expect(spy).toHaveBeenCalledWith(`${apiLocation}/signin`);
+  });
+
+  it('renders profile note with link to user profile', () => {
+    const store = createStore({
+      app: {
+        ...initialState,
+        user: {
+          sessionUser: {
+            username: testUsername,
+            email: 'test@example.com',
+            completedChallenges: []
+          }
+        },
+        userFetchState: { pending: false, complete: true, errored: false }
+      }
+    });
+
+    const { container } = render(
+      <Provider store={store}>
+        <ShowSettings />
+      </Provider>
+    );
+
+    // Trans component renders the interpolated link - find it by href
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+    const profileLink = container.querySelector(`a[href="/${testUsername}"]`);
+    expect(profileLink).toBeInTheDocument();
   });
 });

--- a/client/src/client-only-routes/show-settings.tsx
+++ b/client/src/client-only-routes/show-settings.tsx
@@ -1,15 +1,15 @@
 import React, { useEffect } from 'react';
 import Helmet from 'react-helmet';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 
-import { Spacer } from '@freecodecamp/ui';
+import { Callout, Spacer } from '@freecodecamp/ui';
 import store from 'store';
 import { scroller, Element as ScrollElement } from 'react-scroll';
 import envData from '../../config/env.json';
 import { createFlashMessage } from '../components/Flash/redux';
-import { Loader } from '../components/helpers';
+import { FullWidthRow, Loader, Link } from '../components/helpers';
 import Certification from '../components/settings/certification';
 import Account from '../components/settings/account';
 import DangerZone from '../components/settings/danger-zone';
@@ -183,6 +183,13 @@ export function ShowSettings(props: ShowSettingsProps): JSX.Element {
               {t('settings.for', { username: username })}
             </h1>
           </ScrollElement>
+          <FullWidthRow>
+            <Callout variant='note' label={t('misc.note')}>
+              <Trans i18nKey='settings.profile-note'>
+                <Link to={`/${username}`} />
+              </Trans>
+            </Callout>
+          </FullWidthRow>
           <Spacer size='m' />
           <ScrollElement name='account'>
             <Account

--- a/client/src/components/profile/components/profile-completeness.css
+++ b/client/src/components/profile/components/profile-completeness.css
@@ -1,0 +1,92 @@
+.profile-completeness {
+  padding: 1em;
+  background: var(--primary-background);
+  border: 1px solid var(--quaternary-background);
+  margin-bottom: 1.5em;
+}
+
+.profile-completeness-header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  width: 100%;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  color: var(--primary-color);
+  text-align: left;
+}
+
+.profile-completeness-header:hover {
+  background: none;
+  color: var(--primary-color);
+}
+
+.profile-completeness-bar-container {
+  flex: 1;
+  height: 8px;
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.profile-completeness-bar-fill {
+  height: 100%;
+  background-color: var(--blue-mid);
+  border-radius: 4px;
+  transition: width 0.3s ease;
+}
+
+.profile-completeness-text {
+  white-space: nowrap;
+  font-size: 0.875rem;
+}
+
+.profile-completeness-chevron {
+  display: inline-flex;
+  align-items: center;
+  transition: transform 0.2s ease;
+}
+
+.profile-completeness-chevron svg {
+  width: 15px;
+  height: 15px;
+}
+
+.profile-completeness-chevron.expanded {
+  transform: rotate(180deg);
+}
+
+.profile-completeness-checklist {
+  list-style: none;
+  margin: 1rem 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.profile-completeness-checklist li {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 1rem;
+}
+
+.completeness-checkbox {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 15px;
+  height: 15px;
+  flex-shrink: 0;
+}
+
+.completeness-item-complete {
+  color: var(--primary-color);
+  opacity: 0.7;
+}
+
+.completeness-item-incomplete {
+  color: var(--primary-color);
+}

--- a/client/src/components/profile/components/profile-completeness.test.tsx
+++ b/client/src/components/profile/components/profile-completeness.test.tsx
@@ -1,0 +1,220 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import {
+  ProfileCompleteness,
+  isValidPicture,
+  hasValue
+} from './profile-completeness';
+
+const baseProps = {
+  name: '',
+  about: '',
+  picture: '',
+  location: '',
+  githubProfile: '',
+  linkedin: '',
+  twitter: '',
+  bluesky: '',
+  website: '',
+  portfolio: [],
+  experience: []
+};
+
+describe('hasValue', () => {
+  it('should return false for empty string', () => {
+    expect(hasValue('')).toBe(false);
+  });
+
+  it('should return false for whitespace only', () => {
+    expect(hasValue('   ')).toBe(false);
+  });
+
+  it('should return true for non-empty string', () => {
+    expect(hasValue('John Doe')).toBe(true);
+  });
+
+  it('should return true for string with leading/trailing whitespace', () => {
+    expect(hasValue('  John Doe  ')).toBe(true);
+  });
+});
+
+describe('isValidPicture', () => {
+  it('should return false for empty string', () => {
+    expect(isValidPicture('')).toBe(false);
+  });
+
+  it('should return false for whitespace only', () => {
+    expect(isValidPicture('   ')).toBe(false);
+  });
+
+  it('should return false for freecodecamp sample image', () => {
+    expect(
+      isValidPicture('https://freecodecamp.com/sample-image/avatar.png')
+    ).toBe(false);
+  });
+
+  it('should return false for example.com placeholder', () => {
+    expect(isValidPicture('https://example.com/avatar.png')).toBe(false);
+  });
+
+  it('should return false for identicon.org placeholder', () => {
+    expect(isValidPicture('https://identicon.org/avatar.png')).toBe(false);
+  });
+
+  it('should return false for URL without protocol', () => {
+    expect(isValidPicture('cdn.example.org/avatar.png')).toBe(false);
+  });
+
+  it('should return true for valid URL with https', () => {
+    expect(isValidPicture('https://cdn.mysite.com/avatar.png')).toBe(true);
+  });
+
+  it('should return true for valid URL with http', () => {
+    expect(isValidPicture('http://cdn.mysite.com/avatar.png')).toBe(true);
+  });
+});
+
+describe('<ProfileCompleteness />', () => {
+  it('should render when profile is incomplete', () => {
+    render(<ProfileCompleteness {...baseProps} />);
+    expect(screen.getByRole('button')).toBeInTheDocument();
+  });
+
+  it('should not render when profile is 100% complete', () => {
+    const completeProps = {
+      ...baseProps,
+      name: 'John Doe',
+      about: 'I am a developer',
+      picture: 'https://cdn.mysite.com/avatar.png',
+      location: 'New York',
+      githubProfile: 'https://github.com/johndoe',
+      portfolio: [
+        {
+          id: '1',
+          title: 'Project',
+          url: 'https://example.org',
+          image: '',
+          description: 'A project'
+        }
+      ],
+      experience: [
+        {
+          id: '1',
+          title: 'Developer',
+          company: 'Company',
+          location: 'NYC',
+          startDate: '01/2020',
+          endDate: '',
+          description: 'Worked on stuff',
+          current: true
+        }
+      ]
+    };
+    render(<ProfileCompleteness {...completeProps} />);
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('should display all checklist items when expanded', () => {
+    render(<ProfileCompleteness {...baseProps} />);
+
+    // Should show all 7 items
+    const listItems = screen.getAllByRole('listitem');
+    expect(listItems).toHaveLength(7);
+  });
+
+  it('should start expanded when core items (name, picture, about) are incomplete', () => {
+    render(<ProfileCompleteness {...baseProps} />);
+
+    const button = screen.getByRole('button');
+    expect(button).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('should start collapsed when core items (name, picture, about) are complete', () => {
+    const propsWithCoreComplete = {
+      ...baseProps,
+      name: 'John Doe',
+      about: 'I am a developer',
+      picture: 'https://cdn.mysite.com/avatar.png'
+    };
+    render(<ProfileCompleteness {...propsWithCoreComplete} />);
+
+    const button = screen.getByRole('button');
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('should toggle expanded state when clicked', async () => {
+    const user = userEvent.setup();
+    render(<ProfileCompleteness {...baseProps} />);
+
+    const button = screen.getByRole('button');
+    expect(button).toHaveAttribute('aria-expanded', 'true');
+
+    await user.click(button);
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+
+    await user.click(button);
+    expect(button).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('should calculate weighted percentage correctly', () => {
+    // Name (20) + About (20) = 40% complete
+    const propsWithNameAndAbout = {
+      ...baseProps,
+      name: 'John Doe',
+      about: 'I am a developer'
+    };
+    render(<ProfileCompleteness {...propsWithNameAndAbout} />);
+
+    // Check the progress bar width reflects 40%
+    const progressBar = screen.getByTestId('profile-completeness-progress');
+    expect(progressBar).toHaveStyle({ width: '40%' });
+  });
+
+  it('should mark social as complete if any social link is provided', () => {
+    const propsWithGithub = {
+      ...baseProps,
+      githubProfile: 'https://github.com/johndoe'
+    };
+    render(<ProfileCompleteness {...propsWithGithub} />);
+
+    // Social (10%) should be complete - check progress bar
+    const progressBar = screen.getByTestId('profile-completeness-progress');
+    expect(progressBar).toHaveStyle({ width: '10%' });
+  });
+
+  it('should mark social as complete with linkedin only', () => {
+    const propsWithLinkedin = {
+      ...baseProps,
+      linkedin: 'https://linkedin.com/in/johndoe'
+    };
+    render(<ProfileCompleteness {...propsWithLinkedin} />);
+
+    const progressBar = screen.getByTestId('profile-completeness-progress');
+    expect(progressBar).toHaveStyle({ width: '10%' });
+  });
+
+  it('should mark social as complete with website only', () => {
+    const propsWithWebsite = {
+      ...baseProps,
+      website: 'https://johndoe.com'
+    };
+    render(<ProfileCompleteness {...propsWithWebsite} />);
+
+    const progressBar = screen.getByTestId('profile-completeness-progress');
+    expect(progressBar).toHaveStyle({ width: '10%' });
+  });
+
+  it('should show correct icons for complete and incomplete items', () => {
+    const propsWithName = {
+      ...baseProps,
+      name: 'John Doe'
+    };
+    render(<ProfileCompleteness {...propsWithName} />);
+
+    // Should have 1 green-pass (name complete) and 6 green-not-completed
+    expect(screen.getAllByTestId('green-pass')).toHaveLength(1);
+    expect(screen.getAllByTestId('green-not-completed')).toHaveLength(6);
+  });
+});

--- a/client/src/components/profile/components/profile-completeness.tsx
+++ b/client/src/components/profile/components/profile-completeness.tsx
@@ -1,0 +1,187 @@
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Spacer } from '@freecodecamp/ui';
+import isURL from 'validator/lib/isURL';
+import type {
+  PortfolioProjectData,
+  ExperienceData
+} from '../../../redux/prop-types';
+import { FullWidthRow } from '../../helpers';
+import GreenPass from '../../../assets/icons/green-pass';
+import GreenNotCompleted from '../../../assets/icons/green-not-completed';
+import DropDown from '../../../assets/icons/dropdown';
+import './profile-completeness.css';
+
+interface ProfileCompletenessProps {
+  name: string;
+  about: string;
+  picture: string;
+  location: string;
+  githubProfile: string;
+  linkedin: string;
+  twitter: string;
+  bluesky: string;
+  website: string;
+  portfolio: PortfolioProjectData[];
+  experience: ExperienceData[];
+}
+
+interface CompletionItem {
+  key: string;
+  translationKey: string;
+  isComplete: boolean;
+  weight: number;
+}
+
+export const isValidPicture = (picture: string): boolean => {
+  if (!picture || picture.trim() === '') return false;
+  // Check for known placeholder patterns (same logic as avatar-renderer)
+  if (/freecodecamp\.com\/sample-image/.test(picture)) return false;
+  if (/example\.com|identicon\.org/.test(picture)) return false;
+  // Must be a valid URL
+  return isURL(picture, { require_protocol: true });
+};
+
+export const hasValue = (value: string): boolean =>
+  Boolean(value && value.trim());
+
+export const ProfileCompleteness = ({
+  name,
+  about,
+  picture,
+  location,
+  githubProfile,
+  linkedin,
+  twitter,
+  bluesky,
+  website,
+  portfolio,
+  experience
+}: ProfileCompletenessProps): JSX.Element | null => {
+  const { t } = useTranslation();
+
+  // Collapse by default if core profile items (name, picture, about) are complete
+  const coreItemsComplete =
+    hasValue(name) && isValidPicture(picture) && hasValue(about);
+  const [isExpanded, setIsExpanded] = useState(!coreItemsComplete);
+
+  const completionItems: CompletionItem[] = [
+    {
+      key: 'name',
+      translationKey: 'profile.completeness.name',
+      isComplete: hasValue(name),
+      weight: 20
+    },
+    {
+      key: 'location',
+      translationKey: 'profile.completeness.location',
+      isComplete: hasValue(location),
+      weight: 5
+    },
+    {
+      key: 'picture',
+      translationKey: 'profile.completeness.picture',
+      isComplete: isValidPicture(picture),
+      weight: 20
+    },
+    {
+      key: 'about',
+      translationKey: 'profile.completeness.about',
+      isComplete: hasValue(about),
+      weight: 20
+    },
+    {
+      key: 'social',
+      translationKey: 'profile.completeness.social',
+      isComplete:
+        hasValue(githubProfile) ||
+        hasValue(linkedin) ||
+        hasValue(twitter) ||
+        hasValue(bluesky) ||
+        hasValue(website),
+      weight: 10
+    },
+    {
+      key: 'portfolio',
+      translationKey: 'profile.completeness.portfolio',
+      isComplete: portfolio.length > 0,
+      weight: 15
+    },
+    {
+      key: 'experience',
+      translationKey: 'profile.completeness.experience',
+      isComplete: experience.length > 0,
+      weight: 10
+    }
+  ];
+
+  const totalWeight = completionItems.reduce(
+    (sum, item) => sum + item.weight,
+    0
+  );
+  const completedWeight = completionItems
+    .filter(item => item.isComplete)
+    .reduce((sum, item) => sum + item.weight, 0);
+  const percentage = Math.round((completedWeight / totalWeight) * 100);
+
+  // Don't render if profile is complete
+  if (percentage === 100) {
+    return null;
+  }
+
+  const toggleExpanded = () => setIsExpanded(!isExpanded);
+
+  return (
+    <FullWidthRow>
+      <div className='profile-completeness'>
+        <button
+          className='profile-completeness-header'
+          onClick={toggleExpanded}
+          aria-expanded={isExpanded}
+          type='button'
+        >
+          <span
+            className={`profile-completeness-chevron ${isExpanded ? 'expanded' : ''}`}
+            aria-hidden='true'
+          >
+            <DropDown />
+          </span>
+          <div className='profile-completeness-bar-container'>
+            <div
+              className='profile-completeness-bar-fill'
+              data-testid='profile-completeness-progress'
+              style={{ width: `${percentage}%` }}
+            />
+          </div>
+          <span className='profile-completeness-text'>
+            {t('profile.completeness.heading', { percentage })}
+          </span>
+        </button>
+        {isExpanded && (
+          <ul className='profile-completeness-checklist'>
+            {completionItems.map(item => (
+              <li
+                key={item.key}
+                className={
+                  item.isComplete
+                    ? 'completeness-item-complete'
+                    : 'completeness-item-incomplete'
+                }
+              >
+                <span className='completeness-checkbox' aria-hidden='true'>
+                  {item.isComplete ? (
+                    <GreenPass hushScreenReaderText />
+                  ) : (
+                    <GreenNotCompleted hushScreenReaderText />
+                  )}
+                </span>
+                {t(item.translationKey)}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+      <Spacer size='m' />
+    </FullWidthRow>
+  );
+};

--- a/client/src/components/profile/profile.tsx
+++ b/client/src/components/profile/profile.tsx
@@ -19,6 +19,7 @@ import HeatMap from './components/heat-map';
 import './profile.css';
 import { PortfolioProjects } from './components/portfolio-projects';
 import { ExperienceDisplay } from './components/experience-display';
+import { ProfileCompleteness } from './components/profile-completeness';
 
 interface ProfileProps {
   isSessionUser: boolean;
@@ -102,12 +103,15 @@ function UserProfile({ user, isSessionUser }: ProfileProps): JSX.Element {
       showExperience,
       showTimeLine
     },
+    about,
     calendar,
     completedChallenges,
-    username,
+    name,
+    picture,
     points,
     portfolio,
-    experience
+    experience,
+    username
   } = user;
 
   return (
@@ -118,6 +122,21 @@ function UserProfile({ user, isSessionUser }: ProfileProps): JSX.Element {
           isEditing={isEditing}
           isSessionUser={isSessionUser}
           setIsEditing={setIsEditing}
+        />
+      )}
+      {isSessionUser && (
+        <ProfileCompleteness
+          name={name}
+          about={about}
+          picture={picture}
+          location={user.location}
+          githubProfile={user.githubProfile}
+          linkedin={user.linkedin}
+          twitter={user.twitter}
+          bluesky={user.bluesky}
+          website={user.website}
+          portfolio={portfolio}
+          experience={experience || []}
         />
       )}
       <Camper


### PR DESCRIPTION
This should nudge more people to fill up their details.

<details>
<summary>Various Stages</summary>

<img width="862" height="500" alt="image" src="https://github.com/user-attachments/assets/e72ad52d-175b-4cb8-a2c5-56147cd46562" />

<img width="871" height="739" alt="image" src="https://github.com/user-attachments/assets/2f20f9a2-887f-4112-9374-60cac4412f8c" />

<img width="988" height="466" alt="image" src="https://github.com/user-attachments/assets/13fbfb7c-37f4-4b43-a11c-b1e11a20e05d" />

</details>

It will fully vanish when the profile is 100%

Also added this in the settings:

<details>
<summary>Details</summary>

<img width="998" height="433" alt="image" src="https://github.com/user-attachments/assets/f2a32c7c-b97f-4d72-8024-77c25e786e98" />

</details>

Closes https://github.com/freeCodeCamp/freeCodeCamp/issues/65544