### PR TITLE
fix(client): stop ts editor getting hidden

### DIFF
--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -205,6 +205,25 @@ const mapDispatchToProps = {
   openResetModal: () => openModal('reset')
 };
 
+const setupTSModels = (monaco: typeof monacoEditor) => {
+  const reactFile = monaco.Uri.file(monacoModelFileMap.reactTypes);
+  monaco.editor.createModel(reactTypes['react-18'], 'typescript', reactFile);
+
+  const file = monaco.Uri.file(monacoModelFileMap.tsxFile);
+  return monaco.editor.createModel('', 'typescript', file);
+};
+
+const teardownTSModels = (monaco: typeof monacoEditor) => {
+  const reactFile = monaco.Uri.file(monacoModelFileMap.reactTypes);
+  const tsxFile = monaco.Uri.file(monacoModelFileMap.tsxFile);
+
+  const reactModel = monaco.editor.getModel(reactFile);
+  const tsxModel = monaco.editor.getModel(tsxFile);
+
+  reactModel?.dispose();
+  tsxModel?.dispose();
+};
+
 const modeMap = {
   css: 'css',
   html: 'html',
@@ -400,19 +419,6 @@ const Editor = (props: EditorProps): JSX.Element => {
     // swap and reuse models, we have to create our own models to prevent
     // disposal.
 
-    const setupTSModels = (monaco: typeof monacoEditor) => {
-      const reactFile = monaco.Uri.file(monacoModelFileMap.reactTypes);
-      monaco.editor.createModel(
-        reactTypes['react-18'],
-        'typescript',
-        reactFile
-      );
-
-      const file = monaco.Uri.file(monacoModelFileMap.tsxFile);
-      return monaco.editor.createModel('', 'typescript', file);
-    };
-
-    // TODO: make sure these aren't getting created over and over
     function createModel(contents: string, language: string) {
       if (language !== 'typescript') {
         return monaco.editor.createModel(contents, language);
@@ -1403,13 +1409,14 @@ const Editor = (props: EditorProps): JSX.Element => {
           editorDidMount={editorDidMount}
           editorWillMount={editorWillMount}
           editorWillUnmount={(editor, monaco) => {
-            const reactFile = monaco.Uri.file(monacoModelFileMap.reactTypes);
-            const file = monaco.Uri.file(monacoModelFileMap.tsxFile);
             // Any model we've created has to be manually disposed of to prevent
             // memory leaks.
-            editor.getModel()?.dispose();
-            monaco.editor.getModel(reactFile)?.dispose();
-            monaco.editor.getModel(file)?.dispose();
+            const language = modeMap[challengeFile?.ext ?? 'html'];
+            if (language === 'typescript') {
+              teardownTSModels(monaco);
+            } else {
+              editor.getModel()?.dispose();
+            }
           }}
           onChange={onChange}
           options={{ ...options, folding: !hasEditableRegion() }}


### PR DESCRIPTION
We need to dispose of unused models, but previously closing any editor would dipose of the ts models causing the ts editor to vanish

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes https://github.com/freeCodeCamp/freeCodeCamp/issues/65570

<!-- Feel free to add any additional description of changes below this line -->
