### PR TITLE
refactor(curriculum): clean up unused code + reorganise what's left

### DIFF
--- a/client/utils/build-challenges.js
+++ b/client/utils/build-challenges.js
@@ -3,12 +3,9 @@ const path = require('path');
 const _ = require('lodash');
 
 const {
-  getChallengesForLang
-} = require('@freecodecamp/curriculum/get-challenges');
-
-const {
   getSuperblocks,
-  superBlockToFilename
+  superBlockToFilename,
+  buildCurriculum
 } = require('@freecodecamp/curriculum/build-curriculum');
 const {
   getContentDir,
@@ -72,7 +69,7 @@ exports.replaceChallengeNodes = () => {
 };
 
 exports.buildChallenges = async function buildChallenges() {
-  const curriculum = await getChallengesForLang(curriculumLocale);
+  const curriculum = await buildCurriculum(curriculumLocale);
   const superBlocks = Object.keys(curriculum);
   const blocks = superBlocks
     .map(superBlock => curriculum[superBlock].blocks)

--- a/client/utils/build-challenges.js
+++ b/client/utils/build-challenges.js
@@ -7,7 +7,6 @@ const {
 } = require('@freecodecamp/curriculum/get-challenges');
 
 const {
-  getBlockCreator,
   getSuperblocks,
   superBlockToFilename
 } = require('@freecodecamp/curriculum/build-curriculum');
@@ -17,6 +16,7 @@ const {
   getSuperblockStructure
 } = require('@freecodecamp/curriculum/file-handler');
 const {
+  BlockCreator,
   transformSuperBlock
 } = require('@freecodecamp/curriculum/build-superblock');
 const { getSuperOrder } = require('@freecodecamp/curriculum/super-order');
@@ -25,7 +25,7 @@ const curriculumLocale = process.env.CURRICULUM_LOCALE || 'english';
 
 exports.localeChallengesRootDir = getContentDir(curriculumLocale);
 
-const blockCreator = getBlockCreator(curriculumLocale);
+const blockCreator = new BlockCreator({ lang: curriculumLocale });
 
 function getBlockMetadata(block, superBlock) {
   // Compute metadata for the given block in the specified superblock

--- a/curriculum/src/build-curriculum.test.js
+++ b/curriculum/src/build-curriculum.test.js
@@ -1,12 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 
 import { SuperBlocks } from '@freecodecamp/shared/config/curriculum';
-import {
-  addBlockStructure,
-  getSuperblocks,
-  superBlockNames
-} from './build-curriculum.js';
-import { getCurriculumStructure } from './file-handler.js';
+import { addBlockStructure, superBlockNames } from './build-curriculum.js';
 
 vi.mock('./file-handler');
 
@@ -30,61 +25,6 @@ describe('addBlockStructure', () => {
           { b: 1, order: 1, superBlock: 'yes' }
         ]
       }
-    ]);
-  });
-});
-
-describe('getSuperblocks', () => {
-  it('returns an empty array if no superblocks contain the given block', () => {
-    getCurriculumStructure.mockReturnValue({
-      superblocks: ['superblock-1'] // doesn't matter what this is, but must be defined
-    });
-    const mockAddSuperblockStructure = () => [
-      {
-        blocks: [{ dashedName: 'block-1' }],
-        name: 'superblock-1'
-      }
-    ];
-
-    expect(
-      getSuperblocks('nonexistent-block', mockAddSuperblockStructure)
-    ).toEqual([]);
-  });
-
-  it('returns an array with one superblock if one superblock contains the given block', () => {
-    getCurriculumStructure.mockReturnValue({
-      superblocks: ['superblock-1'] // doesn't matter what this is, but must be defined
-    });
-    const mockAddSuperblockStructure = () => [
-      {
-        blocks: [{ dashedName: 'block-1' }, { dashedName: 'block-2' }],
-        name: 'superblock-1'
-      }
-    ];
-
-    expect(getSuperblocks('block-1', mockAddSuperblockStructure)).toEqual([
-      'superblock-1'
-    ]);
-  });
-
-  it('returns an array with multiple superblocks if multiple superblocks contain the given block', () => {
-    getCurriculumStructure.mockReturnValue({
-      superblocks: ['superblock-1'] // doesn't matter what this is, but must be defined
-    });
-    const mockAddSuperblockStructure = () => [
-      {
-        blocks: [{ dashedName: 'block-1' }, { dashedName: 'block-2' }],
-        name: 'superblock-1'
-      },
-      {
-        blocks: [{ dashedName: 'block-3' }, { dashedName: 'block-1' }],
-        name: 'superblock-2'
-      }
-    ];
-
-    expect(getSuperblocks('block-1', mockAddSuperblockStructure)).toEqual([
-      'superblock-1',
-      'superblock-2'
     ]);
   });
 });

