### PR TITLE
fix(curriculum): change helpCategory from HTML-CSS to JavaScript in lab-lightbox-viewer

### DIFF
--- a/curriculum/structure/blocks/lab-lightbox-viewer.json
+++ b/curriculum/structure/blocks/lab-lightbox-viewer.json
@@ -8,5 +8,5 @@
   "challengeOrder": [
     { "id": "66db57ad34c7089b9b41bfd6", "title": "Build a Lightbox Viewer" }
   ],
-  "helpCategory": "HTML-CSS"
+  "helpCategory": "JavaScript"
 }


### PR DESCRIPTION
This pull request updates the helpCategory in lab-lightbox-viewer.json.

The value was incorrectly set to "HTML-CSS" and has been changed to "JavaScript" to match the correct lab category.


Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #66234 

<!-- Feel free to add any additional description of changes below this line -->
