### PR TITLE
fix(curriculum): remove double punctuation marks at end of sentences

### DIFF
--- a/curriculum/challenges/english/blocks/basic-algorithm-scripting/ac6993d51946422351508a41.md
+++ b/curriculum/challenges/english/blocks/basic-algorithm-scripting/ac6993d51946422351508a41.md
@@ -12,7 +12,7 @@ Truncate a string (first argument) if it is longer than the given maximum string
 
 # --hints--
 
-`truncateString("A-tisket a-tasket A green and yellow basket", 8)` should return the string `A-tisket...`.
+`truncateString("A-tisket a-tasket A green and yellow basket", 8)` should return the string `A-tisket...`
 
 ```js
 assert.strictEqual(
@@ -21,7 +21,7 @@ assert.strictEqual(
 );
 ```
 
-`truncateString("Peter Piper picked a peck of pickled peppers", 11)` should return the string `Peter Piper...`.
+`truncateString("Peter Piper picked a peck of pickled peppers", 11)` should return the string `Peter Piper...`
 
 ```js
 assert.strictEqual(
@@ -54,13 +54,13 @@ assert.strictEqual(
 );
 ```
 
-`truncateString("A-", 1)` should return the string `A...`.
+`truncateString("A-", 1)` should return the string `A...`
 
 ```js
 assert.strictEqual(truncateString('A-', 1), 'A...');
 ```
 
-`truncateString("Absolutely Longer", 2)` should return the string `Ab...`.
+`truncateString("Absolutely Longer", 2)` should return the string `Ab...`
 
 ```js
 assert.strictEqual(truncateString('Absolutely Longer', 2), 'Ab...');

--- a/curriculum/challenges/english/blocks/basic-data-structures/587d7b7b367417b2b2512b16.md
+++ b/curriculum/challenges/english/blocks/basic-data-structures/587d7b7b367417b2b2512b16.md
@@ -39,7 +39,7 @@ While this example may seem convoluted, this level of complexity is not unheard 
 console.log(nestedArray[2][1][0][0][0]);
 ```
 
-This logs the string `deepest-est?`. And now that we know where that piece of data is, we can reset it if we need to:
+This logs the string `deepest-est?` And now that we know where that piece of data is, we can reset it if we need to:
 
 ```js
 nestedArray[2][1][0][0][0] = 'deeper still';

--- a/curriculum/challenges/english/blocks/basic-javascript/56533eb9ac21ba0edf2244b8.md
+++ b/curriculum/challenges/english/blocks/basic-javascript/56533eb9ac21ba0edf2244b8.md
@@ -19,7 +19,7 @@ let ourStr = "I come first. ";
 ourStr += "I come second.";
 ```
 
-`ourStr` now has a value of the string `I come first. I come second.`.
+`ourStr` now has a value of the string `I come first. I come second.`
 
 # --instructions--
 

--- a/curriculum/challenges/english/blocks/basic-javascript/56533eb9ac21ba0edf2244b9.md
+++ b/curriculum/challenges/english/blocks/basic-javascript/56533eb9ac21ba0edf2244b9.md
@@ -17,7 +17,7 @@ const ourName = "freeCodeCamp";
 const ourStr = "Hello, our name is " + ourName + ", how are you?";
 ```
 
-`ourStr` would have a value of the string `Hello, our name is freeCodeCamp, how are you?`.
+`ourStr` would have a value of the string `Hello, our name is freeCodeCamp, how are you?`
 
 # --instructions--
 

--- a/curriculum/challenges/english/blocks/basic-javascript/56533eb9ac21ba0edf2244ed.md
+++ b/curriculum/challenges/english/blocks/basic-javascript/56533eb9ac21ba0edf2244ed.md
@@ -18,7 +18,7 @@ let ourStr = "freeCodeCamp is ";
 ourStr += anAdjective;
 ```
 
-`ourStr` would have the value `freeCodeCamp is awesome!`.
+`ourStr` would have the value `freeCodeCamp is awesome!`
 
 # --instructions--
 

--- a/curriculum/challenges/english/blocks/data-structures/587d825b367417b2b2512c8d.md
+++ b/curriculum/challenges/english/blocks/data-structures/587d825b367417b2b2512c8d.md
@@ -31,7 +31,7 @@ The `myMap` object should exist.
 assert(typeof myMap === 'object');
 ```
 
-`myMap` should contain the key value pair `freeCodeCamp`, `Awesome!`.
+`myMap` should contain the key value pair `freeCodeCamp`, `Awesome!`
 
 ```js
 assert(myMap.get('freeCodeCamp') === 'Awesome!');

--- a/curriculum/challenges/english/blocks/debugging/587d7b85367417b2b2512b39.md
+++ b/curriculum/challenges/english/blocks/debugging/587d7b85367417b2b2512b39.md
@@ -20,7 +20,7 @@ let varOne = myFunction;
 let varTwo = myFunction();
 ```
 
-Here `varOne` is the function `myFunction`, and `varTwo` is the string `You rock!`.
+Here `varOne` is the function `myFunction`, and `varTwo` is the string `You rock!`
 
 # --instructions--
 

--- a/curriculum/challenges/english/blocks/es-a1-learn-greetings-during-the-day/68c488abd71a3e27190965e0.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-greetings-during-the-day/68c488abd71a3e27190965e0.md
@@ -9,7 +9,7 @@ lang: es
 
 # --description--
 
-Elena is starting a conversation. She's using a simple and very common phrase to say "Hi, good morning!".
+Elena is starting a conversation. She's using a simple and very common phrase to say "Hi, good morning!"
 
 # --instructions--
 

--- a/curriculum/challenges/english/blocks/es-a1-learn-greetings-during-the-day/68c88a1c3f01ed15c7ca6c83.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-greetings-during-the-day/68c88a1c3f01ed15c7ca6c83.md
@@ -59,7 +59,7 @@ Focus on the last word of the sentence.
 
 # --explanation--
 
-`Me llamo...` means "My name is...". It literally means "I call myself...", but it's the standard way to introduce your name. For example:  
+`Me llamo...` means "My name is..." It literally means "I call myself...", but it's the standard way to introduce your name. For example:  
 
 `Me llamo Gino.` – My name is Gino.
 

--- a/curriculum/challenges/english/blocks/es-a1-learn-greetings-during-the-day/68c8902d3560395c800ddff5.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-greetings-during-the-day/68c8902d3560395c800ddff5.md
@@ -27,7 +27,7 @@ This phrase has **two words** and means "my name is" in Spanish. It's the standa
 
 # --explanation--
 
-`Me llamo...` means "My name is...". It literally means "I call myself...", but it's the most common way to introduce yourself. For example:  
+`Me llamo...` means "My name is..." It literally means "I call myself...", but it's the most common way to introduce yourself. For example:  
 
 `Me llamo Nielda.` – My name is Nielda.
 

--- a/curriculum/challenges/english/blocks/es-a1-learn-meet-angela-and-basti/690f5a015ec6842542a57d60.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-meet-angela-and-basti/690f5a015ec6842542a57d60.md
@@ -12,7 +12,7 @@ lang: es
 
 The phrase **`Soy de` + [country]** is the most common way to say where you are from.
 
-It's usually the direct answer to the question `¿De dónde eres?`. 
+It's usually the direct answer to the question `¿De dónde eres?` 
 
 This phrase is equivalent to saying "I am from + [country]".
 

--- a/curriculum/challenges/english/blocks/es-a1-learn-meet-angela-and-basti/690f61b1a2b78d305e825d13.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-meet-angela-and-basti/690f61b1a2b78d305e825d13.md
@@ -36,7 +36,7 @@ This is a regional variation of `tú` ("you").
 
 # --explanation--
 
-`¿Y vos?` is a regional way to return the question. It's equivalent to "And you?".
+`¿Y vos?` is a regional way to return the question. It's equivalent to "And you?"
 
 # --scene--
 

--- a/curriculum/challenges/english/blocks/es-a1-learn-meet-angela-and-basti/690f68686781213c9eac4b65.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-meet-angela-and-basti/690f68686781213c9eac4b65.md
@@ -44,9 +44,9 @@ False
 
 # --explanation--
 
-Ángela is asking Sebastián `¿Cuántos años tienes?`.
+Ángela is asking Sebastián `¿Cuántos años tienes?`
 
-This question is equivalent to "How old are you?".
+This question is equivalent to "How old are you?"
 
 Therefore, this is true because Ángela is asking Sebastián about his age. 
 

--- a/curriculum/challenges/english/blocks/es-a1-learn-meet-angela-and-basti/690f6ad7e1192b412653189c.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-meet-angela-and-basti/690f6ad7e1192b412653189c.md
@@ -36,7 +36,7 @@ This is the `tú` conjugation of the verb `tener` ("to have").
 
 # --explanation--
 
-The question is `¿Cuántos años tienes?`.
+The question is `¿Cuántos años tienes?`
 
 `Cuántos` means "How many" and `años` means "years". 
 

--- a/curriculum/challenges/english/blocks/es-a1-learn-meet-angela-and-basti/690f6d6c27b78644af22a833.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-meet-angela-and-basti/690f6d6c27b78644af22a833.md
@@ -64,7 +64,7 @@ The word `veintiuno` means 21.
 
 When referring to age, the word `veintiún` is used instead when it's followed by the word `años` ("years"). This shortened form is used immediately before plural masculine nouns.
 
-After saying his age, Sebastián returns the question to Ángela with `¿Y tú?`.
+After saying his age, Sebastián returns the question to Ángela with `¿Y tú?`
 
 # --scene--
 

--- a/curriculum/challenges/english/blocks/es-a1-learn-meet-angela-and-basti/690f6f11d51d16478c286346.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-meet-angela-and-basti/690f6f11d51d16478c286346.md
@@ -62,7 +62,7 @@ Sebastián is not asking about Ángela's age.
 
 # --explanation--
 
-Sebastián is asking Ángela `¿A qué te dedicas?`.
+Sebastián is asking Ángela `¿A qué te dedicas?`
 
 This is a common way to ask about someone's profession or job.
 

--- a/curriculum/challenges/english/blocks/es-a1-learn-meet-angela-and-basti/69150542094cd0569af7c631.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-meet-angela-and-basti/69150542094cd0569af7c631.md
@@ -30,7 +30,7 @@ After introducing himself, how is Sebastián returning the question to Ángela?
 
 ### --feedback--
 
-This means "Right?". It's not what Sebastián mentions in the dialogue.
+This means "Right?" It's not what Sebastián mentions in the dialogue.
 
 ---
 
@@ -46,7 +46,7 @@ Sebastián uses a simpler phrase to return the question.
 
 ### --feedback--
 
-This phrase means "What are you doing?". It's not used to return a question.
+This phrase means "What are you doing?" It's not used to return a question.
 
 ---
 

--- a/curriculum/challenges/english/blocks/es-a1-learn-meet-angela-and-basti/69160253e5339069a251cd9a.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-meet-angela-and-basti/69160253e5339069a251cd9a.md
@@ -46,7 +46,7 @@ This is the conjugation of the verb `ser` ("to be") for the pronoun `tú` ("you"
 
 The question `¿De dónde eres?` is a common way to ask about someone's place of origin.
 
-It is equivalent to "Where are you from?". 
+It is equivalent to "Where are you from?" 
 
 This question must have the preposition `de` ("from") at the beginning, and the conjugation of the verb `ser` ("to be") because origin is considered a permanent characteristic.
 

--- a/curriculum/challenges/english/blocks/es-a1-practice-first-questions/6910867bb3065a1924502732.md
+++ b/curriculum/challenges/english/blocks/es-a1-practice-first-questions/6910867bb3065a1924502732.md
@@ -70,6 +70,6 @@ This dialogue between Mateo and Camila includes these common phrases:
 
 `Mi nombre es...` means "My name is".
 
-`¿Y tú?` means "And you?". This is used to return a question informally.
+`¿Y tú?` means "And you?" This is used to return a question informally.
 
 `Me llamo...` is the most common way to say your name.

--- a/curriculum/challenges/english/blocks/es-a1-practice-first-questions/6910932c6c4e812ca246cdae.md
+++ b/curriculum/challenges/english/blocks/es-a1-practice-first-questions/6910932c6c4e812ca246cdae.md
@@ -124,9 +124,9 @@ This dialogue between Florencia and Federico reviews fundamental introductory ph
 
 `Mi nombre es` and `Me llamo` are alternative ways to say your name. 
 
-`¿De dónde eres?` means "Where are you from?". This question is answered with **`Soy de` + [country]**.
+`¿De dónde eres?` means "Where are you from?" This question is answered with **`Soy de` + [country]**.
 
-`¿Cuántos años tienes?` means "How old are you?". This question is answered with  **`Tengo` + [number] + `años`**.
+`¿Cuántos años tienes?` means "How old are you?" This question is answered with  **`Tengo` + [number] + `años`**.
 
 `¿Y vos?` means "And you?" and it's used to return a question. It's a regional variation of `¿Y tú?` ("And you?") common in Central American countries like El Salvador, and some South American countries, like Argentina.
 

--- a/curriculum/challenges/english/blocks/es-a1-practice-first-questions/69164df41ff49cc2f332be4c.md
+++ b/curriculum/challenges/english/blocks/es-a1-practice-first-questions/69164df41ff49cc2f332be4c.md
@@ -53,4 +53,4 @@ This question asks "What is your name?"
 
 # --explanation--
 
-To ask someone about their profession, you could use `¿A qué te dedicas?`, which means "What is your profession?" or "What do you do for a living?".
+To ask someone about their profession, you could use `¿A qué te dedicas?`, which means "What is your profession?" or "What do you do for a living?"

--- a/curriculum/challenges/english/blocks/es-a1-practice-greetings-and-farewells/68c850c5eb642cc96ed86544.md
+++ b/curriculum/challenges/english/blocks/es-a1-practice-greetings-and-farewells/68c850c5eb642cc96ed86544.md
@@ -59,7 +59,7 @@ This is not a correct sentence in Spanish. Review the structure that Elena is us
 
 # --explanation--
 
-`Me llamo...` means "My name is...".  
+`Me llamo...` means "My name is..."  
 
 It's the most common way to introduce your name in a conversation. For example:
 

--- a/curriculum/challenges/english/blocks/es-a1-review-first-questions/6910a23b05a7eb4386e6e730.md
+++ b/curriculum/challenges/english/blocks/es-a1-review-first-questions/6910a23b05a7eb4386e6e730.md
@@ -22,7 +22,7 @@ To say where you are from, you should use: **`Soy` + `de` + [country]**. For exa
 
 - `Soy de Guatemala.`
 
-To know where someone is from, ask `¿De dónde eres?`.
+To know where someone is from, ask `¿De dónde eres?`
 
 <br>
 
@@ -63,7 +63,7 @@ To say your profession, you should use: **`Soy` + [profession]**. For example:
 
 - `Soy analista junior.`
 
-Use this question to ask someone about their profession: `¿A qué te dedicas?`.
+Use this question to ask someone about their profession: `¿A qué te dedicas?`
 
 <br>
 
@@ -75,7 +75,7 @@ To say your age in Spanish, you should use: **`Tengo` + [number] + `años`**. Fo
 
 - `Tengo treinta y cinco años.`
 
-You can use this question to ask someone's age: `¿Cuántos años tienes?`.
+You can use this question to ask someone's age: `¿Cuántos años tienes?`
 
 <br>
 

--- a/curriculum/challenges/english/blocks/es-a1-warm-up-first-questions-basics/690e4698c0492430e49c3705.md
+++ b/curriculum/challenges/english/blocks/es-a1-warm-up-first-questions-basics/690e4698c0492430e49c3705.md
@@ -40,7 +40,7 @@ Try again. This phrase means "What is...?" and it's not used to ask about profes
 
 ### --feedback--
 
-This phrase means "Why...?". It's used to ask about a reason, not a profession.
+This phrase means "Why...?" It's used to ask about a reason, not a profession.
 
 ---
 
@@ -48,7 +48,7 @@ This phrase means "Why...?". It's used to ask about a reason, not a profession.
 
 ### --feedback--
 
-This phrase means "By when...?". It's used to ask about a deadline or future time, not a profession.
+This phrase means "By when...?" It's used to ask about a deadline or future time, not a profession.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/blocks/es-a1-warm-up-first-questions-basics/690e4ae1ec236137adc148a1.md
+++ b/curriculum/challenges/english/blocks/es-a1-warm-up-first-questions-basics/690e4ae1ec236137adc148a1.md
@@ -36,7 +36,7 @@ This phrase means "I am okay", not a reply to an introduction.
 
 ### --feedback--
 
-This phrase means "How are you?". It's commonly used to start a conversation, not as a reply to an introduction.
+This phrase means "How are you?" It's commonly used to start a conversation, not as a reply to an introduction.
 
 ---
 

--- a/curriculum/challenges/english/blocks/es6/587d7b88367417b2b2512b47.md
+++ b/curriculum/challenges/english/blocks/es6/587d7b88367417b2b2512b47.md
@@ -20,7 +20,7 @@ console.log(howMany(0, 1, 2));
 console.log(howMany("string", null, [1, 2, 3], { }));
 ```
 
-The console would display the strings `You have passed 3 arguments.` and `You have passed 4 arguments.`.
+The console would display the strings `You have passed 3 arguments.` and `You have passed 4 arguments.`
 
 The rest parameter eliminates the need to use the `arguments` object and allows us to use array methods on the array of parameters passed to the function `howMany`.
 

--- a/curriculum/challenges/english/blocks/es6/587d7b8a367417b2b2512b4e.md
+++ b/curriculum/challenges/english/blocks/es6/587d7b8a367417b2b2512b4e.md
@@ -26,7 +26,7 @@ I am ${person.age} years old.`;
 console.log(greeting);
 ```
 
