### PR TITLE
fix(client): curriculum tag alignment

### DIFF
--- a/client/src/templates/Introduction/intro.css
+++ b/client/src/templates/Introduction/intro.css
@@ -13,7 +13,6 @@
 }
 
 .block-label {
-  align-self: start;
   height: fit-content;
   width: fit-content;
   padding: 1px 6px 2px;


### PR DESCRIPTION
Looks like [this was added here](https://github.com/freeCodeCamp/freeCodeCamp/pull/65596/changes#diff-9dbdebc9f33e04bcdc7e0dff5c105b76957ec0de62ee6321826351ba6444d5fbR16) for the catalog. But I don't see `align-self: start` having any effect on the tags in the catalog - So I think we're fine to change it back. cc @ahmaxed

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #65982

<!-- Feel free to add any additional description of changes below this line -->
