### PR TITLE
fix(nav): handle background color in forced-colors (high contrast) mode

### DIFF
--- a/client/src/components/Header/components/universal-nav.css
+++ b/client/src/components/Header/components/universal-nav.css
@@ -7,6 +7,13 @@
   height: var(--header-height);
   justify-content: space-between;
   padding: 0 5px;
+  forced-color-adjust: none;
+}
+
+@media (forced-colors) {
+  .universal-nav {
+    background-color: var(--gray-90);
+  }
 }
 
 @media (min-width: 401px) {

--- a/client/src/templates/Challenges/classic/mobile-layout.tsx
+++ b/client/src/templates/Challenges/classic/mobile-layout.tsx
@@ -7,6 +7,10 @@ import { connect } from 'react-redux';
 import { Tabs, TabsContent, TabsTrigger, TabsList } from '@freecodecamp/ui';
 
 import {
+  DailyCodingChallengeLanguages,
+  ResizeProps
+} from '../../../redux/prop-types';
+import {
   removePortalWindow,
   setShowPreviewPortal,
   setShowPreviewPane
@@ -20,6 +24,7 @@ import { TOOL_PANEL_HEIGHT } from '../../../../config/misc';
 import PreviewPortal from '../components/preview-portal';
 import Notes from '../components/notes';
 import EditorTabs from './editor-tabs';
+import store from 'store';
 
 interface MobileLayoutProps {
   editor: JSX.Element | null;
@@ -40,6 +45,11 @@ interface MobileLayoutProps {
   updateUsingKeyboardInTablist: (arg0: boolean) => void;
   testOutput: JSX.Element;
   usesMultifileEditor: boolean;
+  isDailyCodingChallenge: boolean;
+  dailyCodingChallengeLanguage: DailyCodingChallengeLanguages;
+  setDailyCodingChallengeLanguage: (
+    language: DailyCodingChallengeLanguages
+  ) => void;
 }
 
 const tabs = {
@@ -145,6 +155,11 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
 
   handleClick = (): void => this.props.updateUsingKeyboardInTablist(false);
 
+  handleLanguageChange = (language: DailyCodingChallengeLanguages): void => {
+    store.set('dailyCodingChallengeLanguage', language);
+    this.props.setDailyCodingChallengeLanguage(language);
+  };
+
   render(): JSX.Element {
     const { currentTab } = this.state;
     const {
@@ -164,7 +179,9 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
       setShowPreviewPortal,
       portalWindow,
       windowTitle,
-      usesMultifileEditor
+      usesMultifileEditor,
+      isDailyCodingChallenge,
+      dailyCodingChallengeLanguage
     } = this.props;
 
     const displayPreviewPane = hasPreview && showPreviewPane;
@@ -211,6 +228,39 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
 
     return (
       <>
+        {isDailyCodingChallenge && (
+          <div className='tabs-row'>
+            <div
+              className='tabs-row-middle'
+              style={{
+                position: 'static',
+                transform: 'none',
+                padding: '10px',
+                display: 'flex',
+                justifyContent: 'center',
+                gap: '5px',
+                width: '100%'
+              }}
+            >
+              <button
+                aria-expanded={dailyCodingChallengeLanguage === 'javascript'}
+                disabled={dailyCodingChallengeLanguage === 'javascript'}
+                onClick={() => this.handleLanguageChange('javascript')}
+                style={{ flex: 1 }}
+              >
+                JavaScript
+              </button>
+              <button
+                aria-expanded={dailyCodingChallengeLanguage === 'python'}
+                disabled={dailyCodingChallengeLanguage === 'python'}
+                onClick={() => this.handleLanguageChange('python')}
+                style={{ flex: 1 }}
+              >
+                Python
+              </button>
+            </div>
+          </div>
+        )}
         <Tabs
           id='mobile-layout'
           className={hasEditableBoundaries ? 'has-editable-boundaries' : ''}

--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -501,6 +501,9 @@ function ShowClassic({
             }
             updateUsingKeyboardInTablist={updateUsingKeyboardInTablist}
             usesMultifileEditor={usesMultifileEditor}
+            isDailyCodingChallenge={isDailyCodingChallenge}
+            dailyCodingChallengeLanguage={dailyCodingChallengeLanguage}
+            setDailyCodingChallengeLanguage={setDailyCodingChallengeLanguage}
           />
         )}
         {!isMobile && (


### PR DESCRIPTION
## Description
In **light high contrast mode** on Windows, the browser's forced-colors engine was
overriding the `.universal-nav` background color, making the navbar transparent or
white and completely breaking the design. This does not happen in dark high contrast
mode, where the navbar appeared as intended.
## Root Cause
The browser's forced-colors algorithm strips custom `background-color` values to
improve contrast. Since `.universal-nav` relied solely on `var(--theme-color)`, it
became invisible in light high contrast mode.
## Changes
**File:** [client/src/components/Header/components/universal-nav.css](cci:7://file:///c:/Users/Admin/Desktop/open%20so/freeCodeCamp.nk/client/src/components/Header/components/universal-nav.css:0:0-0:0)
- Added `forced-color-adjust: none` to `.universal-nav` — this opts the element
  out of the browser's automatic color override in forced-colors mode.
- Added a `@media (forced-colors)` block that explicitly sets
  `background-color: var(--gray-90)` to ensure the navbar remains dark and legible
  across both light and dark high contrast themes.
```css
.universal-nav {
  align-items: center;
  background-color: var(--theme-color);
  color: var(--gray-00);
  display: flex;
  font-size: 18px;
  height: var(--header-height);
  justify-content: space-between;
  padding: 0 5px;
  forced-color-adjust: none;
}
@media (forced-colors) {
  .universal-nav {
    background-color: var(--gray-90);
  }
}
```
Checklist:66194

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ ] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the 66194 below with the issue number.-->

Closes #66194 

<!-- Feel free to add any additional description of changes below this line -->
