### PR TITLE
Fix/h1 whitespace test

### DIFF
--- a/curriculum/challenges/english/blocks/lab-tower-of-hanoi/68773ee26f332a80bc0295db.md
+++ b/curriculum/challenges/english/blocks/lab-tower-of-hanoi/68773ee26f332a80bc0295db.md
@@ -67,8 +67,7 @@ assert isinstance(hanoi_solver(11), str)
 `) })
 ```
 
-`hanoi_solver(2)` should return `[2, 1] [] []\n[2] [1] []\n[] [1] [2]\n
-[] [] [2, 1]`.
+`hanoi_solver(2)` should return `[2, 1] [] []\n[2] [1] []\n[] [1] [2]\n[] [] [2, 1]`.
 
 ```js
 ({ test: () => runPython(`

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f332a88dc25a0fd25c7687a.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f332a88dc25a0fd25c7687a.md
@@ -38,7 +38,7 @@ assert.equal(document.querySelector('h1')?.parentElement?.tagName, "MAIN");
 Your `h1` element should have the text `CAMPER CAFE`.
 
 ```js
-assert.match(code, /<h1>CAMPER CAFE<\/h1>/);
+assert.match(code, /<h1>\s*CAMPER CAFE\s*<\/h1>/i);
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #65575 

### Description

This PR fixes a test issue in Step 2 of the Cafe Menu challenge.

Previously, the test used:

`assert.match(code, /<h1>CAMPER CAFE<\/h1>/);`

This caused valid solutions like:

`<h1>  CAMPER CAFE  </h1>`

to fail, even though HTML automatically ignores surrounding whitespace inside elements.

The test has been updated to:

`assert.match(code, /<h1>\s*CAMPER CAFE\s*<\/h1>/i);`

This allows flexible whitespace while still enforcing the correct content.

This change aligns the test with actual HTML behavior and prevents false negatives for learners.
