### PR TITLE
fix(curriculum): correct MP3 MIME type

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-audio-and-video/6733d8203da84a08a0f5eab4.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-audio-and-video/6733d8203da84a08a0f5eab4.md
@@ -39,7 +39,6 @@ Multimedia Internet Media Extension.
 
 ### --feedback--
 
-
 Please review the part where MIME is defined.
 
 ---
@@ -115,7 +114,6 @@ What is the MIME type for an MP3 file?
 `audio/mp3`
 
 ### --feedback--
-
 
 Please review the part where the MIME type for MP3 is discussed.
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-audio-and-video/6733d8203da84a08a0f5eab4.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-audio-and-video/6733d8203da84a08a0f5eab4.md
@@ -39,7 +39,7 @@ Multimedia Internet Media Extension.
 
 ### --feedback--
 
-Please review the part where MIME is defined.
+Review the part where MIME is defined.
 
 ---
 
@@ -47,7 +47,7 @@ Multiple Internet Mail Extensions.
 
 ### --feedback--
 
-Please review the part where MIME is defined.
+Review the part where MIME is defined.
 
 ---
 
@@ -59,7 +59,7 @@ Media Information and Metadata Encoding.
 
 ### --feedback--
 
-Please review the part where MIME is defined.
+Review the part where MIME is defined.
 
 ## --video-solution--
 
@@ -75,7 +75,7 @@ To compress file sizes for faster internet transfer.
 
 ### --feedback--
 
-Please review the part that explains what a MIME type is used for.
+Review the part that explains what a MIME type is used for.
 
 ---
 
@@ -83,7 +83,7 @@ To encrypt files for secure transmission.
 
 ### --feedback--
 
-Please review the part that explains what a MIME type is used for.
+Review the part that explains what a MIME type is used for.
 
 ---
 
@@ -95,7 +95,7 @@ To convert files between different formats
 
 ### --feedback--
 
-Please review the part that explains what a MIME type is used for.
+Review the part that explains what a MIME type is used for.
 
 ## --video-solution--
 
@@ -115,7 +115,7 @@ What is the MIME type for an MP3 file?
 
 ### --feedback--
 
-Please review the part where the MIME type for MP3 is discussed.
+Review the part where the MIME type for MP3 is discussed.
 
 ---
 
@@ -123,7 +123,7 @@ Please review the part where the MIME type for MP3 is discussed.
 
 ### --feedback--
 
-Please review the part where the MIME type for MP3 is discussed.
+Review the part where the MIME type for MP3 is discussed.
 
 ---
 
@@ -131,7 +131,7 @@ Please review the part where the MIME type for MP3 is discussed.
 
 ### --feedback--
 
-Please review the part where the MIME type for MP3 is discussed.
+Review the part where the MIME type for MP3 is discussed.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-audio-and-video/6733d8203da84a08a0f5eab4.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-audio-and-video/6733d8203da84a08a0f5eab4.md
@@ -39,7 +39,8 @@ Multimedia Internet Media Extension.
 
 ### --feedback--
 
-MIME type was originally for mail.
+
+Please review the part where MIME is defined.
 
 ---
 
@@ -47,7 +48,7 @@ Multiple Internet Mail Extensions.
 
 ### --feedback--
 
-MIME type was originally for mail.
+Please review the part where MIME is defined.
 
 ---
 
@@ -59,7 +60,7 @@ Media Information and Metadata Encoding.
 
 ### --feedback--
 
-MIME type was originally for mail.
+Please review the part where MIME is defined.
 
 ## --video-solution--
 
@@ -75,7 +76,7 @@ To compress file sizes for faster internet transfer.
 
 ### --feedback--
 
-A MIME type indicates the type of file.
+Please review the part that explains what a MIME type is used for.
 
 ---
 
@@ -83,7 +84,7 @@ To encrypt files for secure transmission.
 
 ### --feedback--
 
-A MIME type indicates the type of file.
+Please review the part that explains what a MIME type is used for.
 
 ---
 
@@ -95,7 +96,7 @@ To convert files between different formats
 
 ### --feedback--
 
-A MIME type indicates the type of file.
+Please review the part that explains what a MIME type is used for.
 
 ## --video-solution--
 
@@ -115,7 +116,8 @@ What is the MIME type for an MP3 file?
 
 ### --feedback--
 
