### PR TITLE
fix(curriculum): add missing backtick formatting for Eligible in bobsled challenge

### DIFF
--- a/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/697a49e9860d24853adef67c.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/697a49e9860d24853adef67c.md
@@ -24,7 +24,7 @@ The total weight of the bobsled (athletes plus sled) must not exceed:
 - 390 kg for a 2-person team
 - 630 kg for a 4-person team
 
-Return "Eligible" if the team meets all the requirements, or `"Not Eligible"` if the team fails to meet one or more of the requirements.
+Return `"Eligible"` if the team meets all the requirements, or `"Not Eligible"` if the team fails to meet one or more of the requirements.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/daily-coding-challenges-python/697a49e9860d24853adef67c.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-python/697a49e9860d24853adef67c.md
@@ -24,7 +24,7 @@ The total weight of the bobsled (athletes plus sled) must not exceed:
 - 390 kg for a 2-person team
 - 630 kg for a 4-person team
 
-Return "Eligible" if the team meets all the requirements, or `"Not Eligible"` if the team fails to meet one or more of the requirements.
+Return `"Eligible"` if the team meets all the requirements, or `"Not Eligible"` if the team fails to meet one or more of the requirements.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #65910

## Summary

In the bobsled challenge (Challenge 191: 2026 Winter Games Day 12), the return value `"Eligible"` in the task description was missing inline code formatting (backticks), while `"Not Eligible"` was properly formatted. This inconsistency made the description look incomplete.

This PR wraps `"Eligible"` in backticks to match the formatting of `"Not Eligible"` in both the JavaScript and Python versions of the challenge.

### Files changed

- `curriculum/challenges/english/blocks/daily-coding-challenges-javascript/697a49e9860d24853adef67c.md`
- `curriculum/challenges/english/blocks/daily-coding-challenges-python/697a49e9860d24853adef67c.md`

## Test Plan

- [x] Verified both files now have consistent backtick formatting for `"Eligible"` and `"Not Eligible"` in the description
- [x] No other content was changed