### PR TITLE
fix(api): cleaner exits before respawn

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -41,6 +41,7 @@ import {
   FCC_ENABLE_SWAGGER_UI,
   FCC_ENABLE_SHADOW_CAPTURE,
   FCC_ENABLE_SENTRY_ROUTES,
+  FREECODECAMP_NODE_ENV,
   GROWTHBOOK_FASTIFY_API_HOST,
   GROWTHBOOK_FASTIFY_CLIENT_KEY
 } from './utils/env.js';
@@ -86,7 +87,11 @@ export const buildOptions: FastifyHttpOptions<
   loggerInstance: getLogger(),
   genReqId: () => randomBytes(8).toString('hex'),
   // disabled so we can customise the request/response logging
-  disableRequestLogging: true
+  disableRequestLogging: true,
+  // destroy all connections on close to avoid EADDRINUSE
+  // on restart, in development. Leave default in production.
+  forceCloseConnections:
+    FREECODECAMP_NODE_ENV === 'production' ? ('idle' as const) : true
 };
 
 /**


### PR DESCRIPTION
This is mainly a QoL improvement. I would often find the API hung or crashed or not starting up because of an occupied port.

Root cause chain:
  1. tsx watch sends SIGTERM on file change, waits for the old process to exit, then spawns a new one
  2. The shutdown handler calls fastify.close() then process.exit(0)
  3. process.exit(0) fires the synchronous exit event
  4. Pino's on-exit-leak-free module hooks exit and calls Atomics.wait() to flush the pino-pretty worker thread — blocking the event loop for ~5
  seconds
  5. During that block, libuv can't run uv_close() on the TCP socket handle, so the port stays bound at the OS level
  6. The old process eventually terminates, tsx spawns the new one, but if it tries to bind before the OS fully releases the port → EADDRINUSE

  Fix (two parts):
  - server.ts: Close the HTTP server (closeAllConnections + server.close) and yield one event loop tick (setImmediate) before calling
  fastify.close() and process.exit(). This lets libuv finalize the socket handle while the event loop is still free.
  - app.ts: Set forceCloseConnections: true in dev so server.close() resolves immediately without waiting for keep-alive connections to drain.