### PR TITLE
fix(curriculum): use code instead of editableContents for cafe menu CSS checks

### DIFF
--- a/curriculum/challenges/english/blocks/learn-basic-css-by-building-a-cafe-menu/5f3477aefa51bfc29327200b.md
+++ b/curriculum/challenges/english/blocks/learn-basic-css-by-building-a-cafe-menu/5f3477aefa51bfc29327200b.md
@@ -18,13 +18,13 @@ Start by rewriting the styles you have created into the `styles.css` file. Make 
 Your `styles.css` file should have the `h1, h2, p` type selector.
 
 ```js
-assert(editableContents.replace(/[\s\n]*/g, "").match(/(h1|h2|p),(h1|h2|p),(h1|h2|p){/));
+assert(code.slice(code.indexOf('</html>')).replace(/[\s\n]*/g, "").match(__helpers.concatRegex(__helpers.permutateRegex(['h1', 'h2', 'p'], { elementsSeparator: ',' }), /{/)));
 ```
  
 Your selector should set the `text-align` property to `center`.
 
 ```js
-assert(editableContents.match(/text-align:\s*center;?/));
+assert(code.slice(code.indexOf('</html>')).match(/text-align:\s*center;?/));
 ```
 
 Your code should not contain the `<style>` tags.

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3477aefa51bfc29327200b.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3477aefa51bfc29327200b.md
@@ -18,13 +18,13 @@ Start by rewriting the styles you have created into the `styles.css` file. Make 
 Your `styles.css` file should have the `h1, h2, p` type selector.
 
 ```js
-assert.match(editableContents.replace(/[\s\n]*/g, ""), /(h1|h2|p),(h1|h2|p),(h1|h2|p){/);
+assert.match(code.slice(code.indexOf('</html>')).replace(/[\s\n]*/g, ""), __helpers.concatRegex(__helpers.permutateRegex(['h1', 'h2', 'p'], { elementsSeparator: ',' }), /{/));
 ```
  
 Your selector should set the `text-align` property to `center`.
 
 ```js
-assert.match(editableContents, /text-align:\s*center;?/);
+assert.match(code.slice(code.indexOf('</html>')), /text-align:\s*center;?/);
 ```
 
 Your code should not contain the `<style>` tags.


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #66025

## Changes

The first two hints in both cafe menu challenges (workshop step 10 and learn-basic-css step 14) were testing `editableContents`, which only captures text inside the editable region markers. This caused the tests to pass only when the learner's CSS was placed inside the editable region, and fail otherwise — even with correct code.

Changed to use `code.slice(code.indexOf('</html>'))` which extracts the full CSS file content from the combined sources string (HTML + CSS are concatenated with HTML first). This is consistent with the approach already used by the third hint in the same step (`assert.isFalse(/<\/html>(\n|.)*<\/?\s*style\s*>/.test(code))`).

## Testing

<img width="1709" height="1034" alt="Screenshot 2026-02-24 at 8 53 32 PM" src="https://github.com/user-attachments/assets/d50b5414-1f95-4c44-b0aa-b126f307198a" />


<img width="1710" height="989" alt="Screenshot 2026-02-24 at 8 54 21 PM" src="https://github.com/user-attachments/assets/5ab18dd3-7241-48e7-8d2b-d05c35a59ad9" />
