### PR TITLE
feat: stop using turbo cache for renovate branches

### DIFF
--- a/.github/actions/setup-turbo-cache/action.yml
+++ b/.github/actions/setup-turbo-cache/action.yml
@@ -4,8 +4,6 @@
 #   ├─────────────────────────┼─────────────────┼──────────────────┤
 #   │ main (push)             │ YES             │ YES              │
 #   ├─────────────────────────┼─────────────────┼──────────────────┤
-#   │ renovate/*              │ YES             │ YES              │
-#   ├─────────────────────────┼─────────────────┼──────────────────┤
 #   │ PRs / temp-* / hotfix-* │ YES             │ NO               │
 #   ├─────────────────────────┼─────────────────┼──────────────────┤
 #   │ prod-*                  │ NO              │ NO               │
@@ -63,12 +61,10 @@ runs:
         echo "TURBO_TELEMETRY_DISABLED=1" >> $GITHUB_ENV
 
         # Determine if this context should have write access
-        # Write access: main branch push OR renovate branches
+        # Write access: main branch push
         # Read-only: PRs and other branches (can read from cache, can't pollute it)
         if [[ "$GITHUB_REF_NAME" == "main" && "$GITHUB_EVENT_NAME" == "push" ]]; then
           echo "::notice::Main branch push - Turbo cache READ/WRITE enabled"
-        elif [[ "$GITHUB_REF_NAME" == renovate/* ]]; then
-          echo "::notice::Renovate branch - Turbo cache READ/WRITE enabled"
         else
           # All other contexts: read-only
           # Use TURBO_CACHE=remote:r for read-only remote cache (local still read/write)


### PR DESCRIPTION
This was of marginal utility since devs will typically not be checking out renovate PRs (not often).

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->
