### PR TITLE
test(challenge-parser): add test for 'highlighted-text' class

### DIFF
--- a/tools/challenge-parser/parser/plugins/utils/i18n-stringify.test.js
+++ b/tools/challenge-parser/parser/plugins/utils/i18n-stringify.test.js
@@ -252,6 +252,20 @@ describe('createMdastToHtml', () => {
     );
   });
 
+  // NOTE: The mobile app looks for the 'highlighted-text' class to apply highlighted styles.
+  // Notify the mobile team if the class name is changed or removed.
+  it("should include the 'highlighted-text' class when rendering as span", () => {
+    const toHtml = createMdastToHtml('en-US');
+    const nodes = [
+      {
+        type: 'paragraph',
+        children: [{ type: 'inlineCode', value: 'highlighted' }]
+      }
+    ];
+    const actual = toHtml(nodes);
+    expect(actual).toMatch(/class="highlighted-text"/);
+  });
+
   it('should render as regular code when lang is not zh-CN, en-US, or es', () => {
     const toHtml = createMdastToHtml('zh');
     const nodes = [


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

We updated the challenge parser to use a `<span>` with the `highlighted-text` class instead of a `<code>` element for highlighted text in language super blocks.

The mobile app also relies on this class name for styling: https://github.com/freeCodeCamp/mobile/blob/f8447c4035084198fa0c8d71e1c2043e2584bc88/mobile-app/lib/ui/views/news/html_handler/html_handler.dart#L100-L102

I'm adding a test to verify the presence of the class, to prevent regression.

<!-- Feel free to add any additional description of changes below this line -->
