### PR TITLE
refactor: use pre-built curriculum when starting client

### DIFF
--- a/api/src/utils/get-challenges.ts
+++ b/api/src/utils/get-challenges.ts
@@ -1,18 +1,7 @@
-// TODO: keeping curriculum in memory is handy if we want to field requests that
-// need to 'query' the curriculum, but if we force the client to handle
-// redirectToCurrentChallenge and, instead, only report the current challenge id
-// via the user object, then we should *not* store this so it can be garbage
-// collected.
-import { readFileSync } from 'fs';
-import { fileURLToPath } from 'node:url';
-import { join, dirname } from 'path';
+import { getGeneratedCurriculum } from '@freecodecamp/curriculum/file-handler';
 
-const CURRICULUM_PATH = '../../../curriculum/generated/curriculum.json';
-const __dirname = dirname(fileURLToPath(import.meta.url));
 // Curriculum is read using fs, because it is too large for VSCode's LSP to handle type inference which causes annoying behavior.
-const curriculum = JSON.parse(
-  readFileSync(join(__dirname, CURRICULUM_PATH), 'utf-8')
-) as Curriculum;
+const curriculum = (await getGeneratedCurriculum()) as Curriculum;
 
 interface Challenge {
   id: string;

--- a/api/src/utils/get-challenges.ts
+++ b/api/src/utils/get-challenges.ts
@@ -1,7 +1,18 @@
-import { getGeneratedCurriculum } from '@freecodecamp/curriculum/file-handler';
+// TODO: keeping curriculum in memory is handy if we want to field requests that
+// need to 'query' the curriculum, but if we force the client to handle
+// redirectToCurrentChallenge and, instead, only report the current challenge id
+// via the user object, then we should *not* store this so it can be garbage
+// collected.
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'node:url';
+import { join, dirname } from 'path';
 
+const CURRICULUM_PATH = '../../../curriculum/generated/curriculum.json';
+const __dirname = dirname(fileURLToPath(import.meta.url));
 // Curriculum is read using fs, because it is too large for VSCode's LSP to handle type inference which causes annoying behavior.
-const curriculum = (await getGeneratedCurriculum()) as Curriculum;
+const curriculum = JSON.parse(
+  readFileSync(join(__dirname, CURRICULUM_PATH), 'utf-8')
+) as Curriculum;
 
 interface Challenge {
   id: string;

--- a/client/utils/build-challenges.js
+++ b/client/utils/build-challenges.js
@@ -11,13 +11,12 @@ const {
   getContentDir,
   getBlockStructure,
   getSuperblockStructure,
-  CURRICULUM_DIR
+  getGeneratedCurriculum
 } = require('@freecodecamp/curriculum/file-handler');
 const {
   transformSuperBlock
 } = require('@freecodecamp/curriculum/build-superblock');
 const { getSuperOrder } = require('@freecodecamp/curriculum/super-order');
-const { readFile } = require('fs/promises');
 
 const curriculumLocale = process.env.CURRICULUM_LOCALE || 'english';
 
@@ -70,12 +69,7 @@ exports.replaceChallengeNodes = () => {
 };
 
 exports.buildChallenges = async function buildChallenges() {
-  const curriculum = JSON.parse(
-    await readFile(
-      path.resolve(CURRICULUM_DIR, 'generated', 'curriculum.json'),
-      'utf-8'
-    )
-  );
+  const curriculum = await getGeneratedCurriculum();
   const superBlocks = Object.keys(curriculum);
   const blocks = superBlocks
     .map(superBlock => curriculum[superBlock].blocks)

--- a/client/utils/build-challenges.js
+++ b/client/utils/build-challenges.js
@@ -3,10 +3,6 @@ const path = require('path');
 const _ = require('lodash');
 
 const {
-  getChallengesForLang
-} = require('@freecodecamp/curriculum/get-challenges');
-
-const {
   getBlockCreator,
   getSuperblocks,
   superBlockToFilename
@@ -14,12 +10,14 @@ const {
 const {
   getContentDir,
   getBlockStructure,
-  getSuperblockStructure
+  getSuperblockStructure,
+  CURRICULUM_DIR
 } = require('@freecodecamp/curriculum/file-handler');
 const {
   transformSuperBlock
 } = require('@freecodecamp/curriculum/build-superblock');
 const { getSuperOrder } = require('@freecodecamp/curriculum/super-order');
+const { readFile } = require('fs/promises');
 
 const curriculumLocale = process.env.CURRICULUM_LOCALE || 'english';
 
@@ -72,7 +70,12 @@ exports.replaceChallengeNodes = () => {
 };
 
 exports.buildChallenges = async function buildChallenges() {
-  const curriculum = await getChallengesForLang(curriculumLocale);
+  const curriculum = JSON.parse(
+    await readFile(
+      path.resolve(CURRICULUM_DIR, 'generated', 'curriculum.json'),
+      'utf-8'
+    )
+  );
   const superBlocks = Object.keys(curriculum);
   const blocks = superBlocks
     .map(superBlock => curriculum[superBlock].blocks)

--- a/client/utils/build-challenges.js
+++ b/client/utils/build-challenges.js
@@ -11,12 +11,13 @@ const {
   getContentDir,
   getBlockStructure,
   getSuperblockStructure,
-  getGeneratedCurriculum
+  CURRICULUM_DIR
 } = require('@freecodecamp/curriculum/file-handler');
 const {
   transformSuperBlock
 } = require('@freecodecamp/curriculum/build-superblock');
 const { getSuperOrder } = require('@freecodecamp/curriculum/super-order');
+const { readFile } = require('fs/promises');
 
 const curriculumLocale = process.env.CURRICULUM_LOCALE || 'english';
 
@@ -69,7 +70,12 @@ exports.replaceChallengeNodes = () => {
 };
 
 exports.buildChallenges = async function buildChallenges() {
-  const curriculum = await getGeneratedCurriculum();
+  const curriculum = JSON.parse(
+    await readFile(
+      path.resolve(CURRICULUM_DIR, 'generated', 'curriculum.json'),
+      'utf-8'
+    )
+  );
   const superBlocks = Object.keys(curriculum);
   const blocks = superBlocks
     .map(superBlock => curriculum[superBlock].blocks)

--- a/curriculum/src/config.ts
+++ b/curriculum/src/config.ts
@@ -1,4 +1,5 @@
-import { resolve } from 'path';
+import { resolve } from 'node:path';
+import assert from 'node:assert';
 import { config } from 'dotenv';
 
 import { availableLangs } from '@freecodecamp/shared/config/i18n';
@@ -7,19 +8,14 @@ config({ path: resolve(__dirname, '../../.env') });
 
 const curriculumLangs = availableLangs.curriculum;
 
-// checks that the CURRICULUM_LOCALE exists and is an available language
-export function testedLang() {
-  if (process.env.CURRICULUM_LOCALE) {
-    if (curriculumLangs.includes(process.env.CURRICULUM_LOCALE)) {
-      return process.env.CURRICULUM_LOCALE;
-    } else {
-      throw Error(`${process.env.CURRICULUM_LOCALE} is not a supported language.
-      Before the site can be built, this language needs to be manually approved`);
-    }
-  } else {
-    throw Error('CURRICULUM_LOCALE must be set for testing');
-  }
+function isAllowedLang(lang: string): lang is (typeof curriculumLangs)[number] {
+  return curriculumLangs.includes(lang as (typeof curriculumLangs)[number]);
 }
+
+assert.ok(process.env.CURRICULUM_LOCALE);
+assert.ok(isAllowedLang(process.env.CURRICULUM_LOCALE));
+
+export const CURRICULUM_LOCALE = process.env.CURRICULUM_LOCALE;
 
 export const SHOW_UPCOMING_CHANGES =
   process.env.SHOW_UPCOMING_CHANGES === 'true';

--- a/curriculum/src/file-handler.ts
+++ b/curriculum/src/file-handler.ts
@@ -1,7 +1,7 @@
 import { dirname, resolve } from 'node:path';
 import assert from 'node:assert';
 import { existsSync, readFileSync } from 'node:fs';
-import { mkdir, writeFile } from 'node:fs/promises';
+import { mkdir, writeFile, readFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import debug from 'debug';
 
@@ -26,11 +26,16 @@ if (typeof __dirname !== 'undefined') {
   __dirnameCompat = dirname(fileURLToPath(metaUrl));
 }
 
-export const CURRICULUM_DIR = resolve(__dirnameCompat, '..');
+const CURRICULUM_DIR = resolve(__dirnameCompat, '..');
 const I18N_CURRICULUM_DIR = resolve(
   CURRICULUM_DIR,
   'i18n-curriculum',
   'curriculum'
+);
+const GENERATED_CURRICULUM_DIR = resolve(CURRICULUM_DIR, 'generated');
+const GENERATED_CURRICULUM_FILEPATH = resolve(
+  GENERATED_CURRICULUM_DIR,
+  'curriculum.json'
 );
 const STRUCTURE_DIR = resolve(CURRICULUM_DIR, 'structure');
 const BLOCK_STRUCTURE_DIR = resolve(STRUCTURE_DIR, 'blocks');
@@ -232,6 +237,15 @@ export function getSuperblockStructure(superblockFilename: string) {
 
 export function getSuperblockStructurePath(superblockFilename: string) {
   return resolve(STRUCTURE_DIR, 'superblocks', `${superblockFilename}.json`);
+}
+
+export async function getGeneratedCurriculum() {
+  return JSON.parse(await readFile(GENERATED_CURRICULUM_FILEPATH, 'utf8'));
+}
+
+export async function writeGeneratedCurriculum(curriculum: unknown) {
+  await mkdir(GENERATED_CURRICULUM_DIR, { recursive: true });
+  return writeFile(GENERATED_CURRICULUM_FILEPATH, JSON.stringify(curriculum));
 }
 
 /**

--- a/curriculum/src/file-handler.ts
+++ b/curriculum/src/file-handler.ts
@@ -1,7 +1,7 @@
 import { dirname, resolve } from 'node:path';
 import assert from 'node:assert';
 import { existsSync, readFileSync } from 'node:fs';
-import { mkdir, writeFile, readFile } from 'node:fs/promises';
+import { mkdir, writeFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import debug from 'debug';
 
@@ -26,16 +26,11 @@ if (typeof __dirname !== 'undefined') {
   __dirnameCompat = dirname(fileURLToPath(metaUrl));
 }
 
-const CURRICULUM_DIR = resolve(__dirnameCompat, '..');
+export const CURRICULUM_DIR = resolve(__dirnameCompat, '..');
 const I18N_CURRICULUM_DIR = resolve(
   CURRICULUM_DIR,
   'i18n-curriculum',
   'curriculum'
-);
-const GENERATED_CURRICULUM_DIR = resolve(CURRICULUM_DIR, 'generated');
-const GENERATED_CURRICULUM_FILEPATH = resolve(
-  GENERATED_CURRICULUM_DIR,
-  'curriculum.json'
 );
 const STRUCTURE_DIR = resolve(CURRICULUM_DIR, 'structure');
 const BLOCK_STRUCTURE_DIR = resolve(STRUCTURE_DIR, 'blocks');
@@ -237,15 +232,6 @@ export function getSuperblockStructure(superblockFilename: string) {
 
 export function getSuperblockStructurePath(superblockFilename: string) {
   return resolve(STRUCTURE_DIR, 'superblocks', `${superblockFilename}.json`);
-}
-
-export async function getGeneratedCurriculum() {
-  return JSON.parse(await readFile(GENERATED_CURRICULUM_FILEPATH, 'utf8'));
-}
-
-export async function writeGeneratedCurriculum(curriculum: unknown) {
-  await mkdir(GENERATED_CURRICULUM_DIR, { recursive: true });
-  return writeFile(GENERATED_CURRICULUM_FILEPATH, JSON.stringify(curriculum));
 }
 
 /**

--- a/curriculum/src/file-handler.ts
+++ b/curriculum/src/file-handler.ts
@@ -26,7 +26,7 @@ if (typeof __dirname !== 'undefined') {
   __dirnameCompat = dirname(fileURLToPath(metaUrl));
 }
 
-const CURRICULUM_DIR = resolve(__dirnameCompat, '..');
+export const CURRICULUM_DIR = resolve(__dirnameCompat, '..');
 const I18N_CURRICULUM_DIR = resolve(
   CURRICULUM_DIR,
   'i18n-curriculum',

--- a/curriculum/src/generate/build-curriculum.ts
+++ b/curriculum/src/generate/build-curriculum.ts
@@ -1,5 +1,14 @@
+import fs from 'fs';
+import path from 'path';
+
 import { getChallengesForLang } from '../get-challenges';
 import { CURRICULUM_LOCALE } from '../config';
-import { writeGeneratedCurriculum } from '../file-handler';
 
-void getChallengesForLang(CURRICULUM_LOCALE).then(writeGeneratedCurriculum);
+const globalConfigPath = path.resolve(__dirname, '../../generated/');
+
+void getChallengesForLang(CURRICULUM_LOCALE)
+  .then(JSON.stringify)
+  .then(json => {
+    fs.mkdirSync(globalConfigPath, { recursive: true });
+    fs.writeFileSync(`${globalConfigPath}/curriculum.json`, json);
+  });

--- a/curriculum/src/generate/build-curriculum.ts
+++ b/curriculum/src/generate/build-curriculum.ts
@@ -2,10 +2,18 @@ import fs from 'fs';
 import path from 'path';
 
 import { getChallengesForLang } from '../get-challenges';
+import assert from 'assert';
 
 const globalConfigPath = path.resolve(__dirname, '../../generated/');
 
-void getChallengesForLang('english')
+const curriculumLocale = process.env.CURRICULUM_LOCALE;
+
+assert(
+  curriculumLocale,
+  'CURRICULUM_LOCALE environment variable is required to build curriculum'
+);
+
+void getChallengesForLang(curriculumLocale)
   .then(JSON.stringify)
   .then(json => {
     fs.mkdirSync(globalConfigPath, { recursive: true });

--- a/curriculum/src/generate/build-curriculum.ts
+++ b/curriculum/src/generate/build-curriculum.ts
@@ -1,14 +1,5 @@
-import fs from 'fs';
-import path from 'path';
-
 import { getChallengesForLang } from '../get-challenges';
 import { CURRICULUM_LOCALE } from '../config';
+import { writeGeneratedCurriculum } from '../file-handler';
 
-const globalConfigPath = path.resolve(__dirname, '../../generated/');
-
-void getChallengesForLang(CURRICULUM_LOCALE)
-  .then(JSON.stringify)
-  .then(json => {
-    fs.mkdirSync(globalConfigPath, { recursive: true });
-    fs.writeFileSync(`${globalConfigPath}/curriculum.json`, json);
-  });
+void getChallengesForLang(CURRICULUM_LOCALE).then(writeGeneratedCurriculum);

--- a/curriculum/src/generate/build-curriculum.ts
+++ b/curriculum/src/generate/build-curriculum.ts
@@ -2,18 +2,11 @@ import fs from 'fs';
 import path from 'path';
 
 import { getChallengesForLang } from '../get-challenges';
-import assert from 'assert';
+import { CURRICULUM_LOCALE } from '../config';
 
 const globalConfigPath = path.resolve(__dirname, '../../generated/');
 
-const curriculumLocale = process.env.CURRICULUM_LOCALE;
-
-assert(
-  curriculumLocale,
-  'CURRICULUM_LOCALE environment variable is required to build curriculum'
-);
-
-void getChallengesForLang(curriculumLocale)
+void getChallengesForLang(CURRICULUM_LOCALE)
   .then(JSON.stringify)
   .then(json => {
     fs.mkdirSync(globalConfigPath, { recursive: true });

--- a/curriculum/src/lint-localized.ts
+++ b/curriculum/src/lint-localized.ts
@@ -1,8 +1,8 @@
 import path from 'node:path';
 import { configure } from '@freecodecamp/challenge-linter';
-import { testedLang } from './config';
+import { CURRICULUM_LOCALE } from './config';
 
 const CONFIG_PATH = path.resolve(__dirname, '../challenges/.markdownlint.yaml');
 const { lintAll } = configure(CONFIG_PATH);
 
-lintAll(`challenges/${testedLang()}/**/*.md`);
+lintAll(`challenges/${CURRICULUM_LOCALE}/**/*.md`);

--- a/curriculum/src/test/daily-challenges.test.js
+++ b/curriculum/src/test/daily-challenges.test.js
@@ -4,12 +4,11 @@ vi.stubEnv('SHOW_UPCOMING_CHANGES', 'true');
 
 // We need to use dynamic imports here to ensure the environment variable is set
 // before the module is loaded.
-const { testedLang } = await import('../config.js');
+const { CURRICULUM_LOCALE } = await import('../config.js');
 const { getChallenges } = await import('./test-challenges.js');
 
 describe('Daily Coding Challenges', async () => {
-  const lang = testedLang();
-  const challenges = await getChallenges(lang, {
+  const challenges = await getChallenges(CURRICULUM_LOCALE, {
     superBlock: 'dev-playground'
   });
 
@@ -57,7 +56,7 @@ describe('Daily Coding Challenges', async () => {
       }
 
       // skip these for non-English for now.
-      if (lang !== 'english') continue;
+      if (CURRICULUM_LOCALE !== 'english') continue;
 
       if (jsChallenge.title !== pyChallenge.title) {
         errors.push(

--- a/curriculum/src/test/test-challenges.js
+++ b/curriculum/src/test/test-challenges.js
@@ -16,7 +16,7 @@ import { challengeSchemaValidator } from '../../schema/challenge-schema.js';
 import { curriculumSchemaValidator } from '../../schema/curriculum-schema.js';
 import { validateMetaSchema } from '../../schema/meta-schema.js';
 import { getBlockStructure } from '../file-handler.js';
-import { FCC_CHALLENGE_ID, testedLang } from '../config.js';
+import { FCC_CHALLENGE_ID, CURRICULUM_LOCALE } from '../config.js';
 import ChallengeTitles from './utils/challenge-titles.js';
 import MongoIds from './utils/mongo-ids.js';
 import createPseudoWorker from './utils/pseudo-worker.js';
@@ -79,8 +79,7 @@ async function newPageContext() {
 }
 
 export async function defineTestsForBlock(testFilter) {
-  const lang = testedLang();
-  const challenges = await getChallenges(lang, testFilter);
+  const challenges = await getChallenges(CURRICULUM_LOCALE, testFilter);
   const nonCertificationChallenges = challenges.filter(
     ({ challengeType }) => challengeType !== 7
   );
@@ -107,7 +106,7 @@ export async function defineTestsForBlock(testFilter) {
     }
   }
 
-  const challengeData = { meta, challenges, lang };
+  const challengeData = { meta, challenges, lang: CURRICULUM_LOCALE };
 
   describe('Check challenges', async () => {
     beforeAll(async () => {

--- a/curriculum/turbo.json
+++ b/curriculum/turbo.json
@@ -4,7 +4,7 @@
   "tasks": {
     "build": {
       "outputs": ["dist/**", "generated/**"],
-      "env": ["FCC_*", "SHOW_UPCOMING_CHANGES"]
+      "env": ["FCC_*", "SHOW_UPCOMING_CHANGES", "CURRICULUM_LOCALE"]
     },
     "test": {
       "passThroughEnv": ["VITEST_POOL_ID", "PUPPETEER_WS_ENDPOINT"],

--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -26,6 +26,8 @@ RUN cd api && pnpm prisma generate
 # following env vars.
 ARG SHOW_UPCOMING_CHANGES=false
 ENV SHOW_UPCOMING_CHANGES=$SHOW_UPCOMING_CHANGES
+ARG CURRICULUM_LOCALE=english
+ENV CURRICULUM_LOCALE=$CURRICULUM_LOCALE
 
 RUN pnpm turbo -F=@freecodecamp/api build
 

--- a/tools/challenge-helper-scripts/turbo.json
+++ b/tools/challenge-helper-scripts/turbo.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://v2-8-7.turborepo.dev/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "test": {
+      "env": ["CURRICULUM_LOCALE", "SHOW_UPCOMING_CHANGES"]
+    }
+  }
+}


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This is a fairly large speedup since we're already building the curriculum

<!-- Feel free to add any additional description of changes below this line -->
