### PR TITLE
fix(client): remove ms trophy solution links on timeline

### DIFF
--- a/client/src/components/solution-display-widget/index.tsx
+++ b/client/src/components/solution-display-widget/index.tsx
@@ -198,6 +198,19 @@ export function SolutionDisplayWidget({
     <> {t('certification.project.no-solution-to-display')} </>
   );
 
+  // This is to hide the "view" button on the timeline for the ms trophy challenges,
+  // the solutions for those are a link to a JSON file, which isn't useful
+  const msTrophyIds = [
+    '647f85d407d29547b3bee1bb',
+    '647f87dc07d29547b3bee1bf',
+    '647f882207d29547b3bee1c0',
+    '647f867a07d29547b3bee1bc',
+    '647f877f07d29547b3bee1be',
+    '647f86ff07d29547b3bee1bd'
+  ];
+
+  if (msTrophyIds.includes(id)) return MissingSolutionComponent;
+
   const displayComponents =
     displayContext === 'certification'
       ? {


### PR DESCRIPTION
Fixes the linked issue (removes the "view" button by the MS trophy challenges on the timeline - see images). Not exactly the solution described there, but I'm not certain all MS trophy solution links are in the same format, so I'm not sure I could reliably extract the username from them.

<details><summary>images</summary>

| | |
| - | - |
| Before | <img width="790" height="129" alt="Screenshot 2026-03-03 at 4 39 34 PM" src="https://github.com/user-attachments/assets/2973e3f4-cf65-45c5-a122-b2e42de636bb" /> |
| After | <img width="788" height="142" alt="Screenshot 2026-03-03 at 5 07 49 PM" src="https://github.com/user-attachments/assets/9b39317a-32a5-49d9-97bf-bfd8b5771331" /> |

</details>

I don't like hardcoding the challenge ID's, but the challenge type isn't included in those completed challenges. I thought about adding a getChallengeType function that could get the challenge type for any ID, which might be useful, but it didn't seem worth it for this fix. I guess a different possible fix might have been to check for 'learn.microsoft' in the solutions - didn't really like that either.

To test, you can add the submitted trophy challenges to the db for your local (they're in the certified user data):

<details><summary>data</summary>

```
    {
      id: '647f85d407d29547b3bee1bb',
      solution:
        'https://learn.microsoft.com/api/gamestatus/achievements/learn.wwl.get-started-c-sharp-part-1.trophy?username=moT01&locale=en-us',
      completedDate: 1695064765244
    },
    {
      id: '647f87dc07d29547b3bee1bf',
      solution:
        'https://learn.microsoft.com/api/gamestatus/achievements/learn.wwl.get-started-c-sharp-part-2.trophy?username=moT01&locale=en-us',
      completedDate: 1695064900926
    },
    {
      id: '647f882207d29547b3bee1c0',
      solution:
        'https://learn.microsoft.com/api/gamestatus/achievements/learn.wwl.get-started-c-sharp-part-3.trophy?username=moT01&locale=en-us',
      completedDate: 1695064949460
    },
    {
      id: '647f867a07d29547b3bee1bc',
      solution:
        'https://learn.microsoft.com/api/gamestatus/achievements/learn.wwl.get-started-c-sharp-part-4.trophy?username=moT01&locale=en-us',
      completedDate: 1695064986634
    },
    {
      id: '647f877f07d29547b3bee1be',
      solution:
        'https://learn.microsoft.com/api/gamestatus/achievements/learn.wwl.get-started-c-sharp-part-5.trophy?username=moT01&locale=en-us',
      completedDate: 1695065026465
    },
    {
      id: '647f86ff07d29547b3bee1bd',
      solution:
        'https://learn.microsoft.com/api/gamestatus/achievements/learn.wwl.get-started-c-sharp-part-6.trophy?username=moT01&locale=en-us',
      completedDate: 1695065060157
    }
```

</details>

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #53073

<!-- Feel free to add any additional description of changes below this line -->
