### PR TITLE
fix(client): python terminal

### DIFF
--- a/client/.gitignore
+++ b/client/.gitignore
@@ -8,8 +8,8 @@ yarn-error.log
 .DS_Store
 
 /static/js
-./static/_redirects
-static/curriculum-data
+/static/css
+/static/curriculum-data
 
 # Generated config
 i18n/locales/**/trending.json

--- a/client/src/templates/Challenges/classic/xterm.tsx
+++ b/client/src/templates/Challenges/classic/xterm.tsx
@@ -139,7 +139,7 @@ export const XtermTerminal = ({
 
   return (
     <div style={{ height: dimensions?.height }} ref={termContainerRef}>
-      <link rel='stylesheet' href='/js/xterm.css' />
+      <link rel='stylesheet' href='/css/xterm.css' />
     </div>
   );
 };

--- a/client/tools/copy-browser-scripts.ts
+++ b/client/tools/copy-browser-scripts.ts
@@ -8,12 +8,20 @@ const browserScriptDist = resolve(
 );
 
 const destJsDir = resolve(__dirname, '../static/js');
+const srcJsDir = resolve(browserScriptDist, './js');
+const destCssDir = resolve(__dirname, '../static/css');
+const srcCssDir = resolve(browserScriptDist, './css');
 
 // Everything is done synchronously to keep the script simple. There's no
 // performance benefit to doing this asynchronously since it's already so fast.
 rmSync(destJsDir, { recursive: true, force: true });
+rmSync(destCssDir, { recursive: true, force: true });
 mkdirSync(destJsDir, { recursive: true });
+mkdirSync(destCssDir, { recursive: true });
 
-cpSync(resolve(browserScriptDist, 'artifacts'), destJsDir, {
+cpSync(srcJsDir, destJsDir, {
+  recursive: true
+});
+cpSync(srcCssDir, destCssDir, {
   recursive: true
 });

--- a/curriculum/src/test/vitest-global-setup.mjs
+++ b/curriculum/src/test/vitest-global-setup.mjs
@@ -28,7 +28,7 @@ function setupStubs() {
 
   rmSync(destArtifactsDir, { recursive: true, force: true });
   mkdirSync(destArtifactsDir, { recursive: true });
-  cpSync(path.resolve(browserScriptDist, 'artifacts'), destArtifactsDir, {
+  cpSync(path.resolve(browserScriptDist, 'js'), destArtifactsDir, {
     recursive: true
   });
 }

--- a/tools/client-plugins/browser-scripts/copy-scripts.ts
+++ b/tools/client-plugins/browser-scripts/copy-scripts.ts
@@ -1,0 +1,33 @@
+import { cpSync, mkdirSync, rmSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { version as workerVersion } from '@freecodecamp/browser-scripts/package.json';
+import { version as helperVersion } from '@freecodecamp/curriculum-helpers/package.json';
+
+const __dirname = import.meta.dirname;
+
+const distDir = resolve(__dirname, 'dist');
+
+const destJsDir = resolve(distDir, './js');
+const destCssDir = resolve(distDir, './css');
+
+rmSync(distDir, { recursive: true, force: true });
+mkdirSync(destJsDir, { recursive: true });
+mkdirSync(destCssDir, { recursive: true });
+
+cpSync(
+  resolve(__dirname, './node_modules/sass.js/dist/sass.sync.js'),
+  resolve(destJsDir, 'workers', workerVersion, 'sass.sync.js')
+);
+cpSync(
+  resolve(__dirname, './node_modules/xterm/css/xterm.css'),
+  resolve(destCssDir, 'xterm.css')
+);
+cpSync(
+  resolve(
+    __dirname,
+    './node_modules/@freecodecamp/curriculum-helpers/dist/test-runner'
+  ),
+  resolve(destJsDir, `test-runner/${helperVersion}/`),
+  { recursive: true }
+);

--- a/tools/client-plugins/browser-scripts/package.json
+++ b/tools/client-plugins/browser-scripts/package.json
@@ -29,7 +29,9 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint --max-warnings 0",
-    "build": "NODE_OPTIONS=\"--max-old-space-size=7168\" webpack -c webpack.config.cjs --env production"
+    "build": "pnpm copy-scripts && pnpm bundle",
+    "bundle": "NODE_OPTIONS=\"--max-old-space-size=7168\" webpack -c webpack.config.cjs --env production",
+    "copy-scripts": "tsx ./copy-scripts.ts"
   },
   "type": "module",
   "keywords": [],

--- a/tools/client-plugins/browser-scripts/webpack.config.cjs
+++ b/tools/client-plugins/browser-scripts/webpack.config.cjs
@@ -1,9 +1,6 @@
 const path = require('path');
-const CopyWebpackPlugin = require('copy-webpack-plugin');
 const webpack = require('webpack');
-const {
-  version: helperVersion
-} = require('@freecodecamp/curriculum-helpers/package.json');
+
 const { version } = require('./package.json');
 
 module.exports = (env = {}) => {
@@ -20,8 +17,8 @@ module.exports = (env = {}) => {
     devtool: __DEV__ ? 'inline-source-map' : 'source-map',
     output: {
       chunkFilename: '[name]-[contenthash].js',
-      path: path.resolve(__dirname, `dist/artifacts/workers/${version}`),
-      clean: true
+      path: path.resolve(__dirname, `dist/js/workers/${version}`),
+      clean: false // We handle cleaning in copy-scripts.ts
     },
     stats: {
       // Display bailout reasons
@@ -53,17 +50,6 @@ module.exports = (env = {}) => {
       ]
     },
     plugins: [
-      new CopyWebpackPlugin({
-        patterns: [
-          './node_modules/sass.js/dist/sass.sync.js',
-          // TODO: copy this into the css folder, not the js folder
-          './node_modules/xterm/css/xterm.css',
-          {
-            from: './node_modules/@freecodecamp/curriculum-helpers/dist/test-runner',
-            to: `../../test-runner/${helperVersion}/`
-          }
-        ]
-      }),
       new webpack.ProvidePlugin({
         process: 'process/browser'
       }),


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->
Closes #65564
Fixes a bug introduced by https://github.com/freeCodeCamp/freeCodeCamp/pull/65399 in which I accidentally moved xterm.css preventing the client from finding it.

To reproduce the bug, visit any page which uses the python terminal, e.g. https://www.freecodecamp.dev/learn/python-v9/workshop-report-card-printer/step-1 and see a few more Ws than you were expecting:

<img width="549" height="183" alt="image" src="https://github.com/user-attachments/assets/90a4977c-efc0-422c-a8f0-616f2713e686" />


Thanks to @Dario-DC for the report.

I'll work on some tests soon.

<!-- Feel free to add any additional description of changes below this line -->
