### PR TITLE
fix(curriculum): Controlled element isn’t hidden by default when aria-expanded="false"

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-understanding-aria-expanded-aria-live-and-common-aria-states/672a54ce90c19e9038f481d7.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-aria-expanded-aria-live-and-common-aria-states/672a54ce90c19e9038f481d7.md
@@ -41,7 +41,7 @@ Let's start with `aria-controls`. When used with `aria-expanded`, the `aria-cont
 <link rel="stylesheet" href="styles.css">
 
 <button aria-expanded="false" aria-controls="menu1">Menu</button>
-<ul id="menu1">
+<ul id="menu1" hidden>
   <li>...</li>
   <li>...</li>
 </ul>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #65934

<!-- Feel free to add any additional description of changes below this line -->
