### PR TITLE
fix(client): align flash message text and close button (#65625)

### DIFF
--- a/client/src/components/Flash/flash.css
+++ b/client/src/components/Flash/flash.css
@@ -4,10 +4,10 @@ the CSS rules of `ui-components`'s Alert.
 */
 div.flash-message {
   display: flex;
-  justify-content: space-around;
+  align-items: center;
+  justify-content: space-between;
   flex-direction: row;
-  padding-top: 3px;
-  padding-bottom: 3px;
+  padding: 3px 15px;
   position: fixed;
   width: 100%;
   z-index: var(--z-index-flash);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ x] My pull request targets the `main` branch of freeCodeCamp.
- [ x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #65625

<!-- Feel free to add any additional description of changes below this line -->

The flash message banner displayed after login (and other actions) has misaligned content. The message text and close button are not vertically centered, and justify-content: space-around causes inconsistent horizontal spacing.

**Changes:**
File: client/src/components/Flash/flash.css
  - Added align-items: center to vertically center the text and close button within the banner.
  - Changed justify-content: space-around → justify-content: space-between so the message sits on the left and the close button is flush right (standard banner pattern).
  - Replaced separate padding-top/padding-bottom with shorthand padding: 3px 15px to add horizontal breathing room and prevent content from touching screen edges.