### PR TITLE
fix(curriculum): clarify getShoppingListMsg function calls

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-shopping-list/66c6491fe4c8e0f16845425f.md
+++ b/curriculum/challenges/english/blocks/workshop-shopping-list/66c6491fe4c8e0f16845425f.md
@@ -11,7 +11,7 @@ Now it is time to add another fruit to the list.
 
 Using the same array method as earlier, add the string `"Grapes"` to the end of the `shoppingList` array.
 
-Then, add a `console.log` and call the `getShoppingListMsg` function inside of the `console.log` to see the updated list logged to the console.
+Then, add a `console.log` and call the `getShoppingListMsg` function with `shoppingList` as the parameter inside of the `console.log` to see the updated list logged to the console.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/workshop-shopping-list/66c72a55418cc9247b710827.md
+++ b/curriculum/challenges/english/blocks/workshop-shopping-list/66c72a55418cc9247b710827.md
@@ -7,7 +7,7 @@ dashedName: step-10
 
 # --description--
 
-Next, add a `console.log` and call the `getShoppingListMsg` function inside of the `console.log` to see the updated list logged to the console.
+Next, add a `console.log` and call the `getShoppingListMsg` function with `shoppingList` as the parameter inside of the `console.log` to see the updated list logged to the console.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/workshop-shopping-list/66c72f4d0528bd268a82107b.md
+++ b/curriculum/challenges/english/blocks/workshop-shopping-list/66c72f4d0528bd268a82107b.md
@@ -9,7 +9,7 @@ dashedName: step-12
 
 Now it is time to log the updated `shoppingList` array to the console.
 
-Add another `console.log` and call the `getShoppingListMsg` function inside of the `console.log` to see the updated list logged to the console.
+Add another `console.log` and call the `getShoppingListMsg` function with `shoppingList` as the parameter inside of the `console.log` to see the updated list logged to the console.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/workshop-shopping-list/66c73a0c5b264f2a75164d94.md
+++ b/curriculum/challenges/english/blocks/workshop-shopping-list/66c73a0c5b264f2a75164d94.md
@@ -9,7 +9,7 @@ dashedName: step-15
 
 Now it is time to log the updated `shoppingList` array to the console.
 
-Add a `console.log` and call the `getShoppingListMsg` function inside of the `console.log` to see the updated list logged to the console.
+Add a `console.log` and call the `getShoppingListMsg` function with `shoppingList` as the parameter inside of the `console.log` to see the updated list logged to the console.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/workshop-shopping-list/66c73a7798f6f62b2ae58f22.md
+++ b/curriculum/challenges/english/blocks/workshop-shopping-list/66c73a7798f6f62b2ae58f22.md
@@ -13,7 +13,7 @@ Start by adding a `console.log` statement that logs the message `"It might be ni
 
 Below that `console` statement, use the correct array method to add the string `"Chocolate Cake"` to the beginning of the `shoppingList` array.
 
-Finally, add a `console.log` and call the `getShoppingListMsg` function inside of the `console.log` to see the updated list logged to the console.
+Finally, add a `console.log` and call the `getShoppingListMsg` function with `shoppingList` as the parameter inside of the `console.log` to see the updated list logged to the console.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/workshop-shopping-list/66cbe2319d3845545a293a0b.md
+++ b/curriculum/challenges/english/blocks/workshop-shopping-list/66cbe2319d3845545a293a0b.md
@@ -9,7 +9,7 @@ dashedName: step-6
 
 Now it is time to see the message logged to the console.
 
-Add a `console.log` and call the `getShoppingListMsg` function inside of the `console.log` to see the message logged to the console.
+Add a `console.log` and call the `getShoppingListMsg` with `shoppingList` as the parameter function inside of the `console.log` to see the message logged to the console.
 
 # --hints--
 


### PR DESCRIPTION
Scope: curriculum 

Curriculum Impacted: https://www.freecodecamp.org/learn/javascript-v9/

Update multiple workshop-shopping-list challenge descriptions to explicitly instruct students to pass `shoppingList` as a parameter. This ensures the function calls are technically accurate and match the expected implementation.

Affected steps:
- step-6
- step-7
- step-10
- step-12
- step-15
- step-16

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #64923

<!-- Feel free to add any additional description of changes below this line -->
