### PR TITLE
fix(curriculum): add backticks to 'or' in Python Basics Review

### DIFF
--- a/curriculum/challenges/english/blocks/review-python-basics/67f39b40deaec81a3e40e0c5.md
+++ b/curriculum/challenges/english/blocks/review-python-basics/67f39b40deaec81a3e40e0c5.md
@@ -803,7 +803,7 @@ else:
     print('You are not eligible to vote')
 ```
 
-- **`or` Operator**: This operator returns the first operand if it is truthy, otherwise, it returns the second operand. An or expression results in a truthy value if at least one operand is truthy. Here is an example:
+- **`or` Operator**: This operator returns the first operand if it is truthy, otherwise, it returns the second operand. An `or` expression results in a truthy value if at least one operand is truthy. Here is an example:
 
 ```py
 age = 19


### PR DESCRIPTION
Fixes #66153

## Summary
Wraps 'or' in backticks for proper code formatting in the Python Basics Review challenge.

## Changes
- Updated 'An or expression' to 'An \or\ expression' for consistent code formatting

## Checklist
- [x] I have read and followed the [contributing guidelines](https://contribute.freecodecamp.org)
- [x] This PR fixes a single issue (#66153)
- [x] Changes are limited to the affected challenge file