### PR TITLE
fix(client): fixed the alignment of the "Exam" tag.

### DIFF
--- a/client/src/templates/Introduction/intro.css
+++ b/client/src/templates/Introduction/intro.css
@@ -59,6 +59,7 @@
 }
 
 .block-label-exam {
+  align-self: auto;
   border-color: var(--quaternary-color);
   color: var(--quaternary-color);
 }


### PR DESCRIPTION
Checklist:

 [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
 [x]I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
 [x]My pull request targets the `main` branch of freeCodeCamp.
 [x] I have tested these changes either locally on my machine, or GitHub Codespaces.


Closes #65982

I was able to align the "Exam" curriculum tag by adjusting the intro.css class .block-label-exam to have an auto alignment rather than the inherited alignment from the .block-label class. 
