### PR TITLE
fix: correct login example inconsistency in review-python and review-…

### DIFF
--- a/curriculum/challenges/english/blocks/review-error-handling/67f39bcb48373420f4f12d62.md
+++ b/curriculum/challenges/english/blocks/review-error-handling/67f39bcb48373420f4f12d62.md
@@ -99,25 +99,23 @@ dashedName: review-error-handling
       return f"Welcome, {username}!"
   ```  
 
-  Here's a how you can use the `login` function from the `InvalidCredentialsError` exception:
+  Here's how you can use the `login` function with the `InvalidCredentialsError` exception:
 
   ```py
   # failed login attempt
   try:
       message = login("user", "wrongpassword")
-      print(message)
   except InvalidCredentialsError as e:
       print(f"Login failed: {e}")
+  else:
+      print(message)
 
   # successful login attempt
   try:
       message = login("admin", "password123")
-      print(message)
   except InvalidCredentialsError as e:
-      # This block is not executed because the login was successful
       print(f"Login failed: {e}")
   else:
-      # The else block runs if the 'try' block completes without an exception
       print(message)
   ```
 

--- a/curriculum/challenges/english/blocks/review-python/67f39e391c9b373069def02c.md
+++ b/curriculum/challenges/english/blocks/review-python/67f39e391c9b373069def02c.md
@@ -2041,25 +2041,23 @@ if __name__ == '__main__':
       return f"Welcome, {username}!"
   ```  
 
-  Here's a how you can use the `login` function from the `InvalidCredentialsError` exception:
+  Here's how you can use the `login` function with the `InvalidCredentialsError` exception:
 
   ```py
   # failed login attempt
   try:
       message = login("user", "wrongpassword")
-      print(message)
   except InvalidCredentialsError as e:
       print(f"Login failed: {e}")
+  else:
+      print(message)
 
   # successful login attempt
   try:
       message = login("admin", "password123")
-      print(message)
   except InvalidCredentialsError as e:
-      # This block is not executed because the login was successful
       print(f"Login failed: {e}")
   else:
-      # The else block runs if the 'try' block completes without an exception
       print(message)
   ```
 


### PR DESCRIPTION
## Description
Fixes the inconsistent `InvalidCredentialsError` login examples.
## Changes Made
- Fixed typo: "Here's a how" → "Here's how"
- Fixed wording: "from the `InvalidCredentialsError` exception" → "with the `InvalidCredentialsError` exception"
- Both failed and successful examples now use identical `try/except/else` structure
- Removed duplicate `print(message)` from inside the `try` block
- `message` is now printed only once in the `else` block for both examples
## Files Changed
- [curriculum/challenges/english/blocks/review-python/67f39e391c9b373069def02c.md](cci:7://file:///C:/Users/Admin/Desktop/New%20folder/freeCodeCamp/curriculum/challenges/english/blocks/review-python/67f39e391c9b373069def02c.md:0:0-0:0)
- [curriculum/challenges/english/blocks/review-error-handling/67f39bcb48373420f4f12d62.md](cci:7://file:///C:/Users/Admin/Desktop/New%20folder/freeCodeCamp/curriculum/challenges/english/blocks/review-error-handling/67f39bcb48373420f4f12d62.md:0:0-0:0)
## Before / After
**Before (inconsistent):**
```py
# failed login attempt
try:
    message = login("user", "wrongpassword")
    print(message)
except InvalidCredentialsError as e:
    print(f"Login failed: {e}")
# successful login attempt
try:
    message = login("admin", "password123")
    print(message)
except InvalidCredentialsError as e:
    print(f"Login failed: {e}")
else:
    print(message)
` ` `
**After (consistent):**
```py
# failed login attempt
try:
    message = login("user", "wrongpassword")
except InvalidCredentialsError as e:
    print(f"Login failed: {e}")
else:
    print(message)
# successful login attempt
try:
    message = login("admin", "password123")
except InvalidCredentialsError as e:
    print(f"Login failed: {e}")
else:
    print(message)
```

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ ] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the 66054 below with the issue number.-->

Closes #66054

<!-- Feel free to add any additional description of changes below this line -->
