### PR TITLE
fix(curriculum): add values to radio inputs in hotel feedback form

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a9843525e9fa8046d709b7.md
+++ b/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a9843525e9fa8046d709b7.md
@@ -76,9 +76,9 @@ assert.strictEqual(document.querySelector('button')?.textContent.trim(), 'Submit
 
         <fieldset>
           <legend>Was this your first time at our hotel?</legend>
-          <input id="yes-option" type="radio" name="hotel-stay" />
+          <input id="yes-option" type="radio" name="hotel-stay" value="yes"/>
           <label for="yes-option">Yes</label>
-          <input id="no-option" type="radio" name="hotel-stay" />
+          <input id="no-option" type="radio" name="hotel-stay" value="no" />
           <label for="no-option">No</label>
         </fieldset>
 
@@ -188,9 +188,9 @@ assert.strictEqual(document.querySelector('button')?.textContent.trim(), 'Submit
 
         <fieldset>
           <legend>Was this your first time at our hotel?</legend>
-          <input id="yes-option" type="radio" name="hotel-stay" />
+          <input id="yes-option" type="radio" name="hotel-stay" value="yes"/>
           <label for="yes-option">Yes</label>
-          <input id="no-option" type="radio" name="hotel-stay" />
+          <input id="no-option" type="radio" name="hotel-stay" value="no"/>
           <label for="no-option">No</label>
         </fieldset>
 


### PR DESCRIPTION
 Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request).
- [x] My pull request targets the main branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.


Closes #65677
This pull request adds missing `value` attributes to the radio inputs in step 33 of the Hotel Feedback Form workshop.

Including values for the radio buttons ensures the example reflects proper HTML form submission behavior and follows best practices for learners.

