### PR TITLE
fix(curriculum): add Node.js installation note before Vite setup command

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-introduction-to-javascript-libraries-and-frameworks/6734e88cc46e6dc679420040.md
+++ b/curriculum/challenges/english/blocks/lecture-introduction-to-javascript-libraries-and-frameworks/6734e88cc46e6dc679420040.md
@@ -13,6 +13,8 @@ One of the most popular tools for setting up projects is Vite. Vite, which means
 
 To create a new project with Vite, you will need to use the command line. If you are using Windows machine, then you can use the Command Prompt or Windows PowerShell. If you are using a Mac, then you can use the Terminal app.
 
+In case you don't have Node.js installed, which is needed for npm to work, here is a link for the official Node.js webpage: https://nodejs.org. Follow the installation instructions then come back here to resume your React installation.
+
 Once you have the command line open, you can use the following command:
 
 ```bash


### PR DESCRIPTION
Checklist:

* [x] I have read and followed the [[contribution guidelines](https://contribute.freecodecamp.org/)](https://contribute.freecodecamp.org).
* [x] I have read and followed the [[how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/)](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
* [x] My pull request targets the `main` branch of freeCodeCamp.
* [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #66238

Added a note instructing users to install Node.js before running the Vite npm command. This helps beginners who may not have Node.js installed and encounter errors when trying to run the command.