### PR TITLE
fix(ui): preserve navbar styling in Windows High Contrast Mode

### DIFF
--- a/client/src/components/Header/components/universal-nav.css
+++ b/client/src/components/Header/components/universal-nav.css
@@ -7,6 +7,13 @@
   height: var(--header-height);
   justify-content: space-between;
   padding: 0 5px;
+  forced-color-adjust: none;
+}
+
+@media (forced-colors) {
+  .universal-nav {
+    background-color: var(--gray-90);
+  }
 }
 
 @media (min-width: 401px) {


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #58807

## Summary

- Add `forced-color-adjust: none` to `.universal-nav` to prevent the browser from overriding the navbar background color in Windows High Contrast Mode (light theme)
- Add a `@media (forced-colors)` fallback rule that sets the navbar background to `var(--gray-90)`, ensuring the dark navbar remains visible regardless of the user's forced color scheme

## Test Plan

- [x] Enable Windows High Contrast Mode (light theme) and verify the navbar retains its dark background
- [x] Enable Windows High Contrast Mode (dark theme) and verify no regression
- [x] Verify normal (non-high-contrast) mode is unaffected
- [x] Test in Chrome and Edge on Windows