### PR TITLE
fix(api): setup experience correctly + return it if public

### DIFF
--- a/api/src/routes/public/user.test.ts
+++ b/api/src/routes/public/user.test.ts
@@ -74,6 +74,16 @@ const testUserData: Prisma.userCreateInput = {
       }
     }
   ],
+  experience: [
+    {
+      id: 'exp1',
+      title: 'Software Engineer',
+      company: 'Company A',
+      startDate: '2020-01-01',
+      endDate: '2021-01-01',
+      description: 'Worked on various projects.'
+    }
+  ],
   partiallyCompletedChallenges: [{ id: '123', completedDate: 123 }],
   completedExams: [],
   githubProfile: 'github.com/foobar',
@@ -185,6 +195,7 @@ const publicUserData = {
   ],
   completedExams: testUserData.completedExams,
   completedSurveys: [], // TODO: add surveys
+  experience: testUserData.experience,
   githubProfile: testUserData.githubProfile,
   is2018DataVisCert: testUserData.is2018DataVisCert,
   is2018FullStackCert: testUserData.is2018FullStackCert, // TODO: should this be returned? The client doesn't use it at the moment.
@@ -254,7 +265,7 @@ describe('userRoutes', () => {
         showAbout: true,
         showCerts: true,
         showDonation: true,
-        showExperience: false,
+        showExperience: true,
         showHeatMap: true,
         showLocation: true,
         showName: true,

--- a/api/src/routes/public/user.ts
+++ b/api/src/routes/public/user.ts
@@ -8,12 +8,13 @@ import * as schemas from '../../schemas.js';
 import { splitUser } from '../helpers/user-utils.js';
 import {
   normalizeChallenges,
-  NormalizedChallenge,
+  type NormalizedChallenge,
   normalizeFlags,
   normalizeProfileUI,
   normalizeTwitter,
   normalizeBluesky,
-  removeNulls
+  removeNulls,
+  type NoNullProperties
 } from '../../utils/normalize.js';
 import {
   Calendar,
@@ -48,7 +49,7 @@ type RawUser = {
   name: string;
   points: number;
   portfolio: Portfolio[];
-  experience: Experience[];
+  experience: NoNullProperties<Experience>[];
   profileUI: ProfileUI;
 };
 
@@ -190,7 +191,7 @@ export const userPublicGetRoutes: FastifyPluginCallbackTypebox = (
           name: user.name ?? '',
           points: getPoints(progressTimestamps),
           profileUI: normalizedProfileUI,
-          experience: user.experience ?? []
+          experience: user.experience.map(removeNulls) ?? []
         });
 
         const returnedUser = {

--- a/api/src/schemas/users/get-public-profile.ts
+++ b/api/src/schemas/users/get-public-profile.ts
@@ -1,5 +1,5 @@
 import { Type } from '@fastify/type-provider-typebox';
-import { profileUI, examResults } from '../types.js';
+import { profileUI, examResults, experience } from '../types.js';
 
 export const getPublicProfile = {
   querystring: Type.Object({
@@ -47,6 +47,7 @@ export const getPublicProfile = {
                   examResults
                 })
               ),
+              experience: Type.Array(experience),
               // TODO(Post-MVP): return completedSurveys? Presumably not, since why
               // would this need to be public.
               githubProfile: Type.Optional(Type.String()),

--- a/api/src/utils/create-user.ts
+++ b/api/src/utils/create-user.ts
@@ -14,6 +14,7 @@ export const createResetProperties = () => ({
   completedChallenges: [], // TODO(Post-MVP): Omit this from the document? (prisma will always return [])
   completedExams: [], // TODO(Post-MVP): Omit this from the document? (prisma will always return [])
   currentChallengeId: '',
+  experience: [], // TODO(Post-MVP): Omit this from the document? (prisma will always return [])
   is2018DataVisCert: false,
   is2018FullStackCert: false,
   isA2EnglishCert: false,

--- a/api/src/utils/normalize.ts
+++ b/api/src/utils/normalize.ts
@@ -12,7 +12,7 @@ import { pickBy, mapValues } from 'lodash-es';
 type NullToUndefined<T> = T extends null ? undefined : T;
 type NullToFalse<T> = T extends null ? false : T;
 
-type NoNullProperties<T> = {
+export type NoNullProperties<T> = {
   [P in keyof T]: NullToUndefined<T[P]>;
 };
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

It's not crucial that the user is created with [] for experience, but we should for consistency.

<!-- Feel free to add any additional description of changes below this line -->
