### PR TITLE
fix(curriculum): catch lessons without challenge files

### DIFF
--- a/curriculum/src/test/test-challenges.js
+++ b/curriculum/src/test/test-challenges.js
@@ -219,6 +219,13 @@ async function populateTestsForLang({ lang, challenges, meta }) {
               return;
             }
 
+            it('Has challenge files', function () {
+              expect(
+                challenge.challengeFiles,
+                `challengeFiles should exist. Check that the challenge has a "seed" section in the markdown file.`
+              ).toBeDefined();
+            });
+
             // The python tests are (currently) slow, so we give them more time.
             const timePerTest =
               challengeType === challengeTypes.python ? 10000 : 5000;


### PR DESCRIPTION
E.g. if there's a mistake in the md file.

See https://github.com/freeCodeCamp/freeCodeCamp/pull/65866/changes/ba1803dfd996738d06d0213fdbdcd6e8f5f00340#diff-5cbad6e741071ca526c8ebb7c435fe5ca982009fce435f1d067f7d22eb67198f for example. Thanks to @majestic-owl448 for pointing out how cryptic the error is.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->



<!-- Feel free to add any additional description of changes below this line -->
