### PR TITLE
fix(curriculum): correct wording in explanation section

### DIFF
--- a/curriculum/challenges/english/blocks/learn-how-to-manage-a-conversation/67e6d7b750d7adc99809aea3.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-manage-a-conversation/67e6d7b750d7adc99809aea3.md
@@ -88,4 +88,4 @@ Open the application, switch between views, and observe the disappearing element
 
 # --explanation--
 
-There is a sequence of actions you can to reproduce the bug. You can find them on the `Steps to Reproduce` section. Read these steps and you will be able to correctly answer this question.
+There is a sequence of actions you can follow to reproduce the bug. You can find them in the `Steps to Reproduce` section. Read these steps and you will be able to correctly answer this question.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #65891

<!-- Feel free to add any additional description of changes below this line -->

This PR is to fix wording in the explanation section of how to manage a conversation lecture. 