### PR TITLE
fix(curriculum): remove double punctuation after inline code and quotes

### DIFF
--- a/curriculum/challenges/english/blocks/es-a1-learn-greetings-during-the-day/68c488abd71a3e27190965e0.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-greetings-during-the-day/68c488abd71a3e27190965e0.md
@@ -9,7 +9,7 @@ lang: es
 
 # --description--
 
-Elena is starting a conversation. She's using a simple and very common phrase to say "Hi, good morning!".
+Elena is starting a conversation. She's using a simple and very common phrase to say "Hi, good morning!"
 
 # --instructions--
 

--- a/curriculum/challenges/english/blocks/es-a1-learn-meet-angela-and-basti/690f5a015ec6842542a57d60.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-meet-angela-and-basti/690f5a015ec6842542a57d60.md
@@ -12,7 +12,7 @@ lang: es
 
 The phrase **`Soy de` + [country]** is the most common way to say where you are from.
 
-It's usually the direct answer to the question `¿De dónde eres?`. 
+It's usually the direct answer to the question `¿De dónde eres?` 
 
 This phrase is equivalent to saying "I am from + [country]".
 

--- a/curriculum/challenges/english/blocks/es-a1-learn-meet-angela-and-basti/690f61b1a2b78d305e825d13.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-meet-angela-and-basti/690f61b1a2b78d305e825d13.md
@@ -36,7 +36,7 @@ This is a regional variation of `tú` ("you").
 
 # --explanation--
 
-`¿Y vos?` is a regional way to return the question. It's equivalent to "And you?".
+`¿Y vos?` is a regional way to return the question. It's equivalent to "And you?"
 
 # --scene--
 

--- a/curriculum/challenges/english/blocks/es-a1-learn-meet-angela-and-basti/690f68686781213c9eac4b65.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-meet-angela-and-basti/690f68686781213c9eac4b65.md
@@ -44,9 +44,9 @@ False
 
 # --explanation--
 
-Ángela is asking Sebastián `¿Cuántos años tienes?`.
+Ángela is asking Sebastián `¿Cuántos años tienes?`
 
-This question is equivalent to "How old are you?".
+This question is equivalent to "How old are you?"
 
 Therefore, this is true because Ángela is asking Sebastián about his age. 
 

--- a/curriculum/challenges/english/blocks/es-a1-learn-meet-angela-and-basti/690f6ad7e1192b412653189c.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-meet-angela-and-basti/690f6ad7e1192b412653189c.md
@@ -36,7 +36,7 @@ This is the `tú` conjugation of the verb `tener` ("to have").
 
 # --explanation--
 
-The question is `¿Cuántos años tienes?`.
+The question is `¿Cuántos años tienes?`
 
 `Cuántos` means "How many" and `años` means "years". 
 

--- a/curriculum/challenges/english/blocks/es-a1-learn-meet-angela-and-basti/690f6d6c27b78644af22a833.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-meet-angela-and-basti/690f6d6c27b78644af22a833.md
@@ -64,7 +64,7 @@ The word `veintiuno` means 21.
 
 When referring to age, the word `veintiún` is used instead when it's followed by the word `años` ("years"). This shortened form is used immediately before plural masculine nouns.
 
-After saying his age, Sebastián returns the question to Ángela with `¿Y tú?`.
+After saying his age, Sebastián returns the question to Ángela with `¿Y tú?`
 
 # --scene--
 

--- a/curriculum/challenges/english/blocks/es-a1-learn-meet-angela-and-basti/690f6f11d51d16478c286346.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-meet-angela-and-basti/690f6f11d51d16478c286346.md
@@ -62,7 +62,7 @@ Sebastián is not asking about Ángela's age.
 
 # --explanation--
 
-Sebastián is asking Ángela `¿A qué te dedicas?`.
+Sebastián is asking Ángela `¿A qué te dedicas?`
 
 This is a common way to ask about someone's profession or job.
 

