### PR TITLE
fix(ui): scope range input styles to .soundbar to prevent scrollbar i…

### DIFF
--- a/client/src/components/settings/sound.css
+++ b/client/src/components/settings/sound.css
@@ -5,14 +5,15 @@
   background: var(--quaternary-background);
 }
 
-input[type='range'] {
+.soundbar input[type='range'] {
   appearance: none;
   overflow: hidden;
   border: 2px solid var(--secondary-color);
 }
 
 /* Special styling for WebKit/Blink */
-input[type='range']::-webkit-slider-thumb {
+
+.soundbar input[type='range']::-webkit-slider-thumb {
   box-shadow: -2000px 0 0 2000px var(--gray-45);
   -webkit-appearance: none;
   border: 2px solid var(--primary-color);
@@ -23,7 +24,7 @@ input[type='range']::-webkit-slider-thumb {
 }
 
 /* All the same stuff for Firefox */
-input[type='range']::-moz-range-thumb {
+.soundbar input[type='range']::-moz-range-thumb {
   box-shadow: -2000px 0 0 2000px var(--gray-45);
   border: 2px solid var(--primary-color);
   border-radius: 0;
@@ -33,7 +34,7 @@ input[type='range']::-moz-range-thumb {
   cursor: pointer;
 }
 
-input[type='range']::-moz-range-progress {
+.soundbar input[type='range']::-moz-range-progress {
   background: var(--gray-90);
   height: 25px;
 }


### PR DESCRIPTION
Checklist:

[x] I have read and followed the contribution guidelines.
[x] I have read and followed the how to open a pull request guide.
[x] My pull request targets the main branch of freeCodeCamp.
[x] I have tested these changes locally.

Closes #65805 

Description

Scope `input[type='range']` styles to `.soundbar` so they no longer affect other range inputs or modals.