### PR TITLE
fix(curriculum): make step 3 state tests order-agnostic

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-superhero-application-form/680fc849a6f2be0a8597c593.md
+++ b/curriculum/challenges/english/blocks/workshop-superhero-application-form/680fc849a6f2be0a8597c593.md
@@ -38,7 +38,8 @@ Your `useState` hook for `powerSource` should have an initial value of empty str
   const _a = eval(script);
   const _b = await __helpers.prepTestComponent(exports.SuperheroForm);
 
-  assert.strictEqual(abuseState.calls[2]?.[0], "");
+  const newStateCalls = abuseState.calls.slice(2);
+  assert.isTrue(newStateCalls.some(call => call[0] === ""));
 ```
 
 You should use array destructuring to set a `powers` state variable and a `setPowers` setter.
@@ -68,9 +69,8 @@ Your `useState` hook for `powers` should have an initial value of empty array.
   const _a = eval(script);
   const _b = await __helpers.prepTestComponent(exports.SuperheroForm);
 
-  console.log("State calls:", abuseState.calls)
-
-  assert.deepEqual(abuseState.calls[3]?.[0], []);
+  const newStateCalls = abuseState.calls.slice(2);
+  assert.isTrue(newStateCalls.some(call => Array.isArray(call[0]) && call[0].length === 0));
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #65301

## Description
The issue describes that step 3 of the Superhero Application Form workshop fails when powers and powerSource useState hooks are declared in a different order than expected.

The original tests used hardcoded array indexes to check useState calls:
```ts
assert.strictEqual(abuseState.calls[2]?.[0], "");  // Expected powerSource at index 2
assert.deepEqual(abuseState.calls[3]?.[0], []);    // Expected powers at index 3
```

The fix I'm proposing is to search through the new useState calls (after heroName and realName) for matching values, rather than checking specific indexes:
```ts
const newStateCalls = abuseState.calls.slice(2);
assert.isTrue(newStateCalls.some(call => call[0] === ""));
// and
const newStateCalls = abuseState.calls.slice(2);
assert.isTrue(newStateCalls.some(call => Array.isArray(call[0]) && call[0].length === 0));
``` 
