### PR TITLE
fix(tooling): stop api crashing during seed

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -10,12 +10,14 @@
     "pnpm": ">=10"
   },
   "scripts": {
+    "build": "tsdown --log-level warn --no-clean --format cjs --format esm",
+    "clean": "rm -rf dist",
+    "develop": "tsdown --log-level warn --no-clean --watch src --format cjs --format esm",
+    "lint": "eslint --max-warnings 0",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:ui": "vitest --ui",
-    "type-check": "tsc --noEmit",
-    "build": "tsdown --format cjs --format esm",
-    "lint": "eslint --max-warnings 0"
+    "type-check": "tsc --noEmit"
   },
   "type": "module",
   "exports": {


### PR DESCRIPTION
Cleaning the output confuses tsx --watch, because it sees the unlinking
of the dependencies, but does not see their reappearance. This happens
if the shared package's setup task runs, i.e. during seeding.

The fix is to simply not clean, so the files are never deleted.

I also added a develop task, so that changes in the source will be made
available to the dependents (api and client).

Finally, I lowered the log noise.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
