### PR TITLE
fix(curriculum): typos in lecture absolute and relative paths

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-links/671682dd88e461a8e2620f38.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-links/671682dd88e461a8e2620f38.md
@@ -11,7 +11,7 @@ A path is a string that specifies the location of a file or directory in a file 
 
 An absolute path is a complete link to a resource. It starts from the root directory, includes every other directory, and finally the filename and extension. The "root directory" refers to the top-level directory or folder in a hierarchy.
 
-If you are linking to a resousce on your local machine, use an absolute path, which includes the full directory location of the file. Here's how to link to the `about.html` file with an absolute path:
+If you are linking to a resource on your local machine, use an absolute path, which includes the full directory location of the file. Here's how to link to the `about.html` file with an absolute path:
 
 ```html
 <p>

--- a/curriculum/challenges/english/blocks/lecture-working-with-links/671682dd88e461a8e2620f38.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-links/671682dd88e461a8e2620f38.md
@@ -45,7 +45,7 @@ The URL includes the protocol, `file://`. It also includes the path, which looks
 
 An absolute path shows the full location of a file within a file system and is commonly used for resources on a local machine. An absolute URL includes access information - such as the protocol and, for web resources, the domain name - which tells the browser how and where to retrieve the resource.
 
-Now, lets look at the relative path. A relative path specifies the location of a file relative to the directory of the current file. It does not include the protocol or the domain name, making it shorter and more flexible for internal links within the same website. Here's an example of linking to the `about.html` page from the `contact.html` page, both of which are in the same folder:
+Now, let's look at the relative path. A relative path specifies the location of a file relative to the directory of the current file. It does not include the protocol or the domain name, making it shorter and more flexible for internal links within the same website. Here's an example of linking to the `about.html` page from the `contact.html` page, both of which are in the same folder:
 
 ```html
 <p>
@@ -56,7 +56,7 @@ Now, lets look at the relative path. A relative path specifies the location of a
 
 So imagine you are on the `contact.html` page, and because the `about.html` page is in the same place, you simply get the filename. This is an example of using a relative file path.
 
-So, which should you use and when; an absolute path, an absolute URL or a relative path? Here are the rules you should follow:
+So, which should you use and when: an absolute path, an absolute URL, or a relative path? Here are the rules you should follow:
 
 - Use absolute paths when you want to reference a resource from a fixed location, such as from the root of your site or a known directory on your local machine.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

This PR is to fix typos in lecture absolute and relative paths.

Changes made:
- `Now, lets look at the relative path.` to `Now, let's look at the relative path.`
- `So, which should you use and when; an absolute path, an absolute URL or a relative path?` to `So, which should you use and when: an absolute path, an absolute URL, or a relative path?`
- `If you are linking to a resousce on your local machine` to `If you are linking to a resource on your local machine`