### PR TITLE
fix: align flash banner content properly

### DIFF
--- a/client/src/components/Flash/flash.css
+++ b/client/src/components/Flash/flash.css
@@ -4,8 +4,10 @@ the CSS rules of `ui-components`'s Alert.
 */
 div.flash-message {
   display: flex;
-  justify-content: space-around;
+  justify-content: space-between;
+  align-items: center;
   flex-direction: row;
+  gap: 0.5rem;
   padding-top: 3px;
   padding-bottom: 3px;
   position: fixed;


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the contribution guidelines.
- [x] I have read and followed the how to open a pull request guide.
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes locally.

Closes #65625

### Description

Fixes alignment of the flash/subscription banner so the message text and close button are properly centered.

### Changes

- Updated flexbox alignment in `client/src/components/Flash/flash.css`
- Centered content vertically and improved horizontal spacing

### Testing

- Verified locally using a flash banner
