### PR TITLE
feat(client): add tsconfig support to editor and use it in ts compiler

### DIFF
--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -232,7 +232,8 @@ const modeMap = {
   ts: 'typescript',
   tsx: 'typescript',
   py: 'python',
-  python: 'python'
+  python: 'python',
+  json: 'json'
 };
 
 let monacoThemesDefined = false;
@@ -411,6 +412,11 @@ const Editor = (props: EditorProps): JSX.Element => {
       ...monaco.languages.typescript.typescriptDefaults.getCompilerOptions(),
       jsx: monaco.languages.typescript.JsxEmit.Preserve,
       allowUmdGlobalAccess: true
+    });
+
+    // support JSONC:
+    monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
+      allowComments: true
     });
 
     defineMonacoThemes(monaco, { usesMultifileEditor });

--- a/client/src/templates/Challenges/classic/multifile-editor.tsx
+++ b/client/src/templates/Challenges/classic/multifile-editor.tsx
@@ -19,6 +19,7 @@ export type VisibleEditors = {
   indexts?: boolean;
   indextsx?: boolean;
   mainpy?: boolean;
+  tsconfigjson?: boolean;
 };
 type MultifileEditorProps = Pick<
   EditorProps,
@@ -72,7 +73,8 @@ const MultifileEditor = (props: MultifileEditorProps) => {
       indexts,
       indexjsx,
       indextsx,
-      mainpy
+      mainpy,
+      tsconfigjson
     },
     usesMultifileEditor,
     showProjectPreview,
