### PR TITLE
refactor: use environment, not .env, in ci

### DIFF
--- a/.github/workflows/curriculum-i18n-submodule.yml
+++ b/.github/workflows/curriculum-i18n-submodule.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Set Environment variables
         run: |
-          cp sample.env .env
+          set -a && source sample.env && set +a
 
       - name: Install node_modules
         run: pnpm install

--- a/.github/workflows/curriculum-i18n-submodule.yml
+++ b/.github/workflows/curriculum-i18n-submodule.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Set Environment variables
         run: |
-          cat sample.env >> $GITHUB_ENV
+          sed '/^[[:space:]]*#/d; /^$/d' sample.env >> $GITHUB_ENV
 
       - name: Install node_modules
         run: pnpm install

--- a/.github/workflows/curriculum-i18n-submodule.yml
+++ b/.github/workflows/curriculum-i18n-submodule.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Set Environment variables
         run: |
-          set -a && source sample.env && set +a
+          cat sample.env >> $GITHUB_ENV
 
       - name: Install node_modules
         run: pnpm install

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Set freeCodeCamp Environment Variables
         run: |
-          cp sample.env .env
+          set -a && source sample.env && set +a
 
       - name: Install and Build
         run: |
@@ -153,7 +153,7 @@ jobs:
 
       - name: Set freeCodeCamp Environment Variables (needed by api)
         run: |
-          cp sample.env .env
+          set -a && source sample.env && set +a
 
       - name: Install playwright dependencies
         run: npx playwright install --with-deps

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -154,6 +154,7 @@ jobs:
       - name: Set freeCodeCamp Environment Variables (needed by api)
         run: |
           sed '/^[[:space:]]*#/d; /^$/d' sample.env >> $GITHUB_ENV
+          cp sample.env .env # for docker compose
 
       - name: Install playwright dependencies
         run: npx playwright install --with-deps

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Set freeCodeCamp Environment Variables
         run: |
-          cat sample.env >> $GITHUB_ENV
+          sed '/^[[:space:]]*#/d; /^$/d' sample.env >> $GITHUB_ENV
 
       - name: Install and Build
         run: |
@@ -153,7 +153,7 @@ jobs:
 
       - name: Set freeCodeCamp Environment Variables (needed by api)
         run: |
-          cat sample.env >> $GITHUB_ENV
+          sed '/^[[:space:]]*#/d; /^$/d' sample.env >> $GITHUB_ENV
 
       - name: Install playwright dependencies
         run: npx playwright install --with-deps

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Set freeCodeCamp Environment Variables
         run: |
-          set -a && source sample.env && set +a
+          cat sample.env >> $GITHUB_ENV
 
       - name: Install and Build
         run: |
@@ -153,7 +153,7 @@ jobs:
 
       - name: Set freeCodeCamp Environment Variables (needed by api)
         run: |
-          set -a && source sample.env && set +a
+          cat sample.env >> $GITHUB_ENV
 
       - name: Install playwright dependencies
         run: npx playwright install --with-deps

--- a/.github/workflows/i18n-validate-builds.yml
+++ b/.github/workflows/i18n-validate-builds.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Set freeCodeCamp Environment Variables
         run: |
-          cat sample.env >> $GITHUB_ENV
+          sed '/^[[:space:]]*#/d; /^$/d' sample.env >> $GITHUB_ENV
 
       - name: Install Dependencies
         run: pnpm install

--- a/.github/workflows/i18n-validate-builds.yml
+++ b/.github/workflows/i18n-validate-builds.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Set freeCodeCamp Environment Variables
         run: |
-          set -a && source sample.env && set +a
+          cat sample.env >> $GITHUB_ENV
 
       - name: Install Dependencies
         run: pnpm install

--- a/.github/workflows/i18n-validate-builds.yml
+++ b/.github/workflows/i18n-validate-builds.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Set freeCodeCamp Environment Variables
         run: |
-          cp sample.env .env
+          set -a && source sample.env && set +a
 
       - name: Install Dependencies
         run: pnpm install

--- a/.github/workflows/i18n-validate-prs.yml
+++ b/.github/workflows/i18n-validate-prs.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Set freeCodeCamp Environment Variables
         run: |
-          set -a && source sample.env && set +a
+          cat sample.env >> $GITHUB_ENV
 
       - name: Install Dependencies
         run: pnpm install

--- a/.github/workflows/i18n-validate-prs.yml
+++ b/.github/workflows/i18n-validate-prs.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Set freeCodeCamp Environment Variables
         run: |
-          cat sample.env >> $GITHUB_ENV
+          sed '/^[[:space:]]*#/d; /^$/d' sample.env >> $GITHUB_ENV
 
       - name: Install Dependencies
         run: pnpm install

--- a/.github/workflows/i18n-validate-prs.yml
+++ b/.github/workflows/i18n-validate-prs.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Set freeCodeCamp Environment Variables
         run: |
