### PR TITLE
fix(curriculum): use textContent instead of innerText

### DIFF
--- a/curriculum/challenges/english/blocks/lab-availability-table/66b36358ed4f261d64840c24.md
+++ b/curriculum/challenges/english/blocks/lab-availability-table/66b36358ed4f261d64840c24.md
@@ -269,7 +269,7 @@ assert.equal(document.querySelector('#legend')?.tagName, 'DIV');
 You should have a `span` element with the text `Availability` inside your `#legend`.
 
 ```js
-assert.equal(document.querySelector('#legend span')?.innerText, 'Availability');
+assert.equal(document.querySelector('#legend span')?.textContent.trim(), 'Availability');
 ```
 
 You should have a `div` element with the `id` of `legend-gradient` inside your `#legend`.


### PR DESCRIPTION
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.


Closes #66163 


**What:** Changed `innerText` to `textContent.trim()` in test 32 ("You should have a span element with the text Availability inside your #legend").

**Why:** `innerText` reflects CSS `text-transform` styling, so when a user applies `text-transform: uppercase` to the `#legend span`, the test sees `"AVAILABILITY"` instead of `"Availability"` and falsely fails. `textContent` reads the raw DOM text unaffected by CSS. `.trim()` handles any potential leading/trailing whitespace.
