### PR TITLE
fix(curriculum): misleading explanation of compound assignment operators

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-operator-behavior/673271b4213033d9b661c70e.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-operator-behavior/673271b4213033d9b661c70e.md
@@ -7,7 +7,7 @@ dashedName: what-are-compound-assignment-operators-in-javascript-and-how-do-they
 
 # --interactive--
 
-In JavaScript, all arithmetic operators have a compound assignment form. Compound assignment operators allow you to perform a mathematical operation and reassign the result back to the variable in one line of code. Instead of writing something like this:
+In JavaScript, all arithmetic operators have a compound assignment form. Compound assignment operators provide a concise shorthand for an operation on a variable followed by storing the result in that same variable. They combine the operation and assignment into a shorter form like `x += y`, which is equivalent to writing `x = x + y` but without repeating the variable name. Instead of writing something like this:
 
 :::interactive_editor
 
@@ -126,7 +126,7 @@ Think about how to combine mathematical operations and reassignment.
 
 ---
 
-Perform a mathematical operation and reassign the result to the variable in one line of code.
+Provide a shorter way to perform an operation on a variable and assign the result back to that same variable.
 
 ---
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #65702

<!-- Feel free to add any additional description of changes below this line -->
This PR updates the explanation of compound assignment operators in the JavaScript curriculum to resolve the confusion described in issue #65702.

The previous wording suggested that compound assignment operators are defined by performing an operation and reassignment “in one line of code,” which is also true for standard assignments like x = x + y. This PR clarifies that compound assignment operators are primarily a shorthand syntax that avoids repeating the variable name and improves readability.

The updated explanation:

Clearly distinguishes compound assignment operators from regular assignments

Emphasizes conciseness and intent rather than line count

Uses an explicit equivalence example (x += y vs x = x + y)

Aligns with MDN terminology and JavaScript best practices

No functionality or challenge logic was changed — this is a documentation-only clarification.