### PR TITLE
Fix: common string methods

### DIFF
--- a/curriculum/challenges/english/blocks/review-python-basics/67f39b40deaec81a3e40e0c5.md
+++ b/curriculum/challenges/english/blocks/review-python-basics/67f39b40deaec81a3e40e0c5.md
@@ -247,7 +247,7 @@ print('f' in my_str)  # False
 
 ## Common String Methods
 
-- **`str.upper()`**: This returns a new string with all characters converted to uppercase:
+- **`upper()`**: This string method returns a new string with all characters converted to uppercase:
 
 ```py
 developer = 'Jessica'
@@ -255,7 +255,7 @@ developer = 'Jessica'
 print(developer.upper()) # JESSICA
 ```
 
-- **`str.lower()`**: This returns a new string with all characters converted to lowercase:
+- **`lower()`**: This string method returns a new string with all characters converted to lowercase:
 
 ```py
 developer = 'Jessica'
@@ -263,7 +263,7 @@ developer = 'Jessica'
 print(developer.lower()) # jessica
 ```
 
-- **`str.strip()`**: This returns a copy of the string with specified leading and trailing characters removed (if no argument is passed to the method, it removes leading and trailing whitespace).
+- **`strip()`**: This string method returns a copy of the string with specified leading and trailing characters removed (if no argument is passed to the method, it removes leading and trailing whitespace).
 
 ```py
 greeting = '  hello world  '
@@ -272,7 +272,7 @@ trimmed_my_str = greeting.strip()
 print(trimmed_my_str)  # 'hello world'
 ```
 
-- **`str.replace()`**: This returns a new string with all occurrences of the old string replaced by a new one.
+- **`replace()`**: This string method returns a new string with all occurrences of the old string replaced by a new one.
 
 ```py
 greeting = 'hello world'
@@ -281,7 +281,7 @@ replaced_my_str = greeting.replace('hello', 'hi')
 print(replaced_my_str)  # 'hi world'
 ```
 
-- **`str.split()`**: This is used to split a string into a list using a specified separator. A separator is a string specifying where the split should happen.
+- **`split()`**: This string method is used to split a string into a list using a specified separator. A separator is a string specifying where the split should happen.
 
 ```py
 dashed_name = 'example-dashed-name'
@@ -290,7 +290,7 @@ split_words = dashed_name.split('-')
 print(split_words)  # ['example', 'dashed', 'name']
 ```
 
-- **`str.join()`**: This is used to join elements of an iterable into a string with a separator. An iterable is a collection of elements that can be looped over like a list, string or a tuple. 
+- **`join()`**: This string method is used to join elements of an iterable into a string with a separator. An iterable is a collection of elements that can be looped over like a list, string or a tuple. 
 
 ```py
 example_list = ['example', 'dashed', 'name']
@@ -299,7 +299,7 @@ joined_str = ' '.join(example_list)
 print(joined_str)  # example dashed name
 ```
 
-- **`str.startswith(prefix)`**: This returns a boolean indicating if a string starts with the specified prefix:
+- **`startswith(prefix)`**: This string method returns a boolean indicating if a string starts with the specified prefix:
 
 ```py
 developer = 'Naomi'
@@ -308,7 +308,7 @@ result = developer.startswith('N')
 print(result)  # True
 ```
 
-- **`str.endswith(suffix)`**: This returns a boolean indicating if a string ends with the specified suffix:
+- **`endswith(suffix)`**: This string method returns a boolean indicating if a string ends with the specified suffix:
 
 ```py
 developer = 'Naomi'
@@ -317,7 +317,7 @@ result = developer.endswith('N')
 print(result)  # False
 ```
 
-- **`str.find()`**: This returns the index for the first occurrence of a substring. If one is not found, then `-1` is returned:
+- **`find()`**: This string method returns the index for the first occurrence of a substring. If one is not found, then `-1` is returned:
 
 ```py
 developer = 'Naomi'
@@ -329,42 +329,42 @@ city = 'Los Angeles'
 print(city.find('New')) # -1
 ```
 
-- **`str.count(substring)`**: This counts how many times a substring appears in a string:
+- **`count(substring)`**: This string method counts how many times a substring appears in a string:
 
 ```py
 city = 'Los Angeles'
 print(city.count('e')) # 2
 ```
 
-- **`str.capitalize()`**: This returns a new string with the first character capitalized and the other characters lowercased:
+- **`capitalize()`**: This string method returns a new string with the first character capitalized and the other characters lowercased:
 
 ```py
 dessert = 'chocolate cake'
 print(dessert.capitalize()) # Chocolate cake
 ```
 
-- **`str.isupper()`**: This returns `True` if all letters in the string are uppercase and `False` if otherwise:
+- **`isupper()`**: This string method returns `True` if all letters in the string are uppercase and `False` if otherwise:
 
 ```py
 dessert = 'chocolate cake'
 print(dessert.isupper()) # False
 ```
 