-The console will display the strings `Hello, my name is Zodiac Hasbro!` and `I am 56 years old.`.
+The console will display the strings `Hello, my name is Zodiac Hasbro!` and `I am 56 years old.`
 
 A lot of things happened there. Firstly, the example uses backticks (`` ` ``), not quotes (`'` or `"`), to wrap the string. Secondly, notice that the string is multi-line, both in the code and the output. This saves inserting `\n` within strings. The `${variable}` syntax used above is a placeholder. Basically, you won't have to use concatenation with the `+` operator anymore. To add variables to strings, you just drop the variable in a template string and wrap it with `${` and `}`. Similarly, you can include other expressions in your string literal, for example `${a + b}`. This new way of creating strings gives you more flexibility to create robust strings.
 

--- a/curriculum/challenges/english/blocks/json-apis-and-ajax/587d7fae367417b2b2512be4.md
+++ b/curriculum/challenges/english/blocks/json-apis-and-ajax/587d7fae367417b2b2512be4.md
@@ -30,7 +30,7 @@ Remember how to access data in arrays and objects. Arrays use bracket notation t
 console.log(json[0].altText);
 ```
 
-The console would display the string `A white cat wearing a green helmet shaped melon on its head.`.
+The console would display the string `A white cat wearing a green helmet shaped melon on its head.`
 
 # --instructions--
 

--- a/curriculum/challenges/english/blocks/lab-isbn-validator/686b9720ee1d032bd77a480a.md
+++ b/curriculum/challenges/english/blocks/lab-isbn-validator/686b9720ee1d032bd77a480a.md
@@ -217,7 +217,7 @@ assert "Valid ISBN Code." in out
 }})
 ```
 
-When the user enters `9781530051120,13`, you should see the message `Valid ISBN Code.`.
+When the user enters `9781530051120,13`, you should see the message `Valid ISBN Code.`
 
 ```js
 ({test: () => {runPython(`
@@ -244,7 +244,7 @@ assert "Valid ISBN Code." in out
 }})
 ```
 
-When the user enters `1530051125,10`, you should see the message `Invalid ISBN Code.`.
+When the user enters `1530051125,10`, you should see the message `Invalid ISBN Code.`
 
 ```js
 ({test: () => {runPython(`
@@ -271,7 +271,7 @@ assert "Invalid ISBN Code." in out
 }})
 ```
 
-When the user enters `9781530051120,10`, you should see the message `ISBN-10 code should be 10 digits long.`.
+When the user enters `9781530051120,10`, you should see the message `ISBN-10 code should be 10 digits long.`
 
 ```js
 ({test: () => {runPython(`
@@ -298,7 +298,7 @@ assert "ISBN-10 code should be 10 digits long." in out
 }})
 ```
 
-When the user enters `1530051126,13`, you should see the message `ISBN-13 code should be 13 digits long.`.
+When the user enters `1530051126,13`, you should see the message `ISBN-13 code should be 13 digits long.`
 
 ```js
 ({test: () => {runPython(`
@@ -325,7 +325,7 @@ assert "ISBN-13 code should be 13 digits long." in out
 }})
 ```
 
-When the user enters `15-0051126,10`, you should see the message `Invalid character was found.`.
+When the user enters `15-0051126,10`, you should see the message `Invalid character was found.`
 
 ```js
 ({test: () => {runPython(`
@@ -352,7 +352,7 @@ assert "Invalid character was found." in out
 }})
 ```
 
-When the user enters `1530051126,9`, you should see the message `Length should be 10 or 13.`.
+When the user enters `1530051126,9`, you should see the message `Length should be 10 or 13.`
 
 ```js
 ({test: () => {runPython(`
@@ -379,7 +379,7 @@ assert "Length should be 10 or 13." in out
 }})
 ```
 
-When the user enters `1530051125,A`, you should see the message `Length must be a number.`.
+When the user enters `1530051125,A`, you should see the message `Length must be a number.`
 
 ```js
 ({test: () => {runPython(`
@@ -406,7 +406,7 @@ assert "Length must be a number." in out
 }})
 ```
 
-When the user enters `1530051125`, you should see the message `Enter comma-separated values.`.
+When the user enters `1530051125`, you should see the message `Enter comma-separated values.`
 
 ```js
 ({test: () => {runPython(`
@@ -433,7 +433,7 @@ assert "Enter comma-separated values." in out
 }})
 ```
 
-When the user enters `9971502100,10`, you should see the message `Valid ISBN Code.`.
+When the user enters `9971502100,10`, you should see the message `Valid ISBN Code.`
 
 ```js
 ({test: () => {runPython(`
@@ -460,7 +460,7 @@ assert "Valid ISBN Code." in out
 }})
 ```
 
-When the user enters `080442957X,10`, you should see the message `Valid ISBN Code.`.
+When the user enters `080442957X,10`, you should see the message `Valid ISBN Code.`
 
 ```js
 ({test: () => {runPython(`
@@ -487,7 +487,7 @@ assert "Valid ISBN Code." in out
 }})
 ```
 
-When the user enters `9781947172104,13`, you should see the message `Valid ISBN Code.`.
+When the user enters `9781947172104,13`, you should see the message `Valid ISBN Code.`
 
 ```js
 ({test: () => {runPython(`

--- a/curriculum/challenges/english/blocks/lab-leap-year-calculator/66c06fad3475cd92421b9ac2.md
+++ b/curriculum/challenges/english/blocks/lab-leap-year-calculator/66c06fad3475cd92421b9ac2.md
@@ -22,7 +22,7 @@ A leap year is a year that is divisible by `4`, except for years that are divisi
    - Unless the year is also divisible by `100`, then it is not a leap year.
    - Unless the year is also divisible by `400`, then it is a leap year.
 
-5. If the year is a leap year, return `[year] is a leap year.`. Otherwise, return `[year] is not a leap year.`. You will replace `[year]` with the parameter defined in the `isLeapYear` function.
+5. If the year is a leap year, return `[year] is a leap year.` Otherwise, return `[year] is not a leap year.` You will replace `[year]` with the parameter defined in the `isLeapYear` function.
 6. You should call the `isLeapYear` function with `year` as the argument and assign the result to a variable named `result`.
 7. You should output the `result` variable to the console using `console.log()`.
 
@@ -52,19 +52,19 @@ The `year` variable shouldn't be empty.
 assert.isNotNull(year);
 ```
 
-With `2024` as the value of the `year` variable, the `result` should be `2024 is a leap year.`.
+With `2024` as the value of the `year` variable, the `result` should be `2024 is a leap year.`
 
 ```js
 assert.strictEqual(isLeapYear(2024), '2024 is a leap year.');
 ```
 
-With `2000` as the value of the `year` variable, the `result` should be `2000 is a leap year.`.
+With `2000` as the value of the `year` variable, the `result` should be `2000 is a leap year.`
 
 ```js
 assert.strictEqual(isLeapYear(2000), '2000 is a leap year.');
 ```
 
-With `1900` as the value of the `year` variable, the `result` should be `1900 is not a leap year.`.
+With `1900` as the value of the `year` variable, the `result` should be `1900 is not a leap year.`
 
 ```js
 assert.strictEqual(isLeapYear(1900), '1900 is not a leap year.');

--- a/curriculum/challenges/english/blocks/lab-luhn-algorithm/68507cadbf36aa089a84ce2d.md
+++ b/curriculum/challenges/english/blocks/lab-luhn-algorithm/68507cadbf36aa089a84ce2d.md
@@ -36,7 +36,7 @@ In this lab, you will build a credit card validator using the Luhn algorithm.
 2. Within the `verify_card_number` function:
 
    - You should handle any dashes or spaces that may be present in the card number passed to it.
-   - Return `VALID!` if the card number is valid; otherwise, return `INVALID!`.
+   - Return `VALID!` if the card number is valid; otherwise, return `INVALID!`
 
 When you complete the project, you should see the following messages depending on the input:
 
@@ -59,7 +59,7 @@ You should have a function named `verify_card_number`.
 })
 ```
 
-`verify_card_number('453914889')` should return `VALID!`.
+`verify_card_number('453914889')` should return `VALID!`
 
 ```js
 ({
@@ -69,7 +69,7 @@ You should have a function named `verify_card_number`.
 })
 ```
 
-`verify_card_number('4111-1111-1111-1111')` should return `VALID!`.
+`verify_card_number('4111-1111-1111-1111')` should return `VALID!`
 
 ```js
 ({
@@ -79,7 +79,7 @@ You should have a function named `verify_card_number`.
 })
 ```
 
-`verify_card_number('453914881')` should return `INVALID!`.
+`verify_card_number('453914881')` should return `INVALID!`
 
 ```js
 ({
@@ -89,7 +89,7 @@ You should have a function named `verify_card_number`.
 })
 ```
 
-`verify_card_number('1234 5678 9012 3456')` should return `INVALID!`.
+`verify_card_number('1234 5678 9012 3456')` should return `INVALID!`
 
 ```js
 ({

--- a/curriculum/challenges/english/blocks/lab-number-pattern-generator/6842a6cd9836f0114a5b7a8a.md
+++ b/curriculum/challenges/english/blocks/lab-number-pattern-generator/6842a6cd9836f0114a5b7a8a.md
@@ -16,8 +16,8 @@ In this lab you will practice the basics of Python by building a small app that 
 1. You should define a function named `number_pattern` that takes a single parameter `n` (representing a positive integer).
 1. `number_pattern` should use a `for` loop.
 1. `number_pattern(n)` should return a string with all the integers starting from 1 up to `n` (included) separated by a space. For example, `number_pattern(4)` should return the string `1 2 3 4`.
-1. If the argument passed to the function is not an integer value, the function should return `Argument must be an integer value.`.
-1. If the argument passed to the function is less than 1, the function should return `Argument must be an integer greater than 0.`.
+1. If the argument passed to the function is not an integer value, the function should return `Argument must be an integer value.`
+1. If the argument passed to the function is less than 1, the function should return `Argument must be an integer greater than 0.`
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/lab-one-time-password-generator/67c562286b29447da020d407.md
+++ b/curriculum/challenges/english/blocks/lab-one-time-password-generator/67c562286b29447da020d407.md
@@ -208,7 +208,7 @@ await clock.tickAsync(6000);
 assert.isFalse(button.disabled);
 ```
 
-When the countdown timer reaches `0`, you should display the message `OTP expired. Click the button to generate a new OTP.`.
+When the countdown timer reaches `0`, you should display the message `OTP expired. Click the button to generate a new OTP.`
 
 ```js
   const button = document.querySelector(".container button#generate-otp-button");

--- a/curriculum/challenges/english/blocks/lab-planet-class/68e76b1ce8216249d04df670.md
+++ b/curriculum/challenges/english/blocks/lab-planet-class/68e76b1ce8216249d04df670.md
@@ -17,7 +17,7 @@ dashedName: build-a-planet-class
    - Raises a `TypeError` with the message `name, planet type, and star must be strings` if any of the arguments passed in is not a string type.
    - Raises a `ValueError` with the message `name, planet_type, and star must be non-empty strings` if any of the arguments passed in is an empty string.
    - Assigns the values passed in to the instance attributes `name`, `planet_type`, and `star`.
-1. The `Planet` class should have an `orbit` method that returns a string in the format `{name} is orbiting around {star}...`.
+1. The `Planet` class should have an `orbit` method that returns a string in the format `{name} is orbiting around {star}...`
 1. The `Planet` class should have a `__str__` method that returns a string in the format `Planet: {name} | Type: {planet_type} | Star: {star}`.
 1. You should create three instances of the `Planet` class named `planet_1`, `planet_2`, and `planet_3`.
 1. You should print each planet object to see the `__str__` method output.
@@ -216,7 +216,7 @@ assert _Node(_code).find_class('Planet').has_function('orbit')
 })
 ```
 
-The `orbit` method should return a string in the format `{name} is orbiting around {star}...`.
+The `orbit` method should return a string in the format `{name} is orbiting around {star}...`
 
 ```js
 ({

--- a/curriculum/challenges/english/blocks/lab-polygon-area-calculator/5e444147903586ffb414c94f.md
+++ b/curriculum/challenges/english/blocks/lab-polygon-area-calculator/5e444147903586ffb414c94f.md
@@ -23,7 +23,7 @@ In this project, you will use object-oriented programming to create a `Rectangle
     - `get_area`: Returns area (\\( \text{width} \times \text{height} \\)).
     - `get_perimeter`: Returns perimeter \\( 2(\text{width} + \text{height}) \\).
     - `get_diagonal`: Returns diagonal \\( \sqrt{\text{width}^2 + \text{height}^2} \\).
-    - `get_picture`: Returns a string that represents the shape using lines of `*`. The number of lines should be equal to the height and the number of `*` in each line should be equal to the width. There should be a new line (`\n`) at the end of each line. If the width or height is larger than `50`, this should return the string: `Too big for picture.`.
+    - `get_picture`: Returns a string that represents the shape using lines of `*`. The number of lines should be equal to the height and the number of `*` in each line should be equal to the width. There should be a new line (`\n`) at the end of each line. If the width or height is larger than `50`, this should return the string: `Too big for picture.`
     - `get_amount_inside`: Takes another shape (square or rectangle) as an argument. Returns the number of times the passed in shape could fit inside the shape (with no rotations). For instance, a rectangle with a width of `4` and a height of `8` could fit in two squares with sides of `4`.
 
 3. If an instance of a `Rectangle` is represented as a string, it should look like: `Rectangle(width=5, height=10)`.

--- a/curriculum/challenges/english/blocks/lab-truncate-string/ac6993d51946422351508a41.md
+++ b/curriculum/challenges/english/blocks/lab-truncate-string/ac6993d51946422351508a41.md
@@ -19,7 +19,7 @@ In this lab, you will practice truncating a string to a certain length.
 
 # --hints--
 
-`truncateString("A-tisket a-tasket A green and yellow basket", 8)` should return the string `A-tisket...`.
+`truncateString("A-tisket a-tasket A green and yellow basket", 8)` should return the string `A-tisket...`
 
 ```js
 assert.strictEqual(
@@ -28,7 +28,7 @@ assert.strictEqual(
 );
 ```
 
-`truncateString("Peter Piper picked a peck of pickled peppers", 11)` should return the string `Peter Piper...`.
+`truncateString("Peter Piper picked a peck of pickled peppers", 11)` should return the string `Peter Piper...`
 
 ```js
 assert.strictEqual(
@@ -61,13 +61,13 @@ assert.strictEqual(
 );
 ```
 
-`truncateString("A-", 1)` should return the string `A...`.
+`truncateString("A-", 1)` should return the string `A...`
 
 ```js
 assert.strictEqual(truncateString('A-', 1), 'A...');
 ```
 
-`truncateString("Absolutely Longer", 2)` should return the string `Ab...`.
+`truncateString("Absolutely Longer", 2)` should return the string `Ab...`
 
 ```js
 assert.strictEqual(truncateString('Absolutely Longer', 2), 'Ab...');

--- a/curriculum/challenges/english/blocks/lab-user-configuration-manager/684aaf9ec670c68d20efd0d0.md
+++ b/curriculum/challenges/english/blocks/lab-user-configuration-manager/684aaf9ec670c68d20efd0d0.md
@@ -20,7 +20,7 @@ In this lab, you will build a User Configuration Manager that allows users to ma
     
    - Convert the key and value to lowercase.
    - If the key setting exists, return `Setting '[key]' already exists! Cannot add a new setting with this name.`
-   - If the key setting doesn't exist, add the key-value pair to the given dictionary of settings and return `Setting '[key]' added with value '[value]' successfully!`.
+   - If the key setting doesn't exist, add the key-value pair to the given dictionary of settings and return `Setting '[key]' added with value '[value]' successfully!`
    - The messages returned should have the key and value in lowercase.
 
 1. You should define a function named `update_setting` with two parameters representing a dictionary of settings and a tuple containing a key-value pair.
@@ -116,7 +116,7 @@ The `add_setting` function should have two parameters.
 })
 ```
 
-`add_setting({'theme': 'light'}, ('THEME', 'dark'))` should return the error message `Setting 'theme' already exists! Cannot add a new setting with this name.`.
+`add_setting({'theme': 'light'}, ('THEME', 'dark'))` should return the error message `Setting 'theme' already exists! Cannot add a new setting with this name.`
 
 ```js
 ({
@@ -129,7 +129,7 @@ The `add_setting` function should have two parameters.
 })
 ```
 
-`add_setting({'theme': 'light'}, ('volume', 'high'))` should add a new key-value pair and return the success message `Setting 'volume' added with value 'high' successfully!`.
+`add_setting({'theme': 'light'}, ('volume', 'high'))` should add a new key-value pair and return the success message `Setting 'volume' added with value 'high' successfully!`
 
 ```js
 ({
@@ -205,7 +205,7 @@ The `update_setting` function should convert value to lowercase.
 })
 ```
 
-`update_setting({'theme': 'light'}, ('theme', 'dark'))` should update an existing key and return the success message `Setting 'theme' updated to 'dark' successfully!`.
+`update_setting({'theme': 'light'}, ('theme', 'dark'))` should update an existing key and return the success message `Setting 'theme' updated to 'dark' successfully!`
 
 ```js
 ({
@@ -280,7 +280,7 @@ The `delete_setting` function should have two parameters.
 })
 ```
 
-`delete_setting({'theme': 'light'}, 'theme')` should remove the existing key and return the success message `Setting 'theme' deleted successfully!`.
+`delete_setting({'theme': 'light'}, 'theme')` should remove the existing key and return the success message `Setting 'theme' deleted successfully!`
 
 ```js
 ({

--- a/curriculum/challenges/english/blocks/lab-voting-system/673b567e3ba535dda140d278.md
+++ b/curriculum/challenges/english/blocks/lab-voting-system/673b567e3ba535dda140d278.md
@@ -22,15 +22,15 @@ In this lab, you will build a voting system that uses `Map` to create a poll and
 
    - If the `option` does not already exist in the poll, it should be added to the poll with an empty `Set` as its value to track voters. You should also return the message `Option "<option>" added to the poll.`
 
-   - If the `option` already exists, it should return the message `Option "<option>" already exists.`.
+   - If the `option` already exists, it should return the message `Option "<option>" already exists.`
 
-   - If you try to add an empty option, the function should return the message `Option cannot be empty.`.
+   - If you try to add an empty option, the function should return the message `Option cannot be empty.`
 
 4. You should have a function `vote` that accepts two parameters, `option` (the option to vote for) and `voterId` (a unique ID for the voter).
 
 5. In the `vote` function:
 
-   - If the `option` does not exist in the poll, the function should return the message `Option "<option>" does not exist.`.
+   - If the `option` does not exist in the poll, the function should return the message `Option "<option>" does not exist.`
 
    - If the `option` exists, the function should check if the `voterId` has already voted for this `option`.
 

--- a/curriculum/challenges/english/blocks/learn-about-adverbial-phrases/680a2ae4fff48d4e65e984f5.md
+++ b/curriculum/challenges/english/blocks/learn-about-adverbial-phrases/680a2ae4fff48d4e65e984f5.md
@@ -38,7 +38,7 @@ This dismisses the concern completely, which isn't supportive of what James is a
 
 # --explanation--
 
-`It's possible` is a polite and open-ended way to respond to a question that starts with `Do you think we might...?`. It shows that the speaker thinks the situation could happen and is worth considering, but they're not giving a definite answer.
+`It's possible` is a polite and open-ended way to respond to a question that starts with `Do you think we might...?` It shows that the speaker thinks the situation could happen and is worth considering, but they're not giving a definite answer.
 
 In this case, James is asking if there might be problems with the app's performance on different servers. By saying `It's possible`, Sophie shows she understands and accepts the concern as reasonable. Another example:
 

--- a/curriculum/challenges/english/blocks/learn-about-speculation-and-requests/67efb7e39a3ae7184c508f1b.md
+++ b/curriculum/challenges/english/blocks/learn-about-speculation-and-requests/67efb7e39a3ae7184c508f1b.md
@@ -74,4 +74,4 @@ Sophie makes it clear that guidelines must be followed to avoid issues.
 
 Sophie encourages the team to maintain code quality by following specific guidelines, such as using the correct loop structure, including clear comments, and running all tests before submitting.
 
-Focus on the sentence that starts with `Let's make sure...`.
+Focus on the sentence that starts with `Let's make sure...`

--- a/curriculum/challenges/english/blocks/learn-about-speculation-and-requests/67f52dee33807524435b5714.md
+++ b/curriculum/challenges/english/blocks/learn-about-speculation-and-requests/67f52dee33807524435b5714.md
@@ -80,4 +80,4 @@ Jessica does not mention shutting down servers — she focuses on identifying an
 
 Jessica states that if they find more signs of unauthorized access, they `may need to escalate the situation`. This means the security team may need to take stronger action, such as reporting to management or enforcing additional security measures.
 
-Focus on the sentence that starts with `If we find more signs...`.
+Focus on the sentence that starts with `If we find more signs...`

--- a/curriculum/challenges/english/blocks/learn-about-speculation-and-requests/67f52eaaf9808c24f1711e49.md
+++ b/curriculum/challenges/english/blocks/learn-about-speculation-and-requests/67f52eaaf9808c24f1711e49.md
@@ -80,4 +80,4 @@ Jessica is not ignoring the problem.
 
 Jessica states that she will continue gathering information and keep the team updated. She also asks the team to report anything unusual.
 
-Focus on the sentence that starts with `I'll keep you...`.
+Focus on the sentence that starts with `I'll keep you...`

--- a/curriculum/challenges/english/blocks/learn-about-speculation-and-requests/67f679810774dd278c363d75.md
+++ b/curriculum/challenges/english/blocks/learn-about-speculation-and-requests/67f679810774dd278c363d75.md
@@ -66,4 +66,4 @@ It allows team members to collaborate more effectively.
 
 The text states that peer-to-peer learning encourages team members to `share experiences and solutions`, creating a collaborative environment.
 
-Find how learning from colleagues can enhance understanding and teamwork. Focus on the sentence that starts with `Encouraging peer-to-peer learning allows...`.
+Find how learning from colleagues can enhance understanding and teamwork. Focus on the sentence that starts with `Encouraging peer-to-peer learning allows...`

--- a/curriculum/challenges/english/blocks/learn-about-speculation-and-requests/67f67b465227cf28e6ade47f.md
+++ b/curriculum/challenges/english/blocks/learn-about-speculation-and-requests/67f67b465227cf28e6ade47f.md
@@ -66,4 +66,4 @@ The text suggests combining hands-on exercises with discussions, not replacing t
 
 The text states that starting with a recap of past issues (like a security breach) helps `highlight what went wrong` and `how to avoid similar mistakes`.
 
-Focus on how learning from past mistakes improves future performance. Focus on the sentence that starts with `A good approach is...`.
+Focus on how learning from past mistakes improves future performance. Focus on the sentence that starts with `A good approach is...`

--- a/curriculum/challenges/english/blocks/learn-basic-javascript-by-building-a-role-playing-game/62a8ce73d0dce43468f6689c.md
+++ b/curriculum/challenges/english/blocks/learn-basic-javascript-by-building-a-role-playing-game/62a8ce73d0dce43468f6689c.md
@@ -33,7 +33,7 @@ You should use the concatenation operator to add `newWeapon` to the end of the `
 assert.match(buyWeapon.toString(), /text\.innerText\s*=\s*('|")You now have a \1\s*\+\s*newWeapon/);
 ```
 
-You should use the concatenation operator to end your `text.innerText` string with a `.`.
+You should use the concatenation operator to end your `text.innerText` string with a `.`
 
 ```js
 assert.match(buyWeapon.toString(), /text\.innerText\s*=\s*('|")You now have a \1\s*\+\s*newWeapon\s*\+\s*('|")\.\2/);

--- a/curriculum/challenges/english/blocks/learn-basic-string-and-array-methods-by-building-a-music-player/660ae3eeef9ad289bece426b.md
+++ b/curriculum/challenges/english/blocks/learn-basic-string-and-array-methods-by-building-a-music-player/660ae3eeef9ad289bece426b.md
@@ -25,7 +25,7 @@ const exampleFunction = () => {
 }
 ```
 
-Create a new arrow function and assign it to the variable `printGreeting`. Inside the function body, use the `console.log()` method to print the string `Hello there!`.
+Create a new arrow function and assign it to the variable `printGreeting`. Inside the function body, use the `console.log()` method to print the string `Hello there!`
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/learn-basic-string-and-array-methods-by-building-a-music-player/660aea8782242e8f4bcc42d8.md
+++ b/curriculum/challenges/english/blocks/learn-basic-string-and-array-methods-by-building-a-music-player/660aea8782242e8f4bcc42d8.md
@@ -25,7 +25,7 @@ const greet = name => {
 };
 ```
 
-Create a new named arrow function called `printMessage` that has one parameter called `org`. Inside the body of that function, add a console statement. Inside that console statement, add the template literal `${org} is awesome!`. 
+Create a new named arrow function called `printMessage` that has one parameter called `org`. Inside the body of that function, add a console statement. Inside that console statement, add the template literal `${org} is awesome!` 
 
 Below your `printMessage` function, call the function and pass in the string `"freeCodeCamp"` as an argument.
 
@@ -58,7 +58,7 @@ Your `printMessage` function should have a console statement.
 assert.match(printMessage.toString(),/console\.log\(/);
 ```
 
-Your console statement should include the template literal `${org} is awesome!`.
+Your console statement should include the template literal `${org} is awesome!`
 
 ```js
 assert.match(code, /console\.log\(\s*`[^`]*\${org} is awesome![^`]*`\s*\)/);

--- a/curriculum/challenges/english/blocks/learn-conversation-starters-in-the-break-room/657cb5dd956a8797462da793.md
+++ b/curriculum/challenges/english/blocks/learn-conversation-starters-in-the-break-room/657cb5dd956a8797462da793.md
@@ -8,7 +8,7 @@ lang: en-US
 
 # --description--
 
-When you want to know about someone's character or personality, you can ask, `What is (he/she) like?` or `What are they like?`. These questions are about the qualities of a person, not about their physical appearance.
+When you want to know about someone's character or personality, you can ask, `What is (he/she) like?` or `What are they like?` These questions are about the qualities of a person, not about their physical appearance.
 
 For example, imagine you meet a new student in your programming class and you want to know more about her. You can ask a classmate `What is she like?`
 

--- a/curriculum/challenges/english/blocks/learn-conversation-starters-in-the-break-room/657cea90396c694e4fdcaeba.md
+++ b/curriculum/challenges/english/blocks/learn-conversation-starters-in-the-break-room/657cea90396c694e4fdcaeba.md
@@ -16,7 +16,7 @@ lang: en-US
 
 - `When do we have lunch?` - You want to know the time for lunch.
 
-So, you use `when` whenever you are asking "at what time?" or "on what date?".
+So, you use `when` whenever you are asking "at what time?" or "on what date?"
 
 # --instructions--
 

--- a/curriculum/challenges/english/blocks/learn-conversation-starters-in-the-break-room/657dcf9f7d5c747a19a36c9c.md
+++ b/curriculum/challenges/english/blocks/learn-conversation-starters-in-the-break-room/657dcf9f7d5c747a19a36c9c.md
@@ -10,7 +10,7 @@ lang: en-US
 
 # --description--
 
-When you want to ask about the existence of specific places or things in your current location, you can use the question structure `Are there any ... around here?`. For example:
+When you want to ask about the existence of specific places or things in your current location, you can use the question structure `Are there any ... around here?` For example:
 
 `Are there any Wi-Fi spots around here?` - You're asking if you can find Wi-Fi near this place.
 

--- a/curriculum/challenges/english/blocks/learn-css-grid-by-building-a-magazine/6143d003ad9e9d76766293ec.md
+++ b/curriculum/challenges/english/blocks/learn-css-grid-by-building-a-magazine/6143d003ad9e9d76766293ec.md
@@ -7,7 +7,7 @@ dashedName: step-25
 
 # --description--
 
-Within your `.image-quote` element, nest an `hr` element, a `p` element and a second `hr` element. Give the `p` element a `class` set to `quote` and the text `The millions of people who are learning to code through freeCodeCamp will have an even better resource to help them learn these fundamentals.`.
+Within your `.image-quote` element, nest an `hr` element, a `p` element and a second `hr` element. Give the `p` element a `class` set to `quote` and the text `The millions of people who are learning to code through freeCodeCamp will have an even better resource to help them learn these fundamentals.`
 
 # --hints--
 
@@ -38,7 +38,7 @@ Your new `p` element should have a `class` set to `quote`.
 assert(document.querySelector('.image-quote p')?.classList.contains('quote'));
 ```
 
-Your new `p` element should have the text `The millions of people who are learning to code through freeCodeCamp will have an even better resource to help them learn these fundamentals.`.
+Your new `p` element should have the text `The millions of people who are learning to code through freeCodeCamp will have an even better resource to help them learn these fundamentals.`
 
 ```js
 assert(document.querySelector('.image-quote p')?.innerText === 'The millions of people who are learning to code through freeCodeCamp will have an even better resource to help them learn these fundamentals.');

--- a/curriculum/challenges/english/blocks/learn-determiners-and-advanced-use-of-articles/6811eb80bfcad31376ea7bef.md
+++ b/curriculum/challenges/english/blocks/learn-determiners-and-advanced-use-of-articles/6811eb80bfcad31376ea7bef.md
@@ -70,4 +70,4 @@ Slowdowns
 
 Jake states that developers have experienced slowdowns, especially for users in Europe. Choosing the European provider could improve performance for that region.
 
-Focus on the sentence that starts with `In terms of performance...`. It explains how performance is critical for international user satisfaction.
+Focus on the sentence that starts with `In terms of performance...` It explains how performance is critical for international user satisfaction.

--- a/curriculum/challenges/english/blocks/learn-determiners-and-advanced-use-of-articles/6811ec8382929614621afb3d.md
+++ b/curriculum/challenges/english/blocks/learn-determiners-and-advanced-use-of-articles/6811ec8382929614621afb3d.md
@@ -70,4 +70,4 @@ The company has not yet switched providers; the test is part of the decision pro
 
 Jake says they plan to run a test project with the European provider to check performance, support, and scalability.
 
-He mentions the time in the sentence that starts with `For scalability...`.
+He mentions the time in the sentence that starts with `For scalability...`

--- a/curriculum/challenges/english/blocks/learn-determiners-and-advanced-use-of-articles/68135a133ef5911790856475.md
+++ b/curriculum/challenges/english/blocks/learn-determiners-and-advanced-use-of-articles/68135a133ef5911790856475.md
@@ -78,6 +78,6 @@ Every two weeks
 
 # --explanation--
 
-Focus on the sentence that starts with `We'll have...`.
+Focus on the sentence that starts with `We'll have...`
 
 Bob says the team will have `bi-weekly` meetings to monitor progress and address issues early to avoid delays.

--- a/curriculum/challenges/english/blocks/learn-determiners-and-advanced-use-of-articles/68135ac7afe66e185aeccf0b.md
+++ b/curriculum/challenges/english/blocks/learn-determiners-and-advanced-use-of-articles/68135ac7afe66e185aeccf0b.md
@@ -78,6 +78,6 @@ The project is just starting; Bob is not announcing its end.
 
 # --explanation--
 
-Focus on the sentence that starts with `On the QA side...`.
+Focus on the sentence that starts with `On the QA side...`
 
 Bob is contacting HR to find more QA testers, especially for complex features, because the team currently lacks enough testing support.

--- a/curriculum/challenges/english/blocks/learn-determiners-and-advanced-use-of-articles/68135b64cddd3e18ee480472.md
+++ b/curriculum/challenges/english/blocks/learn-determiners-and-advanced-use-of-articles/68135b64cddd3e18ee480472.md
@@ -78,6 +78,6 @@ Make sure everyone is clear on their responsibilities.
 
 # --explanation--
 
-Focus on the paragraph that starts with `Please reach out if...`.
+Focus on the paragraph that starts with `Please reach out if...`
 
 Bob asks the team to ensure everyone understands their responsibilities by the end of the week, setting up a strong, organized start to the project.

--- a/curriculum/challenges/english/blocks/learn-determiners-and-advanced-use-of-articles/6814f3e6df863e3231c2ce99.md
+++ b/curriculum/challenges/english/blocks/learn-determiners-and-advanced-use-of-articles/6814f3e6df863e3231c2ce99.md
@@ -76,6 +76,6 @@ Server capacity was divided fairly, but analytics tool allocation depends on pro
 
 # --explanation--
 
-Focus on the sentence that starts with `Advanced analytics tools will not be...`.
+Focus on the sentence that starts with `Advanced analytics tools will not be...`
 
 Maria explains that smaller projects are not yet ready for integration with advanced analytics tools, so these tools will not be provided at this stage.

--- a/curriculum/challenges/english/blocks/learn-form-validation-by-building-a-calorie-counter/63c1e1965a898d302e0af4e3.md
+++ b/curriculum/challenges/english/blocks/learn-form-validation-by-building-a-calorie-counter/63c1e1965a898d302e0af4e3.md
@@ -17,7 +17,7 @@ const templateLiteral = `Hello, my name is ${name}~!`;
 console.log(templateLiteral);
 ```
 
-The console will show the string "Hello, my name is Naomi~!".
+The console will show the string "Hello, my name is Naomi~!"
 
 Replace your concatenated string in the `querySelector` with a template literal – be sure to keep the space between your `targetId` variable and `.input-container`.
 

--- a/curriculum/challenges/english/blocks/learn-future-continuous-while-describing-actions/675961ce80a70e23e933fa8c.md
+++ b/curriculum/challenges/english/blocks/learn-future-continuous-while-describing-actions/675961ce80a70e23e933fa8c.md
@@ -22,7 +22,7 @@ Which option correctly uses `haven't` or `hasn't` in a tag question?
 
 ### --feedback--
 
-`Has` is used in the main sentence, so the tag question should be `hasn't she?`.
+`Has` is used in the main sentence, so the tag question should be `hasn't she?`
 
 ---
 
@@ -30,7 +30,7 @@ Which option correctly uses `haven't` or `hasn't` in a tag question?
 
 ### --feedback--
 
-`Have` is used in the main sentence, so the tag question should be `haven't we?`.
+`Have` is used in the main sentence, so the tag question should be `haven't we?`
 
 ---
 
@@ -38,7 +38,7 @@ Which option correctly uses `haven't` or `hasn't` in a tag question?
 
 ### --feedback--
 
-`Have` is used in the main sentence, so the tag question should be `haven't they?`.
+`Have` is used in the main sentence, so the tag question should be `haven't they?`
 
 ---
 

--- a/curriculum/challenges/english/blocks/learn-future-continuous-while-describing-actions/675d10fd9150e00d5ea464c2.md
+++ b/curriculum/challenges/english/blocks/learn-future-continuous-while-describing-actions/675d10fd9150e00d5ea464c2.md
@@ -22,7 +22,7 @@ Which of the following sentences uses a tag question correctly?
 
 ### --feedback--
 
-Since the main sentence is positive, the tag question should be negative: `aren't they?`.
+Since the main sentence is positive, the tag question should be negative: `aren't they?`
 
 ---
 
@@ -34,7 +34,7 @@ Since the main sentence is positive, the tag question should be negative: `aren'
 
 ### --feedback--
 
-The tag question must use the subject `they` instead of the object `them`. The correct form is `are they?`.
+The tag question must use the subject `they` instead of the object `them`. The correct form is `are they?`
 
 ---
 
@@ -42,7 +42,7 @@ The tag question must use the subject `they` instead of the object `them`. The c
 
 ### --feedback--
 
-`Do they?` is used for the verb `do`, not `are`. For a sentence with `are`, the correct tag question is `aren't they?`.
+`Do they?` is used for the verb `do`, not `are`. For a sentence with `are`, the correct tag question is `aren't they?`
 
 ## --video-solution--
 
@@ -50,4 +50,4 @@ The tag question must use the subject `they` instead of the object `them`. The c
 
 # --explanation--
 
-In tag questions, when the main sentence is positive and the subject is plural (like `tokens`), you use a negative tag question, `aren't they?`. This confirms or checks the information. The other options do not follow the correct tag question structure.
+In tag questions, when the main sentence is positive and the subject is plural (like `tokens`), you use a negative tag question, `aren't they?` This confirms or checks the information. The other options do not follow the correct tag question structure.

--- a/curriculum/challenges/english/blocks/learn-future-continuous-while-describing-actions/675d86beee48ab4941767200.md
+++ b/curriculum/challenges/english/blocks/learn-future-continuous-while-describing-actions/675d86beee48ab4941767200.md
@@ -30,7 +30,7 @@ The subject of the main sentence is `we`, but the tag uses `they`, which is a mi
 
 ### --feedback--
 
-The main sentence is negative, so the tag should be positive: `can she?`.
+The main sentence is negative, so the tag should be positive: `can she?`
 
 ---
 

--- a/curriculum/challenges/english/blocks/learn-future-continuous-while-describing-actions/675e7387be428072d95baeac.md
+++ b/curriculum/challenges/english/blocks/learn-future-continuous-while-describing-actions/675e7387be428072d95baeac.md
@@ -60,7 +60,7 @@ This is a contraction of `have not` used in a tag question.
 
 ### --feedback--
 
-This is a part of a confirmation response for questions like `haven't they?`.
+This is a part of a confirmation response for questions like `haven't they?`
 
 ---
 

--- a/curriculum/challenges/english/blocks/learn-greetings-in-your-first-day-at-the-office/65529784e7cb6e24eb03a1af.md
+++ b/curriculum/challenges/english/blocks/learn-greetings-in-your-first-day-at-the-office/65529784e7cb6e24eb03a1af.md
@@ -13,7 +13,7 @@ Maria: Welcome aboard, Tom. How do you like California so far?
 
 # --description--
 
-When you want to ask someone for their opinion or feelings about something, especially a place or an experience, you can use the question `How do you like...?`.
+When you want to ask someone for their opinion or feelings about something, especially a place or an experience, you can use the question `How do you like...?`
 
 Maria is asking Tom about his impressions of California.
 

--- a/curriculum/challenges/english/blocks/learn-greetings-in-your-first-day-at-the-office/656a421a905e792eca05d447.md
+++ b/curriculum/challenges/english/blocks/learn-greetings-in-your-first-day-at-the-office/656a421a905e792eca05d447.md
@@ -13,7 +13,7 @@ Sophie: Where are you from, Tom?
 
 # --description--
 
-When you want to know about someone's origin or the place they grew up, you can ask `Where are you from?`. This question is a common way to know more about a person's background.
+When you want to know about someone's origin or the place they grew up, you can ask `Where are you from?` This question is a common way to know more about a person's background.
 
 # --questions--
 

--- a/curriculum/challenges/english/blocks/learn-greetings-in-your-first-day-at-the-office/656ab828bd06214a51193f3d.md
+++ b/curriculum/challenges/english/blocks/learn-greetings-in-your-first-day-at-the-office/656ab828bd06214a51193f3d.md
@@ -8,7 +8,7 @@ lang: en-US
 
 # --description--
 
-When you want to say that you have a strong interest in something, you can say `I am into...`. This phrase shows what someone likes or enjoys.
+When you want to say that you have a strong interest in something, you can say `I am into...` This phrase shows what someone likes or enjoys.
 
 # --fillInTheBlank--
 

--- a/curriculum/challenges/english/blocks/learn-how-to-describe-places-and-events/66a96725d88e7f5a511d043d.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-describe-places-and-events/66a96725d88e7f5a511d043d.md
@@ -46,4 +46,4 @@ False
 
 # --explanation--
 
-To determine if Lisa is working alone, look for the part of the text that starts with `Her team includes...`. Focus on the sentence that talks about the developers and UX designer.
+To determine if Lisa is working alone, look for the part of the text that starts with `Her team includes...` Focus on the sentence that talks about the developers and UX designer.

--- a/curriculum/challenges/english/blocks/learn-how-to-describe-places-and-events/66b13f2f0c5a415ccd41335e.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-describe-places-and-events/66b13f2f0c5a415ccd41335e.md
@@ -46,4 +46,4 @@ False
 
 # --explanation--
 
-To answer this question, focus on the part of the text that describes Lisa's team. Look for the sentence that mentions `Her team includes...`. This will help you determine if there are developers from Seattle on her team.
+To answer this question, focus on the part of the text that describes Lisa's team. Look for the sentence that mentions `Her team includes...` This will help you determine if there are developers from Seattle on her team.

--- a/curriculum/challenges/english/blocks/learn-how-to-describe-places-and-events/66b52aaddea73da83ef5d442.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-describe-places-and-events/66b52aaddea73da83ef5d442.md
@@ -21,7 +21,7 @@ Listen to the audio and answer the question below.
 
 ## --text--
 
-Which sentence best follows Brian's statement, `We touch on it, but perhaps not in enough detail.`?
+Which sentence best follows Brian's statement, `We touch on it, but perhaps not in enough detail`?
 
 ## --answers--
 

--- a/curriculum/challenges/english/blocks/learn-how-to-describe-places-and-events/66b568bf34c34209600445ad.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-describe-places-and-events/66b568bf34c34209600445ad.md
@@ -30,7 +30,7 @@ Ending the training sessions because of a fishing trip.
 
 ### --feedback--
 
-Focus on what Brian is saying right after `I'm thinking of using...` and `especially for...`.
+Focus on what Brian is saying right after `I'm thinking of using...` and `especially for...`
 
 ---
 
@@ -38,7 +38,7 @@ Changing the topic completely because of phishing attempts.
 
 ### --feedback--
 
-Focus on what Brian is saying right after `I'm thinking of using...` and `especially for...`.
+Focus on what Brian is saying right after `I'm thinking of using...` and `especially for...`
 
 ---
 
@@ -46,7 +46,7 @@ Canceling the training because of phishing attempts.
 
 ### --feedback--
 
-Focus on what Brian is saying right after `I'm thinking of using...` and `especially for...`.
+Focus on what Brian is saying right after `I'm thinking of using...` and `especially for...`
 
 ## --video-solution--
 
@@ -58,7 +58,7 @@ The `Present Continuous` tense is used to talk about actions happening now. The 
 
 To understand what Brian is currently thinking about in terms of the training, listen closely to the part of the audio where he talks about his plans. 
 
-Focus on what Brian is saying right after `I'm thinking of using...` and `especially for...`. This will help you identify his specific thoughts about the training.
+Focus on what Brian is saying right after `I'm thinking of using...` and `especially for...` This will help you identify his specific thoughts about the training.
 
 # --scene--
 

--- a/curriculum/challenges/english/blocks/learn-how-to-describe-places-and-events/66b56c0432933515821a4eeb.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-describe-places-and-events/66b56c0432933515821a4eeb.md
@@ -28,7 +28,7 @@ She suggests canceling the training. This indicates she doesn't support his idea
 
 ### --feedback--
 
-She is not suggesting canceling the training. Pay attention to the words she uses after `Using real-life scenarios makes...`. This will help you find the correct option.
+She is not suggesting canceling the training. Pay attention to the words she uses after `Using real-life scenarios makes...` This will help you find the correct option.
 
 ---
 
@@ -36,7 +36,7 @@ She says the scenarios are irrelevant. This indicates she doesn't like his idea.
 
 ### --feedback--
 
-She doesn't say the scenarios are irrelevant. Pay attention to the words she uses after `Using real-life scenarios makes...`. This will help you find the correct option.
+She doesn't say the scenarios are irrelevant. Pay attention to the words she uses after `Using real-life scenarios makes...` This will help you find the correct option.
 
 ---
 
@@ -48,7 +48,7 @@ She ignores Brian's suggestion completely. This indicates she doesn't understand
 
 ### --feedback--
 
-She didn't ignore Brian. Pay attention to the words she uses after `Using real-life scenarios makes...`. This will help you find the correct option.
+She didn't ignore Brian. Pay attention to the words she uses after `Using real-life scenarios makes...` This will help you find the correct option.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/blocks/learn-how-to-describe-places-and-events/66bbf02b6112f3a2f03c1968.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-describe-places-and-events/66bbf02b6112f3a2f03c1968.md
@@ -14,7 +14,7 @@ This task doesn't have audio. Read the question and select the correct answer.
 
 ## --text--
 
-What does `it` refer to in the sentence `The Live Preview isn't showing in Visual Studio Code. Isn't it supposed to support that feature?`?
+What does `it` refer to in the sentence `The Live Preview isn't showing in Visual Studio Code. Isn't it supposed to support that feature?`
 
 ## --answers--
 

--- a/curriculum/challenges/english/blocks/learn-how-to-describe-places-and-events/66c613a4d11b69cdd746b5ed.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-describe-places-and-events/66c613a4d11b69cdd746b5ed.md
@@ -31,7 +31,7 @@ The auto-completion is outdated.
 
 ### --feedback--
 
-Pay attention to what Sarah says after `it doesn't work if...`. 
+Pay attention to what Sarah says after `it doesn't work if...` 
 
 ---
 
@@ -39,7 +39,7 @@ The computer isn't powerful enough.
 
 ### --feedback--
 
-Pay attention to what Sarah says after `it doesn't work if...`. 
+Pay attention to what Sarah says after `it doesn't work if...` 
 
 ---
 
@@ -47,7 +47,7 @@ The feature is only available in a different IDE.
 
 ### --feedback--
 
-Pay attention to what Sarah says after `it doesn't work if...`. 
+Pay attention to what Sarah says after `it doesn't work if...` 
   
 ## --video-solution--
 

--- a/curriculum/challenges/english/blocks/learn-how-to-describe-places-and-events/66c6155aafccc1d49bf9b32a.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-describe-places-and-events/66c6155aafccc1d49bf9b32a.md
@@ -25,7 +25,7 @@ She wants to know if he needs help setting up the project.
 
 ### --feedback--
 
-Pay attention to what Sarah says after `Have you checked...`.
+Pay attention to what Sarah says after `Have you checked...`
 
 ---
 
@@ -33,7 +33,7 @@ She wants to know if the project is saved.
 
 ### --feedback--
 
-Pay attention to what Sarah says after `Have you checked...`.
+Pay attention to what Sarah says after `Have you checked...`
 
 ---
 
@@ -45,7 +45,7 @@ She wants to know if the auto-completion feature is installed.
 
 ### --feedback--
 
-Pay attention to what Sarah says after `Have you checked...`.
+Pay attention to what Sarah says after `Have you checked...`
   
 ## --video-solution--
 

--- a/curriculum/challenges/english/blocks/learn-how-to-describe-places-and-events/66c62046cf3df2fe7cf92230.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-describe-places-and-events/66c62046cf3df2fe7cf92230.md
@@ -25,7 +25,7 @@ If the project isn't saved correctly.
 
 ### --feedback--
 
-Pay attention to what Sarah says after `but they're not visible if...`.
+Pay attention to what Sarah says after `but they're not visible if...`
 
 ---
 
@@ -33,7 +33,7 @@ If Eclipse isn't updated to the latest version.
 
 ### --feedback--
 
-Pay attention to what Sarah says after `but they're not visible if...`.
+Pay attention to what Sarah says after `but they're not visible if...`
 
 ---
 
@@ -45,7 +45,7 @@ If the Git tools aren't installed manually.
 
 ### --feedback--
 
-Pay attention to what Sarah says after `but they're not visible if...`.
+Pay attention to what Sarah says after `but they're not visible if...`
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/blocks/learn-how-to-discuss-roles-and-responsibilities/65d5d17a45be4e4d56be704a.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-discuss-roles-and-responsibilities/65d5d17a45be4e4d56be704a.md
@@ -12,7 +12,7 @@ lang: en-US
 
 The word `ever` is used in the present perfect tense to talk about experiences at any time up to now. It's often found in questions to ask if someone has done something at least once in their life.
 
-For example, `Have you ever visited Paris?` means "at any time in your life, did you visit Paris?".
+For example, `Have you ever visited Paris?` means "at any time in your life, did you visit Paris?"
 
 # --fillInTheBlank--
 

--- a/curriculum/challenges/english/blocks/learn-how-to-discuss-tech-trends-and-updates/6635fdc8fdd98f2b56c3bcf8.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-discuss-tech-trends-and-updates/6635fdc8fdd98f2b56c3bcf8.md
@@ -28,7 +28,7 @@ Which of the following sentences uses the structure `do you know` followed by an
 
 ### --feedback--
 
-This sentence incorrectly uses a modal verb `can` directly after `Do you know`. It should be `Do you know if he can arrive on time?`.
+This sentence incorrectly uses a modal verb `can` directly after `Do you know`. It should be `Do you know if he can arrive on time?`
 
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-discuss-your-morning-or-evening-routine/6556ba2fe6c3f3846ea71ab2.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-discuss-your-morning-or-evening-routine/6556ba2fe6c3f3846ea71ab2.md
@@ -10,7 +10,7 @@ lang: en-US
 
 # --description--
 
-`It seems like...` is used to express a personal observation or feeling about someone or something, similar to saying `It appears that...` or `It looks as if...`. 
+`It seems like...` is used to express a personal observation or feeling about someone or something, similar to saying `It appears that...` or `It looks as if...` 
 
 For example, you can say `It seems like it's going to rain today` when looking at cloudy skies.
 

--- a/curriculum/challenges/english/blocks/learn-how-to-express-agreement/67af46a4ec8db360d8f0cc7a.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-express-agreement/67af46a4ec8db360d8f0cc7a.md
@@ -68,4 +68,4 @@ The email does not mention team-building as the purpose of the check-ins.
 
 Look for key details in the email that explain what Bob expects from the check-ins.
 
-Pay special attention to the phrase that starts with `I'm confident these regular check-ins...`.
+Pay special attention to the phrase that starts with `I'm confident these regular check-ins...`

--- a/curriculum/challenges/english/blocks/learn-how-to-express-agreement/67b4681b40ac5c3c991e1f51.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-express-agreement/67b4681b40ac5c3c991e1f51.md
@@ -54,7 +54,7 @@ Jim is not specifically asking about a meeting.
 
 Jim is asking if now is a good time to talk. 
 
-`Would` makes the question more polite. Instead of asking directly, `Is now a good time?`, Jim says, `Would now be a good time?`. 
+`Would` makes the question more polite. Instead of asking directly, `Is now a good time?`, Jim says, `Would now be a good time?` 
 
 This sounds softer and more polite because it shows respect for the other person's time.
 

--- a/curriculum/challenges/english/blocks/learn-how-to-express-concerns/67c4df1b2f2b56444eb61fe6.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-express-concerns/67c4df1b2f2b56444eb61fe6.md
@@ -52,7 +52,7 @@ Get additional support.
 
 # --explanation--
 
-A way to propose a solution is by asking a question using `Have you thought about...`. This introduces an idea without making a direct suggestion. For example:
+A way to propose a solution is by asking a question using `Have you thought about...` This introduces an idea without making a direct suggestion. For example:
 
 `Have you thought about automating part of the process?` - This subtly suggests that automation could be a solution.  
 

--- a/curriculum/challenges/english/blocks/learn-how-to-express-concerns/67c9d9f174a5497fa2162cd7.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-express-concerns/67c9d9f174a5497fa2162cd7.md
@@ -68,7 +68,7 @@ Another example:
 
 `Did she explain why the meeting was canceled?` - Here, the question is `Did she explain` and `why the meeting was canceled` is the information she explained. `Did she explain why was the meeting canceled?` would be incorrect.
 
-As a rule of thumb, if the sentence starts with the question word (`Where`, `Why`, `How` etc.), use the question word order, as in `Where did he go?`. If the question word comes after another question, use normal word order, as in `Do you know where he went?`.
+As a rule of thumb, if the sentence starts with the question word (`Where`, `Why`, `How` etc.), use the question word order, as in `Where did he go?` If the question word comes after another question, use normal word order, as in `Do you know where he went?`
 
 # --scene--
 

--- a/curriculum/challenges/english/blocks/learn-how-to-express-disagreement/67af0e8fc6a5cf0b77569a7d.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-express-disagreement/67af0e8fc6a5cf0b77569a7d.md
@@ -68,4 +68,4 @@ The article doesn't focus on extra training programs.
 
 To find the correct answer, look at the section where the article discusses survey results.  
 
-Pay attention to `Most people want to spend it on...`. This phrase help you identify what most remote workers prefer to spend their stipend on.
+Pay attention to `Most people want to spend it on...` This phrase help you identify what most remote workers prefer to spend their stipend on.

--- a/curriculum/challenges/english/blocks/learn-how-to-manage-a-conversation/67ddb0b9b04b5097971a98a1.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-manage-a-conversation/67ddb0b9b04b5097971a98a1.md
@@ -52,7 +52,7 @@ James is not referring to a canceled meeting.
 
 # --explanation--
 
-In casual spoken language, you often leave out words when the meaning is still clear. In this case, `Anything else we should discuss?` is a shortened form of `Is there anything else we should discuss?`. This kind of omission is common in conversation. Another example:
+In casual spoken language, you often leave out words when the meaning is still clear. In this case, `Anything else we should discuss?` is a shortened form of `Is there anything else we should discuss?` This kind of omission is common in conversation. Another example:
 
 `Need any help?` is a shorter way to say `Do you need any help?` – The subject and auxiliary verb are left out, but the meaning stays the same.
 

--- a/curriculum/challenges/english/blocks/learn-how-to-manage-a-conversation/67f08553782e8a05bcd28688.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-manage-a-conversation/67f08553782e8a05bcd28688.md
@@ -72,4 +72,4 @@ The additional support from other resources the team asked for.
 
 # --explanation--
 
-After talking about the integration issues, Brian starts the next part of the message by saying `She also asks...`. Find where this is in the email, and read the line to be able to correctly answer this question.
+After talking about the integration issues, Brian starts the next part of the message by saying `She also asks...` Find where this is in the email, and read the line to be able to correctly answer this question.

--- a/curriculum/challenges/english/blocks/learn-how-to-share-feedback/679d8d1b41573368e0f80348.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-share-feedback/679d8d1b41573368e0f80348.md
@@ -70,4 +70,4 @@ The client does not mention a deadline to solve the issue.
 
 # --explanation--
 
-To answer this question, you should read the question that starts with `Could you please...`. That's where the client request can be found. Read it and you'll be able to answer the question correctly.
+To answer this question, you should read the question that starts with `Could you please...` That's where the client request can be found. Read it and you'll be able to answer the question correctly.

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-numbers-with-a-coworker/6846f0ed1e2d12252ebdc533.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-numbers-with-a-coworker/6846f0ed1e2d12252ebdc533.md
@@ -52,7 +52,7 @@ That comes after development and testing, not during the third phase.
 
 # --explanation--
 
-James says, `The third phase, which includes all initial testing...`.
+James says, `The third phase, which includes all initial testing...`
 
 He does not mention final fixes, marketing, or early planning steps here.
 

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-numbers-with-a-coworker/68470c006cdf6b32eecd265b.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-numbers-with-a-coworker/68470c006cdf6b32eecd265b.md
@@ -68,6 +68,6 @@ The project is still in early stages; Jessica is outlining future tasks and date
 
 # --explanation--
 
-Jessica starts her email with `We've updated...`.
+Jessica starts her email with `We've updated...`
 
 This shows the main purpose: to communicate the updated timeline with clear milestones and deadlines so everyone is aligned and knows what to expect in each phase.

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-numbers-with-a-coworker/68470e1747093934338cb60c.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-numbers-with-a-coworker/68470e1747093934338cb60c.md
@@ -68,6 +68,6 @@ Setting up the core database, because many parts depend on it.
 
 # --explanation--
 
-Focus on the sentence that starts with `One important task is...`.
+Focus on the sentence that starts with `One important task is...`
 
 Jessica points out that setting up the core database is essential because many other parts depend on it, making it a high-priority task in the development phase.

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-numbers-with-a-coworker/68470f0731b5ea34f9c7e58a.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-numbers-with-a-coworker/68470f0731b5ea34f9c7e58a.md
@@ -68,6 +68,6 @@ Onboarding isn't mentioned in the timeline — Jessica is outlining project phas
 
 # --explanation--
 
-Focus on the sentence that starts with `The third phase is...`.
+Focus on the sentence that starts with `The third phase is...`
 
 `The third phase is all about initial testing`, as mentioned in the update. It comes after development and helps prepare for beta testing.

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-numbers-with-a-coworker/68470fc84731be35b39f2d85.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-numbers-with-a-coworker/68470fc84731be35b39f2d85.md
@@ -68,6 +68,6 @@ Three days wouldn't be enough - Jessica allows `two weeks` for this phase.
 
 # --explanation--
 
-Focus on the sentence that starts with `Finally, in the last phase...`.
+Focus on the sentence that starts with `Finally, in the last phase...`
 
 Jessica states that the last phase (beta testing and fixes) will last two weeks to allow enough time to resolve any critical issues.

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-numbers-with-a-coworker/684710868797413676e41de6.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-numbers-with-a-coworker/684710868797413676e41de6.md
@@ -68,6 +68,6 @@ May 16, 2025
 
 # --explanation--
 
-Focus on the sentence that starts with `The final task in this phase is...`.
+Focus on the sentence that starts with `The final task in this phase is...`
 
 Jessica mentions that the final task of the last phase is preparing the deployment documentation, which should be ready by May 16, 2025.

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-numbers-with-a-coworker/68484b5100af0b6bdd343021.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-numbers-with-a-coworker/68484b5100af0b6bdd343021.md
@@ -72,6 +72,6 @@ Spending is not that high yet.
 
 # --explanation--
 
-Focus on the sentence that starts with `So far, we've spent...`.
+Focus on the sentence that starts with `So far, we've spent...`
 
 Alice mentions how much of the total budget has already been spent, primarily on setup and early development work.

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-numbers-with-a-coworker/68484c2ac2fb7f6cac906439.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-numbers-with-a-coworker/68484c2ac2fb7f6cac906439.md
@@ -72,6 +72,6 @@ Cut the `Testing` phase.
 
 # --explanation--
 
-Focus on the sentence that starts with `We'll keep...`.
+Focus on the sentence that starts with `We'll keep...`
 
 Alice says the team will monitor spending and make changes if needed. This shows that the team is staying flexible and responsive to budget needs.

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-activities/66db690a4859eaa462fd4862.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-activities/66db690a4859eaa462fd4862.md
@@ -39,7 +39,7 @@ This response does not provide any details about what tasks or problems need to 
 
 # --explanation--
 
-The correct answer should provide information that directly responds to Bob's question `What do we have to deal with now?`.
+The correct answer should provide information that directly responds to Bob's question `What do we have to deal with now?`
 
 Look for an option that indicates preparation or awareness of the tasks.
 

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-activities/66e32c232273235dd6dc3287.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-activities/66e32c232273235dd6dc3287.md
@@ -62,4 +62,4 @@ Check if the email mentions contacting support as the first action.
 
 To identify the actions the user has taken, look for parts of the email where the user describes what they have tried or done with the app. 
 
-Focus on sentences that mention specific actions, such as `Every time I try to...`.
+Focus on sentences that mention specific actions, such as `Every time I try to...`

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/670538f8565fb514ddf24b85.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/670538f8565fb514ddf24b85.md
@@ -40,7 +40,7 @@ Other words and phrases that can be used with the same meaning as `then` in this
 
 - `I checked the updates. After that, I started debugging.` 
 
-- `I reviewed the requirements. Next, I shared my thoughts with the team.`.
+- `I reviewed the requirements. Next, I shared my thoughts with the team.`
 
 These words help structure descriptions of actions in chronological order.
 

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/6705425a4b3df216cb6de9a7.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/6705425a4b3df216cb6de9a7.md
@@ -38,7 +38,7 @@ Even though this is exactly what she wants to know, it is not a short question.
 
 # --explanation--
 
-James talks about `something odd`. Lisa asks him to identify what this odd thing (`it`) was by asking `What was it?`. `Was` is used because it is a singular thing (`something odd`) and it was found in the past, when James reviewed the error logs.
+James talks about `something odd`. Lisa asks him to identify what this odd thing (`it`) was by asking `What was it?` `Was` is used because it is a singular thing (`something odd`) and it was found in the past, when James reviewed the error logs.
 
 Remember that, in questions, you normally invert verb and subject, so `it was` becomes `was it`. For example:
 

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/670570ad97d26e1d6bad572d.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/670570ad97d26e1d6bad572d.md
@@ -65,4 +65,4 @@ This action wasn't mentioned in the dialogue.
 
 # --explanation--
 
-To find out what was the first thing James did, focus on the sentence that starts with `First I...`.
+To find out what was the first thing James did, focus on the sentence that starts with `First I...`

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/6705725e2814c91dd738e8f4.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/6705725e2814c91dd738e8f4.md
@@ -65,4 +65,4 @@ James doesn't mention this.
 
 # --explanation--
 
-To find out the main cause of the bug, look for the part of the text that talks about the system's connection. Focus on the sentence that starts with `Then, I...`.
+To find out the main cause of the bug, look for the part of the text that talks about the system's connection. Focus on the sentence that starts with `Then, I...`

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/6705742b9616e01e275e5c08.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/6705742b9616e01e275e5c08.md
@@ -65,4 +65,4 @@ Restarting the app wasn't mentioned as part of the solution.
 
 # --explanation--
 
-To find out how James fixed the problem, look for the part of the text that talks about updating the credentials. Focus on the sentence that starts with `We hadn't...`.
+To find out how James fixed the problem, look for the part of the text that talks about updating the credentials. Focus on the sentence that starts with `We hadn't...`

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/67057604ca099f1e7df78e77.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/67057604ca099f1e7df78e77.md
@@ -65,4 +65,4 @@ No mention of a system backup was made, so this doesn't apply to the situation.
 
 # --explanation--
 
-To find out when the credentials were updated, check the part where James explains why the app wasn't working. Focus on the sentence starting with, `We hadn't updated...`. 
+To find out when the credentials were updated, check the part where James explains why the app wasn't working. Focus on the sentence starting with, `We hadn't updated...` 

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/67057e02da44871f492f6f35.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/67057e02da44871f492f6f35.md
@@ -65,4 +65,4 @@ The app is fully operational, not partially working.
 
 # --explanation--
 
-To figure out if the app is working now, look at the last part of James' explanation where he says, `I fixed...`.
+To figure out if the app is working now, look at the last part of James' explanation where he says, `I fixed...`

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/671d1f5590e7110b82940771.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/671d1f5590e7110b82940771.md
@@ -62,4 +62,4 @@ The text focuses on fixing security issues, not documentation.
 
 # --explanation--
 
-Focus on the paragraph that starts with `Last week, our team had to…`. This explains why the team worked late.
+Focus on the paragraph that starts with `Last week, our team had to...` This explains why the team worked late.

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/671d1f7ca5f2aa0bb63b9e22.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/671d1f7ca5f2aa0bb63b9e22.md
@@ -62,4 +62,4 @@ The text teaches the opposite: to stay on top of things and not fall behind.
 
 # --explanation--
 
-Focus on the sentence that starts with `We now know that we need to…`. This teaches the main lesson: integrating security checks during design updates.
+Focus on the sentence that starts with `We now know that we need to...` This teaches the main lesson: integrating security checks during design updates.

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/671d1f94461c820bc68e3694.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/671d1f94461c820bc68e3694.md
@@ -62,4 +62,4 @@ There is no mention of a consultant handling security in the text.
 
 # --explanation--
 
-Focus on the sentence that starts with `Jake, who handles…`. This identifies him as the person responsible for security.
+Focus on the sentence that starts with `Jake, who handles...` This identifies him as the person responsible for security.

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/671d1fab38a4710bd7a6b9c0.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/671d1fab38a4710bd7a6b9c0.md
@@ -62,4 +62,4 @@ They learned to stay on top of things and not fall behind.
 
 # --explanation--
 
-Focus on the sentence that starts with `This experience taught us…`. This highlights the overall takeaway about staying on top of tasks.
+Focus on the sentence that starts with `This experience taught us...` This highlights the overall takeaway about staying on top of tasks.

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/671f78193bb0510709b169b8.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/671f78193bb0510709b169b8.md
@@ -60,4 +60,4 @@ The dream mentioned is related to attending a tech conference, not starting a bu
 
 # --explanation--
 
-Focus on the sentence that starts with `Years ago, Maria and Brian…`. This sentence explains Maria and Brian's goal when they were junior developers, sitting in their office and dreaming about the future.
+Focus on the sentence that starts with `Years ago, Maria and Brian...` This sentence explains Maria and Brian's goal when they were junior developers, sitting in their office and dreaming about the future.

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/671f7834b9a323071f7a325e.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/671f7834b9a323071f7a325e.md
@@ -60,4 +60,4 @@ They were excited about every new programming trend.
 
 # --explanation--
 
-Focus on the sentence that starts with `Back then, they were junior developers…`. This sentence provides insight into how Maria and Brian felt about new programming trends early in their careers.
+Focus on the sentence that starts with `Back then, they were junior developers...` This sentence provides insight into how Maria and Brian felt about new programming trends early in their careers.

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/671f7852f3a7e80737cc21d0.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/671f7852f3a7e80737cc21d0.md
@@ -60,4 +60,4 @@ The focus of the sessions mentioned in the text is more technical and specific.
 
 # --explanation--
 
-Focus on the sentence that starts with `Fast forward to today…`. This sentence lists the sessions that Maria and Brian are attending at PyCon, reflecting their current interests.
+Focus on the sentence that starts with `Fast forward to today...` This sentence lists the sessions that Maria and Brian are attending at PyCon, reflecting their current interests.

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/671f786a18c275074d55d298.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/671f786a18c275074d55d298.md
@@ -60,4 +60,4 @@ The text indicates they are already attending, not planning for a future event.
 
 # --explanation
 
-Focus on the sentence that starts with `Their dream is no longer just a dream…`. This sentence tells us that Maria and Brian are now living the dream they once envisioned.
+Focus on the sentence that starts with `Their dream is no longer just a dream...` This sentence tells us that Maria and Brian are now living the dream they once envisioned.

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/671f788c2665b807636b31a8.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/671f788c2665b807636b31a8.md
@@ -60,4 +60,4 @@ There is no mention of a product launch; the significance lies in achieving thei
 
 # --explanation--
 
-Focus on the sentence that starts with `They promised they would…`. This sentence shows that attending PyCon was their goal, making it significant as it fulfills a long-held promise.
+Focus on the sentence that starts with `They promised they would...` This sentence shows that attending PyCon was their goal, making it significant as it fulfills a long-held promise.

--- a/curriculum/challenges/english/blocks/learn-how-to-use-modal-verbs/67d5681f7a8dd6346ff23196.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-modal-verbs/67d5681f7a8dd6346ff23196.md
@@ -54,12 +54,12 @@ Remember:
 
 `Must` expresses strong necessity or obligation. For example:
 
-`You must wear a seatbelt.`.
+`You must wear a seatbelt.`
 
 `Have to` also expresses obligation but is sometimes less strict than must. For example:
 
-`You have to submit the report by Friday.`.
+`You have to submit the report by Friday.`
 
 `Should` is used for recommendations or advice. For example:
 
-`You should review your notes before the test.`.
+`You should review your notes before the test.`

--- a/curriculum/challenges/english/blocks/learn-how-to-use-modal-verbs/67d5a5fa6dbdc14fd6c078b8.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-modal-verbs/67d5a5fa6dbdc14fd6c078b8.md
@@ -22,7 +22,7 @@ Which sentence is grammatically correct?
 
 ### --feedback--
 
-The correct word order is `What would happen...`.
+The correct word order is `What would happen...`
 
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-use-modal-verbs/67d7e64ac5180e76037508b9.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-modal-verbs/67d7e64ac5180e76037508b9.md
@@ -30,7 +30,7 @@ Modal verbs like `can` and `could` do not use `do` or `does` in questions.
 
 ### --feedback--
 
-Questions with modal verbs should invert the subject and verb: `Can you help me?`, not `You can help me?`.  
+Questions with modal verbs should invert the subject and verb: `Can you help me?`, not `You can help me?`  
 
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-use-prepositions-according-to-context/6839a6376e7c2c8f7ed40f2c.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-prepositions-according-to-context/6839a6376e7c2c8f7ed40f2c.md
@@ -14,7 +14,7 @@ This task doesn't have audio. Read the question below and select the correct ans
 
 ## --text--
 
-Which sentence uses the word `in` the same way as in this sentence: `The server room is located in the building's basement.`?
+Which sentence uses the word `in` the same way as in this sentence: `The server room is located in the building's basement`?
 
 ## --answers--
 

--- a/curriculum/challenges/english/blocks/learn-html-by-building-a-cat-photo-app/5ef9b03c81a63668521804e2.md
+++ b/curriculum/challenges/english/blocks/learn-html-by-building-a-cat-photo-app/5ef9b03c81a63668521804e2.md
@@ -27,7 +27,7 @@ You should only have added one input element for your checkbox. Remove any extra
 assert.lengthOf(document.querySelectorAll('fieldset > input'), 1);
 ```
 
-Your new `input` element should be below the `legend` element with the text `What's your cat's personality?`. You have them in the wrong order.
+Your new `input` element should be below the `legend` element with the text `What's your cat's personality?` You have them in the wrong order.
 
 ```js
 const existingLegendElem = document.querySelectorAll('fieldset > legend')?.[1];

--- a/curriculum/challenges/english/blocks/learn-html-by-building-a-cat-photo-app/5f0d48e7b435f13ab6550051.md
+++ b/curriculum/challenges/english/blocks/learn-html-by-building-a-cat-photo-app/5f0d48e7b435f13ab6550051.md
@@ -38,7 +38,7 @@ assert(
 );
 ```
 
-Your `legend` element's text should be `Is your cat an indoor or outdoor cat?`. You have either omitted the text, have a typo, or it is not between the `legend` element's opening and closing tags.
+Your `legend` element's text should be `Is your cat an indoor or outdoor cat?` You have either omitted the text, have a typo, or it is not between the `legend` element's opening and closing tags.
 
 ```js
 const extraSpacesRemoved = document

--- a/curriculum/challenges/english/blocks/learn-html-by-building-a-cat-photo-app/5f0d4d04b435f13ab6550053.md
+++ b/curriculum/challenges/english/blocks/learn-html-by-building-a-cat-photo-app/5f0d4d04b435f13ab6550053.md
@@ -37,7 +37,7 @@ Your `legend` element should have a closing tag. Closing tags have a `/` just af
 assert(code.match(/<\/legend\>/g).length === 2);
 ```
 
-The `legend` element should have the text `What's your cat's personality?`. You have either omitted the text or have a typo.
+The `legend` element should have the text `What's your cat's personality?` You have either omitted the text or have a typo.
 
 ```js
 const secondFieldset = document.querySelectorAll('fieldset')?.[1];

--- a/curriculum/challenges/english/blocks/learn-html-by-building-a-cat-photo-app/671141f948cbab359e74cc93.md
+++ b/curriculum/challenges/english/blocks/learn-html-by-building-a-cat-photo-app/671141f948cbab359e74cc93.md
@@ -11,7 +11,7 @@ Add `p` tags to turn `See more <a href="https://freecatphotoapp.com">cat photos<
 
 # --hints--
 
-You should add a `p` element around `See more <a href="https://freecatphotoapp.com">cat photos</a> in our gallery.`.
+You should add a `p` element around `See more <a href="https://freecatphotoapp.com">cat photos</a> in our gallery.`
 
 ```js
 const P = document.querySelectorAll('p')[1];

--- a/curriculum/challenges/english/blocks/learn-html-by-building-a-cat-photo-app/671141feba228a35cefba82d.md
+++ b/curriculum/challenges/english/blocks/learn-html-by-building-a-cat-photo-app/671141feba228a35cefba82d.md
@@ -37,7 +37,7 @@ There should only be one instance of the phrase `cute cats` in your code.
 assert.strictEqual(code.indexOf("cute cats"),code.lastIndexOf("cute cats")); 
 ```
 
-The text of the `p` element should still be `Everyone loves cute cats online!`.
+The text of the `p` element should still be `Everyone loves cute cats online!`
 
 ```js
 assert.strictEqual(document.querySelector('p')?.innerText.trim(), "Everyone loves cute cats online!");

--- a/curriculum/challenges/english/blocks/learn-html-forms-by-building-a-registration-form/60fac56271087806def55b33.md
+++ b/curriculum/challenges/english/blocks/learn-html-forms-by-building-a-registration-form/60fac56271087806def55b33.md
@@ -7,7 +7,7 @@ dashedName: step-35
 
 # --description--
 
-Nest the `select` element (with its `option` elements) within a `label` element with the text `How did you hear about us?`. The text should come before the `select` element.
+Nest the `select` element (with its `option` elements) within a `label` element with the text `How did you hear about us?` The text should come before the `select` element.
 
 # --hints--
 
@@ -17,7 +17,7 @@ You should nest only the `select` element within a `label` element.
 assert.exists(document.querySelector('fieldset:nth-child(3) > label:nth-child(3) > select'));
 ```
 
-You should give the `label` element the text `How did you hear about us?`.
+You should give the `label` element the text `How did you hear about us?`
 
 ```js
 assert.equal(document.querySelector('fieldset:nth-child(3) > label:nth-child(3)')?.innerText?.trim(), 'How did you hear about us?');

--- a/curriculum/challenges/english/blocks/learn-html-forms-by-building-a-registration-form/60fad0a812d9890938524f50.md
+++ b/curriculum/challenges/english/blocks/learn-html-forms-by-building-a-registration-form/60fad0a812d9890938524f50.md
@@ -9,7 +9,7 @@ dashedName: step-41
 
 To give Campers an idea of what to put in their bio, the `placeholder` attribute is used. The `placeholder` accepts a text value, which is displayed until the user starts typing.
 
-Give the `textarea` a `placeholder` of `I like coding on the beach...`.
+Give the `textarea` a `placeholder` of `I like coding on the beach...`
 
 # --hints--
 
@@ -19,7 +19,7 @@ You should give the `textarea` a `placeholder` attribute.
 assert.isNotEmpty(document.querySelector('fieldset:nth-child(3) > label:nth-child(4) > textarea')?.placeholder);
 ```
 
-You should give the `placeholder` a value of `I like coding on the beach...`.
+You should give the `placeholder` a value of `I like coding on the beach...`
 
 ```js
 assert.match(document.querySelector('fieldset:nth-child(3) > label:nth-child(4) > textarea')?.placeholder, /^I like coding on the beach\.{3,4}$/);

--- a/curriculum/challenges/english/blocks/learn-more-about-css-pseudo-selectors-by-building-a-balance-sheet/61fd778081276b59d59abad6.md
+++ b/curriculum/challenges/english/blocks/learn-more-about-css-pseudo-selectors-by-building-a-balance-sheet/61fd778081276b59d59abad6.md
@@ -7,7 +7,7 @@ dashedName: step-13
 
 # --description--
 
-In your first `tr`, add a `th` element with the text `Cash This is the cash we currently have on hand.`. Wrap all of that text except `Cash ` in a `span` element with the `class` set to `description`.
+In your first `tr`, add a `th` element with the text `Cash This is the cash we currently have on hand.` Wrap all of that text except `Cash ` in a `span` element with the `class` set to `description`.
 
 Following that, add three `td` elements with the following text (in order): `$25`, `$30`, `$28`. Give the third `td` element a `class` attribute set to `current`.
 
@@ -19,7 +19,7 @@ Your first `tr` should have a `th` element.
 assert(document.querySelector('tbody')?.querySelectorAll('tr')?.[0]?.querySelector('th'));
 ```
 
-Your `th` element should have the text `Cash This is the cash we currently have on hand.`.
+Your `th` element should have the text `Cash This is the cash we currently have on hand.`
 
 ```js
 assert(document.querySelector('tbody')?.querySelectorAll('tr')?.[0]?.querySelector('th')?.innerText === 'Cash This is the cash we currently have on hand.');

--- a/curriculum/challenges/english/blocks/learn-more-about-css-pseudo-selectors-by-building-a-balance-sheet/61fd77f7ad2aeb5ae34d07d6.md
+++ b/curriculum/challenges/english/blocks/learn-more-about-css-pseudo-selectors-by-building-a-balance-sheet/61fd77f7ad2aeb5ae34d07d6.md
@@ -7,7 +7,7 @@ dashedName: step-14
 
 # --description--
 
-In your second `tr` element, add a `th` element with the text `Checking Our primary transactional account.`. Wrap that text, except for `Checking `, in a `span` element with the `class` attribute set to `description`.
+In your second `tr` element, add a `th` element with the text `Checking Our primary transactional account.` Wrap that text, except for `Checking `, in a `span` element with the `class` attribute set to `description`.
 
 Following that, add three `td` elements with the following text (in order): `$54`, `$56`, `$53`. Give the third `td` element a `class` attribute set to `current`.
 
@@ -19,7 +19,7 @@ Your second `tr` should have a `th` element.
 assert(document.querySelector('tbody')?.querySelectorAll('tr')?.[1]?.querySelector('th'));
 ```
 
-Your `th` element should have the text `Checking Our primary transactional account.`.
+Your `th` element should have the text `Checking Our primary transactional account.`
 
 ```js
 assert(document.querySelector('tbody')?.querySelectorAll('tr')?.[1]?.querySelector('th')?.innerText === 'Checking Our primary transactional account.');

--- a/curriculum/challenges/english/blocks/learn-more-about-css-pseudo-selectors-by-building-a-balance-sheet/61fd78621573aa5e8b512f5e.md
+++ b/curriculum/challenges/english/blocks/learn-more-about-css-pseudo-selectors-by-building-a-balance-sheet/61fd78621573aa5e8b512f5e.md
@@ -7,7 +7,7 @@ dashedName: step-15
 
 # --description--
 
-In your third `tr` element, add a `th` element with the text `Savings Funds set aside for emergencies.`. Wrap that text, except for `Savings `, in a `span` element with the `class` attribute set to `description`.
+In your third `tr` element, add a `th` element with the text `Savings Funds set aside for emergencies.` Wrap that text, except for `Savings `, in a `span` element with the `class` attribute set to `description`.
 
 Following that, add three `td` elements with the following text (in order): `$500`, `$650`, `$728`. Give the third `td` element a `class` attribute set to `current`.
 
@@ -19,7 +19,7 @@ Your third `tr` should have a `th` element.
 assert(document.querySelector('tbody')?.querySelectorAll('tr')?.[2]?.querySelector('th'));
 ```
 
-Your `th` element should have the text `Savings Funds set aside for emergencies.`.
+Your `th` element should have the text `Savings Funds set aside for emergencies.`
 
 ```js
 assert(document.querySelector('tbody')?.querySelectorAll('tr')?.[2]?.querySelector('th')?.innerText === 'Savings Funds set aside for emergencies.');

--- a/curriculum/challenges/english/blocks/learn-more-about-css-pseudo-selectors-by-building-a-balance-sheet/61fd933ba685de776a94997e.md
+++ b/curriculum/challenges/english/blocks/learn-more-about-css-pseudo-selectors-by-building-a-balance-sheet/61fd933ba685de776a94997e.md
@@ -7,7 +7,7 @@ dashedName: step-21
 
 # --description--
 
-Within the first `tr`, add a `th` element with the text `Loans The outstanding balance on our startup loan.`. Wrap that text, except for `Loans `, within a `span` element with the `class` set to `description`.
+Within the first `tr`, add a `th` element with the text `Loans The outstanding balance on our startup loan.` Wrap that text, except for `Loans `, within a `span` element with the `class` set to `description`.
 
 Add three `td` elements below that, and give them the following text, in order: `$500`, `$250`, and `$0`. Give the third `td` element a `class` set to `current`.
 
@@ -19,7 +19,7 @@ Your first `tr` should have a `th` element.
 assert(document.querySelectorAll('table')?.[1]?.querySelector('tbody')?.querySelectorAll('tr')?.[0]?.querySelector('th'));
 ```
 
-Your `th` element should have the text `Loans The outstanding balance on our startup loan.`.
+Your `th` element should have the text `Loans The outstanding balance on our startup loan.`
 
 ```js
 assert(document.querySelectorAll('table')?.[1]?.querySelector('tbody')?.querySelectorAll('tr')?.[0]?.querySelector('th')?.innerText === 'Loans The outstanding balance on our startup loan.');

--- a/curriculum/challenges/english/blocks/learn-more-about-css-pseudo-selectors-by-building-a-balance-sheet/61fd94056e0355785fbba4d3.md
+++ b/curriculum/challenges/english/blocks/learn-more-about-css-pseudo-selectors-by-building-a-balance-sheet/61fd94056e0355785fbba4d3.md
@@ -7,7 +7,7 @@ dashedName: step-22
 
 # --description--
 
-Within the second `tr`, add a `th` element with the text `Expenses Annual anticipated expenses, such as payroll.`. Wrap that text, except for `Expenses `, within a `span` element with the `class` set to `description`.
+Within the second `tr`, add a `th` element with the text `Expenses Annual anticipated expenses, such as payroll.` Wrap that text, except for `Expenses `, within a `span` element with the `class` set to `description`.
 
 Add three `td` elements below that, and give them the following text, in order: `$200`, `$300`, and `$400`. Give the third `td` element a `class` set to `current`.
 
@@ -19,7 +19,7 @@ Your second `tr` should have a `th` element.
 assert(document.querySelectorAll('table')?.[1]?.querySelector('tbody')?.querySelectorAll('tr')?.[1]?.querySelector('th'));
 ```
 
-Your `th` element should have the text `Expenses Annual anticipated expenses, such as payroll.`.
+Your `th` element should have the text `Expenses Annual anticipated expenses, such as payroll.`
 
 ```js
 assert(document.querySelectorAll('table')?.[1]?.querySelector('tbody')?.querySelectorAll('tr')?.[1]?.querySelector('th')?.innerText === 'Expenses Annual anticipated expenses, such as payroll.');

--- a/curriculum/challenges/english/blocks/learn-more-about-css-pseudo-selectors-by-building-a-balance-sheet/61fd986ddbcbd47ba8fbc5ec.md
+++ b/curriculum/challenges/english/blocks/learn-more-about-css-pseudo-selectors-by-building-a-balance-sheet/61fd986ddbcbd47ba8fbc5ec.md
@@ -7,7 +7,7 @@ dashedName: step-23
 
 # --description--
 
-Within the third `tr`, add a `th` element with the text `Credit The outstanding balance on our credit card.`. Wrap that text, except for `Credit `, within a `span` element with the `class` set to `description`.
+Within the third `tr`, add a `th` element with the text `Credit The outstanding balance on our credit card.` Wrap that text, except for `Credit `, within a `span` element with the `class` set to `description`.
 
 Add three `td` elements below that, and give them the following text, in order: `$50`, `$50`, and `$75`. Give the third `td` element a `class` set to `current`.
 
@@ -19,7 +19,7 @@ Your third `tr` should have a `th` element.
 assert(document.querySelectorAll('table')?.[1]?.querySelector('tbody')?.querySelectorAll('tr')?.[2]?.querySelector('th'));
 ```
 
-Your `th` element should have the text `Credit The outstanding balance on our credit card.`.
+Your `th` element should have the text `Credit The outstanding balance on our credit card.`
 
 ```js
 assert(document.querySelectorAll('table')?.[1]?.querySelector('tbody')?.querySelectorAll('tr')?.[2]?.querySelector('th')?.innerText === 'Credit The outstanding balance on our credit card.');

--- a/curriculum/challenges/english/blocks/learn-regular-expressions-by-building-a-password-generator/6564d75a923d21815caaa445.md
+++ b/curriculum/challenges/english/blocks/learn-regular-expressions-by-building-a-password-generator/6564d75a923d21815caaa445.md
@@ -13,7 +13,7 @@ Modify `pattern` so that it matches a single literal dot.
 
 # --hints--
 
-You should modify your `pattern` variable into `\.`.
+You should modify your `pattern` variable into `\.`
 
 ```js
 ({ test: () => assert.match(code, /^pattern\s*=\s*("|')\\\.\1/m) })

--- a/curriculum/challenges/english/blocks/lecture-react-strategies-and-debugging/67d1ad82cff954a854bcbcaa.md
+++ b/curriculum/challenges/english/blocks/lecture-react-strategies-and-debugging/67d1ad82cff954a854bcbcaa.md
@@ -17,7 +17,7 @@ For example, say you have three components named `Parent`, `Child`, and `Grandch
 
 Or if the data is even further up the chain, the data might have to be passed to the `Parent` component, too.
 
-Here, the data I want to display is the string `Hello, Prop Drilling!`. It's assigned to the `greeting` variable in the root `App` component:
+Here, the data I want to display is the string `Hello, Prop Drilling!` It's assigned to the `greeting` variable in the root `App` component:
 
 ```jsx
 import "./App.css";
@@ -66,7 +66,7 @@ const Grandchild = ({ greeting }) => {
 export default Grandchild;
 ```
 
-In the browser, you'll see a page with a single `h1` element that has the text `Hello, Prop Drilling!`.
+In the browser, you'll see a page with a single `h1` element that has the text `Hello, Prop Drilling!`
 
 At first, prop drilling might not seem like such a big deal. But as your app grows, it gets harder to understand, debug, and maintain.
 
@@ -102,7 +102,7 @@ const Grandchild = ({ greeting, response }) => {
 export default App;
 ```
 
-In the browser, you'll see a page with an `h1` element that has the text `Hello, Prop Drilling!` and an `h2` element that has the text `I'm not here to play!`.
+In the browser, you'll see a page with an `h1` element that has the text `Hello, Prop Drilling!` and an `h2` element that has the text `I'm not here to play!`
 
 To avoid prop drilling, especially in large, complex applications, consider using the Context API or state management libraries like Redux and Redux Toolkit, Zustand, Recoil, and others.
 

--- a/curriculum/challenges/english/blocks/lecture-react-strategies-and-debugging/67d2f5dacd5e0c749e5d534c.md
+++ b/curriculum/challenges/english/blocks/lecture-react-strategies-and-debugging/67d2f5dacd5e0c749e5d534c.md
@@ -85,7 +85,7 @@ const Child = ({ greeting, response }) => {
 
 Remember that `Grandchild` expects a `response` prop. Because the component receives a different prop, it can't display that text on the page, and just adds and empty `h2` to the DOM. Instead, you'll just see the `h1` element with the text `Hello, Prop Drilling!`, along with the other buttons and text already on the page. The empty `h2` element is still there, but because it's empty, you can't see it without inspecting the DOM.
 
-To fix this, you can inspect the prop progression from the `Parent` component down to the `Child` and edit the prop name directly. If you go to the Components tab, select the `Child` component, and change the `reply` prop to `response`, you'll see the `h2` element on the page with the text `I'm not here to play!`.
+To fix this, you can inspect the prop progression from the `Parent` component down to the `Child` and edit the prop name directly. If you go to the Components tab, select the `Child` component, and change the `reply` prop to `response`, you'll see the `h2` element on the page with the text `I'm not here to play!`
 
 # --questions--
 

--- a/curriculum/challenges/english/blocks/lecture-understanding-asynchronous-programming/673407ca21117a67cf9521ca.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-asynchronous-programming/673407ca21117a67cf9521ca.md
@@ -17,7 +17,7 @@ const aPromise = new Promise((resolve, reject) => {
 });
 ```
 
-In this example, we create a promise that simulates an asynchronous operation using `setTimeout`. After one second, the promise is resolved with the message `Operation successful!`.
+In this example, we create a promise that simulates an asynchronous operation using `setTimeout`. After one second, the promise is resolved with the message `Operation successful!`
 
 Another way to work with promises is to use the `.then` and `.catch` methods.
 

--- a/curriculum/challenges/english/blocks/lecture-understanding-how-http-dns-tcpip-work/69661d1a74e9aa63cb171957.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-how-http-dns-tcpip-work/69661d1a74e9aa63cb171957.md
@@ -23,7 +23,7 @@ The main structure of a domain name is, from right to left:
     
 * **Second-Level Domain (SLD):** the name registered by the person or organization. That would be `freecodecamp` in `freecodecamp.org`. This is what you usually notice first when you see a web address.
     
-* **Third-Level Domain (Subdomain):** used to identify a specific section of the main domain. For example, `www`, which stands for “World Wide Web.” Nowadays, modern web servers automatically handle domain routing, so you can access a website with or without entering `www`. Other examples of subdomains include `blog.`, `shop.`, `support.`, and `api.`.
+* **Third-Level Domain (Subdomain):** used to identify a specific section of the main domain. For example, `www`, which stands for “World Wide Web.” Nowadays, modern web servers automatically handle domain routing, so you can access a website with or without entering `www`. Other examples of subdomains include `blog.`, `shop.`, `support.`, and `api.`
     
 
 Domain names are very helpful to us as humans because they’re easy to remember and type into a browser. However, as you know, computers work with numbers. Your browser has to transform the domain name that you entered into something known as an IP address to find the website you are looking for.

--- a/curriculum/challenges/english/blocks/lecture-understanding-variables-and-data-types/67fe8599c83979345ff9a91a.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-variables-and-data-types/67fe8599c83979345ff9a91a.md
@@ -125,7 +125,7 @@ They define a string to be printed by the `print()` function.
 
 ---
 
-They are used to call a function named `Hello world!`.
+They are used to call a function named `Hello world!`
 
 ### --feedback--
 
@@ -141,7 +141,7 @@ Consider how Python identifies string values in code.
 
 ---
 
-They let Python know to print a variable named `Hello world!`.
+They let Python know to print a variable named `Hello world!`
 
 ### --feedback--
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-code-editors-and-ides/672d45651d83b450801efb3a.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-code-editors-and-ides/672d45651d83b450801efb3a.md
@@ -23,7 +23,7 @@ Depending on your operating system, you might have a context menu (or right-clic
 
 Once it's open, you should see a new blank workspace.
 
-To create a new file, click on the `File` menu at the top-left corner and select `New File...`. Then name your file `index.html` and click on `Save`.
+To create a new file, click on the `File` menu at the top-left corner and select `New File...` Then name your file `index.html` and click on `Save`.
 
 Now you should see your new file in the explorer tab. Try adding some HTML to your `index.html` file.
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-conditional-logic-and-math-methods/673271fd11d063daf0cf8d20.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-conditional-logic-and-math-methods/673271fd11d063daf0cf8d20.md
@@ -140,7 +140,7 @@ console.log(`It's a ${weather} day!`);
 
 :::
 
-If `temperature` is greater than `25`, the code above logs `It's a sunny day!`. If `temperature` is ever less than or equal to `25`, it logs `It's a cool day!`.
+If `temperature` is greater than `25`, the code above logs `It's a sunny day!` If `temperature` is ever less than or equal to `25`, it logs `It's a cool day!`
 
 So, which should you use between an if statement and a ternary? Use a ternary while dealing with a single condition or single expressions, or when you want a compact syntax for simple logic. Use `if/else` statements when you're dealing with complex conditions and multiple statements, as things become unreadable if you nest ternaries. 
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-functions/672d269da46786225e3fe3fd.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-functions/672d269da46786225e3fe3fd.md
@@ -15,7 +15,7 @@ function greet() {
 }
 ```
 
-In this example, we have declared a function called `greet`.  Inside that function, we have a `console.log` that logs the message `Hello, Jessica!`. If we tried to run this code, we would not see the message appear in the console. This is because we need to call the function.
+In this example, we have declared a function called `greet`.  Inside that function, we have a `console.log` that logs the message `Hello, Jessica!` If we tried to run this code, we would not see the message appear in the console. This is because we need to call the function.
 
 A function call, or invocation, is when we actually use or execute the function. To call a function, you will need to reference the function name followed by a set of parentheses:
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-relative-and-absolute-units/672bb851b068e3954a05b9b1.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-relative-and-absolute-units/672bb851b068e3954a05b9b1.md
@@ -41,7 +41,7 @@ You can use the addition (`+`), subtraction (`-`), multiplication (`*`), and div
 
 If there are multiple operands and operators, `calc()` will follow the standard operator precedence rule. You can also add parentheses to establish the order of the operations if needed.
 
-In the example below, you can see a `div` with the text `Hello, World!`.
+In the example below, you can see a `div` with the text `Hello, World!`
 
 Using the CSS type selector for selecting the `div`, you can style it with white text and a dark blue background: 
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-string-formatting-methods/67326c3c3ab931c644cea05b.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-string-formatting-methods/67326c3c3ab931c644cea05b.md
@@ -17,7 +17,7 @@ Whitespace refers to spaces, tabs, or line breaks that occur in a string but are
 let greeting = "   Hello, world!   ";
 ```
 
-In this case, there are spaces before and after the visible text, `Hello, world!`.
+In this case, there are spaces before and after the visible text, `Hello, world!`
 
 The `trim()` method is the most commonly used way to remove whitespace from both the beginning and the end of a string. Here's an example:
 
@@ -32,7 +32,7 @@ console.log(trimmedMessage);  // "Hello!"
 
 :::
 
-In this case, the `trim()` method removes all the leading and trailing spaces, leaving just `Hello!`. Note that any whitespace within the string (between words, for example) is left untouched by `trim()`.
+In this case, the `trim()` method removes all the leading and trailing spaces, leaving just `Hello!` Note that any whitespace within the string (between words, for example) is left untouched by `trim()`.
 
 Sometimes, you may only want to remove whitespace from either the beginning or the end of a string, but not both. This is where `trimStart()` and `trimEnd()` come in.
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-string-modification-methods/67326c3392068ec6184a0c95.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-string-modification-methods/67326c3392068ec6184a0c95.md
@@ -29,7 +29,7 @@ console.log(repeatedWord);  // "Hello!Hello!Hello!"
 
 :::
 
-In this case, the string `Hello!` is repeated three times, resulting in `Hello!Hello!Hello!`.
+In this case, the string `Hello!` is repeated three times, resulting in `Hello!Hello!Hello!`
 
 While the `repeat()` method is useful, there are a few exceptions and limitations to keep in mind.
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-string-search-and-slice-methods/67326c15b3b2f0c5827927cc.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-string-search-and-slice-methods/67326c15b3b2f0c5827927cc.md
@@ -51,7 +51,7 @@ console.log(world);  // world!
 
 :::
 
-Here, `slice(7)` extracts the string from index `7` to the end of the string, resulting in `world!`.
+Here, `slice(7)` extracts the string from index `7` to the end of the string, resulting in `world!`
 
 You can also use negative numbers as indexes. When you use a negative number, it counts backward from the end of the string:
 
@@ -66,7 +66,7 @@ console.log(lastWord);  // fun!
 
 :::
 
-In this case, `slice(-4)` extracts the last four characters from the string, giving us `fun!`.
+In this case, `slice(-4)` extracts the last four characters from the string, giving us `fun!`
 
 Let's say you want to extract a section from the middle of a string. You can provide both the starting and ending indexes to precisely control which part of the string you want:
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-the-dom-click-events-and-web-apis/6733691d88e3053414689276.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-the-dom-click-events-and-web-apis/6733691d88e3053414689276.md
@@ -21,7 +21,7 @@ Here is an example of a `button` element with an inline click event handler:
 
 :::
 
-When the user clicks on the button, the `alert` function is called and an alert dialog is displayed with the message `Hello World!`.
+When the user clicks on the button, the `alert` function is called and an alert dialog is displayed with the message `Hello World!`
 
 Another way to use inline event handlers is to call a function that is defined in a `script` tag in the HTML document. 
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-the-dom-click-events-and-web-apis/6733697661182d357fc643d2.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-the-dom-click-events-and-web-apis/6733697661182d357fc643d2.md
@@ -121,7 +121,7 @@ textCanvasCtx.fillText("Hello HTML Canvas!", 1, 50);
 
 :::
 
-The result in the browser will be the red text `Hello HTML Canvas!`.
+The result in the browser will be the red text `Hello HTML Canvas!`
 
 These's much more you can do with the `Canvas` API. For example, you can combine it with `requestAnimationFrame` to create custom animations, visualizations, games, and more.
 

--- a/curriculum/challenges/english/blocks/object-oriented-programming/587d7db1367417b2b2512b87.md
+++ b/curriculum/challenges/english/blocks/object-oriented-programming/587d7db1367417b2b2512b87.md
@@ -38,7 +38,7 @@ duck.eat();
 duck.fly();
 ```
 
-`duck.eat()` would display the string `nom nom nom` in the console, and `duck.fly()` would display the string `I'm flying!`.
+`duck.eat()` would display the string `nom nom nom` in the console, and `duck.fly()` would display the string `I'm flying!`
 
 # --instructions--
 

--- a/curriculum/challenges/english/blocks/project-euler-problems-201-to-300/5900f4811000cf542c50ff94.md
+++ b/curriculum/challenges/english/blocks/project-euler-problems-201-to-300/5900f4811000cf542c50ff94.md
@@ -20,7 +20,7 @@ The sequence terminates when some $a_n = 1$.
 
 Given any integer, we can list out the sequence of steps. For instance if $a_1 = 231$, then the sequence $\\{a_n\\} = \\{231, 77, 51, 17, 11, 7, 10, 14, 9, 3, 1\\}$ corresponds to the steps "DdDddUUdDD".
 
-Of course, there are other sequences that begin with that same sequence "DdDddUUdDD....".
+Of course, there are other sequences that begin with that same sequence "DdDddUUdDD...."
 
 For instance, if $a_1 = 1004064$, then the sequence is DdDddUUdDDDdUDUUUdDdUUDDDUdDD.
 

--- a/curriculum/challenges/english/blocks/react/5a24c314108439a4d4036163.md
+++ b/curriculum/challenges/english/blocks/react/5a24c314108439a4d4036163.md
@@ -28,7 +28,7 @@ This creates an ES6 class `Kitten` which extends the `React.Component` class. So
 
 # --instructions--
 
-`MyComponent` is defined in the code editor using class syntax. Finish writing the `render` method so it returns a `div` element that contains an `h1` with the text `Hello React!`.
+`MyComponent` is defined in the code editor using class syntax. Finish writing the `render` method so it returns a `div` element that contains an `h1` with the text `Hello React!`
 
 # --hints--
 
@@ -48,7 +48,7 @@ assert(
 );
 ```
 
-The `h1` heading element should contain the string `Hello React!`.
+The `h1` heading element should contain the string `Hello React!`
 
 ```js
 assert(

--- a/curriculum/challenges/english/blocks/react/5a24c314108439a4d4036173.md
+++ b/curriculum/challenges/english/blocks/react/5a24c314108439a4d4036173.md
@@ -20,7 +20,7 @@ React expects you to never modify `state` directly, instead always use `this.set
 
 # --instructions--
 
-There is a `button` element in the code editor which has an `onClick()` handler. This handler is triggered when the `button` receives a click event in the browser, and runs the `handleClick` method defined on `MyComponent`. Within the `handleClick` method, update the component `state` using `this.setState()`. Set the `name` property in `state` to equal the string `React Rocks!`.
+There is a `button` element in the code editor which has an `onClick()` handler. This handler is triggered when the `button` receives a click event in the browser, and runs the `handleClick` method defined on `MyComponent`. Within the `handleClick` method, update the component `state` using `this.setState()`. Set the `name` property in `state` to equal the string `React Rocks!`
 
 Click the button and watch the rendered state update. Don't worry if you don't fully understand how the click handler code works at this point. It's covered in upcoming challenges.
 
@@ -55,7 +55,7 @@ The rendered `h1` heading element should contain text rendered from the componen
   assert(/<h1>TestName<\/h1>/.test(firstValue));
 ```
 
-Calling the `handleClick` method on `MyComponent` should set the name property in state to equal `React Rocks!`.
+Calling the `handleClick` method on `MyComponent` should set the name property in state to equal `React Rocks!`
 
 ```js
   const waitForIt = (fn) =>

--- a/curriculum/challenges/english/blocks/react/5a24c314108439a4d4036174.md
+++ b/curriculum/challenges/english/blocks/react/5a24c314108439a4d4036174.md
@@ -16,11 +16,11 @@ One common way is to explicitly bind `this` in the constructor so `this` becomes
 
 # --instructions--
 
-The code editor has a component with a `state` that keeps track of the text. It also has a method which allows you to set the text to `You clicked!`. However, the method doesn't work because it's using the `this` keyword that is undefined. Fix it by explicitly binding `this` to the `handleClick()` method in the component's constructor.
+The code editor has a component with a `state` that keeps track of the text. It also has a method which allows you to set the text to `You clicked!` However, the method doesn't work because it's using the `this` keyword that is undefined. Fix it by explicitly binding `this` to the `handleClick()` method in the component's constructor.
 
 Next, add a click handler to the `button` element in the render method. It should trigger the `handleClick()` method when the button receives a click event. Remember that the method you pass to the `onClick` handler needs curly braces because it should be interpreted directly as JavaScript.
 
-Once you complete the above steps you should be able to click the button and see `You clicked!`.
+Once you complete the above steps you should be able to click the button and see `You clicked!`
 
 # --hints--
 
@@ -48,7 +48,7 @@ assert(
 );
 ```
 
-Clicking the `button` element should run the `handleClick` method and set the state `text` to `You clicked!`.
+Clicking the `button` element should run the `handleClick` method and set the state `text` to `You clicked!`
 
 ```js
   const waitForIt = (fn) =>

--- a/curriculum/challenges/english/blocks/react/5a24c314108439a4d4036188.md
+++ b/curriculum/challenges/english/blocks/react/5a24c314108439a4d4036188.md
@@ -123,7 +123,7 @@ Each time the button is clicked, the counter state should be incremented by a va
 })();
 ```
 
-When the `GameOfChance` component is first mounted to the DOM and each time the button is clicked thereafter, a single `h1` element should be returned that randomly renders either `You Win!` or `You Lose!`. Note: this can fail randomly. If that happens, please try again.
+When the `GameOfChance` component is first mounted to the DOM and each time the button is clicked thereafter, a single `h1` element should be returned that randomly renders either `You Win!` or `You Lose!` Note: this can fail randomly. If that happens, please try again.
 
 ```js
 (() => {

--- a/curriculum/challenges/english/blocks/redux/5a24c314108439a4d4036159.md
+++ b/curriculum/challenges/english/blocks/redux/5a24c314108439a4d4036159.md
@@ -8,7 +8,7 @@ dashedName: use-the-spread-operator-on-arrays
 
 # --description--
 
-One solution from ES6 to help enforce state immutability in Redux is the spread operator: `...`. The spread operator has a variety of applications, one of which is well-suited to the previous challenge of producing a new array from an existing array. This is relatively new, but commonly used syntax. For example, if you have an array `myArray` and write:
+One solution from ES6 to help enforce state immutability in Redux is the spread operator: `...` The spread operator has a variety of applications, one of which is well-suited to the previous challenge of producing a new array from an existing array. This is relatively new, but commonly used syntax. For example, if you have an array `myArray` and write:
 
 ```js
 let newArray = [...myArray];

--- a/curriculum/challenges/english/blocks/regular-expressions/587d7db8367417b2b2512ba0.md
+++ b/curriculum/challenges/english/blocks/regular-expressions/587d7db8367417b2b2512ba0.md
@@ -34,7 +34,7 @@ Your regex should use the global flag.
 assert(nonAlphabetRegex.global);
 ```
 
-Your regex should find 6 non-alphanumeric characters in the string `The five boxing wizards jump quickly.`.
+Your regex should find 6 non-alphanumeric characters in the string `The five boxing wizards jump quickly.`
 
 ```js
 assert(

--- a/curriculum/challenges/english/blocks/regular-expressions/587d7dba367417b2b2512ba8.md
+++ b/curriculum/challenges/english/blocks/regular-expressions/587d7dba367417b2b2512ba8.md
@@ -10,7 +10,7 @@ dashedName: check-for-all-or-none
 
 Sometimes the patterns you want to search for may have parts of it that may or may not exist. However, it may be important to check for them nonetheless.
 
-You can specify the possible existence of an element with a question mark, `?`. This checks for zero or one of the preceding element. You can think of this symbol as saying the previous element is optional.
+You can specify the possible existence of an element with a question mark, `?` This checks for zero or one of the preceding element. You can think of this symbol as saying the previous element is optional.
 
 For example, there are slight differences in American and British English and you can use the question mark to match both spellings.
 
@@ -30,7 +30,7 @@ Change the regex `favRegex` to match both the American English (`favorite`) and 
 
 # --hints--
 
-Your regex should use the optional symbol, `?`.
+Your regex should use the optional symbol, `?`
 
 ```js
 favRegex.lastIndex = 0;

--- a/curriculum/challenges/english/blocks/regular-expressions/587d7dbb367417b2b2512bab.md
+++ b/curriculum/challenges/english/blocks/regular-expressions/587d7dbb367417b2b2512bab.md
@@ -18,7 +18,7 @@ let silverRegex = /silver/;
 wrongText.replace(silverRegex, "blue");
 ```
 
-The `replace` call would return the string `The sky is blue.`.
+The `replace` call would return the string `The sky is blue.`
 
 You can also access capture groups in the replacement string with dollar signs (`$`).
 

--- a/curriculum/challenges/english/blocks/rosetta-code-challenges/59e09e6d412c5939baa02d16.md
+++ b/curriculum/challenges/english/blocks/rosetta-code-challenges/59e09e6d412c5939baa02d16.md
@@ -82,19 +82,19 @@ Using Markov Algorithm, change the `data` into the desired `outputs` using the 
 assert(typeof markov === 'function');
 ```
 
-`markov(["A -> apple","B -> bag","S -> shop","T -> the","the shop -> my brother","a never used -> .terminating rule"],"I bought a B of As from T S.")` should return the string `I bought a bag of apples from my brother.`.
+`markov(["A -> apple","B -> bag","S -> shop","T -> the","the shop -> my brother","a never used -> .terminating rule"],"I bought a B of As from T S.")` should return the string `I bought a bag of apples from my brother.`
 
 ```js
 assert.deepEqual(markov(rules[0], datas[0]), outputs[0]);
 ```
 
-`markov(["A -> apple","B -> bag","S -> .shop","T -> the","the shop -> my brother","a never used -> .terminating rule"],"I bought a B of As from T S.")` should return the string `I bought a bag of apples from T shop.`.
+`markov(["A -> apple","B -> bag","S -> .shop","T -> the","the shop -> my brother","a never used -> .terminating rule"],"I bought a B of As from T S.")` should return the string `I bought a bag of apples from T shop.`
 
 ```js
 assert.deepEqual(markov(rules[1], datas[1]), outputs[1]);
 ```
 
-`markov(["A -> apple","WWWW -> with","Bgage -> ->.*","B -> bag","->.* -> money","W -> WW","S -> .shop","T -> the","the shop -> my brother","a never used -> .terminating rule"],"I bought a B of As W my Bgage from T S.")` should return the string `I bought a bag of apples with my money from T shop.`.
+`markov(["A -> apple","WWWW -> with","Bgage -> ->.*","B -> bag","->.* -> money","W -> WW","S -> .shop","T -> the","the shop -> my brother","a never used -> .terminating rule"],"I bought a B of As W my Bgage from T S.")` should return the string `I bought a bag of apples with my money from T shop.`
 
 ```js
 assert.deepEqual(markov(rules[2], datas[2]), outputs[2]);

--- a/curriculum/challenges/english/blocks/workshop-balance-sheet/61fd778081276b59d59abad6.md
+++ b/curriculum/challenges/english/blocks/workshop-balance-sheet/61fd778081276b59d59abad6.md
@@ -7,7 +7,7 @@ dashedName: step-13
 
 # --description--
 
-In your first `tr`, add a `th` element with the text `Cash This is the cash we currently have on hand.`. Wrap all of that text except `Cash ` in a `span` element with the `class` set to `description`.
+In your first `tr`, add a `th` element with the text `Cash This is the cash we currently have on hand.` Wrap all of that text except `Cash ` in a `span` element with the `class` set to `description`.
 
 Following that, add three `td` elements with the following text (in order): `$25`, `$30`, `$28`. Give the third `td` element a `class` attribute set to `current`.
 
@@ -21,7 +21,7 @@ const tableRow = tableBody?.querySelectorAll('tr')?.[0];
 assert.isNotNull(tableRow?.querySelector('th'));
 ```
 
-Your `th` element should have the text `Cash This is the cash we currently have on hand.`.
+Your `th` element should have the text `Cash This is the cash we currently have on hand.`
 
 ```js
 const tableBody = document.querySelector('tbody');

--- a/curriculum/challenges/english/blocks/workshop-balance-sheet/61fd77f7ad2aeb5ae34d07d6.md
+++ b/curriculum/challenges/english/blocks/workshop-balance-sheet/61fd77f7ad2aeb5ae34d07d6.md
@@ -7,7 +7,7 @@ dashedName: step-14
 
 # --description--
 
-In your second `tr` element, add a `th` element with the text `Checking Our primary transactional account.`. Wrap that text, except for `Checking `, in a `span` element with the `class` attribute set to `description`.
+In your second `tr` element, add a `th` element with the text `Checking Our primary transactional account.` Wrap that text, except for `Checking `, in a `span` element with the `class` attribute set to `description`.
 
 Following that, add three `td` elements with the following text (in order): `$54`, `$56`, `$53`. Give the third `td` element a `class` attribute set to `current`.
 
@@ -21,7 +21,7 @@ const tableRow = tableBody?.querySelectorAll('tr')?.[1];
 assert.isNotNull(tableRow?.querySelector('th'));
 ```
 
-Your `th` element should have the text `Checking Our primary transactional account.`.
+Your `th` element should have the text `Checking Our primary transactional account.`
 
 ```js
 const tableBody = document.querySelector('tbody');

--- a/curriculum/challenges/english/blocks/workshop-balance-sheet/61fd78621573aa5e8b512f5e.md
+++ b/curriculum/challenges/english/blocks/workshop-balance-sheet/61fd78621573aa5e8b512f5e.md
@@ -7,7 +7,7 @@ dashedName: step-15
 
 # --description--
 
-In your third `tr` element, add a `th` element with the text `Savings Funds set aside for emergencies.`. Wrap that text, except for `Savings `, in a `span` element with the `class` attribute set to `description`.
+In your third `tr` element, add a `th` element with the text `Savings Funds set aside for emergencies.` Wrap that text, except for `Savings `, in a `span` element with the `class` attribute set to `description`.
 
 Following that, add three `td` elements with the following text (in order): `$500`, `$650`, `$728`. Give the third `td` element a `class` attribute set to `current`.
 
@@ -21,7 +21,7 @@ const tableRow = tableBody?.querySelectorAll('tr')?.[2];
 assert.isNotNull(tableRow?.querySelector('th'));
 ```
 
-Your `th` element should have the text `Savings Funds set aside for emergencies.`.
+Your `th` element should have the text `Savings Funds set aside for emergencies.`
 
 ```js
 const tableBody = document.querySelector('tbody');

--- a/curriculum/challenges/english/blocks/workshop-balance-sheet/61fd933ba685de776a94997e.md
+++ b/curriculum/challenges/english/blocks/workshop-balance-sheet/61fd933ba685de776a94997e.md
@@ -7,7 +7,7 @@ dashedName: step-21
 
 # --description--
 
-Within the first `tr`, add a `th` element with the text `Loans The outstanding balance on our startup loan.`. Wrap that text, except for `Loans `, within a `span` element with the `class` set to `description`.
+Within the first `tr`, add a `th` element with the text `Loans The outstanding balance on our startup loan.` Wrap that text, except for `Loans `, within a `span` element with the `class` set to `description`.
 
 Add three `td` elements below that, and give them the following text, in order: `$500`, `$250`, and `$0`. Give the third `td` element a `class` set to `current`.
 
@@ -22,7 +22,7 @@ const tableRow = tbody?.querySelectorAll('tr')?.[0];
 assert.isNotNull(tableRow?.querySelector('th'));
 ```
 
-Your `th` element should have the text `Loans The outstanding balance on our startup loan.`.
+Your `th` element should have the text `Loans The outstanding balance on our startup loan.`
 
 ```js
 const table = document.querySelectorAll('table')?.[1];

--- a/curriculum/challenges/english/blocks/workshop-balance-sheet/61fd94056e0355785fbba4d3.md
+++ b/curriculum/challenges/english/blocks/workshop-balance-sheet/61fd94056e0355785fbba4d3.md
@@ -7,7 +7,7 @@ dashedName: step-22
 
 # --description--
 
-Within the second `tr`, add a `th` element with the text `Expenses Annual anticipated expenses, such as payroll.`. Wrap that text, except for `Expenses `, within a `span` element with the `class` set to `description`.
+Within the second `tr`, add a `th` element with the text `Expenses Annual anticipated expenses, such as payroll.` Wrap that text, except for `Expenses `, within a `span` element with the `class` set to `description`.
 
 Add three `td` elements below that, and give them the following text, in order: `$200`, `$300`, and `$400`. Give the third `td` element a `class` set to `current`.
 
@@ -22,7 +22,7 @@ const tableRow = tbody?.querySelectorAll('tr')?.[1];
 assert.isNotNull(tableRow?.querySelector('th'));
 ```
 
-Your `th` element should have the text `Expenses Annual anticipated expenses, such as payroll.`.
+Your `th` element should have the text `Expenses Annual anticipated expenses, such as payroll.`
 
 ```js
 const table = document.querySelectorAll('table')?.[1];

--- a/curriculum/challenges/english/blocks/workshop-balance-sheet/61fd986ddbcbd47ba8fbc5ec.md
+++ b/curriculum/challenges/english/blocks/workshop-balance-sheet/61fd986ddbcbd47ba8fbc5ec.md
@@ -7,7 +7,7 @@ dashedName: step-23
 
 # --description--
 
-Within the third `tr`, add a `th` element with the text `Credit The outstanding balance on our credit card.`. Wrap that text, except for `Credit `, within a `span` element with the `class` set to `description`.
+Within the third `tr`, add a `th` element with the text `Credit The outstanding balance on our credit card.` Wrap that text, except for `Credit `, within a `span` element with the `class` set to `description`.
 
 Add three `td` elements below that, and give them the following text, in order: `$50`, `$50`, and `$75`. Give the third `td` element a `class` set to `current`.
 
@@ -22,7 +22,7 @@ const tableRow = tbody?.querySelectorAll('tr')?.[2];
 assert.isNotNull(tableRow?.querySelector('th'));
 ```
 
-Your `th` element should have the text `Credit The outstanding balance on our credit card.`.
+Your `th` element should have the text `Credit The outstanding balance on our credit card.`
 
 ```js
 const table = document.querySelectorAll('table')?.[1];

--- a/curriculum/challenges/english/blocks/workshop-blog-page/66a49f685961e997e337cab1.md
+++ b/curriculum/challenges/english/blocks/workshop-blog-page/66a49f685961e997e337cab1.md
@@ -9,7 +9,7 @@ dashedName: step-2
 
 The `header` will be responsible for displaying main title, image and page navigation for the blog.
 
-Inside the `header` element, add an `h1` with the text of `Welcome to Mr. Whiskers' Blog Page!`.
+Inside the `header` element, add an `h1` with the text of `Welcome to Mr. Whiskers' Blog Page!`
 
 # --hints--
 
@@ -25,7 +25,7 @@ You should have a closing `h1` tag.
 assert.match(code, /<\/h1>/i);
 ```
 
-Your `h1` element should have the text of `Welcome to Mr. Whiskers' Blog Page!`. Double check for any spelling errors.
+Your `h1` element should have the text of `Welcome to Mr. Whiskers' Blog Page!` Double check for any spelling errors.
 
 ```js
 const h1Text = document.querySelector("h1")?.innerText.trim();

--- a/curriculum/challenges/english/blocks/workshop-blog-page/66a7e72adf226c02626715a3.md
+++ b/curriculum/challenges/english/blocks/workshop-blog-page/66a7e72adf226c02626715a3.md
@@ -7,7 +7,7 @@ dashedName: step-8
 
 # --description--
 
-Below your `h2` element, add a paragraph element with the text of `Hi there! I'm Jane Doe, a passionate writer who finds endless inspiration in the antics of my beloved cat, Mr. Whiskers.`.
+Below your `h2` element, add a paragraph element with the text of `Hi there! I'm Jane Doe, a passionate writer who finds endless inspiration in the antics of my beloved cat, Mr. Whiskers.`
 
 Below your paragraph element, add another paragraph element with the text of `His playful nature and boundless energy keeps me on my toes. I love him so much.`
 

--- a/curriculum/challenges/english/blocks/workshop-bookstore-page/68ebdbacdd3fa474132cc975.md
+++ b/curriculum/challenges/english/blocks/workshop-bookstore-page/68ebdbacdd3fa474132cc975.md
@@ -7,7 +7,7 @@ dashedName: step-5
 
 # --description--
 
-Below the `h1` element, add a `p` element with this text: `Browse our collection of amazing books!`.
+Below the `h1` element, add a `p` element with this text: `Browse our collection of amazing books!`
 
 # --hints--
 
@@ -17,7 +17,7 @@ You should have a `p` element.
 assert.exists(document.querySelector('p'));
 ```
 
-Your `p` element's text should be: `Browse our collection of amazing books!`. 
+Your `p` element's text should be: `Browse our collection of amazing books!` 
 
 ```js
 assert.equal(document.querySelector('p')?.innerText.trim(), 'Browse our collection of amazing books!');

--- a/curriculum/challenges/english/blocks/workshop-bookstore-page/68ec99e478211dc578699944.md
+++ b/curriculum/challenges/english/blocks/workshop-bookstore-page/68ec99e478211dc578699944.md
@@ -21,7 +21,7 @@ You should have a `p` element nested inside the element having a class of `card`
 assert.exists(document.querySelector('.card p'));
 ```
 
-Your `p` element's text should be `This is an epic story of Sally and her dog Rex as they navigate through other worlds.`.
+Your `p` element's text should be `This is an epic story of Sally and her dog Rex as they navigate through other worlds.`
 
 ```js
 assert.equal(document.querySelector('.card p')?.innerText.trim(), "This is an epic story of Sally and her dog Rex as they navigate through other worlds.");

--- a/curriculum/challenges/english/blocks/workshop-bookstore-page/68eca5412b5dd9d06b3d6404.md
+++ b/curriculum/challenges/english/blocks/workshop-bookstore-page/68eca5412b5dd9d06b3d6404.md
@@ -22,7 +22,7 @@ const cards = document.querySelectorAll('.card');
 assert.exists(cards[1]?.querySelector('p'));
 ```
 
-Your second card's `p` element's text should be `This is the story of Dave as he learns to cook everything from pancakes to pasta, one recipe at a time.`.
+Your second card's `p` element's text should be `This is the story of Dave as he learns to cook everything from pancakes to pasta, one recipe at a time.`
 
 ```js
 const cards = document.querySelectorAll('.card');

--- a/curriculum/challenges/english/blocks/workshop-bookstore-page/68eca6364c5616d393389a30.md
+++ b/curriculum/challenges/english/blocks/workshop-bookstore-page/68eca6364c5616d393389a30.md
@@ -31,7 +31,7 @@ The newly added `p` element should be below the element with a class of `card-co
 assert.exists(document.querySelector('.card-container + p'));
 ```
 
-Your new `p` element's text should be `Review your selections and continue to checkout.`.
+Your new `p` element's text should be `Review your selections and continue to checkout.`
 
 ```js
 const cardContainer = document.querySelector('.card-container');

--- a/curriculum/challenges/english/blocks/workshop-caesar-cipher/6819bc0637b80256a33adccc.md
+++ b/curriculum/challenges/english/blocks/workshop-caesar-cipher/6819bc0637b80256a33adccc.md
@@ -14,7 +14,7 @@ if condition:
     # code to run when condition is true
 ```
 
-At the beginning of your function body, create an `if` statement. For now, use `True` as the condition, and within the `if` statement body return the string `Shift must be an integer value.`.
+At the beginning of your function body, create an `if` statement. For now, use `True` as the condition, and within the `if` statement body return the string `Shift must be an integer value.`
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/workshop-caesar-cipher/6819c7beb4a8289c2b4f24d5.md
+++ b/curriculum/challenges/english/blocks/workshop-caesar-cipher/6819c7beb4a8289c2b4f24d5.md
@@ -7,7 +7,7 @@ dashedName: step-19
 
 # --description--
 
-A negative or null shift should not be accepted by your function. Therefore, after your first `if` statement, create another `if` statement that checks if `shift` is less than `1` and returns the string `Shift must be a positive integer.`.
+A negative or null shift should not be accepted by your function. Therefore, after your first `if` statement, create another `if` statement that checks if `shift` is less than `1` and returns the string `Shift must be a positive integer.`
 
 # --hints--
 
@@ -21,7 +21,7 @@ assert any(_cond.is_equivalent(option) for option in _options)
 `) })
 ```
 
-Your second `if` statement should return `Shift must be a positive integer.`.
+Your second `if` statement should return `Shift must be a positive integer.`
 
 ```js
 ({ test: () => assert(runPython(`_Node(_code).find_function("caesar").find_ifs()[1].find_bodies()[0].has_return("'Shift must be a positive integer.'")`)) })

--- a/curriculum/challenges/english/blocks/workshop-caesar-cipher/6819ca464db219ab86f37dc4.md
+++ b/curriculum/challenges/english/blocks/workshop-caesar-cipher/6819ca464db219ab86f37dc4.md
@@ -11,7 +11,7 @@ As you've already verified, the shift passed to encrypt the text should be posit
 
 Add a second condition to the `if` statement that verifies that `shift` is greater than `25`. Remember that the logical OR operation in Python is implemented through the `or` operator.
 
-Also, update the returned message to `Shift must be an integer between 1 and 25.`.
+Also, update the returned message to `Shift must be an integer between 1 and 25.`
 
 # --hints--
 
@@ -25,7 +25,7 @@ assert any(_cond.is_equivalent(f"shift < 1 or {option}") for option in _options)
 `) })
 ```
 
-Your second `if` statement should return `Shift must be an integer between 1 and 25.`.
+Your second `if` statement should return `Shift must be an integer between 1 and 25.`
 
 ```js
 ({ test: () => assert(runPython(`_Node(_code).find_function("caesar").find_ifs()[1].find_bodies()[0].has_return("'Shift must be an integer between 1 and 25.'")`)) })

--- a/curriculum/challenges/english/blocks/workshop-caesar-cipher/681a44f4c3235f7d8f428545.md
+++ b/curriculum/challenges/english/blocks/workshop-caesar-cipher/681a44f4c3235f7d8f428545.md
@@ -7,7 +7,7 @@ dashedName: step-25
 
 # --description--
 
-Now you're going to test the `decrypt` function. Replace the value assigned to `encrypted_text` with the following string, which represents a message to decrypt: `Pbhentr vf sbhaq va hayvxryl cynprf.`.
+Now you're going to test the `decrypt` function. Replace the value assigned to `encrypted_text` with the following string, which represents a message to decrypt: `Pbhentr vf sbhaq va hayvxryl cynprf.`
 
 Then, declare a variable named `decrypted_text` and assign it a call to `decrypt` with `encrypted_text` as it first argument and a shift of `13` as the second argument.
 

--- a/curriculum/challenges/english/blocks/workshop-calorie-counter/63c1e1965a898d302e0af4e3.md
+++ b/curriculum/challenges/english/blocks/workshop-calorie-counter/63c1e1965a898d302e0af4e3.md
@@ -17,7 +17,7 @@ const templateLiteral = `Hello, my name is ${name}~!`;
 console.log(templateLiteral);
 ```
 
-The console will show the string "Hello, my name is Naomi~!".
+The console will show the string "Hello, my name is Naomi~!"
 
 Replace your concatenated string in the `querySelector` with a template literal – be sure to keep the space between your `targetId` variable and `.input-container`.
 

--- a/curriculum/challenges/english/blocks/workshop-cat-photo-app/671141f948cbab359e74cc93.md
+++ b/curriculum/challenges/english/blocks/workshop-cat-photo-app/671141f948cbab359e74cc93.md
@@ -11,7 +11,7 @@ Add `p` tags to turn `See more <a href="https://freecatphotoapp.com">cat photos<
 
 # --hints--
 
-You should add a `p` element around `See more <a href="https://freecatphotoapp.com">cat photos</a> in our gallery.`.
+You should add a `p` element around `See more <a href="https://freecatphotoapp.com">cat photos</a> in our gallery.`
 
 ```js
 const P = document.querySelectorAll('p')[1];

--- a/curriculum/challenges/english/blocks/workshop-cat-photo-app/671141feba228a35cefba82d.md
+++ b/curriculum/challenges/english/blocks/workshop-cat-photo-app/671141feba228a35cefba82d.md
@@ -37,7 +37,7 @@ There should only be one instance of the phrase `cute cats` in your code.
 assert.strictEqual(code.indexOf("cute cats"),code.lastIndexOf("cute cats")); 
 ```
 
-The text of the `p` element should still be `Everyone loves cute cats online!`.
+The text of the `p` element should still be `Everyone loves cute cats online!`
 
 ```js
 assert.strictEqual(document.querySelector('p')?.innerText?.trim(), "Everyone loves cute cats online!");

--- a/curriculum/challenges/english/blocks/workshop-email-simulator/68540a534c56aeabae6afd58.md
+++ b/curriculum/challenges/english/blocks/workshop-email-simulator/68540a534c56aeabae6afd58.md
@@ -11,12 +11,12 @@ Now you'll simulate sending some emails between the users.
 
 In your `main` function, after creating the users, use the `send_email` method to:
 
-- Have Tory send an email to the `ramy` user object with subject `Hello` and body `Hi Ramy, just saying hello!`.
-- Have Ramy send an email to the `tory` user object with subject `Re: Hello` and body `Hi Tory, hope you are fine.`.
+- Have Tory send an email to the `ramy` user object with subject `Hello` and body `Hi Ramy, just saying hello!`
+- Have Ramy send an email to the `tory` user object with subject `Re: Hello` and body `Hi Tory, hope you are fine.`
 
 # --hints--
 
-You should have Tory send an email to `ramy`, subject `Hello`, and body `Hi Ramy, just saying hello!`.
+You should have Tory send an email to `ramy`, subject `Hello`, and body `Hi Ramy, just saying hello!`
 
 ```js
 ({
@@ -28,7 +28,7 @@ You should have Tory send an email to `ramy`, subject `Hello`, and body `Hi Ramy
 })
 ```
 
-You should have Ramy send an email to `tory`, subject `Re: Hello`, and body `Hi Tory, hope you are fine.`.
+You should have Ramy send an email to `tory`, subject `Re: Hello`, and body `Hi Tory, hope you are fine.`
 
 ```js
 ({

--- a/curriculum/challenges/english/blocks/workshop-emoji-reactor/688c90634eb5ae69845ac35d.md
+++ b/curriculum/challenges/english/blocks/workshop-emoji-reactor/688c90634eb5ae69845ac35d.md
@@ -12,7 +12,7 @@ In this workshop you will create an Emoji Reactor App. The HTML boilerplate and 
 
 Start by creating a `main` element.
 
-Inside the `main` element create an `h1` element with a `class` of `title` and a text of `How are you feeling today?`.
+Inside the `main` element create an `h1` element with a `class` of `title` and a text of `How are you feeling today?`
 
 # --hints--
 
@@ -34,7 +34,7 @@ The `h1` element should have a class of `title`.
 assert.equal(document.querySelector("main > h1")?.className, "title");
 ```
 
-The `h1` element should contain the text `How are you feeling today?`.
+The `h1` element should contain the text `How are you feeling today?`
 
 ```js
 assert.equal(document.querySelector("main > h1")?.textContent.trim(), "How are you feeling today?");

--- a/curriculum/challenges/english/blocks/workshop-emoji-reactor/6899b0d1825ff24e9fe8d747.md
+++ b/curriculum/challenges/english/blocks/workshop-emoji-reactor/6899b0d1825ff24e9fe8d747.md
@@ -9,7 +9,7 @@ dashedName: step-2
 
 Below the `h1` element, add a `p` element with class `description`.
 
-Inside the `p` element write the text `Click on the buttons below to rate your emotions.`.
+Inside the `p` element write the text `Click on the buttons below to rate your emotions.`
 
 # --hints--
 
@@ -25,7 +25,7 @@ The new `p` element should have a class of `description`.
 assert.equal(document.querySelector("h1 + p")?.className, "description");
 ```
 
-The new `p` element should have text of `Click on the buttons below to rate your emotions.`.
+The new `p` element should have text of `Click on the buttons below to rate your emotions.`
 
 ```js
 assert.equal(document.querySelector("h1 + p")?.textContent.trim(), "Click on the buttons below to rate your emotions.");

--- a/curriculum/challenges/english/blocks/workshop-emoji-reactor/6899c30b1d26094e11170c92.md
+++ b/curriculum/challenges/english/blocks/workshop-emoji-reactor/6899c30b1d26094e11170c92.md
@@ -9,7 +9,7 @@ dashedName: step-7
 
 Now you need to add an event listener on the `happyBtn` element.
 
-Write the event listener and its callback so that when the button is clicked the app will log to the console `Button clicked!`.
+Write the event listener and its callback so that when the button is clicked the app will log to the console `Button clicked!`
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/workshop-error-message-component/684cca09aac0fc035db4099f.md
+++ b/curriculum/challenges/english/blocks/workshop-error-message-component/684cca09aac0fc035db4099f.md
@@ -17,13 +17,13 @@ You should have a `strong` element inside your `p` element.
 assert.exists(document.querySelector("p strong"));
 ```
 
-Your `strong` element should have the text `Error!`.
+Your `strong` element should have the text `Error!`
 
 ```js
 assert.equal(document.querySelector("strong")?.textContent, "Error!");
 ```
 
-Your `p` element should have the correct text that ends with `Something went wrong. Please try again.`.
+Your `p` element should have the correct text that ends with `Something went wrong. Please try again.`
 
 ```js
 const remainingText = "Something went wrong. Please try again."

--- a/curriculum/challenges/english/blocks/workshop-greeting-card/6720b3191bbafd269bae0ae8.md
+++ b/curriculum/challenges/english/blocks/workshop-greeting-card/6720b3191bbafd269bae0ae8.md
@@ -9,7 +9,7 @@ dashedName: step-2
 
 Create a `div` element that has an `id` of `greeting-card` and a `class` of `card`.
 
-Inside the `div` element, add an `h1` with the text `Happy Birthday!`. Then add a paragraph element with a `class` called `message` and the text `Wishing you all the happiness and joy on your special day!`.
+Inside the `div` element, add an `h1` with the text `Happy Birthday!` Then add a paragraph element with a `class` called `message` and the text `Wishing you all the happiness and joy on your special day!`
 
 # --hints--
 
@@ -37,7 +37,7 @@ You should have an `h1` element inside the `div` element.
 assert.exists(document.querySelector("div > h1"));
 ```
 
-The `h1` element should contain the text `Happy Birthday!`.
+The `h1` element should contain the text `Happy Birthday!`
 
 ```js
 assert.strictEqual(document.querySelector("div > h1").textContent.trim(), "Happy Birthday!");
@@ -55,7 +55,7 @@ The `p` element should have a `class` of `message`.
 assert.exists(document.querySelector("div > p.message"));
 ```
 
-The `p` element should contain the text `Wishing you all the happiness and joy on your special day!`.
+The `p` element should contain the text `Wishing you all the happiness and joy on your special day!`
 
 ```js
 assert.strictEqual(document.querySelector("div > p.message").textContent.trim(), "Wishing you all the happiness and joy on your special day!");

--- a/curriculum/challenges/english/blocks/workshop-greeting-card/672e44e811e610232fead333.md
+++ b/curriculum/challenges/english/blocks/workshop-greeting-card/672e44e811e610232fead333.md
@@ -7,7 +7,7 @@ dashedName: step-10
 
 # --description--
 
-Add an `h2` to `#send` that contains the text `Sending your card...`, then add a `p` element with the text `Card successfully sent to your recipient!`.
+Add an `h2` to `#send` that contains the text `Sending your card...`, then add a `p` element with the text `Card successfully sent to your recipient!`
 
 # --hints--
 
@@ -17,7 +17,7 @@ The `#send` element should contain a `h2` element.
 assert.exists(document.querySelector("#send > h2"));
 ```
 
-The `h2` element should contain the text `Sending your card...`.
+The `h2` element should contain the text `Sending your card...`
 
 ```js
 assert.strictEqual(document.querySelector("#send > h2").innerText.trim(), "Sending your card...");
@@ -29,7 +29,7 @@ The second element inside `#send` should be a `p` element.
 assert.strictEqual(document.querySelector("#send").children[1].tagName, "P");
 ```
 
-The `p` element should have the text `Card successfully sent to your recipient!`.
+The `p` element should have the text `Card successfully sent to your recipient!`
 
 ```js
 assert.strictEqual(document.querySelector("#send").children[1].innerText.trim(), "Card successfully sent to your recipient!");

--- a/curriculum/challenges/english/blocks/workshop-greeting-card/67332db0f793bf08f2a18528.md
+++ b/curriculum/challenges/english/blocks/workshop-greeting-card/67332db0f793bf08f2a18528.md
@@ -9,7 +9,7 @@ dashedName: step-11
 
 Time to fill the second `section`! 
 
-Add an `h2` element to the `#share` element that contains the text `Sharing your card...`, then add a `p` element with the text `Your card was shared on social media!`.
+Add an `h2` element to the `#share` element that contains the text `Sharing your card...`, then add a `p` element with the text `Your card was shared on social media!`
 
 # --hints--
 
@@ -19,7 +19,7 @@ The `#share` element should contain a `h2` element.
 assert.exists(document.querySelector("#share > h2"));
 ```
 
-The `h2` element should contain the text `Sharing your card...`.
+The `h2` element should contain the text `Sharing your card...`
 
 ```js
 assert.strictEqual(document.querySelector("#share > h2").innerText.trim(), "Sharing your card...");
@@ -31,7 +31,7 @@ The second element inside `#share` should be a `p` element.
 assert.strictEqual(document.querySelector("#share").children[1].tagName, "P");
 ```
 
-The `p` element should have the text `Your card was shared on social media!`.
+The `p` element should have the text `Your card was shared on social media!`
 
 ```js
 assert.strictEqual(document.querySelector("#share").children[1].innerText.trim(), "Your card was shared on social media!");

--- a/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a94ea5df66236ebed260e8.md
+++ b/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a94ea5df66236ebed260e8.md
@@ -11,7 +11,7 @@ The next section in the form will be responsible for asking users if they have s
 
 Start by adding a `fieldset` element.
 
-Inside the `fieldset` element, add a `legend` element with the text of `Was this your first time at our hotel?`. 
+Inside the `fieldset` element, add a `legend` element with the text of `Was this your first time at our hotel?` 
 
 # --hints--
 
@@ -27,7 +27,7 @@ You should have a `legend` element inside of your `fieldset` element.
 assert.lengthOf(document.querySelectorAll('fieldset legend'), 2);
 ```
 
-Your `legend` element should have the text of `Was this your first time at our hotel?`.
+Your `legend` element should have the text of `Was this your first time at our hotel?`
 
 ```js
 assert.strictEqual(document.querySelectorAll('fieldset legend')[1]?.textContent.trim(), 'Was this your first time at our hotel?');

--- a/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a969951120be7818d8ee49.md
+++ b/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a969951120be7818d8ee49.md
@@ -11,7 +11,7 @@ The next section of the form will provide users with the ability to leave a rati
 
 Start by adding a new `fieldset` element with a `legend` element nested inside. The `legend` should have the text `Ratings`.
 
-Below the `legend` element, add a `label` element with the text `How was the service?`. The `for` attribute should be set to `"service"`.
+Below the `legend` element, add a `label` element with the text `How was the service?` The `for` attribute should be set to `"service"`.
 
 # --hints--
 
@@ -39,7 +39,7 @@ Your `fieldset` should have a `label` element below the `legend`.
 assert.lengthOf(document.querySelectorAll('fieldset:nth-of-type(4) legend + label'), 1);
 ```
 
-Your `label` should have the text `How was the service?`.
+Your `label` should have the text `How was the service?`
 
 ```js
 assert.strictEqual(document.querySelectorAll('fieldset:nth-of-type(4) legend + label')[0]?.textContent.trim(), 'How was the service?');

--- a/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a975c259525b7bc2d5c776.md
+++ b/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a975c259525b7bc2d5c776.md
@@ -9,7 +9,7 @@ dashedName: step-28
 
 Your hotel feedback form should also give users the ability to rate the food.
 
-Start by adding a `label` element with the text of `How was the food?`. That `label` element should have a `for` attribute set to `"food"`.
+Start by adding a `label` element with the text of `How was the food?` That `label` element should have a `for` attribute set to `"food"`.
 
 Below your `label` element, add a `select` element with an `id` and `name` set to `"food"`.
 
@@ -21,7 +21,7 @@ You should have a `label` element with the `for` attribute set to `"food"`.
 assert.exists(document.querySelector('label[for="food"]'));
 ```
 
-Your `label` should have the text `How was the food?`.
+Your `label` should have the text `How was the food?`
 
 ```js
 assert.strictEqual(document.querySelector('label[for="food"]')?.textContent.trim(), 'How was the food?');

--- a/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a97f40ddd40d7deb0618b7.md
+++ b/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a97f40ddd40d7deb0618b7.md
@@ -19,7 +19,7 @@ You should have a `label` with a `for` attribute set to `"comments"`.
 assert.exists(document.querySelector('label[for="comments"]'));
 ```
 
-Your `label` should have the text `Other Comments?`.
+Your `label` should have the text `Other Comments?`
 
 ```js
 assert.strictEqual(document.querySelector('label[for="comments"]')?.textContent.trim(), 'Other Comments?');

--- a/curriculum/challenges/english/blocks/workshop-magazine/6143d003ad9e9d76766293ec.md
+++ b/curriculum/challenges/english/blocks/workshop-magazine/6143d003ad9e9d76766293ec.md
@@ -7,7 +7,7 @@ dashedName: step-24
 
 # --description--
 
-Within your `.image-quote` element, nest an `hr` element, a `p` element and a second `hr` element. Give the `p` element a `class` set to `quote` and the text `The millions of people who are learning to code through freeCodeCamp will have an even better resource to help them learn these fundamentals.`.
+Within your `.image-quote` element, nest an `hr` element, a `p` element and a second `hr` element. Give the `p` element a `class` set to `quote` and the text `The millions of people who are learning to code through freeCodeCamp will have an even better resource to help them learn these fundamentals.`
 
 # --hints--
 
@@ -38,7 +38,7 @@ Your new `p` element should have a `class` set to `quote`.
 assert.isTrue(document.querySelector('.image-quote p')?.classList.contains('quote'));
 ```
 
-Your new `p` element should have the text `The millions of people who are learning to code through freeCodeCamp will have an even better resource to help them learn these fundamentals.`.
+Your new `p` element should have the text `The millions of people who are learning to code through freeCodeCamp will have an even better resource to help them learn these fundamentals.`
 
 ```js
 assert.equal(document.querySelector('.image-quote p')?.innerText, 'The millions of people who are learning to code through freeCodeCamp will have an even better resource to help them learn these fundamentals.');

--- a/curriculum/challenges/english/blocks/workshop-major-browsers-list/68ecfa1003d88990bb96a33d.md
+++ b/curriculum/challenges/english/blocks/workshop-major-browsers-list/68ecfa1003d88990bb96a33d.md
@@ -42,7 +42,7 @@ const ddElement = document.querySelector('dl dd');
 assert.exists(ddElement);
 ```
 
-Your `dd` element should contain the text `This is a free web browser developed by Google and first released in 2008.`.
+Your `dd` element should contain the text `This is a free web browser developed by Google and first released in 2008.`
 
 ```js
 const ddElement = document.querySelector('dd');

--- a/curriculum/challenges/english/blocks/workshop-major-browsers-list/68ecfa1003d88990bb96a33e.md
+++ b/curriculum/challenges/english/blocks/workshop-major-browsers-list/68ecfa1003d88990bb96a33e.md
@@ -40,7 +40,7 @@ const ddElements = document.querySelectorAll('dd');
 assert.lengthOf(ddElements, 2);
 ```
 
-Your second `dd` element should contain the text `This is a free web browser developed by the Mozilla Corporation and first created in 2004.`.
+Your second `dd` element should contain the text `This is a free web browser developed by the Mozilla Corporation and first created in 2004.`
 
 ```js
 const ddElement = document.querySelectorAll('dd')[1];

--- a/curriculum/challenges/english/blocks/workshop-major-browsers-list/69038dd51a41ae215fcc030a.md
+++ b/curriculum/challenges/english/blocks/workshop-major-browsers-list/69038dd51a41ae215fcc030a.md
@@ -40,7 +40,7 @@ const ddElements = document.querySelectorAll('dd');
 assert.lengthOf(ddElements, 3);
 ```
 
-Your third `dd` element should contain the text `This browser was developed by Apple and is the default browser for iPhone, iPad and Mac devices.`.
+Your third `dd` element should contain the text `This browser was developed by Apple and is the default browser for iPhone, iPad and Mac devices.`
 
 ```js
 const ddElement = document.querySelectorAll('dd')[2];

--- a/curriculum/challenges/english/blocks/workshop-major-browsers-list/69038f5efad6f722def4a214.md
+++ b/curriculum/challenges/english/blocks/workshop-major-browsers-list/69038f5efad6f722def4a214.md
@@ -40,7 +40,7 @@ const ddElements = document.querySelectorAll('dd');
 assert.lengthOf(ddElements, 4);
 ```
 
-Your fourth `dd` element should contain the text `This is a free web browser first released in 2016 that is based on the Chromium web browser.`.
+Your fourth `dd` element should contain the text `This is a free web browser first released in 2016 that is based on the Chromium web browser.`
 
 ```js
 const ddElement = document.querySelectorAll('dd')[3];

--- a/curriculum/challenges/english/blocks/workshop-major-browsers-list/69038fe7da59ca23a5eba82d.md
+++ b/curriculum/challenges/english/blocks/workshop-major-browsers-list/69038fe7da59ca23a5eba82d.md
@@ -42,7 +42,7 @@ const ddElements = document.querySelectorAll('dd');
 assert.lengthOf(ddElements, 5);
 ```
 
-Your fifth `dd` element should contain the text `This is a free Chromium based web browser first released in 2023 by The Browser Company.`.
+Your fifth `dd` element should contain the text `This is a free Chromium based web browser first released in 2023 by The Browser Company.`
 
 ```js
 const ddElement = document.querySelectorAll('dd')[4];

--- a/curriculum/challenges/english/blocks/workshop-media-catalogue/68b816815f13eca63a588b45.md
+++ b/curriculum/challenges/english/blocks/workshop-media-catalogue/68b816815f13eca63a588b45.md
@@ -15,7 +15,7 @@ def add(x, y):
     return x + y
 ```
 
-Complete your `Movie` class by adding the following docstring to it: `Parent class representing a movie.`.
+Complete your `Movie` class by adding the following docstring to it: `Parent class representing a movie.`
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/workshop-media-catalogue/68b942c9b8cce592f1c33d03.md
+++ b/curriculum/challenges/english/blocks/workshop-media-catalogue/68b942c9b8cce592f1c33d03.md
@@ -7,7 +7,7 @@ dashedName: step-26
 
 # --description--
 
-Now complete the `TVSeries` class by adding the docstring `Child class representing an entire TV series.`.
+Now complete the `TVSeries` class by adding the docstring `Child class representing an entire TV series.`
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/workshop-media-catalogue/68b95956da014b1a8e32ffb3.md
+++ b/curriculum/challenges/english/blocks/workshop-media-catalogue/68b95956da014b1a8e32ffb3.md
@@ -14,7 +14,7 @@ class CustomError(Exception):
     ...
 ```
 
-Create a class named `MediaError`. Make it inherit from the `Exception` class and add to it a docstring saying `Custom exception for media-related errors.`.
+Create a class named `MediaError`. Make it inherit from the `Exception` class and add to it a docstring saying `Custom exception for media-related errors.`
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/workshop-medical-data-validator/6849a0d59a98011bb2e46d12.md
+++ b/curriculum/challenges/english/blocks/workshop-medical-data-validator/6849a0d59a98011bb2e46d12.md
@@ -7,7 +7,7 @@ dashedName: step-11
 
 # --description--
 
-After the `if` statement, print the string `Valid format.`. Then return `True`.
+After the `if` statement, print the string `Valid format.` Then return `True`.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/workshop-medical-data-validator/68529fb26c581f13e901de3a.md
+++ b/curriculum/challenges/english/blocks/workshop-medical-data-validator/68529fb26c581f13e901de3a.md
@@ -7,7 +7,7 @@ dashedName: step-44
 
 # --description--
 
-Right after the `invalid_records` variable, create a `for` loop to iterate over it. For each invalid record, print `Unexpected format '<key>: <val>' at position <index>.`. Replace `<key>`, `<val>`, and `<index>` with the current key, value, and index.
+Right after the `invalid_records` variable, create a `for` loop to iterate over it. For each invalid record, print `Unexpected format '<key>: <val>' at position <index>.` Replace `<key>`, `<val>`, and `<index>` with the current key, value, and index.
 
 Remember that `invalid_records` is a list of keys that refer to invalid records in the current `dictionary`. You will need to take the key from `invalid_records` and look up the value in `dictionary`.
 

--- a/curriculum/challenges/english/blocks/workshop-musical-instrument-inventory/6895e3f91c069e0068a42582.md
+++ b/curriculum/challenges/english/blocks/workshop-musical-instrument-inventory/6895e3f91c069e0068a42582.md
@@ -9,11 +9,11 @@ dashedName: step-9
 
 Inside your `play` method, use `print()` to display a message about playing the instrument.
 
-Use an f-string to include the instrument's name in the message: `The [instrument name] is fun to play!`. The `[instrument name]` should be replaced with the actual name of the instrument.
+Use an f-string to include the instrument's name in the message: `The [instrument name] is fun to play!` The `[instrument name]` should be replaced with the actual name of the instrument.
 
 # --hints--
 
-Your `play` method should use an f-string to display the message `The [instrument name] is fun to play!`. Use `self.name` to access the instrument name.
+Your `play` method should use an f-string to display the message `The [instrument name] is fun to play!` Use `self.name` to access the instrument name.
 
 ```js
 ({

--- a/curriculum/challenges/english/blocks/workshop-musical-instrument-inventory/6895e4940e39950288e406c2.md
+++ b/curriculum/challenges/english/blocks/workshop-musical-instrument-inventory/6895e4940e39950288e406c2.md
@@ -9,7 +9,7 @@ dashedName: step-10
 
 Next, add another method to your class named `get_fact` that returns a fact about the instrument.
 
-This method should have only the `self` parameter and return an f-string that says `The [instrument name] is part of the [instrument type] family of instruments.`.
+This method should have only the `self` parameter and return an f-string that says `The [instrument name] is part of the [instrument type] family of instruments.`
 
 Unlike the `play` method which prints a message directly, this method should return a string that can be used elsewhere in your code.
 

--- a/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68ea7c41f2555e16174e7cfa.md
+++ b/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68ea7c41f2555e16174e7cfa.md
@@ -7,7 +7,7 @@ dashedName: step-3
 
 # --description--
 
-Next, add a paragraph element with the text `Please fill out the form below to help schedule your parent-teacher conference.`. Your paragraph element should also have the classes `description` and `center`.
+Next, add a paragraph element with the text `Please fill out the form below to help schedule your parent-teacher conference.` Your paragraph element should also have the classes `description` and `center`.
 
 # --hints--
 
@@ -17,7 +17,7 @@ You should have a `p` element.
 assert.exists(document.querySelector("p"));
 ```
 
-Your `p` element should have the text `Please fill out the form below to help schedule your parent-teacher conference.`.
+Your `p` element should have the text `Please fill out the form below to help schedule your parent-teacher conference.`
 
 ```js
 assert.strictEqual(document.querySelector("p")?.innerText, "Please fill out the form below to help schedule your parent-teacher conference.");

--- a/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eaa668d4d9fbe529a0e16b.md
+++ b/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eaa668d4d9fbe529a0e16b.md
@@ -19,7 +19,7 @@ Your last `fieldset` should contain a `label` element.
 assert.exists(document.querySelector("fieldset:last-of-type label"));
 ```
 
-The `label` element should have the text `Any specific concerns or topics you'd like to discuss?`.
+The `label` element should have the text `Any specific concerns or topics you'd like to discuss?`
 
 ```js
 const label = document.querySelector("fieldset:last-of-type label");

--- a/curriculum/challenges/english/blocks/workshop-plant-nursery-catalog/6734c10a327760a665b7d5b9.md
+++ b/curriculum/challenges/english/blocks/workshop-plant-nursery-catalog/6734c10a327760a665b7d5b9.md
@@ -11,7 +11,7 @@ In the next few steps, you'll work on a function that will allow you to update t
 
 Create a function named `sellPlants` that takes three arguments: a plant object, the pot size and the number of pots to sell, in this order.
 
-When the specified number of pots is greater than the available pots, make your function return `Not enough <pot-size> size pots for <item-name>. Only <pot-number> left.`. Replace `<pot-size>` with the pot size, `<pot-number>` with the remaining pots for that size, and `<item-name>` with the scientific name of the plant followed by a space and the name of the cultivar wrapped between single quotes.
+When the specified number of pots is greater than the available pots, make your function return `Not enough <pot-size> size pots for <item-name>. Only <pot-number> left.` Replace `<pot-size>` with the pot size, `<pot-number>` with the remaining pots for that size, and `<item-name>` with the scientific name of the plant followed by a space and the name of the cultivar wrapped between single quotes.
 
 To test that everything works, log the result of calling your `sellPlants` function with the `ballerina` object, `"small"`, and `25` to the console. 
 
@@ -42,7 +42,7 @@ Your `sellPlants` function should take three arguments.
 assert.lengthOf(sellPlants, 3);
 ```
 
-`sellPlants(ballerina, "small", 25)` should return `Not enough small size pots for Lavandula stoechas 'Ballerina'. Only 20 left.`.
+`sellPlants(ballerina, "small", 25)` should return `Not enough small size pots for Lavandula stoechas 'Ballerina'. Only 20 left.`
 
 ```js
 assert.equal(sellPlants(ballerina, "small", 25), "Not enough small size pots for Lavandula stoechas 'Ballerina'. Only 20 left.")

--- a/curriculum/challenges/english/blocks/workshop-plant-nursery-catalog/6734eee1f9498cd90f9ae340.md
+++ b/curriculum/challenges/english/blocks/workshop-plant-nursery-catalog/6734eee1f9498cd90f9ae340.md
@@ -7,7 +7,7 @@ dashedName: step-14
 
 # --description--
 
-When there are enough pots to sell you need to update the catalog by subtracting the pots of the specified size. In that case, return `Catalog successfully updated.`.
+When there are enough pots to sell you need to update the catalog by subtracting the pots of the specified size. In that case, return `Catalog successfully updated.`
 
 Modify your function to achieve that. Then, update your function call by passing `10` as third argument instead of `25`.
 
@@ -25,7 +25,7 @@ You should have only one `sellPlants` call in your code.
 assert.lengthOf(__helpers.removeJSComments(code).match(/(?<!function\s+)sellPlants\s*\(/g), 1)
 ```
 
-`sellPlants(ballerina, "small", 25)` should return `Not enough small size pots for Lavandula stoechas 'Ballerina'. Only 10 left.`.
+`sellPlants(ballerina, "small", 25)` should return `Not enough small size pots for Lavandula stoechas 'Ballerina'. Only 10 left.`
 
 ```js
 assert.equal(sellPlants(ballerina, "small", 25), "Not enough small size pots for Lavandula stoechas 'Ballerina'. Only 10 left.")

--- a/curriculum/challenges/english/blocks/workshop-plant-nursery-catalog/6734fa225c6667121e589f7e.md
+++ b/curriculum/challenges/english/blocks/workshop-plant-nursery-catalog/6734fa225c6667121e589f7e.md
@@ -40,13 +40,13 @@ testCatalog.set(royalCrown, { small: 40, medium: 22, large: 9 });
 assert.deepEqual(catalog, testCatalog);
 ```
 
-`sellPlants(ballerina, "small", 10)` should return `Item not found.`.
+`sellPlants(ballerina, "small", 10)` should return `Item not found.`
 
 ```js
 assert.equal(sellPlants(ballerina, "small", 10), "Item not found.")
 ```
 
-`sellPlants(hidcote, "large", 95)` should return `Not enough large size pots for Lavandula angustifolia 'Hidcote'. Only 18 left.`.
+`sellPlants(hidcote, "large", 95)` should return `Not enough large size pots for Lavandula angustifolia 'Hidcote'. Only 18 left.`
 
 ```js
 assert.equal(sellPlants(hidcote, "large", 95), "Not enough large size pots for Lavandula angustifolia 'Hidcote'. Only 18 left.")

--- a/curriculum/challenges/english/blocks/workshop-quincys-job-tips/68e65ec5348e40a739903e6d.md
+++ b/curriculum/challenges/english/blocks/workshop-quincys-job-tips/68e65ec5348e40a739903e6d.md
@@ -7,7 +7,7 @@ dashedName: step-2
 
 # --description--
 
-Now, create a paragraph element below the `h1` element. Inside this paragraph add the text `Learning to code is hard, but as Quincy Larson says, You can become a developer.`.
+Now, create a paragraph element below the `h1` element. Inside this paragraph add the text `Learning to code is hard, but as Quincy Larson says, You can become a developer.`
 
 # --hints--
 
@@ -17,7 +17,7 @@ You should have a `p` element.
 assert.exists(document.querySelector('p'));
 ```
 
-Your paragraph should have the text `Learning to code is hard, but as Quincy Larson says, You can become a developer.`. Double check your spelling.
+Your paragraph should have the text `Learning to code is hard, but as Quincy Larson says, You can become a developer.` Double check your spelling.
 
 ```js
 assert.equal(document.querySelector('p')?.textContent.trim(), "Learning to code is hard, but as Quincy Larson says, You can become a developer.");

--- a/curriculum/challenges/english/blocks/workshop-quincys-job-tips/68e90335bd53a901c41dfc13.md
+++ b/curriculum/challenges/english/blocks/workshop-quincys-job-tips/68e90335bd53a901c41dfc13.md
@@ -35,7 +35,7 @@ Your `q` element should be nested inside the paragraph that is below the `h1` el
 assert.exists(document.querySelector('h1 + p > q'));
 ```
 
-Your `q` element should have the text `You can become a developer.`.
+Your `q` element should have the text `You can become a developer.`
 
 ```js
 assert.equal(document.querySelector('h1 + p > q')?.textContent.trim(), 'You can become a developer.');

--- a/curriculum/challenges/english/blocks/workshop-quincys-job-tips/68ea7e7b916e8270483689b6.md
+++ b/curriculum/challenges/english/blocks/workshop-quincys-job-tips/68ea7e7b916e8270483689b6.md
@@ -17,7 +17,7 @@ Here is an example of a block quotation element with quoted text:
 </blockquote>
 ```
 
-Now, inside the first section, add a block quotation element below the `h2` element with the text `Can you imagine what it would be like to be a successful developer? To have built software systems that people rely upon?`.
+Now, inside the first section, add a block quotation element below the `h2` element with the text `Can you imagine what it would be like to be a successful developer? To have built software systems that people rely upon?`
 
 # --hints--
 
@@ -27,7 +27,7 @@ Inside the first `section` element, you should have a `blockquote` element below
 assert.exists(document.querySelector('section:first-of-type > h2 + blockquote'));
 ```
 
-Your `blockquote` element should have the text `Can you imagine what it would be like to be a successful developer? To have built software systems that people rely upon?`.
+Your `blockquote` element should have the text `Can you imagine what it would be like to be a successful developer? To have built software systems that people rely upon?`
 
 ```js
 const firstBlockquoteEl = document.querySelector('section:first-of-type > h2 + blockquote');

--- a/curriculum/challenges/english/blocks/workshop-quincys-job-tips/68eab6a2b37d2f13602d0c3f.md
+++ b/curriculum/challenges/english/blocks/workshop-quincys-job-tips/68eab6a2b37d2f13602d0c3f.md
@@ -34,28 +34,28 @@ const pElements = document.querySelectorAll('main > section:nth-of-type(2) > blo
 assert.lengthOf(pElements, 4);
 ```
 
-Your first `p` element should have the text `So much of getting a job is who you know.`.
+Your first `p` element should have the text `So much of getting a job is who you know.`
 
 ```js
 const firstPEl = document.querySelector('main > section:nth-of-type(2) > blockquote > p:nth-of-type(1)');
 assert.equal(firstPEl?.innerText.trim(), 'So much of getting a job is who you know.');
 ```
 
-Your second `p` element should have the text `It's OK to be an introvert, but you do need to push your boundaries.`.
+Your second `p` element should have the text `It's OK to be an introvert, but you do need to push your boundaries.`
 
 ```js
 const secondPEl = document.querySelector('main > section:nth-of-type(2) > blockquote > p:nth-of-type(2)');
 assert.equal(secondPEl?.innerText.trim(), "It's OK to be an introvert, but you do need to push your boundaries.");
 ```
 
-Your third `p` element should have the text `Create GitHub, Twitter, LinkedIn, and Discord accounts.`.
+Your third `p` element should have the text `Create GitHub, Twitter, LinkedIn, and Discord accounts.`
 
 ```js
 const thirdPEl = document.querySelector('main > section:nth-of-type(2) > blockquote > p:nth-of-type(3)');
 assert.equal(thirdPEl?.innerText.trim(), 'Create GitHub, Twitter, LinkedIn, and Discord accounts.');
 ```
 
-Your forth `p` element should have the text `Go to tech meetups and conferences. Travel if you have to.`.
+Your forth `p` element should have the text `Go to tech meetups and conferences. Travel if you have to.`
 
 ```js
 const forthPEl = document.querySelector('main > section:nth-of-type(2) > blockquote > p:nth-of-type(4)');

--- a/curriculum/challenges/english/blocks/workshop-quincys-job-tips/68ebe9cd7523d340c0b343d3.md
+++ b/curriculum/challenges/english/blocks/workshop-quincys-job-tips/68ebe9cd7523d340c0b343d3.md
@@ -69,21 +69,21 @@ const pElements = document.querySelectorAll('main > section:nth-of-type(3) > blo
 assert.lengthOf(pElements, 3);
 ```
 
-Your first `p` element should have the text `Share short video demos of your projects.`.
+Your first `p` element should have the text `Share short video demos of your projects.`
 
 ```js
 const firstPEl = document.querySelector('main > section:nth-of-type(3) > blockquote > p:nth-of-type(1)');
 assert.equal(firstPEl?.innerText.trim(), 'Share short video demos of your projects.');
 ```
 
-Your second `p` element should have the text `Keep applying to speak at bigger and bigger conferences.`.
+Your second `p` element should have the text `Keep applying to speak at bigger and bigger conferences.`
 
 ```js
 const secondPEl = document.querySelector('main > section:nth-of-type(3) > blockquote > p:nth-of-type(2)');
 assert.equal(secondPEl?.innerText.trim(), "Keep applying to speak at bigger and bigger conferences.");
 ```
 
-Your third `p` element should have the text `Hang out at hackerspaces and help people who are even newer to coding than you.`.
+Your third `p` element should have the text `Hang out at hackerspaces and help people who are even newer to coding than you.`
 
 ```js
 const thirdPEl = document.querySelector('main > section:nth-of-type(3) > blockquote > p:nth-of-type(3)');

--- a/curriculum/challenges/english/blocks/workshop-registration-form/60fac56271087806def55b33.md
+++ b/curriculum/challenges/english/blocks/workshop-registration-form/60fac56271087806def55b33.md
@@ -7,7 +7,7 @@ dashedName: step-31
 
 # --description--
 
-Nest the `select` element (with its `option` elements) within a `label` element with the text `How did you hear about us?`. The text should come before the `select` element.
+Nest the `select` element (with its `option` elements) within a `label` element with the text `How did you hear about us?` The text should come before the `select` element.
 
 # --hints--
 
@@ -17,7 +17,7 @@ You should nest only the `select` element within a `label` element.
 assert.exists(document.querySelector('fieldset:nth-child(3) > label:nth-child(3) > select'));
 ```
 
-You should give the `label` element the text `How did you hear about us?`.
+You should give the `label` element the text `How did you hear about us?`
 
 ```js
 assert.equal(document.querySelector('fieldset:nth-child(3) > label:nth-child(3)')?.innerText?.trim(), 'How did you hear about us?');

--- a/curriculum/challenges/english/blocks/workshop-registration-form/60fad0a812d9890938524f50.md
+++ b/curriculum/challenges/english/blocks/workshop-registration-form/60fad0a812d9890938524f50.md
@@ -9,7 +9,7 @@ dashedName: step-37
 
 To give Campers an idea of what to put in their bio, the `placeholder` attribute is used. The `placeholder` accepts a text value, which is displayed until the user starts typing.
 
-Give the `textarea` a `placeholder` of `I like coding on the beach...`.
+Give the `textarea` a `placeholder` of `I like coding on the beach...`
 
 # --hints--
 
@@ -19,7 +19,7 @@ You should give the `textarea` a `placeholder` attribute.
 assert.isNotEmpty(document.querySelector('fieldset:nth-child(3) > label:nth-child(4) > textarea')?.placeholder);
 ```
 
-You should give the `placeholder` a value of `I like coding on the beach...`.
+You should give the `placeholder` a value of `I like coding on the beach...`
 
 ```js
 assert.match(document.querySelector('fieldset:nth-child(3) > label:nth-child(4) > textarea')?.placeholder, /^I like coding on the beach\.{3,4}$/);

--- a/curriculum/challenges/english/blocks/workshop-salary-tracker/68c2d31a86d5672ca49d4521.md
+++ b/curriculum/challenges/english/blocks/workshop-salary-tracker/68c2d31a86d5672ca49d4521.md
@@ -9,7 +9,7 @@ dashedName: step-14
 
 Now it's time to add some validation to the `__init__` method. At the beginning of the method, create an `if` statement that checks if either `name` or `level` are not instances of `str`.
 
-Inside the `if` statement, raise a `TypeError` with the message `'name' and 'level' attribute must be of type 'str'.`.
+Inside the `if` statement, raise a `TypeError` with the message `'name' and 'level' attribute must be of type 'str'.`
 
 # --hints--
 
@@ -34,7 +34,7 @@ Your `if` statement should check if either `name` and `level` are not instances 
 `) })
 ```
 
-Your `if` statement should raise a `TypeError` with the message `'name' and 'level' attribute must be of type 'str'.`.
+Your `if` statement should raise a `TypeError` with the message `'name' and 'level' attribute must be of type 'str'.`
 
 ```js
 ({ test: () => assert(runPython(`_Node(_code).find_class("Employee").find_function("__init__").find_ifs()[0].find_bodies()[0].has_stmt('raise TypeError("\\'name\\' and \\'level\\' attribute must be of type \\'str\\'.")')`)) })

--- a/curriculum/challenges/english/blocks/workshop-salary-tracker/68ca758f8160b11757f877ae.md
+++ b/curriculum/challenges/english/blocks/workshop-salary-tracker/68ca758f8160b11757f877ae.md
@@ -17,7 +17,7 @@ You should have a third `if` statement inside your `level` setter.
 ({ test: () => assert(runPython(`_Node(_code).find_class("Employee").find_functions("level")[1].find_ifs()[2]`)) })
 ```
 
-When `new_level` is lower than `self.level`, you should raise a `ValueError` with the message `Cannot change to lower level.`.
+When `new_level` is lower than `self.level`, you should raise a `ValueError` with the message `Cannot change to lower level.`
 
 ```js
 ({ test: () => runPython(`

--- a/curriculum/challenges/english/blocks/workshop-storytelling-app/671f99a5dc221afb86fa2dc0.md
+++ b/curriculum/challenges/english/blocks/workshop-storytelling-app/671f99a5dc221afb86fa2dc0.md
@@ -10,11 +10,11 @@ demoType: onLoad
 
 In this workshop, you will build a storytelling app that allows users to select a type of story and display a short story of that type. The CSS and the HTML boilerplate has been provided for you.
 
-Begin by creating an `h1` element and give it a text `Want to hear a short story?`. 
+Begin by creating an `h1` element and give it a text `Want to hear a short story?` 
 
 # --hints--
 
-You should have an `h1` with the text `Want to hear a short story?`.
+You should have an `h1` with the text `Want to hear a short story?`
 
 ```js
 const h1 = document.querySelector('h1');

--- a/curriculum/challenges/english/blocks/workshop-string-formatter/68e4276483b0c71658aab1ca.md
+++ b/curriculum/challenges/english/blocks/workshop-string-formatter/68e4276483b0c71658aab1ca.md
@@ -25,7 +25,7 @@ Your `userInput` variable should be a string.
 assert.isString(userInput);
 ```
 
-You should assign `"   Hello World!   "` to your `userInput` variable. Make sure there are three spaces before the `H` and three spaces after the `!`.
+You should assign `"   Hello World!   "` to your `userInput` variable. Make sure there are three spaces before the `H` and three spaces after the `!`
 
 ```js
 assert.equal(userInput, "   Hello World!   ");

--- a/curriculum/challenges/english/blocks/workshop-superhero-application-form/680900675ae3d54ee19590c8.md
+++ b/curriculum/challenges/english/blocks/workshop-superhero-application-form/680900675ae3d54ee19590c8.md
@@ -7,7 +7,7 @@ dashedName: step-8
 
 # --description--
 
-Next, create a `label` with the `className` of `section` and `column`, and the text `How did you get your powers?`. Inside the `label`, create a `select` element.
+Next, create a `label` with the `className` of `section` and `column`, and the text `How did you get your powers?` Inside the `label`, create a `select` element.
 
 # --hints--
 
@@ -18,7 +18,7 @@ const labelEl = document?.querySelector("label.section.column");
 assert.exists(labelEl);
 ```
 
-Your `label` element should have the text `How did you get your powers?`.
+Your `label` element should have the text `How did you get your powers?`
 
 ```js
 const labelEl = document?.querySelector("label.section.column");

--- a/curriculum/challenges/english/blocks/workshop-tailwind-cta-component/685523c05fb41d0848c4b52f.md
+++ b/curriculum/challenges/english/blocks/workshop-tailwind-cta-component/685523c05fb41d0848c4b52f.md
@@ -7,7 +7,7 @@ dashedName: step-2
 
 # --description--
 
-Inside the first `div` element, create a `span` element with the text `Soundflow`, a `h1` element with the text `Discover New Music`, and a `p` element with the text `Stream your favorite tracks and discover new artists.`.
+Inside the first `div` element, create a `span` element with the text `Soundflow`, a `h1` element with the text `Discover New Music`, and a `p` element with the text `Stream your favorite tracks and discover new artists.`
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/workshop-tailwind-pricing-component/686386e76197458b7dfd52ed.md
+++ b/curriculum/challenges/english/blocks/workshop-tailwind-pricing-component/686386e76197458b7dfd52ed.md
@@ -7,11 +7,11 @@ dashedName: step-4
 
 # --description--
 
-Under the `p` element you just added, create another `p` element with the text `Start exploring millions of songs with basic features and ads.`. Under that, create an empty `ul` element.
+Under the `p` element you just added, create another `p` element with the text `Start exploring millions of songs with basic features and ads.` Under that, create an empty `ul` element.
 
 # --hints--
 
-You should create another `p` element with the text `Start exploring millions of songs with basic features and ads.`.
+You should create another `p` element with the text `Start exploring millions of songs with basic features and ads.`
 
 ```js
 const paragraphs = document.querySelectorAll("p")

--- a/curriculum/challenges/english/blocks/workshop-teacher-chatbot/66b6e80d6c3f0b329c360283.md
+++ b/curriculum/challenges/english/blocks/workshop-teacher-chatbot/66b6e80d6c3f0b329c360283.md
@@ -15,7 +15,7 @@ Remember to replace `[subject]` with the `subject` variable and use proper templ
 
 # --hints--
 
-Your `console` statement should output the message `Here is an example of accessing the first letter in the word [subject].`. 
+Your `console` statement should output the message `Here is an example of accessing the first letter in the word [subject].` 
 
 ```js
 assert.match(code, /console\.log\(`Here\s+is\s+an\s+example\s+of\s+accessing\s+the\s+first\s+letter\s+in\s+the\s+word\s+\${subject}\.`\);?/);

--- a/curriculum/challenges/english/blocks/workshop-teacher-chatbot/66b6f586767a1534f3097353.md
+++ b/curriculum/challenges/english/blocks/workshop-teacher-chatbot/66b6f586767a1534f3097353.md
@@ -15,7 +15,7 @@ Then add another `console` statement that outputs the second letter of the `subj
 
 # --hints--
 
-Your `console` statement should output the message `Here is an example of accessing the second letter in the word [subject].`. 
+Your `console` statement should output the message `Here is an example of accessing the second letter in the word [subject].` 
 
 ```js
 assert.match(code, /console\.log\(`Here\s+is\s+an\s+example\s+of\s+accessing\s+the\s+second\s+letter\s+in\s+the\s+word\s+\$\{subject\}\.`\);?/);

--- a/curriculum/challenges/english/blocks/workshop-toggle-text-app/67cd46ec4ec904186ad52ba5.md
+++ b/curriculum/challenges/english/blocks/workshop-toggle-text-app/67cd46ec4ec904186ad52ba5.md
@@ -7,7 +7,7 @@ dashedName: step-3
 
 # --description--
 
-Below your `button` element, add a paragraph element with an `id` of `message` and the text `I love freeCodeCamp!`.
+Below your `button` element, add a paragraph element with an `id` of `message` and the text `I love freeCodeCamp!`
 
 # --hints--
 
@@ -23,7 +23,7 @@ Your paragraph element should have an `id` of `message`.
 assert.exists(document.getElementById("message"))
 ```
 
-Your paragraph element should have the text `I love freeCodeCamp!`.
+Your paragraph element should have the text `I love freeCodeCamp!`
 
 ```js
 const paraEl = document.querySelector("p");

--- a/curriculum/challenges/english/blocks/zh-a1-learn-understanding-greetings-and-introductions/68ee3d533f5542daa3c0cf6a.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-understanding-greetings-and-introductions/68ee3d533f5542daa3c0cf6a.md
@@ -14,7 +14,7 @@ When you want to tell someone your name in Chinese, you can use a very common an
 
 `​我是 (wǒ shì)​​` + name.
 
-It means "I am..." or "My name is...". `我 (wǒ)` means "I". Think of `是 (shì)` as the verb "to be" in English.
+It means "I am..." or "My name is..." `我 (wǒ)` means "I". Think of `是 (shì)` as the verb "to be" in English.
 
 # --instructions--
 
@@ -60,7 +60,7 @@ This is a greeting, not the speaker's name.
 
 # --explanation--
 
-`我是 (wǒ shì)​​` means "I am..." or "My name is...". It uses the verb `是 (shì)` after the pronoun `我 (wǒ)`, which means "I", to show identity. For example:
+`我是 (wǒ shì)​​` means "I am..." or "My name is..." It uses the verb `是 (shì)` after the pronoun `我 (wǒ)`, which means "I", to show identity. For example:
 
 `我是刘明 (wǒ shì liú míng)。` — I am Liu Ming.
 

--- a/curriculum/challenges/english/blocks/zh-a1-learn-understanding-greetings-and-introductions/68ef88102807cb08f733588d.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-understanding-greetings-and-introductions/68ef88102807cb08f733588d.md
@@ -29,7 +29,7 @@ This word has two characters. It means "I am...", and is used to introduce your 
 
 # --explanation--
 
-`我是 (wǒ shì)` means "I am..." or "My name is...". You can use it followed by your name to tell someone who you are.
+`我是 (wǒ shì)` means "I am..." or "My name is..." You can use it followed by your name to tell someone who you are.
 
 # --scene--
 

--- a/curriculum/challenges/english/blocks/zh-a1-learn-understanding-greetings-and-introductions/68ef8ef35b26ef1fd797d55f.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-understanding-greetings-and-introductions/68ef8ef35b26ef1fd797d55f.md
@@ -60,7 +60,7 @@ Teacher is a profession, not a nationality.
 
 `我是中国人 (wǒ shì zhōng guó rén)` uses the structure `我是 (wǒ shì)` + nationality to state where someone is from.
 
-`我是 (wǒ shì)` means "I am...". A nationality is formed by adding `人 (rén)`, meaning "person", to the country name.
+`我是 (wǒ shì)` means "I am..." A nationality is formed by adding `人 (rén)`, meaning "person", to the country name.
 
 `中国 (zhōng guó)` means "China", so `中国人 (zhōng guó rén)` means a person from China.
 

--- a/curriculum/challenges/english/blocks/zh-a1-learn-understanding-greetings-and-introductions/6929acce4fc06b7554c10a1e.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-understanding-greetings-and-introductions/6929acce4fc06b7554c10a1e.md
@@ -14,7 +14,7 @@ This task doesn't have audio. Read the question below and select the correct ans
 
 ## --text--
 
-Which option means "I'm Chinese. I'm a developer."?
+Which option means "I'm Chinese. I'm a developer"?
 
 ## --answers--
 

--- a/curriculum/challenges/english/blocks/zh-a1-learn-understanding-greetings-and-introductions/6929aee7c53c517844d45ab6.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-understanding-greetings-and-introductions/6929aee7c53c517844d45ab6.md
@@ -14,7 +14,7 @@ This task doesn't have audio. Read the question below and select the correct ans
 
 ## --text--
 
-Which option means "I'm Singaporean. I'm a designer."?
+Which option means "I'm Singaporean. I'm a designer"?
 
 ## --answers--
 

--- a/curriculum/challenges/english/blocks/zh-a1-learn-understanding-greetings-and-introductions/6929b1a87c66927c3fdbb1de.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-understanding-greetings-and-introductions/6929b1a87c66927c3fdbb1de.md
@@ -14,7 +14,7 @@ This task doesn't have audio. Read the question below and select the correct ans
 
 ## --text--
 
-Which option means "I'm Canadian."?
+Which option means "I'm Canadian"?
 
 ## --answers--
 

--- a/curriculum/challenges/english/blocks/zh-a1-learn-understanding-questions-and-answers/6904c51ee5d1fb78335b71bf.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-understanding-questions-and-answers/6904c51ee5d1fb78335b71bf.md
@@ -57,7 +57,7 @@ She isn't asking where the person is from.
 
 `什么 (shén me)` means "what", and it is a question word used to ask about unknown information. `名字 (míng zi)` means "name".
 
-`什么名字 (shén me míng zi)` means "what name". `你叫什么名字 (nǐ jiào shén me míng zi)？` means "what is your name?". Wang Hua is asking for the other person's name.
+`什么名字 (shén me míng zi)` means "what name". `你叫什么名字 (nǐ jiào shén me míng zi)？` means "what is your name?" Wang Hua is asking for the other person's name.
 
 # --scene--
 

--- a/curriculum/challenges/english/blocks/zh-a1-learn-understanding-questions-and-answers/6909747cd7497056dc7618ef.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-understanding-questions-and-answers/6909747cd7497056dc7618ef.md
@@ -10,7 +10,7 @@ lang: zh-CN
 
 # --description--
 
-You've learned that you can introduce your name with `我是 (wǒ shì)` + name. You can use another structure, `我叫 (wǒ jiào)` + name. It literally means "I'm called...", and can be understood as "My name is...".
+You've learned that you can introduce your name with `我是 (wǒ shì)` + name. You can use another structure, `我叫 (wǒ jiào)` + name. It literally means "I'm called...", and can be understood as "My name is..."
 
 # --instructions--
 
@@ -56,7 +56,7 @@ This reverses the order of the speaker's name.
 
 # --explanation--
 
-`我叫 (wǒ jiào)` means "I am called..." or "My name is...". `叫 (jiào)` means "to be called". Here it's used to show identity. For example:
+`我叫 (wǒ jiào)` means "I am called..." or "My name is..." `叫 (jiào)` means "to be called". Here it's used to show identity. For example:
 
 `我叫王华 (wǒ jiào wáng huá)。` — I am called Wang Hua, or, my name is Wang Hua.
 

--- a/curriculum/challenges/english/blocks/zh-a1-learn-understanding-questions-and-answers/6911bcdd1ef7e704c8137b2c.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-understanding-questions-and-answers/6911bcdd1ef7e704c8137b2c.md
@@ -11,7 +11,7 @@ inputType: pinyin-to-hanzi
 
 # --description--
 
-When you want to ask someone about their situation after you've shared yours, you can use `你呢 (nǐ ne)`, which means "How about you?" or "And you?".
+When you want to ask someone about their situation after you've shared yours, you can use `你呢 (nǐ ne)`, which means "How about you?" or "And you?"
 
 The interrogative particle `呢 (ne)` is pronounced with a neutral tone. It's often used after a pronoun to form a question about the situation mentioned previously.
 
@@ -31,11 +31,11 @@ Listen to the audio and complete the sentence below.
 
 ### --feedback--
 
-These two characters mean "How about you?" or "And you?". Don't forget to type 5 at the end for neutral tone syllables.
+These two characters mean "How about you?" or "And you?" Don't forget to type 5 at the end for neutral tone syllables.
 
 # --explanation--
 
-`你呢 (nǐ ne)` combines the pronoun `你 (nǐ)` meaning "you" with the particle `呢 (ne)`, to form a question about the situation mentioned previously. It means "How about you?" or "And you?". It helps keep the conversation going in a friendly and natural way. For example:
+`你呢 (nǐ ne)` combines the pronoun `你 (nǐ)` meaning "you" with the particle `呢 (ne)`, to form a question about the situation mentioned previously. It means "How about you?" or "And you?" It helps keep the conversation going in a friendly and natural way. For example:
 
 `我是数据分析师 (wǒ shì shù jù fēn xī shī)。你呢 (nǐ ne)？` - I'm a data analyst. And you?
 

--- a/curriculum/challenges/english/blocks/zh-a1-learn-understanding-questions-and-answers/69147bede8101708ef0cac97.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-understanding-questions-and-answers/69147bede8101708ef0cac97.md
@@ -54,7 +54,7 @@ He confirms his job, but doesn't mention whether he likes it or not.
 
 Liu Ming says `是的 (shì de)`, which means "yes", to give a positive answer, and then says `我是 (wǒ shì) UI 设计师 (shè jì shī)`, which means "I am a UI designer" to confirm his profession.
 
-Then, he asks `你呢 (nǐ ne)？`, which means "And you?". This is asking about Wang Hua's profession and keeping the conversation going.
+Then, he asks `你呢 (nǐ ne)？`, which means "And you?" This is asking about Wang Hua's profession and keeping the conversation going.
 
 # --scene--
 

--- a/curriculum/challenges/english/blocks/zh-a1-learn-understanding-questions-and-answers/692a641fcd6ab4173e3e285f.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-understanding-questions-and-answers/692a641fcd6ab4173e3e285f.md
@@ -30,7 +30,7 @@ This means the opposite of "yes".
 
 ### --feedback--
 
-This means "isn't it?" or "right?".
+This means "isn't it?" or "right?"
 
 ---
 

--- a/curriculum/challenges/english/blocks/zh-a1-learn-understanding-questions-and-answers/692a805cac4208491a67242d.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-understanding-questions-and-answers/692a805cac4208491a67242d.md
@@ -34,7 +34,7 @@ This means "unhappy".
 
 ### --feedback--
 
-This is a question meaning "Are you happy?".
+This is a question meaning "Are you happy?"
 
 ---
 

--- a/curriculum/challenges/english/blocks/zh-a1-practice-exchanging-basic-information/69182f75cc96e43363541510.md
+++ b/curriculum/challenges/english/blocks/zh-a1-practice-exchanging-basic-information/69182f75cc96e43363541510.md
@@ -73,6 +73,6 @@ If you want to ask a question, don't forget to first introduce the question poli
 
 In order to know a person's name, you can use `叫什么 (jiào shén me)`.
 
-If you've just introduced yourself and want to ask the other person the same, simply say `你呢 (nǐ ne)?`.
+If you've just introduced yourself and want to ask the other person the same, simply say `你呢 (nǐ ne)?`
 
 To express that you feel the same way as the other person, you can say `我也是 (wǒ yě shì)`.

--- a/curriculum/challenges/english/blocks/zh-a1-review-introduction-questions/6918362cb49e2a3adf102413.md
+++ b/curriculum/challenges/english/blocks/zh-a1-review-introduction-questions/6918362cb49e2a3adf102413.md
@@ -50,7 +50,7 @@ Speaker B: `是的 (shì de)，我是设计师 (wǒ shì shè jì shī)。` – 
 
 ### Asking Follow-up Questions with `你呢 (nǐ ne)？`
 
-`你呢 (nǐ ne)` is a natural way to ask the person you're speaking to a question about a previously mentioned topic, meaning "How about you?" or "And you?". Examples:
+`你呢 (nǐ ne)` is a natural way to ask the person you're speaking to a question about a previously mentioned topic, meaning "How about you?" or "And you?" Examples:
 
 - `我是中国人 (wǒ shì zhōng guó rén)。你呢 (nǐ ne)？` – I am Chinese. And you?
 
@@ -60,7 +60,7 @@ Speaker B: `是的 (shì de)，我是设计师 (wǒ shì shè jì shī)。` – 
 
 ## Using `我叫 (wǒ jiào)` to Introduce Your Name
 
-`我叫 (wǒ jiào)` + name is a commonly used structure to introduce someone's name, similar to `我是 (wǒ shì)` + name. It means "I am called..." or "My name is...".
+`我叫 (wǒ jiào)` + name is a commonly used structure to introduce someone's name, similar to `我是 (wǒ shì)` + name. It means "I am called..." or "My name is..."
 
 <br />
 


### PR DESCRIPTION
## Summary
- Remove extraneous punctuation marks after closing backticks and double quotes across 234 curriculum files (361 instances)
- Fix patterns: `text.`**.**, `text!`**.**, `text?`**.**, `text…`**.** (backtick), and `"text?"`.**, `"text!"`.**, `"text."`.** (double-quote)
- Replace Unicode ellipsis character (`…`) with three dots (`...`) in backtick references
- Handle edge cases where `.`+`?` conflicts by removing the inner period to preserve question marks

## Test plan
- [x] Grep verification confirms zero remaining double punctuation patterns across curriculum
- [x] All changes are content-only (hint text, explanations, descriptions) — no test assertions or code modified
- [x] Spot-checked diffs across multiple file types (rosetta-code, English for developers, Chinese curriculum)
- [ ] Reviewer should verify a sample of changes render correctly in the curriculum UI

Closes #65383

Contributed via [Token Steward](https://github.com/mainnebula/token-steward) — this repo was identified as a high-impact open-source project worth contributing to. A developer donated their surplus Claude Code tokens to help.