### PR TITLE
fix(curriculum): update test for flexibility workshop shopping cart

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-shopping-cart/63eea5cea403a81a68ae493c.md
+++ b/curriculum/challenges/english/blocks/workshop-shopping-cart/63eea5cea403a81a68ae493c.md
@@ -45,7 +45,10 @@ The callback function should return whether the `id` property of `item` is stric
 
 ```js
 const cart = new ShoppingCart();
-assert.match(cart.addItem.toString(),/products\.find\(\s*function\s*\(\s*item\s*\)\s*\{\s*return\s+(?:item(?:\.id|\[['"]id['"]\])\s*===\s*id|id\s*===\s*item(?:\.id|\[['"]id['"]\]))\s*;?\s*\}/);
+assert.match(
+  cart.addItem.toString(),
+  /products\.find\(\s*function\s*\(\s*item\s*\)\s*\{\s*return\s+(?:item(?:\.id|\[(?<first>'|")id\k<first>\])\s*===\s*id|id\s*===\s*item(?:\.id|\[(?<second>'|")id\k<second>\]))\s*;?\s*\}/
+);
 ```
 
 You should assign the value of the `.find()` method to the `product` variable.

--- a/curriculum/challenges/english/blocks/workshop-shopping-cart/63eea5cea403a81a68ae493c.md
+++ b/curriculum/challenges/english/blocks/workshop-shopping-cart/63eea5cea403a81a68ae493c.md
@@ -45,7 +45,7 @@ The callback function should return whether the `id` property of `item` is stric
 
 ```js
 const cart = new ShoppingCart();
-assert.match(cart.addItem.toString(), /products\.find\(\s*function\s*\(\s*item\s*\)\s*\{\s*return\s+item\.id\s*===\s*id\s*;?\s*\}/);
+assert.match(cart.addItem.toString(),/(?:item(?:\.id|\[['"]id['"]\])\s*===\s*id|id\s*===\s*item(?:\.id|\[['"]id['"]\]))/);
 ```
 
 You should assign the value of the `.find()` method to the `product` variable.

--- a/curriculum/challenges/english/blocks/workshop-shopping-cart/63eea5cea403a81a68ae493c.md
+++ b/curriculum/challenges/english/blocks/workshop-shopping-cart/63eea5cea403a81a68ae493c.md
@@ -45,7 +45,7 @@ The callback function should return whether the `id` property of `item` is stric
 
 ```js
 const cart = new ShoppingCart();
-assert.match(cart.addItem.toString(),/(?:item(?:\.id|\[['"]id['"]\])\s*===\s*id|id\s*===\s*item(?:\.id|\[['"]id['"]\]))/);
+assert.match(cart.addItem.toString(),/products\.find\(\s*function\s*\(\s*item\s*\)\s*\{\s*return\s+(?:item(?:\.id|\[['"]id['"]\])\s*===\s*id|id\s*===\s*item(?:\.id|\[['"]id['"]\]))\s*;?\s*\}/);
 ```
 
 You should assign the value of the `.find()` method to the `product` variable.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #66061 

<!-- Feel free to add any additional description of changes below this line -->

This  PR is to update test in step 18 of workshop shopping cart.

Changes made:
- The test now passes for `id === item.id` or `item["id"] === id` or `item['id'] === id` and vice versa.