### PR TITLE
fix(curriculum): correct hint to reference source element

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f268880219c2485bd71d2a.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f268880219c2485bd71d2a.md
@@ -13,7 +13,7 @@ Add the `src` attribute with the value `https://cdn.freecodecamp.org/curriculum/
 
 # --hints--
 
-Your `video` element should have a `src` attribute.
+Your `source` element should have a `src` attribute.
 
 ```js
 const source = document.querySelector('source');


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #65823 

This PR fixes an incorrect hint in Step 9 of the HTML video player workshop.