### PR TITLE
fix(curriculum): enforce recursion in Build a Countdown challenge

### DIFF
--- a/curriculum/challenges/english/blocks/basic-javascript/5cc0bd7a49b71cb96132e54c.md
+++ b/curriculum/challenges/english/blocks/basic-javascript/5cc0bd7a49b71cb96132e54c.md
@@ -12,7 +12,7 @@ Continuing from the previous challenge, we provide you another opportunity to cr
 
 # --instructions--
 
-We have defined a function named `rangeOfNumbers` with two parameters. The function should return an array of integers which begins with a number represented by the `startNum` parameter and ends with a number represented by the `endNum` parameter. The starting number will always be less than or equal to the ending number. Your function must use recursion by calling itself and not use loops of any kind. It should also work for cases where both `startNum` and `endNum` are the same.
+We have defined a function named `rangeOfNumbers` with two parameters. The function should return an array of integers which begins with a number represented by the `startNum` parameter and ends with a number represented by the `endNum` parameter. The starting number will always be less than or equal to the ending number. Your function must use recursion by calling itself and not use loops or array methods (`for`, `while`, `Array.from`, `forEach`, `map`, `filter`, `reduce`). It should also work for cases where both `startNum` and `endNum` are the same.
 
 # --hints--
 
@@ -22,19 +22,20 @@ Your function should return an array.
 assert(Array.isArray(rangeOfNumbers(5, 10)));
 ```
 
-Your code should not use any loop syntax (`for` or `while` or higher order functions such as `forEach`, `map`, `filter`, or `reduce`).
+Your code should not use any loop syntax (`for`, `while`, `Array.from()` or higher order functions such as `forEach`, `map`, `filter`, or `reduce`).
 
 ```js
 assert(
-  !__helpers.removeJSComments(code).match(/for|while|forEach|map|filter|reduce/g)
+  !__helpers.removeJSComments(code).match(/for|while|forEach|map|filter|reduce|Array\.from/g)
 );
 ```
 
 `rangeOfNumbers` should use recursion (call itself) to solve this challenge.
 
 ```js
