### PR TITLE
fix(challenge-parser): display hanzi-pinyin pairs properly in quiz audio transcript

### DIFF
--- a/tools/challenge-parser/parser/__fixtures__/with-chinese-quizzes.md
+++ b/tools/challenge-parser/parser/__fixtures__/with-chinese-quizzes.md
@@ -8,6 +8,24 @@
 
 Quiz 1, question 1 with `中文 (zhōng wén)`
 
+#### --audio--
+
+```json
+{
+  "audio": {
+    "filename": "7.3-1.mp3",
+    "startTimestamp": 24.7,
+    "finishTimestamp": 26.2
+  },
+  "transcript": [
+    {
+      "character": "Wang Hua",
+      "text": "你好 (nǐ hǎo)。"
+    }
+  ]
+}
+```
+
 #### --distractors--
 
 Quiz 1, question 1, distractor 1 with `中文 (zhōng wén)`

--- a/tools/challenge-parser/parser/plugins/add-quizzes.js
+++ b/tools/challenge-parser/parser/plugins/add-quizzes.js
@@ -1,6 +1,9 @@
 const { root } = require('mdast-builder');
 const { getSection, getAllSections } = require('./utils/get-section');
-const { createMdastToHtml } = require('./utils/i18n-stringify');
+const {
+  createMdastToHtml,
+  parseHanziPinyinPairs
+} = require('./utils/i18n-stringify');
 
 const { splitOnThematicBreak } = require('./utils/split-on-thematic-break');
 
@@ -65,6 +68,22 @@ function plugin() {
                 `--audio-- transcript line ${index} must have character and text properties`
               );
             }
+          });
+
+          // Convert hanzi-pinyin pairs in transcript text to HTML ruby elements
+          audioData.transcript = audioData.transcript.map(line => {
+            if (parseHanziPinyinPairs(line.text).length > 0) {
+              const nodes = [
+                {
+                  type: 'paragraph',
+                  children: [{ type: 'inlineCode', value: line.text }]
+                }
+              ];
+              const html = toHtml(nodes);
+              const innerHtml = html.replace(/^<p>|<\/p>$/g, '');
+              return { ...line, text: innerHtml };
+            }
+            return line;
           });
 
           questionData.audioData = audioData;

--- a/tools/challenge-parser/parser/plugins/add-quizzes.test.js
+++ b/tools/challenge-parser/parser/plugins/add-quizzes.test.js
@@ -124,6 +124,12 @@ describe('add-quizzes plugin', () => {
     expect(firstQuestion.answer).toBe(
       '<p>Quiz 1, question 1, answer with <ruby>中文<rp>(</rp><rt>zhōng wén</rt><rp>)</rp></ruby></p>'
     );
+    expect(firstQuestion.audioData.transcript).toEqual([
+      {
+        character: 'Wang Hua',
+        text: '<ruby>你好<rp>(</rp><rt>nǐ hǎo</rt><rp>)</rp></ruby>。'
+      }
+    ]);
   });
 
   it('should render Chinese in quizzes when lang is zh-CN and the text does not contain hanzi (pinyin) format', () => {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR is a follow-up to #65711.

I forgot to handle Hanzi-Pinyin pairs in Chinese transcripts so the text was not rendered as a `ruby` element.

| Before | After |
| --- | --- |
| <img width="618" height="261" alt="Screenshot 2026-03-04 at 03 42 57" src="https://github.com/user-attachments/assets/af752301-6b7d-4378-a4ee-f7844ae98bd3" /> | <img width="624" height="297" alt="Screenshot 2026-03-04 at 03 22 02" src="https://github.com/user-attachments/assets/45e2a50c-5f39-49fc-a37d-71a3630dfd79" /> |

<!-- Feel free to add any additional description of changes below this line -->
