### PR TITLE
Improve Python list definition for clarity

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-understanding-variables-and-data-types/67fe859a00971c34a23abd43.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-variables-and-data-types/67fe859a00971c34a23abd43.md
@@ -97,7 +97,7 @@ my_range_var = range(5)
 print('Range:', my_range_var) # Range: range(0, 5)
 ```
 
-- List: An ordered collection of elements that supports different data types.
+- List: An ordered, mutable collection of elements that can store multiple data types.
     
 ```python
 my_list = [22, 'Hello world', 3.14, True]

--- a/curriculum/challenges/english/blocks/review-python-basics/67f39b40deaec81a3e40e0c5.md
+++ b/curriculum/challenges/english/blocks/review-python-basics/67f39b40deaec81a3e40e0c5.md
@@ -119,7 +119,7 @@ my_range_var = range(5)
 print(my_range_var) # range(0, 5)
 ```
 
-- **List**: An ordered collection of elements that supports different data types:
+- **List**: An ordered, mutable collection of elements that can store multiple data types:
 
 ```py
 my_list = [22, 'Hello world', 3.14, True]


### PR DESCRIPTION
This PR clarifies the definition of Python lists by highlighting that lists are mutable collections. 
The previous wording focused on supporting multiple data types, which may be misleading since other Python collections also support heterogeneous data.