### PR TITLE
fix(curriculum): add value attribute instruction for hotel feedback radios

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a9521bc70162712caf118d.md
+++ b/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a9521bc70162712caf118d.md
@@ -20,7 +20,7 @@ Here is an example of two radio buttons:
 
 In this example, the radio buttons are grouped together by using the same `name` attribute value. This means that only one radio button can be selected at a time.
 
-Below your `legend` element, add a `radio` button with the `id` set to `"yes-option"`, and the `name` attribute set to `"hotel-stay"`.
+Below your `legend` element, add a `radio` button with the `id` set to `"yes-option"`, the `name` attribute set to `"hotel-stay"`, and a `value` attribute set to `"yes"`.
 
 Below your `radio` button, add a `label` element with the text `Yes` and a `for` attribute set to `"yes-option"`.
 
@@ -42,6 +42,15 @@ Your `radio` button should have a `name` attribute set to `"hotel-stay"`.
 
 ```js
 assert.strictEqual(document.querySelector('fieldset:nth-of-type(2) legend + input[type="radio"]')?.name, 'hotel-stay');
+```
+
+Your radio button should have a `value` attribute set to `"yes"`.
+
+```js
+assert.strictEqual(
+  document.querySelector('fieldset:nth-of-type(2) legend + input[type="radio"]')?.value,
+  'yes'
+);
 ```
 
 You should have a `label` element below your `radio` button.

--- a/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a954b2bcddba72076c1857.md
+++ b/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a954b2bcddba72076c1857.md
@@ -7,7 +7,7 @@ dashedName: step-17
 
 # --description--
 
-Below your `label` element, add a `radio` button with the `id` set to `"no-option"`, and the name attribute set to `"hotel-stay"`.
+Below your `label` element, add a `radio` button with the `id` set to `"no-option"`, the `name` attribute set to `"hotel-stay"`, and a `value` attribute set to `"no"`. 
 
 Below your new `radio` button, add another `label` element with the `for` attribute set to `"no-option"`. The text for the `label` should be `No`.
 
@@ -37,6 +37,15 @@ Your `input` element should have a `name` attribute of `"hotel-stay"`.
 
 ```js
 assert.strictEqual(document.querySelector('fieldset:nth-of-type(2) label + input')?.name, 'hotel-stay');
+```
+
+Your input element should have a `value` attribute set to `"no"`.
+
+```js
+assert.strictEqual(
+  document.querySelector('fieldset:nth-of-type(2) label + input')?.value,
+  'no'
+);
 ```
 
 You should have a second `label` element below your second `input` element.
