### PR TITLE
fix(curriculum): remove unused ::: marker

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-arrays-variables-and-naming-practices/6732c6ba2ea42b610b9f9ce1.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-arrays-variables-and-naming-practices/6732c6ba2ea42b610b9f9ce1.md
@@ -14,7 +14,7 @@ const fruits = ['apple', 'banana', 'orange'];
 console.log(fruits.length); // 3
 ```
 
-:::
+
 
 It's possible to have arrays with empty slots. Empty slots are defined as slots with nothing in them. This is different than an array with the value of `undefined`. These types of arrays are known as sparse arrays. Here is an example:
 


### PR DESCRIPTION
This PR removes an unused `:::` marker from the lesson content.

The marker does not wrap an `:::interactive_editor` block and appears to be leftover content, which could confuse learners or contributors reviewing the markdown.

---

### Checklist

- [x] I have read and followed the contribution guidelines.
- [x] I have read and followed the how to open a pull request guide.
- [x] My pull request targets the main branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #65755