@@ -102,6 +104,7 @@ const MultifileEditor = (props: MultifileEditorProps) => {
   if (scriptjs) editorKeys.push('scriptjs');
   if (mainpy) editorKeys.push('mainpy');
   if (indexts) editorKeys.push('indexts');
+  if (tsconfigjson) editorKeys.push('tsconfigjsonc');
 
   const editorAndSplitterKeys = editorKeys.reduce((acc: string[] | [], key) => {
     if (acc.length === 0) {

--- a/client/src/templates/Challenges/classic/multifile-editor.tsx
+++ b/client/src/templates/Challenges/classic/multifile-editor.tsx
@@ -104,7 +104,7 @@ const MultifileEditor = (props: MultifileEditorProps) => {
   if (scriptjs) editorKeys.push('scriptjs');
   if (mainpy) editorKeys.push('mainpy');
   if (indexts) editorKeys.push('indexts');
-  if (tsconfigjson) editorKeys.push('tsconfigjsonc');
+  if (tsconfigjson) editorKeys.push('tsconfigjson');
 
   const editorAndSplitterKeys = editorKeys.reduce((acc: string[] | [], key) => {
     if (acc.length === 0) {

--- a/client/utils/__fixtures__/challenges.ts
+++ b/client/utils/__fixtures__/challenges.ts
@@ -1,4 +1,4 @@
-import { ChallengeFile } from "../../src/redux/prop-types";
+import { ChallengeFile } from '../../src/redux/prop-types';
 
 export const challengeFiles: ChallengeFile[] = [
   {
@@ -13,7 +13,7 @@ export const challengeFiles: ChallengeFile[] = [
     tail: '',
     editableRegionBoundaries: [],
     usesMultifileEditor: true,
-    path: 'index.ts',
+    path: 'index.ts'
   },
   {
     contents: 'some css',
@@ -27,7 +27,7 @@ export const challengeFiles: ChallengeFile[] = [
     tail: '',
     editableRegionBoundaries: [],
     usesMultifileEditor: true,
-    path: 'styles.css',
+    path: 'styles.css'
   },
   {
     contents: 'some html',
@@ -41,7 +41,7 @@ export const challengeFiles: ChallengeFile[] = [
     tail: '',
     editableRegionBoundaries: [],
     usesMultifileEditor: true,
-    path: 'index.html',
+    path: 'index.html'
   },
   {
     contents: 'some js',
@@ -55,7 +55,7 @@ export const challengeFiles: ChallengeFile[] = [
     tail: '',
     editableRegionBoundaries: [],
     usesMultifileEditor: true,
-    path: 'script.js',
+    path: 'script.js'
   },
   {
     contents: 'some jsx',
@@ -69,7 +69,7 @@ export const challengeFiles: ChallengeFile[] = [
     tail: '',
     editableRegionBoundaries: [],
     usesMultifileEditor: true,
-    path: 'index.jsx',
+    path: 'index.jsx'
   },
   {
     contents: 'some tsx',
@@ -83,6 +83,20 @@ export const challengeFiles: ChallengeFile[] = [
     tail: '',
     editableRegionBoundaries: [],
     usesMultifileEditor: true,
-    path: 'index.tsx',
+    path: 'index.tsx'
+  },
+  {
+    contents: '{\n  "compilerOptions": {}\n}',
+    error: null,
+    ext: 'json',
+    head: '',
+    history: ['tsconfig.jsonc'],
+    fileKey: 'tsconfigjsonc',
+    name: 'tsconfig',
+    seed: '{\n  "compilerOptions": {}\n}',
+    tail: '',
+    editableRegionBoundaries: [],
+    usesMultifileEditor: true,
+    path: 'tsconfig.jsonc'
   }
-]
+];

--- a/client/utils/__fixtures__/challenges.ts
+++ b/client/utils/__fixtures__/challenges.ts
@@ -90,13 +90,13 @@ export const challengeFiles: ChallengeFile[] = [
     error: null,
     ext: 'json',
     head: '',
-    history: ['tsconfig.jsonc'],
-    fileKey: 'tsconfigjsonc',
+    history: ['tsconfig.json'],
+    fileKey: 'tsconfigjson',
     name: 'tsconfig',
     seed: '{\n  "compilerOptions": {}\n}',
     tail: '',
     editableRegionBoundaries: [],
     usesMultifileEditor: true,
-    path: 'tsconfig.jsonc'
+    path: 'tsconfig.json'
   }
 ];

--- a/client/utils/sort-challengefiles.test.ts
+++ b/client/utils/sort-challengefiles.test.ts
@@ -15,7 +15,7 @@ describe('sort-files', () => {
       expect(sorted.length).toEqual(expected.length);
     });
 
-    it('should sort the objects into jsx, tsx, html, css, js, ts order', () => {
+    it('should sort the objects into jsx, tsx, html, css, js, ts, tsconfig order', () => {
       const sorted = sortChallengeFiles(challengeFiles);
       const sortedKeys = sorted.map(({ fileKey }) => fileKey);
       const expected = [
@@ -24,7 +24,8 @@ describe('sort-files', () => {
         'indexhtml',
         'stylescss',
         'scriptjs',
-        'indexts'
+        'indexts',
+        'tsconfigjson'
       ];
       expect(sortedKeys).toStrictEqual(expected);
     });

--- a/client/utils/sort-challengefiles.ts
+++ b/client/utils/sort-challengefiles.ts
@@ -14,6 +14,8 @@ export function sortChallengeFiles<File extends { fileKey: string }>(
     if (b.fileKey === 'scriptjs') return 1;
     if (a.fileKey === 'indexts') return -1;
     if (b.fileKey === 'indexts') return 1;
+    if (a.fileKey === 'tsconfigjson') return -1;
+    if (b.fileKey === 'tsconfigjson') return 1;
     return 0;
   });
 }

--- a/curriculum/challenges/english/blocks/workshop-curriculum-outline/682ba2318000b62f179bdf04.md
+++ b/curriculum/challenges/english/blocks/workshop-curriculum-outline/682ba2318000b62f179bdf04.md
@@ -45,19 +45,6 @@ assert.match(code, /\<h1\s*\>\s*Welcome\s*to\s*freeCodeCamp\s*\<\/h1\s*\>/i);
 
 ```html
 --fcc-editable-region--
-<script src="index.ts"></script>
+Welcome to freeCodeCamp
 --fcc-editable-region--
-```
-
-```ts
-const x: number = "NaN";
-```
-
-```json
-{
-  "compilerOptions": {
-    // uncomment line below to compile
-    // "noCheck": true
-  }
-}
 ```

--- a/curriculum/challenges/english/blocks/workshop-curriculum-outline/682ba2318000b62f179bdf04.md
+++ b/curriculum/challenges/english/blocks/workshop-curriculum-outline/682ba2318000b62f179bdf04.md
@@ -45,6 +45,19 @@ assert.match(code, /\<h1\s*\>\s*Welcome\s*to\s*freeCodeCamp\s*\<\/h1\s*\>/i);
 
 ```html
 --fcc-editable-region--
-Welcome to freeCodeCamp
+<script src="index.ts"></script>
 --fcc-editable-region--
+```
+
+```ts
+const x: number = "NaN";
+```
+
+```json
+{
+  "compilerOptions": {
+    // uncomment line below to compile
+    // "noCheck": true
+  }
+}
 ```

--- a/packages/challenge-builder/src/build.test.ts
+++ b/packages/challenge-builder/src/build.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { getTSConfig } from './build';
+import { ChallengeFile } from '@freecodecamp/shared/utils/polyvinyl';
+
+describe('getTSConfig', () => {
+  it("should return the tsconfig file's contents if it exists", () => {
+    const compileOptions = 'any string is valid here';
+    const challengeFiles = [
+      { name: 'index', ext: 'ts' },
+      { name: 'tsconfig', ext: 'json', contents: compileOptions }
+    ] as ChallengeFile[];
+
+    expect(getTSConfig(challengeFiles)).toEqual(compileOptions);
+  });
+
+  it('should return null if there is no tsconfig file', () => {
+    const challengeFiles = [
+      { name: 'index', ext: 'ts' },
+      { name: 'app', ext: 'ts' }
+    ] as ChallengeFile[];
+
+    expect(getTSConfig(challengeFiles)).toBeNull();
+  });
+
+  it('should throw an error if there are multiple tsconfig.json files', () => {
+    const challengeFiles = [
+      { name: 'index', ext: 'ts' },
+      { name: 'tsconfig', ext: 'json' },
+      { name: 'tsconfig', ext: 'json' }
+    ] as ChallengeFile[];
+
+    expect(() => getTSConfig(challengeFiles)).toThrow(
+      'TypeScript challenge must include only one tsconfig.json file'
+    );
+  });
+});

--- a/packages/challenge-builder/src/build.ts
+++ b/packages/challenge-builder/src/build.ts
@@ -8,6 +8,7 @@ import {
   getPythonTransformers,
   getMultifileJSXTransformers
 } from './transformers.js';
+import { setupTSCompiler } from './typescript-worker-handler.js';
 
 interface Source {
   index: string;
@@ -165,6 +166,38 @@ type BuildResult = {
   error?: unknown;
 };
 
+function hasTS(challengeFiles: ChallengeFile[]) {
+  return challengeFiles.some(
+    challengeFile => challengeFile.ext === 'ts' || challengeFile.ext === 'tsx'
+  );
+}
+
+export function getTSConfig(challengeFiles: ChallengeFile[]) {
+  const tsConfigFiles = challengeFiles.filter(
+    file => file.name === 'tsconfig' && file.ext === 'json'
+  );
+
+  if (tsConfigFiles.length > 1) {
+    throw new Error(
+      'TypeScript challenge must include only one tsconfig.json file'
+    );
+  }
+
+  return tsConfigFiles.length === 1 ? tsConfigFiles[0].contents : null;
+}
+
+async function configureTSCompiler(challengeFiles: ChallengeFile[]) {
+  if (hasTS(challengeFiles)) {
+    const tsConfig = getTSConfig(challengeFiles);
+
+    if (tsConfig) {
+      await setupTSCompiler(tsConfig);
+    } else {
+      await setupTSCompiler();
+    }
+  }
+}
+
 // TODO: All the buildXChallenge files have a similar structure, so make that
 // abstraction (function, class, whatever) and then create the various functions
 // out of it.
@@ -182,6 +215,9 @@ async function buildDOMChallenge(
   const hasJsx = challengeFiles.some(
     challengeFile => challengeFile.ext === 'jsx' || challengeFile.ext === 'tsx'
   );
+
+  await configureTSCompiler(challengeFiles);
+
   const isMultifile = challengeFiles.length > 1;
 
   const requiresReact16 = required.some(({ src }) =>
@@ -230,6 +266,7 @@ async function buildJSChallenge(
     ...(getTransformers(options) as unknown as ApplyFunctionProps[])
   );
 
+  await configureTSCompiler(challengeFiles);
   const finalFiles = await Promise.all(challengeFiles?.map(pipeLine));
   const error = finalFiles.find(({ error }) => error)?.error;
 

--- a/packages/challenge-builder/src/build.ts
+++ b/packages/challenge-builder/src/build.ts
@@ -172,10 +172,11 @@ function hasTS(challengeFiles: ChallengeFile[]) {
   );
 }
 
+const isTSConfig = (f: { name: string; ext: string }) =>
+  f.name === 'tsconfig' && f.ext === 'json';
+
 export function getTSConfig(challengeFiles: ChallengeFile[]) {
-  const tsConfigFiles = challengeFiles.filter(
-    file => file.name === 'tsconfig' && file.ext === 'json'
-  );
+  const tsConfigFiles = challengeFiles.filter(isTSConfig);
 
   if (tsConfigFiles.length > 1) {
     throw new Error(
@@ -217,13 +218,8 @@ async function buildDOMChallenge(
   );
 
   await configureTSCompiler(challengeFiles);
-
-  const isMultifile = challengeFiles.length > 1;
-
-  const requiresReact16 = required.some(({ src }) =>
-    src?.includes('https://cdnjs.cloudflare.com/ajax/libs/react/16.')
-  );
-
+  const sourceFiles = challengeFiles.filter(file => !isTSConfig(file));
+  const isMultifile = sourceFiles.length > 1;
   // I'm reasonably sure this is fine, but we need to migrate transformers to
   // TypeScript to be sure.
   const transformers: ApplyFunctionProps[] = (isMultifile && hasJsx
@@ -231,7 +227,7 @@ async function buildDOMChallenge(
     : getTransformers(options)) as unknown as ApplyFunctionProps[];
 
   const pipeLine = composeFunctions(...transformers);
-  const finalFiles = await Promise.all(challengeFiles.map(pipeLine));
+  const finalFiles = await Promise.all(sourceFiles.map(pipeLine));
   const error = finalFiles.find(({ error }) => error)?.error;
   const contents = (await embedFilesInHtml(finalFiles)) as string;
 
@@ -244,6 +240,10 @@ async function buildDOMChallenge(
         template,
         contents
       };
+
+  const requiresReact16 = required.some(({ src }) =>
+    src?.includes('https://cdnjs.cloudflare.com/ajax/libs/react/16.')
+  );
 
   return {
     challengeType,
@@ -267,7 +267,8 @@ async function buildJSChallenge(
   );
 
   await configureTSCompiler(challengeFiles);
-  const finalFiles = await Promise.all(challengeFiles?.map(pipeLine));
+  const sourceFiles = challengeFiles.filter(file => !isTSConfig(file));
+  const finalFiles = await Promise.all(sourceFiles?.map(pipeLine));
   const error = finalFiles.find(({ error }) => error)?.error;
 
   const toBuild = error ? [] : finalFiles;

--- a/packages/challenge-builder/src/transformers.js
+++ b/packages/challenge-builder/src/transformers.js
@@ -18,10 +18,7 @@ import {
 import { version } from '@freecodecamp/browser-scripts/package.json';
 
 import { WorkerExecutor } from './worker-executor';
-import {
-  compileTypeScriptCode,
-  setupTSCompiler
-} from './typescript-worker-handler';
+import { compileTypeScriptCode } from './typescript-worker-handler';
 
 const protectTimeout = 100;
 const testProtectTimeout = 1500;
@@ -148,7 +145,6 @@ const getJSXModuleTranspiler = loopProtectOptions => async challengeFile => {
 
 const getTSTranspiler = loopProtectOptions => async challengeFile => {
   await loadBabel();
-  await setupTSCompiler();
   const babelOptions = getBabelOptions(presetsJS, loopProtectOptions);
   return flow(
     partial(transformHeadTailAndContents, compileTypeScriptCode),
@@ -159,7 +155,6 @@ const getTSTranspiler = loopProtectOptions => async challengeFile => {
 const getTSXModuleTranspiler = loopProtectOptions => async challengeFile => {
   await loadBabel();
   await loadPresetReact();
-  await setupTSCompiler();
   const baseOptions = getBabelOptions(presetsJSX, loopProtectOptions);
   const babelOptions = {
     ...baseOptions,

--- a/packages/challenge-builder/src/transformers.js
+++ b/packages/challenge-builder/src/transformers.js
@@ -379,7 +379,18 @@ function challengeFilesToObject(challengeFiles) {
   const scriptJs = challengeFiles.find(file => file.fileKey === 'scriptjs');
   const indexTs = challengeFiles.find(file => file.fileKey === 'indexts');
   const indexTsx = challengeFiles.find(file => file.fileKey === 'indextsx');
-  return { indexHtml, indexJsx, stylesCss, scriptJs, indexTs, indexTsx };
+  const tsconfigJson = challengeFiles.find(
+    file => file.fileKey === 'tsconfigjson'
+  );
+  return {
+    indexHtml,
+    indexJsx,
+    stylesCss,
+    scriptJs,
+    indexTs,
+    indexTsx,
+    tsconfigJson
+  };
 }
 
 const parseAndTransform = async function (transform, contents) {

--- a/packages/challenge-builder/src/typescript-worker-handler.ts
+++ b/packages/challenge-builder/src/typescript-worker-handler.ts
@@ -31,9 +31,7 @@ export function compileTypeScriptCode(code: string): Promise<string> {
   });
 }
 
-export function setupTSCompiler(
-  compilerOptions?: Record<string, unknown>
-): Promise<boolean> {
+export function setupTSCompiler(compilerOptions?: string): Promise<boolean> {
   return awaitResponse({
     messenger: getTypeScriptWorker(),
     message: { type: 'setup', ...(compilerOptions && { compilerOptions }) },

--- a/packages/challenge-builder/src/typescript-worker-handler.ts
+++ b/packages/challenge-builder/src/typescript-worker-handler.ts
@@ -31,10 +31,10 @@ export function compileTypeScriptCode(code: string): Promise<string> {
   });
 }
 
-export function setupTSCompiler(compilerOptions?: string): Promise<boolean> {
+export function setupTSCompiler(tsconfig?: string): Promise<boolean> {
   return awaitResponse({
     messenger: getTypeScriptWorker(),
-    message: { type: 'setup', ...(compilerOptions && { compilerOptions }) },
+    message: { type: 'setup', ...(tsconfig && { tsconfig }) },
     onMessage: (data, onSuccess) => {
       if (data.type === 'ready') {
         onSuccess(true);

--- a/packages/shared/src/utils/polyvinyl.ts
+++ b/packages/shared/src/utils/polyvinyl.ts
@@ -1,4 +1,4 @@
-const exts = ['js', 'html', 'css', 'jsx', 'ts', 'tsx', 'py'] as const;
+const exts = ['js', 'html', 'css', 'jsx', 'ts', 'tsx', 'py', 'json'] as const;
 export type Ext = (typeof exts)[number];
 
 export interface IncompleteChallengeFile {

--- a/tools/challenge-parser/parser/__fixtures__/simple.md
+++ b/tools/challenge-parser/parser/__fixtures__/simple.md
@@ -58,6 +58,14 @@ body {
 var x = 'y';
 ```
 
+```json
+{
+  "compilerOptions": {
+    "target": "ES2020"
+  }
+}
+```
+
 
 # --solutions--
 

--- a/tools/challenge-parser/parser/__snapshots__/index.acceptance.test.js.snap
+++ b/tools/challenge-parser/parser/__snapshots__/index.acceptance.test.js.snap
@@ -381,7 +381,7 @@ exports[`challenge parser > should parse a simple md file 1`] = `
   }
 }",
       "editableRegionBoundaries": [],
-      "ext": "jsonc",
+      "ext": "json",
       "head": "",
       "id": "",
       "name": "tsconfig",

--- a/tools/challenge-parser/parser/__snapshots__/index.acceptance.test.js.snap
+++ b/tools/challenge-parser/parser/__snapshots__/index.acceptance.test.js.snap
@@ -374,6 +374,19 @@ exports[`challenge parser > should parse a simple md file 1`] = `
       "name": "script",
       "tail": "",
     },
+    {
+      "contents": "{
+  "compilerOptions": {
+    "target": "ES2020"
+  }
+}",
+      "editableRegionBoundaries": [],
+      "ext": "jsonc",
+      "head": "",
+      "id": "",
+      "name": "tsconfig",
+      "tail": "",
+    },
   ],
   "description": "<section id="description">
 <p>Paragraph 1</p>

--- a/tools/challenge-parser/parser/plugins/__snapshots__/add-seed.test.js.snap
+++ b/tools/challenge-parser/parser/plugins/__snapshots__/add-seed.test.js.snap
@@ -35,6 +35,19 @@ exports[`add-seed plugin > should have an output to match the snapshot 1`] = `
       "name": "script",
       "tail": "",
     },
+    {
+      "contents": "{
+  "compilerOptions": {
+    "target": "ES2020"
+  }
+}",
+      "editableRegionBoundaries": [],
+      "ext": "jsonc",
+      "head": "",
+      "id": "",
+      "name": "tsconfig",
+      "tail": "",
+    },
   ],
 }
 `;

--- a/tools/challenge-parser/parser/plugins/__snapshots__/add-seed.test.js.snap
+++ b/tools/challenge-parser/parser/plugins/__snapshots__/add-seed.test.js.snap
@@ -42,7 +42,7 @@ exports[`add-seed plugin > should have an output to match the snapshot 1`] = `
   }
 }",
       "editableRegionBoundaries": [],
-      "ext": "jsonc",
+      "ext": "json",
       "head": "",
       "id": "",
       "name": "tsconfig",

--- a/tools/challenge-parser/parser/plugins/add-seed.test.js
+++ b/tools/challenge-parser/parser/plugins/add-seed.test.js
@@ -272,6 +272,19 @@ const Button = () => {
 };`);
   });
 
+  it('handles json', () => {
+    expect.assertions(1);
+    plugin(simpleAST, file);
+    const {
+      data: { challengeFiles }
+    } = file;
+    const tsconfigjsonc = challengeFiles.find(x => x.ext === 'json');
+
+    expect(tsconfigjsonc.contents).toBe(
+      `{\n  "compilerOptions": {\n    "target": "ES2020"\n  }\n}`
+    );
+  });
+
   it('should throw an error if a seed has no contents', () => {
     expect.assertions(1);
     expect(() => plugin(withEmptyContentsAST, file)).toThrow(

--- a/tools/challenge-parser/parser/plugins/utils/get-file-visitor.js
+++ b/tools/challenge-parser/parser/plugins/utils/get-file-visitor.js
@@ -8,7 +8,16 @@ const keyToSection = {
   head: 'before-user-code',
   tail: 'after-user-code'
 };
-const supportedLanguages = ['js', 'css', 'html', 'jsx', 'py', 'ts', 'tsx'];
+const supportedLanguages = [
+  'js',
+  'css',
+  'html',
+  'jsx',
+  'py',
+  'ts',
+  'tsx',
+  'json'
+];
 const longToShortLanguages = {
   javascript: 'js',
   typescript: 'ts',
@@ -30,7 +39,8 @@ function getFilenames(lang) {
   const langToFilename = {
     js: 'script',
     css: 'styles',
-    py: 'main'
+    py: 'main',
+    json: 'tsconfig'
   };
   return langToFilename[lang] ?? 'index';
 }

--- a/tools/client-plugins/browser-scripts/modules/typescript-compiler.ts
+++ b/tools/client-plugins/browser-scripts/modules/typescript-compiler.ts
@@ -1,5 +1,6 @@
 import type { VirtualTypeScriptEnvironment } from '@typescript/vfs';
 import type { CompilerHost, CompilerOptions } from 'typescript';
+import { parse } from 'jsonc-parser';
 
 import reactTypes from './react-types.json';
 
@@ -16,12 +17,19 @@ export class Compiler {
     this.tsvfs = tsvfs;
   }
 
-  async setup(opts?: { useNodeModules?: boolean; compilerOptions?: unknown }) {
+  async setup(opts?: {
+    useNodeModules?: boolean;
+    rawCompilerOptions?: string;
+  }) {
     const ts = this.ts;
     const tsvfs = this.tsvfs;
 
-    const parsedOptions = ts.convertCompilerOptionsFromJson(
-      opts?.compilerOptions ?? {},
+    const parsedOptions = opts?.rawCompilerOptions
+      ? (parse(opts?.rawCompilerOptions) as unknown)
+      : undefined;
+
+    const validatedOptions = ts.convertCompilerOptionsFromJson(
+      parsedOptions ?? {},
       '/'
     );
 
@@ -34,7 +42,7 @@ export class Compiler {
       // 3.8.0-rc."
       jsx: ts.JsxEmit.Preserve, // Babel will handle JSX,
       allowUmdGlobalAccess: true, // Necessary because React is loaded via a UMD script.
-      ...parsedOptions.options
+      ...validatedOptions.options
     };
 
     const fsMap = opts?.useNodeModules

--- a/tools/client-plugins/browser-scripts/modules/typescript-compiler.ts
+++ b/tools/client-plugins/browser-scripts/modules/typescript-compiler.ts
@@ -28,8 +28,10 @@ export class Compiler {
       : undefined;
 
     // For now we're only interested in the compilerOptions, so that's all we're
-    // extracting and validating.  For everything else, we would need
-    // parseJsonConfigFileContent and a virtual config file system.
+    // extracting and validating.  For everything else, we could
+    // parseJsonConfigFileContent and create a host using createSystem and
+    // fsMap, but that needs compilerOptions... This is a bit of a chicken and
+    // egg problem, which we don't need to solve yet.
     const validatedOptions = ts.convertCompilerOptionsFromJson(
       parsedOptions?.compilerOptions ?? {},
       './'

--- a/tools/client-plugins/browser-scripts/modules/typescript-compiler.ts
+++ b/tools/client-plugins/browser-scripts/modules/typescript-compiler.ts
@@ -1,6 +1,5 @@
 import type { VirtualTypeScriptEnvironment } from '@typescript/vfs';
 import type { CompilerHost, CompilerOptions } from 'typescript';
-import { parse } from 'jsonc-parser';
 
 import reactTypes from './react-types.json';
 
@@ -17,20 +16,23 @@ export class Compiler {
     this.tsvfs = tsvfs;
   }
 
-  async setup(opts?: {
-    useNodeModules?: boolean;
-    rawCompilerOptions?: string;
-  }) {
+  async setup(opts?: { useNodeModules?: boolean; tsconfig?: string }) {
     const ts = this.ts;
     const tsvfs = this.tsvfs;
 
-    const parsedOptions = opts?.rawCompilerOptions
-      ? (parse(opts?.rawCompilerOptions) as unknown)
+    // This just parses the JSON, it doesn't do any validation.
+    const parsedOptions = opts?.tsconfig
+      ? (ts.parseConfigFileTextToJson('', opts.tsconfig).config as {
+          compilerOptions?: unknown;
+        })
       : undefined;
 
+    // For now we're only interested in the compilerOptions, so that's all we're
+    // extracting and validating.  For everything else, we would need
+    // parseJsonConfigFileContent and a virtual config file system.
     const validatedOptions = ts.convertCompilerOptionsFromJson(
-      parsedOptions ?? {},
-      '/'
+      parsedOptions?.compilerOptions ?? {},
+      './'
     );
 
     const compilerOptions: CompilerOptions = {

--- a/tools/client-plugins/browser-scripts/typescript-worker.ts
+++ b/tools/client-plugins/browser-scripts/typescript-worker.ts
@@ -26,7 +26,7 @@ interface TSCompiledMessage {
 interface SetupEvent extends MessageEvent {
   data: {
     type: 'setup';
-    compilerOptions?: string;
+    tsconfig?: string;
   };
 }
 
@@ -82,7 +82,7 @@ function handleCancelRequest({ value }: { value: number }) {
 
 async function handleSetupRequest(data: SetupEvent['data'], port: MessagePort) {
   await compiler.setup({
-    rawCompilerOptions: data.compilerOptions
+    tsconfig: data.tsconfig
   });
   // We freeze this to prevent learners from getting the worker into a weird
   // state.

--- a/tools/client-plugins/browser-scripts/typescript-worker.ts
+++ b/tools/client-plugins/browser-scripts/typescript-worker.ts
@@ -1,4 +1,3 @@
-import type { CompilerOptions } from 'typescript';
 import { Compiler } from './modules/typescript-compiler';
 
 // Most of the ts types are only a guideline. This is because we're not bundling
@@ -27,7 +26,7 @@ interface TSCompiledMessage {
 interface SetupEvent extends MessageEvent {
   data: {
     type: 'setup';
-    compilerOptions?: CompilerOptions;
+    compilerOptions?: string;
   };
 }
 
@@ -83,7 +82,7 @@ function handleCancelRequest({ value }: { value: number }) {
 
 async function handleSetupRequest(data: SetupEvent['data'], port: MessagePort) {
   await compiler.setup({
-    compilerOptions: data.compilerOptions
+    rawCompilerOptions: data.compilerOptions
   });
   // We freeze this to prevent learners from getting the worker into a weird
   // state.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Draft because

- [x] the tests have not been updated to use tsconfig.  
- [x] Also, some caching might be smart since the compiler is not exactly swift to set up. Deferred to followup. It's not crucial until we have a lot of TS lessons and the tests start to slow.
- [x] Finally, the tsconfig should be expected to be `{ compilerOptions: {}}`, but at the moment the whole thing is treated as being the `compilerOptions`.

<!-- Feel free to add any additional description of changes below this line -->
