### PR TITLE
fix(client): link MS Learn timeline View button to user profile

### DIFF
--- a/client/src/components/solution-display-widget/index.tsx
+++ b/client/src/components/solution-display-widget/index.tsx
@@ -16,6 +16,29 @@ interface Props {
   displayContext: 'timeline' | 'settings' | 'certification';
 }
 
+// MS Learn trophy solutions are stored as API URLs that return JSON.
+// Extract the username and link to their profile achievements page instead.
+function getMsLearnProfileUrl(
+  solution: string | null | undefined
+): string | null {
+  if (!solution) return null;
+  try {
+    const url = new URL(solution);
+    if (
+      url.hostname === 'learn.microsoft.com' &&
+      url.pathname.startsWith('/api/')
+    ) {
+      const username = url.searchParams.get('username');
+      if (username) {
+        return `https://learn.microsoft.com/users/${username}/achievements`;
+      }
+    }
+  } catch {
+    // Not a valid URL, return null
+  }
+  return null;
+}
+
 export function SolutionDisplayWidget({
   completedChallenge,
   projectTitle,
@@ -26,6 +49,8 @@ export function SolutionDisplayWidget({
 }: Props): JSX.Element | null {
   const { id, solution, githubLink } = completedChallenge;
   const { t } = useTranslation();
+  const solutionHref =
+    getMsLearnProfileUrl(solution) ?? solution ?? undefined;
   const viewText = t('buttons.view');
   const viewCode = t('buttons.view-code');
   const viewProject = t('buttons.view-project');
@@ -54,7 +79,7 @@ export function SolutionDisplayWidget({
           // This expression is only to resolve TypeScript error.
           // There won't be a case where the link has an invalid `href`
           // as this component is only rendered if `solution` is truthy.
-          href={solution ?? undefined}
+          href={solutionHref}
           rel='noopener noreferrer'
           target='_blank'
         >
@@ -81,7 +106,7 @@ export function SolutionDisplayWidget({
       // This expression is only to resolve TypeScript error.
       // There won't be a case where the link has an invalid `href`
       // as this component is only rendered if `solution` is truthy.
-      href={solution ?? undefined}
+      href={solutionHref}
       rel='noopener noreferrer'
       target='_blank'
     >
@@ -140,7 +165,7 @@ export function SolutionDisplayWidget({
             // This expression is only to resolve TypeScript error.
             // There won't be a case where the link has an invalid `href`
             // as this component is only rendered if `solution` is truthy.
-            href={solution ?? undefined}
+            href={solutionHref}
             rel='noopener noreferrer'
             target='_blank'
           >
@@ -169,7 +194,7 @@ export function SolutionDisplayWidget({
       // This expression is only to resolve TypeScript error.
       // There won't be a case where the link has an invalid `href`
       // as this component is only rendered if `solution` is truthy.
-      href={solution ?? undefined}
+      href={solutionHref}
       rel='noopener noreferrer'
       target='_blank'
     >


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #53073

## Summary

- The View button for MS Learn C# trophy achievements in the Timeline currently links to the raw JSON API endpoint (`learn.microsoft.com/api/gamestatus/achievements/...`), showing raw JSON instead of a useful page
- This adds a `getMsLearnProfileUrl` helper that detects MS Learn API URLs in the stored solution, extracts the `username` query parameter, and constructs a proper profile achievements URL (`learn.microsoft.com/users/{username}/achievements`)
- Non-MS Learn solutions are unaffected; the fallback behavior is unchanged

## Test Plan

- [x] Complete an MS Learn C# trophy challenge with a linked Microsoft account
- [x] Navigate to the user profile Timeline section
- [x] Click the "View" button for an MS Learn trophy entry
- [x] Verify it opens the profile achievements URL instead of the raw API JSON endpoint
- [x] Verify other (non-MS Learn) View buttons still work as before