### PR TITLE
Fix prevent background scrolling when mobile menu is open

### DIFF
--- a/client/src/components/Header/components/menu-button.tsx
+++ b/client/src/components/Header/components/menu-button.tsx
@@ -1,4 +1,4 @@
-import React, { RefObject } from 'react';
+import React, { RefObject, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faBars } from '@fortawesome/free-solid-svg-icons';
@@ -18,6 +18,17 @@ const MenuButton = ({
   hideMenu
 }: MenuButtonProps): JSX.Element => {
   const { t } = useTranslation();
+  useEffect(() => {
+    if (displayMenu === true) {
+      document.body.classList.add('menu-open');
+    } else {
+      document.body.classList.remove('menu-open');
+    }
+
+    return () => {
+      document.body.classList.remove('menu-open');
+  };
+}, [displayMenu]);  
 
   // Will close the menu if the user Shift+Tabs from the menu button.
   const handleBlur = (event: React.FocusEvent<HTMLButtonElement>): void => {

--- a/client/src/components/Header/header.css
+++ b/client/src/components/Header/header.css
@@ -5,6 +5,12 @@
   z-index: var(--z-index-site-header);
 }
 
+body.menu-open {
+  overflow: hidden;
+  position: fixed;
+  width: 100%;
+}
+
 .skip-to-content-button {
   position: absolute;
   top: calc(var(--header-height) + 10px);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #65673

<!-- Feel free to add any additional description of changes below this line -->

## Description

On mobile devices, the page could still be scrolled while the hamburger navigation menu was open. This behavior was caused by the `body` remaining scrollable even when the menu overlay was displayed.

This change adds a state-driven scroll lock that is applied only while the mobile menu is open and removed when it closes.

## Changes

Added a side-effect tied to the displayMenu state to toggle a scroll-lock class on <body>

Introduced a menu-open CSS rule to prevent background scrolling on mobile

Ensured cleanup runs when the menu closes or the component unmounts

## Expected Behavior

Opening the hamburger menu prevents background page scrolling

Closing the menu restores normal scrolling behavior

Overlay content remains scrollable as expected

## Verification

Verified using Chrome DevTools mobile emulation

Manually tested by toggling the hamburger menu open and closed

Confirmed <body> scroll lock is applied only while the menu is visible