### PR TITLE
feat: allow caller to audit specific languages

### DIFF
--- a/curriculum/src/challenge-auditor/index.ts
+++ b/curriculum/src/challenge-auditor/index.ts
@@ -1,3 +1,4 @@
+import { parseArgs } from 'node:util';
 import { flatten } from 'lodash/fp';
 
 import { availableLangs } from '@freecodecamp/shared/config/i18n';
@@ -7,6 +8,11 @@ import {
 } from '@freecodecamp/shared/config/curriculum';
 
 import { getChallengesForLang } from '../get-challenges.js';
+import { isEmpty } from 'lodash';
+
+const {
+  values: { language: languages }
+} = parseArgs({ options: { language: { type: 'string', multiple: true } } });
 
 // TODO: re-organise the types to a common 'types' folder that can be shared
 // between the workspaces so we don't have to declare ChallengeNode here and in
@@ -43,9 +49,9 @@ const getChallenges = async (lang: string) => {
 void (async () => {
   let actionShouldFail = false;
 
-  const langsToCheck = availableLangs.curriculum.filter(
-    lang => String(lang) !== 'english'
-  );
+  const langsToCheck = isEmpty(languages)
+    ? availableLangs.curriculum.filter(lang => String(lang) !== 'english')
+    : languages!;
   for (const language of langsToCheck) {
     console.log(`\n=== ${language} ===`);
     const certs = getAuditedSuperBlocks({ language });


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Usage example: `pnpm audit-challenges --language=german --language=espanol`

<!-- Feel free to add any additional description of changes below this line -->
