### PR TITLE
fix(curriculum): correct hint and tests to target button inside third list item

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-reusable-mega-navbar/6745d799beeb822076a4da9d.md
+++ b/curriculum/challenges/english/blocks/workshop-reusable-mega-navbar/6745d799beeb822076a4da9d.md
@@ -13,10 +13,10 @@ The `aria-expanded` attribute will communicate to screen reader users that the b
 
 # --hints--
 
-You should create a `button` element inside the second list item.
+You should create a `button` element inside the third list item.
 
 ```js
-assert.exists(document.querySelector('li button'));
+assert.exists(document.querySelector('li:nth-of-type(3) button'));
 ```
 
 Your `button` element should have an `aria-expanded` attribute set to `false`.
@@ -28,7 +28,10 @@ assert.equal(document.querySelector('button')?.getAttribute('aria-expanded'), 'f
 Your `button` element should have the text `Apps`.
 
 ```js
-assert.equal(document.querySelector('li button')?.textContent, 'Apps');
+assert.equal(
+  document.querySelector('li:nth-of-type(3) button')?.textContent,
+  'Apps'
+);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-reusable-mega-navbar/6745d799beeb822076a4da9d.md
+++ b/curriculum/challenges/english/blocks/workshop-reusable-mega-navbar/6745d799beeb822076a4da9d.md
@@ -22,7 +22,10 @@ assert.exists(document.querySelector('li:nth-of-type(3) button'));
 Your `button` element should have an `aria-expanded` attribute set to `false`.
 
 ```js
-assert.equal(document.querySelector('button')?.getAttribute('aria-expanded'), 'false');
+assert.equal(
+  document.querySelector('li:nth-of-type(3) button')?.getAttribute('aria-expanded'),
+  'false'
+);
 ```
 
 Your `button` element should have the text `Apps`.


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #65840

Corrected the hint text from "second" to "third" list item.
Updated the test selectors to specifically target the button inside the third li.