### PR TITLE
fix(curriculum): replace innerText with textContent in legend span test

### DIFF
--- a/curriculum/challenges/english/blocks/lab-availability-table/66b36358ed4f261d64840c24.md
+++ b/curriculum/challenges/english/blocks/lab-availability-table/66b36358ed4f261d64840c24.md
@@ -269,7 +269,10 @@ assert.equal(document.querySelector('#legend')?.tagName, 'DIV');
 You should have a `span` element with the text `Availability` inside your `#legend`.
 
 ```js
-assert.equal(document.querySelector('#legend span')?.innerText, 'Availability');
+assert.equal(
+  document.querySelector('#legend span')?.textContent.trim(),
+  'Availability'
+);
 ```
 
 You should have a `div` element with the `id` of `legend-gradient` inside your `#legend`.


### PR DESCRIPTION
## Checklist:

- [x] I have read and followed the contribution guidelines.
- [x] I have read and followed the how to open a pull request guide.
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes locally.

Closes #66163

---

## Description

Replaced `innerText` with `textContent.trim()` in the legend span assertion to prevent false test failures when CSS `text-transform` is applied.