### PR TITLE
fix(curriculum): reorder intros for superblock back-end-development-and-apis-v9

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -4689,12 +4689,6 @@
           "Learn about Node.js core libraries, how to install Node.js on your computer, and the advantages and disadvantages of using Node.js on the back-end."
         ]
       },
-      "review-node-js-core-modules": {
-        "title": "Node JS Core Modules Review",
-        "intro": [
-          "Review Node JS Core Modules concepts to prepare for the upcoming quiz."
-        ]
-      },
       "review-node-js-intro": {
         "title": "NodeJS Intro Review",
         "intro": [
@@ -4709,6 +4703,30 @@
         "title": "Working with Node Core Modules",
         "intro": [
           "Learn about the node.js core modules, such as fs, buffer, stream, path modules, and more, so you can understand what Node gives you out of the box to build efficient applications without relying on third-party libraries."
+        ]
+      },
+      "review-node-js-core-modules": {
+        "title": "Node JS Core Modules Review",
+        "intro": [
+          "Review Node JS Core Modules concepts to prepare for the upcoming quiz."
+        ]
+      },
+      "quiz-node-js-core-modules": {
+        "title": "NodeJS Core Modules Quiz",
+        "intro": [
+          "Test what you've learned about Node.js core modules with this quiz."
+        ]
+      },
+      "lecture-introduction-to-npm": {
+        "title": "Introduction to npm",
+        "intro": [
+          "In these lessons, you will learn about npm, and how it can help you manage your project's dependencies."
+        ]
+      },
+      "lecture-working-with-npm-scripts": {
+        "title": "Working with npm Scripts",
+        "intro": [
+          "Learn about npm scripts, publishing packages to the npm registry, and working with CommonJS and ES modules. These lessons cover essential Node.js development tools and module systems."
         ]
       },
       "lecture-understanding-how-http-dns-tcpip-work": {
@@ -4727,18 +4745,6 @@
         "title": "Understanding the REST API and Web Services",
         "intro": [
           "In these lessons, you will learn about REST APIs and web services, and how they allow different applications to communicate with each other over the internet."
-        ]
-      },
-      "lecture-introduction-to-npm": {
-        "title": "Introduction to npm",
-        "intro": [
-          "In these lessons, you will learn about npm, and how it can help you manage your project's dependencies."
-        ]
-      },
-      "lecture-working-with-npm-scripts": {
-        "title": "Working with npm Scripts",
-        "intro": [
-          "Learn about npm scripts, publishing packages to the npm registry, and working with CommonJS and ES modules. These lessons cover essential Node.js development tools and module systems."
         ]
       },
       "exam-back-end-development-and-apis-certification": {


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #XXXXX

Source order file:
`curriculum/structure/superblocks/back-end-development-and-apis-v9.json`

Note: This PR also adds `quiz-node-js-core-modules` that was in `relational-databases-v9` to `back-end-development-and-apis-v9` where it belongs. It is removed from `relationa-databases-v9` in https://github.com/freeCodeCamp/freeCodeCamp/pull/66294

this will also fix this missing title:
<img width="750" height="171" alt="image" src="https://github.com/user-attachments/assets/2c3f9082-194e-4a14-8cce-3967936e5a30" />