-- **`str.islower()`**: This returns `True` if all letters in the string are lowercase and `False` if otherwise:
+- **`islower()`**: This string method returns `True` if all letters in the string are lowercase and `False` if otherwise:
 
 ```py
 dessert = 'chocolate cake'
 print(dessert.islower()) # True
 ```
 
-- **`str.title()`**: This returns a new string with the first letter of each word capitalized:
+- **`title()`**: This string method returns a new string with the first letter of each word capitalized:
 
 ```py
 city = 'los angeles'
 print(city.title()) # Los Angeles
 ```
 
-- **`str.maketrans()`**: This method is used to create a table of 1 to 1 character mappings for translation. It is often used with the `translate()` method which applies that table to a string and return the translated result.
+- **`maketrans()`**: This string method is used to create a table of 1 to 1 character mappings for translation. It is often used with the `translate()` method which applies that table to a string and return the translated result.
 
 ```py
 trans_table = str.maketrans('abc', '123')

--- a/curriculum/challenges/english/blocks/review-python-basics/67f39b40deaec81a3e40e0c5.md
+++ b/curriculum/challenges/english/blocks/review-python-basics/67f39b40deaec81a3e40e0c5.md
@@ -272,7 +272,7 @@ trimmed_my_str = greeting.strip()
 print(trimmed_my_str)  # 'hello world'
 ```
 
-- **`replace()`**: This returns a new string with all occurrences of the old string replaced by a new one.
+- **`str.replace()`**: This returns a new string with all occurrences of the old string replaced by a new one.
 
 ```py
 greeting = 'hello world'
@@ -281,7 +281,7 @@ replaced_my_str = greeting.replace('hello', 'hi')
 print(replaced_my_str)  # 'hi world'
 ```
 
-- **`split()`**: This is used to split a string into a list using a specified separator. A separator is a string specifying where the split should happen.
+- **`str.split()`**: This is used to split a string into a list using a specified separator. A separator is a string specifying where the split should happen.
 
 ```py
 dashed_name = 'example-dashed-name'
@@ -290,7 +290,7 @@ split_words = dashed_name.split('-')
 print(split_words)  # ['example', 'dashed', 'name']
 ```
 
-- **`join()`**: This is used to join elements of an iterable into a string with a separator. An iterable is a collection of elements that can be looped over like a list, string or a tuple. 
+- **`str.join()`**: This is used to join elements of an iterable into a string with a separator. An iterable is a collection of elements that can be looped over like a list, string or a tuple. 
 
 ```py
 example_list = ['example', 'dashed', 'name']

--- a/curriculum/challenges/english/blocks/review-python/67f39e391c9b373069def02c.md
+++ b/curriculum/challenges/english/blocks/review-python/67f39e391c9b373069def02c.md
@@ -247,7 +247,7 @@ print('f' in my_str)  # False
 
 ## Common String Methods
 
-- **`str.upper()`**: This returns a new string with all characters converted to uppercase:
+- **`upper()`**: This string method returns a new string with all characters converted to uppercase:
 
 ```py
 developer = 'Jessica'
@@ -255,7 +255,7 @@ developer = 'Jessica'
 print(developer.upper()) # JESSICA
 ```
 
-- **`str.lower()`**: This returns a new string with all characters converted to lowercase:
+- **`lower()`**: This string method returns a new string with all characters converted to lowercase:
 
 ```py
 developer = 'Jessica'
@@ -263,7 +263,7 @@ developer = 'Jessica'
 print(developer.lower()) # jessica
 ```
 
-- **`str.strip()`**: This returns a copy of the string with specified leading and trailing characters removed (if no argument is passed to the method, it removes leading and trailing whitespace).
+- **`strip()`**: This string method returns a copy of the string with specified leading and trailing characters removed (if no argument is passed to the method, it removes leading and trailing whitespace).
 
 ```py
 greeting = '  hello world  '
@@ -272,7 +272,7 @@ trimmed_my_str = greeting.strip()
 print(trimmed_my_str)  # 'hello world'
 ```
 
-- **`str.replace()`**: This returns a new string with all occurrences of the old string replaced by a new one.
+- **`replace()`**: This string method returns a new string with all occurrences of the old string replaced by a new one.
 
 ```py
 greeting = 'hello world'
@@ -281,7 +281,7 @@ replaced_my_str = greeting.replace('hello', 'hi')
 print(replaced_my_str)  # 'hi world'
 ```
 
-- **`str.split()`**: This is used to split a string into a list using a specified separator. A separator is a string specifying where the split should happen.
+- **`split()`**: This string method is used to split a string into a list using a specified separator. A separator is a string specifying where the split should happen.
 
 ```py
 dashed_name = 'example-dashed-name'
@@ -290,7 +290,7 @@ split_words = dashed_name.split('-')
 print(split_words)  # ['example', 'dashed', 'name']
 ```
 
-- **`str.join()`**: This is used to join elements of an iterable into a string with a separator. An iterable is a collection of elements that can be looped over like a list, string or a tuple. 
+- **`join()`**: This string method is used to join elements of an iterable into a string with a separator. An iterable is a collection of elements that can be looped over like a list, string or a tuple. 
 
 ```py
 example_list = ['example', 'dashed', 'name']
