### PR TITLE
refactor: move static curriculum data out of redux

### DIFF
--- a/client/src/redux/action-types.js
+++ b/client/src/redux/action-types.js
@@ -37,7 +37,6 @@ export const actionTypes = createTypes(
     'updateDonationFormState',
     'updateUserToken',
     'postChargeProcessing',
-    'updateAllChallengesInfo',
     'updateCardRedirecting',
     ...createAsyncTypes('updateCard'),
     ...createAsyncTypes('fetchUser'),

--- a/client/src/redux/actions.ts
+++ b/client/src/redux/actions.ts
@@ -51,10 +51,6 @@ export const toggleTheme = createAction(actionTypes.toggleTheme);
 export const setTheme = createAction(actionTypes.setTheme);
 export const initializeTheme = createAction(actionTypes.initializeTheme);
 
-export const updateAllChallengesInfo = createAction(
-  actionTypes.updateAllChallengesInfo
-);
-
 export const postCharge = createAction(actionTypes.postCharge);
 export const postChargeProcessing = createAction(
   actionTypes.postChargeProcessing

--- a/client/src/redux/index.js
+++ b/client/src/redux/index.js
@@ -65,10 +65,6 @@ export const initialState = {
   userFetchState: {
     ...defaultFetchState
   },
-  allChallengesInfo: {
-    challengeNodes: [],
-    certificateNodes: []
-  },
   userProfileFetchState: {
     ...defaultFetchState
   },
@@ -168,10 +164,6 @@ export const reducer = handleActions(
     [actionTypes.postChargeError]: (state, { payload }) => ({
       ...state,
       donationFormState: { ...defaultDonationFormState, error: payload }
-    }),
-    [actionTypes.updateAllChallengesInfo]: (state, { payload }) => ({
-      ...state,
-      allChallengesInfo: { ...payload }
     }),
     [actionTypes.fetchUser]: state => ({
       ...state,

--- a/client/src/redux/selectors.js
+++ b/client/src/redux/selectors.js
@@ -7,7 +7,7 @@ import {
 
 import { randomBetween } from '../utils/random-between';
 import { getSessionChallengeData } from '../utils/session-storage';
-import { superBlockStructuresSelector } from '../templates/Introduction/redux';
+import { curriculumData } from '../services/curriculum-data';
 import { ns as MainApp } from './action-types';
 
 export const savedChallengesSelector = state =>
@@ -122,22 +122,6 @@ export const createUserByNameSelector = username => state => {
 };
 
 export const userFetchStateSelector = state => state[MainApp].userFetchState;
-export const allChallengesInfoSelector = state =>
-  state[MainApp].allChallengesInfo;
-
-export const needsCurriculumDataSelector = createSelector(
-  allChallengesInfoSelector,
-  superBlockStructuresSelector,
-  (allChallengesInfo, superBlockStructures) => {
-    return (
-      !allChallengesInfo?.challengeNodes?.length ||
-      !Object.keys(superBlockStructures).length
-    );
-  }
-);
-
-export const getSuperBlockStructure = (state, superBlock) =>
-  superBlockStructuresSelector(state)[superBlock];
 
 export const completedChallengesIdsSelector = createSelector(
   completedChallengesSelector,
@@ -150,21 +134,13 @@ export const completedDailyCodingChallengesIdsSelector = createSelector(
 );
 
 export const completionStateSelector = createSelector(
-  [
-    allChallengesInfoSelector,
-    completedChallengesIdsSelector,
-    superBlockStructuresSelector,
-    state => state.challenge.challengeMeta
-  ],
-  (
-    allChallengesInfo,
-    completedChallengesIds,
-    superBlockStructures,
-    challengeMeta
-  ) => {
-    const { challengeNodes } = allChallengesInfo;
+  [completedChallengesIdsSelector, state => state.challenge.challengeMeta],
+  (completedChallengesIds, challengeMeta) => {
+    const challengeNodes = curriculumData.challengeNodes;
 
-    const structure = superBlockStructures[challengeMeta.superBlock];
+    const structure = curriculumData.getSuperBlockStructure(
+      challengeMeta.superBlock
+    );
 
     const chapters = structure?.chapters ?? [];
 

--- a/client/src/services/curriculum-data.ts
+++ b/client/src/services/curriculum-data.ts
@@ -1,0 +1,57 @@
+import type {
+  ChallengeNode,
+  CertificateNode,
+  SuperBlockStructure
+} from '../redux/prop-types';
+
+/**
+ * CurriculumDataService manages static curriculum data.
+ *
+ * The data is loaded once via useStaticQuery and never changes during
+ * runtime. Since it's static there's no need for Redux or React Context to
+ * manage it. Keeping the data outside of Redux means the immutability checks
+ * will not ruin render performance.
+ */
+class CurriculumDataService {
+  #challengeNodes: ChallengeNode[] = [];
+  #certificateNodes: CertificateNode[] = [];
+  #superBlockStructures: Record<string, SuperBlockStructure> = {};
+
+  initialize(data: {
+    challengeNodes: ChallengeNode[];
+    certificateNodes: CertificateNode[];
+    superBlockStructures: Record<string, SuperBlockStructure>;
+  }): void {
+    this.#challengeNodes = data.challengeNodes;
+    this.#certificateNodes = data.certificateNodes;
+    this.#superBlockStructures = data.superBlockStructures;
+  }
+
+  get hasData(): boolean {
+    return (
+      this.#challengeNodes.length > 0 ||
+      this.#certificateNodes.length > 0 ||
+      Object.keys(this.#superBlockStructures).length > 0
+    );
+  }
+
+  get challengeNodes(): ChallengeNode[] {
+    return this.#challengeNodes;
+  }
+
+  get certificateNodes(): CertificateNode[] {
+    return this.#certificateNodes;
+  }
+
+  get superBlockStructures(): Record<string, SuperBlockStructure> {
+    return this.#superBlockStructures;
+  }
+
+  getSuperBlockStructure(superBlock: string): SuperBlockStructure | undefined {
+    return this.#superBlockStructures[superBlock];
+  }
+}
+
+// The class is just a convenience, there's no need for there to be more than
+// one instance of it.
+export const curriculumData = new CurriculumDataService();

--- a/client/src/templates/Challenges/components/completion-modal.test.tsx
+++ b/client/src/templates/Challenges/components/completion-modal.test.tsx
@@ -15,14 +15,13 @@ import {
   isBlockNewlyCompletedSelector,
   currentBlockIdsSelector
 } from '../redux/selectors';
-import {
-  completedChallengesIdsSelector,
-  allChallengesInfoSelector
-} from '../../../redux/selectors';
+import { completedChallengesIdsSelector } from '../../../redux/selectors';
+import { curriculumData } from '../../../services/curriculum-data';
 import { getTestRunner } from '../utils/build';
 import CompletionModal, { combineFileData } from './completion-modal';
 import { mockCurriculumData } from '../utils/__fixtures__/curriculum-data';
 import { useStaticQuery } from 'gatsby';
+import { ChallengeNode, SuperBlockStructure } from '../../../redux/prop-types';
 vi.mock('../../../analytics');
 vi.mock('../../../utils/fire-confetti');
 vi.mock('../../../components/Progress');
@@ -41,8 +40,6 @@ const mockIsBlockNewlyCompletedSelector = isBlockNewlyCompletedSelector as Mock;
 const mockCurrentBlockIdsSelector = vi.mocked(currentBlockIdsSelector);
 const mockCompletedChallengesIdsSelector =
   completedChallengesIdsSelector as unknown as Mock;
-const mockAllChallengesInfoSelector =
-  allChallengesInfoSelector as unknown as Mock;
 const mockGetTestRunner = getTestRunner as Mock;
 mockBuildEnabledSelector.mockReturnValue(true);
 mockChallengeTestsSelector.mockReturnValue([
@@ -64,6 +61,17 @@ const fakeCompletedChallengesIds = ['1', '3', '5', '7', '8'];
 describe('<CompletionModal />', () => {
   beforeEach(() => {
     vi.mocked(useStaticQuery).mockReturnValue(mockCurriculumData);
+    // Initialize curriculum data singleton for tests
+    const structuresMap: Record<string, SuperBlockStructure> = {};
+    mockCurriculumData.allSuperBlockStructure.nodes.forEach(node => {
+      structuresMap[node.superBlock] = node as SuperBlockStructure;
+    });
+    curriculumData.initialize({
+      challengeNodes: mockCurriculumData.allChallengeNode
+        .nodes as unknown as ChallengeNode[],
+      certificateNodes: mockCurriculumData.allCertificateNode.nodes,
+      superBlockStructures: structuresMap
+    });
   });
 
   describe('fireConfetti', () => {
@@ -91,10 +99,7 @@ describe('<CompletionModal />', () => {
       });
       mockCurrentBlockIdsSelector.mockReturnValue(blockIds);
       mockCompletedChallengesIdsSelector.mockReturnValue(['step1', 'step2']);
-      mockAllChallengesInfoSelector.mockReturnValue({
-        challengeNodes: [{ challenge: { id: challengeId } }],
-        certificateNodes: []
-      });
+      // Curriculum data is initialized in beforeEach
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       await runSaga(store, executeChallengeSaga, { payload }).done;
@@ -118,9 +123,11 @@ describe('<CompletionModal />', () => {
         isLastChallengeInBlock: true,
         challengeType: 'mock_challenge_type'
       });
-      mockAllChallengesInfoSelector.mockReturnValue({
+      // Reset curriculum data to empty state to test the guard
+      curriculumData.initialize({
+        certificateNodes: [],
         challengeNodes: [],
-        certificateNodes: []
+        superBlockStructures: {}
       });
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore

--- a/client/src/templates/Challenges/redux/completion-epic.test.js
+++ b/client/src/templates/Challenges/redux/completion-epic.test.js
@@ -19,8 +19,7 @@ describe('completionEpic', () => {
         value: {
           challenge: { challengeMeta: { challengeType: 0 } },
           app: {
-            user: { username: 'test' },
-            allChallengesInfo: { challengeNodes: [], certificateNodes: [] }
+            user: { username: 'test' }
           }
         }
       };

--- a/client/src/templates/Challenges/redux/execute-challenge-saga.js
+++ b/client/src/templates/Challenges/redux/execute-challenge-saga.js
@@ -54,7 +54,7 @@ import {
   updateLogs,
   updateTests
 } from './actions';
-import { allChallengesInfoSelector } from '../../../redux/selectors';
+import { curriculumData } from '../../../services/curriculum-data';
 import {
   challengeDataSelector,
   challengeMetaSelector,
@@ -142,8 +142,7 @@ export function* executeChallengeSaga({ payload }) {
     const isBlockCompleted = yield select(isBlockNewlyCompletedSelector);
     if (challengeComplete) {
       playTone('tests-completed');
-      const allChallengesInfo = yield select(allChallengesInfoSelector);
-      if (isBlockCompleted && allChallengesInfo?.challengeNodes?.length) {
+      if (isBlockCompleted && curriculumData.hasData) {
         fireConfetti();
       }
     } else {

--- a/client/src/templates/Challenges/redux/selectors.js
+++ b/client/src/templates/Challenges/redux/selectors.js
@@ -2,16 +2,16 @@ import { createSelector } from 'reselect';
 import { challengeTypes } from '@freecodecamp/shared/config/challenge-types';
 import {
   completedChallengesSelector,
-  allChallengesInfoSelector,
   isSignedInSelector,
   completionStateSelector,
   completedChallengesIdsSelector,
   completedDailyCodingChallengesIdsSelector
 } from '../../../redux/selectors';
+import { curriculumData } from '../../../services/curriculum-data';
 import {
-  getCurrentBlockIds,
   getCompletedChallengesInBlock,
-  getCompletedPercentage
+  getCompletedPercentage,
+  getCurrentBlockIds
 } from '../../../utils/get-completion-percentage';
 import { ns } from './action-types';
 
@@ -120,9 +120,12 @@ export const challengeDataSelector = state => {
 
 export const currentBlockIdsSelector = createSelector(
   challengeMetaSelector,
-  allChallengesInfoSelector,
-  (challengeMeta, allChallengesInfo) => {
+  challengeMeta => {
     const { block, certification, challengeType } = challengeMeta;
+    const allChallengesInfo = {
+      challengeNodes: curriculumData.challengeNodes,
+      certificateNodes: curriculumData.certificateNodes
+    };
 
     return getCurrentBlockIds(
       allChallengesInfo,

--- a/client/src/templates/Challenges/utils/fetch-all-curriculum-data.tsx
+++ b/client/src/templates/Challenges/utils/fetch-all-curriculum-data.tsx
@@ -1,22 +1,14 @@
-import { useEffect } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import { useStaticQuery, graphql } from 'gatsby';
 
-import { updateAllChallengesInfo } from '../../../redux/actions';
 import { submitChallenge } from '../redux/actions';
-import {
-  updateSuperBlockStructures,
-  superBlockStructuresSelector
-} from '../../../templates/Introduction/redux';
-import {
-  allChallengesInfoSelector,
-  needsCurriculumDataSelector
-} from '../../../redux/selectors';
+import { curriculumData } from '../../../services/curriculum-data';
 import type {
   CertificateNode,
   ChallengeNode,
   SuperBlockStructure
 } from '../../../redux/prop-types';
+import { useEffect } from 'react';
 
 interface AllCurriculumData {
   allChallengeNode: { nodes: ChallengeNode[] };
@@ -25,15 +17,6 @@ interface AllCurriculumData {
 }
 
 export function useFetchAllCurriculumData(): void {
-  const dispatch = useDispatch();
-  const needsCurriculumData = useSelector(needsCurriculumDataSelector);
-  const allChallengesInfo = useSelector(allChallengesInfoSelector) as {
-    challengeNodes?: Array<{ challenge: { id: string } }>;
-  } | null;
-  const superBlockStructures = useSelector(
-    superBlockStructuresSelector
-  ) as Record<string, SuperBlockStructure>;
-
   const {
     allChallengeNode: { nodes: challengeNodes },
     allCertificateNode: { nodes: certificateNodes },
@@ -82,42 +65,25 @@ export function useFetchAllCurriculumData(): void {
     }
   `);
 
+  // Initialize curriculum data if necessary. The useEffect slightly improves
+  // hot-reloading, since, in principle, the data can change without a full page
+  // refresh. However, it's still Gatsby, so hot-reloading is not guaranteed.
   useEffect(() => {
-    // Only dispatch if curriculum data is needed
-    if (!needsCurriculumData) return;
+    const structuresMap: Record<string, SuperBlockStructure> = {};
+    superBlockStructureNodes.forEach(node => {
+      structuresMap[node.superBlock] = node;
+    });
 
-    // Update allChallengesInfo if not already loaded
-    if (!allChallengesInfo?.challengeNodes?.length) {
-      dispatch(
-        updateAllChallengesInfo({
-          challengeNodes,
-          certificateNodes
-        })
-      );
-    }
-
-    // Update superBlockStructures if not already loaded
-    if (Object.keys(superBlockStructures || {}).length === 0) {
-      const structuresMap: Record<string, SuperBlockStructure> = {};
-      superBlockStructureNodes.forEach(node => {
-        structuresMap[node.superBlock] = node;
-      });
-      dispatch(updateSuperBlockStructures(structuresMap));
-    }
-  }, [
-    dispatch,
-    needsCurriculumData,
-    challengeNodes,
-    certificateNodes,
-    superBlockStructureNodes,
-    allChallengesInfo,
-    superBlockStructures
-  ]);
+    curriculumData.initialize({
+      challengeNodes,
+      certificateNodes,
+      superBlockStructures: structuresMap
+    });
+  }, [challengeNodes, certificateNodes, superBlockStructureNodes]);
 }
 
 export function useSubmit() {
-  // The submitChallenge epic needs the curriculum data to be loaded, so this
-  // useFetchAllCurriculumData call must happen first.
+  // Ensure curriculum data is loaded before challenge submission
   useFetchAllCurriculumData();
   const dispatch = useDispatch();
 

--- a/client/src/templates/Introduction/redux/index.js
+++ b/client/src/templates/Introduction/redux/index.js
@@ -7,25 +7,16 @@ export const ns = 'curriculumMap';
 const initialState = {
   expandedState: {
     block: {}
-  },
-  superBlockStructures: {}
+  }
 };
 
-const types = createTypes(
-  ['resetExpansion', 'toggleBlock', 'updateSuperBlockStructures'],
-  ns
-);
+const types = createTypes(['resetExpansion', 'toggleBlock'], ns);
 
 export const resetExpansion = createAction(types.resetExpansion);
 export const toggleBlock = createAction(types.toggleBlock);
-export const updateSuperBlockStructures = createAction(
-  types.updateSuperBlockStructures
-);
 
 export const makeExpandedBlockSelector = block => state =>
   !!state[ns].expandedState.block[block];
-export const superBlockStructuresSelector = state =>
-  state[ns].superBlockStructures || {};
 
 export const reducer = handleActions(
   {
@@ -44,10 +35,6 @@ export const reducer = handleActions(
           [payload]: !state.expandedState.block[payload]
         }
       }
-    }),
-    [types.updateSuperBlockStructures]: (state, { payload }) => ({
-      ...state,
-      superBlockStructures: { ...payload }
     })
   },
   initialState


### PR DESCRIPTION
This is motivated in part by the fact that filling the store makes redux painfully slow and in part by the fact the data is static, so doesn't need managing.

The dev issues can be mitigated by skipping immutibility checks, but those checks can and have found bugs, so I went with a separate in-memory store

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->
