### PR TITLE
fix(tests): flaky speaking modal tests

### DIFF
--- a/e2e/multiple-choice-question-challenge.spec.ts
+++ b/e2e/multiple-choice-question-challenge.spec.ts
@@ -23,13 +23,11 @@ test.describe('Multiple Choice Question Challenge - With Speaking Modal', () => 
     const speakingButtons = page.getByRole('button', {
       name: translations['speaking-modal']['speaking-button']
     });
-    const speakingButtonCount = await speakingButtons.count();
-    expect(speakingButtonCount).toBeGreaterThan(0);
+    await expect(speakingButtons).toHaveCount(2);
 
-    const radioCount = await page.getByRole('radio').count();
-    expect(speakingButtonCount).toBe(radioCount);
+    await expect(page.getByRole('radio')).toHaveCount(2);
 
-    for (let i = 0; i < speakingButtonCount; i++) {
+    for (let i = 0; i < 2; i++) {
       const btn = speakingButtons.nth(i);
       await expect(btn).toBeVisible();
 
@@ -100,15 +98,12 @@ test.describe('Multiple Choice Question Challenge - Without Speaking Modal', () 
   test('should not show speaking controls on a challenge without speaking', async ({
     page
   }) => {
-    const radioCount = await page.getByRole('radio').count();
-    expect(radioCount).toBeGreaterThan(1);
+    await expect(page.getByRole('radio')).toHaveCount(12);
 
-    const speakingButtonsCount = await page
-      .getByRole('button', {
+    await expect(
+      page.getByRole('button', {
         name: translations['speaking-modal']['speaking-button']
       })
-      .count();
-
-    expect(speakingButtonsCount).toBe(0);
+    ).toHaveCount(0);
   });
 });


### PR DESCRIPTION
They are now brittle, because changes to those pages can break the tests, but that will be immediately obvious and easy to fix,

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->
