### PR TITLE
fix(curriculum): add Safari-specific guidance for audio element 

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-audio-and-video-elements/67168278ac6df6a799555db5.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-audio-and-video-elements/67168278ac6df6a799555db5.md
@@ -34,7 +34,7 @@ Press play in the preview window to hear one of Quincy Larson's songs. To hear a
 
 :::
 
-The `controls` attribute enables users to manage audio playback, including adjusting volume, and pausing, or resuming playback. The `controls` attribute is a boolean attribute that can be added to an element to enable built-in playback controls. If omitted, no controls will be shown.
+The `controls` attribute enables users to manage audio playback, including adjusting volume, and pausing, or resuming playback. Most browsers also display volume controls as part of the standard controls. However, some browsers like Safari may not show volume controls, expecting users to manage volume through system-level settings instead. The `controls` attribute is a boolean attribute that can be added to an element to enable built-in playback controls. If omitted, no controls will be shown.
 
 Apart from the `src` and `controls` attributes, there are several other attributes that enhance the functionality of the `audio` element. The `loop` attribute is a boolean attribute that makes the audio replay continuously. 
 
@@ -54,7 +54,7 @@ Here's an example of using the `loop` attribute to play one of Quincy Larson's s
 
 Another attribute you can use is the `muted` attribute. When present in the `audio` element, this boolean attribute will start the audio in a muted state. Here's an example of using the `muted` attribute.
 
-To hear the music, enable the interactive editor and click on the volume icon in the audio player. 
+To hear the music, enable the interactive editor and click on the volume icon in the audio player. Note: Safari users may need to adjust the volume using system controls, as Safari typically doesn't display volume controls on the audio player.
 
 :::interactive_editor
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #65531

## Summary
Added browser-specific notes to the HTML5 audio element curriculum to clarify Safari's behavior with volume controls.

## Changes
- Added clarification that most browsers display volume controls as part of standard audio player controls, but Safari may not show them
- Added note directing Safari users to adjust volume through system-level settings instead
- Updated instructions in the muted attribute example to account for Safari's behavior

<img width="1436" height="971" alt="Screenshot 2026-01-29 at 9 32 43 AM" src="https://github.com/user-attachments/assets/7da2d6f5-b3e2-4f95-b89e-8db1512640e2" />

<img width="1436" height="971" alt="Screenshot 2026-01-29 at 9 32 56 AM" src="https://github.com/user-attachments/assets/95e7e8b8-c39c-4aad-9bc3-cf3ab09b6cf9" />
