### PR TITLE
fix(client): sidebar font & profile placeholders

### DIFF
--- a/client/src/client-only-routes/show-settings.css
+++ b/client/src/client-only-routes/show-settings.css
@@ -13,8 +13,12 @@
   padding-left: 0;
 }
 
-.settings-sidebar-nav ul li {
+.settings-sidebar-nav > ul > li {
   margin-bottom: 0.5rem;
+}
+
+.settings-sidebar-nav ul ul li {
+  margin-bottom: 0.15rem;
 }
 
 .settings-sidebar-nav {
@@ -22,9 +26,24 @@
   position: sticky;
   top: var(--header-height);
   padding: 1rem 0;
-  overflow-y: scroll;
+  overflow-y: auto;
   height: calc(100vh - var(--header-height));
   border-right: 3px solid var(--tertiary-background);
+  scrollbar-width: thin;
+  scrollbar-color: var(--quaternary-background) var(--secondary-background);
+}
+
+.settings-sidebar-nav::-webkit-scrollbar {
+  width: 6px;
+}
+
+.settings-sidebar-nav::-webkit-scrollbar-track {
+  background: var(--secondary-background);
+}
+
+.settings-sidebar-nav::-webkit-scrollbar-thumb {
+  background-color: var(--quaternary-background);
+  border-radius: 3px;
 }
 
 .settings-sidebar-nav .sidebar-nav-section-heading {
@@ -43,6 +62,7 @@
   text-decoration: none;
   cursor: pointer;
   padding: 0 1rem 0rem 2rem;
+  font-size: 0.85rem;
 }
 
 .settings-sidebar-nav .sidebar-nav-section-heading.active,

--- a/client/src/components/profile/components/about.tsx
+++ b/client/src/components/profile/components/about.tsx
@@ -180,6 +180,7 @@ const AboutSettings = ({
                 type='text'
                 value={formValues.name}
                 id='about-name-input'
+                placeholder='Camper Bot'
               />
             </FormGroup>
             <FormGroup controlId='about-location'>
@@ -191,6 +192,7 @@ const AboutSettings = ({
                 type='text'
                 value={formValues.location}
                 id='about-location-input'
+                placeholder='San Francisco, CA'
               />
             </FormGroup>
             <FormGroup controlId='about-picture'>
@@ -202,6 +204,7 @@ const AboutSettings = ({
                 type='url'
                 value={formValues.picture}
                 id='about-picture-input'
+                placeholder='https://github.com/ghost.png'
               />
               {!isPictureUrlValid && (
                 <ShowImageValidationWarning
@@ -218,6 +221,7 @@ const AboutSettings = ({
                 onChange={handleAboutChange}
                 value={formValues.about}
                 id='about-about-input'
+                placeholder='A short bio about yourself'
               />
             </FormGroup>
           </div>


### PR DESCRIPTION
Tweaked the placeholders and nicer looking sidebar

<details>
<summary>Details</summary>

<table>
<tr>
 <td>Before
 <td>After
<tr>
 <td><img width="640" alt="image" src="https://github.com/user-attachments/assets/b9a9c093-1038-4137-90a5-67470c64ce6e" />
<td><img width="640" alt="image" src="https://github.com/user-attachments/assets/e9007b73-7099-49ad-96b4-a0ad2d19695c" />
<tr>
 <td><img width="1280" alt="image" src="https://github.com/user-attachments/assets/1b079d0f-0a83-4854-a483-ab3b70e8a413" />
 <td><img width="1280" alt="image" src="https://github.com/user-attachments/assets/27f22877-1a01-47fb-8574-676869d10f51" />
</table>

</details>