### PR TITLE
fix(curriculum): use correct indentation and fix comment

### DIFF
--- a/curriculum/challenges/english/blocks/review-classes-and-objects/67f39d848979082814c07d9c.md
+++ b/curriculum/challenges/english/blocks/review-classes-and-objects/67f39d848979082814c07d9c.md
@@ -80,19 +80,19 @@ print(my_car_1.describe())  # This car is a red Tesla Model S
 
 ```python
 class Car:
- def __init__(self, color, model):
-   self.color = color  
-   self.model = model  
+    def __init__(self, color, model):
+        self.color = color  
+        self.model = model  
 
- def describe(self):
-   return f'This car is a {self.color} {self.model}'
+    def describe(self):
+        return f'This car is a {self.color} {self.model}'
 
 my_car_1 = Car('red', 'Tesla Model S')
 my_car_2 = Car('green', 'Lamborghini Revuelto')
 
-print(my_car_1.describe()) # Calling methods using the dot notation
+print(my_car_1.describe()) # Calling method using the dot notation
 
-print(my_car_2.describe()) # Calling methods using the dot notation
+print(my_car_2.describe()) # Calling method using the dot notation
 ```
 
 ## Dunder (Magic) Methods

--- a/curriculum/challenges/english/blocks/review-python/67f39e391c9b373069def02c.md
+++ b/curriculum/challenges/english/blocks/review-python/67f39e391c9b373069def02c.md
@@ -2149,19 +2149,19 @@ print(my_car_1.describe())  # This car is a red Tesla Model S
 
 ```python
 class Car:
- def __init__(self, color, model):
-   self.color = color  
-   self.model = model  
+    def __init__(self, color, model):
+        self.color = color  
+        self.model = model  
 
- def describe(self):
-   return f'This car is a {self.color} {self.model}'
+    def describe(self):
+        return f'This car is a {self.color} {self.model}'
 
 my_car_1 = Car('red', 'Tesla Model S')
 my_car_2 = Car('green', 'Lamborghini Revuelto')
 
-print(my_car_1.describe()) # Calling methods using the dot notation
+print(my_car_1.describe()) # Calling method using the dot notation
 
-print(my_car_2.describe()) # Calling methods using the dot notation
+print(my_car_2.describe()) # Calling method using the dot notation
 ```
 
 ## Dunder (Magic) Methods


### PR DESCRIPTION
Files changed:

[freeCodeCamp/curriculum/challenges/english/blocks/review-classes-and-objects/67f39d848979082814c07d9c.md](https://github.com/freeCodeCamp/freeCodeCamp/blob/ef8bc8a225e8e0c5492b1af9475283810c6a6f65/curriculum/challenges/english/blocks/review-classes-and-objects/67f39d848979082814c07d9c.md#L82-L95)

[freeCodeCamp/curriculum/challenges/english/blocks/review-python/67f39e391c9b373069def02c.md](https://github.com/freeCodeCamp/freeCodeCamp/blob/ef8bc8a225e8e0c5492b1af9475283810c6a6f65/curriculum/challenges/english/blocks/review-python/67f39e391c9b373069def02c.md#L2149-L2167)

I updated the indentation and fixed the minor typo in the comments. I hope I followed the process properly, I read all the material related but I may have missed something. Please point it out if I did. This is a small change and doesn't require much more of a description, but this keeps coding conventions consistent in the curriculum.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #66067

<!-- Feel free to add any additional description of changes below this line -->
