### PR TITLE
fix(curriculum): set non-zero input before testing select changes in currency converter lab

### DIFF
--- a/curriculum/challenges/english/blocks/lab-currency-converter/67eaa957114d373deb3a9149.md
+++ b/curriculum/challenges/english/blocks/lab-currency-converter/67eaa957114d373deb3a9149.md
@@ -147,6 +147,14 @@ Changing the value of the first `select` element should display the new converte
 ```js
   const s = await __helpers.prepTestComponent(window.index.CurrencyConverter);
 
+  const inp = s.querySelector('input[type="number"]');
+  assert.exists(inp);
+  await React.act(async () => {
+    inp.value = 10;
+    const ev = new Event("change", { bubbles: true, cancelable: false });
+    inp[Object.keys(inp).find((k) => k.startsWith("__reactProps"))].onChange({...ev, target: inp});
+  });
+
   const nonFormContentBefore = getInnerTextExcept(s, "input,select");
   const resultBefore = nonFormContentBefore.match(/(\d+\.\d{2})\s*([A-Z]{3})/);
 
@@ -172,9 +180,17 @@ Changing the value of the second `select` element should display the new convert
 ```js
   const s = await __helpers.prepTestComponent(window.index.CurrencyConverter);
 
+  const inp = s.querySelector('input[type="number"]');
+  assert.exists(inp);
+  await React.act(async () => {
+    inp.value = 10;
+    const ev = new Event("change", { bubbles: true, cancelable: false });
+    inp[Object.keys(inp).find((k) => k.startsWith("__reactProps"))].onChange({...ev, target: inp});
+  });
+
   const nonFormContentBefore = getInnerTextExcept(s, "input,select");
   const resultBefore = nonFormContentBefore.match(/(\d+\.\d{2})\s*([A-Z]{3})/);
-  
+
   const [_first, second] = s.querySelectorAll('select');
   assert.exists(second);
   await changeSelectValue(second);


### PR DESCRIPTION
## Summary

Fixes a bug in the Currency Converter lab where tests 7 and 8 ("Changing the value of the first/second `select` element should display the new converted amount") fail when the learner initializes the amount state to `0`.

**Root cause:** When the initial amount is `0`, any currency conversion still produces `0.00`. Changing the `select` element does not change the displayed value (`0.00 EUR` -> `0.00 GBP`), so the `assert.notEqual(resultBefore[1], resultAfter[1])` assertion fails because both are `"0.00"`.

**Fix:** Both tests now set the input value to `10` before testing the select change behavior. This ensures the converted amount actually changes when the currency is changed, making the tests independent of the learner's chosen initial amount value.

This follows the same pattern already used by the last test ("The converted amount should be displayed in the format `XX.XX CCC`...") which sets `inp.value = 10` before assertions.

Closes #65756

## Test plan

- [ ] Verify tests 7 and 8 pass with `useState(0)` as initial amount
- [ ] Verify tests 7 and 8 still pass with `useState(1)` as initial amount
- [ ] Verify all other tests in the lab still pass