### PR TITLE
fix(curriculum): add test for falsy value in lab travel weather planner

### DIFF
--- a/curriculum/challenges/english/blocks/lab-travel-weather-planner/694acade1d4afdbce71e5840.md
+++ b/curriculum/challenges/english/blocks/lab-travel-weather-planner/694acade1d4afdbce71e5840.md
@@ -146,7 +146,7 @@ You should use the `print()` function to display the result.
 ({ test: () => runPython(`assert _Node(_code).block_has_call("print")`) })
 ```
 
-When the `distance` is a falsy value, the program should print `False`.
+When `distance_mi` is a falsy value, the program should print `False`.
 
 ```js
 ({ test: () => runPython(`

--- a/curriculum/challenges/english/blocks/lab-travel-weather-planner/694acade1d4afdbce71e5840.md
+++ b/curriculum/challenges/english/blocks/lab-travel-weather-planner/694acade1d4afdbce71e5840.md
@@ -146,6 +146,65 @@ You should use the `print()` function to display the result.
 ({ test: () => runPython(`assert _Node(_code).block_has_call("print")`) })
 ```
 
+When the `distance` is a falsy value, the program should print `False`.
+
+```js
+({ test: () => runPython(`
+import ast, io, contextlib
+
+VARIABLES = {
+    "distance_mi",
+    "is_raining",
+    "has_bike",
+    "has_car",
+    "has_ride_share_app"
+}
+
+def run_case(env, expected):
+    tree = ast.parse(_code)
+
+    tree.body = [
+        node for node in tree.body
+        if not (
+            isinstance(node, ast.Assign)
+            and isinstance(node.targets[0], ast.Name)
+            and node.targets[0].id in VARIABLES
+        )
+    ]
+
+    clean_code = compile(tree, "<ast>", "exec")
+
+    buffer = io.StringIO()
+    with contextlib.redirect_stdout(buffer):
+        exec(clean_code, env)
+
+    assert buffer.getvalue().strip() == expected
+
+
+run_case(
+    {
+        "distance_mi": 0,
+        "is_raining": False,
+        "has_bike": True,
+        "has_car": True,
+        "has_ride_share_app": True
+    },
+    "False"
+)
+
+run_case(
+    {
+        "distance_mi": 0.0,
+        "is_raining": False,
+        "has_bike": True,
+        "has_car": True,
+        "has_ride_share_app": True
+    },
+    "False"
+)
+`) })
+```
+
 When the distance is `1` mile or less and it is not raining, the program should print `True`.
 
 ```js


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #65981

<!-- Feel free to add any additional description of changes below this line -->

This PR is to add test to check for falsy value of `distance_mi` according to the user story 4.