### PR TITLE
fix(curriculum): correct typos in python basics

### DIFF
--- a/curriculum/challenges/english/blocks/review-python-basics/67f39b40deaec81a3e40e0c5.md
+++ b/curriculum/challenges/english/blocks/review-python-basics/67f39b40deaec81a3e40e0c5.md
@@ -156,7 +156,7 @@ print(isinstance('John Doe', int)) # False
 
 ## Working with Strings
 
-- **Definition**: As you recall from JavaScript, strings are immutable which means you can not change them after they have been created. In Python, you can use either single or double quotes. It is recommended to chose a rule and stick with it:
+- **Definition**: As you recall from JavaScript, strings are immutable which means you can not change them after they have been created. In Python, you can use either single or double quotes. It is recommended to choose a rule and stick with it:
 
 ```py
 developer = 'Jessica'
@@ -213,7 +213,7 @@ print(greeting) # My name is Jessica.
 str[start:stop:step]
 ```
 
-The start position represents the index where the extraction should be begin. The stop position is where the slice should end. This position is non inclusive. The step position represents the interval to increment for the slicing. Here are some examples:
+The start position represents the index where the extraction should begin. The stop position is where the slice should end. This position is non inclusive. The step position represents the interval to increment for the slicing. Here are some examples:
 
 ```py
 message = 'Python is fun!'

--- a/curriculum/challenges/english/blocks/review-python/67f39e391c9b373069def02c.md
+++ b/curriculum/challenges/english/blocks/review-python/67f39e391c9b373069def02c.md
@@ -213,7 +213,7 @@ print(greeting) # My name is Jessica.
 str[start:stop:step]
 ```
 
-The start position represents the index where the extraction should be begin. The stop position is where the slice should end. This position is non inclusive. The step position represents the interval to increment for the slicing. Here are some examples:
+The start position represents the index where the extraction should begin. The stop position is where the slice should end. This position is non inclusive. The step position represents the interval to increment for the slicing. Here are some examples:
 
 ```py
 message = 'Python is fun!'


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #66002

<!-- Feel free to add any additional description of changes below this line -->
This PR fixes two typos in the Python Basics Review curriculum: 
1. Removed the extra word "be".
2. Corrected "chose" to "choose".