### PR TITLE
fix(curriculum): update JS fundamentals quiz Number object question

### DIFF
--- a/curriculum/challenges/english/blocks/quiz-javascript-fundamentals/66edcd875b0d91de1fbbb492.md
+++ b/curriculum/challenges/english/blocks/quiz-javascript-fundamentals/66edcd875b0d91de1fbbb492.md
@@ -118,23 +118,23 @@ console.log(stringArray);
 
 #### --text--
 
-How can you convert a string literal into a Number object?
+Which of the following returns a `Number` object from the string `"123"`?
 
 #### --distractors--
 
-With the `Object()` constructor.
+`Object("123")`
 
 ---
 
-With the `.toNumber()` method.
+`"123".toNumber()`
 
 ---
 
-With the `.parseInt()` method.
+`Number("123")`
 
 #### --answer--
 
-With the `Number()` constructor.
+`new Number("123")`
 
 ### --question--
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #65973

<!-- Changes made -->
The question "How can you convert a string literal into a Number object?" was ambiguous and had an incorrect answer. `Number()` without `new` returns a number primitive, not a `Number` object.

Updated the question to be more specific and concrete:
- **Question:** Changed to "Which of the following returns a `Number` object from the string `"123"`?"
- **Distractors:** Updated to concrete code examples (`Object("123")`, `"123".toNumber()`, `Number("123")`)
- **Answer:** Changed to `new Number("123")` which correctly returns a `Number` object