### PR TITLE
fix(curriculum): correct indentation in boolean and conditionals lecture example...

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-booleans-and-conditionals/67fe85a3db9bad35f2b6a2bd.md
+++ b/curriculum/challenges/english/blocks/lecture-booleans-and-conditionals/67fe85a3db9bad35f2b6a2bd.md
@@ -68,9 +68,8 @@ The following code would raise an `IndentationError`, which is Python's way to s
 
 ```py
 age = 18
-
 if age >= 18:
-print('You are an adult') # IndentationError: expected an indented block after 'if' statement on line 3
+    print('You are an adult')# IndentationError: expected an indented block after 'if' statement on line 3
 ```
 
 Though you can use any number spaces (as long as you are consistent) to determine each level of indentation, the Python style guide recommends using four spaces.


### PR DESCRIPTION
### Description

This PR fixes the indentation in the Boolean and Conditionals lecture example.
The `print('You are an adult')` line was not properly indented, which could confuse learners. 
I have corrected the indentation to follow Python standards.

Closes #65999

### Checklist

- [x] I have read and followed the contribution guidelines.
- [x] I have read and followed the how to open a pull request guide.
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes locally.
