### PR TITLE
fix(curriculum): correct background-size example and add missing border-style example

### DIFF
--- a/curriculum/challenges/english/blocks/review-css-backgrounds-and-borders/671a88d636cebc5fbd407b78.md
+++ b/curriculum/challenges/english/blocks/review-css-backgrounds-and-borders/671a88d636cebc5fbd407b78.md
@@ -185,8 +185,7 @@ Here's an example using `background-size: contain`:
 <style>
   body {
     background-image: url("https://cdn.freecodecamp.org/curriculum/cat-photo-app/relaxing-cat.jpg");
-    background-size: cover;
-    background-repeat: no-repeat;
+    background-size: contain;
     min-height: 100px;
   }
 </style>
@@ -348,6 +347,7 @@ Here's an example using different `border-style` values:
 <div class="solid-border">Solid border</div>
 <div class="dashed-border">Dashed border</div>
 <div class="dotted-border">Dotted border</div>
+<div class="double-border">Double border</div>
 ```
 
 ```css
@@ -365,6 +365,12 @@ Here's an example using different `border-style` values:
 
 .dotted-border {
   border: 3px dotted green;
+  margin-bottom: 10px;
+  padding: 10px;
+}
+
+.double-border {
+  border: 3px double purple;
   padding: 10px;
 }
 ```


### PR DESCRIPTION
## Summary

- Fixed the `background-size` example in the "Lists, Links, Background and Borders Review" page: the description says `background-size: contain` but the code used `background-size: cover`. Changed it to `contain` to match.
- Removed the unrelated `background-repeat: no-repeat` line from the `background-size` example, since it is demonstrated separately in its own section below.
- Added a missing `double` border-style example to the `border-style` section, since `double` is listed as an accepted value but was not demonstrated.

Closes #65810

## Checklist
- [x] Code change matches the description in the issue
- [x] Minimal change — only the affected examples are modified