### PR TITLE
fix(curriculum): disallow flexbox usage in Colored Boxes lab

### DIFF
--- a/curriculum/challenges/english/blocks/lab-colored-boxes/66f3f6eb66ea9dc41cdc30df.md
+++ b/curriculum/challenges/english/blocks/lab-colored-boxes/66f3f6eb66ea9dc41cdc30df.md
@@ -115,6 +115,13 @@ The `.color5` element should have a background color set.
 assert.isNotEmpty(new __helpers.CSSHelp(document).getStyle('.color5')?.getPropVal('background-color', true));
 ```
 
+You should not use `flexbox` for this lab.
+
+```js
+const flexRegex = /display\s*:\s*(inline-)?flex/i;
+assert.isFalse(flexRegex.test(__helpers.removeCssComments(code)));
+```
+
 # --seed--
 
 ## --seed-contents--
@@ -164,12 +171,10 @@ assert.isNotEmpty(new __helpers.CSSHelp(document).getStyle('.color5')?.getPropVa
 ```css
 body {
     font-family: Arial, sans-serif;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
     margin: 0;
     padding: 20px;
     background-color: #f4f4f4;
+    text-align: center;
 }
 
 h1 {
@@ -182,12 +187,10 @@ h1 {
     gap: 10px;
     width: 100%;
     max-width: 800px;
+    margin: 0 auto;
 }
 
 .color-box {
-    display: flex;
-    justify-content: center;
-    align-items: center;
     font-weight: bold;
     border-radius: 8px;
     text-align: center;


### PR DESCRIPTION
## Checklist

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #65150

## Summary

- Added a final test that disallows `display: flex` and `display: inline-flex` in the CSS, checking the raw source code via `__helpers.removeCssComments(code)`.
- Updated the solution CSS to remove all flexbox usage:
  - `body`: replaced `display: flex; flex-direction: column; align-items: center` with `text-align: center`
  - `.color-grid`: added `margin: 0 auto` for centering
  - `.color-box`: removed unnecessary `display: flex; justify-content: center; align-items: center`