### PR TITLE
chore(tools/challenge-helper-scripts): migrate tests to Vitest v4

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -979,8 +979,8 @@ importers:
         specifier: ^8.2.5
         version: 8.2.11
       '@vitest/ui':
-        specifier: ^3.2.4
-        version: 3.2.4(vitest@3.2.4)
+        specifier: ^4.0.15
+        version: 4.0.15(vitest@4.0.15)
       bson:
         specifier: ^7.0.0
         version: 7.0.0
@@ -1003,8 +1003,8 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
       vitest:
-        specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@25.2.3)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@26.1.0)(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+        specifier: ^4.0.15
+        version: 4.0.15(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(@vitest/ui@4.0.15)(jiti@2.6.1)(jsdom@26.1.0)(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
 
   tools/challenge-parser:
     dependencies:

--- a/tools/challenge-helper-scripts/package.json
+++ b/tools/challenge-helper-scripts/package.json
@@ -37,7 +37,7 @@
     "@total-typescript/ts-reset": "^0.6.1",
     "@types/glob": "^8.0.1",
     "@types/inquirer": "^8.2.5",
-    "@vitest/ui": "^3.2.4",
+    "@vitest/ui": "^4.0.15",
     "bson": "^7.0.0",
     "eslint": "^9.39.1",
     "glob": "^8.1.0",
@@ -45,6 +45,6 @@
     "inquirer": "8.2.6",
     "prettier": "3.2.5",
     "typescript": "5.9.3",
-    "vitest": "^3.2.4"
+    "vitest": "^4.0.15"
   }
 }

--- a/tools/challenge-helper-scripts/utils.test.ts
+++ b/tools/challenge-helper-scripts/utils.test.ts
@@ -25,7 +25,11 @@ vi.mock('gray-matter', () => {
 
 vi.mock('bson', () => {
   return {
-    ObjectId: vi.fn(() => ({ toString: () => mockChallengeId }))
+    ObjectId: vi.fn().mockImplementation(function () {
+      return {
+        toString: () => mockChallengeId
+      };
+    })
   };
 });
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Related #64735

Upgrades challenge-helper-scripts workspace to Vitest v4.

- Updated mocks to comply with Vitest v4 constructor behavior
- Fixed failing tests due to breaking changes