### PR TITLE
fix(curriculum): enforce recursion in Build a Countdown challenge

### DIFF
--- a/curriculum/challenges/english/blocks/lab-countdown/5cd9a70215d3c4e65518328f.md
+++ b/curriculum/challenges/english/blocks/lab-countdown/5cd9a70215d3c4e65518328f.md
@@ -66,7 +66,7 @@ Your code should not rely on any kind of loops (`for`, `while` or higher order f
 
 ```js
 assert(
-  !__helpers.removeJSComments(code).match(/for|while|forEach|map|filter|reduce/g)
+  !__helpers.removeJSComments(code).match(/for|while|forEach|map|filter|reduce|Array\.from/g)
 );
 ```
 
@@ -74,7 +74,7 @@ You should use recursion to solve this problem.
 
 ```js
 assert(
-  countdown.toString().match(/countdown\s*\(.+\)/)
+  __helpers.removeJSComments(code).match(/countdown/g).length >= 2
 );
 ```
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #66261


<!-- Feel free to add any additional description of changes below this line -->

This PR fixes a loophole in the "Build a Countdown" challenge where students could pass the tests using `Array.from()` or other non-recursive methods despite the requirement to use recursion.

**Proposed Changes:**
- Updated the forbidden methods regex to include `Array.from`.
- Improved the recursion detection logic by requiring at least two occurrences of the function name `countdown` (one for definition and one for the recursive call) after removing comments.
