### PR TITLE
fix(curriculum): replace step-style dashedName in N-Queens lab

### DIFF
--- a/curriculum/challenges/english/blocks/lab-n-queens-problem/68dbc6b7e8f794a2ae69bc74.md
+++ b/curriculum/challenges/english/blocks/lab-n-queens-problem/68dbc6b7e8f794a2ae69bc74.md
@@ -2,7 +2,7 @@
 id: 68dbc6b7e8f794a2ae69bc74
 title: Implement the N-Queens Algorithm
 challengeType: 27
-dashedName: step-1
+dashedName: implement-the-n-queens-algorithm
 ---
 
 # --description--


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.


Closes #65743

Replaces step-1 dashedName in the N-Queens lab with a descriptive dashedName.
Labs should not use step-style names.

Since this change updates the lab URL, I’ve opened a separate PR in the client-config repository to add the required redirect.

Redirect PR: https://github.com/freeCodeCamp/client-config/pull/27