### PR TITLE
fix(curriculum): correct example output in budget app to match example code

### DIFF
--- a/curriculum/challenges/english/blocks/build-a-budget-app-project/5e44413e903586ffb414c94e.md
+++ b/curriculum/challenges/english/blocks/build-a-budget-app-project/5e44413e903586ffb414c94e.md
@@ -39,7 +39,7 @@ And here is an example of the output:
 
 ```bash
 *************Food*************
-initial deposit        1000.00
+deposit                1000.00
 groceries               -10.15
 restaurant and more foo -15.89
 Transfer to Clothing    -50.00

--- a/curriculum/challenges/english/blocks/lab-budget-app/5e44413e903586ffb414c94e.md
+++ b/curriculum/challenges/english/blocks/lab-budget-app/5e44413e903586ffb414c94e.md
@@ -45,7 +45,7 @@ In this lab, you will build a simple budget app that tracks spending in differen
 
    ```bash
    *************Food*************
-   initial deposit        1000.00
+   deposit                1000.00
    groceries               -10.15
    restaurant and more foo -15.89
    Transfer to Clothing    -50.00


### PR DESCRIPTION
## Summary

Closes #65898

The example usage in the budget app instructions shows `food.deposit(1000, 'deposit')`, but the example output incorrectly displays `initial deposit        1000.00` instead of `deposit                1000.00`.

Since the `deposit` method stores the description exactly as passed, the output should show `deposit` (the literal string passed as the description), not `initial deposit`.

This fix corrects the example output in both:
- `lab-budget-app` (v9 lab)
- `build-a-budget-app-project` (legacy project)

This is consistent with the existing test on line 704-709 which uses `deposit(900, "deposit")` and expects `deposit` in the string output.

## Checklist
- [x] Verified that the corrected output matches what the code would actually produce
- [x] Verified column alignment: 23-char description + 7-char amount = 30 chars per line
- [x] Both lab and project versions updated