### PR TITLE
fix(client): redirect MS Learn timeline view to profile

### DIFF
--- a/client/src/client-only-routes/show-project-links.tsx
+++ b/client/src/client-only-routes/show-project-links.tsx
@@ -95,6 +95,7 @@ const ShowProjectLinks = (props: ShowProjectLinksProps): JSX.Element => {
       <SolutionDisplayWidget
         completedChallenge={completedProject}
         projectTitle={projectTitle}
+        username={username}
         displayContext='certification'
         showUserCode={showUserCode}
         showProjectPreview={showProjectPreview}

--- a/client/src/components/profile/components/time-line.test.tsx
+++ b/client/src/components/profile/components/time-line.test.tsx
@@ -14,7 +14,7 @@ const store = createStore();
 
 beforeEach(() => {
   // @ts-expect-error
-  useStaticQuery.mockImplementationOnce(() => ({
+  useStaticQuery.mockImplementation(() => ({
     allChallengeNode: {
       edges: [
         {
@@ -78,6 +78,31 @@ describe('<TimeLine />', () => {
     viewButtons.forEach(button => {
       expect(button).toBeInTheDocument();
     });
+  });
+
+  it('redirects MS Learn API solution to MS Learn profile when username is present', () => {
+    const propsWithMsLearnSolution = {
+      ...propsForOnlySolution,
+      completedMap: [
+        {
+          id: '5e46f802ac417301a38fb92b',
+          solution:
+            'https://learn.microsoft.com/api/gamestatus/achievements/123',
+          completedDate: 1604311988825
+        }
+      ]
+    };
+    // @ts-expect-error
+    render(<TimeLine {...propsWithMsLearnSolution} />, store);
+
+    const viewLink = screen.getByRole('link', {
+      name: 'buttons.view settings.labels.solution-for (aria.opens-new-window)'
+    });
+
+    expect(viewLink).toHaveAttribute(
+      'href',
+      'https://learn.microsoft.com/en-us/users/developmentuser/'
+    );
   });
 });
 

--- a/client/src/components/profile/components/time-line.test.tsx
+++ b/client/src/components/profile/components/time-line.test.tsx
@@ -104,6 +104,28 @@ describe('<TimeLine />', () => {
       'https://learn.microsoft.com/en-us/users/developmentuser/'
     );
   });
+
+  it('does not render MS Learn link when username is missing', () => {
+    const propsWithoutUsername = {
+      completedMap: [
+        {
+          id: '5e46f802ac417301a38fb92b',
+          solution:
+            'https://learn.microsoft.com/api/gamestatus/achievements/123',
+          completedDate: 1604311988825
+        }
+      ]
+    };
+
+    // @ts-expect-error
+    render(<TimeLine {...propsWithoutUsername} />, store);
+
+    expect(
+      screen.queryByRole('link', {
+        name: 'buttons.view settings.labels.solution-for (aria.opens-new-window)'
+      })
+    ).toBeNull();
+  });
 });
 
 const contents = 'This is not JS';

--- a/client/src/components/profile/components/time-line.tsx
+++ b/client/src/components/profile/components/time-line.tsx
@@ -120,6 +120,7 @@ function TimelineInner({
       <SolutionDisplayWidget
         completedChallenge={completedChallenge}
         projectTitle={projectTitle}
+        username={username}
         showUserCode={() => viewSolution(completedChallenge)}
         showProjectPreview={() => viewProject(completedChallenge)}
         showExamResults={() => viewExamResults(completedChallenge)}

--- a/client/src/components/settings/certification.tsx
+++ b/client/src/components/settings/certification.tsx
@@ -178,7 +178,7 @@ function CertificationSettings(props: CertificationSettingsProps) {
   const handleSolutionModalHide = () => initialiseState();
 
   const getProjectSolution = (projectId: string, projectTitle: string) => {
-    const { completedChallenges, openModal } = props;
+    const { completedChallenges, username, openModal } = props;
     const completedProject = find(
       completedChallenges,
       ({ id }) => projectId === id
@@ -221,6 +221,7 @@ function CertificationSettings(props: CertificationSettingsProps) {
       <SolutionDisplayWidget
         completedChallenge={completedProject}
         projectTitle={projectTitle}
+        username={username}
         showExamResults={showExamResults}
         showUserCode={showUserCode}
         showProjectPreview={showProjectPreview}

--- a/client/src/components/solution-display-widget/index.tsx
+++ b/client/src/components/solution-display-widget/index.tsx
@@ -7,6 +7,24 @@ import { useTranslation } from 'react-i18next';
 import { CompletedChallenge } from '../../redux/prop-types';
 import { getSolutionDisplayType } from '../../utils/solution-display-type';
 
+// Resolves the correct "view" URL for a completed challenge.
+// MS Learn API solutions redirect to the user's MS Learn profile.
+function getViewUrl(
+  solution: string | undefined | null,
+  username?: string
+): string | undefined {
+  if (
+    typeof solution === 'string' &&
+    solution.startsWith('https://learn.microsoft.com/api/')
+  ) {
+    return username
+      ? `https://learn.microsoft.com/en-us/users/${username}/`
+      : undefined;
+  }
+
+  return solution ?? undefined;
+}
+
 interface Props {
   completedChallenge: CompletedChallenge;
   projectTitle: string;
@@ -26,17 +44,18 @@ export function SolutionDisplayWidget({
   showExamResults,
   displayContext
 }: Props): JSX.Element | null {
+  const { t } = useTranslation();
   const { id, solution, githubLink } = completedChallenge;
+  const viewUrl = getViewUrl(solution, username);
+
   const isMsLearnApiSolution =
     typeof solution === 'string' &&
     solution.startsWith('https://learn.microsoft.com/api/');
 
-  const viewUrl = isMsLearnApiSolution
-    ? username
-      ? `https://learn.microsoft.com/en-us/users/${username}/`
-      : undefined
-    : solution ?? undefined;
-  const { t } = useTranslation();
+  if (isMsLearnApiSolution && !viewUrl) {
+    return null;
+  }
+
   const viewText = t('buttons.view');
   const viewCode = t('buttons.view-code');
   const viewProject = t('buttons.view-project');
@@ -62,8 +81,6 @@ export function SolutionDisplayWidget({
       <Dropdown.Menu>
         <MenuItem
           variant='primary'
-          // This expression is only to resolve TypeScript error.
-          // There won't be a case where the link has an invalid `href`
           // as this component is only rendered if `solution` is truthy.
           href={viewUrl}
           rel='noopener noreferrer'
@@ -89,8 +106,6 @@ export function SolutionDisplayWidget({
   const ShowProjectLinkForCertification = (
     <Button
       block={true}
-      // This expression is only to resolve TypeScript error.
-      // There won't be a case where the link has an invalid `href`
       // as this component is only rendered if `solution` is truthy.
       href={viewUrl}
       rel='noopener noreferrer'
@@ -148,8 +163,6 @@ export function SolutionDisplayWidget({
         <Dropdown.Menu>
           <MenuItem
             variant='primary'
-            // This expression is only to resolve TypeScript error.
-            // There won't be a case where the link has an invalid `href`
             // as this component is only rendered if `solution` is truthy.
             href={viewUrl}
             rel='noopener noreferrer'
@@ -177,8 +190,6 @@ export function SolutionDisplayWidget({
     <Button
       block={true}
       variant='primary'
-      // This expression is only to resolve TypeScript error.
-      // There won't be a case where the link has an invalid `href`
       // as this component is only rendered if `solution` is truthy.
       href={viewUrl}
       rel='noopener noreferrer'

--- a/client/src/components/solution-display-widget/index.tsx
+++ b/client/src/components/solution-display-widget/index.tsx
@@ -7,16 +7,22 @@ import { useTranslation } from 'react-i18next';
 import { CompletedChallenge } from '../../redux/prop-types';
 import { getSolutionDisplayType } from '../../utils/solution-display-type';
 
+function isMsLearnApiUrl(
+  solution: string | null | undefined
+): solution is string {
+  return (
+    typeof solution === 'string' &&
+    solution.startsWith('https://learn.microsoft.com/api/')
+  );
+}
+
 // Resolves the correct "view" URL for a completed challenge.
 // MS Learn API solutions redirect to the user's MS Learn profile.
 function getViewUrl(
   solution: string | undefined | null,
   username?: string
 ): string | undefined {
-  if (
-    typeof solution === 'string' &&
-    solution.startsWith('https://learn.microsoft.com/api/')
-  ) {
+  if (isMsLearnApiUrl(solution)) {
     return username
       ? `https://learn.microsoft.com/en-us/users/${username}/`
       : undefined;
@@ -48,9 +54,7 @@ export function SolutionDisplayWidget({
   const { id, solution, githubLink } = completedChallenge;
   const viewUrl = getViewUrl(solution, username);
 
-  const isMsLearnApiSolution =
-    typeof solution === 'string' &&
-    solution.startsWith('https://learn.microsoft.com/api/');
+  const isMsLearnApiSolution = isMsLearnApiUrl(solution);
 
   if (isMsLearnApiSolution && !viewUrl) {
     return null;

--- a/client/src/components/solution-display-widget/index.tsx
+++ b/client/src/components/solution-display-widget/index.tsx
@@ -10,6 +10,7 @@ import { getSolutionDisplayType } from '../../utils/solution-display-type';
 interface Props {
   completedChallenge: CompletedChallenge;
   projectTitle: string;
+  username?: string;
   showUserCode: () => void;
   showProjectPreview?: () => void;
   showExamResults?: () => void;
@@ -19,12 +20,22 @@ interface Props {
 export function SolutionDisplayWidget({
   completedChallenge,
   projectTitle,
+  username,
   showUserCode,
   showProjectPreview,
   showExamResults,
   displayContext
 }: Props): JSX.Element | null {
   const { id, solution, githubLink } = completedChallenge;
+  const isMsLearnApiSolution =
+    typeof solution === 'string' &&
+    (solution.includes('learn.microsoft.com/api/gamestatus') ||
+      solution.includes('learn.microsoft.com/api/achievements/user'));
+
+  const viewUrl =
+    isMsLearnApiSolution && username
+      ? `https://learn.microsoft.com/users/${username}/`
+      : solution ?? undefined;
   const { t } = useTranslation();
   const viewText = t('buttons.view');
   const viewCode = t('buttons.view-code');
@@ -54,7 +65,7 @@ export function SolutionDisplayWidget({
           // This expression is only to resolve TypeScript error.
           // There won't be a case where the link has an invalid `href`
           // as this component is only rendered if `solution` is truthy.
-          href={solution ?? undefined}
+          href={viewUrl}
           rel='noopener noreferrer'
           target='_blank'
         >
@@ -81,7 +92,7 @@ export function SolutionDisplayWidget({
       // This expression is only to resolve TypeScript error.
       // There won't be a case where the link has an invalid `href`
       // as this component is only rendered if `solution` is truthy.
-      href={solution ?? undefined}
+      href={viewUrl}
       rel='noopener noreferrer'
       target='_blank'
     >
@@ -140,7 +151,7 @@ export function SolutionDisplayWidget({
             // This expression is only to resolve TypeScript error.
             // There won't be a case where the link has an invalid `href`
             // as this component is only rendered if `solution` is truthy.
-            href={solution ?? undefined}
+            href={viewUrl}
             rel='noopener noreferrer'
             target='_blank'
           >
@@ -169,7 +180,7 @@ export function SolutionDisplayWidget({
       // This expression is only to resolve TypeScript error.
       // There won't be a case where the link has an invalid `href`
       // as this component is only rendered if `solution` is truthy.
-      href={solution ?? undefined}
+      href={viewUrl}
       rel='noopener noreferrer'
       target='_blank'
     >

--- a/client/src/components/solution-display-widget/index.tsx
+++ b/client/src/components/solution-display-widget/index.tsx
@@ -29,13 +29,13 @@ export function SolutionDisplayWidget({
   const { id, solution, githubLink } = completedChallenge;
   const isMsLearnApiSolution =
     typeof solution === 'string' &&
-    (solution.includes('learn.microsoft.com/api/gamestatus') ||
-      solution.includes('learn.microsoft.com/api/achievements/user'));
+    solution.startsWith('https://learn.microsoft.com/api/');
 
-  const viewUrl =
-    isMsLearnApiSolution && username
-      ? `https://learn.microsoft.com/users/${username}/`
-      : solution ?? undefined;
+  const viewUrl = isMsLearnApiSolution
+    ? username
+      ? `https://learn.microsoft.com/en-us/users/${username}/`
+      : undefined
+    : solution ?? undefined;
   const { t } = useTranslation();
   const viewText = t('buttons.view');
   const viewCode = t('buttons.view-code');


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #53073

Fixes the Timeline **View** button for Microsoft Learn trophies, which currently links to Microsoft Learn API endpoints and shows raw JSON.

The View link now redirects to the user’s Microsoft Learn profile page, displaying the correct UI.
