### PR TITLE
fix(curriculum): clarify English-only text in workshop-magazine step 19

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-magazine/6143b9e1f5035c6e5f2a8231.md
+++ b/curriculum/challenges/english/blocks/workshop-magazine/6143b9e1f5035c6e5f2a8231.md
@@ -9,7 +9,7 @@ dashedName: step-19
 
 Within your `ul` element, create six `li` elements. Add an `h4` element with a `class` set to `list-subtitle` and a `p` element to each of your `li` elements.
 
-Then give the `h4` and `p` elements the following text content, in order, with each `h4` using what's on the left side of the colon, and each `p` using what's on the right:
+Then give the `h4` and `p` elements the following text content, in order, with each `h4` using what's on the left side of the colon, and each `p` using what's on the right. The text below is in English and should be added to your code exactly as written:
 
 - `V1 - 2014`: `We launched freeCodeCamp with a simple list of 15 resources, including Harvard's CS50 and Stanford's Database Class.`
 - `V2 - 2015`: `We added interactive algorithm challenges.`


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #65994

## Description

In the Spanish version of the workshop-magazine Step 19 challenge, the instructions are translated to Spanish by Crowdin, but the tests expect the English text values. This causes learners on the Spanish site to fail the tests even when following the (translated) instructions.

### Fix

Added a clarifying sentence to the description: *"The text below is in English and should be added to your code exactly as written"* — so when Crowdin translates the surrounding instructions to Spanish, learners will understand that the inline code text values must be entered exactly as shown in English.