### PR TITLE
fix(curriculum): enforce heroName and realName initial state value in step 2

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-superhero-application-form/680900675ae3d54ee19590c3.md
+++ b/curriculum/challenges/english/blocks/workshop-superhero-application-form/680900675ae3d54ee19590c3.md
@@ -40,7 +40,7 @@ Your `useState` hook for `heroName` should have an initial value of empty string
   const _a = eval(script);
   const _b = await __helpers.prepTestComponent(exports.SuperheroForm);
   
-  assert.equal(abuseState.calls[0]?.[0], "");
+  assert.strictEqual(abuseState.calls[0]?.[0], "");
 ```
 
 You should use the array destructuring syntax to set a `realName` state variable and a `setRealName` setter.
@@ -70,7 +70,7 @@ Your `useState` hook for `realName` should have an initial value of empty string
   const _a = eval(script);
   const _b = await __helpers.prepTestComponent(exports.SuperheroForm);
 
-  assert.equal(abuseState.calls[1]?.[0], "");
+  assert.strictEqual(abuseState.calls[1]?.[0], "");
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:


- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Ensure that heroName and realName only pass when initialized with useState('').
Prevents useState([]) from incorrectly passing the tests.