-          cp sample.env .env
+          set -a && source sample.env && set +a
 
       - name: Install Dependencies
         run: pnpm install

--- a/.github/workflows/node.js-tests.yml
+++ b/.github/workflows/node.js-tests.yml
@@ -64,8 +64,8 @@ jobs:
 
       - name: Set Environment variables
         run: |
-          cp sample.env .env
-          cat .env
+          set -a && source sample.env && set +a
+          cat sample.env
 
       - name: Install node_modules
         run: pnpm install
@@ -116,7 +116,7 @@ jobs:
 
       - name: Set freeCodeCamp Environment Variables
         run: |
-          cp sample.env .env
+          set -a && source sample.env && set +a
 
       - name: Install and Build
         run: |
@@ -158,8 +158,8 @@ jobs:
 
       - name: Set Environment variables
         run: |
-          cp sample.env .env
-          cat .env
+          set -a && source sample.env && set +a
+          cat sample.env
 
       - name: Start MongoDB
         run: docker compose -f docker/docker-compose.yml up -d
@@ -210,9 +210,9 @@ jobs:
 
       - name: Set Environment variables
         run: |
-          cp sample.env .env
+          set -a && source sample.env && set +a
           echo 'SHOW_UPCOMING_CHANGES=true' >> .env
-          cat .env
+          cat sample.env
 
       - name: Start MongoDB
         run: docker compose -f docker/docker-compose.yml up -d
@@ -265,8 +265,8 @@ jobs:
 
       - name: Set Environment variables
         run: |
-          cp sample.env .env
-          cat .env
+          set -a && source sample.env && set +a
+          cat sample.env
 
       - name: Start MongoDB
         uses: supercharge/mongodb-github-action@315db7fe45ac2880b7758f1933e6e5d59afd5e94 # 1.12.1

--- a/.github/workflows/node.js-tests.yml
+++ b/.github/workflows/node.js-tests.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Set Environment variables
         run: |
-          set -a && source sample.env && set +a
+          cat sample.env >> $GITHUB_ENV
           cat sample.env
 
       - name: Install node_modules
@@ -116,7 +116,7 @@ jobs:
 
       - name: Set freeCodeCamp Environment Variables
         run: |
-          set -a && source sample.env && set +a
+          cat sample.env >> $GITHUB_ENV
 
       - name: Install and Build
         run: |
@@ -158,7 +158,7 @@ jobs:
 
       - name: Set Environment variables
         run: |
-          set -a && source sample.env && set +a
+          cat sample.env >> $GITHUB_ENV
           cat sample.env
 
       - name: Start MongoDB
@@ -210,7 +210,7 @@ jobs:
 
       - name: Set Environment variables
         run: |
-          set -a && source sample.env && set +a
+          cat sample.env >> $GITHUB_ENV
           echo 'SHOW_UPCOMING_CHANGES=true' >> .env
           cat sample.env
 
@@ -265,7 +265,7 @@ jobs:
 
       - name: Set Environment variables
         run: |
-          set -a && source sample.env && set +a
+          cat sample.env >> $GITHUB_ENV
           cat sample.env
 
       - name: Start MongoDB

--- a/.github/workflows/node.js-tests.yml
+++ b/.github/workflows/node.js-tests.yml
@@ -46,7 +46,7 @@ jobs:
           fi
 
       - name: Check format of sample.env
-        run: docker run --rm -v `pwd`:/app -w /app dotenvlinter/dotenv-linter check --ignore-checks sample.env
+        run: docker run --rm -v `pwd`:/app -w /app dotenvlinter/dotenv-linter check --ignore-checks UnorderedKey sample.env
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6

--- a/.github/workflows/node.js-tests.yml
+++ b/.github/workflows/node.js-tests.yml
@@ -45,6 +45,9 @@ jobs:
             exit 1
           fi
 
+      - name: Check format of sample.env
+        run: docker run --rm -v `pwd`:/app -w /app dotenvlinter/dotenv-linter check --ignore-checks sample.env
+
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
         with:

--- a/.github/workflows/node.js-tests.yml
+++ b/.github/workflows/node.js-tests.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Set Environment variables
         run: |
-          cat sample.env >> $GITHUB_ENV
+          sed '/^[[:space:]]*#/d; /^$/d' sample.env >> $GITHUB_ENV
           cat sample.env
 
       - name: Install node_modules
@@ -116,7 +116,7 @@ jobs:
 
       - name: Set freeCodeCamp Environment Variables
         run: |
-          cat sample.env >> $GITHUB_ENV
+          sed '/^[[:space:]]*#/d; /^$/d' sample.env >> $GITHUB_ENV
 
       - name: Install and Build
         run: |
@@ -158,7 +158,7 @@ jobs:
 
       - name: Set Environment variables
         run: |
