### PR TITLE
fix(curriculum): remove duplicated 'represented' in Python certification lesson

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-employee-profile-generator/694bf6eb530e19a9c48c59f4.md
+++ b/curriculum/challenges/english/blocks/workshop-employee-profile-generator/694bf6eb530e19a9c48c59f4.md
@@ -9,7 +9,7 @@ dashedName: step-13
 
 Concatenating many strings using `+` and converting numbers using `str()` can get messy and hard to read.
 
-Python 3.6 introduced **f-strings** to solve this. By adding the letter `f` before the opening quote, you can put variables and expressions inside replacement fields represented represented by curly braces `{}`. For example:
+Python 3.6 introduced **f-strings** to solve this. By adding the letter `f` before the opening quote, you can put variables and expressions inside replacement fields represented by curly braces `{}`. For example:
 
 ```python
 name = 'John'


### PR DESCRIPTION

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.


Closes #65939


This PR removes a duplicated word ("represented") in the Python Certification workshop lesson instructions (Build an Employee Profile Generator – step 13).

The duplicate word was removed for clarity and correctness.

