### PR TITLE
fix(curriculum): add CSS property checks for width and height in Colored Boxes lab

### DIFF
--- a/curriculum/challenges/english/blocks/lab-colored-boxes/66f3f6eb66ea9dc41cdc30df.md
+++ b/curriculum/challenges/english/blocks/lab-colored-boxes/66f3f6eb66ea9dc41cdc30df.md
@@ -115,6 +115,19 @@ The `.color5` element should have a background color set.
 assert.isNotEmpty(new __helpers.CSSHelp(document).getStyle('.color5')?.getPropVal('background-color', true));
 ```
 
+You should not use `display: flex` in this lab.
+
+```js
+const elements = document.querySelectorAll('body, body *');
+
+elements.forEach(el => {
+  assert.notStrictEqual(
+    getComputedStyle(el).display,
+    'flex'
+  );
+});
+```
+
 # --seed--
 
 ## --seed-contents--
@@ -164,9 +177,6 @@ assert.isNotEmpty(new __helpers.CSSHelp(document).getStyle('.color5')?.getPropVa
 ```css
 body {
     font-family: Arial, sans-serif;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
     margin: 0;
     padding: 20px;
     background-color: #f4f4f4;
@@ -185,9 +195,6 @@ h1 {
 }
 
 .color-box {
-    display: flex;
-    justify-content: center;
-    align-items: center;
     font-weight: bold;
     border-radius: 8px;
     text-align: center;

--- a/curriculum/challenges/english/blocks/lab-colored-boxes/66f3f6eb66ea9dc41cdc30df.md
+++ b/curriculum/challenges/english/blocks/lab-colored-boxes/66f3f6eb66ea9dc41cdc30df.md
@@ -64,15 +64,22 @@ colorGridChildren.forEach((child, index) => {
 });
 ```
 
-The `.color-box` element should have a set `width` and `height`.
+The `.color-box` class should have the `width` and `height` properties set.
+
+```js
+const cssHelp = new __helpers.CSSHelp(document);
+assert.isNotEmpty(cssHelp.getStyle('.color-box')?.getPropVal('width', true));
+assert.isNotEmpty(cssHelp.getStyle('.color-box')?.getPropVal('height', true));
+```
+
+The `.color-box` element should have a non-zero `width` and `height`. If the boxes are not visible in the preview, try resizing the preview window to a larger size.
 
 ```js
 const colorBox = document.querySelector('.color-box');
 assert.exists(colorBox);
 
-const colorBoxStyles = getComputedStyle(colorBox);
-const width = colorBoxStyles.width;
-const height = colorBoxStyles.height;
+const width = getComputedStyle(colorBox).width;
+const height = getComputedStyle(colorBox).height;
 
 assert.notStrictEqual(width, '0px');
 assert.notStrictEqual(height, '0px');
@@ -113,19 +120,6 @@ The `.color5` element should have a background color set.
 
 ```js
 assert.isNotEmpty(new __helpers.CSSHelp(document).getStyle('.color5')?.getPropVal('background-color', true));
-```
-
-You should not use `display: flex` in this lab.
-
-```js
-const elements = document.querySelectorAll('body, body *');
-
-elements.forEach(el => {
-  assert.notStrictEqual(
-    getComputedStyle(el).display,
-    'flex'
-  );
-});
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/lab-colored-boxes/66f3f6eb66ea9dc41cdc30df.md
+++ b/curriculum/challenges/english/blocks/lab-colored-boxes/66f3f6eb66ea9dc41cdc30df.md
@@ -75,14 +75,15 @@ assert.isNotEmpty(cssHelp.getStyle('.color-box')?.getPropVal('height', true));
 The `.color-box` elements should always have a non-zero `width` and `height`. Try to resize the preview to a smaller size, make sure that the boxes do not disappear.
 
 ```js
-const colorBox = document.querySelector('.color-box');
-assert.exists(colorBox);
+const colorBoxes = document.querySelectorAll('.color-box');
+assert.isNotEmpty(colorBoxes);
 
-const width = getComputedStyle(colorBox).width;
-const height = getComputedStyle(colorBox).height;
-
-assert.notStrictEqual(width, '0px');
-assert.notStrictEqual(height, '0px');
+colorBoxes.forEach(box => {
+  const width = getComputedStyle(box).width;
+  const height = getComputedStyle(box).height;
+  assert.notStrictEqual(width, '0px');
+  assert.notStrictEqual(height, '0px');
+});
 ```
 
 The `.color1` element should have a hexadecimal background color.
@@ -171,6 +172,9 @@ assert.isNotEmpty(new __helpers.CSSHelp(document).getStyle('.color5')?.getPropVa
 ```css
 body {
     font-family: Arial, sans-serif;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
     margin: 0;
     padding: 20px;
     background-color: #f4f4f4;
@@ -189,6 +193,9 @@ h1 {
 }
 
 .color-box {
+    display: flex;
+    justify-content: center;
+    align-items: center;
     font-weight: bold;
     border-radius: 8px;
     text-align: center;

--- a/curriculum/challenges/english/blocks/lab-colored-boxes/66f3f6eb66ea9dc41cdc30df.md
+++ b/curriculum/challenges/english/blocks/lab-colored-boxes/66f3f6eb66ea9dc41cdc30df.md
@@ -72,7 +72,7 @@ assert.isNotEmpty(cssHelp.getStyle('.color-box')?.getPropVal('width', true));
 assert.isNotEmpty(cssHelp.getStyle('.color-box')?.getPropVal('height', true));
 ```
 
-The `.color-box` element should have a non-zero `width` and `height`. If the boxes are not visible in the preview, try resizing the preview window to a larger size.
+The `.color-box` elements should always have a non-zero `width` and `height`. Try to resize the preview to a smaller size, make sure that the boxes do not disappear.
 
 ```js
 const colorBox = document.querySelector('.color-box');


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #65150

This PR adds a final test to disallow the use of `display: flex` in the "Design a Set of Colored Boxes" lab.