### PR TITLE
fix(curriculum): return false from has() mock in plant nursery step 17

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-plant-nursery-catalog/6734fa225c6667121e589f7e.md
+++ b/curriculum/challenges/english/blocks/workshop-plant-nursery-catalog/6734fa225c6667121e589f7e.md
@@ -19,7 +19,7 @@ Your `sellPlants` function should call the `has` method on `catalog`.
 let flag = false;
 const temp = catalog.has;
 try {
-    catalog.has = (p) => {flag = true}
+    catalog.has = (p) => {flag = true; return false;}
     sellPlants("test", "", 0);
     sellPlants(imperialGem, "medium", 200);
     assert.isTrue(flag);


### PR DESCRIPTION
Checklist:
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #66035

## Summary
The original mock `(p) => {flag = true}` returns `undefined`, which only works with truthy/falsy checks like `!catalog.has(plant)`.

With `(p) => {flag = true; return false;}` it makes the mock behave like the real `Map.prototype.has()` when a key is not there. So both valid approaches now pass:                                                                   
- !catalog.has(plant)
- catalog.has(plant) === false                                                                                                      