@@ -97,7 +106,7 @@ assert.strictEqual(document.querySelector('fieldset:nth-of-type(2) input:nth-of-
         </fieldset>
         <fieldset>
           <legend>Was this your first time at our hotel?</legend>
-          <input id="yes-option" type="radio" name="hotel-stay" />
+          <input id="yes-option" type="radio" name="hotel-stay" value="yes" />
           <label for="yes-option">Yes</label>
           --fcc-editable-region--
           

--- a/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a9577022877d72d8f43b4f.md
+++ b/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a9577022877d72d8f43b4f.md
@@ -74,9 +74,9 @@ assert.strictEqual(document.querySelector('fieldset:nth-of-type(3) legend')?.inn
 
         <fieldset>
           <legend>Was this your first time at our hotel?</legend>
-          <input id="yes-option" type="radio" name="hotel-stay" />
+          <input id="yes-option" type="radio" name="hotel-stay" value="yes" />
           <label for="yes-option">Yes</label>
-          <input id="no-option" type="radio" name="hotel-stay" />
+          <input id="no-option" type="radio" name="hotel-stay" value="no" />
           <label for="no-option">No</label>
         </fieldset>
 

--- a/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a95d0eff8168747805f1f3.md
+++ b/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a95d0eff8168747805f1f3.md
@@ -112,9 +112,9 @@ assert.strictEqual(document.querySelector("fieldset:nth-of-type(3) input[type='c
 
         <fieldset>
           <legend>Was this your first time at our hotel?</legend>
-          <input id="yes-option" type="radio" name="hotel-stay" />
+          <input id="yes-option" type="radio" name="hotel-stay" value="yes" />
           <label for="yes-option">Yes</label>
-          <input id="no-option" type="radio" name="hotel-stay" />
+          <input id="no-option" type="radio" name="hotel-stay" value="no" />
           <label for="no-option">No</label>
         </fieldset>
 

--- a/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a96127422411756204bc1b.md
+++ b/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a96127422411756204bc1b.md
@@ -96,9 +96,9 @@ assert.strictEqual(document.querySelector('fieldset:nth-of-type(3) input[type="c
 
         <fieldset>
           <legend>Was this your first time at our hotel?</legend>
-          <input id="yes-option" type="radio" name="hotel-stay" />
+          <input id="yes-option" type="radio" name="hotel-stay" value="yes" />
           <label for="yes-option">Yes</label>
-          <input id="no-option" type="radio" name="hotel-stay" />
+          <input id="no-option" type="radio" name="hotel-stay" value="no" />
           <label for="no-option">No</label>
         </fieldset>
 

--- a/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a962954f4e0d76223b37ed.md
+++ b/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a962954f4e0d76223b37ed.md
@@ -130,9 +130,9 @@ assert.strictEqual(document.querySelector('fieldset:nth-of-type(3) input[value="
 
         <fieldset>
           <legend>Was this your first time at our hotel?</legend>
-          <input id="yes-option" type="radio" name="hotel-stay" />
+          <input id="yes-option" type="radio" name="hotel-stay" value="yes" />
           <label for="yes-option">Yes</label>
-          <input id="no-option" type="radio" name="hotel-stay" />
+          <input id="no-option" type="radio" name="hotel-stay" value="no" />
           <label for="no-option">No</label>
         </fieldset>
 

--- a/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a9689b1bf24b7750898a1b.md
+++ b/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a9689b1bf24b7750898a1b.md
@@ -92,9 +92,9 @@ assert.strictEqual(document.querySelector('fieldset:nth-of-type(3) input[value="
 
         <fieldset>
           <legend>Was this your first time at our hotel?</legend>
-          <input id="yes-option" type="radio" name="hotel-stay" />
+          <input id="yes-option" type="radio" name="hotel-stay" value="yes" />
           <label for="yes-option">Yes</label>
-          <input id="no-option" type="radio" name="hotel-stay" />
+          <input id="no-option" type="radio" name="hotel-stay" value="no" />
           <label for="no-option">No</label>
         </fieldset>
 

--- a/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a969951120be7818d8ee49.md
+++ b/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a969951120be7818d8ee49.md
@@ -92,9 +92,9 @@ assert.strictEqual(document.querySelectorAll('fieldset:nth-of-type(4) legend + l
 
         <fieldset>
           <legend>Was this your first time at our hotel?</legend>
-          <input id="yes-option" type="radio" name="hotel-stay" />
+          <input id="yes-option" type="radio" name="hotel-stay" value="yes" />
           <label for="yes-option">Yes</label>
-          <input id="no-option" type="radio" name="hotel-stay" />
+          <input id="no-option" type="radio" name="hotel-stay" value="no" />
           <label for="no-option">No</label>
         </fieldset>
 

--- a/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a96b01f33ef178dfca9e42.md
+++ b/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a96b01f33ef178dfca9e42.md
@@ -84,9 +84,9 @@ assert.exists(document.querySelector('select[id="service"]'));
 
         <fieldset>
           <legend>Was this your first time at our hotel?</legend>
-          <input id="yes-option" type="radio" name="hotel-stay" />
+          <input id="yes-option" type="radio" name="hotel-stay" value="yes" />
           <label for="yes-option">Yes</label>
-          <input id="no-option" type="radio" name="hotel-stay" />
+          <input id="no-option" type="radio" name="hotel-stay" value="no" />
           <label for="no-option">No</label>
         </fieldset>
 

--- a/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a972137acd1179fa3fe8a0.md
+++ b/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a972137acd1179fa3fe8a0.md
@@ -129,9 +129,9 @@ assert.strictEqual(document.querySelector('option[value="excellent"]')?.textCont
 
         <fieldset>
           <legend>Was this your first time at our hotel?</legend>
-          <input id="yes-option" type="radio" name="hotel-stay" />
+          <input id="yes-option" type="radio" name="hotel-stay" value="yes" />
           <label for="yes-option">Yes</label>
-          <input id="no-option" type="radio" name="hotel-stay" />
+          <input id="no-option" type="radio" name="hotel-stay" value="no" />
           <label for="no-option">No</label>
         </fieldset>
 

--- a/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a975260401487af226b290.md
+++ b/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a975260401487af226b290.md
@@ -66,9 +66,9 @@ assert.exists(document.querySelector('option[value="excellent"][selected]'));
 
         <fieldset>
           <legend>Was this your first time at our hotel?</legend>
-          <input id="yes-option" type="radio" name="hotel-stay" />
+          <input id="yes-option" type="radio" name="hotel-stay" value="yes" />
           <label for="yes-option">Yes</label>
-          <input id="no-option" type="radio" name="hotel-stay" />
+          <input id="no-option" type="radio" name="hotel-stay" value="no" />
           <label for="no-option">No</label>
         </fieldset>
 

--- a/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a975c259525b7bc2d5c776.md
+++ b/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a975c259525b7bc2d5c776.md
@@ -80,9 +80,9 @@ assert.exists(document.querySelector('label + select[name="food"]'));
 
         <fieldset>
           <legend>Was this your first time at our hotel?</legend>
-          <input id="yes-option" type="radio" name="hotel-stay" />
+          <input id="yes-option" type="radio" name="hotel-stay" value="yes" />
           <label for="yes-option">Yes</label>
-          <input id="no-option" type="radio" name="hotel-stay" />
+          <input id="no-option" type="radio" name="hotel-stay" value="no" />
           <label for="no-option">No</label>
         </fieldset>
 

--- a/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a97ca8c4cbae7d0bb6e0ad.md
+++ b/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a97ca8c4cbae7d0bb6e0ad.md
@@ -138,9 +138,9 @@ assert.exists(document.querySelector('fieldset:nth-of-type(4) select#food option
 
         <fieldset>
           <legend>Was this your first time at our hotel?</legend>
-          <input id="yes-option" type="radio" name="hotel-stay" />
+          <input id="yes-option" type="radio" name="hotel-stay" value="yes" />
           <label for="yes-option">Yes</label>
-          <input id="no-option" type="radio" name="hotel-stay" />
+          <input id="no-option" type="radio" name="hotel-stay" value="no" />
           <label for="no-option">No</label>
         </fieldset>
 

--- a/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a97f40ddd40d7deb0618b7.md
+++ b/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a97f40ddd40d7deb0618b7.md
@@ -66,9 +66,9 @@ assert.strictEqual(document.querySelector('label[for="comments"]')?.textContent.
 
         <fieldset>
           <legend>Was this your first time at our hotel?</legend>
-          <input id="yes-option" type="radio" name="hotel-stay" />
+          <input id="yes-option" type="radio" name="hotel-stay" value="yes" />
           <label for="yes-option">Yes</label>
-          <input id="no-option" type="radio" name="hotel-stay" />
+          <input id="no-option" type="radio" name="hotel-stay" value="no" />
           <label for="no-option">No</label>
         </fieldset>
 

--- a/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a9824ac5d9f77ec304969f.md
+++ b/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a9824ac5d9f77ec304969f.md
@@ -70,9 +70,9 @@ assert.exists(document.querySelector('label + textarea'));
 
         <fieldset>
           <legend>Was this your first time at our hotel?</legend>
-          <input id="yes-option" type="radio" name="hotel-stay" />
+          <input id="yes-option" type="radio" name="hotel-stay" value="yes" />
           <label for="yes-option">Yes</label>
-          <input id="no-option" type="radio" name="hotel-stay" />
+          <input id="no-option" type="radio" name="hotel-stay" value="no" />
           <label for="no-option">No</label>
         </fieldset>
 

--- a/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a9836b339fed7f9a8fe35a.md
+++ b/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a9836b339fed7f9a8fe35a.md
@@ -78,9 +78,9 @@ assert.exists(document.querySelector('textarea[rows="10"]'));
 
         <fieldset>
           <legend>Was this your first time at our hotel?</legend>
-          <input id="yes-option" type="radio" name="hotel-stay" />
+          <input id="yes-option" type="radio" name="hotel-stay" value="yes" />
           <label for="yes-option">Yes</label>
-          <input id="no-option" type="radio" name="hotel-stay" />
+          <input id="no-option" type="radio" name="hotel-stay" value="no" />
           <label for="no-option">No</label>
         </fieldset>
 

--- a/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a9843525e9fa8046d709b7.md
+++ b/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a9843525e9fa8046d709b7.md
@@ -76,9 +76,9 @@ assert.strictEqual(document.querySelector('button')?.textContent.trim(), 'Submit
 
         <fieldset>
           <legend>Was this your first time at our hotel?</legend>
-          <input id="yes-option" type="radio" name="hotel-stay" />
+          <input id="yes-option" type="radio" name="hotel-stay" value="yes" />
           <label for="yes-option">Yes</label>
-          <input id="no-option" type="radio" name="hotel-stay" />
+          <input id="no-option" type="radio" name="hotel-stay" value="no" />
           <label for="no-option">No</label>
         </fieldset>
 
@@ -188,9 +188,9 @@ assert.strictEqual(document.querySelector('button')?.textContent.trim(), 'Submit
 
         <fieldset>
           <legend>Was this your first time at our hotel?</legend>
-          <input id="yes-option" type="radio" name="hotel-stay" />
+          <input id="yes-option" type="radio" name="hotel-stay" value="yes" />
           <label for="yes-option">Yes</label>
-          <input id="no-option" type="radio" name="hotel-stay" />
+          <input id="no-option" type="radio" name="hotel-stay" value="no" />
           <label for="no-option">No</label>
         </fieldset>
 

--- a/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66ad24c7eb8c121000c603a6.md
+++ b/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66ad24c7eb8c121000c603a6.md
@@ -66,9 +66,9 @@ assert.exists(document.querySelector("input#reputation[checked]"));
 
         <fieldset>
           <legend>Was this your first time at our hotel?</legend>
-          <input id="yes-option" type="radio" name="hotel-stay" />
+          <input id="yes-option" type="radio" name="hotel-stay" value="yes" />
           <label for="yes-option">Yes</label>
-          <input id="no-option" type="radio" name="hotel-stay" />
+          <input id="no-option" type="radio" name="hotel-stay" value="no" />
           <label for="no-option">No</label>
         </fieldset>
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #65677

Adds instruction and tests in steps 16 and 17 to require value attributes
on radio inputs in the Hotel Feedback Form workshop.

Updates downstream seed code to include the completed radio inputs,
ensuring consistent form behavior and best practices for learners.