### PR TITLE
fix(tooling): return all superblocks containing a filtered block

### DIFF
--- a/curriculum/src/filter.test.js
+++ b/curriculum/src/filter.test.js
@@ -120,6 +120,30 @@ describe('filterByBlock', () => {
     ]);
   });
 
+  it('returns all superblocks containing that block', () => {
+    const superblocks = [
+      {
+        name: 'superblock-1',
+        blocks: [{ dashedName: 'block-1' }, { dashedName: 'block-2' }]
+      },
+      {
+        name: 'superblock-2',
+        blocks: [{ dashedName: 'block-1' }, { dashedName: 'block-2' }]
+      }
+    ];
+    const filtered = filterByBlock(superblocks, { block: 'block-1' });
+    expect(filtered).toEqual([
+      {
+        name: 'superblock-1',
+        blocks: [{ dashedName: 'block-1' }]
+      },
+      {
+        name: 'superblock-2',
+        blocks: [{ dashedName: 'block-1' }]
+      }
+    ]);
+  });
+
   it('returns an empty array if no blocks match the specified block', () => {
     const superblocks = [
       {

--- a/curriculum/src/filter.ts
+++ b/curriculum/src/filter.ts
@@ -1,7 +1,7 @@
 import comparison from 'string-similarity';
 
 /**
- * Filters the superblocks array to include, at most, a single superblock with the specified block.
+ * Filters the superblocks array to include any superblocks with the specified block.
  * If no block is provided, returns the original superblocks array.
  *
  * @param {Array<Object>} superblocks - Array of superblock objects, each containing a blocks array.
@@ -15,14 +15,14 @@ export function filterByBlock<T extends { blocks: { dashedName: string }[] }>(
 ): T[] {
   if (!block) return superblocks;
 
-  const superblock = superblocks
+  const remainingSuperblocks = superblocks
     .map(superblock => ({
       ...superblock,
       blocks: superblock.blocks.filter(({ dashedName }) => dashedName === block)
     }))
-    .find(superblock => superblock.blocks.length > 0);
+    .filter(superblock => superblock.blocks.length > 0);
 
-  return superblock ? [superblock] : [];
+  return remainingSuperblocks;
 }
 
 /**

--- a/curriculum/src/test/test-challenges.js
+++ b/curriculum/src/test/test-challenges.js
@@ -79,11 +79,20 @@ async function newPageContext() {
 }
 
 export async function defineTestsForBlock(testFilter) {
-  const challenges = await getChallenges(CURRICULUM_LOCALE, testFilter);
-  const nonCertificationChallenges = challenges.filter(
+  const allChallenges = await getChallenges(CURRICULUM_LOCALE, testFilter);
+  const nonCertificationChallenges = allChallenges.filter(
     ({ challengeType }) => challengeType !== 7
   );
-  if (isEmpty(nonCertificationChallenges)) {
+
+  // This is a bit of a dirty hack, but when we're testing, we only need to
+  // validate the challenges for the block we're testing once, rather than
+  // once for each superBlock the challenge appears in.
+  const firstSuperBlock = allChallenges[0]?.superBlock;
+  const challenges = nonCertificationChallenges.filter(
+    ({ superBlock }) => superBlock === firstSuperBlock
+  );
+
+  if (isEmpty(challenges)) {
     console.warn(
       `No non-certification challenges to test for block ${testFilter.block}.`
     );


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This isn't the prettiest. The problem is the challenges are not independent of their containing structures (blocks, chapters etc.), so we can't easily compose them. This means seemingly simple tasks like "validate a challenge" or "create a block" are quite convoluted. 

For example, the output block (i.e. collection of challenge objects in that block that's produced during the build) are duplicated for each superblock that has the block. The only differences are the `superBlock`, `block`, `superOrder` and `order` properties. They have to be in the challenge objects and have to be different, because the client uses them when building the UI. However, we don't care about the differences when testing the block - we only want to test it once, hence the filtering by `superBlock` hack.

The "proper" fix is quite involved, so I think we should live with the hack for now and do it properly in https://github.com/freeCodeCamp/curriculum-db/

<!-- Feel free to add any additional description of changes below this line -->
