### PR TITLE
fix(curriculum): improve tests for useState management of color input

### DIFF
--- a/curriculum/challenges/english/blocks/lab-color-picker/67bf4350777ac6ffdc027745.md
+++ b/curriculum/challenges/english/blocks/lab-color-picker/67bf4350777ac6ffdc027745.md
@@ -126,10 +126,38 @@ assert.strictEqual(mostCertainlyAnInput.value, "#ffffff");
 The initial value of your `#color-input` should be managed by your `useState` hook.
 
 ```js
-const declaredState = code.match(/(?:const|let|var)\s*\[\s*(.*)\s*,.*\]\s*=\s*useState/);
-const declaredStateVar = declaredState?.[1];
-const regex = new RegExp(`value\s*=\s*\{\s*${declaredStateVar}\s*}`);
-assert.match(code, regex);
+const abuseState = __helpers.spyOn(React, "useState");
+const script = [...document.querySelectorAll("script")].find((s) => s.dataset.src === "index.jsx").innerText;
+const exports = {};
+const _a = eval(script);
+
+// Render the component to get the initial state
+const rendered = await __helpers.prepTestComponent(exports.ColorPicker);
+const inputElement = rendered.querySelector('#color-input');
+assert.exists(inputElement, "Could not find #color-input element");
+
+// Get the initial input value (should be #ffffff from previous test)
+const initialValue = inputElement.value;
+
+// Find which useState call manages this input's value
+const stateIndex = abuseState.returns.findIndex(([stateValue]) => stateValue === initialValue);
+assert.isAtLeast(stateIndex, 0, "The #color-input value must be managed by a useState hook");
+
+// Get the setter function for that state
+const [, setterFunction] = abuseState.returns[stateIndex];
+
+// Update the state and verify the input value changes accordingly
+const newColor = '#123456';
+await React.act(async () => {
+  setterFunction(newColor);
+});
+
+// Verify the input's value reflects the state change
+assert.strictEqual(
+  inputElement.value,
+  newColor,
+  "The #color-input value should update when the useState state changes"
+);
 ```
 
 When your `#color-input` value is changed, your `#color-picker-container` should change its background color to reflect that value.

--- a/curriculum/challenges/english/blocks/lab-color-picker/67bf4350777ac6ffdc027745.md
+++ b/curriculum/challenges/english/blocks/lab-color-picker/67bf4350777ac6ffdc027745.md
@@ -131,28 +131,22 @@ const script = [...document.querySelectorAll("script")].find((s) => s.dataset.sr
 const exports = {};
 const _a = eval(script);
 
-// Render the component to get the initial state
 const rendered = await __helpers.prepTestComponent(exports.ColorPicker);
 const inputElement = rendered.querySelector('#color-input');
 assert.exists(inputElement, "Could not find #color-input element");
 
-// Get the initial input value (should be #ffffff from previous test)
 const initialValue = inputElement.value;
 
-// Find which useState call manages this input's value
 const stateIndex = abuseState.returns.findIndex(([stateValue]) => stateValue === initialValue);
 assert.isAtLeast(stateIndex, 0, "The #color-input value must be managed by a useState hook");
 
-// Get the setter function for that state
 const [, setterFunction] = abuseState.returns[stateIndex];
 
-// Update the state and verify the input value changes accordingly
 const newColor = '#123456';
 await React.act(async () => {
   setterFunction(newColor);
 });
 
-// Verify the input's value reflects the state change
 assert.strictEqual(
   inputElement.value,
   newColor,


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #64358  

## Summary
The color picker challenge test was searching code as text for the pattern `value={stateVar}`, which failed when learners used sub-components with different prop names.

Changed the test to actually render the component and verify the input's value updates when state changes. This tests the requirement (state controls input) rather than specific code patterns.

Now accepts **both** inline and sub-component solutions while still catching invalid solutions.
