### PR TITLE
fix(curriculum): fix typo in conversation challenge explanation

### DIFF
--- a/curriculum/challenges/english/blocks/learn-how-to-manage-a-conversation/67e6d7b750d7adc99809aea3.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-manage-a-conversation/67e6d7b750d7adc99809aea3.md
@@ -88,4 +88,4 @@ Open the application, switch between views, and observe the disappearing element
 
 # --explanation--
 
-There is a sequence of actions you can to reproduce the bug. You can find them on the `Steps to Reproduce` section. Read these steps and you will be able to correctly answer this question.
+There is a sequence of actions you can follow to reproduce the bug. You can find them on the `Steps to Reproduce` section. Read these steps and you will be able to correctly answer this question.


### PR DESCRIPTION
Fix typo in conversation challenge explanation.

This PR supersedes #65892.

Closes #65891