### PR TITLE
fix(curriculum): add missing backtick formatting for Eligible in bobsled challenge

### DIFF
--- a/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/697a49e9860d24853adef67c.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/697a49e9860d24853adef67c.md
@@ -24,7 +24,7 @@ The total weight of the bobsled (athletes plus sled) must not exceed:
 - 390 kg for a 2-person team
 - 630 kg for a 4-person team
 
-Return "Eligible" if the team meets all the requirements, or `"Not Eligible"` if the team fails to meet one or more of the requirements.
+Return `"Eligible"` if the team meets all the requirements, or `"Not Eligible"` if the team fails to meet one or more of the requirements.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/daily-coding-challenges-python/697a49e9860d24853adef67c.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-python/697a49e9860d24853adef67c.md
@@ -24,7 +24,7 @@ The total weight of the bobsled (athletes plus sled) must not exceed:
 - 390 kg for a 2-person team
 - 630 kg for a 4-person team
 
-Return "Eligible" if the team meets all the requirements, or `"Not Eligible"` if the team fails to meet one or more of the requirements.
+Return `"Eligible"` if the team meets all the requirements, or `"Not Eligible"` if the team fails to meet one or more of the requirements.
 
 # --hints--
 


### PR DESCRIPTION
## Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #65910 

<!-- Feel free to add any additional description of changes below this line -->

## Description:

Added backticks in 2 files to ensure formatting in challenge is consistent 
makes "Eligible" display as `"Eligible"` instead