### PR TITLE
fix(curriculum): Add test to check if distance_mi is falsy

### DIFF
--- a/curriculum/challenges/english/blocks/lab-travel-weather-planner/694acade1d4afdbce71e5840.md
+++ b/curriculum/challenges/english/blocks/lab-travel-weather-planner/694acade1d4afdbce71e5840.md
@@ -45,6 +45,12 @@ You should assign a number to your `distance_mi` variable.
 ({ test: () => runPython(`assert isinstance(distance_mi, (int, float))`) })
 ```
 
+If the value of `distance_mi` is falsy, print `False`
+
+```js
+({ test: () => runPython(`assert bool(distance_mi)`) })
+```
+
 You should have a variable named `is_raining`.
 
 ```js


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #65981

[Adds](url) a test to the [Travel Weather Planner Lab](https://www.freecodecamp.org/learn/python-v9/lab-travel-weather-planner/build-a-travel-weather-planner) to check if the variable `distance_mi` is truthy.

I did attempt to test the changes I made using the `test-curriculum-content` script, and the test failed. It looks like it has to do with a module that's imported in the script. This kind of testing is a little out of my wheelhouse, so I'm not quite sure what to do about it. Any insight/direction would be greatly appreciated for future contributions. I've attached a screenshot of the test error I ran into.

![Screenshot 2026-02-24 at 01 14 56](https://github.com/user-attachments/assets/4f4b0ab3-ce7a-43a2-a948-761ff2e5a02e)

