### PR TITLE
fix(client): accessibility code examples

### DIFF
--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -55,11 +55,7 @@ import {
   isChallengeCompletedSelector
 } from '../redux/selectors';
 import GreenPass from '../../../assets/icons/green-pass';
-import {
-  enhancePrismAccessibility,
-  makePrismCollapsible,
-  setScrollbarArrowStyles
-} from '../utils/index';
+import { makePrismCollapsible, setScrollbarArrowStyles } from '../utils/index';
 import { initializeMathJax, isMathJaxAllowed } from '../../../utils/math-jax';
 import { getScrollbarWidth } from '../../../utils/scrollbar-width';
 import { isProjectBased } from '../../../utils/curriculum-layout';
@@ -884,7 +880,6 @@ const Editor = (props: EditorProps): JSX.Element => {
     descContainer.appendChild(jawHeading);
     descContainer.appendChild(desc);
     desc.innerHTML = description;
-    Prism.hooks.add('complete', enhancePrismAccessibility);
 
     // To reduce confusion on the first workshop. Will need to find a better solution.
     if (props.block !== 'workshop-curriculum-outline') {

--- a/client/src/templates/Challenges/components/challenge-transcript.test.tsx
+++ b/client/src/templates/Challenges/components/challenge-transcript.test.tsx
@@ -102,12 +102,19 @@ describe('<ChallengeTranscript />', () => {
       />
     );
 
-    const preElement = screen.getByRole('region');
+    const preElement = screen.getByText(
+      (_, element) =>
+        element?.tagName === 'PRE' &&
+        element.textContent?.includes('console.log("hi")') === true
+    );
     expect(preElement).toBeVisible();
     expect(preElement.tagName).toBe('PRE');
 
-    // eslint-disable-next-line testing-library/no-node-access
-    const codeElement = preElement.querySelector('code');
+    const codeElement = screen.getByText(
+      (_, element) =>
+        element?.tagName === 'CODE' &&
+        element.textContent?.includes('console.log("hi")') === true
+    );
     expect(codeElement).toBeInTheDocument();
     expect(preElement).toHaveTextContent('console.log("hi")');
   });

--- a/client/src/templates/Challenges/components/prism-formatted.tsx
+++ b/client/src/templates/Challenges/components/prism-formatted.tsx
@@ -1,6 +1,5 @@
 import Prism from 'prismjs';
 import React, { useRef, useEffect } from 'react';
-import { enhancePrismAccessibility } from '../utils';
 
 interface PrismFormattedProps {
   className?: string;
@@ -25,7 +24,6 @@ function PrismFormatted({
   useEffect(() => {
     // Just in case 'current' has not been created, though it should have been.
     if (instructionsRef.current) {
-      Prism.hooks.add('complete', enhancePrismAccessibility);
       Prism.highlightAllUnder(instructionsRef.current);
 
       const preElements = instructionsRef.current.querySelectorAll('pre');

--- a/client/src/templates/Challenges/utils/index.ts
+++ b/client/src/templates/Challenges/utils/index.ts
@@ -33,55 +33,6 @@ export function transformEditorLink(url: string): string {
     );
 }
 
-// Adds region role and accessible name to PrismJS code blocks
-export function enhancePrismAccessibility(
-  prismEnv: Prism.hooks.ElementHighlightedEnvironment
-): void {
-  const langs: { [key: string]: string } = {
-    js: 'JavaScript',
-    javascript: 'JavaScript',
-    css: 'CSS',
-    html: 'HTML',
-    python: 'python',
-    py: 'python',
-    xml: 'XML',
-    jsx: 'JSX',
-    scss: 'SCSS',
-    sql: 'SQL',
-    http: 'HTTP',
-    json: 'JSON',
-    pug: 'pug',
-    ts: 'TypeScript',
-    typescript: 'TypeScript',
-    tsx: 'TSX',
-    csharp: 'C#',
-    clike: 'CLike',
-    c: 'C',
-    cpp: 'C++'
-  };
-  const parent = prismEnv?.element?.parentElement;
-  if (
-    !parent ||
-    parent.nodeName !== 'PRE' ||
-    parent.tabIndex !== 0 ||
-    parent.dataset.noAria === 'true'
-  ) {
-    return;
-  }
-
-  parent.setAttribute('role', 'region');
-  const codeType = prismEnv.element?.className
-    .replace(/language-(.*)/, '$1')
-    .toLowerCase();
-  const codeName = langs[codeType] || '';
-  parent.setAttribute(
-    'aria-label',
-    i18next.t('aria.code-example', {
-      codeName
-    })
-  );
-}
-
 // Make PrismJS code blocks collapsible
 export function makePrismCollapsible(
   prismEnv: Prism.hooks.ElementHighlightedEnvironment


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

In affected Python question flows, JAWS announced only a generic label (for example, “code example” / “python code example”) and did not read the actual code content when navigating normally. This made code-based questions inaccessible for blind learners.

After this change, code blocks keep native semantics and no longer get generic landmark labeling. This prevents screen readers from stopping at a container label instead of the code itself, so learners can access the code content directly.

`enhancePrismAccessibility` added `role="region"` + ` aria-label="... code example"` to code containers. In the affected JAWS flow, that generic landmark label was announced instead of the code content, which blocked access to the actual example text.

Closes #66156

<!-- Feel free to add any additional description of changes below this line -->
