### PR TITLE
fix(client): prevent undefined.txt filename for daily coding challenge download

### DIFF
--- a/client/src/client-only-routes/show-daily-coding-challenge.tsx
+++ b/client/src/client-only-routes/show-daily-coding-challenge.tsx
@@ -43,14 +43,16 @@ function formatChallengeData({
   python
 }: DailyCodingChallengeFromDb) {
   const baseChallengeProps = {
-    date,
-    id,
-    challengeNumber,
-    title,
-    description: formatDescription(description),
-    superBlock: 'daily-coding-challenge',
-    block: 'daily-coding-challenge',
-    usesMultifileEditor: true,
+  date,
+  id,
+  challengeNumber,
+  title,
+  dashedName: `challenge-${challengeNumber}`,
+  description: formatDescription(description),
+  superBlock: 'daily-coding-challenge',
+  block: 'daily-coding-challenge',
+  usesMultifileEditor: true,
+
 
     // props to satisfy the show classic component
     instructions: '',

--- a/client/src/client-only-routes/show-daily-coding-challenge.tsx
+++ b/client/src/client-only-routes/show-daily-coding-challenge.tsx
@@ -66,18 +66,18 @@ function formatChallengeData({
   };
 
   const pageContext = {
-    challengeMeta: {
-      id,
-      superBlock: 'daily-coding-challenge',
-      block: 'daily-coding-challenge',
-      disableLoopProtectTests: true,
+  challengeMeta: {
+    id,
+    dashedName: `challenge-${challengeNumber}`,
+    superBlock: 'daily-coding-challenge',
+    block: 'daily-coding-challenge',
+    disableLoopProtectTests: true,
+    isFirstStep: false,
+    nextChallegePath: undefined,
+    prevChallengePath: undefined,
+    disableLoopProtectPreview: false
+  },
 
-      // props to satisfy the show classic component
-      isFirstStep: false,
-      nextChallegePath: undefined,
-      prevChallengePath: undefined,
-      disableLoopProtectPreview: false
-    },
 
     // props to satisfy the show classic component
     projectPreview: {


### PR DESCRIPTION
Fixes #62018

## Description
Daily Coding Challenge downloads were being saved as `undefined.txt` because `dashedName` was missing from the daily challenge metadata.

## Changes
- Added `dashedName` to `baseChallengeProps`
- Added `dashedName` to `challengeMeta`
- Ensures downloaded solution filename is `challenge-{number}.txt`

---

### Checklist:

- [x] I have read and followed the contribution guidelines.
- [x] I have read and followed the how to open a pull request guide.
- [x] My pull request targets the main branch.
- [x] I have tested these changes locally.
