### PR TITLE
fix(curriculum): correct python tests for letters-numbers challenge

### DIFF
--- a/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/69738771fb5a7b8b24cca29e.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/69738771fb5a7b8b24cca29e.md
@@ -17,7 +17,7 @@ Given a string containing only letters and numbers, return a new string where a 
 assert.equal(separateLettersAndNumbers("ABC123"), "ABC-123");
 ```
 
-`separateLettersAndNumbers("Route66")` should return `"Route-66`.
+`separateLettersAndNumbers("Route66")` should return `"Route-66"`.
 
 ```js
 assert.equal(separateLettersAndNumbers("Route66"), "Route-66");

--- a/curriculum/challenges/english/blocks/daily-coding-challenges-python/69738771fb5a7b8b24cca29e.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-python/69738771fb5a7b8b24cca29e.md
@@ -20,12 +20,12 @@ TestCase().assertEqual(separate_letters_and_numbers("ABC123"), "ABC-123")`)
 }})
 ```
 
-`separate_letters_and_numbers("Route66")` should return `"Route-66`.
+`separate_letters_and_numbers("Route66")` should return `"Route-66"`.
 
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertEqual(separate_letters_and_numbers("ABC123"), "ABC-123")`)
+TestCase().assertEqual(separate_letters_and_numbers("Route66"), "Route-66")`)
 }})
 ```
 
@@ -34,7 +34,7 @@ TestCase().assertEqual(separate_letters_and_numbers("ABC123"), "ABC-123")`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertEqual(separate_letters_and_numbers("ABC123"), "ABC-123")`)
+TestCase().assertEqual(separate_letters_and_numbers("H3LL0W0RLD"), "H-3-LL-0-W-0-RLD")`)
 }})
 ```
 
@@ -43,7 +43,7 @@ TestCase().assertEqual(separate_letters_and_numbers("ABC123"), "ABC-123")`)
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertEqual(separate_letters_and_numbers("ABC123"), "ABC-123")`)
+TestCase().assertEqual(separate_letters_and_numbers("a1b2c3d4"), "a-1-b-2-c-3-d-4")`)
 }})
 ```
 


### PR DESCRIPTION
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #65554

### Description
Fixes missing closing quotes in JS/Python challenge descriptions and updates Python tests to properly test different inputs for the Letters-Numbers challenge.
