### PR TITLE
refactor(challenge-helper-scripts): update challengeLang type to ChallengeLang

### DIFF
--- a/tools/challenge-helper-scripts/create-language-block.ts
+++ b/tools/challenge-helper-scripts/create-language-block.ts
@@ -7,7 +7,8 @@ import { ObjectId } from 'bson';
 import {
   SuperBlocks,
   languageSuperBlocks,
-  chapterBasedSuperBlocks
+  chapterBasedSuperBlocks,
+  type ChallengeLang
 } from '@freecodecamp/shared/config/curriculum';
 
 import { BlockLayouts, BlockLabel } from '@freecodecamp/shared/config/blocks';
@@ -95,7 +96,7 @@ async function createLanguageBlock(
     moduleTitle
   });
 
-  const challengeLang = getLangFromSuperBlock(superBlock);
+  const challengeLang: ChallengeLang = getLangFromSuperBlock(superBlock);
   const challengeId: ObjectId = new ObjectId();
 
   await createMetaJson(
@@ -241,7 +242,7 @@ async function createMetaJson(
 async function createDialogueChallenge(
   challengeId: ObjectId,
   block: string,
-  challengeLang: string
+  challengeLang: ChallengeLang
 ): Promise<ObjectId> {
   const { blockContentDir } = getContentConfig('english') as {
     blockContentDir: string;
@@ -262,7 +263,7 @@ async function createQuizChallenge(
   block: string,
   title: string,
   questionCount: number,
-  challengeLang: string
+  challengeLang: ChallengeLang
 ): Promise<ObjectId> {
   return createQuizFile({
     challengeId,

--- a/tools/challenge-helper-scripts/create-next-task.ts
+++ b/tools/challenge-helper-scripts/create-next-task.ts
@@ -17,7 +17,10 @@ const createNextTask = async () => {
 
   const prevChallengeId =
     meta.challengeOrder[meta.challengeOrder.length - 1]?.id;
-  const challengeLang = prevChallengeId && getChallenge(prevChallengeId)?.lang;
+
+  const challengeLang = prevChallengeId
+    ? getChallenge(prevChallengeId)?.lang
+    : undefined;
 
   const inputType = await getInputType(challengeType, challengeLang);
 

--- a/tools/challenge-helper-scripts/helpers/get-challenge-template.ts
+++ b/tools/challenge-helper-scripts/helpers/get-challenge-template.ts
@@ -1,4 +1,5 @@
 import { ObjectId } from 'bson';
+import type { ChallengeLang } from '@freecodecamp/shared/config/curriculum';
 
 const sanitizeTitle = (title: string) => {
   return title.includes(':') || title.includes("'") ? `"${title}"` : title;
@@ -10,7 +11,7 @@ interface ChallengeOptions {
   dashedName: string;
   challengeType: string;
   questionCount?: number;
-  challengeLang?: string;
+  challengeLang?: ChallengeLang;
   inputType?: string;
 }
 

--- a/tools/challenge-helper-scripts/helpers/get-input-type.ts
+++ b/tools/challenge-helper-scripts/helpers/get-input-type.ts
@@ -4,7 +4,7 @@ import { challengeTypes } from '@freecodecamp/shared/config/challenge-types';
 
 export const getInputType = async (
   challengeType: string,
-  challengeLang?: string
+  challengeLang?: ChallengeLang
 ): Promise<string | undefined> => {
   const isRequired =
     parseInt(challengeType) === challengeTypes.fillInTheBlank &&

--- a/tools/challenge-helper-scripts/helpers/get-step-template.test.ts
+++ b/tools/challenge-helper-scripts/helpers/get-step-template.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { ObjectId } from 'bson';
 import { getStepTemplate } from './get-step-template.js';
+import { ChallengeLang } from '@freecodecamp/shared/config/curriculum';
 
 const props = {
   challengeId: new ObjectId('60d4ebe4801158d1abe1b18f'),
@@ -65,8 +66,11 @@ dashedName: step-5
 lang: es
 ---`;
 
-    expect(getStepTemplate({ ...props, challengeLang: 'es' })).match(
-      new RegExp(`^${frontMatter}`)
-    );
+    expect(
+      getStepTemplate({
+        ...props,
+        challengeLang: ChallengeLang.Spanish
+      })
+    ).match(new RegExp(`^${frontMatter}`));
   });
 });

--- a/tools/challenge-helper-scripts/helpers/get-step-template.ts
+++ b/tools/challenge-helper-scripts/helpers/get-step-template.ts
@@ -1,4 +1,5 @@
 import { ObjectId } from 'bson';
+import type { ChallengeLang } from '@freecodecamp/shared/config/curriculum';
 import { insertErms } from './insert-erms.js';
 
 // Builds a block
@@ -25,7 +26,7 @@ type StepOptions = {
   stepNum: number;
   challengeType?: number;
   isFirstChallenge?: boolean;
-  challengeLang?: string;
+  challengeLang?: ChallengeLang;
 };
 
 export interface ChallengeSeed {

--- a/tools/challenge-helper-scripts/utils.ts
+++ b/tools/challenge-helper-scripts/utils.ts
@@ -5,6 +5,7 @@ import matter from 'gray-matter';
 import { uniq } from 'lodash';
 
 import { challengeTypes } from '@freecodecamp/shared/config/challenge-types';
+import type { ChallengeLang } from '@freecodecamp/shared/config/curriculum';
 import { parseCurriculumStructure } from '@freecodecamp/curriculum/build-curriculum';
 import { parseMDSync } from '../challenge-parser/parser/index.js';
 import { getMetaData, updateMetaData } from './helpers/project-metadata.js';
@@ -23,7 +24,7 @@ interface Options {
   projectPath?: string;
   challengeSeeds?: ChallengeSeed[];
   isFirstChallenge?: boolean;
-  challengeLang?: string;
+  challengeLang?: ChallengeLang;
 }
 
 interface QuizOptions {
@@ -32,7 +33,7 @@ interface QuizOptions {
   title: string;
   dashedName: string;
   questionCount: number;
-  challengeLang?: string;
+  challengeLang?: ChallengeLang;
 }
 
 export async function getAllBlocks() {
@@ -108,7 +109,7 @@ const createDialogueFile = ({
 }: {
   challengeId: ObjectId;
   projectPath: string;
-  challengeLang: string;
+  challengeLang: ChallengeLang;
 }): ObjectId => {
   const challengeType = challengeTypes.dialogue.toString();
   const template = getTemplate(challengeType);
@@ -274,7 +275,7 @@ const updateTaskMarkdownFiles = (): void => {
 type Challenge = {
   challengeType: number;
   challengeFiles: ChallengeSeed[];
-  lang?: string;
+  lang?: ChallengeLang;
 };
 
 const getChallenge = (challengeId: string): Challenge => {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

`challengeLang` comes from the challenges' `lang` property, which can only be one of these:

https://github.com/freeCodeCamp/freeCodeCamp/blob/a6b34d01b754d6bb849f45ba04d7fd7d038f11ac/packages/shared/src/config/curriculum.ts#L81-L85

<!-- Feel free to add any additional description of changes below this line -->
