### PR TITLE
refactor: use eslint directly in lint-staged

### DIFF
--- a/packages/eslint-config/.lintstagedrc.js
+++ b/packages/eslint-config/.lintstagedrc.js
@@ -19,10 +19,7 @@ export const createLintStagedConfig = cwd => {
       // just run prettier.
       return lintableFiles.length === 0
         ? prettierCommand
-        : [
-            'turbo lint -- --fix ' + lintableFiles.join(' '),
-            ...prettierCommand
-          ];
+        : ['eslint --fix ' + lintableFiles.join(' '), ...prettierCommand];
     },
     '*.!(mjs|js|ts|tsx|css|md)': files =>
       files.map(filename => `prettier --write --ignore-unknown '${filename}'`),


### PR DESCRIPTION
This is a compromise.  It can fail if the contributor has not run other commands (e.g. develop) recently, but it means that the 'lint' command itself can be more general. i.e. run more than one type of linting at once without having to have commands for each.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
