### PR TITLE
fix(curriculum): clarify slicing syntax

### DIFF
--- a/curriculum/challenges/english/blocks/review-loops-and-sequences/67f39b91583dec1e1eddbb9e.md
+++ b/curriculum/challenges/english/blocks/review-loops-and-sequences/67f39b91583dec1e1eddbb9e.md
@@ -121,7 +121,7 @@ name, *rest = developer
 
 - If the number of variables on the left side of the assignment operator doesn't match the total number of items in the list, then you will receive a `ValueError`.
 
-- **Slicing Lists**: Slicing is the concept of accessing a portion of a list by using the slice operator `:`. To slice a list that starts at index `1` and ends at index `3`, you can use the following syntax:
+- **Slicing Lists**: Slicing is the concept of accessing a portion of a list by using the slice operator `:`. To slice a list that starts at index `1` and ends before index `3`, you can use the following syntax:
 
 ```python
 desserts = ['Cake', 'Cookies', 'Ice Cream', 'Pie']

--- a/curriculum/challenges/english/blocks/review-python/67f39e391c9b373069def02c.md
+++ b/curriculum/challenges/english/blocks/review-python/67f39e391c9b373069def02c.md
@@ -959,7 +959,7 @@ name, *rest = developer
 
 - If the number of variables on the left side of the assignment operator doesn't match the total number of items in the list, then you will receive a `ValueError`.
 
-- **Slicing Lists**: Slicing is the concept of accessing a portion of a list by using the slice operator `:`. To slice a list that starts at index `1` and ends at index `3`, you can use the following syntax:
+- **Slicing Lists**: Slicing is the concept of accessing a portion of a list by using the slice operator `:`. To slice a list that starts at index `1` and ends before index `3`, you can use the following syntax:
 
 ```python
 desserts = ['Cake', 'Cookies', 'Ice Cream', 'Pie']


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #66066

<!-- Feel free to add any additional description of changes below this line -->
Updated slicing syntax mistake made on `review-python` and `review-loops-and-sequences`. Both should now be written as requested.