### PR TITLE
fix(curriculum): add UTC clarification note to odd or even day challenge

### DIFF
--- a/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/696655d24b614176d4c9b78d.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/696655d24b614176d4c9b78d.md
@@ -14,6 +14,8 @@ Given a timestamp (number of milliseconds since the Unix epoch), return:
 
 For example, given `1769472000000`, a timestamp for January 27th, 2026, return `"odd"` because the day number (`27`) is an odd number.
 
+Note: The timestamp is in milliseconds and you should use the date in the UTC timezone, not in your local time.
+
 # --hints--
 
 `oddOrEvenDay(1769472000000)` should return `"odd"`.

--- a/curriculum/challenges/english/blocks/daily-coding-challenges-python/696655d24b614176d4c9b78d.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-python/696655d24b614176d4c9b78d.md
@@ -14,6 +14,8 @@ Given a timestamp (number of milliseconds since the Unix epoch), return:
 
 For example, given `1769472000000`, a timestamp for January 27th, 2026, return `"odd"` because the day number (`27`) is an odd number.
 
+Note: The timestamp is in milliseconds and should be interpreted in `"UTC (Unix time)"`, not your local timezone.
+
 # --hints--
 
 `odd_or_even_day(1769472000000)` should return `"odd"`.

--- a/curriculum/challenges/english/blocks/daily-coding-challenges-python/696655d24b614176d4c9b78d.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-python/696655d24b614176d4c9b78d.md
@@ -14,7 +14,7 @@ Given a timestamp (number of milliseconds since the Unix epoch), return:
 
 For example, given `1769472000000`, a timestamp for January 27th, 2026, return `"odd"` because the day number (`27`) is an odd number.
 
-Note: The timestamp is in milliseconds and should be interpreted in `"UTC (Unix time)"`, not your local timezone.
+Note: The timestamp is in milliseconds and you should use the date in the UTC timezone, not in your local time.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.


Closes #65521

Adds a note clarifying that the timestamp should be interpreted in UTC to avoid timezone-related confusion.