### PR TITLE
fix(curriculum): remove double punctuation in B1 English Task 65383

### DIFF
--- a/curriculum/challenges/english/blocks/learn-how-to-use-modal-verbs/67d5681f7a8dd6346ff23196.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-modal-verbs/67d5681f7a8dd6346ff23196.md
@@ -54,12 +54,12 @@ Remember:
 
 `Must` expresses strong necessity or obligation. For example:
 
-`You must wear a seatbelt.`.
+`You must wear a seatbelt`.
 
 `Have to` also expresses obligation but is sometimes less strict than must. For example:
 
-`You have to submit the report by Friday.`.
+`You have to submit the report by Friday`.
 
 `Should` is used for recommendations or advice. For example:
 
-`You should review your notes before the test.`.
+`You should review your notes before the test`.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #65383 

<!-- Feel free to add any additional description of changes below this line -->
This PR fixes instances of double punctuation at the end of high-lighted sentences in Task 65383 of the B1 English for Developers curriculum.