-assert(
-  rangeOfNumbers.toString().match(/rangeOfNumbers\s*\(.+\)/)
+assert.isAtLeast(
+  (__helpers.removeJSComments(rangeOfNumbers.toString()).match(/rangeOfNumbers\s*\(.+\)/g) || []).length,
+  2
 );
 ```
 

--- a/curriculum/challenges/english/blocks/basic-javascript/5cc0bd7a49b71cb96132e54c.md
+++ b/curriculum/challenges/english/blocks/basic-javascript/5cc0bd7a49b71cb96132e54c.md
@@ -12,7 +12,7 @@ Continuing from the previous challenge, we provide you another opportunity to cr
 
 # --instructions--
 
-We have defined a function named `rangeOfNumbers` with two parameters. The function should return an array of integers which begins with a number represented by the `startNum` parameter and ends with a number represented by the `endNum` parameter. The starting number will always be less than or equal to the ending number. Your function must use recursion by calling itself and not use loops or array methods (`for`, `while`, `Array.from`, `forEach`, `map`, `filter`, `reduce`). It should also work for cases where both `startNum` and `endNum` are the same.
+We have defined a function named `rangeOfNumbers` with two parameters. The function should return an array of integers which begins with a number represented by the `startNum` parameter and ends with a number represented by the `endNum` parameter. The starting number will always be less than or equal to the ending number. Your function must use recursion by calling itself and not use loops of any kind. It should also work for cases where both `startNum` and `endNum` are the same.
 
 # --hints--
 
@@ -22,20 +22,19 @@ Your function should return an array.
 assert(Array.isArray(rangeOfNumbers(5, 10)));
 ```
 
-Your code should not use any loop syntax (`for`, `while`, `Array.from()` or higher order functions such as `forEach`, `map`, `filter`, or `reduce`).
+Your code should not use any loop syntax (`for` or `while` or higher order functions such as `forEach`, `map`, `filter`, or `reduce`).
 
 ```js
 assert(
-  !__helpers.removeJSComments(code).match(/for|while|forEach|map|filter|reduce|Array\.from/g)
+  !__helpers.removeJSComments(code).match(/for|while|forEach|map|filter|reduce/g)
 );
 ```
 
 `rangeOfNumbers` should use recursion (call itself) to solve this challenge.
 
 ```js
-assert.isAtLeast(
-  (__helpers.removeJSComments(rangeOfNumbers.toString()).match(/rangeOfNumbers\s*\(.+\)/g) || []).length,
-  2
+assert(
+  rangeOfNumbers.toString().match(/rangeOfNumbers\s*\(.+\)/)
 );
 ```
 

--- a/curriculum/challenges/english/blocks/lab-countdown/5cd9a70215d3c4e65518328f.md
+++ b/curriculum/challenges/english/blocks/lab-countdown/5cd9a70215d3c4e65518328f.md
@@ -21,7 +21,7 @@ If the starting number is less than `1`, there is nothing to countdown, so retur
 - `countdown(0)` should return `[]`
 - `countdown(-3)` should return `[]`
 
-To complete the lab, you must build the result using recursion and you must not use loops (`for`, `while`) or array-iteration methods (`forEach`, `map`, `filter`, `reduce`). Each call should produce its own result array (don't use globals to store the countdown).
+To complete the lab, you must build the result using recursion and you must not use loops (`for`, `while`), `Array.from()`, or array-iteration methods (`forEach`, `map`, `filter`, `reduce`). Each call should produce its own result array (don't use globals to store the countdown).
 
 **Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab.
 
@@ -31,7 +31,7 @@ To complete the lab, you must build the result using recursion and you must not 
 2. The `countdown` function should take a single argument `n` (a number).
 3. If `n` is less than `1`, `countdown` should return an empty array.
 4. Otherwise, `countdown` should return an array containing the integers from `n` down to `1` in descending order.
-5. You must use recursion (the function should call itself) and must not use loops of any kind (`for`, `while`, or higher-order methods like `forEach`, `map`, `filter`, `reduce`).
+5. You must use recursion (the function should call itself) and must not use loops of any kind (`for`, `while`, `Array.from()`, or higher-order methods like `forEach`, `map`, `filter`, `reduce`).
 6. Each recursive call should use a smaller value than the previous call (for example, `n - 1`) so the function reaches its base case.
 7. The solution should not use global variables to store or cache the result array.
 8. Calling `countdown` multiple times with different inputs should always return the correct, independent result.
@@ -62,11 +62,11 @@ assert.deepStrictEqual(countdown(10), [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
 assert.deepStrictEqual(countdown(5), [5, 4, 3, 2, 1]);
 ```
 
-Your code should not rely on any kind of loops (`for`, `while` or higher order functions such as `forEach`, `map`, `filter`, and `reduce`).
+Your code should not rely on any kind of loops (`for`, `while`, `Array.from()` or higher order functions such as `forEach`, `map`, `filter`, and `reduce`).
 
 ```js
 assert(
-  !__helpers.removeJSComments(code).match(/for|while|forEach|map|filter|reduce/g)
+  !__helpers.removeJSComments(code).match(/for|while|forEach|map|filter|reduce|Array\.from/g)
 );
 ```
 

--- a/curriculum/challenges/english/blocks/lab-countdown/5cd9a70215d3c4e65518328f.md
+++ b/curriculum/challenges/english/blocks/lab-countdown/5cd9a70215d3c4e65518328f.md
@@ -74,7 +74,7 @@ You should use recursion to solve this problem.
 
 ```js
 assert.isAtLeast(
-  (__helpers.removeJSComments(countdown.toString()).match(/countdown\s*\(.+\)/g) || []).length,
+  __helpers.removeJSComments(countdown.toString()).match(/countdown\s*\(.+\)/g)?.length,
   2
 );
 ```

--- a/curriculum/challenges/english/blocks/lab-countdown/5cd9a70215d3c4e65518328f.md
+++ b/curriculum/challenges/english/blocks/lab-countdown/5cd9a70215d3c4e65518328f.md
@@ -21,7 +21,7 @@ If the starting number is less than `1`, there is nothing to countdown, so retur
 - `countdown(0)` should return `[]`
 - `countdown(-3)` should return `[]`
 
-To complete the lab, you must build the result using recursion and you must not use loops (`for`, `while`), `Array.from()`, or array-iteration methods (`forEach`, `map`, `filter`, `reduce`). Each call should produce its own result array (don't use globals to store the countdown).
+To complete the lab, you must build the result using recursion and you must not use loops (`for`, `while`) or array-iteration methods (`forEach`, `map`, `filter`, `reduce`). Each call should produce its own result array (don't use globals to store the countdown).
 
 **Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab.
 
@@ -31,7 +31,7 @@ To complete the lab, you must build the result using recursion and you must not 
 2. The `countdown` function should take a single argument `n` (a number).
 3. If `n` is less than `1`, `countdown` should return an empty array.
 4. Otherwise, `countdown` should return an array containing the integers from `n` down to `1` in descending order.
-5. You must use recursion (the function should call itself) and must not use loops of any kind (`for`, `while`, `Array.from()`, or higher-order methods like `forEach`, `map`, `filter`, `reduce`).
+5. You must use recursion (the function should call itself) and must not use loops of any kind (`for`, `while`, or higher-order methods like `forEach`, `map`, `filter`, `reduce`).
 6. Each recursive call should use a smaller value than the previous call (for example, `n - 1`) so the function reaches its base case.
 7. The solution should not use global variables to store or cache the result array.
 8. Calling `countdown` multiple times with different inputs should always return the correct, independent result.
@@ -62,11 +62,11 @@ assert.deepStrictEqual(countdown(10), [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
 assert.deepStrictEqual(countdown(5), [5, 4, 3, 2, 1]);
 ```
 
-Your code should not rely on any kind of loops (`for`, `while`, `Array.from()` or higher order functions such as `forEach`, `map`, `filter`, and `reduce`).
+Your code should not rely on any kind of loops (`for`, `while` or higher order functions such as `forEach`, `map`, `filter`, and `reduce`).
 
 ```js
 assert(
-  !__helpers.removeJSComments(code).match(/for|while|forEach|map|filter|reduce|Array\.from/g)
+  !__helpers.removeJSComments(code).match(/for|while|forEach|map|filter|reduce/g)
 );
 ```
 
@@ -74,7 +74,7 @@ You should use recursion to solve this problem.
 
 ```js
 assert.isAtLeast(
-  __helpers.removeJSComments(countdown.toString()).match(/countdown\s*\(.+\)/g).length,
+  (__helpers.removeJSComments(countdown.toString()).match(/countdown\s*\(.+\)/g) || []).length,
   2
 );
 ```

--- a/curriculum/challenges/english/blocks/lab-countdown/5cd9a70215d3c4e65518328f.md
+++ b/curriculum/challenges/english/blocks/lab-countdown/5cd9a70215d3c4e65518328f.md
@@ -21,7 +21,7 @@ If the starting number is less than `1`, there is nothing to countdown, so retur
 - `countdown(0)` should return `[]`
 - `countdown(-3)` should return `[]`
 
-To complete the lab, you must build the result using recursion and you must not use loops (`for`, `while`) or array-iteration methods (`forEach`, `map`, `filter`, `reduce`). Each call should produce its own result array (don't use globals to store the countdown).
+To complete the lab, you must build the result using recursion and you must not use loops (`for`, `while`), `Array.from()`, or array-iteration methods (`forEach`, `map`, `filter`, `reduce`). Each call should produce its own result array (don't use globals to store the countdown).
 
 **Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab.
 
@@ -31,7 +31,7 @@ To complete the lab, you must build the result using recursion and you must not 
 2. The `countdown` function should take a single argument `n` (a number).
 3. If `n` is less than `1`, `countdown` should return an empty array.
 4. Otherwise, `countdown` should return an array containing the integers from `n` down to `1` in descending order.
-5. You must use recursion (the function should call itself) and must not use loops of any kind (`for`, `while`, or higher-order methods like `forEach`, `map`, `filter`, `reduce`).
+5. You must use recursion (the function should call itself) and must not use loops of any kind (`for`, `while`, `Array.from()`, or higher-order methods like `forEach`, `map`, `filter`, `reduce`).
 6. Each recursive call should use a smaller value than the previous call (for example, `n - 1`) so the function reaches its base case.
 7. The solution should not use global variables to store or cache the result array.
 8. Calling `countdown` multiple times with different inputs should always return the correct, independent result.
@@ -62,7 +62,7 @@ assert.deepStrictEqual(countdown(10), [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
 assert.deepStrictEqual(countdown(5), [5, 4, 3, 2, 1]);
 ```
 
-Your code should not rely on any kind of loops (`for`, `while` or higher order functions such as `forEach`, `map`, `filter`, and `reduce`).
+Your code should not rely on any kind of loops (`for`, `while`, `Array.from()` or higher order functions such as `forEach`, `map`, `filter`, and `reduce`).
 
 ```js
 assert(
@@ -73,8 +73,9 @@ assert(
 You should use recursion to solve this problem.
 
 ```js
-assert(
-  __helpers.removeJSComments(code).match(/countdown/g).length >= 2
+assert.isAtLeast(
+  __helpers.removeJSComments(countdown.toString()).match(/countdown\s*\(.+\)/g).length,
+  2
 );
 ```
 

--- a/curriculum/challenges/english/blocks/lab-countdown/5cd9a70215d3c4e65518328f.md
+++ b/curriculum/challenges/english/blocks/lab-countdown/5cd9a70215d3c4e65518328f.md
@@ -66,7 +66,7 @@ Your code should not rely on any kind of loops (`for`, `while` or higher order f
 
 ```js
 assert(
-  !__helpers.removeJSComments(code).match(/for|while|forEach|map|filter|reduce/g)
+  !__helpers.removeJSComments(code).match(/for|while|forEach|map|filter|reduce|Array\.from/g)
 );
 ```
 
@@ -74,7 +74,7 @@ You should use recursion to solve this problem.
 
 ```js
 assert(
-  countdown.toString().match(/countdown\s*\(.+\)/)
+  __helpers.removeJSComments(code).match(/countdown/g).length >= 2
 );
 ```
 

--- a/curriculum/challenges/english/blocks/lab-range-of-numbers/5cc0bd7a49b71cb96132e54c.md
+++ b/curriculum/challenges/english/blocks/lab-range-of-numbers/5cc0bd7a49b71cb96132e54c.md
@@ -17,7 +17,7 @@ Examples:
 Requirements:
 
 - Use recursion (the function must call itself)
-- No loops or array methods (`for`, `while`, `forEach`, `map`, `filter`, `reduce`)
+- No loops or array methods (`for`, `while`, `Array.from`, `forEach`, `map`, `filter`, `reduce`)
 
 **Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab.
 
@@ -26,7 +26,7 @@ Requirements:
 1. You should create a function named `rangeOfNumbers` that takes two parameters: `startNum` and `endNum`.
 1. The function should return an array of integers that begins with the number represented by the `startNum` parameter and ends with the number represented by the `endNum` parameter (inclusive).
 1. The `startNum` will always be less than or equal to the `endNum`.
-1. Your function must use recursion by calling itself. It should not use any loop syntax (`for`, `while`, or higher-order functions such as `forEach`, `map`, `filter`, or `reduce`).
+1. Your function must use recursion by calling itself. It should not use any loop syntax (`for`, `while`, `Array.from()`, or higher-order functions such as `forEach`, `map`, `filter`, or `reduce`).
 1. The function should handle the base case where `startNum` equals `endNum` by returning an array containing just that single number.
 1. For the recursive case, the function should call itself with modified parameters to build the array, then add the current number to the result.
 1. The function should not rely on global variables to cache or build the array.
@@ -51,19 +51,20 @@ Your function should return an array.
 assert(Array.isArray(rangeOfNumbers(5, 10)));
 ```
 
-Your code should not use any loop syntax (`for` or `while` or higher order functions such as `forEach`, `map`, `filter`, or `reduce`).
+Your code should not use any loop syntax (`for`, `while`, `Array.from()` or higher order functions such as `forEach`, `map`, `filter`, or `reduce`).
 
 ```js
 assert(
-  !__helpers.removeJSComments(code).match(/for|while|forEach|map|filter|reduce/g)
+  !__helpers.removeJSComments(code).match(/for|while|forEach|map|filter|reduce|Array\.from/g)
 );
 ```
 
 `rangeOfNumbers` should use recursion (call itself) to solve this challenge.
 
 ```js
-assert(
-  rangeOfNumbers.toString().match(/rangeOfNumbers\s*\(.+\)/)
+assert.isAtLeast(
+  (__helpers.removeJSComments(rangeOfNumbers.toString()).match(/rangeOfNumbers\s*\(.+\)/g) || []).length,
+  2
 );
 ```
 

--- a/curriculum/challenges/english/blocks/lab-range-of-numbers/5cc0bd7a49b71cb96132e54c.md
+++ b/curriculum/challenges/english/blocks/lab-range-of-numbers/5cc0bd7a49b71cb96132e54c.md
@@ -63,7 +63,7 @@ assert(
 
 ```js
 assert.isAtLeast(
-  (__helpers.removeJSComments(rangeOfNumbers.toString()).match(/rangeOfNumbers\s*\(.+\)/g) || []).length,
+  __helpers.removeJSComments(rangeOfNumbers.toString()).match(/rangeOfNumbers\s*\(.+\)/g)?.length,
   2
 );
 ```


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #66261

<!-- Feel free to add any additional description of changes below this line -->

This PR addresses a loophole in the "Build a Countdown" challenge where non-recursive solutions (like `Array.from()`) were able to pass the tests.

**Summary of Changes:**
- **Description & Hints**: Updated to explicitly state that `Array.from()` and other loop-like methods are prohibited.
- **Forbidden Methods Test**: Added `Array.from` to the regex that prevents the use of forbidden methods.
- **Recursion Test**: Replaced the previous test with a more robust one using `countdown.toString()` and `assert.isAtLeast` to ensure at least two recursive calls are detected within the function body, as suggested by maintainers.
