### PR TITLE
fix: correct quiz wording from 'Number object' to 'number'

### DIFF
--- a/curriculum/challenges/english/blocks/quiz-javascript-fundamentals/66edcd875b0d91de1fbbb492.md
+++ b/curriculum/challenges/english/blocks/quiz-javascript-fundamentals/66edcd875b0d91de1fbbb492.md
@@ -118,7 +118,7 @@ console.log(stringArray);
 
 #### --text--
 
-How can you convert a string literal into a Number object?
+How can you convert a string literal into a number?
 
 #### --distractors--
 


### PR DESCRIPTION
## Checklist:

- [x] I have read and followed the contribution guidelines.
- [x] I have read and followed the how to open a pull request guide.
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #65973

## Description

This PR updates the wording of a quiz question in the JavaScript Fundamentals Quiz.

The original question stated:

"How can you convert a string literal into a Number object?"

However, `Number()` returns a number primitive, not a `Number` object. To avoid confusion and align with JavaScript best practices, the question has been updated to:

"How can you convert a string literal into a number?"

No functional changes were made.
