### PR TITLE
fix(curriculum): allow whitespace in Camper Cafe test

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f332a88dc25a0fd25c7687a.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f332a88dc25a0fd25c7687a.md
@@ -38,7 +38,7 @@ assert.equal(document.querySelector('h1')?.parentElement?.tagName, "MAIN");
 Your `h1` element should have the text `CAMPER CAFE`.
 
 ```js
-assert.match(code, /<h1>CAMPER CAFE<\/h1>/);
+assert.match(code, /<h1>\s*CAMPER CAFE\s*<\/h1>/i);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f332a88dc25a0fd25c7687a.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f332a88dc25a0fd25c7687a.md
@@ -38,7 +38,7 @@ assert.equal(document.querySelector('h1')?.parentElement?.tagName, "MAIN");
 Your `h1` element should have the text `CAMPER CAFE`.
 
 ```js
-assert.match(code, /<h1>\s*CAMPER CAFE\s*<\/h1>/i);
+assert.equal(document.querySelector("h1")?.innerText.trim(), "CAMPER CAFE");
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #65575

###Description

This PR fixes a test issue in Step 2 of the Cafe Menu challenge.

Previously, the test used a regex to check the exact `<h1>` markup, which caused valid solutions with surrounding whitespace (for example, `<h1>  CAMPER CAFE  </h1>`) to fail, even though HTML ignores extra whitespace inside elements.

The test has been updated to use a DOM-based assertion with `innerText.trim()`, which correctly reflects how browsers handle whitespace and is consistent with other steps in the workshop.