### PR TITLE
fix(curriculum) : stringify uncloneable search params in Basic Node Post Challenge 

### DIFF
--- a/curriculum/challenges/english/blocks/basic-node-and-express/587d7fb2367417b2b2512bf8.md
+++ b/curriculum/challenges/english/blocks/basic-node-and-express/587d7fb2367417b2b2512bf8.md
@@ -36,7 +36,7 @@ Test 1 : Your API endpoint should respond with the correct name
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded'
     },
-    body: new URLSearchParams({ first: 'Mick', last: 'Jagger' })
+    body: new URLSearchParams({ first: 'Mick', last: 'Jagger' }).toString()
   });
   if (!response.ok) {
     throw new Error(await response.text());
@@ -51,7 +51,7 @@ Test 1 : Your API endpoint should respond with the correct name
 
 Test 2 : Your API endpoint should respond with the correct name
 
-```js
+```js 
   const response = await fetch(code + '/name', {
     method: 'POST',
     headers: {
@@ -60,7 +60,7 @@ Test 2 : Your API endpoint should respond with the correct name
     body: new URLSearchParams({
       first: 'Keith',
       last: 'Richards'
-    })
+    }).toString()
   });
   if (!response.ok) {
     throw new Error(await response.text());

--- a/curriculum/challenges/english/blocks/basic-node-and-express/587d7fb2367417b2b2512bf8.md
+++ b/curriculum/challenges/english/blocks/basic-node-and-express/587d7fb2367417b2b2512bf8.md
@@ -51,7 +51,7 @@ Test 1 : Your API endpoint should respond with the correct name
 
 Test 2 : Your API endpoint should respond with the correct name
 
-```js 
+```js
   const response = await fetch(code + '/name', {
     method: 'POST',
     headers: {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
This should fix the long standing issue of campers not being able to pass the basic node Express challenge due to the URLSearchParams object not being able to be cloned.

The reason why it can't be cloned for the record is because it is a object with methods; and the `postMessage` function won't like that. 