### PR TITLE
fix(curriculum): correct typo in depth first search lesson

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-understanding-graphs-and-trees/68baa5e4f0e07f079245ca08.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-graphs-and-trees/68baa5e4f0e07f079245ca08.md
@@ -150,7 +150,7 @@ Depth-first search (DFS) is commonly used to solve puzzles with a single solutio
 
 This algorithm can be implemented using recursion or a stack data structure to keep track of the visited nodes.
 
-Stacks follow the LIFO (last in, first out) method, where the last node that was added to the stack is the first one to be removed from the stack
+Stacks follow the LIFO (last in, first out) method, where the last node that was added to the stack is the first one to be removed from the stack.
 
 The algorithm works like this:
 

--- a/curriculum/challenges/english/blocks/lecture-understanding-graphs-and-trees/68baa5e4f0e07f079245ca08.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-graphs-and-trees/68baa5e4f0e07f079245ca08.md
@@ -150,7 +150,7 @@ Depth-first search (DFS) is commonly used to solve puzzles with a single solutio
 
 This algorithm can be implemented using recursion or a stack data structure to keep track of the visited nodes.
 
-Stacks follow the LIFO (last in, first out) method, where the last node that was added to the stack is the first one to the removed from the stack.
+Stacks follow the LIFO (last in, first out) method, where the last node that was added to the stack is the first one to be removed from the stack
 
 The algorithm works like this:
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #65646

<!-- Feel free to add any additional description of changes below this line -->

This PR fixes a small grammatical typo in the Depth First Search lesson.

The phrase “to the removed from the stack” has been corrected to
“to be removed from the stack” for clarity.

Fixes #65646

