### PR TITLE
fix(curriculum): use 'concatenate' instead of 'append' in workshop-pin-extractor #66143

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-pin-extractor/68592b42b9c7f27cbe123203.md
+++ b/curriculum/challenges/english/blocks/workshop-pin-extractor/68592b42b9c7f27cbe123203.md
@@ -9,7 +9,7 @@ dashedName: step-15
 
 The third line of the poem is missing a third word, so the pin is shorter than expected.
 
-Add an `else` clause that appends a `'0'` to `secret_code` when there are not enough words, so that all lines of the poem are used to find digits.
+Add an `else` clause that to concatenate a `'0'` to `secret_code` when there are not enough words, so that all lines of the poem are used to find digits.
 
 # --hints--
 


### PR DESCRIPTION
Clarified the instruction for handling insufficient words in the poem.

Checklist:

[ x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org/).
[ x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
[ x] My pull request targets the main branch of freeCodeCamp.
[ x] I have tested these changes either locally on my machine, or GitHub Codespaces.
Closes https://github.com/freeCodeCamp/freeCodeCamp/issues/66134

Changes made:

Fixed the incorrect verb in the challenge description (changed “appends” → “concatenates”).
<img width="1448" height="331" alt="Screenshot 2026-02-28 204328" src="https://github.com/user-attachments/assets/df3c2927-57c2-4bac-899f-2ae05e4f2203" />
