### PR TITLE
fix(client): daily-coding-challenge routing

### DIFF
--- a/client/src/client-only-routes/show-daily-coding-challenge.tsx
+++ b/client/src/client-only-routes/show-daily-coding-challenge.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react';
-import { useParams } from '@gatsbyjs/reach-router';
 import store from 'store';
 import ShowClassic from '../templates/Challenges/classic/show';
 import { Loader } from '../components/helpers';
@@ -140,9 +139,7 @@ function formatChallengeData({
   return props;
 }
 
-function ShowDailyCodingChallenge(): JSX.Element {
-  const { date } = useParams<{ date?: string }>();
-
+function ShowDailyCodingChallenge({ date }: { date: string }): JSX.Element {
   const initLanguage =
     (store.get(
       'dailyCodingChallengeLanguage'

--- a/client/src/pages/learn/daily-coding-challenge/[...].tsx
+++ b/client/src/pages/learn/daily-coding-challenge/[...].tsx
@@ -1,30 +1,16 @@
 /* eslint-disable filenames-simple/naming-convention */
-import { Router } from '@gatsbyjs/reach-router';
-import { withPrefix } from 'gatsby';
 import React from 'react';
 
 import ShowDailyCodingChallenge from '../../../client-only-routes/show-daily-coding-challenge';
-import RedirectToArchive from '../../../components/redirect-daily-challenge-archive';
 
-const inlineStyles = {
-  minHeight: 0,
-  height: '100%'
-};
+interface Props {
+  params: {
+    '*': string;
+  };
+}
 
-function DailyCodingChallengeAll(): JSX.Element {
-  return (
-    // Router adds an element around the editor, messing with the layout because the editor is a flex item
-    // These few inline styles fix it.
-    <Router style={inlineStyles}>
-      <ShowDailyCodingChallenge
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        path={withPrefix('/learn/daily-coding-challenge/:date')}
-      />
-
-      <RedirectToArchive default />
-    </Router>
-  );
+function DailyCodingChallengeAll(props: Props): JSX.Element {
+  return <ShowDailyCodingChallenge date={props.params['*']} />;
 }
 
 DailyCodingChallengeAll.displayName = 'DailyCodingChallengeAll';

--- a/client/src/pages/learn/daily-coding-challenge/[...].tsx
+++ b/client/src/pages/learn/daily-coding-challenge/[...].tsx
@@ -2,6 +2,8 @@
 import React from 'react';
 
 import ShowDailyCodingChallenge from '../../../client-only-routes/show-daily-coding-challenge';
+import RedirectToArchive from '../../../components/redirect-daily-challenge-archive';
+import { isValidDateString } from '../../../components/daily-coding-challenge/helpers';
 
 interface Props {
   params: {
@@ -10,6 +12,10 @@ interface Props {
 }
 
 function DailyCodingChallengeAll(props: Props): JSX.Element {
+  if (!isValidDateString(props.params['*'])) {
+    return <RedirectToArchive />;
+  }
+
   return <ShowDailyCodingChallenge date={props.params['*']} />;
 }
 

--- a/e2e/daily-coding-challenge.spec.ts
+++ b/e2e/daily-coding-challenge.spec.ts
@@ -250,5 +250,10 @@ test.describe('Daily Coding Challenge Archive', () => {
     await expect(page.getByTestId('calendar-day-completed')).toHaveCount(1);
 
     await expect(page.getByTestId('calendar-day-not-completed')).toHaveCount(3);
+
+    await page.getByTestId('calendar-day-completed').click();
+    await expect(page).toHaveURL(
+      `/learn/daily-coding-challenge/${todayUsCentral}`
+    );
   });
 });

--- a/e2e/daily-coding-challenge.spec.ts
+++ b/e2e/daily-coding-challenge.spec.ts
@@ -66,11 +66,9 @@ const mockApiAllChallenges = [
 const mockDaysInMonth = new Date(year, month, 0).getDate();
 
 test.describe('Daily Coding Challenges', () => {
-  test('should show not found page for invalid date', async ({ page }) => {
+  test('should redirect to archive for invalid date', async ({ page }) => {
     await page.goto('/learn/daily-coding-challenge/invalid-date');
-    await expect(
-      page.getByText(/daily coding challenge not found\./i)
-    ).toBeVisible();
+    await expect(page).toHaveURL('/learn/daily-coding-challenge/archive');
   });
 
   test('should show not found page for date without challenge', async ({


### PR DESCRIPTION
Turns out mixing two types of routing for the same page (gatsby + reach) doesn't really work. This removes the reach router code and lets Gatsby handle it

Closes: https://github.com/freeCodeCamp/freeCodeCamp/issues/65931

Tests to follow.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->
