### PR TITLE
fix(curriculum): remove invalid size in radial gradient

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-backgrounds-and-borders/672b98be592cfb451f651451.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-backgrounds-and-borders/672b98be592cfb451f651451.md
@@ -59,7 +59,7 @@ background: radial-gradient(shape size at position, color-stop1, color-stop2, ..
 
 On the syntax, the `shape` specifies the shape of gradient which could be `circle` or `ellipse`.
 
-The `size` determines the size of the gradient's ending shape which could be `closest-side`, `closest-corner`, `farthest-side`, `farthest-corner`, `contain`, or `cover`.
+The `size` determines the size of the gradient's ending shape which could be `closest-side`, `closest-corner`, `farthest-side` or `farthest-corner`.
 
 `position` determines the position of the gradient's center which could be specified using keywords (such as `center`, `top left`, `bottom right`) or precise values (such as `50% 50%`, `10px 20px`).
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #64981 

<!-- Feel free to add any additional description of changes below this line -->

This PR is to remove the invalid size `contain` and `cover` from Background Gradient lecture.