-Incorrect. The registered MIME type for MP3 is `audio/mpeg`.
+
+Please review the part where the MIME type for MP3 is discussed.
 
 ---
 
@@ -123,7 +125,7 @@ Incorrect. The registered MIME type for MP3 is `audio/mpeg`.
 
 ### --feedback--
 
-Incorrect. The registered MIME type for MP3 is `audio/mpeg`.
+Please review the part where the MIME type for MP3 is discussed.
 
 ---
 
@@ -131,7 +133,7 @@ Incorrect. The registered MIME type for MP3 is `audio/mpeg`.
 
 ### --feedback--
 
-Incorrect. The registered MIME type for MP3 is `audio/mpeg`.
+Please review the part where the MIME type for MP3 is discussed.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-audio-and-video/6733d8203da84a08a0f5eab4.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-audio-and-video/6733d8203da84a08a0f5eab4.md
@@ -109,10 +109,6 @@ What is the MIME type for an MP3 file?
 
 `audio/mpeg`
 
-### --feedback--
-
-An MP3 file cannot contain video.
-
 ---
 
 `audio/mp3`

--- a/curriculum/challenges/english/blocks/lecture-working-with-audio-and-video/6733d8203da84a08a0f5eab4.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-audio-and-video/6733d8203da84a08a0f5eab4.md
@@ -17,7 +17,7 @@ Nearly every file format has a MIME type. HTML, for example, has the type `text/
 
 The MIME type can tell an application, such as your browser, how to handle a specific file. In the case of audio and video, the MIME type indicates it is a multimedia format that can be embedded in the web page.
 
-An MP3 file has the MIME type `audio/mp3`. An MP4, however, can have the MIME type `audio/mp4` OR `video/mp4`, depending on whether it's a video file or audio-only. This distinction tells the browser how to handle the file.
+An MP3 file has the MIME type `audio/mpeg`. An MP4, however, can have the MIME type `audio/mp4` OR `video/mp4`, depending on whether it's a video file or audio-only. This distinction tells the browser how to handle the file.
 
 There are plenty of other file formats, such as the waveform format WAV, the multipurpose OGG, WMV for the Windows media player, the open source MKV, and many more.
 
@@ -117,6 +117,10 @@ An MP3 file cannot contain video.
 
 `audio/mp3`
 
+### --feedback--
+
+The registered MIME type for MP3 is `audio/mpeg`.
+
 ---
 
 `video/mp3`
@@ -135,4 +139,4 @@ An MP3 file cannot contain video.
 
 ## --video-solution--
 
-2
+1

--- a/curriculum/challenges/english/blocks/lecture-working-with-audio-and-video/6733d8203da84a08a0f5eab4.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-audio-and-video/6733d8203da84a08a0f5eab4.md
@@ -115,7 +115,7 @@ What is the MIME type for an MP3 file?
 
 ### --feedback--
 
-The registered MIME type for MP3 is `audio/mpeg`.
+Incorrect. The registered MIME type for MP3 is `audio/mpeg`.
 
 ---
 
@@ -123,7 +123,7 @@ The registered MIME type for MP3 is `audio/mpeg`.
 
 ### --feedback--
 
-An MP3 file cannot contain video.
+Incorrect. The registered MIME type for MP3 is `audio/mpeg`.
 
 ---
 
@@ -131,7 +131,7 @@ An MP3 file cannot contain video.
 
 ### --feedback--
 
-An MP3 file cannot contain video.
+Incorrect. The registered MIME type for MP3 is `audio/mpeg`.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/blocks/review-javascript-audio-and-video/6723cf27c6e9a0c3f3041385.md
+++ b/curriculum/challenges/english/blocks/review-javascript-audio-and-video/6723cf27c6e9a0c3f3041385.md
@@ -71,7 +71,7 @@ The `Audio()` constructor has properties just as it has methods. Those propertie
 
 - **MIME type**: A MIME type, standing for Multipurpose Internet Mail Extensions, is a standardized way to programmatically indicate a file type. The MIME type can tell an application, such as your browser, how to handle a specific file. In the case of audio and video, the MIME type indicates it is a multimedia format that can be embedded in the web page.
 - **`source` Element**: This is used to specify a file type and source - and can include multiple different types by using multiple source elements. When you do this, the browser will determine the best format to use for the user's current environment.
-- **MP3**: This is a type of digital file format used to store music, audio, or sound. It's a compressed version of a sound recording that makes the file size smaller, so it's easier to store and share. MP3 has the widest browser support and the MIME type of `audio/mp3`.
+- **MP3**: This is a type of digital file format used to store music, audio, or sound. It's a compressed version of a sound recording that makes the file size smaller, so it's easier to store and share. MP3 has the widest browser support and the MIME type of `audio/mpeg`.
 - **MP4**: An MP4 is a type of digital file format used to store video and audio. It serves as a container that holds both the video (images) and the sound (music or speech) in one file. An MP4, can have the MIME type `audio/mp4` OR `video/mp4`, depending on whether it's a video file or audio-only.
 - Other formats are `WMV` which is associated with the Windows Media Player app, `OGG`, `MKV`, `AVI`, and more.
 

--- a/curriculum/challenges/english/blocks/review-javascript/6723d3cfdd0717d3f1bf27e3.md
+++ b/curriculum/challenges/english/blocks/review-javascript/6723d3cfdd0717d3f1bf27e3.md
@@ -2372,7 +2372,7 @@ function pauseAudio() {
 
 - **MIME type**: A MIME type, standing for Multipurpose Internet Mail Extensions, is a standardized way to programmatically indicate a file type. The MIME type can tell an application, such as your browser, how to handle a specific file. In the case of audio and video, the MIME type indicates it is a multimedia format that can be embedded in the web page.
 - **`source` Element**: This is used to specify a file type and source - and can include multiple different types by using multiple source elements. When you do this, the browser will determine the best format to use for the user's current environment.
-- **MP3**: This is a type of digital file format used to store music, audio, or sound. It's a compressed version of a sound recording that makes the file size smaller, so it's easier to store and share. An MP3 file has the MIME type audio/mp3
+- **MP3**: This is a type of digital file format used to store music, audio, or sound. It's a compressed version of a sound recording that makes the file size smaller, so it's easier to store and share. An MP3 file has the MIME type `audio/mpeg`.
 - **MP4**: An MP4 is a type of digital file format used to store video and audio. It serves as a container that holds both the video (images) and the sound (music or speech) in one file. An MP4, can have the MIME type audio/mp4 OR video/mp4, depending on whether it's a video file or audio-only. 
 
 ## codecs

--- a/curriculum/challenges/english/blocks/review-javascript/6723d3cfdd0717d3f1bf27e3.md
+++ b/curriculum/challenges/english/blocks/review-javascript/6723d3cfdd0717d3f1bf27e3.md
@@ -2373,7 +2373,7 @@ function pauseAudio() {
 - **MIME type**: A MIME type, standing for Multipurpose Internet Mail Extensions, is a standardized way to programmatically indicate a file type. The MIME type can tell an application, such as your browser, how to handle a specific file. In the case of audio and video, the MIME type indicates it is a multimedia format that can be embedded in the web page.
 - **`source` Element**: This is used to specify a file type and source - and can include multiple different types by using multiple source elements. When you do this, the browser will determine the best format to use for the user's current environment.
 - **MP3**: This is a type of digital file format used to store music, audio, or sound. It's a compressed version of a sound recording that makes the file size smaller, so it's easier to store and share. An MP3 file has the MIME type `audio/mpeg`.
-- **MP4**: An MP4 is a type of digital file format used to store video and audio. It serves as a container that holds both the video (images) and the sound (music or speech) in one file. An MP4, can have the MIME type audio/mp4 OR video/mp4, depending on whether it's a video file or audio-only. 
+- **MP4**: An MP4 is a type of digital file format used to store video and audio. It serves as a container that holds both the video (images) and the sound (music or speech) in one file. An MP4, can have the MIME type `audio/mp4` OR `video/mp4`, depending on whether it's a video file or audio-only. 
 
 ## codecs
 


### PR DESCRIPTION
Checklist:
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #65549 

This PR corrects the MP3 MIME type from `audio/mp3` to `audio/mpeg` in the JS V9 curriculum content.
- Updates lecture content and review blocks
- Updates quiz solution to accept `audio/mpeg`
- Adds feedback explaining why `audio/mp3` is incorrect


