### PR TITLE
fix(curriculum): correct stack typo

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-common-data-structures/6895d06b5968736797c408e5.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-common-data-structures/6895d06b5968736797c408e5.md
@@ -43,7 +43,7 @@ The time complexity of the push and pop operations is typically `O(1)`, a consta
 
 When you push an element onto the stack, the element is simply added to the top.
 
-When you pop an element form the stack, the element at the top is removed.
+When you pop an element from the stack, the element at the top is removed.
 
 Therefore, the time it takes to perform these operations remains constant regardless of the size of the stack.
 


### PR DESCRIPTION
 Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the main branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #65522

This pull request fixes a small typo in the "How do stacks and queues work?"
lesson in the Python curriculum by correcting "form the stack" to
"from the stack", improving clarity for learners.

