### PR TITLE
fix(ui): simplify challenge archive calendar with tooltip for language details

### DIFF
--- a/client/src/components/daily-coding-challenge/calendar-day.tsx
+++ b/client/src/components/daily-coding-challenge/calendar-day.tsx
@@ -1,11 +1,8 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { Spacer } from '@freecodecamp/ui';
 import { Link } from '../helpers';
 import GreenPass from '../../assets/icons/green-pass';
 import GreenNotCompleted from '../../assets/icons/green-not-completed';
-import JavaScriptIcon from '../../assets/icons/javascript';
-import PythonIcon from '../../assets/icons/python';
 import { formatDisplayDate } from './helpers';
 
 interface CalendarDayProps {
@@ -15,24 +12,6 @@ interface CalendarDayProps {
   completedLanguages?: string[];
   isAvailable?: boolean;
   title?: string;
-}
-
-function Checkmark({ completed }: { completed: boolean }): JSX.Element {
-  return completed ? (
-    <span
-      className='dc-checkmark dc-small-checkmark completed'
-      data-playwright-test-label='calendar-day-completed'
-    >
-      <GreenPass />
-    </span>
-  ) : (
-    <span
-      className='dc-checkmark dc-small-checkmark not-completed'
-      data-playwright-test-label='calendar-day-not-completed'
-    >
-      <GreenNotCompleted />
-    </span>
-  );
 }
 
 function DailyCodingChallengeCalendarDay({
@@ -62,6 +41,12 @@ function DailyCodingChallengeCalendarDay({
       </button>
     );
 
+  const isCompleted = completedLanguages.length > 0;
+  const jsCompleted = completedLanguages.includes('javascript');
+  const pyCompleted = completedLanguages.includes('python');
+
+  const tooltipContent = `JavaScript: ${jsCompleted ? '\u2713' : '\u2717'}<br/>Python: ${pyCompleted ? '\u2713' : '\u2717'}`;
+
   // isAvailable -> render link to challenge
   return (
     <Link
@@ -69,6 +54,8 @@ function DailyCodingChallengeCalendarDay({
       className='calendar-day available'
       data-playwright-test-label='calendar-day'
       aria-label={`${date && formatDisplayDate(date)}`}
+      data-tip={tooltipContent}
+      data-for='calendar-tooltip'
     >
       <span className='calendar-day-number' aria-hidden='true'>
         {dayNumber}
@@ -79,34 +66,20 @@ function DailyCodingChallengeCalendarDay({
       <div className='dc-info'>
         <div className='dc-title'>{title}</div>
 
-        {completedLanguages.length === 2 ? (
-          <span className='dc-checkmark dc-big-checkmark completed'>
-            <span className='dc-spacer'>
-              <Spacer size='s' />
-            </span>
+        {isCompleted ? (
+          <span
+            className='dc-checkmark dc-day-checkmark completed'
+            data-playwright-test-label='calendar-day-completed'
+          >
             <GreenPass />
           </span>
         ) : (
-          <div className='dc-languages'>
-            <hr />
-            <div className='dc-language'>
-              <div className='dc-language-icon'>
-                <JavaScriptIcon />
-              </div>
-              <div className='dc-language-name'>JavaScript</div>
-              <Checkmark
-                completed={completedLanguages.includes('javascript')}
-              />
-            </div>
-
-            <div className='dc-language'>
-              <div className='dc-language-icon'>
-                <PythonIcon />
-              </div>
-              <div className='dc-language-name'>Python</div>
-              <Checkmark completed={completedLanguages.includes('python')} />
-            </div>
-          </div>
+          <span
+            className='dc-checkmark dc-day-checkmark not-completed'
+            data-playwright-test-label='calendar-day-not-completed'
+          >
+            <GreenNotCompleted />
+          </span>
         )}
       </div>
     </Link>

--- a/client/src/components/daily-coding-challenge/calendar.css
+++ b/client/src/components/daily-coding-challenge/calendar.css
@@ -29,7 +29,7 @@
 .calendar-day {
   position: relative;
   padding: 10px 10px 20px;
-  min-height: 200px;
+  min-height: 150px;
   border: 1px solid var(--tertiary-color);
   background-color: var(--primary-background);
   text-decoration: none;
@@ -50,6 +50,7 @@
 .dc-info {
   display: flex;
   flex-direction: column;
+  align-items: center;
   height: 100%;
 }
 
@@ -58,48 +59,16 @@
   text-align: center;
   align-self: center;
   margin-top: 5px;
-  height: 50px;
-  margin-bottom: -5px;
+  margin-bottom: 5px;
 }
 
-.dc-languages {
-  padding: 0 15px;
-}
-
-.dc-language {
-  font-size: 0.8rem;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 10px;
-}
-
-.dc-language-icon {
-  fill: var(--primary-color);
-}
-
-.dc-language-icon svg {
-  width: 25px;
-  height: 25px;
-}
-
-.dc-small-checkmark {
-  position: relative;
-  /* top: -5px; */
-}
-
-.dc-small-checkmark svg {
-  width: 20px;
-  height: 20px;
-}
-
-.dc-big-checkmark {
+.dc-day-checkmark {
   margin: 0 auto;
 }
 
-.dc-big-checkmark svg {
-  width: 50px;
-  height: 50px;
+.dc-day-checkmark svg {
+  width: 35px;
+  height: 35px;
 }
 
 .not-available:hover,
@@ -124,8 +93,6 @@
   color: var(--primary-background);
 }
 
-.available:hover .dc-language-icon svg path,
-.available:active .dc-language-icon svg path,
 .available:hover .completed svg circle,
 .available:active .completed svg circle {
   fill: var(--primary-background);
@@ -145,15 +112,23 @@
 }
 
 .available:hover .dc-title,
-.available:active .dc-title,
-.available:hover .dc-language-name,
-.available:active .dc-language-name {
+.available:active .dc-title {
   color: var(--primary-background);
 }
 
 .available:hover .dc-number,
 .available:active .dc-number {
   color: var(--quaternary-background);
+}
+
+.calendar-day-tooltip {
+  color: var(--primary-color) !important;
+  background-color: var(--primary-background) !important;
+  border: 1px solid var(--primary-color) !important;
+}
+
+.calendar-day-tooltip::after {
+  border-top-color: var(--primary-color) !important;
 }
 
 @media (max-width: 500px) {
@@ -169,20 +144,8 @@
     font-size: 0.8rem;
   }
 
-  .dc-info hr {
-    margin: 10px 0;
-  }
-
   .calendar-day {
-    min-height: 170px;
-  }
-
-  .dc-language {
-    justify-content: center;
-  }
-
-  .dc-language-name {
-    display: none;
+    min-height: 120px;
   }
 }
 
@@ -192,12 +155,11 @@
   }
 
   .calendar-day {
-    min-height: 125px;
+    min-height: 100px;
     padding: 10px;
   }
 
-  .dc-title,
-  .dc-info hr {
+  .dc-title {
     display: none;
   }
 
@@ -207,15 +169,11 @@
     align-items: center;
     height: 80%;
   }
-
-  .dc-spacer {
-    display: none;
-  }
 }
 
 @media (max-width: 815px) {
   .calendar-day {
-    min-height: 100px;
+    min-height: 80px;
     padding: 0;
   }
 
@@ -224,12 +182,8 @@
     padding-right: 5px;
   }
 
-  .dc-languages {
-    padding: 0;
-  }
-
-  .dc-big-checkmark svg {
-    width: 40px;
-    height: 40px;
+  .dc-day-checkmark svg {
+    width: 25px;
+    height: 25px;
   }
 }

--- a/client/src/components/daily-coding-challenge/calendar.tsx
+++ b/client/src/components/daily-coding-challenge/calendar.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
 import { useTranslation } from 'react-i18next';
+import ReactTooltip from 'react-tooltip';
 import { Button, Callout, Container, Col, Row, Spacer } from '@freecodecamp/ui';
 import {
   completedDailyCodingChallengesSelector,
@@ -186,15 +187,13 @@ function DailyCodingChallengeCalendar({
   // we just need to change the month, the year can stay the same
   // because it just rolls over, e.g. (index) 12, 2024 will be Jan, 2025
   const nextMonth = () => {
-    setMonthInfo(
-      m => m && getMonthInfo(m.year, m.index + 1, dailyChallengesMap)
-    );
+    setMonthInfo(m => m && getMonthInfo(m.year, m.index + 1, dailyChallengesMap));
+    setTimeout(() => ReactTooltip.rebuild(), 0);
   };
 
   const prevMonth = () => {
-    setMonthInfo(
-      m => m && getMonthInfo(m.year, m.index - 1, dailyChallengesMap)
-    );
+    setMonthInfo(m => m && getMonthInfo(m.year, m.index - 1, dailyChallengesMap));
+    setTimeout(() => ReactTooltip.rebuild(), 0);
   };
 
   const hasOlderChallenges = (
@@ -304,6 +303,12 @@ function DailyCodingChallengeCalendar({
 
       <Spacer size='s' />
       <div className='calendar-grid'>{monthInfo.days}</div>
+      <ReactTooltip
+        id='calendar-tooltip'
+        className='calendar-day-tooltip'
+        effect='solid'
+        html={true}
+      />
       <Spacer size='l' />
 
       {!isSignedIn && (

--- a/e2e/daily-coding-challenge.spec.ts
+++ b/e2e/daily-coding-challenge.spec.ts
@@ -251,6 +251,6 @@ test.describe('Daily Coding Challenge Archive', () => {
 
     await expect(page.getByTestId('calendar-day-completed')).toHaveCount(1);
 
-    await expect(page.getByTestId('calendar-day-not-completed')).toHaveCount(3);
+    await expect(page.getByTestId('calendar-day-not-completed')).toHaveCount(1);
   });
 });


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #63944

## Summary

- Replaced per-language checkmarks and icons in each calendar day cell with a single completion checkmark (completed if at least one language is done, not completed otherwise)
- Moved per-language completion details (JavaScript/Python status) into a hover tooltip, following the existing pattern from the profile activity calendar (`react-tooltip`)
- Reduced calendar day cell `min-height` values since the cells no longer contain inline language rows
- Removed unused CSS classes for language icons, language names, and per-language checkmarks
- Updated e2e test to match the new single-checkmark-per-day behavior

This addresses the maintainer-agreed approach from #63944:
> - keep the checkmarks
> - hide certain details in a tooltip

The tooltip follows the same `react-tooltip` pattern already used in `client/src/components/profile/components/heat-map.tsx` and styled consistently with the existing `react-tooltip` theme.

## Test Plan

- [x] Verify calendar days show a single checkmark (green pass if any language completed, empty circle if none)
- [x] Hover over a calendar day cell and confirm the tooltip shows per-language completion status
- [x] Verify tooltip appears/disappears correctly when navigating between months
- [x] Check responsive behavior at different breakpoints
- [x] Run existing e2e tests