### PR TITLE
fix(curriculum): reorder unpacking lists review (#66100)

### DIFF
--- a/curriculum/challenges/english/blocks/review-loops-and-sequences/67f39b91583dec1e1eddbb9e.md
+++ b/curriculum/challenges/english/blocks/review-loops-and-sequences/67f39b91583dec1e1eddbb9e.md
@@ -112,6 +112,8 @@ developer = ['Alice', 34, 'Rust Developer']
 name, age, job = developer
 ```
 
+- If the number of variables on the left side of the assignment operator doesn't match the total number of items in the list, then you will receive a `ValueError`.
+
 - **Collecting Remaining Items From a List**: To collect any remaining elements from a list, you can use the asterisk (`*`) operator like this:
 
 ```py
@@ -119,7 +121,7 @@ developer = ['Alice', 34, 'Rust Developer']
 name, *rest = developer
 ```
 
-- If the number of variables on the left side of the assignment operator doesn't match the total number of items in the list, then you will receive a `ValueError`.
+
 
 - **Slicing Lists**: Slicing is the concept of accessing a portion of a list by using the slice operator `:`. To slice a list that starts at index `1` and ends at index `3`, you can use the following syntax:
 

--- a/curriculum/challenges/english/blocks/review-python/67f39e391c9b373069def02c.md
+++ b/curriculum/challenges/english/blocks/review-python/67f39e391c9b373069def02c.md
@@ -950,6 +950,8 @@ developer = ['Alice', 34, 'Rust Developer']
 name, age, job = developer
 ```
 
+- If the number of variables on the left side of the assignment operator doesn't match the total number of items in the list, then you will receive a `ValueError`.
+
 - **Collecting Remaining Items From a List**: To collect any remaining elements from a list, you can use the asterisk (`*`) operator like this:
 
 ```py
@@ -957,7 +959,6 @@ developer = ['Alice', 34, 'Rust Developer']
 name, *rest = developer
 ```
 
-- If the number of variables on the left side of the assignment operator doesn't match the total number of items in the list, then you will receive a `ValueError`.
 
 - **Slicing Lists**: Slicing is the concept of accessing a portion of a list by using the slice operator `:`. To slice a list that starts at index `1` and ends at index `3`, you can use the following syntax:
 


### PR DESCRIPTION
Closes #66100

## Changes

Moved the `ValueError` bullet point in two files to appear **before** the "Collecting Remaining Items From a List" section instead of after it.

### Files modified:
- `curriculum/challenges/english/blocks/review-python/67f39e391c9b373069def02c.md`
- `curriculum/challenges/english/blocks/review-loops-and-sequences/67f39b91583dec1e1eddbb9e.md`

### Before:
1. Unpacking Values from a List
2. Collecting Remaining Items From a List
3. ValueError line ❌

### After:
1. Unpacking Values from a List
2. ValueError line ✅
3. Collecting Remaining Items From a List

---

### PR Checklist

- [x] I have read the [contributing guidelines](https://contribute.freecodecamp.org)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings