### PR TITLE
fix: replace em dash character with &mdash; entity in workshop-quincy…

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-quincys-job-tips/68eaa9ef8a0867071f195f59.md
+++ b/curriculum/challenges/english/blocks/workshop-quincys-job-tips/68eaa9ef8a0867071f195f59.md
@@ -18,7 +18,7 @@ Here's an example:
   <blockquote cite="https://www.freecodecamp.org/news/is-college-worth-it/">
     The first thing you should consider about education is this is an economic decision.
   </blockquote>
-  <p>—Quincy Larson, <cite>Is College Still Worth it? Tips from my 20 Years in Adult Education</cite></p>
+  <p>&mdash;Quincy Larson, <cite>Is College Still Worth it? Tips from my 20 Years in Adult Education</cite></p>
 </div>
 ```
 
@@ -39,11 +39,11 @@ const citeEl = document.querySelector('blockquote + p > cite');
 assert.equal(citeEl?.innerText.trim(), 'How to Learn to Code and Get a Developer Job [Full Book]');
 ```
 
-Ignoring the `cite` element you just added, the text of the `p` element should still be `—Quincy Larson, How to Learn to Code and Get a Developer Job [Full Book]`.
+Ignoring the `cite` element you just added, the text of the `p` element should still be `&mdash;Quincy Larson, How to Learn to Code and Get a Developer Job [Full Book]`.
 
 ```js
 const pElCleanedText = document.querySelector('blockquote + p')?.innerText.trim().replaceAll(/ {2,}/g, ' ');
-assert.equal(pElCleanedText, '—Quincy Larson, How to Learn to Code and Get a Developer Job [Full Book]');
+assert.equal(pElCleanedText, '&mdash;Quincy Larson, How to Learn to Code and Get a Developer Job [Full Book]');
 ```
 
 # --seed--
@@ -73,7 +73,7 @@ assert.equal(pElCleanedText, '—Quincy Larson, How to Learn to Code and Get a D
         </blockquote>
         <p>
       --fcc-editable-region--
-          —Quincy Larson, How to Learn to Code and Get a Developer Job [Full Book]
+          &mdash;Quincy Larson, How to Learn to Code and Get a Developer Job [Full Book]
       --fcc-editable-region--
         </p>
       </section>

--- a/curriculum/challenges/english/blocks/workshop-quincys-job-tips/68eab45aceb7c00fd8de4fed.md
+++ b/curriculum/challenges/english/blocks/workshop-quincys-job-tips/68eab45aceb7c00fd8de4fed.md
@@ -78,7 +78,7 @@ assert.equal(blockquoteEl?.getAttribute('cite'), 'https://www.freecodecamp.org/n
           Can you imagine what it would be like to be a successful developer? To have built software systems that people rely upon?
         </blockquote>
         <p>
-          —Quincy Larson, <cite>How to Learn to Code and Get a Developer Job [Full Book]</cite>
+          &mdash;Quincy Larson, <cite>How to Learn to Code and Get a Developer Job [Full Book]</cite>
         </p>
       </section>
       <section>

--- a/curriculum/challenges/english/blocks/workshop-quincys-job-tips/68eab6a2b37d2f13602d0c3f.md
+++ b/curriculum/challenges/english/blocks/workshop-quincys-job-tips/68eab6a2b37d2f13602d0c3f.md
@@ -88,7 +88,7 @@ assert.equal(forthPEl?.innerText.trim(), 'Go to tech meetups and conferences. Tr
           Can you imagine what it would be like to be a successful developer? To have built software systems that people rely upon?
         </blockquote>
         <p>
-          —Quincy Larson, <cite>How to Learn to Code and Get a Developer Job [Full Book]</cite>
+          &mdash;Quincy Larson, <cite>How to Learn to Code and Get a Developer Job [Full Book]</cite>
         </p>
       </section>
       <section>

--- a/curriculum/challenges/english/blocks/workshop-quincys-job-tips/68ebe9cd7523d340c0b343d3.md
+++ b/curriculum/challenges/english/blocks/workshop-quincys-job-tips/68ebe9cd7523d340c0b343d3.md
@@ -116,7 +116,7 @@ assert.equal(thirdPEl?.innerText.trim(), 'Hang out at hackerspaces and help peop
           Can you imagine what it would be like to be a successful developer? To have built software systems that people rely upon?
         </blockquote>
         <p>
-          —Quincy Larson, <cite>How to Learn to Code and Get a Developer Job [Full Book]</cite>
+          &mdash;Quincy Larson, <cite>How to Learn to Code and Get a Developer Job [Full Book]</cite>
         </p>
       </section>
       <section>
@@ -162,7 +162,7 @@ assert.equal(thirdPEl?.innerText.trim(), 'Hang out at hackerspaces and help peop
           Can you imagine what it would be like to be a successful developer? To have built software systems that people rely upon?
         </blockquote>
         <p>
-          —Quincy Larson, <cite>How to Learn to Code and Get a Developer Job [Full Book]</cite>
+          &mdash;Quincy Larson, <cite>How to Learn to Code and Get a Developer Job [Full Book]</cite>
         </p>
       </section>
 


### PR DESCRIPTION
## Checklist:

- [x] I have read and followed the contribution guidelines.
- [x] I have read and followed the how to open a pull request guide.
- [x] My pull request targets the main branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #65331

## Changes Made:
Replaced em dash character (—) with HTML entity (`&mdash;`) in the following files for consistency:

- [68eaa9ef8a0867071f195f59.md](cci:7://file:///e:/GitHub/Opensource/freeCodeCamp/curriculum/challenges/english/blocks/workshop-quincys-job-tips/68eaa9ef8a0867071f195f59.md:0:0-0:0) (lines 21, 42, 46, 76)
- [68eab45aceb7c00fd8de4fed.md](cci:7://file:///e:/GitHub/Opensource/first-contributions/68eab45aceb7c00fd8de4fed.md:0:0-0:0) (line 81)
- [68eab6a2b37d2f13602d0c3f.md](cci:7://file:///e:/GitHub/Opensource/first-contributions/68eab6a2b37d2f13602d0c3f.md:0:0-0:0) (line 91)
- [68ebe9cd7523d340c0b343d3.md](cci:7://file:///e:/GitHub/Opensource/first-contributions/68ebe9cd7523d340c0b343d3.md:0:0-0:0) (lines 119, 165)

## How I tested:
Changes were made and tested locally using Git CLI and VS Code.