### PR TITLE
fix(curriculum): note Safari audio volume behavior

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-audio-and-video-elements/67168278ac6df6a799555db5.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-audio-and-video-elements/67168278ac6df6a799555db5.md
@@ -34,7 +34,9 @@ Press play in the preview window to hear one of Quincy Larson's songs. To hear a
 
 :::
 
-The `controls` attribute enables users to manage audio playback, including adjusting volume, and pausing, or resuming playback. The `controls` attribute is a boolean attribute that can be added to an element to enable built-in playback controls. If omitted, no controls will be shown.
+The `controls` attribute enables users to manage audio playback, including pausing or resuming playback. The `controls` attribute is a boolean attribute that can be added to an element to enable built-in playback controls. If omitted, no controls will be shown.
+
+Note: Some browsers, such as Safari, may not display a volume control by default even when the `controls` attribute is present.
 
 Apart from the `src` and `controls` attributes, there are several other attributes that enhance the functionality of the `audio` element. The `loop` attribute is a boolean attribute that makes the audio replay continuously. 
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #65531

This pull request updates the Responsive Web Design curriculum to clarify that some browsers, such as Safari, may not display an audio volume control by default even when the `controls` attribute is present.

This helps prevent confusion for learners while keeping the lesson aligned with real-world browser behavior.