### PR TITLE
fix(curriculum): improve test for step-75 workshop city skyline

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-city-skyline/5d822fd413a79914d39e9917.md
+++ b/curriculum/challenges/english/blocks/workshop-city-skyline/5d822fd413a79914d39e9917.md
@@ -25,19 +25,43 @@ Add a `repeating-linear-gradient` to `.fb1c` below the one that's there; use you
 You should not alter the first `repeating-linear-gradient`.
 
 ```js
-assert.match(new __helpers.CSSHelp(document).getStyle(".fb1c")?.getPropVal('background', true), /repeating-linear-gradient\(90deg,var\(--building-color4\)(0%)?,var\(--building-color4\)10%,transparent10%,transparent15%\)/);
+const fb1c = document.querySelector("style").textContent.match(/\.fb1c\s*\{([\s\S]*?)\}/);
+assert.isNotNull(fb1c);
+
+const fb1cStyles = fb1c[1];
+const bg = fb1cStyles.match(/background\s*:\s*([\s\S]*)/);
+assert.isNotNull(bg);
+
+const background = bg[1];
+assert.match(background, /repeating-linear-gradient\(\s*90deg\s*,\s*var\(--building-color4\)\s*,\s*var\(--building-color4\)\s*10%\s*,\s*transparent\s*10%\s*,\s*transparent\s*15%\s*\)/);
 ```
 
 You should add a `repeating-linear-gradient` with a first color of `--building-color4` from `0%` to `10%`.
 
 ```js
-assert.match(new __helpers.CSSHelp(document).getStyle(".fb1c")?.getPropVal('background', true), /repeating-linear-gradient\(90deg,var\(--building-color4\)(0%)?,var\(--building-color4\)10%,transparent10%,transparent15%\),repeating-linear-gradient\(var(\(--building-color4\)(0%)?,var\(--building-color4\)10%|\(--building-color4\)0%10%)/);
+const fb1c = document.querySelector("style").textContent.match(/\.fb1c\s*\{([\s\S]*?)\}/);
+assert.isNotNull(fb1c);
+
+const fb1cStyles = fb1c[1];
+const bg = fb1cStyles.match(/background\s*:\s*([\s\S]*)/);
+assert.isNotNull(bg);
+
+const background = bg[1];
+assert.match(background, /repeating-linear-gradient\(\s*var\(--building-color4\)(?:\s*0%)?\s*,\s*var\(--building-color4\)\s*10%/);
 ```
 
 You should use a second color of `--window-color4` from `10%` to `90%`.
 
 ```js
-assert.match(new __helpers.CSSHelp(document).getStyle(".fb1c")?.getPropVal('background', true), /,(var\(--window-color4\)10%,var\(--window-color4\)90%\)|var\(--window-color4\)10%90%\))$/);
+const fb1c = document.querySelector("style").textContent.match(/\.fb1c\s*\{([\s\S]*?)\}/);
+assert.isNotNull(fb1c);
+
+const fb1cStyles = fb1c[1];
+const bg = fb1cStyles.match(/background\s*:\s*([\s\S]*)/);
+assert.isNotNull(bg);
+
+const background = bg[1];
+assert.match(background, /var\(--window-color4\)\s*10%\s*,\s*var\(--window-color4\)\s*90%/);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-city-skyline/5d822fd413a79914d39e9917.md
+++ b/curriculum/challenges/english/blocks/workshop-city-skyline/5d822fd413a79914d39e9917.md
@@ -25,7 +25,7 @@ Add a `repeating-linear-gradient` to `.fb1c` below the one that's there; use you
 You should not alter the first `repeating-linear-gradient`.
 
 ```js
-const fb1c = code.match(/\.fb1c\s*\{([\s\S]*?)\}/);
+const fb1c = __helpers.removeCssComments(code).match(/\.fb1c\s*\{([\s\S]*?)\}/);
 assert.exists(fb1c);
 
 const background = fb1c[1].match(/background\s*:\s*([^;]*)/);

--- a/curriculum/challenges/english/blocks/workshop-city-skyline/5d822fd413a79914d39e9917.md
+++ b/curriculum/challenges/english/blocks/workshop-city-skyline/5d822fd413a79914d39e9917.md
@@ -28,12 +28,22 @@ You should not alter the first `repeating-linear-gradient`.
 const fb1c = document.querySelector("style").textContent.match(/\.fb1c\s*\{([\s\S]*?)\}/);
 assert.isNotNull(fb1c);
 
-const fb1cStyles = fb1c[1];
-const bg = fb1cStyles.match(/background\s*:\s*([\s\S]*)/);
-assert.isNotNull(bg);
+const background = fb1c[1].match(/background\s*:\s*([^;]*)/);
+assert.isNotNull(background);
 