@@ -299,7 +299,7 @@ joined_str = ' '.join(example_list)
 print(joined_str)  # example dashed name
 ```
 
-- **`str.startswith(prefix)`**: This returns a boolean indicating if a string starts with the specified prefix:
+- **`startswith(prefix)`**: This string method returns a boolean indicating if a string starts with the specified prefix:
 
 ```py
 developer = 'Naomi'
@@ -308,7 +308,7 @@ result = developer.startswith('N')
 print(result)  # True
 ```
 
-- **`str.endswith(suffix)`**: This returns a boolean indicating if a string ends with the specified suffix:
+- **`endswith(suffix)`**: This string method returns a boolean indicating if a string ends with the specified suffix:
 
 ```py
 developer = 'Naomi'
@@ -317,7 +317,7 @@ result = developer.endswith('N')
 print(result)  # False
 ```
 
-- **`str.find()`**: This returns the index for the first occurrence of a substring. If one is not found, then `-1` is returned:
+- **`find()`**: This string method returns the index for the first occurrence of a substring. If one is not found, then `-1` is returned:
 
 ```py
 developer = 'Naomi'
@@ -329,42 +329,42 @@ city = 'Los Angeles'
 print(city.find('New')) # -1
 ```
 
-- **`str.count(substring)`**: This counts how many times a substring appears in a string:
+- **`count(substring)`**: This string method counts how many times a substring appears in a string:
 
 ```py
 city = 'Los Angeles'
 print(city.count('e')) # 2
 ```
 
-- **`str.capitalize()`**: This returns a new string with the first character capitalized and the other characters lowercased:
+- **`capitalize()`**: This string method returns a new string with the first character capitalized and the other characters lowercased:
 
 ```py
 dessert = 'chocolate cake'
 print(dessert.capitalize()) # Chocolate cake
 ```
 
-- **`str.isupper()`**: This returns `True` if all letters in the string are uppercase and `False` if otherwise:
+- **`isupper()`**: This string method returns `True` if all letters in the string are uppercase and `False` if otherwise:
 
 ```py
 dessert = 'chocolate cake'
 print(dessert.isupper()) # False
 ```
 
-- **`str.islower()`**: This returns `True` if all letters in the string are lowercase and `False` if otherwise:
+- **`islower()`**: This string method returns `True` if all letters in the string are lowercase and `False` if otherwise:
 
 ```py
 dessert = 'chocolate cake'
 print(dessert.islower()) # True
 ```
 
-- **`str.title()`**: This returns a new string with the first letter of each word capitalized:
+- **`title()`**: This string method returns a new string with the first letter of each word capitalized:
 
 ```py
 city = 'los angeles'
 print(city.title()) # Los Angeles
 ```
 
-- **`str.maketrans()`**: This method is used to create a table of 1 to 1 character mappings for translation. It is often used with the `translate()` method which applies that table to a string and return the translated result.
+- **`maketrans()`**: This string method is used to create a table of 1 to 1 character mappings for translation. It is often used with the `translate()` method which applies that table to a string and return the translated result.
 
 ```py
 trans_table = str.maketrans('abc', '123')

--- a/curriculum/challenges/english/blocks/review-python/67f39e391c9b373069def02c.md
+++ b/curriculum/challenges/english/blocks/review-python/67f39e391c9b373069def02c.md
@@ -272,7 +272,7 @@ trimmed_my_str = greeting.strip()
 print(trimmed_my_str)  # 'hello world'
 ```
 
-- **`replace()`**: This returns a new string with all occurrences of the old string replaced by a new one.
+- **`str.replace()`**: This returns a new string with all occurrences of the old string replaced by a new one.
 
 ```py
 greeting = 'hello world'
@@ -281,7 +281,7 @@ replaced_my_str = greeting.replace('hello', 'hi')
 print(replaced_my_str)  # 'hi world'
 ```
 
-- **`split()`**: This is used to split a string into a list using a specified separator. A separator is a string specifying where the split should happen.
+- **`str.split()`**: This is used to split a string into a list using a specified separator. A separator is a string specifying where the split should happen.
 
 ```py
 dashed_name = 'example-dashed-name'
@@ -290,7 +290,7 @@ split_words = dashed_name.split('-')
 print(split_words)  # ['example', 'dashed', 'name']
 ```
 
-- **`join()`**: This is used to join elements of an iterable into a string with a separator. An iterable is a collection of elements that can be looped over like a list, string or a tuple. 
+- **`str.join()`**: This is used to join elements of an iterable into a string with a separator. An iterable is a collection of elements that can be looped over like a list, string or a tuple. 
 
 ```py
 example_list = ['example', 'dashed', 'name']


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #66053

This issue is in Two files ,I updated the descriptions of `replace()`, `split()`, `join()`, etc to clearly indicate they are string methods called on a string instance, rather than adding `str.` dot notation prefix.
