### PR TITLE
fix(ci): test upcoming changes

### DIFF
--- a/.github/workflows/node.js-tests.yml
+++ b/.github/workflows/node.js-tests.yml
@@ -214,8 +214,7 @@ jobs:
       - name: Set Environment variables
         run: |
           sed '/^[[:space:]]*#/d; /^$/d' sample.env >> $GITHUB_ENV
-          echo 'SHOW_UPCOMING_CHANGES=true' >> .env
-          cat sample.env
+          echo 'SHOW_UPCOMING_CHANGES=true' >> $GITHUB_ENV
 
       - name: Start MongoDB
         run: docker compose -f docker/docker-compose.yml up -d


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

The two actions should have different hashes for curriculum:build, but they didn't. This should fix it.

See:
https://github.com/freeCodeCamp/freeCodeCamp/actions/runs/21913175262/job/63274701699
https://github.com/freeCodeCamp/freeCodeCamp/actions/runs/21913175262/job/63274701953

the hashes are the same.

<!-- Feel free to add any additional description of changes below this line -->
