### PR TITLE
fix(curriculum): improve lightbox display tests and allow vw/vh units

### DIFF
--- a/curriculum/challenges/english/blocks/lab-lightbox-viewer/66db57ad34c7089b9b41bfd6.md
+++ b/curriculum/challenges/english/blocks/lab-lightbox-viewer/66db57ad34c7089b9b41bfd6.md
@@ -138,14 +138,12 @@ const height = style?.height;
 
 assert.oneOf(
   width,
-  ["100%", "100vw"],
-  `Expected width to be 100% or 100vw, got ${width}`
+  ["100%", "100vw"]
 );
 
 assert.oneOf(
   height,
-  ["100%", "100vh"],
-  `Expected height to be 100% or 100vh, got ${height}`
+  ["100%", "100vh"]
 );
 ```
 

--- a/curriculum/challenges/english/blocks/lab-lightbox-viewer/66db57ad34c7089b9b41bfd6.md
+++ b/curriculum/challenges/english/blocks/lab-lightbox-viewer/66db57ad34c7089b9b41bfd6.md
@@ -136,13 +136,15 @@ const style = new __helpers.CSSHelp(document).getStyle(".lightbox");
 const width = style?.width;
 const height = style?.height;
 
-assert.isTrue(
-  width === "100%" || width === "100vw",
+assert.oneOf(
+  width,
+  ["100%", "100vw"],
   `Expected width to be 100% or 100vw, got ${width}`
 );
 
-assert.isTrue(
-  height === "100%" || height === "100vh",
+assert.oneOf(
+  height,
+  ["100%", "100vh"],
   `Expected height to be 100% or 100vh, got ${height}`
 );
 ```

--- a/curriculum/challenges/english/blocks/lab-lightbox-viewer/66db57ad34c7089b9b41bfd6.md
+++ b/curriculum/challenges/english/blocks/lab-lightbox-viewer/66db57ad34c7089b9b41bfd6.md
@@ -215,9 +215,9 @@ function getComputedDisplay(element) {
   return window.getComputedStyle(element).display;
 }
 
-lightbox.style.display = "flex";
+lightbox.classList.add("show");
 
-background.dispatchEvent(new Event("click"));
+background.dispatchEvent(new Event("click", { bubbles: true }));
 
 assert.strictEqual(getComputedDisplay(lightbox), "none");
 ```
@@ -231,9 +231,9 @@ function getComputedDisplay(element) {
   return window.getComputedStyle(element).display;
 }
 
-lightbox.style.display = "flex";
+lightbox.classList.add("show");
 
-lightbox.dispatchEvent(new Event("click"));
+lightbox.dispatchEvent(new Event("click", { bubbles: true }));
 
 assert.strictEqual(getComputedDisplay(lightbox), "none");
 ```

--- a/curriculum/challenges/english/blocks/lab-lightbox-viewer/66db57ad34c7089b9b41bfd6.md
+++ b/curriculum/challenges/english/blocks/lab-lightbox-viewer/66db57ad34c7089b9b41bfd6.md
@@ -211,15 +211,18 @@ When your `.lightbox` element is visible and you click the `#close-btn` button, 
 
 ```js
 const lightbox = document.querySelector(".lightbox");
-const background = document.getElementById("close-btn"); 
+const closeBtn = document.getElementById("close-btn"); 
+const galleryItem = document.querySelector(".gallery-item");
 
 function getComputedDisplay(element) {
   return window.getComputedStyle(element).display;
 }
 
-lightbox.classList.add("show");
+galleryItem.dispatchEvent(new Event("click", { bubbles: true }));
 
-background.dispatchEvent(new Event("click", { bubbles: true }));
+assert.strictEqual(getComputedDisplay(lightbox), "flex");
+
+closeBtn.dispatchEvent(new Event("click", { bubbles: true }));
 
 assert.strictEqual(getComputedDisplay(lightbox), "none");
 ```
@@ -233,7 +236,10 @@ function getComputedDisplay(element) {
   return window.getComputedStyle(element).display;
 }
 
-lightbox.classList.add("show");
+const galleryItem = document.querySelector(".gallery-item");
+galleryItem.dispatchEvent(new Event("click", { bubbles: true }));
+
+assert.strictEqual(getComputedDisplay(lightbox), "flex");
 
 lightbox.dispatchEvent(new Event("click", { bubbles: true }));
 

--- a/curriculum/challenges/english/blocks/lab-lightbox-viewer/66db57ad34c7089b9b41bfd6.md
+++ b/curriculum/challenges/english/blocks/lab-lightbox-viewer/66db57ad34c7089b9b41bfd6.md
@@ -131,8 +131,20 @@ assert.equal(new __helpers.CSSHelp(document).getStyle(".lightbox")?.position, "f
 Your `.lightbox` element should cover the entire viewport.
 
 ```js
-assert.equal(new __helpers.CSSHelp(document).getStyle(".lightbox")?.width, "100%");
-assert.equal(new __helpers.CSSHelp(document).getStyle(".lightbox")?.height, "100%");
+const style = new __helpers.CSSHelp(document).getStyle(".lightbox");
+
+const width = style?.width;
+const height = style?.height;
+
+assert.isTrue(
+  width === "100%" || width === "100vw",
+  `Expected width to be 100% or 100vw, got ${width}`
+);
+
+assert.isTrue(
+  height === "100%" || height === "100vh",
+  `Expected height to be 100% or 100vh, got ${height}`
+);
 ```
 
 Your `.lightbox` element should be aligned with top left corner of the container.


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #60168

Updates the Lightbox Viewer tests to accept viewport units (`100vw` / `100vh`)
and support class-based display toggling. Removes reliance on inline styles
and uses bubbling click events to better reflect real user behavior.