### PR TITLE
fix: align exam tags vertically

### DIFF
--- a/client/src/templates/Introduction/components/super-block-accordion.css
+++ b/client/src/templates/Introduction/components/super-block-accordion.css
@@ -151,6 +151,10 @@ button .block-header-button-text {
   font-size: 0.6rem;
 }
 
+.super-block-accordion .block-label-exam {
+  margin-top: 7px;
+}
+
 .super-block-accordion
   .module-panel
   .accordion-block-expanded


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #65982

Summary of Changes:
Fixed vertical alignment issues for the "Exam" tag on superblock pages. The tag was previously sitting too high compared to the surrounding text.

Technical Details:

Added margin on the top

Screenshots:

Before: 
<img width="884" height="108" alt="www freecodecamp org_learn_responsive-web-design-v9_" src="https://github.com/user-attachments/assets/d9bb56b4-0eea-4abb-9d0d-f660b383abf7" />

After: 
<img width="884" height="108" alt="localhost_8000_learn_responsive-web-design-v9_" src="https://github.com/user-attachments/assets/17a48371-96aa-4bf5-bd1a-1f3239ac1f9d" />
