### PR TITLE
fix(client): prevent horizontal scrollbar on superblock intro page

### DIFF
--- a/client/src/components/layouts/global.css
+++ b/client/src/components/layouts/global.css
@@ -93,6 +93,7 @@ rt {
 .default-layout {
   margin-top: var(--header-height);
   background: var(--secondary-background);
+  overflow-x: clip;
 }
 
 .default-layout:only-child {


### PR DESCRIPTION
## Summary

- Fixes horizontal scrollbar appearing on the Full Stack Developer superblock introduction page (and potentially any other page using the `100vw` full-width container pattern)
- Adds `overflow-x: clip` to the `.default-layout` wrapper to contain the overflow from the `100vw`-based full-width container, which includes the scrollbar width and causes a ~7px horizontal overflow

## Root Cause

The `.full-width-container` class uses the well-known CSS pattern:
```css
left: 50%;
margin-left: -50vw;
margin-right: -50vw;
width: 100vw;
```
The `vw` unit includes the scrollbar width, so `100vw` is slightly wider than the visible viewport when a vertical scrollbar is present, causing a horizontal scrollbar.

## Fix

Adding `overflow-x: clip` to `.default-layout` prevents the horizontal scrollbar without:
- Affecting the visual full-width effect of the benefits container
- Creating a new scroll context (unlike `overflow-x: hidden`)
- Impacting vertical scrolling behavior

## Verification

Tested by inspecting the live site and confirming:
- Before: `document.documentElement.scrollWidth > document.documentElement.clientWidth` was `true`
- After applying fix: horizontal scroll is eliminated (`hasHorizontalScroll: false`)

Closes #65697

## Test plan

- [ ] Visit `/learn/full-stack-developer-v9/` and verify no horizontal scrollbar appears
- [ ] Verify the full-width benefits container still renders correctly
- [ ] Check other `/learn/*` pages to confirm no visual regressions