### PR TITLE
fix: stop mutating redux state (savedChallenges)

### DIFF
--- a/client/src/templates/Challenges/classic/saved-challenges.test.ts
+++ b/client/src/templates/Challenges/classic/saved-challenges.test.ts
@@ -130,4 +130,20 @@ describe('mergeChallengeFiles', () => {
       }
     ]);
   });
+
+  it('should not mutate the original files and savedChallengeFiles arrays', () => {
+    const files: ChallengeFile[] = [jsChallenge, cssChallenge];
+    const savedChallengeFiles: SavedChallengeFile[] = [
+      savedJsChallenge,
+      savedCssChallenge
+    ];
+
+    const filesCopy = JSON.parse(JSON.stringify(files));
+    const savedFilesCopy = JSON.parse(JSON.stringify(savedChallengeFiles));
+
+    mergeChallengeFiles(files, savedChallengeFiles);
+
+    expect(files).toEqual(filesCopy);
+    expect(savedChallengeFiles).toEqual(savedFilesCopy);
+  });
 });

--- a/client/src/templates/Challenges/classic/saved-challenges.ts
+++ b/client/src/templates/Challenges/classic/saved-challenges.ts
@@ -8,10 +8,10 @@ export function mergeChallengeFiles(
   if (!savedFiles) return files;
   if (files.length !== savedFiles.length) return files;
 
-  const sortedChallengeFiles = files.sort((a, b) =>
+  const sortedChallengeFiles = files.toSorted((a, b) =>
     a.fileKey.localeCompare(b.fileKey)
   );
-  const sortedSavedChallengeFiles = savedFiles.sort((a, b) =>
+  const sortedSavedChallengeFiles = savedFiles.toSorted((a, b) =>
     a.fileKey.localeCompare(b.fileKey)
   );
 


### PR DESCRIPTION
mergeChallengeFiles was not functional and one of the things it mutated was redux state.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->
