### PR TITLE
fix(curriculum): update test to assert valid year value lab leap year calculator

### DIFF
--- a/curriculum/challenges/english/blocks/lab-leap-year-calculator/66c06fad3475cd92421b9ac2.md
+++ b/curriculum/challenges/english/blocks/lab-leap-year-calculator/66c06fad3475cd92421b9ac2.md
@@ -44,7 +44,9 @@ You should declare a variable `year` and assign it a value to check if it is a l
 
 ```js
 assert.isDefined(year);
-assert.isTrue(Number.isInteger(year) && year >= 0);
+assert.isNumber(year);
+assert.isAtLeast(year, 0);
+assert.isTrue((Number.isInteger(year));
 ```
 
 The `year` variable shouldn't be empty.

--- a/curriculum/challenges/english/blocks/lab-leap-year-calculator/66c06fad3475cd92421b9ac2.md
+++ b/curriculum/challenges/english/blocks/lab-leap-year-calculator/66c06fad3475cd92421b9ac2.md
@@ -44,6 +44,7 @@ You should declare a variable `year` and assign it a value to check if it is a l
 
 ```js
 assert.isDefined(year);
+assert.isTrue(Number.isInteger(year) && year >= 0);
 ```
 
 The `year` variable shouldn't be empty.

--- a/curriculum/challenges/english/blocks/lab-leap-year-calculator/66c06fad3475cd92421b9ac2.md
+++ b/curriculum/challenges/english/blocks/lab-leap-year-calculator/66c06fad3475cd92421b9ac2.md
@@ -46,7 +46,7 @@ You should declare a variable `year` and assign it a value to check if it is a l
 assert.isDefined(year);
 assert.isNumber(year);
 assert.isAtLeast(year, 0);
-assert.isTrue((Number.isInteger(year));
+assert.isTrue(Number.isInteger(year));
 ```
 
 The `year` variable shouldn't be empty.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

This PR is to update test in lab leap year calculator to assert for valid year value.

Changes:

- Added test to assert that value assigned to year is a integer and greater than equal to 0.
- The test now fails for values string, array, NaN, Infinity, decimals, negative values.