### PR TITLE
fix: prevent background scroll when mobile/website menu is open

### DIFF
--- a/client/src/components/Header/index.tsx
+++ b/client/src/components/Header/index.tsx
@@ -72,14 +72,21 @@ class Header extends React.Component<Props, { displayMenu: boolean }> {
 
   showMenu(): void {
     this.setState({ displayMenu: true }, () => {
+      document.body.style.overflow = 'hidden';
       document.addEventListener('click', this.handleClickOutside);
     });
   }
 
   hideMenu(): void {
     this.setState({ displayMenu: false }, () => {
+      document.body.style.overflow = '';
       document.removeEventListener('click', this.handleClickOutside);
     });
+  }
+
+  componentWillUnmount(): void {
+    document.body.style.overflow = '';
+    document.removeEventListener('click', this.handleClickOutside);
   }
 
   render(): JSX.Element {


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the contribution guidelines.
- [x] I have read and followed the how to open a pull request guide.
- [x] My pull request targets the main branch of freeCodeCamp.
- [x] I have tested these changes locally.

Closes #65673

### Summary

This PR prevents the background page from scrolling when the mobile navigation menu is open on mobile devices.

### Changes

 Updated `client/src/components/Header/index.tsx`
 Added `document.body.style.overflow = 'hidden'` when menu opens
 Restored scrolling when the menu closes or component unmounts

### Testing

 Opened the site in a desktop browser
 Enabled mobile view using DevTools (device toolbar)
 Opened the hamburger menu
 Verified that background scrolling is disabled
