### PR TITLE
fix(client): prevent scrollbar injection when opening modals

### DIFF
--- a/client/src/components/layouts/global.css
+++ b/client/src/components/layouts/global.css
@@ -607,6 +607,15 @@ pre code {
   color: var(--background-danger);
 }
 
+/*
+ * The @freecodecamp/ui Modal uses `overflow-scroll` on the modal container,
+ * which always shows scrollbars even when content doesn't overflow.
+ * Override to `overflow: auto` so scrollbars only appear when needed.
+ */
+#headlessui-portal-root .overflow-scroll {
+  overflow: auto;
+}
+
 .text-start {
   text-align: start;
 }


### PR DESCRIPTION
**Checklist:**

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org/).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #65674

## Description

Scrollbars are injected into the page when opening modals (e.g. reset modal, help modal, completion modal) in Chrome. This is caused by the `@freecodecamp/ui` Modal component using the Tailwind class `overflow-scroll` on its container `<div>`, which applies `overflow: scroll` — always showing scrollbars regardless of whether content overflows.

### Fix

Added a CSS override in `global.css` targeting the modal container inside the HeadlessUI portal:

```css
#headlessui-portal-root .overflow-scroll {
  overflow: auto;
}
```

This changes `overflow: scroll` (always show scrollbars) → `overflow: auto` (only show when content overflows), eliminating the scrollbar flash and layout shift in Chrome.

> **Note:** The upstream fix belongs in the [`@freecodecamp/ui` package](https://github.com/freeCodeCamp/ui/issues/743). This CSS override is a workaround until that is released.