--- a/curriculum/src/build-curriculum.test.js
+++ b/curriculum/src/build-curriculum.test.js
@@ -1,9 +1,7 @@
-import path from 'node:path';
 import { describe, it, expect, vi } from 'vitest';
 
 import { SuperBlocks } from '@freecodecamp/shared/config/curriculum';
 import {
-  createCommentMap,
   addBlockStructure,
   getSuperblocks,
   superBlockNames
@@ -11,90 +9,6 @@ import {
 import { getCurriculumStructure } from './file-handler.js';
 
 vi.mock('./file-handler');
-
-describe('createCommentMap', () => {
-  const dictionaryDir = path.resolve(
-    import.meta.dirname,
-    '..',
-    '__fixtures__',
-    'dictionaries'
-  );
-  const incompleteDictDir = path.resolve(
-    import.meta.dirname,
-    '..',
-    '__fixtures__',
-    'incomplete-dicts'
-  );
-
-  it('returns an object', () => {
-    expect(typeof createCommentMap(dictionaryDir, dictionaryDir)).toBe(
-      'object'
-    );
-  });
-
-  it('fallback to the untranslated string', () => {
-    expect.assertions(2);
-    const commentMap = createCommentMap(incompleteDictDir, incompleteDictDir);
-    expect(commentMap['To be translated one'].spanish).toEqual(
-      'Spanish translation one'
-    );
-    expect(commentMap['To be translated two'].spanish).toEqual(
-      'To be translated two'
-    );
-  });
-
-  it('returns an object with an expected form', () => {
-    expect.assertions(4);
-    const expectedIds = [
-      'To be translated one',
-      'To be translated two',
-      'Not translated one',
-      'Not translated two'
-    ];
-    const map = createCommentMap(dictionaryDir, dictionaryDir);
-    expect(Object.keys(map)).toEqual(expect.arrayContaining(expectedIds));
-
-    const mapValue = map['To be translated one'];
-
-    expect(Object.keys(mapValue)).toEqual(
-      expect.arrayContaining(['chinese', 'spanish'])
-    );
-    expect(typeof mapValue.chinese).toBe('string');
-    expect(typeof mapValue.spanish).toBe('string');
-  });
-
-  it('returns an object with expected values', () => {
-    expect.assertions(9);
-    const expectedIds = [
-      'To be translated one',
-      'To be translated two',
-      'Not translated one',
-      'Not translated two'
-    ];
-    const map = createCommentMap(dictionaryDir, dictionaryDir);
-    expect(Object.keys(map)).toEqual(expect.arrayContaining(expectedIds));
-
-    const translatedOne = map['To be translated one'];
-
-    expect(translatedOne.chinese).toBe('Chinese translation one');
-    expect(translatedOne.spanish).toBe('Spanish translation one');
-
-    const translatedTwo = map['To be translated two'];
-
-    expect(translatedTwo.chinese).toBe('Chinese translation two');
-    expect(translatedTwo.spanish).toBe('Spanish translation two');
-
-    const untranslatedOne = map['Not translated one'];
-
-    expect(untranslatedOne.chinese).toBe('Not translated one');
-    expect(untranslatedOne.spanish).toBe('Not translated one');
-
-    const untranslatedTwo = map['Not translated two'];
-
-    expect(untranslatedTwo.chinese).toBe('Not translated two');
-    expect(untranslatedTwo.spanish).toBe('Not translated two');
-  });
-});
 
 describe('addBlockStructure', () => {
   it('should override the order and superblock coming from getBlockStructure', () => {

--- a/curriculum/src/build-curriculum.ts
+++ b/curriculum/src/build-curriculum.ts
@@ -94,6 +94,13 @@ export const superBlockNames = {
   'css-animations': SuperBlocks.CssAnimations
 };
 
+export const superBlockToFilename = Object.entries(superBlockNames).reduce(
+  (map, entry) => {
+    return { ...map, [entry[1]]: entry[0] };
+  },
+  {}
+);
+
 /**
  * Builds an array of superblock structures from a curriculum object
 

--- a/curriculum/src/build-curriculum.ts
+++ b/curriculum/src/build-curriculum.ts
@@ -1,16 +1,15 @@
-import { readdirSync, readFileSync, existsSync } from 'fs';
-import { resolve, basename } from 'path';
+import { readdirSync, existsSync } from 'node:fs';
+import { resolve, basename } from 'node:path';
 
 import { isEmpty, isUndefined } from 'lodash';
 import debug from 'debug';
 
-import type { CommentDictionary } from '../../tools/challenge-parser/translation-parser/index.js';
 import { SuperBlocks } from '@freecodecamp/shared/config/curriculum';
 import {
   SuperblockCreator,
-  BlockCreator,
   transformSuperBlock,
-  BlockInfo
+  BlockInfo,
+  BlockCreator
 } from './build-superblock.js';
 
 import { buildCertification } from './build-certification.js';
@@ -18,7 +17,6 @@ import { getSuperOrder } from './super-order.js';
 import { applyFilters, closestFilters, type Filter } from './filter.js';
 import {
   getContentDir,
-  getLanguageConfig,
   getCurriculumStructure,
   getBlockStructure,
   getSuperblockStructure,
@@ -28,136 +26,6 @@ import {
 } from './file-handler.js';
 import { SHOW_UPCOMING_CHANGES } from './config.js';
 const log = debug('fcc:build-curriculum');
-
-/**
- * Creates a BlockCreator instance for a specific language with appropriate configuration
- * @param {string} lang - The language code (e.g., 'english', 'spanish', etc.)
- * @param {boolean} [skipValidation=false] - Whether to skip validation of challenges
- * @param {Object} [opts] - Optional configuration object
- * @param {string} [opts.baseDir] - Base directory for curriculum content
- * @param {string} [opts.i18nBaseDir] - Base directory for i18n curriculum content
- * @param {string} [opts.structureDir] - Directory containing curriculum structure
- * @returns {BlockCreator} A configured BlockCreator instance
- */
-export const getBlockCreator = (lang: string, skipValidation?: boolean) => {
-  const {
-    blockContentDir,
-    i18nBlockContentDir,
-    dictionariesDir,
-    i18nDictionariesDir
-  } = getLanguageConfig(lang);
-
-  const targetDictionariesDir =
-    lang === 'english' ? dictionariesDir : i18nDictionariesDir;
-
-  return new BlockCreator({
-    lang,
-    blockContentDir,
-    i18nBlockContentDir,
-    commentTranslations: createCommentMap(
-      dictionariesDir,
-      targetDictionariesDir
-    ),
-    skipValidation: skipValidation ?? false
-  });
-};
-
-/**
- * Gets a translation entry for a specific English ID and text across all languages
- * @param {Object} dicts - Dictionary object containing translations for each language
- * @param {Object} params - Parameters object
- * @param {string} params.engId - The English ID to look up in dictionaries
- * @param {string} params.text - The fallback English text to use if translation not found
- * @returns {Object} Object mapping language codes to translated text or fallback English text
- */
-export function getTranslationEntry(
-  dicts: Record<string, Record<string, unknown>>,
-  { engId, text }: { engId: string; text: string }
-) {
-  return Object.keys(dicts).reduce((acc, lang) => {
-    const entry = dicts[lang]?.[engId];
-    if (entry) {
-      return { ...acc, [lang]: entry };
-    } else {
-      // default to english
-      return { ...acc, [lang]: text };
-    }
-  }, {});
-}
-
-/**
- * Creates a mapping of English comments to their translations across all supported languages
- * @param {string} dictionariesDir - Path to the main (english) dictionaries directory
- * @param {string} targetDictionariesDir - Path to the target (i18n or english) dictionaries directory
- * @returns {Object} Object mapping English comment text to translations in all languages
- */
-export function createCommentMap(
-  dictionariesDir: string,
-  targetDictionariesDir: string
-): CommentDictionary {
-  log(
-    `Creating comment map from ${dictionariesDir} and ${targetDictionariesDir}`
-  );
-  const languages = readdirSync(targetDictionariesDir);
-
-  const dictionaries = languages.reduce((acc, lang) => {
-    const commentsPath = resolve(targetDictionariesDir, lang, 'comments.json');
-    const commentsData = JSON.parse(readFileSync(commentsPath, 'utf8'));
-    return {
-      ...acc,
-      [lang]: commentsData
-    };
-  }, {});
-
-  const COMMENTS_TO_TRANSLATE = JSON.parse(
-    readFileSync(resolve(dictionariesDir, 'english', 'comments.json'), 'utf8')
-  ) as Record<string, string>;
-
-  const COMMENTS_TO_NOT_TRANSLATE = JSON.parse(
-    readFileSync(
-      resolve(dictionariesDir, 'english', 'comments-to-not-translate.json'),
-      'utf8'
-    )
-  ) as Record<string, string>;
-
-  // map from english comment text to translations
-  const translatedCommentMap = Object.entries(COMMENTS_TO_TRANSLATE).reduce(
-    (acc, [id, text]) => {
-      return {
-        ...acc,
-        [text]: getTranslationEntry(dictionaries, { engId: id, text })
-      };
-    },
-    {} as CommentDictionary
-  );
-
-  // map from english comment text to itself
-  const untranslatableCommentMap = Object.values(
-    COMMENTS_TO_NOT_TRANSLATE
-  ).reduce((acc, text) => {
-    const englishEntry = languages.reduce(
-      (acc, lang) => ({
-        ...acc,
-        [lang]: text
-      }),
-      {}
-    );
-    return {
-      ...acc,
-      [text]: englishEntry
-    };
-  }, {} as CommentDictionary);
-
-  const allComments = { ...translatedCommentMap, ...untranslatableCommentMap };
-
-  // the english entries need to be added here, because english is not in
-  // languages
-  Object.keys(allComments).forEach(comment => {
-    allComments[comment]!.english = comment;
-  });
-
-  return allComments;
-}
 
 // Map of superblock filenames to their SuperBlocks enum values
 export const superBlockNames = {
@@ -356,11 +224,11 @@ export async function parseCurriculumStructure(filter?: Filter) {
 export async function buildCurriculum(lang: string, filters?: Filter) {
   // Block validation assumes the entire block is being built, if that's not the
   // case, skip validation
-  const skipBlockValidation = filters?.challengeId !== undefined;
+  const skipValidation = filters?.challengeId !== undefined;
   const contentDir = getContentDir(lang);
 
   const builder = new SuperblockCreator(
-    getBlockCreator(lang, skipBlockValidation)
+    new BlockCreator({ lang, skipValidation })
   );
 
   const { fullSuperblockList, certifications } =

--- a/curriculum/src/build-curriculum.ts
+++ b/curriculum/src/build-curriculum.ts
@@ -39,17 +39,13 @@ const log = debug('fcc:build-curriculum');
  * @param {string} [opts.structureDir] - Directory containing curriculum structure
  * @returns {BlockCreator} A configured BlockCreator instance
  */
-export const getBlockCreator = (
-  lang: string,
-  skipValidation?: boolean,
-  opts?: { baseDir: string; i18nBaseDir: string; structureDir: string }
-) => {
+export const getBlockCreator = (lang: string, skipValidation?: boolean) => {
   const {
     blockContentDir,
     i18nBlockContentDir,
     dictionariesDir,
     i18nDictionariesDir
-  } = getLanguageConfig(lang, opts);
+  } = getLanguageConfig(lang);
 
   const targetDictionariesDir =
     lang === 'english' ? dictionariesDir : i18nDictionariesDir;

--- a/curriculum/src/build-curriculum.ts
+++ b/curriculum/src/build-curriculum.ts
@@ -224,7 +224,7 @@ export async function buildCurriculum(lang: string, filters?: Filter) {
   };
 
   const liveSuperblocks = fullSuperblockList.filter(({ name }) => {
-    const superOrder = getSuperOrder(name);
+    const superOrder = getSuperOrder(name, SHOW_UPCOMING_CHANGES);
     const upcomingSuperOrder = getSuperOrder(name, true);
 
     if (isUndefined(superOrder) && isUndefined(upcomingSuperOrder)) {

--- a/curriculum/src/build-curriculum.ts
+++ b/curriculum/src/build-curriculum.ts
@@ -153,24 +153,6 @@ export function addBlockStructure(
   }));
 }
 
-/**
- * Returns a list of all the superblocks that contain the given block
- * @param {string} block
- */
-export function getSuperblocks(
-  block: string,
-  _addSuperblockStructure = addSuperblockStructure
-) {
-  const { superblocks } = getCurriculumStructure();
-  const withStructure = _addSuperblockStructure(superblocks);
-
-  return withStructure
-    .filter(({ blocks }) =>
-      blocks.some(({ dashedName }) => dashedName === block)
-    )
-    .map(({ name }) => name);
-}
-
 function validateBlocks(superblocks: SuperBlocks[], blockStructureDir: string) {
   const withSuperblockStructure = addSuperblockStructure(superblocks, true);
   const blockInSuperblocks = withSuperblockStructure

--- a/curriculum/src/build-curriculum.ts
+++ b/curriculum/src/build-curriculum.ts
@@ -101,7 +101,7 @@ export const superBlockNames = {
  * @returns {Array<Object>} Array of superblock structure objects with filename, name, and blocks
  * @throws {Error} When a superblock file is not found
  */
-export function addSuperblockStructure(
+function addSuperblockStructure(
   superBlockFilenames: string[],
   showComingSoon = SHOW_UPCOMING_CHANGES
 ) {

--- a/curriculum/src/build-curriculum.ts
+++ b/curriculum/src/build-curriculum.ts
@@ -94,13 +94,6 @@ export const superBlockNames = {
   'css-animations': SuperBlocks.CssAnimations
 };
 
-export const superBlockToFilename = Object.entries(superBlockNames).reduce(
-  (map, entry) => {
-    return { ...map, [entry[1]]: entry[0] };
-  },
-  {}
-);
-
 /**
  * Builds an array of superblock structures from a curriculum object
 

--- a/curriculum/src/build-superblock.ts
+++ b/curriculum/src/build-superblock.ts
@@ -488,7 +488,7 @@ export class BlockCreator {
       return null;
     }
 
-    const superOrder = getSuperOrder(superBlock);
+    const superOrder = getSuperOrder(superBlock, SHOW_UPCOMING_CHANGES);
     if (superOrder === undefined)
       throw Error(`Superblock not found: ${superBlock}`);
     const meta = {

--- a/curriculum/src/challenge-auditor/index.ts
+++ b/curriculum/src/challenge-auditor/index.ts
@@ -6,11 +6,7 @@ import {
   getAuditedSuperBlocks
 } from '@freecodecamp/shared/config/curriculum';
 
-import { getChallengesForLang } from '../get-challenges.js';
-
-// TODO: re-organise the types to a common 'types' folder that can be shared
-// between the workspaces so we don't have to declare ChallengeNode here and in
-// the client.
+import { buildCurriculum } from '../build-curriculum.js';
 
 // This cannot be imported from the client, without causing tsc to attempt to
 // compile the client (something it cannot do)
@@ -22,11 +18,8 @@ type ChallengeNode = {
   challengeType: number;
 };
 
-// Adding types for getChallengesForLang is possible, but not worth the effort
-// at this time.
-
 const getChallenges = async (lang: string) => {
-  const curriculum = await getChallengesForLang(lang);
+  const curriculum = await buildCurriculum(lang);
   return (
     Object.keys(curriculum)
       // @ts-expect-error - curriculum comes from a JS file.

--- a/curriculum/src/file-handler.ts
+++ b/curriculum/src/file-handler.ts
@@ -244,19 +244,13 @@ export function getSuperblockStructurePath(superblockFilename: string) {
  * @returns {Object} Object containing all relevant directory paths for the language
  * @throws {AssertionError} When required i18n directories don't exist for non-English languages
  */
-export function getLanguageConfig(
-  lang: string,
-  { baseDir, i18nBaseDir } = {
-    baseDir: CURRICULUM_DIR,
-    i18nBaseDir: I18N_CURRICULUM_DIR
-  }
-) {
-  const contentDir = resolve(baseDir, 'challenges', 'english');
-  const i18nContentDir = resolve(i18nBaseDir, 'challenges', lang);
+export function getLanguageConfig(lang: string) {
+  const contentDir = resolve(CURRICULUM_DIR, 'challenges', 'english');
+  const i18nContentDir = resolve(I18N_CURRICULUM_DIR, 'challenges', lang);
   const blockContentDir = resolve(contentDir, 'blocks');
   const i18nBlockContentDir = resolve(i18nContentDir, 'blocks');
-  const dictionariesDir = resolve(baseDir, 'dictionaries');
-  const i18nDictionariesDir = resolve(i18nBaseDir, 'dictionaries');
+  const dictionariesDir = resolve(CURRICULUM_DIR, 'dictionaries');
+  const i18nDictionariesDir = resolve(I18N_CURRICULUM_DIR, 'dictionaries');
 
   if (lang !== 'english') {
     assert(

--- a/curriculum/src/generate/build-curriculum.ts
+++ b/curriculum/src/generate/build-curriculum.ts
@@ -1,11 +1,12 @@
 import fs from 'fs';
 import path from 'path';
 
-import { getChallengesForLang } from '../get-challenges';
+import { curriculumFilter } from '../config.js';
+import { buildCurriculum } from '../build-curriculum.js';
 
 const globalConfigPath = path.resolve(__dirname, '../../generated/');
 
-void getChallengesForLang('english')
+void buildCurriculum('english', curriculumFilter)
   .then(JSON.stringify)
   .then(json => {
     fs.mkdirSync(globalConfigPath, { recursive: true });

--- a/curriculum/src/get-challenges.test.js
+++ b/curriculum/src/get-challenges.test.js
@@ -1,41 +1,32 @@
 import { describe, it, expect } from 'vitest';
 
-import { hasEnglishSource, getChallengesForLang } from './get-challenges.js';
+import { hasEnglishSource } from './get-challenges.js';
 
 const EXISTING_CHALLENGE_PATH = 'challenge.md';
 const MISSING_CHALLENGE_PATH = 'no/challenge.md';
 
 const basePath = '../__fixtures__';
 
-describe('create non-English challenge', () => {
-  describe('getChallengesForLang', () => {
-    it('throws if lang is an invalid language', async () => {
-      await expect(() => getChallengesForLang('notlang')).rejects.toThrow(
-        'notlang is not an accepted language'
-      );
-    });
+describe('hasEnglishSource', () => {
+  it('returns a boolean', async () => {
+    const sourceExists = await hasEnglishSource(
+      basePath,
+      EXISTING_CHALLENGE_PATH
+    );
+    expect(typeof sourceExists).toBe('boolean');
   });
-  describe('hasEnglishSource', () => {
-    it('returns a boolean', async () => {
-      const sourceExists = await hasEnglishSource(
-        basePath,
-        EXISTING_CHALLENGE_PATH
-      );
-      expect(typeof sourceExists).toBe('boolean');
-    });
-    it('returns true if the English challenge exists', async () => {
-      const sourceExists = await hasEnglishSource(
-        basePath,
-        EXISTING_CHALLENGE_PATH
-      );
-      expect(sourceExists).toBe(true);
-    });
-    it('returns false if the English challenge is missing', async () => {
-      const sourceExists = await hasEnglishSource(
-        basePath,
-        MISSING_CHALLENGE_PATH
-      );
-      expect(sourceExists).toBe(false);
-    });
+  it('returns true if the English challenge exists', async () => {
+    const sourceExists = await hasEnglishSource(
+      basePath,
+      EXISTING_CHALLENGE_PATH
+    );
+    expect(sourceExists).toBe(true);
+  });
+  it('returns false if the English challenge is missing', async () => {
+    const sourceExists = await hasEnglishSource(
+      basePath,
+      MISSING_CHALLENGE_PATH
+    );
+    expect(sourceExists).toBe(false);
   });
 });

--- a/curriculum/src/get-challenges.ts
+++ b/curriculum/src/get-challenges.ts
@@ -2,26 +2,7 @@ import { access as _access, constants } from 'fs';
 import { resolve, join } from 'path';
 import { promisify } from 'util';
 
-import { availableLangs } from '@freecodecamp/shared/config/i18n';
-import { buildCurriculum } from './build-curriculum.js';
-import { curriculumFilter } from './config.js';
-import type { Filter } from './filter.js';
-
-const { curriculum: curriculumLangs } = availableLangs;
-
 const access = promisify(_access);
-
-export async function getChallengesForLang(
-  lang: string,
-  filters: Filter = curriculumFilter // default to global curriculum filter, but allow override (e.g. when testing specific blocks)
-) {
-  const invalidLang = !curriculumLangs.includes(lang);
-  if (invalidLang)
-    throw Error(`${lang} is not an accepted language.
-Accepted languages are ${curriculumLangs.join(', ')}`);
-
-  return buildCurriculum(lang, filters);
-}
 
 export async function hasEnglishSource(
   basePath: string,

--- a/curriculum/src/super-order.test.ts
+++ b/curriculum/src/super-order.test.ts
@@ -55,13 +55,13 @@ describe('createSuperOrder', () => {
 
 describe('getSuperOrder', () => {
   it('returns a number for valid curriculum', () => {
-    expect(typeof getSuperOrder('responsive-web-design')).toBe('number');
+    expect(typeof getSuperOrder('responsive-web-design', false)).toBe('number');
   });
 
   it('returns undefined for unknown curriculum', () => {
-    expect(getSuperOrder('')).toBeUndefined();
-    expect(getSuperOrder('respansive-wib-desoin')).toBeUndefined();
-    expect(getSuperOrder('certifications')).toBeUndefined();
+    expect(getSuperOrder('', false)).toBeUndefined();
+    expect(getSuperOrder('respansive-wib-desoin', false)).toBeUndefined();
+    expect(getSuperOrder('certifications', false)).toBeUndefined();
   });
 
   it('returns numbers for all current curriculum', () => {

--- a/curriculum/src/super-order.ts
+++ b/curriculum/src/super-order.ts
@@ -1,5 +1,4 @@
 import { generateSuperBlockList } from '@freecodecamp/shared/config/curriculum';
-import { SHOW_UPCOMING_CHANGES } from './config.js';
 
 export function createSuperOrder(superBlocks: string[]) {
   const superOrder: { [sb: string]: number } = {};
@@ -13,7 +12,7 @@ export function createSuperOrder(superBlocks: string[]) {
 
 export function getSuperOrder(
   superblock: string,
-  showUpcomingChanges = SHOW_UPCOMING_CHANGES
+  showUpcomingChanges: boolean
 ) {
   const flatSuperBlockMap = generateSuperBlockList({
     showUpcomingChanges


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This should be a pure refactor. The motivation is that I was working on https://github.com/freeCodeCamp/freeCodeCamp/pull/65878, noticed that the tooling was a little convoluted and kept hacking until it was a little clearer.

One thing I was hoping to do, but failed to, was to remove the dependence of the tests on the environment variables. Maybe next time!

<!-- Feel free to add any additional description of changes below this line -->
