### PR TITLE
refactor: create middleware for each redux store

### DIFF
--- a/client/src/redux/create-store.ts
+++ b/client/src/redux/create-store.ts
@@ -17,22 +17,21 @@ declare const module: {
   };
 };
 
-const clientSide = isBrowser();
-
-const sagaMiddleware = createSagaMiddleware({
-  context: {
-    document: clientSide ? document : {}
-  }
-});
-const epicMiddleware = createEpicMiddleware({
-  dependencies: {
-    window: clientSide ? window : {},
-    location: clientSide ? window.location : {},
-    document: clientSide ? document : {}
-  }
-});
-
 export const createStore = (preloadedState = {}) => {
+  const clientSide = isBrowser();
+  const sagaMiddleware = createSagaMiddleware({
+    context: {
+      document: clientSide ? document : {}
+    }
+  });
+  const epicMiddleware = createEpicMiddleware({
+    dependencies: {
+      window: clientSide ? window : {},
+      location: clientSide ? window.location : {},
+      document: clientSide ? document : {}
+    }
+  });
+
   const store = configureStore({
     // @ts-expect-error RTK uses unknown, Redux uses any
     reducer: rootReducer,


### PR DESCRIPTION
This should make the tests less noisy

> redux-observable | WARNING: this middleware is already associated with a store. createEpicMiddleware should be called for every store.
>
> Learn more: https://goo.gl/2GQ7Da

should stop appearing.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->
