### PR TITLE
fix: add brief decorator explanation to getters and setters lesson

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-understanding-object-oriented-programming-and-encapsulation/68c128cbd77e4ba9ed671937.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-object-oriented-programming-and-encapsulation/68c128cbd77e4ba9ed671937.md
@@ -21,7 +21,9 @@ When you use a method, you always have to call it with parentheses. But with a p
 
 For example, you might want to calculate a value or check that a new value is valid before saving it. Instead of calling a method for that, you can use an attribute-like way to do that.
 
-To create a property, you define a method and place the `@property` decorator above it. This tells Python to treat the method as a property.
+In Python, a decorator is a function that modifies the functionalities of other functions, without changing the function's code.
+
+While it is possible to create custom decorators, this is beyond the scope of this lesson. Just know that to create a property, you define a method and place the `@property` decorator above it. This tells Python to treat the method as a property.
 
 That takes us to getters. Here's how to create one with the `@property` decorator:
 


### PR DESCRIPTION
Addresses issue #62747 by adding a concise explanation of Python decorators to the 'What are Getters and Setters' lesson before the @property example. The explanation defines what decorators are, clarifies that custom decorators are beyond the lesson scope, and connects them to property creation.

Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #62747