### PR TITLE
Fix/ms username transaction

### DIFF
--- a/api/src/routes/protected/user.ts
+++ b/api/src/routes/protected/user.ts
@@ -440,17 +440,19 @@ export const userRoutes: FastifyPluginCallbackTypebox = (
 
         // TODO(Post-MVP): make userId unique and then we can upsert.
 
-        await fastify.prisma.msUsername.deleteMany({
-          where: { userId: user.id }
-        });
-
-        await fastify.prisma.msUsername.create({
-          data: {
-            msUsername: userName,
-            ttl,
-            userId: user.id
-          }
-        });
+        // TODO(Post-MVP): make userId unique and then we can upsert.
+        await fastify.prisma.$transaction([
+          fastify.prisma.msUsername.deleteMany({
+            where: { userId: user.id }
+          }),
+          fastify.prisma.msUsername.create({
+            data: {
+              msUsername: userName,
+              ttl,
+              userId: user.id
+            }
+          })
+        ]);
 
         return { msUsername: userName };
       } catch (err) {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

### Description
This PR improves the robustness of the Microsoft Username linking logic in [user.ts](cci:7://file:///d:/freeCodeCamp/api/src/utils/create-user.ts:0:0-0:0) by wrapping the update operations in a transaction.

**The Issue:**
Previously, when a user updated their Microsoft transcript link, the API would first delete all existing `msUsername` records for that user and *then* attempt to create the new record. These were independent operations. If the [create](cci:1://file:///d:/freeCodeCamp/api/src/utils/create-user.ts:55:0-105:1) step failed (due to a database error, connection issue, or constraint violation), the user's previous link would already be permanently deleted, resulting in unintended data loss.

**The Fix:**
I have wrapped the `deleteMany` and [create](cci:1://file:///d:/freeCodeCamp/api/src/utils/create-user.ts:55:0-105:1) operations in a `fastify.prisma.$transaction`. This ensures atomicity: if the creation of the new record fails for any reason, the deletion of the old record is rolled back, leaving the user's data in a consistent state.

### Related Issue
N/A (Improves data integrity/atomicity)