### PR TITLE
fix(curriculum): clarify constant wording in workshop

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-string-formatter/68e4276483b0c71658aab1d3.md
+++ b/curriculum/challenges/english/blocks/workshop-string-formatter/68e4276483b0c71658aab1d3.md
@@ -16,7 +16,7 @@ const str = "abcd";
 str.slice(0, 3); // "abc"
 ```
 
-Change the value of the `camelCasedVersion` from an empty string to the result of using the `slice()` method on the `lowercaseWord` variable. Pass in the number `0` and `5` which represent the start and end indices for the `slice()` method.
+You should change the existing `camelCasedVersion` assignment by replacing the empty string with `lowercaseWord.slice(0, 5)`.
 
 Now you should see the word `"camel"` in the console.
 

--- a/curriculum/challenges/english/blocks/workshop-string-formatter/68e4276483b0c71658aab1d3.md
+++ b/curriculum/challenges/english/blocks/workshop-string-formatter/68e4276483b0c71658aab1d3.md
@@ -7,7 +7,7 @@ dashedName: step-14
 
 # --description--
 
-As you recall from earlier lessons and workshops, you can extract portions of a string by using the `slice()` method .
+As you recall from earlier lessons and workshops, you can extract portions of a string by using the `slice()` method.
 
 Here is a reminder:
 

--- a/curriculum/challenges/english/blocks/workshop-string-formatter/68e4276483b0c71658aab1d3.md
+++ b/curriculum/challenges/english/blocks/workshop-string-formatter/68e4276483b0c71658aab1d3.md
@@ -7,7 +7,7 @@ dashedName: step-14
 
 # --description--
 
-As you recall from earlier lessons and workshops, you can extract portions of a string by using the `slice()` method.
+As you recall from earlier lessons and workshops, you can extract portions of a string by using the `slice()` method .
 
 Here is a reminder:
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #66017

<!-- Feel free to add any additional description of changes below this line -->
