### PR TITLE
fix(curriculum): clarify superscript element question wording

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-specialized-semantic-elements/672995ffdfd2f337f5f215f8.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-specialized-semantic-elements/672995ffdfd2f337f5f215f8.md
@@ -129,7 +129,7 @@ The example should represent an exponent with a number displayed above the norma
 
 ## --text--
 
-What should be used instead of the superscript element if you want to style text with a raised baseline for typographical reasons?
+What should be used instead of the superscript element when text is raised purely for visual or styling purposes?
 
 ## --answers--
 


### PR DESCRIPTION
Checklist:
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #65614
### Description
This updates the quiz question in the "How Do You Display Mathematical Equations and Chemical Formulas in HTML?" lecture to correctly distinguish semantic usage of the `<sup>` element vs. using CSS for purely visual styling.

The previous wording referred to "typographical reasons" while expecting the answer "CSS", which could be misleading since `<sup>` is intended for typographical conventions.