### PR TITLE
fix(client): redirect /challenges/** correctly

### DIFF
--- a/client/src/pages/challenges.test.tsx
+++ b/client/src/pages/challenges.test.tsx
@@ -1,5 +1,5 @@
 import { render } from '@testing-library/react';
-import { navigate, withPrefix } from 'gatsby';
+import { navigate } from 'gatsby';
 import React from 'react';
 import { describe, it, expect } from 'vitest';
 
@@ -7,7 +7,7 @@ import Challenges from './challenges/index';
 import ChallengesRedirect from './challenges/[...]';
 
 describe('Challenges', () => {
-  const learn = withPrefix('/learn');
+  const learn = '/learn';
 
   it('should handle redirect to /learn', () => {
     render(<Challenges />);

--- a/client/src/utils/to-learn-path.test.ts
+++ b/client/src/utils/to-learn-path.test.ts
@@ -1,10 +1,9 @@
-import { withPrefix } from 'gatsby';
 import { describe, it, expect } from 'vitest';
 
 import toLearnPath from './to-learn-path';
 
 describe('To learn path utility (toLearnPath)', () => {
-  const learn = withPrefix('/learn');
+  const learn = '/learn';
 
   it('should include /learn', () => {
     expect(toLearnPath({})).toMatch(`${learn}`);

--- a/client/src/utils/to-learn-path.ts
+++ b/client/src/utils/to-learn-path.ts
@@ -1,5 +1,3 @@
-import { withPrefix } from 'gatsby';
-
 interface ToLearnPathKwargs {
   block?: string;
   challenge?: string;
@@ -26,5 +24,5 @@ export default function toLearnPath({
     }
 
     return path;
-  }, withPrefix('/learn'));
+  }, '/learn');
 }


### PR DESCRIPTION
withPrefix is only necessary when stepping outside of gatsby. Gatsby's navigate automatically prefixes anything passed to it.

Fixes failing tests on https://github.com/freeCodeCamp/freeCodeCamp/pull/65930

There's another problem with https://github.com/freeCodeCamp/client-config/blob/5deb3f6fa6c057a3cd23ef51aad5218cf4eaca1d/serve.json#L49-L52 so this PR doesn't stop https://www.freecodecamp.org/espanol/challenges redirecting to https://www.freecodecamp.org/learn, but once serve is behaving correctly, the client should handle redirects correctly.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
