### PR TITLE
fix(curriculum): rename heap module to heapq and correct heap property outputs

### DIFF
--- a/curriculum/challenges/english/blocks/review-graphs-and-trees/67f39e06b8a11b2de9ccd361.md
+++ b/curriculum/challenges/english/blocks/review-graphs-and-trees/67f39e06b8a11b2de9ccd361.md
@@ -98,7 +98,7 @@ The heap property determines the relationship between parent and child nodes. Th
   - The value of each parent node is less than or equal to the values of its children.
   - The smallest element is at the root.
 
-### Python `heap` module example
+### Python `heapq` module example
 
 ```py
 import heapq
@@ -110,12 +110,15 @@ my_heap = []
 heapq.heappush(my_heap, 9)
 heapq.heappush(my_heap, 3)
 heapq.heappush(my_heap, 5)
+print(my_heap) # [3, 9, 5]
 
 # Remove smallest element
 print(heapq.heappop(my_heap))  # 3
+print(my_heap) # [5, 9]
 
 # Push + Pop in one step
-print(heapq.heappushpop(my_heap, 2)) # 2
+print(heapq.heappushpop(my_heap, 7)) # 5
+print(my_heap) # [7, 9]
 
 # Transform list into heap
 nums = [5, 7, 3, 1]

--- a/curriculum/challenges/english/blocks/review-python/67f39e391c9b373069def02c.md
+++ b/curriculum/challenges/english/blocks/review-python/67f39e391c9b373069def02c.md
@@ -2823,7 +2823,7 @@ The heap property determines the relationship between parent and child nodes. Th
   - The value of each parent node is less than or equal to the values of its children.
   - The smallest element is at the root.
 
-### Python `heap` module example
+### Python `heapq` module example
 
 ```py
 import heapq
@@ -2835,12 +2835,15 @@ my_heap = []
 heapq.heappush(my_heap, 9)
 heapq.heappush(my_heap, 3)
 heapq.heappush(my_heap, 5)
+print(my_heap) # [3, 9, 5]
 
 # Remove smallest element
 print(heapq.heappop(my_heap))  # 3
+print(my_heap) # [5, 9]
 
 # Push + Pop in one step
-print(heapq.heappushpop(my_heap, 2)) # 2
+print(heapq.heappushpop(my_heap, 7)) # 5
+print(my_heap) # [7, 9]
 
 # Transform list into heap
 nums = [5, 7, 3, 1]


### PR DESCRIPTION


Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #66099

<!-- Feel free to add any additional description of changes below this line -->

This PR renames module from heap to heapq, changes heappushpop example, and adds print statements with comments to help visualize. 

I noticed when printing my_heap after having 9, 3, 5 added, the output would actually be [3, 9, 5] because min_heap just has a requirement that the parent shall be less than the child.
