### PR TITLE
fix(curriculum): enforce powerSource useState('') in Step 3

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-superhero-application-form/680fc849a6f2be0a8597c593.md
+++ b/curriculum/challenges/english/blocks/workshop-superhero-application-form/680fc849a6f2be0a8597c593.md
@@ -21,24 +21,30 @@ Your `powerSource` and `setPowerSource` should use the `useState` hook.
 
 ```js
   const abuseState = __helpers.spyOn(React, "useState");
-  const script = [...document.querySelectorAll("script")].find((s) => s.dataset.src ===  "index.jsx").innerText;
-  const exports = {};
-  const _a = eval(script);
-  const _b = await __helpers.prepTestComponent(exports.SuperheroForm);
+	const script = [...document.querySelectorAll("script")].find(
+  	(s) => s.dataset.src === "index.jsx"
+	).innerText;
+	const exports = {};
+	eval(script);
+	await __helpers.prepTestComponent(exports.SuperheroForm);
 
-  assert.isAtLeast(abuseState.calls.length, 3);
+	assert.isAtLeast(abuseState.calls.length, 3);
 ```
 
 Your `useState` hook for `powerSource` should have an initial value of empty string.
 
 ```js
-  const abuseState = __helpers.spyOn(React, "useState");
-  const script = [...document.querySelectorAll("script")].find((s) => s.dataset.src ===  "index.jsx").innerText;
-  const exports = {};
-  const _a = eval(script);
-  const _b = await __helpers.prepTestComponent(exports.SuperheroForm);
+  assert.equal(
+    abuseState.calls[2]?.[0],
+    "",
+    "powerSource must be initialized with '' (empty string)"
+);
 
-  assert.equal(abuseState.calls[2]?.[0], "");
+assert.notDeepEqual(
+  abuseState.calls[2]?.[0],
+  [],
+  "powerSource cannot be initialized with an empty array"
+);
 ```
 
 You should use array destructuring to set a `powers` state variable and a `setPowers` setter.
@@ -50,27 +56,18 @@ assert.match(code, /(const|let|var)\s+\[\s*powers\s*,\s*setPowers\s*\]/);
 Your `powers` and `setPowers` should use the `useState` hook.
 
 ```js
-  const abuseState = __helpers.spyOn(React, "useState");
-  const script = [...document.querySelectorAll("script")].find((s) => s.dataset.src ===  "index.jsx").innerText;
-  const exports = {};
-  const _a = eval(script);
-  const _b = await __helpers.prepTestComponent(exports.SuperheroForm);
-
   assert.isAtLeast(abuseState.calls.length, 4);
 ```
 
 Your `useState` hook for `powers` should have an initial value of empty array.
 
 ```js
-  const abuseState = __helpers.spyOn(React, "useState");
-  const script = [...document.querySelectorAll("script")].find((s) => s.dataset.src ===  "index.jsx").innerText;
-  const exports = {};
-  const _a = eval(script);
-  const _b = await __helpers.prepTestComponent(exports.SuperheroForm);
-
-  console.log("State calls:", abuseState.calls)
-
-  assert.deepEqual(abuseState.calls[3]?.[0], []);
+  console.log("State calls:", abuseState.calls);
+  assert.deepEqual(
+    abuseState.calls[3]?.[0],
+    [],
+    "powers must be initialized with an empty array"
+);
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #65621

<!-- Feel free to add any additional description of changes below this line -->

This PR fixes Step 3 of the Superhero Application Form challenge.

- The `powerSource` state variable must now be initialized with an empty string (`useState('')`) as intended.
- The tests now **reject `useState([])`** for `powerSource`.
- `powers` state variable still correctly initializes with an empty array (`useState([])`).

### Why this is needed

Previously, the tests allowed `powerSource` to be initialized with an empty array, which was inconsistent with the challenge instructions. This caused confusion and allowed incorrect solutions to pass.

### How it was fixed

- Updated the test code to explicitly check that `powerSource` is `''` and **not** `[]`.
- Verified that the tests still correctly check `powers` initialization.

This ensures that learners now follow the instructions correctly and prevents unintended solutions from passing.
