### PR TITLE
fix: block creation and hot reloading

### DIFF
--- a/client/utils/gatsby/challenge-page-creator.js
+++ b/client/utils/gatsby/challenge-page-creator.js
@@ -135,9 +135,7 @@ exports.createChallengePages = function (
   };
 };
 
-// TODO: figure out a cleaner way to get the last challenge in a block. Create
-// it during the curriculum build process and attach it to the first challenge?
-// That would remove the need to analyse allChallengeEdges.
+// TODO: figure out a cleaner way to get the last challenge in a block.
 function getProjectPreviewConfig(challenge, allChallengeNodes) {
   const { block } = challenge;
 

--- a/tools/challenge-helper-scripts/commands.ts
+++ b/tools/challenge-helper-scripts/commands.ts
@@ -8,6 +8,7 @@ import {
   insertStepIntoMeta,
   updateStepTitles
 } from './utils.js';
+import { ObjectId } from 'bson';
 
 async function deleteStep(stepNum: number): Promise<void> {
   if (stepNum < 1) {
@@ -54,13 +55,16 @@ async function insertStep(stepNum: number): Promise<void> {
   const challengeType =
     previousChallenge?.challengeType ?? nextChallenge?.challengeType;
 
-  const stepId = createStepFile({
+  const challengeId = new ObjectId();
+
+  createStepFile({
+    challengeId,
     stepNum,
     challengeType,
     challengeSeeds
   });
 
-  await insertStepIntoMeta({ stepNum, stepId });
+  await insertStepIntoMeta({ stepNum, stepId: challengeId });
   updateStepTitles();
   console.log(`Successfully inserted new step #${stepNum}`);
 }
@@ -74,8 +78,9 @@ async function createEmptySteps(num: number): Promise<void> {
 
   const nextStepNum = getMetaData().challengeOrder.length + 1;
   for (let stepNum = nextStepNum; stepNum < nextStepNum + num; stepNum++) {
-    const stepId = createStepFile({ stepNum });
-    await insertStepIntoMeta({ stepNum, stepId });
+    const challengeId = new ObjectId();
+    createStepFile({ stepNum, challengeId });
+    await insertStepIntoMeta({ stepNum, stepId: challengeId });
   }
   console.log(`Successfully added ${num} steps`);
 }

--- a/tools/challenge-helper-scripts/create-language-block.ts
+++ b/tools/challenge-helper-scripts/create-language-block.ts
@@ -602,4 +602,4 @@ void getAllBlocks()
       );
     }
   )
-  .then(() => console.log('All set.  Restart the client to see the changes.'));
+  .then(() => console.log('All set.  Refresh the page to see the changes.'));

--- a/tools/challenge-helper-scripts/create-language-block.ts
+++ b/tools/challenge-helper-scripts/create-language-block.ts
@@ -96,23 +96,7 @@ async function createLanguageBlock(
   });
 
   const challengeLang = getLangFromSuperBlock(superBlock);
-  let challengeId: ObjectId;
-
-  if (blockLabel === BlockLabel.quiz) {
-    challengeId = await createQuizChallenge(
-      block,
-      title,
-      questionCount!,
-      challengeLang
-    );
-    blockLayout = BlockLayouts.Link;
-  } else {
-    challengeId = await createDialogueChallenge(
-      superBlock,
-      block,
-      challengeLang
-    );
-  }
+  const challengeId: ObjectId = new ObjectId();
 
   await createMetaJson(
     block,
@@ -122,6 +106,19 @@ async function createLanguageBlock(
     blockLabel,
     blockLayout
   );
+
+  if (blockLabel === BlockLabel.quiz) {
+    await createQuizChallenge(
+      challengeId,
+      block,
+      title,
+      questionCount!,
+      challengeLang
+    );
+    blockLayout = BlockLayouts.Link;
+  } else {
+    await createDialogueChallenge(challengeId, block, challengeLang);
+  }
 
   const superblockFilename = (
     superBlockToFilename as Record<SuperBlocks, string>
@@ -242,7 +239,7 @@ async function createMetaJson(
 }
 
 async function createDialogueChallenge(
-  superBlock: SuperBlocks,
+  challengeId: ObjectId,
   block: string,
   challengeLang: string
 ): Promise<ObjectId> {
@@ -254,18 +251,21 @@ async function createDialogueChallenge(
   await fs.mkdir(newChallengeDir, { recursive: true });
 
   return createDialogueFile({
+    challengeId,
     projectPath: newChallengeDir + '/',
     challengeLang: challengeLang
   });
 }
 
 async function createQuizChallenge(
+  challengeId: ObjectId,
   block: string,
   title: string,
   questionCount: number,
   challengeLang: string
 ): Promise<ObjectId> {
   return createQuizFile({
+    challengeId,
     projectPath: await createBlockFolder(block),
     title: title,
     dashedName: block,

--- a/tools/challenge-helper-scripts/create-project.ts
+++ b/tools/challenge-helper-scripts/create-project.ts
@@ -97,27 +97,29 @@ async function createProject(projectArgs: CreateProjectArgs) {
     projectArgs.title
   );
 
+  const challengeId = new ObjectId();
+
   if (projectArgs.blockLabel === BlockLabel.quiz) {
     if (projectArgs.questionCount == null) {
       throw new Error(
         'Property `questionCount` is null when creating new Quiz Challenge'
       );
     }
-    const challengeId = await createQuizChallenge(
-      projectArgs.block,
-      projectArgs.title,
-      projectArgs.questionCount
-    );
-    void createMetaJson(
+    await createMetaJson(
       projectArgs.superBlock,
       projectArgs.block,
       projectArgs.title,
       projectArgs.helpCategory,
       challengeId
     );
+    await createQuizChallenge({
+      challengeId,
+      block: projectArgs.block,
+      title: projectArgs.title,
+      questionCount: projectArgs.questionCount
+    });
   } else {
-    const challengeId = await createFirstChallenge(projectArgs.block);
-    void createMetaJson(
+    await createMetaJson(
       projectArgs.superBlock,
       projectArgs.block,
       projectArgs.title,
@@ -127,7 +129,7 @@ async function createProject(projectArgs: CreateProjectArgs) {
       projectArgs.blockLabel,
       projectArgs.blockLayout
     );
-    // TODO: remove once we stop relying on markdown in the client.
+    await createFirstChallenge({ block: projectArgs.block, challengeId });
   }
 
   if (
@@ -192,7 +194,13 @@ async function createMetaJson(
   await writeBlockStructure(block, newMeta);
 }
 
-async function createFirstChallenge(block: string): Promise<ObjectId> {
+async function createFirstChallenge({
+  block,
+  challengeId
+}: {
+  block: string;
+  challengeId: ObjectId;
+}) {
   // TODO: would be nice if the extension made sense for the challenge, but, at
   // least until react I think they're all going to be html anyway.
   const challengeSeeds = [
@@ -203,7 +211,8 @@ async function createFirstChallenge(block: string): Promise<ObjectId> {
     }
   ];
   // including trailing slash for compatibility with createStepFile
-  return createStepFile({
+  createStepFile({
+    challengeId,
     projectPath: await createBlockFolder(block),
     stepNum: 1,
     challengeType: 0,
@@ -212,12 +221,19 @@ async function createFirstChallenge(block: string): Promise<ObjectId> {
   });
 }
 
-async function createQuizChallenge(
-  block: string,
-  title: string,
-  questionCount: number
-): Promise<ObjectId> {
+async function createQuizChallenge({
+  challengeId,
+  block,
+  title,
+  questionCount
+}: {
+  challengeId: ObjectId;
+  block: string;
+  title: string;
+  questionCount: number;
+}): Promise<ObjectId> {
   return createQuizFile({
+    challengeId,
     projectPath: await createBlockFolder(block),
     title: title,
     dashedName: block,

--- a/tools/challenge-helper-scripts/create-project.ts
+++ b/tools/challenge-helper-scripts/create-project.ts
@@ -412,4 +412,4 @@ void getAllBlocks()
         })
     )
   )
-  .then(() => console.log('All set.  Restart the client to see the changes.'));
+  .then(() => console.log('All set.  Refresh the page to see the changes.'));

--- a/tools/challenge-helper-scripts/rename-block.ts
+++ b/tools/challenge-helper-scripts/rename-block.ts
@@ -108,4 +108,4 @@ void getAllBlocks()
     async ({ newBlock, newName, oldBlock }: RenameBlockArgs) =>
       await renameBlock({ newBlock, newName, oldBlock })
   )
-  .then(() => console.log('All set.  Restart the client to see the changes.'));
+  .then(() => console.log('All set.  Refresh the page to see the changes.'));

--- a/tools/challenge-helper-scripts/utils.ts
+++ b/tools/challenge-helper-scripts/utils.ts
@@ -17,6 +17,7 @@ import {
 import { getTemplate } from './helpers/get-challenge-template.js';
 
 interface Options {
+  challengeId: ObjectId;
   stepNum: number;
   challengeType?: number;
   projectPath?: string;
@@ -26,6 +27,7 @@ interface Options {
 }
 
 interface QuizOptions {
+  challengeId: ObjectId;
   projectPath?: string;
   title: string;
   dashedName: string;
@@ -49,13 +51,12 @@ export async function getAllBlocks() {
 const createStepFile = ({
   stepNum,
   challengeType,
+  challengeId,
   projectPath = getProjectPath(),
   challengeSeeds = [],
   isFirstChallenge = false,
   challengeLang
-}: Options): ObjectId => {
-  const challengeId = new ObjectId();
-
+}: Options) => {
   const template = getStepTemplate({
     challengeId,
     challengeSeeds,
@@ -66,8 +67,6 @@ const createStepFile = ({
   });
 
   fs.writeFileSync(`${projectPath}${challengeId.toString()}.md`, template);
-
-  return challengeId;
 };
 
 const createChallengeFile = (
@@ -79,13 +78,13 @@ const createChallengeFile = (
 };
 
 const createQuizFile = ({
+  challengeId,
   projectPath = getProjectPath(),
   title,
   dashedName,
   questionCount,
   challengeLang
 }: QuizOptions): ObjectId => {
-  const challengeId = new ObjectId();
   const challengeType = challengeTypes.quiz.toString();
   const template = getTemplate(challengeType);
 
@@ -103,13 +102,14 @@ const createQuizFile = ({
 };
 
 const createDialogueFile = ({
+  challengeId,
   projectPath,
   challengeLang
 }: {
+  challengeId: ObjectId;
   projectPath: string;
   challengeLang: string;
 }): ObjectId => {
-  const challengeId = new ObjectId();
   const challengeType = challengeTypes.dialogue.toString();
   const template = getTemplate(challengeType);
 

--- a/tools/client-plugins/gatsby-source-challenges/gatsby-node.js
+++ b/tools/client-plugins/gatsby-source-challenges/gatsby-node.js
@@ -18,8 +18,6 @@ const {
 // createPagesStatefully only runs once, but we need the following when
 // updating challenges, so they have to be stored in memory.
 let allChallengeNodes;
-let idToNextPathCurrentCurriculum;
-let idToPrevPathCurrentCurriculum;
 const filepathToStatefullyCreatedNodes = new Map();
 const filePathToCreatedNodes = new Map();
 // reverse lookup, to detect if an updated file has "overwritten" another file
@@ -256,6 +254,22 @@ exports.sourceNodes = function sourceChallengesSourceNodes(
   });
 };
 
+const createIdToNextPathMap = nodes =>
+  nodes.reduce((map, node, index) => {
+    const nextNode = nodes[index + 1];
+    const nextPath = nextNode ? nextNode.challenge.fields.slug : null;
+    if (nextPath) map[node.id] = nextPath;
+    return map;
+  }, {});
+
+const createIdToPrevPathMap = nodes =>
+  nodes.reduce((map, node, index) => {
+    const prevNode = nodes[index - 1];
+    const prevPath = prevNode ? prevNode.challenge.fields.slug : null;
+    if (prevPath) map[node.id] = prevPath;
+    return map;
+  }, {});
+
 exports.createPagesStatefully = async function ({ graphql, actions }) {
   const result = await graphql(`
     {
@@ -324,25 +338,10 @@ exports.createPagesStatefully = async function ({ graphql, actions }) {
     ({ node }) => node
   );
 
-  const createIdToNextPathMap = nodes =>
-    nodes.reduce((map, node, index) => {
-      const nextNode = nodes[index + 1];
-      const nextPath = nextNode ? nextNode.challenge.fields.slug : null;
-      if (nextPath) map[node.id] = nextPath;
-      return map;
-    }, {});
-
-  const createIdToPrevPathMap = nodes =>
-    nodes.reduce((map, node, index) => {
-      const prevNode = nodes[index - 1];
-      const prevPath = prevNode ? prevNode.challenge.fields.slug : null;
-      if (prevPath) map[node.id] = prevPath;
-      return map;
-    }, {});
-
-  idToNextPathCurrentCurriculum = createIdToNextPathMap(allChallengeNodes);
-
-  idToPrevPathCurrentCurriculum = createIdToPrevPathMap(allChallengeNodes);
+  const idToNextPathCurrentCurriculum =
+    createIdToNextPathMap(allChallengeNodes);
+  const idToPrevPathCurrentCurriculum =
+    createIdToPrevPathMap(allChallengeNodes);
 
   const nodeToPage = createChallengePages(actions.createPage, {
     idToNextPathCurrentCurriculum,
@@ -364,6 +363,10 @@ exports.createPages = function ({ actions }) {
     [...allChallengeNodes, ...newNodes],
     ['challenge.superOrder', 'challenge.order', 'challenge.challengeOrder']
   );
+
+  const idToNextPathCurrentCurriculum = createIdToNextPathMap(sortedNodes);
+  const idToPrevPathCurrentCurriculum = createIdToPrevPathMap(sortedNodes);
+
   for (const node of newNodes) {
     const nodeToPage = createChallengePages(actions.createPage, {
       idToNextPathCurrentCurriculum,

--- a/tools/client-plugins/gatsby-source-challenges/gatsby-node.js
+++ b/tools/client-plugins/gatsby-source-challenges/gatsby-node.js
@@ -120,6 +120,10 @@ exports.sourceNodes = function sourceChallengesSourceNodes(
   }
 
   function handleChallengeUpdate(filePath, action = 'changed') {
+    // This has to be a blunt instrument, since we're not watching the structure
+    // files. If a .md file changes, we have to assume the structure may have
+    // changed too and update the structure nodes accordingly.
+    createSuperBlockStructureNodes();
     if (action === 'deleted') {
       // We have to return before calling onSourceChange, since the file is
       // gone.

--- a/tools/client-plugins/gatsby-source-challenges/gatsby-node.js
+++ b/tools/client-plugins/gatsby-source-challenges/gatsby-node.js
@@ -1,5 +1,7 @@
 const chokidar = require('chokidar');
 
+const { sortBy } = require('lodash');
+
 const {
   getSuperblockStructure
 } = require('@freecodecamp/curriculum/file-handler');
@@ -352,15 +354,23 @@ exports.createPagesStatefully = async function ({ graphql, actions }) {
 };
 
 exports.createPages = function ({ actions }) {
+  if (!allChallengeNodes) return;
+
   // actions.createPage has to be called in the createPages hook
-  const nodes = [...filePathToCreatedNodes.values()].flat();
-  for (const node of nodes) {
+  const newNodes = [...filePathToCreatedNodes.values()].flat();
+  // Nodes need sorting so createChallengePages can find the first and last
+  // challenges in a block.
+  const sortedNodes = sortBy(
+    [...allChallengeNodes, ...newNodes],
+    ['challenge.superOrder', 'challenge.order', 'challenge.challengeOrder']
+  );
+  for (const node of newNodes) {
     const nodeToPage = createChallengePages(actions.createPage, {
       idToNextPathCurrentCurriculum,
       idToPrevPathCurrentCurriculum
     });
 
-    nodeToPage(node, 0, allChallengeNodes);
+    nodeToPage(node, 0, sortedNodes);
   }
 
   // It's important NOT to clear the createdNodes, since Gatsby deletes any


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Now contributors can leave the client running while creating new blocks and have it dynamically update. Also, inter-challenge navigation should update correctly. For example, if we have challenges `[a,b,c]` and insert `b2` -> `[a,b,b2,c]`, then a user completing `b` should be taken to `b2`, not `c`. Previously you had to restart the client for this to work.

There's one known issue remaining: if you delete existing challenges the navigation won't work as it should. This is enough of an edge case that I don't think it's worth the time to fix.

<!-- Feel free to add any additional description of changes below this line -->
