### PR TITLE
feat(challenge-helper-scripts): add example of quiz with audio to quiz template

### DIFF
--- a/tools/challenge-helper-scripts/helpers/get-challenge-template.ts
+++ b/tools/challenge-helper-scripts/helpers/get-challenge-template.ts
@@ -85,19 +85,10 @@ Test 1
 \`\`\`
 `;
 
-const getQuizChallengeTemplate = (
-  options: ChallengeOptions
-): string => `${buildFrontMatter(options)}
+const getQuizChallengeTemplate = (options: ChallengeOptions): string => {
+  const count = options.questionCount!;
 
-# --description--
-
-To pass the quiz, you must correctly answer at least ${options.questionCount! == 20 ? '18' : '9'} of the ${options.questionCount!.toString()} questions below.
-
-# --quizzes--
-
-## --quiz--
-
-${`### --question--
+  const regularQuestion = `### --question--
 
 #### --text--
 
@@ -119,7 +110,65 @@ Placeholder distractor 3
 
 Placeholder answer
 
-`.repeat(options.questionCount! - 1)}
+`;
+
+  const questionWithAudio = `### --question--
+
+#### --text--
+
+Placeholder question
+
+#### --audio--
+
+\`\`\`json
+{
+  "audio": {
+    "filename": "1.1-1.mp3",
+    "startTimestamp": 5.7,
+    "finishTimestamp": 6.48
+  },
+  "transcript": [
+    {
+      "character": "Tom",
+      "text": "Hi, I'm Tom."
+    }
+  ]
+}
+\`\`\`
+
+#### --distractors--
+
+Placeholder distractor 1
+
+---
+
+Placeholder distractor 2
+
+---
+
+Placeholder distractor 3
+
+#### --answer--
+
+Placeholder answer
+
+`;
+
+  const firstQuestion = options.challengeLang
+    ? questionWithAudio
+    : regularQuestion;
+
+  return `${buildFrontMatter(options)}
+
+# --description--
+
+To pass the quiz, you must correctly answer at least ${count == 20 ? '18' : '9'} of the ${count.toString()} questions below.
+
+# --quizzes--
+
+## --quiz--
+
+${firstQuestion}${regularQuestion.repeat(Math.max(0, count - 2))}
 ### --question--
 
 #### --text--
@@ -142,6 +191,7 @@ Placeholder distractor 3
 
 Placeholder answer
 `;
+};
 
 const getVideoChallengeTemplate = (
   options: ChallengeOptions


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Quizzes now support audio in questions, so I'm adding an example to the quiz template. (We only use audio in language quizzes so I'm using a `lang` check in the generation logic.)

Closes https://github.com/freeCodeCamp/language-curricula/issues/74

<!-- Feel free to add any additional description of changes below this line -->