-const background = bg[1];
-assert.match(background, /repeating-linear-gradient\(\s*90deg\s*,\s*var\(--building-color4\)\s*,\s*var\(--building-color4\)\s*10%\s*,\s*transparent\s*10%\s*,\s*transparent\s*15%\s*\)/);
+assert.match(background[1], /repeating-linear-gradient\(\s*90deg\s*,\s*var\(--building-color4\)\s*(?:0%)?\s*,\s*var\(--building-color4\)\s*10%\s*,\s*transparent\s*10%\s*,\s*transparent\s*15%\s*\)/);
+```
+
+You should have a comma (`,`) after the first `repeating-linear-gradient`.
+
+```js
+const fb1c = document.querySelector("style").textContent.match(/\.fb1c\s*\{([\s\S]*?)\}/);
+assert.isNotNull(fb1c);
+
+const background = fb1c[1].match(/background\s*:\s*([^;]*)/);
+assert.isNotNull(background);
+
+assert.match(background[1], /repeating-linear-gradient\(\s*90deg\s*,\s*var\(--building-color4\)\s*(?:0%)?\s*,\s*var\(--building-color4\)\s*10%\s*,\s*transparent\s*10%\s*,\s*transparent\s*15%\s*\)\s*,/);
 ```
 
 You should add a `repeating-linear-gradient` with a first color of `--building-color4` from `0%` to `10%`.
@@ -42,12 +52,10 @@ You should add a `repeating-linear-gradient` with a first color of `--building-c
 const fb1c = document.querySelector("style").textContent.match(/\.fb1c\s*\{([\s\S]*?)\}/);
 assert.isNotNull(fb1c);
 
-const fb1cStyles = fb1c[1];
-const bg = fb1cStyles.match(/background\s*:\s*([\s\S]*)/);
-assert.isNotNull(bg);
+const background = fb1c[1].match(/background\s*:\s*([^;]*)/);
+assert.isNotNull(background);
 
