### PR TITLE
fix: correct Python custom exception example (fixes #66054)

### DIFF
--- a/curriculum/challenges/english/blocks/review-python/67f39e391c9b373069def02c.md
+++ b/curriculum/challenges/english/blocks/review-python/67f39e391c9b373069def02c.md
@@ -2041,7 +2041,7 @@ if __name__ == '__main__':
       return f"Welcome, {username}!"
   ```  
 
-  Here's a how you can use the `login` function from the `InvalidCredentialsError` exception:
+  Here's how you can use the `login` function with the `InvalidCredentialsError` exception:
 
   ```py
   # failed login attempt
@@ -2054,9 +2054,7 @@ if __name__ == '__main__':
   # successful login attempt
   try:
       message = login("admin", "password123")
-      print(message)
   except InvalidCredentialsError as e:
-      # This block is not executed because the login was successful
       print(f"Login failed: {e}")
   else:
       # The else block runs if the 'try' block completes without an exception


### PR DESCRIPTION
## Description
Fixes #66054

### Changes:
1. Fixed typo: "Here's a how" -> "Here's how"
2. Changed "from the InvalidCredentialsError" -> "with the InvalidCredentialsError"
3. Removed duplicate \ in successful login example (was printing twice)
4. Removed misleading comment in except block

### Before:
\- Successful example had \ both in \ and \ blocks

### After:
\- \ only in the \ block (runs after successful try)