### PR TITLE
fix: use inline code for sup element in lecture question

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-specialized-semantic-elements/672995ffdfd2f337f5f215f8.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-specialized-semantic-elements/672995ffdfd2f337f5f215f8.md
@@ -129,7 +129,7 @@ The example should represent an exponent with a number displayed above the norma
 
 ## --text--
 
-What should be used instead of the superscript element if you want to style text with a raised baseline for typographical reasons?
+What should be used instead of the `sup` element if you want to style text with a raised baseline for typographical reasons?
 
 ## --answers--
 


### PR DESCRIPTION
This pull request fixes a Markdown formatting issue in a curriculum lecture.

The question text now uses inline code formatting (`sup`) instead of plain text when referring to the HTML element, preventing unintended HTML rendering and aligning with freeCodeCamp curriculum style guidelines.