--- a/curriculum/challenges/english/blocks/es-a1-learn-meet-angela-and-basti/69160253e5339069a251cd9a.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-meet-angela-and-basti/69160253e5339069a251cd9a.md
@@ -46,7 +46,7 @@ This is the conjugation of the verb `ser` ("to be") for the pronoun `tú` ("you"
 
 The question `¿De dónde eres?` is a common way to ask about someone's place of origin.
 
-It is equivalent to "Where are you from?". 
+It is equivalent to "Where are you from?" 
 
 This question must have the preposition `de` ("from") at the beginning, and the conjugation of the verb `ser` ("to be") because origin is considered a permanent characteristic.
 

--- a/curriculum/challenges/english/blocks/es-a1-practice-first-questions/69164df41ff49cc2f332be4c.md
+++ b/curriculum/challenges/english/blocks/es-a1-practice-first-questions/69164df41ff49cc2f332be4c.md
@@ -53,4 +53,4 @@ This question asks "What is your name?"
 
 # --explanation--
 
-To ask someone about their profession, you could use `¿A qué te dedicas?`, which means "What is your profession?" or "What do you do for a living?".
+To ask someone about their profession, you could use `¿A qué te dedicas?`, which means "What is your profession?" or "What do you do for a living?"

--- a/curriculum/challenges/english/blocks/es-a1-practice-greetings-and-farewells/68c850c5eb642cc96ed86544.md
+++ b/curriculum/challenges/english/blocks/es-a1-practice-greetings-and-farewells/68c850c5eb642cc96ed86544.md
@@ -59,7 +59,7 @@ This is not a correct sentence in Spanish. Review the structure that Elena is us
 
 # --explanation--
 
-`Me llamo...` means "My name is...".  
+`Me llamo...` means "My name is..."  
 
 It's the most common way to introduce your name in a conversation. For example:
 

--- a/curriculum/challenges/english/blocks/es-a1-review-first-questions/6910a23b05a7eb4386e6e730.md
+++ b/curriculum/challenges/english/blocks/es-a1-review-first-questions/6910a23b05a7eb4386e6e730.md
@@ -22,7 +22,7 @@ To say where you are from, you should use: **`Soy` + `de` + [country]**. For exa
 
 - `Soy de Guatemala.`
 
-To know where someone is from, ask `¿De dónde eres?`.
+To know where someone is from, ask `¿De dónde eres?`
 
 <br>
 
@@ -63,7 +63,7 @@ To say your profession, you should use: **`Soy` + [profession]**. For example:
 
 - `Soy analista junior.`
 
-Use this question to ask someone about their profession: `¿A qué te dedicas?`.
+Use this question to ask someone about their profession: `¿A qué te dedicas?`
 
 <br>
 
@@ -75,7 +75,7 @@ To say your age in Spanish, you should use: **`Tengo` + [number] + `años`**. Fo
 
 - `Tengo treinta y cinco años.`
 
-You can use this question to ask someone's age: `¿Cuántos años tienes?`.
+You can use this question to ask someone's age: `¿Cuántos años tienes?`
 
 <br>
 

--- a/curriculum/challenges/english/blocks/lab-isbn-validator/686b9720ee1d032bd77a480a.md
+++ b/curriculum/challenges/english/blocks/lab-isbn-validator/686b9720ee1d032bd77a480a.md
@@ -244,7 +244,7 @@ assert "Valid ISBN Code." in out
 }})
 ```
 
-When the user enters `1530051125,10`, you should see the message `Invalid ISBN Code.`.
+When the user enters `1530051125,10`, you should see the message `Invalid ISBN Code.`
 
 ```js
 ({test: () => {runPython(`

--- a/curriculum/challenges/english/blocks/lab-luhn-algorithm/68507cadbf36aa089a84ce2d.md
+++ b/curriculum/challenges/english/blocks/lab-luhn-algorithm/68507cadbf36aa089a84ce2d.md
@@ -36,7 +36,7 @@ In this lab, you will build a credit card validator using the Luhn algorithm.
 2. Within the `verify_card_number` function:
 
    - You should handle any dashes or spaces that may be present in the card number passed to it.
-   - Return `VALID!` if the card number is valid; otherwise, return `INVALID!`.
+   - Return `VALID!` if the card number is valid; otherwise, return `INVALID!`
 
 When you complete the project, you should see the following messages depending on the input:
 
@@ -59,7 +59,7 @@ You should have a function named `verify_card_number`.
 })
 ```
 
-`verify_card_number('453914889')` should return `VALID!`.
+`verify_card_number('453914889')` should return `VALID!`
 
 ```js
 ({
@@ -69,7 +69,7 @@ You should have a function named `verify_card_number`.
 })
 ```
 
-`verify_card_number('4111-1111-1111-1111')` should return `VALID!`.
+`verify_card_number('4111-1111-1111-1111')` should return `VALID!`
 
 ```js
 ({
@@ -79,7 +79,7 @@ You should have a function named `verify_card_number`.
 })
 ```
 
-`verify_card_number('453914881')` should return `INVALID!`.
+`verify_card_number('453914881')` should return `INVALID!`
 
 ```js
 ({
@@ -89,7 +89,7 @@ You should have a function named `verify_card_number`.
 })
 ```
 
-`verify_card_number('1234 5678 9012 3456')` should return `INVALID!`.
+`verify_card_number('1234 5678 9012 3456')` should return `INVALID!`
 
 ```js
 ({

--- a/curriculum/challenges/english/blocks/lab-one-time-password-generator/67c562286b29447da020d407.md
+++ b/curriculum/challenges/english/blocks/lab-one-time-password-generator/67c562286b29447da020d407.md
@@ -208,7 +208,7 @@ await clock.tickAsync(6000);
 assert.isFalse(button.disabled);
 ```
 
-When the countdown timer reaches `0`, you should display the message `OTP expired. Click the button to generate a new OTP.`.
+When the countdown timer reaches `0`, you should display the message `OTP expired. Click the button to generate a new OTP.`
 
 ```js
   const button = document.querySelector(".container button#generate-otp-button");

--- a/curriculum/challenges/english/blocks/lab-truncate-string/ac6993d51946422351508a41.md
+++ b/curriculum/challenges/english/blocks/lab-truncate-string/ac6993d51946422351508a41.md
@@ -19,7 +19,7 @@ In this lab, you will practice truncating a string to a certain length.
 
 # --hints--
 
-`truncateString("A-tisket a-tasket A green and yellow basket", 8)` should return the string `A-tisket...`.
+`truncateString("A-tisket a-tasket A green and yellow basket", 8)` should return the string `A-tisket...`
 
 ```js
 assert.strictEqual(
@@ -28,7 +28,7 @@ assert.strictEqual(
 );
 ```
 
-`truncateString("Peter Piper picked a peck of pickled peppers", 11)` should return the string `Peter Piper...`.
+`truncateString("Peter Piper picked a peck of pickled peppers", 11)` should return the string `Peter Piper...`
 
 ```js
 assert.strictEqual(
@@ -61,13 +61,13 @@ assert.strictEqual(
 );
 ```
 
-`truncateString("A-", 1)` should return the string `A...`.
+`truncateString("A-", 1)` should return the string `A...`
 
 ```js
 assert.strictEqual(truncateString('A-', 1), 'A...');
 ```
 
-`truncateString("Absolutely Longer", 2)` should return the string `Ab...`.
+`truncateString("Absolutely Longer", 2)` should return the string `Ab...`
 
 ```js
 assert.strictEqual(truncateString('Absolutely Longer', 2), 'Ab...');

--- a/curriculum/challenges/english/blocks/learn-about-speculation-and-requests/67efb7e39a3ae7184c508f1b.md
+++ b/curriculum/challenges/english/blocks/learn-about-speculation-and-requests/67efb7e39a3ae7184c508f1b.md
@@ -74,4 +74,4 @@ Sophie makes it clear that guidelines must be followed to avoid issues.
 
 Sophie encourages the team to maintain code quality by following specific guidelines, such as using the correct loop structure, including clear comments, and running all tests before submitting.
 
-Focus on the sentence that starts with `Let's make sure...`.
+Focus on the sentence that starts with `Let's make sure...`

--- a/curriculum/challenges/english/blocks/learn-about-speculation-and-requests/67f52dee33807524435b5714.md
+++ b/curriculum/challenges/english/blocks/learn-about-speculation-and-requests/67f52dee33807524435b5714.md
@@ -80,4 +80,4 @@ Jessica does not mention shutting down servers — she focuses on identifying an
 
 Jessica states that if they find more signs of unauthorized access, they `may need to escalate the situation`. This means the security team may need to take stronger action, such as reporting to management or enforcing additional security measures.
 
-Focus on the sentence that starts with `If we find more signs...`.
+Focus on the sentence that starts with `If we find more signs...`

--- a/curriculum/challenges/english/blocks/learn-about-speculation-and-requests/67f52eaaf9808c24f1711e49.md
+++ b/curriculum/challenges/english/blocks/learn-about-speculation-and-requests/67f52eaaf9808c24f1711e49.md
@@ -80,4 +80,4 @@ Jessica is not ignoring the problem.
 
 Jessica states that she will continue gathering information and keep the team updated. She also asks the team to report anything unusual.
 
-Focus on the sentence that starts with `I'll keep you...`.
+Focus on the sentence that starts with `I'll keep you...`

--- a/curriculum/challenges/english/blocks/learn-about-speculation-and-requests/67f679810774dd278c363d75.md
+++ b/curriculum/challenges/english/blocks/learn-about-speculation-and-requests/67f679810774dd278c363d75.md
@@ -66,4 +66,4 @@ It allows team members to collaborate more effectively.
 
 The text states that peer-to-peer learning encourages team members to `share experiences and solutions`, creating a collaborative environment.
 
-Find how learning from colleagues can enhance understanding and teamwork. Focus on the sentence that starts with `Encouraging peer-to-peer learning allows...`.
+Find how learning from colleagues can enhance understanding and teamwork. Focus on the sentence that starts with `Encouraging peer-to-peer learning allows...`

--- a/curriculum/challenges/english/blocks/learn-about-speculation-and-requests/67f67b465227cf28e6ade47f.md
+++ b/curriculum/challenges/english/blocks/learn-about-speculation-and-requests/67f67b465227cf28e6ade47f.md
@@ -66,4 +66,4 @@ The text suggests combining hands-on exercises with discussions, not replacing t
 
 The text states that starting with a recap of past issues (like a security breach) helps `highlight what went wrong` and `how to avoid similar mistakes`.
 
-Focus on how learning from past mistakes improves future performance. Focus on the sentence that starts with `A good approach is...`.
+Focus on how learning from past mistakes improves future performance. Focus on the sentence that starts with `A good approach is...`

--- a/curriculum/challenges/english/blocks/learn-conversation-starters-in-the-break-room/657b2d1876594db821b5da16.md
+++ b/curriculum/challenges/english/blocks/learn-conversation-starters-in-the-break-room/657b2d1876594db821b5da16.md
@@ -22,7 +22,7 @@ The difference between `maybe` and `we can` is that `maybe` suggests a possibili
 
 ## --text--
 
-What does Sarah mean by saying `Maybe we can...`?
+What does Sarah mean by saying `Maybe we can...`
 
 ## --answers--
 

--- a/curriculum/challenges/english/blocks/learn-conversation-starters-in-the-break-room/657cea90396c694e4fdcaeba.md
+++ b/curriculum/challenges/english/blocks/learn-conversation-starters-in-the-break-room/657cea90396c694e4fdcaeba.md
@@ -16,7 +16,7 @@ lang: en-US
 
 - `When do we have lunch?` - You want to know the time for lunch.
 
-So, you use `when` whenever you are asking "at what time?" or "on what date?".
+So, you use `when` whenever you are asking "at what time?" or "on what date?"
 
 # --instructions--
 

--- a/curriculum/challenges/english/blocks/learn-conversation-starters-in-the-break-room/657dc65ba83c584136bea3e4.md
+++ b/curriculum/challenges/english/blocks/learn-conversation-starters-in-the-break-room/657dc65ba83c584136bea3e4.md
@@ -21,7 +21,7 @@ To `assign tasks` means to give specific work or duties to someone. For example:
 
 ## --text--
 
-What does Tom want to know by asking `Does Maria assign tasks...`?
+What does Tom want to know by asking `Does Maria assign tasks...`
 
 ## --answers--
 

--- a/curriculum/challenges/english/blocks/learn-determiners-and-advanced-use-of-articles/6811ec8382929614621afb3d.md
+++ b/curriculum/challenges/english/blocks/learn-determiners-and-advanced-use-of-articles/6811ec8382929614621afb3d.md
@@ -70,4 +70,4 @@ The company has not yet switched providers; the test is part of the decision pro
 
 Jake says they plan to run a test project with the European provider to check performance, support, and scalability.
 
-He mentions the time in the sentence that starts with `For scalability...`.
+He mentions the time in the sentence that starts with `For scalability...`

--- a/curriculum/challenges/english/blocks/learn-determiners-and-advanced-use-of-articles/68135a133ef5911790856475.md
+++ b/curriculum/challenges/english/blocks/learn-determiners-and-advanced-use-of-articles/68135a133ef5911790856475.md
@@ -78,6 +78,6 @@ Every two weeks
 
 # --explanation--
 
-Focus on the sentence that starts with `We'll have...`.
+Focus on the sentence that starts with `We'll have...`
 
 Bob says the team will have `bi-weekly` meetings to monitor progress and address issues early to avoid delays.

--- a/curriculum/challenges/english/blocks/learn-determiners-and-advanced-use-of-articles/68135ac7afe66e185aeccf0b.md
+++ b/curriculum/challenges/english/blocks/learn-determiners-and-advanced-use-of-articles/68135ac7afe66e185aeccf0b.md
@@ -78,6 +78,6 @@ The project is just starting; Bob is not announcing its end.
 
 # --explanation--
 
-Focus on the sentence that starts with `On the QA side...`.
+Focus on the sentence that starts with `On the QA side...`
 
 Bob is contacting HR to find more QA testers, especially for complex features, because the team currently lacks enough testing support.

--- a/curriculum/challenges/english/blocks/learn-determiners-and-advanced-use-of-articles/68135b64cddd3e18ee480472.md
+++ b/curriculum/challenges/english/blocks/learn-determiners-and-advanced-use-of-articles/68135b64cddd3e18ee480472.md
@@ -78,6 +78,6 @@ Make sure everyone is clear on their responsibilities.
 
 # --explanation--
 
-Focus on the paragraph that starts with `Please reach out if...`.
+Focus on the paragraph that starts with `Please reach out if...`
 
 Bob asks the team to ensure everyone understands their responsibilities by the end of the week, setting up a strong, organized start to the project.

--- a/curriculum/challenges/english/blocks/learn-determiners-and-advanced-use-of-articles/6814f3e6df863e3231c2ce99.md
+++ b/curriculum/challenges/english/blocks/learn-determiners-and-advanced-use-of-articles/6814f3e6df863e3231c2ce99.md
@@ -76,6 +76,6 @@ Server capacity was divided fairly, but analytics tool allocation depends on pro
 
 # --explanation--
 
-Focus on the sentence that starts with `Advanced analytics tools will not be...`.
+Focus on the sentence that starts with `Advanced analytics tools will not be...`
 
 Maria explains that smaller projects are not yet ready for integration with advanced analytics tools, so these tools will not be provided at this stage.

--- a/curriculum/challenges/english/blocks/learn-future-continuous-while-describing-actions/675961ce80a70e23e933fa8c.md
+++ b/curriculum/challenges/english/blocks/learn-future-continuous-while-describing-actions/675961ce80a70e23e933fa8c.md
@@ -22,7 +22,7 @@ Which option correctly uses `haven't` or `hasn't` in a tag question?
 
 ### --feedback--
 
-`Has` is used in the main sentence, so the tag question should be `hasn't she?`.
+`Has` is used in the main sentence, so the tag question should be `hasn't she?`
 
 ---
 
@@ -30,7 +30,7 @@ Which option correctly uses `haven't` or `hasn't` in a tag question?
 
 ### --feedback--
 
-`Have` is used in the main sentence, so the tag question should be `haven't we?`.
+`Have` is used in the main sentence, so the tag question should be `haven't we?`
 
 ---
 
@@ -38,7 +38,7 @@ Which option correctly uses `haven't` or `hasn't` in a tag question?
 
 ### --feedback--
 
-`Have` is used in the main sentence, so the tag question should be `haven't they?`.
+`Have` is used in the main sentence, so the tag question should be `haven't they?`
 
 ---
 

--- a/curriculum/challenges/english/blocks/learn-future-continuous-while-describing-actions/675d86beee48ab4941767200.md
+++ b/curriculum/challenges/english/blocks/learn-future-continuous-while-describing-actions/675d86beee48ab4941767200.md
@@ -30,7 +30,7 @@ The subject of the main sentence is `we`, but the tag uses `they`, which is a mi
 
 ### --feedback--
 
-The main sentence is negative, so the tag should be positive: `can she?`.
+The main sentence is negative, so the tag should be positive: `can she?`
 
 ---
 

--- a/curriculum/challenges/english/blocks/learn-future-continuous-while-describing-actions/675e7387be428072d95baeac.md
+++ b/curriculum/challenges/english/blocks/learn-future-continuous-while-describing-actions/675e7387be428072d95baeac.md
@@ -60,7 +60,7 @@ This is a contraction of `have not` used in a tag question.
 
 ### --feedback--
 
-This is a part of a confirmation response for questions like `haven't they?`.
+This is a part of a confirmation response for questions like `haven't they?`
 
 ---
 

--- a/curriculum/challenges/english/blocks/learn-greetings-in-your-first-day-at-the-office/65529784e7cb6e24eb03a1af.md
+++ b/curriculum/challenges/english/blocks/learn-greetings-in-your-first-day-at-the-office/65529784e7cb6e24eb03a1af.md
@@ -13,7 +13,7 @@ Maria: Welcome aboard, Tom. How do you like California so far?
 
 # --description--
 
-When you want to ask someone for their opinion or feelings about something, especially a place or an experience, you can use the question `How do you like...?`.
+When you want to ask someone for their opinion or feelings about something, especially a place or an experience, you can use the question `How do you like...?`
 
 Maria is asking Tom about his impressions of California.
 

--- a/curriculum/challenges/english/blocks/learn-how-to-describe-places-and-events/66b52aaddea73da83ef5d442.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-describe-places-and-events/66b52aaddea73da83ef5d442.md
@@ -21,7 +21,7 @@ Listen to the audio and answer the question below.
 
 ## --text--
 
-Which sentence best follows Brian's statement, `We touch on it, but perhaps not in enough detail.`?
+Which sentence best follows Brian's statement, `We touch on it, but perhaps not in enough detail.`
 
 ## --answers--
 

--- a/curriculum/challenges/english/blocks/learn-how-to-describe-places-and-events/66c613a4d11b69cdd746b5ed.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-describe-places-and-events/66c613a4d11b69cdd746b5ed.md
@@ -31,7 +31,7 @@ The auto-completion is outdated.
 
 ### --feedback--
 
-Pay attention to what Sarah says after `it doesn't work if...`. 
+Pay attention to what Sarah says after `it doesn't work if...` 
 
 ---
 
@@ -39,7 +39,7 @@ The computer isn't powerful enough.
 
 ### --feedback--
 
-Pay attention to what Sarah says after `it doesn't work if...`. 
+Pay attention to what Sarah says after `it doesn't work if...` 
 
 ---
 
@@ -47,7 +47,7 @@ The feature is only available in a different IDE.
 
 ### --feedback--
 
-Pay attention to what Sarah says after `it doesn't work if...`. 
+Pay attention to what Sarah says after `it doesn't work if...` 
   
 ## --video-solution--
 

--- a/curriculum/challenges/english/blocks/learn-how-to-describe-places-and-events/66c6155aafccc1d49bf9b32a.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-describe-places-and-events/66c6155aafccc1d49bf9b32a.md
@@ -25,7 +25,7 @@ She wants to know if he needs help setting up the project.
 
 ### --feedback--
 
-Pay attention to what Sarah says after `Have you checked...`.
+Pay attention to what Sarah says after `Have you checked...`
 
 ---
 
@@ -33,7 +33,7 @@ She wants to know if the project is saved.
 
 ### --feedback--
 
-Pay attention to what Sarah says after `Have you checked...`.
+Pay attention to what Sarah says after `Have you checked...`
 
 ---
 
@@ -45,7 +45,7 @@ She wants to know if the auto-completion feature is installed.
 
 ### --feedback--
 
-Pay attention to what Sarah says after `Have you checked...`.
+Pay attention to what Sarah says after `Have you checked...`
   
 ## --video-solution--
 

--- a/curriculum/challenges/english/blocks/learn-how-to-describe-places-and-events/66c62046cf3df2fe7cf92230.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-describe-places-and-events/66c62046cf3df2fe7cf92230.md
@@ -25,7 +25,7 @@ If the project isn't saved correctly.
 
 ### --feedback--
 
-Pay attention to what Sarah says after `but they're not visible if...`.
+Pay attention to what Sarah says after `but they're not visible if...`
 
 ---
 
@@ -33,7 +33,7 @@ If Eclipse isn't updated to the latest version.
 
 ### --feedback--
 
-Pay attention to what Sarah says after `but they're not visible if...`.
+Pay attention to what Sarah says after `but they're not visible if...`
 
 ---
 
@@ -45,7 +45,7 @@ If the Git tools aren't installed manually.
 
 ### --feedback--
 
-Pay attention to what Sarah says after `but they're not visible if...`.
+Pay attention to what Sarah says after `but they're not visible if...`
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/blocks/learn-how-to-discuss-roles-and-responsibilities/65d5d17a45be4e4d56be704a.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-discuss-roles-and-responsibilities/65d5d17a45be4e4d56be704a.md
@@ -12,7 +12,7 @@ lang: en-US
 
 The word `ever` is used in the present perfect tense to talk about experiences at any time up to now. It's often found in questions to ask if someone has done something at least once in their life.
 
-For example, `Have you ever visited Paris?` means "at any time in your life, did you visit Paris?".
+For example, `Have you ever visited Paris?` means "at any time in your life, did you visit Paris?"
 
 # --fillInTheBlank--
 

--- a/curriculum/challenges/english/blocks/learn-how-to-discuss-tech-trends-and-updates/6635fdc8fdd98f2b56c3bcf8.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-discuss-tech-trends-and-updates/6635fdc8fdd98f2b56c3bcf8.md
@@ -28,7 +28,7 @@ Which of the following sentences uses the structure `do you know` followed by an
 
 ### --feedback--
 
-This sentence incorrectly uses a modal verb `can` directly after `Do you know`. It should be `Do you know if he can arrive on time?`.
+This sentence incorrectly uses a modal verb `can` directly after `Do you know`. It should be `Do you know if he can arrive on time?`
 
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-discuss-your-morning-or-evening-routine/6556ba2fe6c3f3846ea71ab2.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-discuss-your-morning-or-evening-routine/6556ba2fe6c3f3846ea71ab2.md
@@ -10,7 +10,7 @@ lang: en-US
 
 # --description--
 
-`It seems like...` is used to express a personal observation or feeling about someone or something, similar to saying `It appears that...` or `It looks as if...`. 
+`It seems like...` is used to express a personal observation or feeling about someone or something, similar to saying `It appears that...` or `It looks as if...` 
 
 For example, you can say `It seems like it's going to rain today` when looking at cloudy skies.
 

--- a/curriculum/challenges/english/blocks/learn-how-to-express-agreement/67af46a4ec8db360d8f0cc7a.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-express-agreement/67af46a4ec8db360d8f0cc7a.md
@@ -68,4 +68,4 @@ The email does not mention team-building as the purpose of the check-ins.
 
 Look for key details in the email that explain what Bob expects from the check-ins.
 
-Pay special attention to the phrase that starts with `I'm confident these regular check-ins...`.
+Pay special attention to the phrase that starts with `I'm confident these regular check-ins...`

--- a/curriculum/challenges/english/blocks/learn-how-to-express-agreement/67b4681b40ac5c3c991e1f51.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-express-agreement/67b4681b40ac5c3c991e1f51.md
@@ -54,7 +54,7 @@ Jim is not specifically asking about a meeting.
 
 Jim is asking if now is a good time to talk. 
 
-`Would` makes the question more polite. Instead of asking directly, `Is now a good time?`, Jim says, `Would now be a good time?`. 
+`Would` makes the question more polite. Instead of asking directly, `Is now a good time?`, Jim says, `Would now be a good time?` 
 
 This sounds softer and more polite because it shows respect for the other person's time.
 

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-hobbies-and-interests/65802ee9706eb103aea442f8.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-hobbies-and-interests/65802ee9706eb103aea442f8.md
@@ -14,7 +14,7 @@ This task doesn't have audio. Read the question below and select the correct ans
 
 ## --text--
 
-Which of the following best completes the phrase `Really? That sounds great!`?
+Which of the following best completes the phrase `Really? That sounds great! ...`
 
 ## --answers--
 

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-numbers-with-a-coworker/6846f0ed1e2d12252ebdc533.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-numbers-with-a-coworker/6846f0ed1e2d12252ebdc533.md
@@ -52,7 +52,7 @@ That comes after development and testing, not during the third phase.
 
 # --explanation--
 
-James says, `The third phase, which includes all initial testing...`.
+James says, `The third phase, which includes all initial testing...`
 
 He does not mention final fixes, marketing, or early planning steps here.
 

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-numbers-with-a-coworker/68470c006cdf6b32eecd265b.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-numbers-with-a-coworker/68470c006cdf6b32eecd265b.md
@@ -68,6 +68,6 @@ The project is still in early stages; Jessica is outlining future tasks and date
 
 # --explanation--
 
-Jessica starts her email with `We've updated...`.
+Jessica starts her email with `We've updated...`
 
 This shows the main purpose: to communicate the updated timeline with clear milestones and deadlines so everyone is aligned and knows what to expect in each phase.

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-numbers-with-a-coworker/68470e1747093934338cb60c.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-numbers-with-a-coworker/68470e1747093934338cb60c.md
@@ -68,6 +68,6 @@ Setting up the core database, because many parts depend on it.
 
 # --explanation--
 
-Focus on the sentence that starts with `One important task is...`.
+Focus on the sentence that starts with `One important task is...`
 
 Jessica points out that setting up the core database is essential because many other parts depend on it, making it a high-priority task in the development phase.

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-numbers-with-a-coworker/68470f0731b5ea34f9c7e58a.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-numbers-with-a-coworker/68470f0731b5ea34f9c7e58a.md
@@ -68,6 +68,6 @@ Onboarding isn't mentioned in the timeline — Jessica is outlining project phas
 
 # --explanation--
 
-Focus on the sentence that starts with `The third phase is...`.
+Focus on the sentence that starts with `The third phase is...`
 
 `The third phase is all about initial testing`, as mentioned in the update. It comes after development and helps prepare for beta testing.

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-numbers-with-a-coworker/68470fc84731be35b39f2d85.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-numbers-with-a-coworker/68470fc84731be35b39f2d85.md
@@ -68,6 +68,6 @@ Three days wouldn't be enough - Jessica allows `two weeks` for this phase.
 
 # --explanation--
 
-Focus on the sentence that starts with `Finally, in the last phase...`.
+Focus on the sentence that starts with `Finally, in the last phase...`
 
 Jessica states that the last phase (beta testing and fixes) will last two weeks to allow enough time to resolve any critical issues.

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-numbers-with-a-coworker/684710868797413676e41de6.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-numbers-with-a-coworker/684710868797413676e41de6.md
@@ -68,6 +68,6 @@ May 16, 2025
 
 # --explanation--
 
-Focus on the sentence that starts with `The final task in this phase is...`.
+Focus on the sentence that starts with `The final task in this phase is...`
 
 Jessica mentions that the final task of the last phase is preparing the deployment documentation, which should be ready by May 16, 2025.

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-numbers-with-a-coworker/68484b5100af0b6bdd343021.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-numbers-with-a-coworker/68484b5100af0b6bdd343021.md
@@ -72,6 +72,6 @@ Spending is not that high yet.
 
 # --explanation--
 
-Focus on the sentence that starts with `So far, we've spent...`.
+Focus on the sentence that starts with `So far, we've spent...`
 
 Alice mentions how much of the total budget has already been spent, primarily on setup and early development work.

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-numbers-with-a-coworker/68484c2ac2fb7f6cac906439.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-numbers-with-a-coworker/68484c2ac2fb7f6cac906439.md
@@ -72,6 +72,6 @@ Cut the `Testing` phase.
 
 # --explanation--
 
-Focus on the sentence that starts with `We'll keep...`.
+Focus on the sentence that starts with `We'll keep...`
 
 Alice says the team will monitor spending and make changes if needed. This shows that the team is staying flexible and responsive to budget needs.

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-activities/66db690a4859eaa462fd4862.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-activities/66db690a4859eaa462fd4862.md
@@ -39,7 +39,7 @@ This response does not provide any details about what tasks or problems need to 
 
 # --explanation--
 
-The correct answer should provide information that directly responds to Bob's question `What do we have to deal with now?`.
+The correct answer should provide information that directly responds to Bob's question `What do we have to deal with now?`
 
 Look for an option that indicates preparation or awareness of the tasks.
 

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-activities/66e32c232273235dd6dc3287.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-activities/66e32c232273235dd6dc3287.md
@@ -62,4 +62,4 @@ Check if the email mentions contacting support as the first action.
 
 To identify the actions the user has taken, look for parts of the email where the user describes what they have tried or done with the app. 
 
-Focus on sentences that mention specific actions, such as `Every time I try to...`.
+Focus on sentences that mention specific actions, such as `Every time I try to...`

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/670538f8565fb514ddf24b85.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/670538f8565fb514ddf24b85.md
@@ -40,7 +40,7 @@ Other words and phrases that can be used with the same meaning as `then` in this
 
 - `I checked the updates. After that, I started debugging.` 
 
-- `I reviewed the requirements. Next, I shared my thoughts with the team.`.
+- `I reviewed the requirements. Next, I shared my thoughts with the team.`
 
 These words help structure descriptions of actions in chronological order.
 

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/670570ad97d26e1d6bad572d.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/670570ad97d26e1d6bad572d.md
@@ -65,4 +65,4 @@ This action wasn't mentioned in the dialogue.
 
 # --explanation--
 
-To find out what was the first thing James did, focus on the sentence that starts with `First I...`.
+To find out what was the first thing James did, focus on the sentence that starts with `First I...`

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/6705725e2814c91dd738e8f4.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/6705725e2814c91dd738e8f4.md
@@ -65,4 +65,4 @@ James doesn't mention this.
 
 # --explanation--
 
-To find out the main cause of the bug, look for the part of the text that talks about the system's connection. Focus on the sentence that starts with `Then, I...`.
+To find out the main cause of the bug, look for the part of the text that talks about the system's connection. Focus on the sentence that starts with `Then, I...`

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/6705742b9616e01e275e5c08.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/6705742b9616e01e275e5c08.md
@@ -65,4 +65,4 @@ Restarting the app wasn't mentioned as part of the solution.
 
 # --explanation--
 
-To find out how James fixed the problem, look for the part of the text that talks about updating the credentials. Focus on the sentence that starts with `We hadn't...`.
+To find out how James fixed the problem, look for the part of the text that talks about updating the credentials. Focus on the sentence that starts with `We hadn't...`

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/67057604ca099f1e7df78e77.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/67057604ca099f1e7df78e77.md
@@ -65,4 +65,4 @@ No mention of a system backup was made, so this doesn't apply to the situation.
 
 # --explanation--
 
-To find out when the credentials were updated, check the part where James explains why the app wasn't working. Focus on the sentence starting with, `We hadn't updated...`. 
+To find out when the credentials were updated, check the part where James explains why the app wasn't working. Focus on the sentence starting with, `We hadn't updated...` 

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/67057e02da44871f492f6f35.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/67057e02da44871f492f6f35.md
@@ -65,4 +65,4 @@ The app is fully operational, not partially working.
 
 # --explanation--
 
-To figure out if the app is working now, look at the last part of James' explanation where he says, `I fixed...`.
+To figure out if the app is working now, look at the last part of James' explanation where he says, `I fixed...`

--- a/curriculum/challenges/english/blocks/learn-how-to-use-modal-verbs/67d5a5fa6dbdc14fd6c078b8.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-modal-verbs/67d5a5fa6dbdc14fd6c078b8.md
@@ -22,7 +22,7 @@ Which sentence is grammatically correct?
 
 ### --feedback--
 
-The correct word order is `What would happen...`.
+The correct word order is `What would happen...`
 
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-use-modal-verbs/67d7e64ac5180e76037508b9.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-modal-verbs/67d7e64ac5180e76037508b9.md
@@ -30,7 +30,7 @@ Modal verbs like `can` and `could` do not use `do` or `does` in questions.
 
 ### --feedback--
 
-Questions with modal verbs should invert the subject and verb: `Can you help me?`, not `You can help me?`.  
+Questions with modal verbs should invert the subject and verb: `Can you help me?`, not `You can help me?`  
 
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-use-prepositions-according-to-context/6839a6376e7c2c8f7ed40f2c.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-prepositions-according-to-context/6839a6376e7c2c8f7ed40f2c.md
@@ -14,7 +14,7 @@ This task doesn't have audio. Read the question below and select the correct ans
 
 ## --text--
 
-Which sentence uses the word `in` the same way as in this sentence: `The server room is located in the building's basement`?
+Which sentence uses the word `in` the same way as in this sentence: `The server room is located in the building's basement.`
 
 ## --answers--
 

--- a/curriculum/challenges/english/blocks/lecture-react-strategies-and-debugging/67d2f5dacd5e0c749e5d534c.md
+++ b/curriculum/challenges/english/blocks/lecture-react-strategies-and-debugging/67d2f5dacd5e0c749e5d534c.md
@@ -85,7 +85,7 @@ const Child = ({ greeting, response }) => {
 
 Remember that `Grandchild` expects a `response` prop. Because the component receives a different prop, it can't display that text on the page, and just adds and empty `h2` to the DOM. Instead, you'll just see the `h1` element with the text `Hello, Prop Drilling!`, along with the other buttons and text already on the page. The empty `h2` element is still there, but because it's empty, you can't see it without inspecting the DOM.
 
-To fix this, you can inspect the prop progression from the `Parent` component down to the `Child` and edit the prop name directly. If you go to the Components tab, select the `Child` component, and change the `reply` prop to `response`, you'll see the `h2` element on the page with the text `I'm not here to play!`.
+To fix this, you can inspect the prop progression from the `Parent` component down to the `Child` and edit the prop name directly. If you go to the Components tab, select the `Child` component, and change the `reply` prop to `response`, you'll see the `h2` element on the page with the text `I'm not here to play!`
 
 # --questions--
 

--- a/curriculum/challenges/english/blocks/lecture-understanding-asynchronous-programming/673407ca21117a67cf9521ca.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-asynchronous-programming/673407ca21117a67cf9521ca.md
@@ -17,7 +17,7 @@ const aPromise = new Promise((resolve, reject) => {
 });
 ```
 
-In this example, we create a promise that simulates an asynchronous operation using `setTimeout`. After one second, the promise is resolved with the message `Operation successful!`.
+In this example, we create a promise that simulates an asynchronous operation using `setTimeout`. After one second, the promise is resolved with the message `Operation successful!`
 
 Another way to work with promises is to use the `.then` and `.catch` methods.
 

--- a/curriculum/challenges/english/blocks/lecture-understanding-how-http-dns-tcpip-work/69661d1a74e9aa63cb171957.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-how-http-dns-tcpip-work/69661d1a74e9aa63cb171957.md
@@ -23,7 +23,7 @@ The main structure of a domain name is, from right to left:
     
 * **Second-Level Domain (SLD):** the name registered by the person or organization. That would be `freecodecamp` in `freecodecamp.org`. This is what you usually notice first when you see a web address.
     
-* **Third-Level Domain (Subdomain):** used to identify a specific section of the main domain. For example, `www`, which stands for “World Wide Web.” Nowadays, modern web servers automatically handle domain routing, so you can access a website with or without entering `www`. Other examples of subdomains include `blog.`, `shop.`, `support.`, and `api.`.
+* **Third-Level Domain (Subdomain):** used to identify a specific section of the main domain. For example, `www`, which stands for “World Wide Web.” Nowadays, modern web servers automatically handle domain routing, so you can access a website with or without entering `www`. Other examples of subdomains include `blog.`, `shop.`, `support.`, and `api.`
     
 
 Domain names are very helpful to us as humans because they’re easy to remember and type into a browser. However, as you know, computers work with numbers. Your browser has to transform the domain name that you entered into something known as an IP address to find the website you are looking for.

--- a/curriculum/challenges/english/blocks/lecture-understanding-variables-and-data-types/67fe8599c83979345ff9a91a.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-variables-and-data-types/67fe8599c83979345ff9a91a.md
@@ -125,7 +125,7 @@ They define a string to be printed by the `print()` function.
 
 ---
 
-They are used to call a function named `Hello world!`.
+They are used to call a function named `Hello world!`
 
 ### --feedback--
 
@@ -141,7 +141,7 @@ Consider how Python identifies string values in code.
 
 ---
 
-They let Python know to print a variable named `Hello world!`.
+They let Python know to print a variable named `Hello world!`
 
 ### --feedback--
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-relative-and-absolute-units/672bb851b068e3954a05b9b1.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-relative-and-absolute-units/672bb851b068e3954a05b9b1.md
@@ -41,7 +41,7 @@ You can use the addition (`+`), subtraction (`-`), multiplication (`*`), and div
 
 If there are multiple operands and operators, `calc()` will follow the standard operator precedence rule. You can also add parentheses to establish the order of the operations if needed.
 
-In the example below, you can see a `div` with the text `Hello, World!`.
+In the example below, you can see a `div` with the text `Hello, World!`
 
 Using the CSS type selector for selecting the `div`, you can style it with white text and a dark blue background: 
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-string-modification-methods/67326c3392068ec6184a0c95.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-string-modification-methods/67326c3392068ec6184a0c95.md
@@ -29,7 +29,7 @@ console.log(repeatedWord);  // "Hello!Hello!Hello!"
 
 :::
 
-In this case, the string `Hello!` is repeated three times, resulting in `Hello!Hello!Hello!`.
+In this case, the string `Hello!` is repeated three times, resulting in `Hello!Hello!Hello!`
 
 While the `repeat()` method is useful, there are a few exceptions and limitations to keep in mind.
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-string-search-and-slice-methods/67326c15b3b2f0c5827927cc.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-string-search-and-slice-methods/67326c15b3b2f0c5827927cc.md
@@ -51,7 +51,7 @@ console.log(world);  // world!
 
 :::
 
-Here, `slice(7)` extracts the string from index `7` to the end of the string, resulting in `world!`.
+Here, `slice(7)` extracts the string from index `7` to the end of the string, resulting in `world!`
 
 You can also use negative numbers as indexes. When you use a negative number, it counts backward from the end of the string:
 
@@ -66,7 +66,7 @@ console.log(lastWord);  // fun!
 
 :::
 
-In this case, `slice(-4)` extracts the last four characters from the string, giving us `fun!`.
+In this case, `slice(-4)` extracts the last four characters from the string, giving us `fun!`
 
 Let's say you want to extract a section from the middle of a string. You can provide both the starting and ending indexes to precisely control which part of the string you want:
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-the-dom-click-events-and-web-apis/6733691d88e3053414689276.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-the-dom-click-events-and-web-apis/6733691d88e3053414689276.md
@@ -21,7 +21,7 @@ Here is an example of a `button` element with an inline click event handler:
 
 :::
 
-When the user clicks on the button, the `alert` function is called and an alert dialog is displayed with the message `Hello World!`.
+When the user clicks on the button, the `alert` function is called and an alert dialog is displayed with the message `Hello World!`
 
 Another way to use inline event handlers is to call a function that is defined in a `script` tag in the HTML document. 
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-the-dom-click-events-and-web-apis/6733697661182d357fc643d2.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-the-dom-click-events-and-web-apis/6733697661182d357fc643d2.md
@@ -121,7 +121,7 @@ textCanvasCtx.fillText("Hello HTML Canvas!", 1, 50);
 
 :::
 
-The result in the browser will be the red text `Hello HTML Canvas!`.
+The result in the browser will be the red text `Hello HTML Canvas!`
 
 These's much more you can do with the `Canvas` API. For example, you can combine it with `requestAnimationFrame` to create custom animations, visualizations, games, and more.
 

--- a/curriculum/challenges/english/blocks/project-euler-problems-201-to-300/5900f4811000cf542c50ff94.md
+++ b/curriculum/challenges/english/blocks/project-euler-problems-201-to-300/5900f4811000cf542c50ff94.md
@@ -20,7 +20,7 @@ The sequence terminates when some $a_n = 1$.
 
 Given any integer, we can list out the sequence of steps. For instance if $a_1 = 231$, then the sequence $\\{a_n\\} = \\{231, 77, 51, 17, 11, 7, 10, 14, 9, 3, 1\\}$ corresponds to the steps "DdDddUUdDD".
 
-Of course, there are other sequences that begin with that same sequence "DdDddUUdDD...".
+Of course, there are other sequences that begin with that same sequence "DdDddUUdDD...."
 
 For instance, if $a_1 = 1004064$, then the sequence is DdDddUUdDDDdUDUUUdDdUUDDDUdDD.
 

--- a/curriculum/challenges/english/blocks/workshop-bookstore-page/68ebdbacdd3fa474132cc975.md
+++ b/curriculum/challenges/english/blocks/workshop-bookstore-page/68ebdbacdd3fa474132cc975.md
@@ -7,7 +7,7 @@ dashedName: step-5
 
 # --description--
 
-Below the `h1` element, add a `p` element with this text: `Browse our collection of amazing books!`.
+Below the `h1` element, add a `p` element with this text: `Browse our collection of amazing books!`
 
 # --hints--
 
@@ -17,7 +17,7 @@ You should have a `p` element.
 assert.exists(document.querySelector('p'));
 ```
 
-Your `p` element's text should be: `Browse our collection of amazing books!`. 
+Your `p` element's text should be: `Browse our collection of amazing books!` 
 
 ```js
 assert.equal(document.querySelector('p')?.innerText.trim(), 'Browse our collection of amazing books!');

--- a/curriculum/challenges/english/blocks/workshop-calorie-counter/63c1e1965a898d302e0af4e3.md
+++ b/curriculum/challenges/english/blocks/workshop-calorie-counter/63c1e1965a898d302e0af4e3.md
@@ -17,7 +17,7 @@ const templateLiteral = `Hello, my name is ${name}~!`;
 console.log(templateLiteral);
 ```
 
-The console will show the string "Hello, my name is Naomi~!".
+The console will show the string "Hello, my name is Naomi~!"
 
 Replace your concatenated string in the `querySelector` with a template literal – be sure to keep the space between your `targetId` variable and `.input-container`.
 

--- a/curriculum/challenges/english/blocks/workshop-cat-photo-app/671141feba228a35cefba82d.md
+++ b/curriculum/challenges/english/blocks/workshop-cat-photo-app/671141feba228a35cefba82d.md
@@ -37,7 +37,7 @@ There should only be one instance of the phrase `cute cats` in your code.
 assert.strictEqual(code.indexOf("cute cats"),code.lastIndexOf("cute cats")); 
 ```
 
-The text of the `p` element should still be `Everyone loves cute cats online!`.
+The text of the `p` element should still be `Everyone loves cute cats online!`
 
 ```js
 assert.strictEqual(document.querySelector('p')?.innerText?.trim(), "Everyone loves cute cats online!");

--- a/curriculum/challenges/english/blocks/workshop-email-simulator/68540a534c56aeabae6afd58.md
+++ b/curriculum/challenges/english/blocks/workshop-email-simulator/68540a534c56aeabae6afd58.md
@@ -11,12 +11,12 @@ Now you'll simulate sending some emails between the users.
 
 In your `main` function, after creating the users, use the `send_email` method to:
 
-- Have Tory send an email to the `ramy` user object with subject `Hello` and body `Hi Ramy, just saying hello!`.
+- Have Tory send an email to the `ramy` user object with subject `Hello` and body `Hi Ramy, just saying hello!`
 - Have Ramy send an email to the `tory` user object with subject `Re: Hello` and body `Hi Tory, hope you are fine.`
 
 # --hints--
 
-You should have Tory send an email to `ramy`, subject `Hello`, and body `Hi Ramy, just saying hello!`.
+You should have Tory send an email to `ramy`, subject `Hello`, and body `Hi Ramy, just saying hello!`
 
 ```js
 ({

--- a/curriculum/challenges/english/blocks/workshop-emoji-reactor/688c90634eb5ae69845ac35d.md
+++ b/curriculum/challenges/english/blocks/workshop-emoji-reactor/688c90634eb5ae69845ac35d.md
@@ -12,7 +12,7 @@ In this workshop you will create an Emoji Reactor App. The HTML boilerplate and 
 
 Start by creating a `main` element.
 
-Inside the `main` element create an `h1` element with a `class` of `title` and a text of `How are you feeling today?`.
+Inside the `main` element create an `h1` element with a `class` of `title` and a text of `How are you feeling today?`
 
 # --hints--
 
@@ -34,7 +34,7 @@ The `h1` element should have a class of `title`.
 assert.equal(document.querySelector("main > h1")?.className, "title");
 ```
 
-The `h1` element should contain the text `How are you feeling today?`.
+The `h1` element should contain the text `How are you feeling today?`
 
 ```js
 assert.equal(document.querySelector("main > h1")?.textContent.trim(), "How are you feeling today?");

--- a/curriculum/challenges/english/blocks/workshop-emoji-reactor/6899b0d1825ff24e9fe8d747.md
+++ b/curriculum/challenges/english/blocks/workshop-emoji-reactor/6899b0d1825ff24e9fe8d747.md
@@ -25,7 +25,7 @@ The new `p` element should have a class of `description`.
 assert.equal(document.querySelector("h1 + p")?.className, "description");
 ```
 
-The new `p` element should have text of `Click on the buttons below to rate your emotions.`.
+The new `p` element should have text of `Click on the buttons below to rate your emotions.`
 
 ```js
 assert.equal(document.querySelector("h1 + p")?.textContent.trim(), "Click on the buttons below to rate your emotions.");

--- a/curriculum/challenges/english/blocks/workshop-emoji-reactor/6899c30b1d26094e11170c92.md
+++ b/curriculum/challenges/english/blocks/workshop-emoji-reactor/6899c30b1d26094e11170c92.md
@@ -9,7 +9,7 @@ dashedName: step-7
 
 Now you need to add an event listener on the `happyBtn` element.
 
-Write the event listener and its callback so that when the button is clicked the app will log to the console `Button clicked!`.
+Write the event listener and its callback so that when the button is clicked the app will log to the console `Button clicked!`
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/workshop-error-message-component/684cca09aac0fc035db4099f.md
+++ b/curriculum/challenges/english/blocks/workshop-error-message-component/684cca09aac0fc035db4099f.md
@@ -17,7 +17,7 @@ You should have a `strong` element inside your `p` element.
 assert.exists(document.querySelector("p strong"));
 ```
 
-Your `strong` element should have the text `Error!`.
+Your `strong` element should have the text `Error!`
 
 ```js
 assert.equal(document.querySelector("strong")?.textContent, "Error!");

--- a/curriculum/challenges/english/blocks/workshop-greeting-card/672e44e811e610232fead333.md
+++ b/curriculum/challenges/english/blocks/workshop-greeting-card/672e44e811e610232fead333.md
@@ -7,7 +7,7 @@ dashedName: step-10
 
 # --description--
 
-Add an `h2` to `#send` that contains the text `Sending your card...`, then add a `p` element with the text `Card successfully sent to your recipient!`.
+Add an `h2` to `#send` that contains the text `Sending your card...`, then add a `p` element with the text `Card successfully sent to your recipient!`
 
 # --hints--
 
@@ -17,7 +17,7 @@ The `#send` element should contain a `h2` element.
 assert.exists(document.querySelector("#send > h2"));
 ```
 
-The `h2` element should contain the text `Sending your card...`.
+The `h2` element should contain the text `Sending your card...`
 
 ```js
 assert.strictEqual(document.querySelector("#send > h2").innerText.trim(), "Sending your card...");
@@ -29,7 +29,7 @@ The second element inside `#send` should be a `p` element.
 assert.strictEqual(document.querySelector("#send").children[1].tagName, "P");
 ```
 
-The `p` element should have the text `Card successfully sent to your recipient!`.
+The `p` element should have the text `Card successfully sent to your recipient!`
 
 ```js
 assert.strictEqual(document.querySelector("#send").children[1].innerText.trim(), "Card successfully sent to your recipient!");

--- a/curriculum/challenges/english/blocks/workshop-greeting-card/67332db0f793bf08f2a18528.md
+++ b/curriculum/challenges/english/blocks/workshop-greeting-card/67332db0f793bf08f2a18528.md
@@ -9,7 +9,7 @@ dashedName: step-11
 
 Time to fill the second `section`! 
 
-Add an `h2` element to the `#share` element that contains the text `Sharing your card...`, then add a `p` element with the text `Your card was shared on social media!`.
+Add an `h2` element to the `#share` element that contains the text `Sharing your card...`, then add a `p` element with the text `Your card was shared on social media!`
 
 # --hints--
 
@@ -19,7 +19,7 @@ The `#share` element should contain a `h2` element.
 assert.exists(document.querySelector("#share > h2"));
 ```
 
-The `h2` element should contain the text `Sharing your card...`.
+The `h2` element should contain the text `Sharing your card...`
 
 ```js
 assert.strictEqual(document.querySelector("#share > h2").innerText.trim(), "Sharing your card...");
@@ -31,7 +31,7 @@ The second element inside `#share` should be a `p` element.
 assert.strictEqual(document.querySelector("#share").children[1].tagName, "P");
 ```
 
-The `p` element should have the text `Your card was shared on social media!`.
+The `p` element should have the text `Your card was shared on social media!`
 
 ```js
 assert.strictEqual(document.querySelector("#share").children[1].innerText.trim(), "Your card was shared on social media!");

--- a/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a94ea5df66236ebed260e8.md
+++ b/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a94ea5df66236ebed260e8.md
@@ -11,7 +11,7 @@ The next section in the form will be responsible for asking users if they have s
 
 Start by adding a `fieldset` element.
 
-Inside the `fieldset` element, add a `legend` element with the text of `Was this your first time at our hotel?`. 
+Inside the `fieldset` element, add a `legend` element with the text of `Was this your first time at our hotel?` 
 
 # --hints--
 
@@ -27,7 +27,7 @@ You should have a `legend` element inside of your `fieldset` element.
 assert.lengthOf(document.querySelectorAll('fieldset legend'), 2);
 ```
 
-Your `legend` element should have the text of `Was this your first time at our hotel?`.
+Your `legend` element should have the text of `Was this your first time at our hotel?`
 
 ```js
 assert.strictEqual(document.querySelectorAll('fieldset legend')[1]?.textContent.trim(), 'Was this your first time at our hotel?');

--- a/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a97f40ddd40d7deb0618b7.md
+++ b/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a97f40ddd40d7deb0618b7.md
@@ -19,7 +19,7 @@ You should have a `label` with a `for` attribute set to `"comments"`.
 assert.exists(document.querySelector('label[for="comments"]'));
 ```
 
-Your `label` should have the text `Other Comments?`.
+Your `label` should have the text `Other Comments?`
 
 ```js
 assert.strictEqual(document.querySelector('label[for="comments"]')?.textContent.trim(), 'Other Comments?');

--- a/curriculum/challenges/english/blocks/workshop-magazine/6143d003ad9e9d76766293ec.md
+++ b/curriculum/challenges/english/blocks/workshop-magazine/6143d003ad9e9d76766293ec.md
@@ -7,7 +7,7 @@ dashedName: step-24
 
 # --description--
 
-Within your `.image-quote` element, nest an `hr` element, a `p` element and a second `hr` element. Give the `p` element a `class` set to `quote` and the text `The millions of people who are learning to code through freeCodeCamp will have an even better resource to help them learn these fundamentals.`.
+Within your `.image-quote` element, nest an `hr` element, a `p` element and a second `hr` element. Give the `p` element a `class` set to `quote` and the text `The millions of people who are learning to code through freeCodeCamp will have an even better resource to help them learn these fundamentals.`
 
 # --hints--
 
@@ -38,7 +38,7 @@ Your new `p` element should have a `class` set to `quote`.
 assert.isTrue(document.querySelector('.image-quote p')?.classList.contains('quote'));
 ```
 
-Your new `p` element should have the text `The millions of people who are learning to code through freeCodeCamp will have an even better resource to help them learn these fundamentals.`.
+Your new `p` element should have the text `The millions of people who are learning to code through freeCodeCamp will have an even better resource to help them learn these fundamentals.`
 
 ```js
 assert.equal(document.querySelector('.image-quote p')?.innerText, 'The millions of people who are learning to code through freeCodeCamp will have an even better resource to help them learn these fundamentals.');

--- a/curriculum/challenges/english/blocks/workshop-major-browsers-list/69038fe7da59ca23a5eba82d.md
+++ b/curriculum/challenges/english/blocks/workshop-major-browsers-list/69038fe7da59ca23a5eba82d.md
@@ -42,7 +42,7 @@ const ddElements = document.querySelectorAll('dd');
 assert.lengthOf(ddElements, 5);
 ```
 
-Your fifth `dd` element should contain the text `This is a free Chromium based web browser first released in 2023 by The Browser Company.`.
+Your fifth `dd` element should contain the text `This is a free Chromium based web browser first released in 2023 by The Browser Company.`
 
 ```js
 const ddElement = document.querySelectorAll('dd')[4];

--- a/curriculum/challenges/english/blocks/workshop-media-catalogue/68b95956da014b1a8e32ffb3.md
+++ b/curriculum/challenges/english/blocks/workshop-media-catalogue/68b95956da014b1a8e32ffb3.md
@@ -14,7 +14,7 @@ class CustomError(Exception):
     ...
 ```
 
-Create a class named `MediaError`. Make it inherit from the `Exception` class and add to it a docstring saying `Custom exception for media-related errors.`.
+Create a class named `MediaError`. Make it inherit from the `Exception` class and add to it a docstring saying `Custom exception for media-related errors.`
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eaa668d4d9fbe529a0e16b.md
+++ b/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eaa668d4d9fbe529a0e16b.md
@@ -19,7 +19,7 @@ Your last `fieldset` should contain a `label` element.
 assert.exists(document.querySelector("fieldset:last-of-type label"));
 ```
 
-The `label` element should have the text `Any specific concerns or topics you'd like to discuss?`.
+The `label` element should have the text `Any specific concerns or topics you'd like to discuss?`
 
 ```js
 const label = document.querySelector("fieldset:last-of-type label");

--- a/curriculum/challenges/english/blocks/workshop-quincys-job-tips/68ea7e7b916e8270483689b6.md
+++ b/curriculum/challenges/english/blocks/workshop-quincys-job-tips/68ea7e7b916e8270483689b6.md
@@ -17,7 +17,7 @@ Here is an example of a block quotation element with quoted text:
 </blockquote>
 ```
 
-Now, inside the first section, add a block quotation element below the `h2` element with the text `Can you imagine what it would be like to be a successful developer? To have built software systems that people rely upon?`.
+Now, inside the first section, add a block quotation element below the `h2` element with the text `Can you imagine what it would be like to be a successful developer? To have built software systems that people rely upon?`
 
 # --hints--
 
@@ -27,7 +27,7 @@ Inside the first `section` element, you should have a `blockquote` element below
 assert.exists(document.querySelector('section:first-of-type > h2 + blockquote'));
 ```
 
-Your `blockquote` element should have the text `Can you imagine what it would be like to be a successful developer? To have built software systems that people rely upon?`.
+Your `blockquote` element should have the text `Can you imagine what it would be like to be a successful developer? To have built software systems that people rely upon?`
 
 ```js
 const firstBlockquoteEl = document.querySelector('section:first-of-type > h2 + blockquote');

--- a/curriculum/challenges/english/blocks/workshop-registration-form/60fad0a812d9890938524f50.md
+++ b/curriculum/challenges/english/blocks/workshop-registration-form/60fad0a812d9890938524f50.md
@@ -9,7 +9,7 @@ dashedName: step-37
 
 To give Campers an idea of what to put in their bio, the `placeholder` attribute is used. The `placeholder` accepts a text value, which is displayed until the user starts typing.
 
-Give the `textarea` a `placeholder` of `I like coding on the beach...`.
+Give the `textarea` a `placeholder` of `I like coding on the beach...`
 
 # --hints--
 
@@ -19,7 +19,7 @@ You should give the `textarea` a `placeholder` attribute.
 assert.isNotEmpty(document.querySelector('fieldset:nth-child(3) > label:nth-child(4) > textarea')?.placeholder);
 ```
 
-You should give the `placeholder` a value of `I like coding on the beach...`.
+You should give the `placeholder` a value of `I like coding on the beach...`
 
 ```js
 assert.match(document.querySelector('fieldset:nth-child(3) > label:nth-child(4) > textarea')?.placeholder, /^I like coding on the beach\.{3,4}$/);

--- a/curriculum/challenges/english/blocks/workshop-storytelling-app/671f99a5dc221afb86fa2dc0.md
+++ b/curriculum/challenges/english/blocks/workshop-storytelling-app/671f99a5dc221afb86fa2dc0.md
@@ -10,11 +10,11 @@ demoType: onLoad
 
 In this workshop, you will build a storytelling app that allows users to select a type of story and display a short story of that type. The CSS and the HTML boilerplate has been provided for you.
 
-Begin by creating an `h1` element and give it a text `Want to hear a short story?`. 
+Begin by creating an `h1` element and give it a text `Want to hear a short story?` 
 
 # --hints--
 
-You should have an `h1` with the text `Want to hear a short story?`.
+You should have an `h1` with the text `Want to hear a short story?`
 
 ```js
 const h1 = document.querySelector('h1');

--- a/curriculum/challenges/english/blocks/workshop-string-formatter/68e4276483b0c71658aab1ca.md
+++ b/curriculum/challenges/english/blocks/workshop-string-formatter/68e4276483b0c71658aab1ca.md
@@ -25,7 +25,7 @@ Your `userInput` variable should be a string.
 assert.isString(userInput);
 ```
 
-You should assign `"   Hello World!   "` to your `userInput` variable. Make sure there are three spaces before the `H` and three spaces after the `!`.
+You should assign `"   Hello World!   "` to your `userInput` variable. Make sure there are three spaces before the `H` and three spaces after the `!`
 
 ```js
 assert.equal(userInput, "   Hello World!   ");

--- a/curriculum/challenges/english/blocks/workshop-teacher-chatbot/66b6e80d6c3f0b329c360283.md
+++ b/curriculum/challenges/english/blocks/workshop-teacher-chatbot/66b6e80d6c3f0b329c360283.md
@@ -15,7 +15,7 @@ Remember to replace `[subject]` with the `subject` variable and use proper templ
 
 # --hints--
 
-Your `console` statement should output the message `Here is an example of accessing the first letter in the word [subject].`
+Your `console` statement should output the message `Here is an example of accessing the first letter in the word [subject].` 
 
 ```js
 assert.match(code, /console\.log\(`Here\s+is\s+an\s+example\s+of\s+accessing\s+the\s+first\s+letter\s+in\s+the\s+word\s+\${subject}\.`\);?/);

--- a/curriculum/challenges/english/blocks/workshop-teacher-chatbot/66b6f586767a1534f3097353.md
+++ b/curriculum/challenges/english/blocks/workshop-teacher-chatbot/66b6f586767a1534f3097353.md
@@ -15,7 +15,7 @@ Then add another `console` statement that outputs the second letter of the `subj
 
 # --hints--
 
-Your `console` statement should output the message `Here is an example of accessing the second letter in the word [subject].`
+Your `console` statement should output the message `Here is an example of accessing the second letter in the word [subject].` 
 
 ```js
 assert.match(code, /console\.log\(`Here\s+is\s+an\s+example\s+of\s+accessing\s+the\s+second\s+letter\s+in\s+the\s+word\s+\$\{subject\}\.`\);?/);

--- a/curriculum/challenges/english/blocks/workshop-toggle-text-app/67cd46ec4ec904186ad52ba5.md
+++ b/curriculum/challenges/english/blocks/workshop-toggle-text-app/67cd46ec4ec904186ad52ba5.md
@@ -7,7 +7,7 @@ dashedName: step-3
 
 # --description--
 
-Below your `button` element, add a paragraph element with an `id` of `message` and the text `I love freeCodeCamp!`.
+Below your `button` element, add a paragraph element with an `id` of `message` and the text `I love freeCodeCamp!`
 
 # --hints--
 
@@ -23,7 +23,7 @@ Your paragraph element should have an `id` of `message`.
 assert.exists(document.getElementById("message"))
 ```
 
-Your paragraph element should have the text `I love freeCodeCamp!`.
+Your paragraph element should have the text `I love freeCodeCamp!`
 
 ```js
 const paraEl = document.querySelector("p");

--- a/curriculum/challenges/english/blocks/zh-a1-learn-understanding-greetings-and-introductions/6929acce4fc06b7554c10a1e.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-understanding-greetings-and-introductions/6929acce4fc06b7554c10a1e.md
@@ -14,7 +14,7 @@ This task doesn't have audio. Read the question below and select the correct ans
 
 ## --text--
 
-Which option means "I'm Chinese. I'm a developer."?
+Which option means "I'm Chinese. I'm a developer."
 
 ## --answers--
 

--- a/curriculum/challenges/english/blocks/zh-a1-learn-understanding-greetings-and-introductions/6929aee7c53c517844d45ab6.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-understanding-greetings-and-introductions/6929aee7c53c517844d45ab6.md
@@ -14,7 +14,7 @@ This task doesn't have audio. Read the question below and select the correct ans
 
 ## --text--
 
-Which option means "I'm Singaporean. I'm a designer."?
+Which option means "I'm Singaporean. I'm a designer."
 
 ## --answers--
 

--- a/curriculum/challenges/english/blocks/zh-a1-learn-understanding-greetings-and-introductions/6929b1a87c66927c3fdbb1de.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-understanding-greetings-and-introductions/6929b1a87c66927c3fdbb1de.md
@@ -14,7 +14,7 @@ This task doesn't have audio. Read the question below and select the correct ans
 
 ## --text--
 
-Which option means "I'm Canadian."?
+Which option means "I'm Canadian."
 
 ## --answers--
 

--- a/curriculum/challenges/english/blocks/zh-a1-learn-understanding-questions-and-answers/692a641fcd6ab4173e3e285f.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-understanding-questions-and-answers/692a641fcd6ab4173e3e285f.md
@@ -30,7 +30,7 @@ This means the opposite of "yes".
 
 ### --feedback--
 
-This means "isn't it?" or "right?".
+This means "isn't it?" or "right?"
 
 ---
 

--- a/curriculum/challenges/english/blocks/zh-a1-learn-understanding-questions-and-answers/692a805cac4208491a67242d.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-understanding-questions-and-answers/692a805cac4208491a67242d.md
@@ -34,7 +34,7 @@ This means "unhappy".
 
 ### --feedback--
 
-This is a question meaning "Are you happy?".
+This is a question meaning "Are you happy?"
 
 ---
 

--- a/curriculum/challenges/english/blocks/zh-a1-practice-exchanging-basic-information/69182f75cc96e43363541510.md
+++ b/curriculum/challenges/english/blocks/zh-a1-practice-exchanging-basic-information/69182f75cc96e43363541510.md
@@ -73,6 +73,6 @@ If you want to ask a question, don't forget to first introduce the question poli
 
 In order to know a person's name, you can use `叫什么 (jiào shén me)`.
 
-If you've just introduced yourself and want to ask the other person the same, simply say `你呢 (nǐ ne)?`.
+If you've just introduced yourself and want to ask the other person the same, simply say `你呢 (nǐ ne)?`
 
 To express that you feel the same way as the other person, you can say `我也是 (wǒ yě shì)`.


### PR DESCRIPTION
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
 - [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
 - [x] My pull request targets the `main` branch of freeCodeCamp.
 - [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

 Closes #65383

 Removed redundant punctuation marks that appear after closing backticks or double quotes when the quoted content already ends with terminal punctuation (period, exclamation mark, or question mark).   

For example:
  - `You must wear a seatbelt.`. → `You must wear a seatbelt.`
  - `What was it?`. → `What was it?`
  - `React Rocks!`. → `React Rocks!`