### PR TITLE
fix: rename lab title from 'Build a Discount Calculator' to 'Build an Apply Discount Function'

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -4055,7 +4055,7 @@
         ]
       },
       "lab-discount-calculator": {
-        "title": "Build a Discount Calculator",
+        "title": "Build an Apply Discount Function",
         "intro": [
           "In this lab, you will practice basic Python by building a calculator to apply a discount to a price."
         ]

--- a/curriculum/structure/blocks/lab-discount-calculator.json
+++ b/curriculum/structure/blocks/lab-discount-calculator.json
@@ -1,9 +1,9 @@
 {
-  "name": "Build a Discount Calculator",
+  "name": "Build an Apply Discount Function",
   "isUpcomingChange": false,
   "dashedName": "lab-discount-calculator",
   "challengeOrder": [
-    { "id": "695774002591bbc5f8cf3e53", "title": "Build a Discount Calculator" }
+    { "id": "695774002591bbc5f8cf3e53", "title": "Build an Apply Discount Function" }
   ],
   "helpCategory": "Python",
   "blockLayout": "link",


### PR DESCRIPTION
Renamed the lab title to eliminate topic overlap with the workshop of the same name on the forum.

Files updated:
- client/i18n/locales/english/intro.json 
- curriculum/structure/blocks/lab-discount-calculator.json

Workshop title remains unchanged as intended.

Closes #66074