### PR TITLE
fix(client): update css selector for soundbar styling

### DIFF
--- a/client/src/components/settings/sound.css
+++ b/client/src/components/settings/sound.css
@@ -3,16 +3,13 @@
   width: 100%;
   height: 25px;
   background: var(--quaternary-background);
-}
-
-input[type='range'] {
   appearance: none;
   overflow: hidden;
   border: 2px solid var(--secondary-color);
 }
 
 /* Special styling for WebKit/Blink */
-input[type='range']::-webkit-slider-thumb {
+.soundbar::-webkit-slider-thumb {
   box-shadow: -2000px 0 0 2000px var(--gray-45);
   -webkit-appearance: none;
   border: 2px solid var(--primary-color);
@@ -23,7 +20,7 @@ input[type='range']::-webkit-slider-thumb {
 }
 
 /* All the same stuff for Firefox */
-input[type='range']::-moz-range-thumb {
+.soundbar::-moz-range-thumb {
   box-shadow: -2000px 0 0 2000px var(--gray-45);
   border: 2px solid var(--primary-color);
   border-radius: 0;
@@ -33,7 +30,7 @@ input[type='range']::-moz-range-thumb {
   cursor: pointer;
 }
 
-input[type='range']::-moz-range-progress {
+.soundbar::-moz-range-progress {
   background: var(--gray-90);
   height: 25px;
 }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #65805 

<!-- Feel free to add any additional description of changes below this line -->

This PR is to update `input[type='range']` selectors to `.soundbar` in sound.css so the styles are scoped and don't affect other range inputs.