### PR TITLE
Update 619d36103839c82efa95dd34.md

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-flappy-penguin/619d36103839c82efa95dd34.md
+++ b/curriculum/challenges/english/blocks/workshop-flappy-penguin/619d36103839c82efa95dd34.md
@@ -29,6 +29,14 @@ You should give `.penguin` a `transition-delay` of `--fcc-expected--`, but found
 assert.equal(new __helpers.CSSHelp(document).getStyle('.penguin')?.transitionDelay, '0ms');
 ```
 
+'You should give `.penguin` a `transition-property` of `transform`
+
+```js
+assert.equal(
+  new __helpers.CSSHelp(document).getStyle('.penguin')?.transitionProperty,
+  'transform',
+ ```
+
 # --seed--
 
 ## --seed-contents--


### PR DESCRIPTION
Checklist:

 I have read and followed the contribution guidelines.
 I have read and followed the how to open a pull request guide.
 My pull request targets the main branch of freeCodeCamp.
 I have tested these changes either locally on my machine, or GitHub Codespaces.
Closes ##65492
### What was wrong
Step 103 of the "Build a Flappy Penguin" workshop accepted invalid CSS like: `.penguin { transition: active 1s ease-in-out 0ms; }`

This happened because the test only checked transition-duration, -timing-function, and -delay, but did not check the actual property being transitioned.

### What this fixes
This adds a check for the computed `transitionProperty` of the `.penguin` element and ensures it must be `"transform"`.

Now only a correct answer like:

.penguin { transition: transform 1s ease-in-out 0ms; }

will pass.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ ] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
