### PR TITLE
fix(client): daily challenge calendar

### DIFF
--- a/client/src/components/daily-coding-challenge/calendar-day.tsx
+++ b/client/src/components/daily-coding-challenge/calendar-day.tsx
@@ -5,7 +5,7 @@ import GreenPass from '../../assets/icons/green-pass';
 import GreenNotCompleted from '../../assets/icons/green-not-completed';
 import JavaScriptIcon from '../../assets/icons/javascript';
 import PythonIcon from '../../assets/icons/python';
-import { formatDisplayDate, truncateTitle } from './helpers';
+import { formatDisplayDate, truncate } from './helpers';
 
 interface CalendarDayProps {
   dayNumber: number;

--- a/client/src/components/daily-coding-challenge/calendar-day.tsx
+++ b/client/src/components/daily-coding-challenge/calendar-day.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { Spacer } from '@freecodecamp/ui';
 import { Link } from '../helpers';
 import GreenPass from '../../assets/icons/green-pass';
 import GreenNotCompleted from '../../assets/icons/green-not-completed';
 import JavaScriptIcon from '../../assets/icons/javascript';
 import PythonIcon from '../../assets/icons/python';
-import { formatDisplayDate } from './helpers';
+import { formatDisplayDate, truncateTitle } from './helpers';
 
 interface CalendarDayProps {
   dayNumber: number;
@@ -17,29 +16,11 @@ interface CalendarDayProps {
   title?: string;
 }
 
-function Checkmark({ completed }: { completed: boolean }): JSX.Element {
-  return completed ? (
-    <span
-      className='dc-checkmark dc-small-checkmark completed'
-      data-playwright-test-label='calendar-day-completed'
-    >
-      <GreenPass />
-    </span>
-  ) : (
-    <span
-      className='dc-checkmark dc-small-checkmark not-completed'
-      data-playwright-test-label='calendar-day-not-completed'
-    >
-      <GreenNotCompleted />
-    </span>
-  );
-}
-
 function DailyCodingChallengeCalendarDay({
   dayNumber,
   date,
   isAvailable = false,
-  title,
+  title = '',
   completedLanguages = [],
   challengeNumber
 }: CalendarDayProps): JSX.Element {
@@ -74,39 +55,38 @@ function DailyCodingChallengeCalendarDay({
         {dayNumber}
       </span>
 
-      <div className='dc-number'>#{challengeNumber}</div>
+      <span className='dc-number'>#{challengeNumber}</span>
 
       <div className='dc-info'>
-        <div className='dc-title'>{title}</div>
+        <div className='dc-title-wrap'>
+          <div className='dc-title'>{truncateTitle(title)}</div>
+        </div>
 
-        {completedLanguages.length === 2 ? (
-          <span className='dc-checkmark dc-big-checkmark completed'>
-            <span className='dc-spacer'>
-              <Spacer size='s' />
+        {completedLanguages.length > 0 ? (
+          <>
+            <span className='dc-checkmark completed'>
+              <GreenPass />
             </span>
-            <GreenPass />
-          </span>
-        ) : (
-          <div className='dc-languages'>
-            <hr />
-            <div className='dc-language'>
-              <div className='dc-language-icon'>
-                <JavaScriptIcon />
-              </div>
-              <div className='dc-language-name'>JavaScript</div>
-              <Checkmark
-                completed={completedLanguages.includes('javascript')}
-              />
-            </div>
 
-            <div className='dc-language'>
-              <div className='dc-language-icon'>
-                <PythonIcon />
-              </div>
-              <div className='dc-language-name'>Python</div>
-              <Checkmark completed={completedLanguages.includes('python')} />
+            <div className='dc-languages'>
+              {completedLanguages.includes('javascript') && (
+                <div className='dc-language-icon'>
+                  <JavaScriptIcon />
+                  <span className='sr-only'>JavaScript</span>
+                </div>
+              )}
+              {completedLanguages.includes('python') && (
+                <div className='dc-language-icon'>
+                  <PythonIcon />
+                  <span className='sr-only'>Python</span>
+                </div>
+              )}
             </div>
-          </div>
+          </>
+        ) : (
+          <span className='dc-checkmark not-completed'>
+            <GreenNotCompleted />
+          </span>
         )}
       </div>
     </Link>

--- a/client/src/components/daily-coding-challenge/calendar-day.tsx
+++ b/client/src/components/daily-coding-challenge/calendar-day.tsx
@@ -16,6 +16,23 @@ interface CalendarDayProps {
   title?: string;
 }
 
+function Checkmark({ isCompleted }: { isCompleted: boolean }) {
+  return isCompleted ? (
+    <span
+      className='dc-checkmark completed'
+      data-playwright-test-label='calendar-day-completed'
+    >
+      <GreenPass />
+    </span>
+  ) : (
+    <span
+      className='dc-checkmark not-completed'
+      data-playwright-test-label='calendar-day-not-completed'
+    >
+      <GreenNotCompleted />
+    </span>
+  );
+}
 function DailyCodingChallengeCalendarDay({
   dayNumber,
   date,
@@ -25,6 +42,7 @@ function DailyCodingChallengeCalendarDay({
   challengeNumber
 }: CalendarDayProps): JSX.Element {
   const { t } = useTranslation();
+  const completed = completedLanguages.length > 0;
 
   // dayNumber = 0 -> render nothing
   if (dayNumber === 0) return <div></div>;
@@ -59,41 +77,25 @@ function DailyCodingChallengeCalendarDay({
 
       <div className='dc-info'>
         <div className='dc-title-wrap'>
-          <div className='dc-title'>{truncateTitle(title)}</div>
+          <div className='dc-title'>{truncate(title)}</div>
         </div>
 
-        {completedLanguages.length > 0 ? (
-          <>
-            <span
-              className='dc-checkmark completed'
-              data-playwright-test-label='calendar-day-completed'
-            >
-              <GreenPass />
-            </span>
+        <Checkmark isCompleted={completed} />
 
-            <div className='dc-languages'>
-              {completedLanguages.includes('javascript') && (
-                <div className='dc-language-icon'>
-                  <JavaScriptIcon />
-                  <span className='sr-only'>JavaScript</span>
-                </div>
-              )}
-              {completedLanguages.includes('python') && (
-                <div className='dc-language-icon'>
-                  <PythonIcon />
-                  <span className='sr-only'>Python</span>
-                </div>
-              )}
+        <div className='dc-languages'>
+          {completedLanguages.includes('javascript') && (
+            <div className='dc-language-icon'>
+              <JavaScriptIcon />
+              <span className='sr-only'>JavaScript</span>
             </div>
-          </>
-        ) : (
-          <span
-            className='dc-checkmark not-completed'
-            data-playwright-test-label='calendar-day-not-completed'
-          >
-            <GreenNotCompleted />
-          </span>
-        )}
+          )}
+          {completedLanguages.includes('python') && (
+            <div className='dc-language-icon'>
+              <PythonIcon />
+              <span className='sr-only'>Python</span>
+            </div>
+          )}
+        </div>
       </div>
     </Link>
   );

--- a/client/src/components/daily-coding-challenge/calendar-day.tsx
+++ b/client/src/components/daily-coding-challenge/calendar-day.tsx
@@ -64,7 +64,10 @@ function DailyCodingChallengeCalendarDay({
 
         {completedLanguages.length > 0 ? (
           <>
-            <span className='dc-checkmark completed'>
+            <span
+              className='dc-checkmark completed'
+              data-playwright-test-label='calendar-day-completed'
+            >
               <GreenPass />
             </span>
 
@@ -84,7 +87,10 @@ function DailyCodingChallengeCalendarDay({
             </div>
           </>
         ) : (
-          <span className='dc-checkmark not-completed'>
+          <span
+            className='dc-checkmark not-completed'
+            data-playwright-test-label='calendar-day-not-completed'
+          >
             <GreenNotCompleted />
           </span>
         )}

--- a/client/src/components/daily-coding-challenge/calendar.css
+++ b/client/src/components/daily-coding-challenge/calendar.css
@@ -28,7 +28,7 @@
 
 .calendar-day {
   position: relative;
-  padding: 10px 10px 20px;
+  padding: 5px;
   min-height: 200px;
   border: 1px solid var(--tertiary-color);
   background-color: var(--primary-background);
@@ -37,41 +37,61 @@
 
 .calendar-day-number {
   position: absolute;
+  font-size: 0.8em;
   top: 0;
-  left: 5px;
+  right: 5px;
+  color: var(--gray-45);
 }
 
 .dc-number {
+  position: absolute;
+  top: 0;
+  left: 5px;
+  font-size: 0.8em;
   font-style: italic;
   color: var(--gray-45);
-  text-align: center;
 }
 
 .dc-info {
+  position: relative;
+  padding-top: 15px;
   display: flex;
   flex-direction: column;
   height: 100%;
 }
 
-.dc-title {
+.dc-title-wrap {
   width: 100%;
+  min-height: 55px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px 10px;
+}
+
+.dc-title {
   text-align: center;
-  align-self: center;
-  margin-top: 5px;
+  font-size: 0.9em;
+}
+
+.dc-checkmark {
+  width: 100%;
+  position: absolute;
+  top: 50%;
+}
+
+.dc-checkmark svg {
+  width: 50px;
   height: 50px;
-  margin-bottom: -5px;
+  margin: 0 auto;
 }
 
 .dc-languages {
-  padding: 0 15px;
-}
-
-.dc-language {
-  font-size: 0.8rem;
+  position: absolute;
+  bottom: 0;
+  left: 0;
   display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 10px;
+  gap: 2px;
 }
 
 .dc-language-icon {
@@ -81,25 +101,6 @@
 .dc-language-icon svg {
   width: 25px;
   height: 25px;
-}
-
-.dc-small-checkmark {
-  position: relative;
-  /* top: -5px; */
-}
-
-.dc-small-checkmark svg {
-  width: 20px;
-  height: 20px;
-}
-
-.dc-big-checkmark {
-  margin: 0 auto;
-}
-
-.dc-big-checkmark svg {
-  width: 50px;
-  height: 50px;
 }
 
 .not-available:hover,
@@ -132,6 +133,17 @@
   stroke: var(--primary-background);
 }
 
+.dc-language-icon svg path {
+  fill: var(--gray-45);
+  stroke: var(--gray-45);
+}
+
+.available:hover .dc-language-icon svg path,
+.available:active .dc-language-icon svg path {
+  fill: var(--quaternary-background);
+  stroke: var(--quaternary-background);
+}
+
 .available:hover .not-completed svg circle,
 .available:active .not-completed svg circle {
   fill: var(--primary-color);
@@ -162,74 +174,41 @@
   }
 }
 
-@media (max-width: 1345px) {
-  .calendar-day-number,
-  .dc-number,
-  .dc-title {
-    font-size: 0.8rem;
-  }
-
-  .dc-info hr {
-    margin: 10px 0;
-  }
-
-  .calendar-day {
-    min-height: 170px;
-  }
-
-  .dc-language {
-    justify-content: center;
-  }
-
-  .dc-language-name {
-    display: none;
-  }
-}
-
-@media (max-width: 1115px) {
-  .calendar-grid {
-    max-width: unset;
-  }
-
-  .calendar-day {
-    min-height: 125px;
-    padding: 10px;
-  }
-
-  .dc-title,
-  .dc-info hr {
-    display: none;
-  }
-
-  .dc-info {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    height: 80%;
-  }
-
-  .dc-spacer {
-    display: none;
-  }
-}
-
 @media (max-width: 815px) {
   .calendar-day {
     min-height: 100px;
     padding: 0;
   }
 
-  .dc-number {
-    text-align: right;
-    padding-right: 5px;
+  .calendar-day-number {
+    display: none;
   }
 
-  .dc-languages {
+  .dc-info {
+    padding: 0;
+    justify-content: center;
+  }
+
+  .dc-title-wrap {
+    display: none;
+  }
+
+  .dc-checkmark {
+    top: unset;
+  }
+
+  .dc-checkmark svg {
+    width: 40px;
+    height: 40px;
+  }
+}
+
+@media (max-width: 1300px) {
+  .dc-title-wrap {
     padding: 0;
   }
 
-  .dc-big-checkmark svg {
-    width: 40px;
-    height: 40px;
+  .dc-title {
+    font-size: 0.8em;
   }
 }

--- a/client/src/components/daily-coding-challenge/helpers.ts
+++ b/client/src/components/daily-coding-challenge/helpers.ts
@@ -33,3 +33,11 @@ export function formatDisplayDate(dateString: string) {
   }
   return format(parsedDate, 'MMMM d, yyyy');
 }
+
+export function truncateTitle(title: string) {
+  const maxLength = 35;
+  if (title.length <= maxLength) {
+    return title;
+  }
+  return title.slice(0, maxLength) + '...';
+}

--- a/client/src/components/daily-coding-challenge/helpers.ts
+++ b/client/src/components/daily-coding-challenge/helpers.ts
@@ -34,10 +34,9 @@ export function formatDisplayDate(dateString: string) {
   return format(parsedDate, 'MMMM d, yyyy');
 }
 
-export function truncateTitle(title: string) {
-  const maxLength = 35;
-  if (title.length <= maxLength) {
-    return title;
+export function truncate(str: string, maxLength = 35) {
+  if (str.length <= maxLength) {
+    return str;
   }
-  return title.slice(0, maxLength) + '...';
+  return str.slice(0, maxLength) + '...';
 }

--- a/e2e/daily-coding-challenge.spec.ts
+++ b/e2e/daily-coding-challenge.spec.ts
@@ -249,7 +249,7 @@ test.describe('Daily Coding Challenge Archive', () => {
 
     await expect(page.getByTestId('calendar-day-completed')).toHaveCount(1);
 
-    await expect(page.getByTestId('calendar-day-not-completed')).toHaveCount(3);
+    await expect(page.getByTestId('calendar-day-not-completed')).toHaveCount(1);
 
     await page.getByTestId('calendar-day-completed').click();
     await expect(page).toHaveURL(


### PR DESCRIPTION
This simplifies the daily challenge calendar UI and fixes some issues.

<details><summary>images</summary>

| | |
| - | - |
| Before | <img width="1369" height="461" alt="Screenshot 2026-03-02 at 1 17 52 PM" src="https://github.com/user-attachments/assets/3da71f01-74e4-4d6f-b679-6bb2d0e90d50" /> |
| After | <img width="1367" height="460" alt="Screenshot 2026-03-02 at 1 16 25 PM" src="https://github.com/user-attachments/assets/3cd9842c-6a53-4524-9be3-bec21f40cd2b" /> |

^ one main difference - now you get the big checkmark for completing any language, and the languages you've completed the challenge in show up at the bottom. This reflects how it behaves in the database. Formerly, you needed to complete both languages to get the big checkmark.

</details>

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #65847
Closes #63944 - it's not the exact solution discussed here, but I think this new UI simplifies things and solves the issue.

<!-- Feel free to add any additional description of changes below this line -->