-const background = bg[1];
-assert.match(background, /repeating-linear-gradient\(\s*var\(--building-color4\)(?:\s*0%)?\s*,\s*var\(--building-color4\)\s*10%/);
+assert.match(background[1], /repeating-linear-gradient\([\s\S]*?\)\s*,\s*repeating-linear-gradient\(\s*var\(--building-color4\)\s*(?:0%)?\s*,\s*var\(--building-color4\)\s*10%/);
 ```
 
 You should use a second color of `--window-color4` from `10%` to `90%`.
@@ -56,12 +64,10 @@ You should use a second color of `--window-color4` from `10%` to `90%`.
 const fb1c = document.querySelector("style").textContent.match(/\.fb1c\s*\{([\s\S]*?)\}/);
 assert.isNotNull(fb1c);
 
-const fb1cStyles = fb1c[1];
-const bg = fb1cStyles.match(/background\s*:\s*([\s\S]*)/);
-assert.isNotNull(bg);
+const background = fb1c[1].match(/background\s*:\s*([^;]*)/);
+assert.isNotNull(background);
 
-const background = bg[1];
-assert.match(background, /var\(--window-color4\)\s*10%\s*,\s*var\(--window-color4\)\s*90%/);
+assert.match(background[1], /repeating-linear-gradient\([\s\S]*?\)\s*,\s*repeating-linear-gradient\([\s\S]*?var\(--window-color4\)\s*10%\s*,\s*var\(--window-color4\)\s*90%/);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-city-skyline/5d822fd413a79914d39e9917.md
+++ b/curriculum/challenges/english/blocks/workshop-city-skyline/5d822fd413a79914d39e9917.md
@@ -25,11 +25,11 @@ Add a `repeating-linear-gradient` to `.fb1c` below the one that's there; use you
 You should not alter the first `repeating-linear-gradient`.
 
 ```js
-const fb1c = document.querySelector("style").textContent.match(/\.fb1c\s*\{([\s\S]*?)\}/);
-assert.isNotNull(fb1c);
+const fb1c = code.match(/\.fb1c\s*\{([\s\S]*?)\}/);
+assert.exists(fb1c);
 
 const background = fb1c[1].match(/background\s*:\s*([^;]*)/);
-assert.isNotNull(background);
+assert.exists(background);
 
 assert.match(background[1], /repeating-linear-gradient\(\s*90deg\s*,\s*var\(--building-color4\)\s*(?:0%)?\s*,\s*var\(--building-color4\)\s*10%\s*,\s*transparent\s*10%\s*,\s*transparent\s*15%\s*\)/);
 ```
@@ -37,11 +37,11 @@ assert.match(background[1], /repeating-linear-gradient\(\s*90deg\s*,\s*var\(--bu
 You should have a comma (`,`) after the first `repeating-linear-gradient`.
 
 ```js
-const fb1c = document.querySelector("style").textContent.match(/\.fb1c\s*\{([\s\S]*?)\}/);
-assert.isNotNull(fb1c);
+const fb1c = code.match(/\.fb1c\s*\{([\s\S]*?)\}/);
+assert.exists(fb1c);
 
 const background = fb1c[1].match(/background\s*:\s*([^;]*)/);
-assert.isNotNull(background);
+assert.exists(background);
 
 assert.match(background[1], /repeating-linear-gradient\(\s*90deg\s*,\s*var\(--building-color4\)\s*(?:0%)?\s*,\s*var\(--building-color4\)\s*10%\s*,\s*transparent\s*10%\s*,\s*transparent\s*15%\s*\)\s*,/);
 ```
@@ -49,11 +49,11 @@ assert.match(background[1], /repeating-linear-gradient\(\s*90deg\s*,\s*var\(--bu
 You should add a `repeating-linear-gradient` with a first color of `--building-color4` from `0%` to `10%`.
 
 ```js
-const fb1c = document.querySelector("style").textContent.match(/\.fb1c\s*\{([\s\S]*?)\}/);
-assert.isNotNull(fb1c);
+const fb1c = code.match(/\.fb1c\s*\{([\s\S]*?)\}/);
+assert.exists(fb1c);
 
 const background = fb1c[1].match(/background\s*:\s*([^;]*)/);
-assert.isNotNull(background);
+assert.exists(background);
 
 assert.match(background[1], /repeating-linear-gradient\([\s\S]*?\)\s*,\s*repeating-linear-gradient\(\s*var\(--building-color4\)\s*(?:0%)?\s*,\s*var\(--building-color4\)\s*10%/);
 ```
@@ -61,11 +61,11 @@ assert.match(background[1], /repeating-linear-gradient\([\s\S]*?\)\s*,\s*repeati
 You should use a second color of `--window-color4` from `10%` to `90%`.
 
 ```js
-const fb1c = document.querySelector("style").textContent.match(/\.fb1c\s*\{([\s\S]*?)\}/);
-assert.isNotNull(fb1c);
+const fb1c = code.match(/\.fb1c\s*\{([\s\S]*?)\}/);
+assert.exists(fb1c);
 
 const background = fb1c[1].match(/background\s*:\s*([^;]*)/);
-assert.isNotNull(background);
+assert.exists(background);
 
 assert.match(background[1], /repeating-linear-gradient\([\s\S]*?\)\s*,\s*repeating-linear-gradient\([\s\S]*?var\(--window-color4\)\s*10%\s*,\s*var\(--window-color4\)\s*90%/);
 ```

--- a/curriculum/challenges/english/blocks/workshop-city-skyline/5d822fd413a79914d39e9917.md
+++ b/curriculum/challenges/english/blocks/workshop-city-skyline/5d822fd413a79914d39e9917.md
@@ -37,7 +37,7 @@ assert.match(background[1], /repeating-linear-gradient\(\s*90deg\s*,\s*var\(--bu
 You should have a comma (`,`) after the first `repeating-linear-gradient`.
 
 ```js
-const fb1c = code.match(/\.fb1c\s*\{([\s\S]*?)\}/);
+const fb1c = __helpers.removeCssComments(code).match(/\.fb1c\s*\{([\s\S]*?)\}/);
 assert.exists(fb1c);
 
 const background = fb1c[1].match(/background\s*:\s*([^;]*)/);
@@ -49,7 +49,7 @@ assert.match(background[1], /repeating-linear-gradient\(\s*90deg\s*,\s*var\(--bu
 You should add a `repeating-linear-gradient` with a first color of `--building-color4` from `0%` to `10%`.
 
 ```js
-const fb1c = code.match(/\.fb1c\s*\{([\s\S]*?)\}/);
+const fb1c = __helpers.removeCssComments(code).match(/\.fb1c\s*\{([\s\S]*?)\}/);
 assert.exists(fb1c);
 
 const background = fb1c[1].match(/background\s*:\s*([^;]*)/);
@@ -61,7 +61,7 @@ assert.match(background[1], /repeating-linear-gradient\([\s\S]*?\)\s*,\s*repeati
 You should use a second color of `--window-color4` from `10%` to `90%`.
 
 ```js
-const fb1c = code.match(/\.fb1c\s*\{([\s\S]*?)\}/);
+const fb1c = __helpers.removeCssComments(code).match(/\.fb1c\s*\{([\s\S]*?)\}/);
 assert.exists(fb1c);
 
 const background = fb1c[1].match(/background\s*:\s*([^;]*)/);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #60083

<!-- Feel free to add any additional description of changes below this line -->

This PR is to improve the test for step-75 of workshop city skyline.

Changes made:

- The updated tests assert raw `background` property value in `.fb1c` using regex, instead of relying on computed styles

- The tests now fail only for the specific part of the value that has an error, instead of all tests failing. This makes debugging easier for learners