### PR TITLE
fix(api): return all privacy values so client can update them

### DIFF
--- a/api/src/routes/public/user.test.ts
+++ b/api/src/routes/public/user.test.ts
@@ -258,7 +258,15 @@ describe('userRoutes', () => {
       const lockedUserProfileUI = {
         isLocked: true,
         showAbout: true,
-        showPortfolio: false
+        showCerts: true,
+        showDonation: true,
+        showExperience: true,
+        showHeatMap: true,
+        showLocation: true,
+        showName: true,
+        showPoints: true,
+        showPortfolio: true,
+        showTimeLine: true
       };
       const unlockedUserProfileUI = {
         isLocked: false,

--- a/api/src/schemas/settings/update-my-profile-ui.ts
+++ b/api/src/schemas/settings/update-my-profile-ui.ts
@@ -1,20 +1,10 @@
 import { Type } from '@fastify/type-provider-typebox';
 
+import { profileUI } from '../types.js';
+
 export const updateMyProfileUI = {
   body: Type.Object({
-    profileUI: Type.Object({
-      isLocked: Type.Boolean(),
-      showAbout: Type.Boolean(),
-      showCerts: Type.Boolean(),
-      showDonation: Type.Boolean(),
-      showHeatMap: Type.Boolean(),
-      showLocation: Type.Boolean(),
-      showName: Type.Boolean(),
-      showPoints: Type.Boolean(),
-      showPortfolio: Type.Boolean(),
-      showExperience: Type.Boolean(),
-      showTimeLine: Type.Boolean()
-    })
+    profileUI
   }),
   response: {
     200: Type.Object({

--- a/api/src/schemas/types.ts
+++ b/api/src/schemas/types.ts
@@ -70,17 +70,17 @@ export const surveyTitles = Type.Union([
 ]);
 
 export const profileUI = Type.Object({
-  isLocked: Type.Optional(Type.Boolean()),
-  showAbout: Type.Optional(Type.Boolean()),
-  showCerts: Type.Optional(Type.Boolean()),
-  showDonation: Type.Optional(Type.Boolean()),
-  showHeatMap: Type.Optional(Type.Boolean()),
-  showLocation: Type.Optional(Type.Boolean()),
-  showName: Type.Optional(Type.Boolean()),
-  showPoints: Type.Optional(Type.Boolean()),
-  showPortfolio: Type.Optional(Type.Boolean()),
-  showTimeLine: Type.Optional(Type.Boolean()),
-  showExperience: Type.Optional(Type.Boolean())
+  isLocked: Type.Boolean(),
+  showAbout: Type.Boolean(),
+  showCerts: Type.Boolean(),
+  showDonation: Type.Boolean(),
+  showHeatMap: Type.Boolean(),
+  showLocation: Type.Boolean(),
+  showName: Type.Boolean(),
+  showPoints: Type.Boolean(),
+  showPortfolio: Type.Boolean(),
+  showTimeLine: Type.Boolean(),
+  showExperience: Type.Boolean()
 });
 
 export const experience = Type.Object({

--- a/api/src/schemas/user/get-session-user.ts
+++ b/api/src/schemas/user/get-session-user.ts
@@ -124,7 +124,7 @@ export const getSessionUser = {
             })
           ),
           experience: Type.Optional(Type.Array(experience)),
-          profileUI: Type.Optional(profileUI),
+          profileUI,
           sendQuincyEmail: Type.Union([Type.Null(), Type.Boolean()]), //           // Tri-state: null (likely new user), true (subscribed), false (unsubscribed)
           theme: Type.String(),
           twitter: Type.Optional(Type.String()),

--- a/api/src/utils/normalize.test.ts
+++ b/api/src/utils/normalize.test.ts
@@ -78,7 +78,7 @@ describe('normalize', () => {
       expect(normalizeProfileUI(input)).toEqual(defaultProfileUI);
     });
 
-    test('should convert all "null" values to "undefined"', () => {
+    test('should convert all "null" values to "false"', () => {
       const input = {
         isLocked: null,
         showAbout: false,
@@ -93,17 +93,17 @@ describe('normalize', () => {
         showExperience: null
       };
       expect(normalizeProfileUI(input)).toEqual({
-        isLocked: undefined,
+        isLocked: false,
         showAbout: false,
-        showCerts: undefined,
-        showDonation: undefined,
-        showHeatMap: undefined,
-        showLocation: undefined,
-        showName: undefined,
-        showPoints: undefined,
-        showPortfolio: undefined,
-        showTimeLine: undefined,
-        showExperience: undefined
+        showCerts: false,
+        showDonation: false,
+        showHeatMap: false,
+        showLocation: false,
+        showName: false,
+        showPoints: false,
+        showPortfolio: false,
+        showTimeLine: false,
+        showExperience: false
       });
     });
   });

--- a/api/src/utils/normalize.ts
+++ b/api/src/utils/normalize.ts
@@ -124,9 +124,9 @@ export const normalizeChallengeType = (
  */
 export const normalizeProfileUI = (
   maybeProfileUI: ProfileUI | null
-): NoNullProperties<ProfileUI> => {
+): DefaultToFalse<ProfileUI> => {
   return maybeProfileUI
-    ? removeNulls(maybeProfileUI)
+    ? normalizeFlags(maybeProfileUI)
     : {
         isLocked: true,
         showAbout: false,


### PR DESCRIPTION
The client doesn't default missing privacy values to false and so makes a bad request if they're missing

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes https://github.com/freeCodeCamp/freeCodeCamp/issues/65600

<!-- Feel free to add any additional description of changes below this line -->
