### PR TITLE
fix(transpiler): exclude transform-spread to preserve native spread behavior

### DIFF
--- a/packages/challenge-builder/src/transformers.js
+++ b/packages/challenge-builder/src/transformers.js
@@ -62,6 +62,13 @@ async function loadBabel() {
   );
 }
 
+// Exclude transform-spread so that the native spread operator is preserved.
+// Babel's transform-spread plugin converts [...arr] into [].concat(arr), which
+// incorrectly preserves empty slots (holes) in arrays instead of converting
+// them to undefined. All browsers that can run freeCodeCamp support spread
+// natively, so this transformation is unnecessary.
+const presetEnvOptions = { exclude: ['transform-spread'] };
+
 async function loadPresetEnv() {
   if (!presetEnv)
     presetEnv = await import(
@@ -69,7 +76,7 @@ async function loadPresetEnv() {
     );
 
   presetsJS = {
-    presets: [presetEnv]
+    presets: [[presetEnv, presetEnvOptions]]
   };
 }
 
@@ -84,7 +91,7 @@ async function loadPresetReact() {
     );
 
   presetsJSX = {
-    presets: [presetEnv, presetReact]
+    presets: [[presetEnv, presetEnvOptions], presetReact]
   };
 }
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #62199

## Summary

The spread operator (`...`) behaves incorrectly in the challenge editor when used on arrays with empty slots. For example, `[...Array(3)]` should produce `[undefined, undefined, undefined]` but instead produces `[empty x 3]`.

### Root Cause

Babel's `@babel/plugin-transform-spread` (included via `@babel/preset-env`) transforms `[...arr]` into `[].concat(arr)`. While functionally equivalent for most cases, `Array.prototype.concat` preserves empty slots (holes) in arrays, whereas the native spread operator converts them to `undefined`.

### Fix

Exclude `transform-spread` from `@babel/preset-env` in the challenge code transpiler (`packages/challenge-builder/src/transformers.js`). This is safe because all modern browsers natively support the spread operator.

## Test Plan

- [x] Verify `[...Array(3)]` produces `[undefined, undefined, undefined]` in the challenge editor
- [x] Verify `0 in [...Array(5)]` evaluates to `true` in the challenge editor
- [x] Run existing challenge-builder tests
- [x] Verify JavaScript challenges still execute correctly in the editor
- [x] Verify React/JSX challenges still execute correctly in the editor