### PR TITLE
Harden GitHub Actions workflow against potential shell injection

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -29,12 +29,16 @@ jobs:
     steps:
       - name: Setup
         id: setup
+        env:
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+          INPUT_SHOW_UPCOMING_CHANGES: ${{ inputs.show_upcoming_changes }}
+          INPUT_API_LOG_LVL: ${{ inputs.api_log_lvl || 'info' }}
         run: |
-          BRANCH="${{ github.ref_name }}"
+          BRANCH="$GITHUB_REF_NAME"
           echo "Current branch: $BRANCH"
 
           # Convert boolean input to string 'true' or 'false'
-          if [[ "${{ inputs.show_upcoming_changes }}" == "true" ]]; then
+          if [[ "$INPUT_SHOW_UPCOMING_CHANGES" == "true" ]]; then
             echo "show_upcoming_changes=true" >> $GITHUB_OUTPUT
           else
             echo "show_upcoming_changes=false" >> $GITHUB_OUTPUT
@@ -45,13 +49,13 @@ jobs:
               echo "site_tld=org" >> $GITHUB_OUTPUT
               echo "tgt_env_short=prd" >> $GITHUB_OUTPUT
               echo "tgt_env_long=production" >> $GITHUB_OUTPUT
-              echo "api_log_lvl=${{ inputs.api_log_lvl || 'info' }}" >> $GITHUB_OUTPUT
+              echo "api_log_lvl=$INPUT_API_LOG_LVL" >> $GITHUB_OUTPUT
               ;;
             *)
               echo "site_tld=dev" >> $GITHUB_OUTPUT
               echo "tgt_env_short=stg" >> $GITHUB_OUTPUT
               echo "tgt_env_long=staging" >> $GITHUB_OUTPUT
-              echo "api_log_lvl=${{ inputs.api_log_lvl || 'info' }}" >> $GITHUB_OUTPUT
+              echo "api_log_lvl=$INPUT_API_LOG_LVL" >> $GITHUB_OUTPUT
               ;;
           esac
 


### PR DESCRIPTION
What this PR does

This PR updates the deploy-api GitHub Actions workflow to avoid directly interpolating GitHub context values and workflow inputs inside a run: shell script.

Instead, the values are first assigned to environment variables via the env: block and then safely referenced from the shell with proper quoting.

Why this change is needed

Static analysis flagged the workflow for potential shell injection risk caused by using expressions like ${{ github.ref_name }} and ${{ inputs.* }} directly inside the shell script.

While the workflow’s behavior is unchanged, directly interpolating untrusted values into a shell context can be unsafe and is discouraged by GitHub Actions security guidance and common SAST rules.

Summary of changes

Move GitHub context and workflow inputs into environment variables using env:

Reference only shell variables inside the run: script

Preserve existing logic and outputs without functional changes

Security impact

This change reduces the risk of shell injection by ensuring all user-controlled values cross a controlled environment boundary before being used by the shell.

Backwards compatibility

No behavior changes

No interface changes

Outputs and deployment logic remain identical

Notes on policy compliance

No application logic was modified

No secrets, credentials, or permissions were changed

The change aligns with GitHub Actions security best practices

No generated content is introduced into runtime code paths