### PR TITLE
fix: specify which trademark symbol is used in html entities lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-html-fundamentals/67083868d5fdcb17bf8c14bd.md
+++ b/curriculum/challenges/english/blocks/lecture-html-fundamentals/67083868d5fdcb17bf8c14bd.md
@@ -41,7 +41,7 @@ Another type of character reference would be the decimal numeric reference. This
 
 Here is an example of using the decimal numeric reference for the less than symbol. 
 
-Enable the interactive editor and change the code to see different symbols. You can use `&#169;` for the copyright symbol and `&#174;` for the trademark symbol.
+Enable the interactive editor and change the code to see different symbols. You can use `&#169;` for the copyright symbol and `&#174;` for the registered trademark symbol.
 
 :::interactive_editor
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!-- Feel free to add any additional description of changes below this line -->
Someone wrote into the support inbox about this. There are a couple of different trademark symbols, and the one we use in this lecture, `&#174;` is for a registered trademark.

This PR makes it clear that `&#174;` is the HTML entity for the registered trademark symbol (®).

But we could consider leaving the text as-is and updating the HTML entity example to `&#8482;` which is for the other, perhaps more common, trademark symbol (™).