### PR TITLE
fix(tooling): handle lecture metadata and templates in create-project

### DIFF
--- a/tools/challenge-helper-scripts/create-project.ts
+++ b/tools/challenge-helper-scripts/create-project.ts
@@ -8,6 +8,7 @@ import {
   SuperBlocks,
   chapterBasedSuperBlocks
 } from '@freecodecamp/shared/config/curriculum';
+import { challengeTypes } from '@freecodecamp/shared/config/challenge-types';
 import { BlockLayouts, BlockLabel } from '@freecodecamp/shared/config/blocks';
 import {
   createBlockFolder,
@@ -130,7 +131,17 @@ async function createProject(projectArgs: CreateProjectArgs) {
       projectArgs.blockLabel,
       projectArgs.blockLayout
     );
-    await createFirstChallenge({ block: projectArgs.block, challengeId });
+
+    const challengeType =
+      projectArgs.blockLabel === BlockLabel.lecture
+        ? challengeTypes.multipleChoice
+        : challengeTypes.html;
+
+    await createFirstChallenge({
+      block: projectArgs.block,
+      challengeId,
+      challengeType
+    });
   }
 
   if (
@@ -176,14 +187,14 @@ async function createMetaJson(
 ) {
   let newMeta;
   if (chapterBasedSuperBlocks.includes(superBlock)) {
-    newMeta = getBaseMeta('FullStack');
+    newMeta = getBaseMeta('FullStack', blockLabel);
     newMeta.blockLabel = blockLabel;
     newMeta.blockLayout = blockLayout;
     if (blockLabel === BlockLabel.workshop) {
       newMeta.hasEditableBoundaries = true;
     }
   } else {
-    newMeta = getBaseMeta('Step');
+    newMeta = getBaseMeta('Step', blockLabel);
     newMeta.order = order;
   }
   newMeta.name = title;
@@ -197,10 +208,12 @@ async function createMetaJson(
 
 async function createFirstChallenge({
   block,
-  challengeId
+  challengeId,
+  challengeType = challengeTypes.html
 }: {
   block: string;
   challengeId: ObjectId;
+  challengeType?: number;
 }) {
   // TODO: would be nice if the extension made sense for the challenge, but, at
   // least until react I think they're all going to be html anyway.
@@ -216,7 +229,7 @@ async function createFirstChallenge({
     challengeId,
     projectPath: await createBlockFolder(block),
     stepNum: 1,
-    challengeType: 0,
+    challengeType,
     challengeSeeds,
     isFirstChallenge: true
   });

--- a/tools/challenge-helper-scripts/helpers/get-base-meta.ts
+++ b/tools/challenge-helper-scripts/helpers/get-base-meta.ts
@@ -53,18 +53,30 @@ const languageMeta = {
 };
 
 export const getBaseMeta = (
-  projectType: 'Step' | 'Quiz' | 'Language' | 'FullStack'
+  projectType: 'Step' | 'Quiz' | 'Language' | 'FullStack',
+  blockLabel?: string
 ): Meta => {
+  let meta: Meta;
   switch (projectType) {
     case 'Step':
-      return stepMeta;
+      meta = { ...stepMeta };
+      break;
     case 'Quiz':
-      return quizMeta;
+      meta = { ...quizMeta };
+      break;
     case 'FullStack':
-      return fullStackStepMeta;
+      meta = { ...fullStackStepMeta };
+      break;
     case 'Language':
-      return languageMeta;
+      meta = { ...languageMeta };
+      break;
     default:
-      return stepMeta;
+      meta = { ...stepMeta };
   }
+
+  if (blockLabel === 'lecture') {
+    meta.usesMultifileEditor = false;
+  }
+
+  return meta;
 };

--- a/tools/challenge-helper-scripts/utils.ts
+++ b/tools/challenge-helper-scripts/utils.ts
@@ -58,14 +58,29 @@ const createStepFile = ({
   isFirstChallenge = false,
   challengeLang
 }: Options) => {
-  const template = getStepTemplate({
-    challengeId,
-    challengeSeeds,
-    stepNum,
-    challengeType,
-    isFirstChallenge,
-    challengeLang
-  });
+  let template: string;
+  if (
+    challengeType === challengeTypes.multipleChoice ||
+    challengeType === challengeTypes.video
+  ) {
+    const templateFn = getTemplate(challengeType.toString());
+    template = templateFn({
+      challengeId,
+      title: `Step ${stepNum}`,
+      dashedName: `step-${stepNum}`,
+      challengeType: challengeType.toString(),
+      challengeLang
+    });
+  } else {
+    template = getStepTemplate({
+      challengeId,
+      challengeSeeds,
+      stepNum,
+      challengeType,
+      isFirstChallenge,
+      challengeLang
+    });
+  }
 
   fs.writeFileSync(`${projectPath}${challengeId.toString()}.md`, template);
 };


### PR DESCRIPTION
Addresses issue #62452 by updating the `create-new-project` helper script to correctly handle "lecture" blocks.

### Changes Made:
- **Metadata Fix:** Modified `getBaseMeta.ts` to set `usesMultifileEditor: false` for blocks labeled as `lecture`.
- **Project Configuration:** Updated [create-project.ts](cci:7://file:///Users/pro/freeCodeCamp/tools/challenge-helper-scripts/create-project.ts:0:0-0:0) to detect `lecture` labels and set the default `challengeType` to `19` (Multiple Choice).
- **Template Logic:** Updated [utils.ts](cci:7://file:///Users/pro/freeCodeCamp/tools/challenge-helper-scripts/utils.ts:0:0-0:0) to ensure that Multiple Choice and Video challenge types use their respective high-level templates instead of the legacy step-based template.

Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org/#/).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #62452
