### PR TITLE
refactor: stop curriculum tests depending on client

### DIFF
--- a/client/config/cert-and-project-map.test.ts
+++ b/client/config/cert-and-project-map.test.ts
@@ -1,0 +1,75 @@
+import path from 'node:path';
+import fs from 'node:fs';
+import { describe, test, expect } from 'vitest';
+
+import { getContentDir } from '@freecodecamp/curriculum/file-handler';
+import { buildCertification } from '@freecodecamp/curriculum/build-certification';
+
+import { allCerts } from './cert-and-project-map';
+
+describe('certifications', () => {
+  const certificationsDir = path.resolve(
+    getContentDir('english'),
+    'certifications'
+  );
+
+  const certificationFiles = fs.readdirSync(certificationsDir);
+
+  certificationFiles.forEach(filename => {
+    test(`${filename} should have matching items in cert-and-project-map`, () => {
+      const filePath = path.join(certificationsDir, filename);
+      const result = buildCertification(filePath);
+
+      const certData = result.challenges[0];
+      const certTests = certData.tests;
+
+      const matchingCert = allCerts.find(cert => cert.id === certData.id);
+
+      expect(
+        matchingCert,
+        `Cert ID ${certData.id} not found in allCerts.`
+      ).toBeDefined();
+      expect(
+        matchingCert,
+        `Matching cert has no 'projects' property`
+      ).toHaveProperty('projects');
+
+      // skip legacy-full-stack as it has no projects
+      if (filename !== 'legacy-full-stack.yml') {
+        expect(
+          Array.isArray(matchingCert?.projects),
+          `Matching cert 'projects' is not an array`
+        ).toBe(true);
+
+        const certProjects = matchingCert?.projects;
+
+        expect(
+          certProjects?.length,
+          `Project count mismatch: allCerts has ${certProjects?.length} projects, YAML has ${certTests.length} tests`
+        ).toBe(certTests.length);
+
+        certTests.forEach((test, i) => {
+          expect(
+            test,
+            `Test at index ${i} in missing id property`
+          ).toHaveProperty('id');
+          expect(
+            test,
+            `Test at index ${i} missing title property`
+          ).toHaveProperty('title');
+
+          const matchingProject = certProjects?.[i];
+
+          expect(
+            matchingProject,
+            `No project found at index ${i} for test ${test.id}`
+          ).toBeDefined();
+          expect(
+            matchingProject?.id,
+            `Project ID mismatch at index ${i}: allCerts has "${matchingProject?.id}", YAML has "${test.id}"`
+          ).toBe(test.id);
+        });
+      }
+    });
+  });
+});

--- a/client/tools/external-curriculum/build-external-curricula-data-v2.ts
+++ b/client/tools/external-curriculum/build-external-curricula-data-v2.ts
@@ -8,7 +8,7 @@ import {
   chapterBasedSuperBlocks
 } from '@freecodecamp/shared/config/curriculum';
 import type { Chapter } from '@freecodecamp/shared/config/chapters';
-import { getSuperblockStructure } from '../../../curriculum/src/file-handler';
+import { getSuperblockStructure } from '@freecodecamp/curriculum/file-handler';
 import { patchBlock } from './patches';
 import {
   availableBackgrounds,

--- a/client/utils/build-challenges.js
+++ b/client/utils/build-challenges.js
@@ -4,22 +4,22 @@ const _ = require('lodash');
 
 const {
   getChallengesForLang
-} = require('../../curriculum/dist/get-challenges.js');
+} = require('@freecodecamp/curriculum/get-challenges');
 
 const {
   getBlockCreator,
   getSuperblocks,
   superBlockToFilename
-} = require('../../curriculum/dist/build-curriculum.js');
+} = require('@freecodecamp/curriculum/build-curriculum');
 const {
   getContentDir,
   getBlockStructure,
   getSuperblockStructure
-} = require('../../curriculum/dist/file-handler.js');
+} = require('@freecodecamp/curriculum/file-handler');
 const {
   transformSuperBlock
-} = require('../../curriculum/dist/build-superblock.js');
-const { getSuperOrder } = require('../../curriculum/dist/super-order.js');
+} = require('@freecodecamp/curriculum/build-superblock');
+const { getSuperOrder } = require('@freecodecamp/curriculum/super-order');
 
 const curriculumLocale = process.env.CURRICULUM_LOCALE || 'english';
 

