### PR TITLE
perf: cache challenges on build

### DIFF
--- a/curriculum/src/build-superblock.test.js
+++ b/curriculum/src/build-superblock.test.js
@@ -378,9 +378,18 @@ describe('buildSuperblock pure functions', () => {
     test('should add meta properties to challenge', () => {
       const challenge = { id: '1' };
 
+      const updatedChallenge = addMetaToChallenge(challenge, dummyBlockMeta);
+
+      expect(updatedChallenge).toEqual(expectedChallengeProperties);
+    });
+
+    test('should not mutate the original challenge', () => {
+      const challenge = { id: '1' };
+      const challengeCopy = { ...challenge };
+
       addMetaToChallenge(challenge, dummyBlockMeta);
 
-      expect(challenge).toEqual(expectedChallengeProperties);
+      expect(challenge).toEqual(challengeCopy);
     });
 
     test('should add chapter and module properties when present in meta', () => {
@@ -391,9 +400,12 @@ describe('buildSuperblock pure functions', () => {
         module: 'module-1'
       };
 
-      addMetaToChallenge(challenge, metaWithChapterAndModule);
+      const updatedChallenge = addMetaToChallenge(
+        challenge,
+        metaWithChapterAndModule
+      );
 
-      expect(challenge).toMatchObject({
+      expect(updatedChallenge).toMatchObject({
         ...expectedChallengeProperties,
         chapter: 'chapter-1',
         module: 'module-1'

--- a/curriculum/src/build-superblock.ts
+++ b/curriculum/src/build-superblock.ts
@@ -1,6 +1,6 @@
 import { existsSync, readdirSync } from 'fs';
 import { join, resolve, basename } from 'path';
-import { isEmpty } from 'lodash';
+import { isEmpty, cloneDeep } from 'lodash';
 import debug from 'debug';
 
 import { parseMD } from '../../tools/challenge-parser/parser';
@@ -8,7 +8,8 @@ import { createPoly } from '@freecodecamp/shared/utils/polyvinyl';
 import { isAuditedSuperBlock } from '@freecodecamp/shared/utils/is-audited';
 import {
   CommentDictionary,
-  translateCommentsInChallenge
+  translateCommentsInChallenge,
+  type Challenge as ParsedChallenge
 } from '../../tools/challenge-parser/translation-parser';
 import { SuperBlocks } from '@freecodecamp/shared/config/curriculum';
 import type { Chapter } from '@freecodecamp/shared/config/chapters';
@@ -42,6 +43,8 @@ interface Meta extends BlockStructure {
   superBlock: SuperBlocks;
   superOrder: number;
 }
+
+const challengeCache = new Map<string, ParsedChallenge>();
 
 /**
  * Validates challenges against meta.json challengeOrder
@@ -145,9 +148,11 @@ export function buildBlock(foundChallenges: Challenge[], meta: Meta) {
  * @returns {object} The challenge object with added meta information
  */
 export function addMetaToChallenge(
-  challenge: Partial<Challenge>,
+  challengeIn: Partial<Challenge>,
   meta: Meta
 ): Challenge {
+  const challenge = cloneDeep(challengeIn);
+
   const challengeOrderIndex = meta.challengeOrder.findIndex(
     ({ id }) => id === challenge.id
   );
@@ -329,11 +334,15 @@ export class BlockCreator {
 
     const challengePath = langUsed === 'english' ? englishPath : i18nPath;
 
-    const challenge = translateCommentsInChallenge(
-      await parser(challengePath),
-      langUsed,
-      this.commentTranslations
-    );
+    const cachedChallenge = challengeCache.get(challengePath);
+
+    const challenge =
+      cachedChallenge ??
+      translateCommentsInChallenge(
+        await parser(challengePath),
+        langUsed,
+        this.commentTranslations
+      );
 
     challenge.translationPending = this.lang !== 'english' && !isAudited;
     // Add source location to allow tracing back to original file (necessary to
@@ -343,6 +352,8 @@ export class BlockCreator {
       block,
       filename
     );
+
+    challengeCache.set(challengePath, challenge);
 
     return finalizeChallenge(challenge, meta);
   }


### PR DESCRIPTION
Since we're duplicating blocks, we can save a few seconds on a build by keeping parsed challenges in memory

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
