### PR TITLE
fix(client): set dashedName for daily coding challenges

### DIFF
--- a/client/src/client-only-routes/show-daily-coding-challenge.tsx
+++ b/client/src/client-only-routes/show-daily-coding-challenge.tsx
@@ -49,6 +49,7 @@ function formatChallengeData({
     description: formatDescription(description),
     superBlock: 'daily-coding-challenge',
     block: 'daily-coding-challenge',
+    dashedName: `challenge-${challengeNumber}`,
     usesMultifileEditor: true,
 
     // props to satisfy the show classic component
@@ -67,6 +68,7 @@ function formatChallengeData({
       id,
       superBlock: 'daily-coding-challenge',
       block: 'daily-coding-challenge',
+      dashedName: `challenge-${challengeNumber}`,
       disableLoopProtectTests: true,
 
       // props to satisfy the show classic component

--- a/client/src/redux/prop-types.ts
+++ b/client/src/redux/prop-types.ts
@@ -313,6 +313,7 @@ export type DailyCodingChallengeNode = {
     notes: string;
     videoUrl?: string;
     translationPending: false;
+    dashedName: string;
     saveSubmissionToDB?: boolean;
   };
 };
@@ -322,6 +323,7 @@ export type DailyCodingChallengePageContext = {
     block: 'daily-coding-challenge';
     id: string;
     superBlock: 'daily-coding-challenge';
+    dashedName: string;
     disableLoopProtectTests: boolean;
 
     // props to satisfy the show classic component


### PR DESCRIPTION
## Description
Fixes the issue where Daily Challenge solution downloads were saved as `undefined.txt`.

The `dashedName` property was missing from the client-side metadata formatting logic in [show-daily-coding-challenge.tsx](cci:7://file:///Users/pro/freeCodeCamp/client/src/client-only-routes/show-daily-coding-challenge.tsx:0:0-0:0). This PR adds the missing property, deriving it from the challenge number (e.g., `challenge-1`), ensuring the [CompletionModal](cci:1://file:///Users/pro/freeCodeCamp/client/src/templates/Challenges/components/completion-modal.tsx:73:0-199:1) has the correct filename for downloads.

## Related Issue
Fixes #62018

## Checklist
- [x] Added `dashedName` to the daily challenge types in [prop-types.ts](cci:7://file:///Users/pro/freeCodeCamp/client/src/redux/prop-types.ts:0:0-0:0).
- [x] Updated [formatChallengeData](cci:1://file:///Users/pro/freeCodeCamp/client/src/client-only-routes/show-daily-coding-challenge.tsx:34:0-141:1) to populate `dashedName` in both challenge data and metadata.
- [x] Verified the fix with `pnpm type-check` (passed).
- [x] Verified the fix with a custom simulation script (all assertions passed).

Closes #62018 