### PR TITLE
fix: enable filtered tests/development

### DIFF
--- a/client/turbo.json
+++ b/client/turbo.json
@@ -3,9 +3,11 @@
   "extends": ["//"],
   "tasks": {
     "build": {
+      "env": ["FCC_*"],
       "outputs": ["public/**"]
     },
     "setup": {
+      "env": ["FCC_*"],
       "outputs": [
         "config/env.json",
         "i18n/locales/*.json",

--- a/client/turbo.json
+++ b/client/turbo.json
@@ -6,6 +6,9 @@
       "env": ["FCC_*"],
       "outputs": ["public/**"]
     },
+    "develop": {
+      "env": ["FCC_*"]
+    },
     "setup": {
       "env": ["FCC_*"],
       "outputs": [

--- a/curriculum/package.json
+++ b/curriculum/package.json
@@ -50,7 +50,7 @@
     "test:watch": "pnpm test-gen && vitest",
     "test-gen": "tsx ./src/test/utils/generate-block-tests.ts",
     "test-tooling": "pnpm test --project @freecodecamp/curriculum",
-    "test-content": "pnpm test --project test"
+    "test-content": "pnpm test-gen && pnpm test --project test"
   },
   "devDependencies": {
     "@babel/core": "7.23.7",

--- a/curriculum/turbo.json
+++ b/curriculum/turbo.json
@@ -3,7 +3,11 @@
   "extends": ["//"],
   "tasks": {
     "build": {
-      "outputs": ["dist/**", "generated/**"]
+      "outputs": ["dist/**", "generated/**"],
+      "env": ["FCC_*"]
+    },
+    "test": {
+      "env": ["FCC_*"]
     }
   }
 }

--- a/curriculum/turbo.json
+++ b/curriculum/turbo.json
@@ -8,6 +8,9 @@
     },
     "test": {
       "env": ["FCC_*"]
+    },
+    "test-content": {
+      "env": ["FCC_*"]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -65,6 +65,9 @@
     "serve:client-ci": "cd ./client && pnpm run serve-ci",
     "start": "turbo setup && npm-run-all -p develop:server serve:client",
     "test": "turbo test",
+    "test-client": "turbo -F=@freecodecamp/client test",
+    "test-api": "turbo -F=@freecodecamp/api test",
+    "test-curriculum-content": "turbo -F=@freecodecamp/curriculum test-content",
     "prepare": "husky",
     "playwright:run": "pnpm -F e2e run playwright:run",
     "playwright:watch": "pnpm -F e2e run playwright:watch"

--- a/tools/scripts/test_challenges.sh
+++ b/tools/scripts/test_challenges.sh
@@ -10,5 +10,5 @@ IFS=',' challengeIDS=($input)
 for challengeID in "${challengeIDS[@]}";
 do
   challengeID="$(tr -d ' ' <<< "$challengeID")"
-  FCC_CHALLENGE_ID=$challengeID pnpm run test:curriculum
+  FCC_CHALLENGE_ID=$challengeID pnpm turbo -F=@freecodecamp/curriculum test
 done

--- a/turbo.json
+++ b/turbo.json
@@ -6,6 +6,7 @@
     "lint": { "dependsOn": ["setup"] },
     "setup": { "dependsOn": ["^build"] },
     "test": { "dependsOn": ["setup"] },
+    "test-content": { "dependsOn": ["setup"] },
     "type-check": { "dependsOn": ["setup"] },
     "//#lint-root": {
       "dependsOn": ["@freecodecamp/shared#build"]


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Based off https://github.com/freeCodeCamp/freeCodeCamp/pull/65526. Now you can pass `FCC_*` env vars to `test` and `develop` (and `build` script for the client + curriculum) and they should behave correctly.

<!-- Feel free to add any additional description of changes below this line -->
