### PR TITLE
fix(curriculum): clarify JPG lossy compression quiz question

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-images-and-svgs/67167835def3588873f339c6.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-images-and-svgs/67167835def3588873f339c6.md
@@ -91,7 +91,7 @@ Review the middle of the lesson to see which of these options was not mentioned.
 
 ## --text--
 
-Which file format should you never compress?
+Which file format uses lossy compression, meaning re-compressing it will degrade the image quality?
 
 ## --answers--
 
@@ -99,7 +99,7 @@ WEBP
 
 ### --feedback--
 
-This format is not lossless, so compressing it would result in a degraded quality.
+WEBP supports both lossy and lossless compression modes, so it can be compressed without permanent quality loss.
 
 ---
 
@@ -107,7 +107,7 @@ PNG
 
 ### --feedback--
 
-This format is not lossless, so compressing it would result in a degraded quality.
+PNG uses lossless compression, meaning the original image quality is fully preserved when compressed.
 
 ---
 
@@ -119,7 +119,7 @@ GIF
 
 ### --feedback--
 
-This format is not lossless, so compressing it would result in a degraded quality.
+GIF uses lossless compression, so compressing it does not result in degraded quality.
 
 ## --video-solution--
 


### PR DESCRIPTION
Fixes #66213

## Problem
The quiz question asked "Which file format should you never compress?" 
which is technically misleading. Additionally, the feedback messages 
for the wrong answers (WEBP, PNG, GIF) incorrectly stated 
"This format is not lossless" — which actually describes JPG, 
not those formats.

## Changes Made
- Reworded question to accurately describe lossy compression
- Fixed feedback for WEBP: clarified it supports both lossy and lossless
- Fixed feedback for PNG: clarified it uses lossless compression
- Fixed feedback for GIF: clarified it uses lossless compression