### PR TITLE
fix(curriculum): add box-shadow to css review

### DIFF
--- a/curriculum/challenges/english/blocks/review-css-colors/671a90c1cf517678b130419e.md
+++ b/curriculum/challenges/english/blocks/review-css-colors/671a90c1cf517678b130419e.md
@@ -99,7 +99,7 @@ div {
 
 ```html
 <link rel="stylesheet" href="styles.css">
-<h3 class="hex-text">Hex Text</h3>
+<h1 class="hex-text">Hex Text</h1>
 <p class="hex-bg">Hex Background</p>
 ```
 
@@ -117,12 +117,19 @@ p {
 
 ## The `box-shadow` Property and Colors
 
-- **Definition**: The `box-shadow` property applies one or more shadows around an element’s box.
-- **Color in Shadows**: The shadow color can be defined using named colors, hex values, `rgb()`, `rgba()`, `hsl()`, or `hsla()`.
-- **Transparency**: Using `rgba()` or `hsla()` allows you to control the shadow’s transparency with an alpha value.
-- **Blur Effect**: The blur radius controls how soft the shadow appears.
+- **Definition**: The `box-shadow` property applies one or more shadows around an element.
+- **Offset Values**: You must specify horizontal (`offset-x`) and vertical (`offset-y`) values. Positive `offset-x` moves the shadow to the right, while negative values move it to the left. Positive `offset-y` moves the shadow down, while negative values move it up. If a value is `0`, you do not need to include a unit.
+- **Blur Radius**: This optional value controls how blurry the shadow appears. If not included, it defaults to `0`, which creates sharp edges. The higher the value, the softer the shadow.
+- **Spread Radius**: This optional value controls how much the shadow expands or shrinks. If not included, it defaults to `0`.
+- **Shadow Color**: You can specify the color using named colors, hex values, `rgb()`, `rgba()`, `hsl()`, or `hsla()` functions.
+- **`inset` Keyword**: Adding the `inset` keyword places the shadow inside the element instead of outside.
+- **Applying Multiple Box Shadows**: You can apply multiple shadows by separating them with commas. Shadows are layered from front to back.
 
-### Example
+### Syntax
+
+```css
+box-shadow: offset-x offset-y blur-radius spread-radius color;
+```
 
 :::interactive_editor
 
@@ -136,7 +143,7 @@ p {
   width: 200px;
   padding: 20px;
   background-color: lightblue;
-  box-shadow: 0 0 20px rgba(0, 0, 0, 0.5);
+  box-shadow: 10px 10px 20px rgba(0, 0, 0, 0.5);
 }
 ```
 

--- a/curriculum/challenges/english/blocks/review-css-colors/671a90c1cf517678b130419e.md
+++ b/curriculum/challenges/english/blocks/review-css-colors/671a90c1cf517678b130419e.md
@@ -115,7 +115,7 @@ p {
 
 :::
 
-## The `box-shadow` Property and Colors
+## The `box-shadow` Property
 
 - **Definition**: The `box-shadow` property applies one or more shadows around an element.
 - **Offset Values**: You must specify horizontal (`offset-x`) and vertical (`offset-y`) values. Positive `offset-x` moves the shadow to the right, while negative values move it to the left. Positive `offset-y` moves the shadow down, while negative values move it up. If a value is `0`, you do not need to include a unit.

--- a/curriculum/challenges/english/blocks/review-css-colors/671a90c1cf517678b130419e.md
+++ b/curriculum/challenges/english/blocks/review-css-colors/671a90c1cf517678b130419e.md
@@ -115,6 +115,33 @@ p {
 
 :::
 
+## The `box-shadow` Property and Colors
+
+- **Definition**: The `box-shadow` property applies one or more shadows around an element’s box.
+- **Color in Shadows**: The shadow color can be defined using named colors, hex values, `rgb()`, `rgba()`, `hsl()`, or `hsla()`.
+- **Transparency**: Using `rgba()` or `hsla()` allows you to control the shadow’s transparency with an alpha value.
+- **Blur Effect**: The blur radius controls how soft the shadow appears.
+
+### Example
+
+:::interactive_editor
+
+```html
+<link rel="stylesheet" href="styles.css">
+<div class="shadow-box">Shadow Color Example</div>
+```
+
+```css
+.shadow-box {
+  width: 200px;
+  padding: 20px;
+  background-color: lightblue;
+  box-shadow: 0 0 20px rgba(0, 0, 0, 0.5);
+}
+```
+
+:::
+
 ## Linear and Radial Gradients 
 
 - **Linear Gradients**: These gradients create a gradual blend between colors along a straight line. You can control the direction of this line using keywords like `to top`, `to right`, `to bottom right`, or angles like `45deg`. You can use any valid CSS color and as many color stops as you would like.

--- a/curriculum/challenges/english/blocks/review-css/671a9a0a140c2b9d6a75629f.md
+++ b/curriculum/challenges/english/blocks/review-css/671a9a0a140c2b9d6a75629f.md
@@ -373,6 +373,41 @@ Review the concepts below to prepare for the upcoming exam.
 - **Blur Radius**: The blur radius is optional but will make the shadow look a lot smoother and more subtle. The default value of the radius blur is zero. The higher the value, the bigger the blur, which means that the shadow becomes lighter.
 - **Applying Multiple Text Shadows**: The text can have more than one shadow. The shadows will be applied in layers, from front to back, with the first shadow at the top.
 
+## `box-shadow` Property
+
+- **Definition**: The `box-shadow` property applies one or more shadows around an element.
+- **Offset Values**: You must specify horizontal (`offset-x`) and vertical (`offset-y`) values. Positive `offset-x` moves the shadow to the right, while negative values move it to the left. Positive `offset-y` moves the shadow down, while negative values move it up. If a value is `0`, you do not need to include a unit.
+- **Blur Radius**: This optional value controls how blurry the shadow appears. If not included, it defaults to `0`, which creates sharp edges. The higher the value, the softer the shadow.
+- **Spread Radius**: This optional value controls how much the shadow expands or shrinks. If not included, it defaults to `0`.
+- **Shadow Color**: You can specify the color using named colors, hex values, `rgb()`, `rgba()`, `hsl()`, or `hsla()` functions.
+- **`inset` Keyword**: Adding the `inset` keyword places the shadow inside the element instead of outside.
+- **Applying Multiple Box Shadows**: You can apply multiple shadows by separating them with commas. Shadows are layered from front to back.
+
+### Syntax
+
+```css
+box-shadow: offset-x offset-y blur-radius spread-radius color;
+```
+
+:::interactive_editor
+
+```html
+<div class="shadow-box">Shadow Example</div>
+
+<style>
+.shadow-box {
+  width: 200px;
+  padding: 20px;
+  margin: 20px;
+  background-color: lightblue;
+  text-align: center;
+  box-shadow: 10px 10px 20px rgba(0, 0, 0, 0.4);
+}
+</style>
+```
+
+:::
+
 ## Color Contrast Tools
 
 - **WebAIM's Color Contrast Checker**: This online tool allows you to input the foreground and background colors of your design and instantly see if they meet the Web Content Accessibility Guidelines (WCAG) standards. 

--- a/curriculum/challenges/english/blocks/review-css/671a9a0a140c2b9d6a75629f.md
+++ b/curriculum/challenges/english/blocks/review-css/671a9a0a140c2b9d6a75629f.md
@@ -217,7 +217,42 @@ Review the concepts below to prepare for the upcoming exam.
 - **`rgba()` Function**: This function adds a fourth value —alpha— that controls the transparency of the color. 
 - **`hsl()` Function**: HSL stands for Hue, Saturation, and Lightness — three key components that define a color. 
 - **`hsla()` Function**: This function adds a fourth value — alpha — that controls the opacity of the color.
-- **Hexadecimal**: A hex code (short for hexadecimal code) is a six-character string used to represent colors in the RGB color model. The "hex" refers to the base-16 numbering system, which uses digits 0 to 9 and letters A to F. 
+- **Hexadecimal**: A hex code (short for hexadecimal code) is a six-character string used to represent colors in the RGB color model. The "hex" refers to the base-16 numbering system, which uses digits 0 to 9 and letters A to F.
+
+## `box-shadow` Property
+
+- **Definition**: The `box-shadow` property applies one or more shadows around an element.
+- **Offset Values**: You must specify horizontal (`offset-x`) and vertical (`offset-y`) values. Positive `offset-x` moves the shadow to the right, while negative values move it to the left. Positive `offset-y` moves the shadow down, while negative values move it up. If a value is `0`, you do not need to include a unit.
+- **Blur Radius**: This optional value controls how blurry the shadow appears. If not included, it defaults to `0`, which creates sharp edges. The higher the value, the softer the shadow.
+- **Spread Radius**: This optional value controls how much the shadow expands or shrinks. If not included, it defaults to `0`.
+- **Shadow Color**: You can specify the color using named colors, hex values, `rgb()`, `rgba()`, `hsl()`, or `hsla()` functions.
+- **`inset` Keyword**: Adding the `inset` keyword places the shadow inside the element instead of outside.
+- **Applying Multiple Box Shadows**: You can apply multiple shadows by separating them with commas. Shadows are layered from front to back.
+
+### Syntax
+
+```css
+box-shadow: offset-x offset-y blur-radius spread-radius color;
+```
+
+:::interactive_editor
+
+```html
+<div class="shadow-box">Shadow Example</div>
+
+<style>
+.shadow-box {
+  width: 200px;
+  padding: 20px;
+  margin: 20px;
+  background-color: lightblue;
+  text-align: center;
+  box-shadow: 10px 10px 20px rgba(0, 0, 0, 0.4);
+}
+</style>
+```
+
+:::
 
 ## Linear and Radial Gradients 
 
@@ -372,41 +407,6 @@ Review the concepts below to prepare for the upcoming exam.
 - **Shadow Color**: You can also customize the color of the shadow by specifying this value before or after the offset. If the color is not specified, the browser will determine the color automatically, so it's usually best to set it explicitly.
 - **Blur Radius**: The blur radius is optional but will make the shadow look a lot smoother and more subtle. The default value of the radius blur is zero. The higher the value, the bigger the blur, which means that the shadow becomes lighter.
 - **Applying Multiple Text Shadows**: The text can have more than one shadow. The shadows will be applied in layers, from front to back, with the first shadow at the top.
-
-## `box-shadow` Property
-
-- **Definition**: The `box-shadow` property applies one or more shadows around an element.
-- **Offset Values**: You must specify horizontal (`offset-x`) and vertical (`offset-y`) values. Positive `offset-x` moves the shadow to the right, while negative values move it to the left. Positive `offset-y` moves the shadow down, while negative values move it up. If a value is `0`, you do not need to include a unit.
-- **Blur Radius**: This optional value controls how blurry the shadow appears. If not included, it defaults to `0`, which creates sharp edges. The higher the value, the softer the shadow.
-- **Spread Radius**: This optional value controls how much the shadow expands or shrinks. If not included, it defaults to `0`.
-- **Shadow Color**: You can specify the color using named colors, hex values, `rgb()`, `rgba()`, `hsl()`, or `hsla()` functions.
-- **`inset` Keyword**: Adding the `inset` keyword places the shadow inside the element instead of outside.
-- **Applying Multiple Box Shadows**: You can apply multiple shadows by separating them with commas. Shadows are layered from front to back.
-
-### Syntax
-
-```css
-box-shadow: offset-x offset-y blur-radius spread-radius color;
-```
-
-:::interactive_editor
-
-```html
-<div class="shadow-box">Shadow Example</div>
-
-<style>
-.shadow-box {
-  width: 200px;
-  padding: 20px;
-  margin: 20px;
-  background-color: lightblue;
-  text-align: center;
-  box-shadow: 10px 10px 20px rgba(0, 0, 0, 0.4);
-}
-</style>
-```
-
-:::
 
 ## Color Contrast Tools
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.


Closes #65874

This PR adds the missing `box-shadow` property to the CSS chapter review and CSS colors review