### PR TITLE
feat: add additional syntax error examples in if-else lesson

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-booleans-and-conditionals/67fe85a3db9bad35f2b6a2bd.md
+++ b/curriculum/challenges/english/blocks/lecture-booleans-and-conditionals/67fe85a3db9bad35f2b6a2bd.md
@@ -75,6 +75,42 @@ print('You are an adult') # IndentationError: expected an indented block after '
 
 Though you can use any number spaces (as long as you are consistent) to determine each level of indentation, the Python style guide recommends using four spaces.
 
+The following code would raise a SyntaxError, which is Python's way to signal that the structure of the conditional statement is incorrect:
+
+```py
+age = 18
+
+if age >= 18:
+    print('You are an adult')
+
+print('Checking age...')
+
+else:
+    print('You are a minor')  # SyntaxError: invalid syntax
+```
+
+This happens because no statements are allowed between an if block and its corresponding else clause. The else must immediately follow the if block.
+
+The following code would also raise a SyntaxError, because an else clause cannot exist without a preceding if statement:
+
+```py
+else:
+    print('This will not work')  # SyntaxError: invalid syntax
+```
+An else clause must always follow an if or elif statement.
+
+
+The following code would raise a SyntaxError, which indicates that Python expected a colon (:) after the condition:
+
+```py
+age = 18
+
+if age >= 18
+    print('You are an adult')  # SyntaxError: expected ':'
+```
+
+Python requires a colon at the end of every if, elif, and else statement to define the beginning of a block.
+
 Blocks are also found in loops and functions, which you'll learn about in future lessons.
 
 Going back to our example, if `age` is anything less than `18`, nothing is printed in the terminal:


### PR DESCRIPTION
## Checklist:

- [x] I have read and followed the contribution guidelines.
- [x] I have read and followed the how to open a pull request guide.
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #65999 

## Description

This pull request adds additional `SyntaxError` examples to the Boolean and conditional statements lesson.

Specifically, it includes:

- An example showing that statements cannot appear between an `if` block and its corresponding `else`.
- An example demonstrating that `else` cannot be used without a preceding `if`.
- An example showing the error raised when a colon (`:`) is missing after an `if` condition.

These additions aim to strengthen learners' understanding of Python's conditional structure by demonstrating common structural mistakes alongside the existing `IndentationError` example.