--- a/curriculum/package.json
+++ b/curriculum/package.json
@@ -8,6 +8,10 @@
     "node": ">=24",
     "pnpm": ">=10"
   },
+  "exports": {
+    "./file-handler": "./dist/file-handler.js",
+    "./build-certification": "./dist/build-certification.js"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/freeCodeCamp/freeCodeCamp.git"

--- a/curriculum/package.json
+++ b/curriculum/package.json
@@ -9,8 +9,12 @@
     "pnpm": ">=10"
   },
   "exports": {
+    "./build-certification": "./dist/build-certification.js",
+    "./build-curriculum": "./dist/build-curriculum.js",
+    "./build-superblock": "./dist/build-superblock.js",
     "./file-handler": "./dist/file-handler.js",
-    "./build-certification": "./dist/build-certification.js"
+    "./get-challenges": "./dist/get-challenges.js",
+    "./super-order": "./dist/super-order.js"
   },
   "repository": {
     "type": "git",

--- a/curriculum/src/build-certification.test.js
+++ b/curriculum/src/build-certification.test.js
@@ -1,25 +1,19 @@
 import fs from 'fs';
 import path from 'path';
-import { fileURLToPath } from 'url';
 import { describe, test, expect } from 'vitest';
 
-import { allCerts } from '../../client/config/cert-and-project-map.js';
 import { buildCertification } from './build-certification.js';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+import { getContentDir } from './file-handler.js';
 
 describe('build-certification', () => {
-  const certificationsDir = path.join(
-    __dirname,
-    '..',
-    'challenges/english/certifications'
+  const certificationsDir = path.resolve(
+    getContentDir('english'),
+    'certifications'
   );
-  const yamlFiles = fs
-    .readdirSync(certificationsDir)
-    .filter(file => file.endsWith('.yml'));
 
-  yamlFiles.forEach(file => {
+  const certificationFiles = fs.readdirSync(certificationsDir);
+
+  certificationFiles.forEach(file => {
     describe(`${file} file`, () => {
       const filePath = path.join(certificationsDir, file);
       const result = buildCertification(filePath);
@@ -36,59 +30,6 @@ describe('build-certification', () => {
         expect(certData).toHaveProperty('challengeType');
         expect(certData).toHaveProperty('tests');
         expect(Array.isArray(certData.tests)).toBe(true);
-      });
-
-      test('Should have matching items in cert-and-project-map', () => {
-        const certData = result.challenges[0];
-        const certTests = certData.tests;
-
-        const matchingCert = allCerts.find(cert => cert.id === certData.id);
-
-        expect(
-          matchingCert,
-          `Cert ID ${certData.id} not found in allCerts.`
-        ).toBeDefined();
-        expect(
-          matchingCert,
-          `Matching cert has no 'projects' property`
-        ).toHaveProperty('projects');
-
-        // skip legacy-full-stack as it has no projects
-        if (file !== 'legacy-full-stack.yml') {
-          expect(
-            Array.isArray(matchingCert.projects),
-            `Matching cert 'projects' is not an array`
-          ).toBe(true);
-
-          const certProjects = matchingCert.projects;
-
-          expect(
-            certProjects.length,
-            `Project count mismatch: allCerts has ${certProjects.length} projects, YAML has ${certTests.length} tests`
-          ).toBe(certTests.length);
-
-          certTests.forEach((test, i) => {
-            expect(
-              test,
-              `Test at index ${i} in missing id property`
-            ).toHaveProperty('id');
-            expect(
-              test,
-              `Test at index ${i} missing title property`
-            ).toHaveProperty('title');
-
-            const matchingProject = certProjects[i];
-
-            expect(
-              matchingProject,
-              `No project found at index ${i} for test ${test.id}`
-            ).toBeDefined();
-            expect(
-              matchingProject.id,
-              `Project ID mismatch at index ${i}: allCerts has "${matchingProject.id}", YAML has "${test.id}"`
-            ).toBe(test.id);
-          });
-        }
       });
     });
   });

--- a/curriculum/src/build-certification.ts
+++ b/curriculum/src/build-certification.ts
@@ -1,6 +1,18 @@
 import { readFileSync } from 'fs';
 import { load } from 'js-yaml';
 
-export const buildCertification = (filePath: string) => ({
-  challenges: [load(readFileSync(filePath, 'utf8'))]
+interface CertificationChallenge {
+  id: string;
+  title: string;
+  certification: string;
+  challengeType: number;
+  tests: { id: string; title: string }[];
+}
+
+export const buildCertification = (
+  filePath: string
+): {
+  challenges: CertificationChallenge[];
+} => ({
+  challenges: [load(readFileSync(filePath, 'utf8')) as CertificationChallenge]
 });

--- a/curriculum/src/challenge-auditor/index.ts
+++ b/curriculum/src/challenge-auditor/index.ts
@@ -1,11 +1,12 @@
 import { flatten } from 'lodash/fp';
 
 import { availableLangs } from '@freecodecamp/shared/config/i18n';
-import { getChallengesForLang } from '../../../curriculum/src/get-challenges';
 import {
   SuperBlocks,
   getAuditedSuperBlocks
 } from '@freecodecamp/shared/config/curriculum';
+
+import { getChallengesForLang } from '../get-challenges.js';
 
 // TODO: re-organise the types to a common 'types' folder that can be shared
 // between the workspaces so we don't have to declare ChallengeNode here and in

--- a/curriculum/tsconfig.json
+++ b/curriculum/tsconfig.json
@@ -3,6 +3,7 @@
     "rootDir": "./src",
     "outDir": "./dist",
     "declaration": true,
+    "declarationMap": true,
     "target": "es2022",
     "module": "nodenext",
     "strict": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -927,6 +927,9 @@ importers:
 
   tools/challenge-helper-scripts:
     devDependencies:
+      '@freecodecamp/curriculum':
+        specifier: workspace:*
+        version: link:../../curriculum
       '@freecodecamp/eslint-config':
         specifier: workspace:*
         version: link:../../packages/eslint-config
@@ -21118,7 +21121,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vitest: 4.0.15(@opentelemetry/api@1.9.0)(@types/node@24.10.9)(@vitest/ui@4.0.15)(jiti@2.6.1)(jsdom@26.1.0)(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(terser@5.28.1)(tsx@4.21.0)(yaml@2.8.1)
+      vitest: 4.0.15(@opentelemetry/api@1.9.0)(@types/node@24.10.9)(@vitest/ui@4.0.15)(jiti@2.6.1)(jsdom@26.1.0)(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(terser@5.28.1)(tsx@4.19.1)(yaml@2.8.1)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -23720,7 +23723,7 @@ snapshots:
       confusing-browser-globals: 1.0.11
       eslint: 7.32.0
       eslint-plugin-flowtype: 5.10.0(eslint@7.32.0)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@4.33.0(eslint@7.32.0)(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@4.33.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.4(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react-hooks: 4.6.0(eslint@9.39.2(jiti@2.6.1))
@@ -23750,7 +23753,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@4.33.0(eslint@7.32.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@4.33.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -23804,7 +23807,7 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@4.33.0(eslint@7.32.0)(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@4.33.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -23815,7 +23818,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@4.33.0(eslint@7.32.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@4.33.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.2(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -25053,7 +25056,7 @@ snapshots:
       eslint-config-react-app: 6.0.0(@typescript-eslint/eslint-plugin@4.33.0(@typescript-eslint/parser@4.33.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)(typescript@5.9.3))(@typescript-eslint/parser@4.33.0(eslint@7.32.0)(typescript@5.9.3))(babel-eslint@10.1.0(eslint@9.39.2(jiti@2.6.1)))(eslint-plugin-flowtype@5.10.0(eslint@7.32.0))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@4.33.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0))(eslint-plugin-jsx-a11y@6.10.2(eslint@7.32.0))(eslint-plugin-react-hooks@4.6.0(eslint@7.32.0))(eslint-plugin-react@7.37.4(eslint@7.32.0))(eslint@7.32.0)(typescript@5.9.3)
       eslint-plugin-flowtype: 5.10.0(eslint@7.32.0)
       eslint-plugin-graphql: 4.0.0(@types/node@24.10.9)(graphql@15.8.0)(typescript@5.9.3)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@4.33.0(eslint@7.32.0)(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@4.33.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.4(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react-hooks: 4.6.0(eslint@9.39.2(jiti@2.6.1))

--- a/tools/challenge-helper-scripts/create-language-block.ts
+++ b/tools/challenge-helper-scripts/create-language-block.ts
@@ -16,8 +16,8 @@ import {
   writeBlockStructure,
   createBlockFolder,
   getSuperblockStructure
-} from '../../curriculum/src/file-handler.js';
-import { superBlockToFilename } from '../../curriculum/src/build-curriculum.js';
+} from '@freecodecamp/curriculum/file-handler';
+import { superBlockToFilename } from '@freecodecamp/curriculum/build-curriculum';
 import { getBaseMeta } from './helpers/get-base-meta.js';
 import { createIntroMD } from './helpers/create-intro.js';
 import {

--- a/tools/challenge-helper-scripts/create-project.ts
+++ b/tools/challenge-helper-scripts/create-project.ts
@@ -12,8 +12,8 @@ import { BlockLayouts, BlockLabel } from '@freecodecamp/shared/config/blocks';
 import {
   createBlockFolder,
   writeBlockStructure
-} from '../../curriculum/src/file-handler.js';
-import { superBlockToFilename } from '../../curriculum/src/build-curriculum.js';
+} from '@freecodecamp/curriculum/file-handler';
+import { superBlockToFilename } from '@freecodecamp/curriculum/build-curriculum';
 import {
   createQuizFile,
   createStepFile,

--- a/tools/challenge-helper-scripts/create-quiz.ts
+++ b/tools/challenge-helper-scripts/create-quiz.ts
@@ -8,8 +8,8 @@ import { SuperBlocks } from '@freecodecamp/shared/config/curriculum';
 import {
   createBlockFolder,
   writeBlockStructure
-} from '../../curriculum/src/file-handler.js';
-import { superBlockToFilename } from '../../curriculum/src/build-curriculum.js';
+} from '@freecodecamp/curriculum/file-handler';
+import { superBlockToFilename } from '@freecodecamp/curriculum/build-curriculum';
 import { createQuizFile, getAllBlocks, validateBlockName } from './utils.js';
 import { getBaseMeta } from './helpers/get-base-meta.js';
 import { createIntroMD } from './helpers/create-intro.js';

--- a/tools/challenge-helper-scripts/create-this-challenge.ts
+++ b/tools/challenge-helper-scripts/create-this-challenge.ts
@@ -11,7 +11,7 @@ import { ObjectId } from 'bson';
 import {
   getBlockStructure,
   writeBlockStructure
-} from '../../curriculum/src/file-handler.js';
+} from '@freecodecamp/curriculum/file-handler';
 import { createChallengeFile } from './utils.js';
 import { getProjectPath } from './helpers/get-project-info.js';
 import { getBlock, type Meta } from './helpers/project-metadata.js';

--- a/tools/challenge-helper-scripts/helpers/create-project.test.ts
+++ b/tools/challenge-helper-scripts/helpers/create-project.test.ts
@@ -2,13 +2,13 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import {
   getSuperblockStructure,
   writeSuperblockStructure
-} from '../../../curriculum/src/file-handler.js';
+} from '@freecodecamp/curriculum/file-handler';
 import {
   updateChapterModuleSuperblockStructure,
   updateSimpleSuperblockStructure
 } from './create-project.js';
 
-vi.mock('../../../curriculum/src/file-handler');
+vi.mock('@freecodecamp/curriculum/file-handler');
 
 const mockGetSuperblockStructure = vi.mocked(getSuperblockStructure);
 const mockWriteSuperblockStructure = vi.mocked(writeSuperblockStructure);

--- a/tools/challenge-helper-scripts/helpers/create-project.ts
+++ b/tools/challenge-helper-scripts/helpers/create-project.ts
@@ -3,7 +3,7 @@
 import {
   getSuperblockStructure,
   writeSuperblockStructure
-} from '../../../curriculum/src/file-handler.js';
+} from '@freecodecamp/curriculum/file-handler';
 import { insertInto } from './utils.js';
 
 export async function updateSimpleSuperblockStructure(

--- a/tools/challenge-helper-scripts/helpers/project-metadata.test.ts
+++ b/tools/challenge-helper-scripts/helpers/project-metadata.test.ts
@@ -1,9 +1,9 @@
 import { join } from 'path';
 import { describe, it, expect, vi } from 'vitest';
-import { getBlockStructure } from '../../../curriculum/src/file-handler.js';
+import { getBlockStructure } from '@freecodecamp/curriculum/file-handler';
 import { getMetaData } from './project-metadata.js';
 
-vi.mock('../../../curriculum/src/file-handler');
+vi.mock('@freecodecamp/curriculum/file-handler');
 
 const commonPath = join('curriculum', 'challenges', 'blocks');
 const block = 'block-name';

--- a/tools/challenge-helper-scripts/helpers/project-metadata.ts
+++ b/tools/challenge-helper-scripts/helpers/project-metadata.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import {
   getBlockStructure,
   writeBlockStructure
-} from '../../../curriculum/src/file-handler.js';
+} from '@freecodecamp/curriculum/file-handler';
 import type { BlockLabel } from '@freecodecamp/shared/config/blocks';
 import { getProjectPath } from './get-project-info.js';
 

--- a/tools/challenge-helper-scripts/package.json
+++ b/tools/challenge-helper-scripts/package.json
@@ -31,9 +31,10 @@
     "type-check": "tsc --noEmit"
   },
   "devDependencies": {
+    "@freecodecamp/curriculum": "workspace:*",
     "@freecodecamp/eslint-config": "workspace:*",
-    "@total-typescript/ts-reset": "^0.6.1",
     "@freecodecamp/shared": "workspace:*",
+    "@total-typescript/ts-reset": "^0.6.1",
     "@types/glob": "^8.0.1",
     "@types/inquirer": "^8.2.5",
     "@vitest/ui": "^3.2.4",

--- a/tools/challenge-helper-scripts/rename-block.ts
+++ b/tools/challenge-helper-scripts/rename-block.ts
@@ -14,7 +14,7 @@ import {
   writeSuperblockStructure,
   getContentConfig,
   getCurriculumStructure
-} from '../../curriculum/src/file-handler';
+} from '@freecodecamp/curriculum/file-handler';
 import matter from 'gray-matter';
 
 interface RenameBlockArgs {

--- a/tools/challenge-helper-scripts/utils.ts
+++ b/tools/challenge-helper-scripts/utils.ts
@@ -5,7 +5,7 @@ import matter from 'gray-matter';
 import { uniq } from 'lodash';
 
 import { challengeTypes } from '@freecodecamp/shared/config/challenge-types';
-import { parseCurriculumStructure } from '../../curriculum/src/build-curriculum.js';
+import { parseCurriculumStructure } from '@freecodecamp/curriculum/build-curriculum';
 import { parseMDSync } from '../challenge-parser/parser/index.js';
 import { getMetaData, updateMetaData } from './helpers/project-metadata.js';
 import { getProjectPath } from './helpers/get-project-info.js';

--- a/tools/client-plugins/gatsby-source-challenges/gatsby-node.js
+++ b/tools/client-plugins/gatsby-source-challenges/gatsby-node.js
@@ -1,10 +1,10 @@
 const chokidar = require('chokidar');
 const {
   getSuperblockStructure
-} = require('@freecodecamp/curriculum/dist/file-handler');
+} = require('@freecodecamp/curriculum/file-handler');
 const {
   superBlockToFilename
-} = require('@freecodecamp/curriculum/dist/build-curriculum');
+} = require('@freecodecamp/curriculum/build-curriculum');
 
 const { createChallengeNode } = require('./create-challenge-nodes');
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

The deeper issue is that cert-and-project-map is part of the client rather than the curriculum, but one step at at time!

<!-- Feel free to add any additional description of changes below this line -->
