### PR TITLE
fix(curriculum): clarify elif evaluation order

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-booleans-and-conditionals/67fe85a3db9bad35f2b6a2bd.md
+++ b/curriculum/challenges/english/blocks/lecture-booleans-and-conditionals/67fe85a3db9bad35f2b6a2bd.md
@@ -111,10 +111,10 @@ There might be situations in which you want to account for multiple conditions. 
 Here's the syntax:
 
 ```python
-if condition:
-   pass # Code to execute if condition is True
+if condition1:
+   pass # Code to execute if condition1 is True
 elif condition2:
-   pass # Code to execute if condition2 is True
+   pass # Code to execute if condition1 is False and condition2 is True
 else:
    pass # Code to execute if all conditions are False
 ```

--- a/curriculum/challenges/english/blocks/review-python-basics/67f39b40deaec81a3e40e0c5.md
+++ b/curriculum/challenges/english/blocks/review-python-basics/67f39b40deaec81a3e40e0c5.md
@@ -711,7 +711,7 @@ if age >= 18:
     print('You are an adult') # You are an adult
 ```
 
-- **`elif` Statement**: These are conditions that come after an `if` statement. If the `elif` condition evaluates to `True`, then that block of code will run.
+- **`elif` Statement**: These are conditions that come after an `if` statement. An `elif` block runs only if all previous conditions evaluate to `False` and its own condition evaluates to `True`.
 
 ```py
 age = 16

--- a/curriculum/challenges/english/blocks/workshop-movie-ticket-booking-calculator/696cbb3985e23420cd45c58f.md
+++ b/curriculum/challenges/english/blocks/workshop-movie-ticket-booking-calculator/696cbb3985e23420cd45c58f.md
@@ -13,7 +13,7 @@ The `if...elif...else` statement is used to check multiple conditions in order.
 if condition1:
    # Code to execute if condition1 is True
 elif condition2:
-   # Code to execute if condition2 is True
+   # Code to execute if condition1 is False and condition2 is True
 else:
    # Code to execute if all conditions are False
 ```


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.


Closes #65558 

This PR clarifies that `elif` conditions are evaluated only after the
preceding `if` (and earlier `elif`) conditions evaluate to False.