-          cat sample.env >> $GITHUB_ENV
+          sed '/^[[:space:]]*#/d; /^$/d' sample.env >> $GITHUB_ENV
           cat sample.env
 
       - name: Start MongoDB
@@ -210,7 +210,7 @@ jobs:
 
       - name: Set Environment variables
         run: |
-          cat sample.env >> $GITHUB_ENV
+          sed '/^[[:space:]]*#/d; /^$/d' sample.env >> $GITHUB_ENV
           echo 'SHOW_UPCOMING_CHANGES=true' >> .env
           cat sample.env
 
@@ -265,7 +265,7 @@ jobs:
 
       - name: Set Environment variables
         run: |
-          cat sample.env >> $GITHUB_ENV
+          sed '/^[[:space:]]*#/d; /^$/d' sample.env >> $GITHUB_ENV
           cat sample.env
 
       - name: Start MongoDB

--- a/api/src/utils/env.ts
+++ b/api/src/utils/env.ts
@@ -8,7 +8,11 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const envPath = path.resolve(__dirname, '../../../.env');
 const { error } = config({ path: envPath });
 
-if (error && process.env.FREECODECAMP_NODE_ENV !== 'production') {
+if (
+  error &&
+  process.env.FREECODECAMP_NODE_ENV == 'production' &&
+  process.env.NODE_ENV !== 'test'
+) {
   console.warn(`
   ----------------------------------------------------
   Warning: .env file not found.

--- a/api/turbo.json
+++ b/api/turbo.json
@@ -39,7 +39,41 @@
       ]
     },
     "test": {
-      "passThroughEnv": ["VITEST_WORKER_ID"]
+      "passThroughEnv": ["VITEST_WORKER_ID"],
+      "env": [
+        "API_LOCATION",
+        "AUTH0_CLIENT_ID",
+        "AUTH0_CLIENT_SECRET",
+        "AUTH0_DOMAIN",
+        "COOKIE_DOMAIN",
+        "COOKIE_SECRET",
+        "DEPLOYMENT_ENV",
+        "DEPLOYMENT_VERSION",
+        "EMAIL_PROVIDER",
+        "FCC_API_LOG_LEVEL",
+        "FCC_API_LOG_TRANSPORT",
+        "FCC_ENABLE_DEV_LOGIN_MODE",
+        "FCC_ENABLE_SENTRY_ROUTES",
+        "FCC_ENABLE_SHADOW_CAPTURE",
+        "FCC_ENABLE_SWAGGER_UI",
+        "FCC_ENABLE_TEST_LOGGING",
+        "FREECODECAMP_NODE_ENV",
+        "GROWTHBOOK_FASTIFY_API_HOST",
+        "GROWTHBOOK_FASTIFY_CLIENT_KEY",
+        "HOME_LOCATION",
+        "HOST",
+        "JWT_SECRET",
+        "MAILPIT_HOST",
+        "NODE_ENV",
+        "PORT",
+        "SENTRY_DSN",
+        "SENTRY_ENVIRONMENT",
+        "SES_ID",
+        "SES_REGION",
+        "SES_SECRET",
+        "SHOW_UPCOMING_CHANGES",
+        "STRIPE_SECRET_KEY"
+      ]
     }
   }
 }

--- a/curriculum/src/config.ts
+++ b/curriculum/src/config.ts
@@ -17,7 +17,7 @@ export function testedLang() {
       Before the site can be built, this language needs to be manually approved`);
     }
   } else {
-    throw Error('LOCALE must be set for testing');
+    throw Error('CURRICULUM_LOCALE must be set for testing');
   }
 }
 

--- a/curriculum/turbo.json
+++ b/curriculum/turbo.json
@@ -13,6 +13,9 @@
     "test-content": {
       "passThroughEnv": ["VITEST_POOL_ID", "PUPPETEER_WS_ENDPOINT"],
       "env": ["FCC_*", "CURRICULUM_LOCALE", "SHOW_UPCOMING_CHANGES"]
+    },
+    "lint": {
+      "env": ["CURRICULUM_LOCALE"]
     }
   }
 }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

The rationale is that this is both closer to production and works with caching.

The alternative is to add .env to inputs, which should work, but that means each environment that should be equivalent needs the same .env file. That's not what we want for production-like environments and it makes cache misses more likely.  Reason being, any difference in .env (including changes to comments) will invalidate the entire cache.

I didn't mess with gitpod or devcontainers since the former seems unsupported and I wasn't sure where we're going with the latter.

This is related to https://github.com/freeCodeCamp/freeCodeCamp/pull/65653, but I wanted to explore this in isolation.

Note: this is a draft because I'm expecting tests to fail and I want to make sure that's the case. If it's not, then I need figure out why.

<!-- Feel free to add any additional description of changes below this line -->
