### PR TITLE
chore(curriculum): clarify Step 9 print instruction

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-report-card-printer/694648acde178bb8202d9516.md
+++ b/curriculum/challenges/english/blocks/workshop-report-card-printer/694648acde178bb8202d9516.md
@@ -11,7 +11,7 @@ The output is `False`, which shows that `score` is not an `int`.
 
 Another common kind of number in Python is `float`, which represents a number with decimals. Replace `int` with `float` in the existing `isinstance()` call to confirm this.
 
-Finally, print `score` and its data type to complete the report card.
+Finally, print `score` and its data type below the last print call to complete the report card.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #65693

<!-- Feel free to add any additional description of changes below this line -->

This PR improves the clarity of the instructions in Step 9, where multiple campers are consistently running into the same confusion.

Currently, the step asks learners to:

update the existing 'isinstance()' check, and

print 'score' and its data type

However, the wording does not make it explicit that the second requirement should be done using a new 'print()' statement, added below the existing one. As a result, many campers attempt to add additional arguments to the existing 'print()' call, which causes the tests to fail.

## What changed

The final instruction line has been updated to:

“Finally, print score and its data type below the last print call to complete the report card.”

This small wording change keeps the step structure intact while clearly signaling that:

the existing 'print()' should be updated first, and

a new 'print()' statement should be added afterward.

## Why this helps

Aligns with how previous steps trained learners to modify existing lines

Removes ambiguity without changing code, tests, or step order

Addresses the root cause of repeated help requests for this step

## Alternative options (not implemented)

If further clarity is desired in the future, two other approaches could also work:

1. Explicit intent without showing code
For example, stating that learners should end the step with two print statements related to score.

2. Separate the actions into two steps
One step for updating the isinstance() check and a following step for printing score and its type. This would be pedagogically clean, but more invasive.

For now, the wording update provides a minimal, low-risk improvement that resolves the confusion.