### PR TITLE
fix(curriculum): clarify compound assignment operator explanation

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-operator-behavior/673271b4213033d9b661c70e.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-operator-behavior/673271b4213033d9b661c70e.md
@@ -7,7 +7,7 @@ dashedName: what-are-compound-assignment-operators-in-javascript-and-how-do-they
 
 # --interactive--
 
-In JavaScript, all arithmetic operators have a compound assignment form. Compound assignment operators allow you to perform a mathematical operation and reassign the result back to the variable in one line of code. Instead of writing something like this:
+In JavaScript, all arithmetic operators have a compound assignment form. Compound assignment operators combine the operation and assignment concisely, avoiding repetition of the variable. Instead of writing something like this:
 
 :::interactive_editor
 
@@ -126,7 +126,7 @@ Think about how to combine mathematical operations and reassignment.
 
 ---
 
-Perform a mathematical operation and reassign the result to the variable in one line of code.
+Combine the operation and assignment concisely, avoiding repetition of the variable.
 
 ---
 


### PR DESCRIPTION
## Checklist

- [x] I have read and followed the contribution guidelines.
- [x] I have read and followed the how to open a pull request guide.
- [x] My pull request targets the main branch of freeCodeCamp.
- [x] I have tested these changes locally.

Closes #65702 

## Description

This PR improves the explanation of compound assignment operators in the JavaScript curriculum.

The current wording states that compound assignment operators allow performing an operation and reassignment "in one line of code". This is misleading because the standard form (e.g. `num = num + 2`) is also written in one line.

The explanation has been updated to clarify the actual purpose of compound assignment operators: combining the operation and assignment concisely while avoiding repetition of the variable.

This update is applied both:
- In the lesson explanation
- In the quiz answer at the bottom

This improves conceptual clarity for learners and better reflects why compound assignment operators exist.
