### PR TITLE
fix(curriculum): format `or` operator correctly in python review basics lesson

### DIFF
--- a/curriculum/challenges/english/blocks/review-python-basics/67f39b40deaec81a3e40e0c5.md
+++ b/curriculum/challenges/english/blocks/review-python-basics/67f39b40deaec81a3e40e0c5.md
@@ -803,7 +803,7 @@ else:
     print('You are not eligible to vote')
 ```
 
-- **`or` Operator**: This operator returns the first operand if it is truthy, otherwise, it returns the second operand. An or expression results in a truthy value if at least one operand is truthy. Here is an example:
+- **`or` Operator**: This operator returns the first operand if it is truthy, otherwise, it returns the second operand. An `or` expression results in a truthy value if at least one operand is truthy. Here is an example:
 
 ```py
 age = 19


### PR DESCRIPTION
## Description
This PR fixes a formatting issue in the Python basics curriculum where the `or` operator explanation was not formatted as inline code.

## Changes
- Updated the sentence to format `or` using backticks for consistency with curriculum styling guidelines

## Checklist:
- [x] I have read and followed the contribution guidelines.
- [x] I have read and followed the how to open a pull request guide.
- [x] My pull request targets the main branch of freeCodeCamp.
- [x] I have tested these changes locally.

Closes #66153