### PR TITLE
fix(curriculum): enforce powerSource initial state value in step 3

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-superhero-application-form/680fc849a6f2be0a8597c593.md
+++ b/curriculum/challenges/english/blocks/workshop-superhero-application-form/680fc849a6f2be0a8597c593.md
@@ -32,13 +32,9 @@ Your `powerSource` and `setPowerSource` should use the `useState` hook.
 Your `useState` hook for `powerSource` should have an initial value of empty string.
 
 ```js
-  const abuseState = __helpers.spyOn(React, "useState");
-  const script = [...document.querySelectorAll("script")].find((s) => s.dataset.src ===  "index.jsx").innerText;
-  const exports = {};
-  const _a = eval(script);
-  const _b = await __helpers.prepTestComponent(exports.SuperheroForm);
-
-  assert.equal(abuseState.calls[2]?.[0], "");
+const queryValue = code.match(/(?:const|let|var)\s+\[\s*powerSource\s*,\s*setPowerSource\s*\]\s*=\s*useState\(\s*(['"])(.*?)\1\s*\)/)?.[2] ?? null;
+assert.typeOf(queryValue, "string");
+assert.lengthOf(queryValue, 0);
 ```
 
 You should use array destructuring to set a `powers` state variable and a `setPowers` setter.

--- a/curriculum/challenges/english/blocks/workshop-superhero-application-form/680fc849a6f2be0a8597c593.md
+++ b/curriculum/challenges/english/blocks/workshop-superhero-application-form/680fc849a6f2be0a8597c593.md
@@ -32,9 +32,13 @@ Your `powerSource` and `setPowerSource` should use the `useState` hook.
 Your `useState` hook for `powerSource` should have an initial value of empty string.
 
 ```js
-const queryValue = code.match(/(?:const|let|var)\s+\[\s*powerSource\s*,\s*setPowerSource\s*\]\s*=\s*useState\(\s*(['"])(.*?)\1\s*\)/)?.[2] ?? null;
-assert.typeOf(queryValue, "string");
-assert.lengthOf(queryValue, 0);
+  const abuseState = __helpers.spyOn(React, "useState");
+  const script = [...document.querySelectorAll("script")].find((s) => s.dataset.src ===  "index.jsx").innerText;
+  const exports = {};
+  const _a = eval(script);
+  const _b = await __helpers.prepTestComponent(exports.SuperheroForm);
+
+  assert.strictEqual(abuseState.calls[2]?.[0], "");
 ```
 
 You should use array destructuring to set a `powers` state variable and a `setPowers` setter.


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.


Closes #65621

This change ensures that `powerSource` only passes when initialized with an empty string (`useState('')`) and does not allow `useState([])` to pass.

I noticed the same pattern in Step 2 and can update it similarly if needed.