### PR TITLE
fix(ui): show username rules in a tooltip

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -330,6 +330,9 @@
       "sound-mode": "Campfire Mode",
       "keyboard-shortcuts": "Enable Keyboard Shortcuts"
     },
+    "tooltips": {
+      "username": "Your username must be longer than 3 characters,be lowercase, contain approved characters(a-z, 0-9, dashes, and underscores), and not be an HTTP status code"
+    },
     "headings": {
       "account": "Account",
       "certs": "Certifications",

--- a/client/src/components/profile/components/username.tsx
+++ b/client/src/components/profile/components/username.tsx
@@ -215,6 +215,7 @@ class UsernameSettings extends Component<UsernameProps, UsernameState> {
               name='username-settings'
               onChange={this.handleChange}
               value={formValue}
+              title={t('settings.tooltips.username')}
               id='username-settings'
             />
           </FormGroup>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #65626

<!-- Feel free to add any additional description of changes below this line -->
A very quick PR that demonstrates how I think the issue should be solved. I blocked it because no discussion has been done as to simple display the help inside of a label as opposed to the tooltip this PR provided. 