### PR TITLE
fix(curriculum): use 'concatenate' instead of 'append' in workshop-pin-extractor

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-pin-extractor/68592b42b9c7f27cbe123203.md
+++ b/curriculum/challenges/english/blocks/workshop-pin-extractor/68592b42b9c7f27cbe123203.md
@@ -9,7 +9,7 @@ dashedName: step-15
 
 The third line of the poem is missing a third word, so the pin is shorter than expected.
 
-Add an `else` clause that appends a `'0'` to `secret_code` when there are not enough words, so that all lines of the poem are used to find digits.
+Add an `else` clause that concatenates a `'0'` to `secret_code` when there are not enough words, so that all lines of the poem are used to find digits.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #66134

<!-- Feel free to add any additional description of changes below this line -->
**Changes made:**
- Fixed the incorrect verb in the challenge description (changed “appends” → “concatenates”).