### PR TITLE
fix(curriculum): format Eligible text consistently in daily challenge 191

### DIFF
--- a/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/697a49e9860d24853adef67c.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/697a49e9860d24853adef67c.md
@@ -24,7 +24,7 @@ The total weight of the bobsled (athletes plus sled) must not exceed:
 - 390 kg for a 2-person team
 - 630 kg for a 4-person team
 
-Return "Eligible" if the team meets all the requirements, or `"Not Eligible"` if the team fails to meet one or more of the requirements.
+Return `"Eligible"` if the team meets all the requirements, or `"Not Eligible"` if the team fails to meet one or more of the requirements.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/daily-coding-challenges-python/697a49e9860d24853adef67c.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-python/697a49e9860d24853adef67c.md
@@ -24,7 +24,7 @@ The total weight of the bobsled (athletes plus sled) must not exceed:
 - 390 kg for a 2-person team
 - 630 kg for a 4-person team
 
-Return "Eligible" if the team meets all the requirements, or `"Not Eligible"` if the team fails to meet one or more of the requirements.
+Return `"Eligible"` if the team meets all the requirements, or `"Not Eligible"` if the team fails to meet one or more of the requirements.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #65910

## Description

In the Daily Coding Challenge 191 (Bobsled), the task description has inconsistent formatting for return values:

- `"Not Eligible"` was wrapped in backticks (inline code formatting)
- `"Eligible"` was plain text without backticks

This PR wraps `"Eligible"` in backticks to match the formatting of `"Not Eligible"`, fixing the inconsistency in both the JavaScript and Python versions of the challenge.

### Files changed
- `curriculum/challenges/english/blocks/daily-coding-challenges-javascript/697a49e9860d24853adef67c.md`
- `curriculum/challenges/english/blocks/daily-coding-challenges-python/697a49e9860d24853adef67c.md`