### PR TITLE
fix(curriculum): change Guest to null in prompt lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-strings-in-javascript/673263f4a5899da8124542fd.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-strings-in-javascript/673263f4a5899da8124542fd.md
@@ -44,7 +44,7 @@ btn.addEventListener("click", () => {
 
 In this example, when the user clicks on the button, the `prompt()` method displays a dialog box with the message `What is your name?` and an input field that initially contains the value `Guest`.
 
-If the user types their name and presses "OK", the `userName` variable will store the entered value. If the user presses "Cancel," the `userName` variable will be set to `null`. `null` signifies that the user did not provide any input. The output paragraph will then display a greeting message using the provided name or `null` if the user canceled.
+If the user types their name and presses "OK", the `userName` variable will store the entered value. If the user presses "Cancel," the `userName` variable will be set to `null`. `null` signifies that the user did not provide any input. The output paragraph will then display a greeting message using the provided name or `null` if the user canceled. You will learn techniques to avoid displaying `null` when a user cancels the prompt in future lessons.
 
 Keep in mind that the `prompt()` method will halt the execution of the script until the user interacts with the dialog box.
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-strings-in-javascript/673263f4a5899da8124542fd.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-strings-in-javascript/673263f4a5899da8124542fd.md
@@ -44,7 +44,7 @@ btn.addEventListener("click", () => {
 
 In this example, when the user clicks on the button, the `prompt()` method displays a dialog box with the message `What is your name?` and an input field that initially contains the value `Guest`.
 
-If the user types their name and presses "OK", the `userName` variable will store the entered value. If the user presses "Cancel," the `userName` variable will be set to `null`. `null` signifies that the user did not provide any input. The output paragraph will then display a greeting message using the provided name or `Guest` if the user canceled.
+If the user types their name and presses "OK", the `userName` variable will store the entered value. If the user presses "Cancel," the `userName` variable will be set to `null`. `null` signifies that the user did not provide any input. The output paragraph will then display a greeting message using the provided name or `null` if the user canceled.
 
 Keep in mind that the `prompt()` method will halt the execution of the script until the user interacts with the dialog box.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x]  I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #65769

<!-- Feel free to add any additional description of changes below this line -->

This PR is to update the word `Guest` to `null` in prompt() method lecture.