### PR TITLE
fix(curriculum): add String.length and correct Unicode explanation

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-string-character-methods/672d266034b5242126271995.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-string-character-methods/672d266034b5242126271995.md
@@ -9,7 +9,7 @@ dashedName: what-is-ascii-and-how-does-it-work-with-charcodeat-and-fromcharcode
 
 In programming, understanding how characters are represented as numbers is fundamental. This is where ASCII comes in. ASCII, short for American Standard Code for Information Interchange, is a character encoding standard used in computers to represent text. It assigns a numeric value to each character, which is universally recognized by machines.
 
-In this lesson, we will explore what ASCII is, how it works, and how you can use JavaScript methods like `charCodeAt()` and `fromCharCode()` to interact with ASCII values.
+In this lesson, we will explore what ASCII is, how it works, and how JavaScript methods like `charCodeAt()` and `fromCharCode()` relate to character encoding. While JavaScript strings use Unicode (UTF-16) internally, ASCII values match the first 128 Unicode characters, which is why ASCII-based examples work in JavaScript.
 
 ASCII is a system for encoding characters such as letters, digits, and symbols into numerical values. Each character is mapped to a specific number.
 
@@ -22,7 +22,7 @@ The ASCII standard covers 128 characters including:
 - Common punctuation marks and symbols (!, @, #, and so on).
 - Control characters (such as newline and tab).  
 
-In JavaScript, you can easily access the ASCII code of a character using the `charCodeAt()` method. This method is called on a string and returns the ASCII code of the character at a specified index.
+In JavaScript, you can access the numeric code of a character using the `charCodeAt()` method. This method returns the UTF-16 code unit of the character at a specified index. For the first 128 characters, this value matches the ASCII code.
 
 Let’s take a look at an example:
 
@@ -35,9 +35,9 @@ console.log(letter.charCodeAt(0));  // 65
 
 :::
 
-In this example, `A` is the first character of the string, and calling `charCodeAt(0)` returns its ASCII value, `65`.
+In this example, `A` is the first character of the string, and calling `charCodeAt(0)` returns its numeric code (which matches its ASCII value for basic Latin characters), `65`.
 
-You can also use this method with other characters to find their ASCII values:
+You can also use this method with other characters to find their numeric code values:
 
 :::interactive_editor
 
@@ -48,9 +48,9 @@ console.log(symbol.charCodeAt(0));  // 33
 
 :::
 
-Here, the ASCII code for the exclamation mark `!` is returned as `33`.
+Here, the numeric code for the exclamation mark `!` is returned as `33` (which matches its ASCII value).
 
-While `charCodeAt()` helps you retrieve the ASCII value of a character, the `fromCharCode()` method allows you to do the opposite: convert an ASCII code into its corresponding character.
+While `charCodeAt()` helps you retrieve the numeric code of a character, the `fromCharCode()` method allows you to do the opposite: convert a UTF-16 code unit (which matches ASCII for basic characters) into its corresponding character.
 
 Let's see this in action:
 
@@ -63,7 +63,7 @@ console.log(char);  //  A
 
 :::
 
-In this example, `fromCharCode(65)` converts the ASCII value `65` back to the character `A`.
+In this example, `fromCharCode(65)` converts the numeric code `65` (which matches the ASCII value for `A`) back to the character `A`.
 
 Another example would be converting the number `97` to its corresponding lowercase letter:
 
@@ -76,7 +76,7 @@ console.log(char);  // a
 
 :::
 
-These methods are particularly useful when you need to manipulate or compare characters based on their ASCII values.
+These methods are particularly useful when you need to manipulate or compare characters based on their numeric code values.
 
 For instance, you might use `charCodeAt()` to check if a character is uppercase, lowercase, or a digit by comparing its ASCII value.
 
@@ -94,7 +94,7 @@ The number of characters in the string.
 
 ### --feedback--
 
-Think about how characters are represented as numbers in the ASCII system.
+Think about how characters are represented as numeric code values in JavaScript.
 
 ---
 
@@ -102,11 +102,11 @@ The index of a character in the string.
 
 ### --feedback--
 
-Think about how characters are represented as numbers in the ASCII system.
+Think about how characters are represented as numeric code values in JavaScript.
 
 ---
 
-The ASCII value of a character at a specified index.
+The UTF-16 code unit of a character at a specified index.
 
 ---
 
@@ -114,7 +114,7 @@ The hexadecimal representation of a character.
 
 ### --feedback--
 
-Think about how characters are represented as numbers in the ASCII system.
+Think about how characters are represented as numeric code values in JavaScript.
 
 ## --video-solution--
 
@@ -162,7 +162,7 @@ Refer to the section of the lesson that discusses `fromCharCode()`.
 
 ## --text--
 
-Which of the following is an example of how ASCII encoding is useful in programming?
+Which of the following is an example of how character encoding is useful in programming?
 
 ## --answers--
 
@@ -170,7 +170,7 @@ To check if a string contains only uppercase letters.
 
 ### --feedback--
 
-Think about what you can do when characters are represented by their ASCII numbers.
+Think about what you can do when characters are represented by their numeric code values.
 
 ---
 
@@ -178,7 +178,7 @@ To calculate the length of a string.
 
 ### --feedback--
 
-Think about what you can do when characters are represented by their ASCII numbers.
+Think about what you can do when characters are represented by their numeric code values.
 
 ---
 
@@ -186,7 +186,7 @@ To convert a number into a floating-point value.
 
 ### --feedback--
 
-Think about what you can do when characters are represented by their ASCII numbers.
+Think about what you can do when characters are represented by their numeric code values.
 
 ---
 

--- a/curriculum/challenges/english/blocks/review-javascript-strings/6723c1946e4cd7909a836bb4.md
+++ b/curriculum/challenges/english/blocks/review-javascript-strings/6723c1946e4cd7909a836bb4.md
@@ -59,8 +59,9 @@ console.log(greeting); // "Hello, Jessica!"
 
 ## ASCII, the `charCodeAt()` Method and the `fromCharCode()` Method
 
-- **ASCII**: ASCII, short for American Standard Code for Information Interchange, is a character encoding standard used in computers to represent text. It assigns a numeric value to each character, which is universally recognized by machines. 
-- **The `charCodeAt()` Method**: This method is called on a string and returns the ASCII code of the character at a specified index.
+- **ASCII**: ASCII (American Standard Code for Information Interchange) is a character encoding standard used to represent basic English characters using numeric values. Earlier lessons introduce `charCodeAt()` and `fromCharCode()` using ASCII examples.
+- **Unicode**: JavaScript strings use Unicode internally, specifically UTF-16 encoding. For the first 128 characters (basic Latin letters, digits, and common symbols), the Unicode values match ASCII codes. This is why ASCII-based examples continue to work in JavaScript.
+- **The `charCodeAt()` Method**: This method returns the UTF-16 code unit of the character at a specified index. For basic Latin characters, this value matches the ASCII code.
 
 :::interactive_editor
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.


Closes #65648

This PR addresses:
- Adding the commonly used `String.length` property to the JavaScript Strings review lesson.
- Correcting the description of `charCodeAt()` to clarify that JavaScript strings use Unicode (UTF-16), with ASCII values matching only for basic Latin characters.