### PR TITLE
fix(curriculum): remove unused ::: interactive marker from lesson content

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-arrays-variables-and-naming-practices/6732c6ba2ea42b610b9f9ce1.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-arrays-variables-and-naming-practices/6732c6ba2ea42b610b9f9ce1.md
@@ -14,8 +14,6 @@ const fruits = ['apple', 'banana', 'orange'];
 console.log(fruits.length); // 3
 ```
 
-:::
-
 It's possible to have arrays with empty slots. Empty slots are defined as slots with nothing in them. This is different than an array with the value of `undefined`. These types of arrays are known as sparse arrays. Here is an example:
 
 ```js


### PR DESCRIPTION
## Description

In the lesson **"How Do You Get the Length for an Array, and How Can You Create an Empty Array of Fixed Length?"**, there is a stray `:::` marker left after the first code example in the description. This marker does not wrap any `:::interactive_editor` block and serves no purpose. This PR removes the unused `:::` line and the extra blank line, leaving exactly one blank line between the code fence and the next paragraph.

## Checklist

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org/).
- [x] I have read [freeCodeCamp's how to open a pull request](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request) guide.
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes locally on my machine.

Closes #65755