### PR TITLE
fix(curriculum): wrap video element in backticks

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f6f97af9749a42260a43.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f6f97af9749a42260a43.md
@@ -13,7 +13,7 @@ The `controls` attribute is a boolean attribute and does not need a value.
 
 Add the `controls` attribute to the `video` element.
 
-Now you should see the video element displayed on the page.
+Now you should see the `video` element displayed on the page.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #65826

This PR wraps the `video` element in backticks in the challenge description to follow freeCodeCamp curriculum style guidelines.
