### PR TITLE
fix(client):  daily challenge solution downloads as challengeNumber.txt

### DIFF
--- a/client/src/client-only-routes/show-daily-coding-challenge.tsx
+++ b/client/src/client-only-routes/show-daily-coding-challenge.tsx
@@ -46,6 +46,7 @@ function formatChallengeData({
     id,
     challengeNumber,
     title,
+    dashedName: `challenge-${challengeNumber}`,
     description: formatDescription(description),
     superBlock: 'daily-coding-challenge',
     block: 'daily-coding-challenge',
@@ -65,6 +66,7 @@ function formatChallengeData({
   const pageContext = {
     challengeMeta: {
       id,
+      dashedName: `challenge-${challengeNumber}`,
       superBlock: 'daily-coding-challenge',
       block: 'daily-coding-challenge',
       disableLoopProtectTests: true,


### PR DESCRIPTION
Checklist:

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #62018 

<!-- Feel free to add any additional description of changes below this line -->
When a successful solution to a daily challenge was found, the user had an option to download the solution to a .txt file onto their device. The downloaded file was always named undefined.txt, which my be difficult to locate on the user's device, especially if multiple solutions are downloaded. This fix addresses this, by downloading them as challange-{challengeNumber}.txt

Video of working download: 
https://github.com/user-attachments/assets/f555ad50-cf3a-43f0-9d90-46b706de5235
