### PR TITLE
fix(curriculum): reorder intros for superblock relational-databases-v9

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -4352,15 +4352,15 @@
       "code-editors": "Code Editors",
       "bash-fundamentals": "Bash Fundamentals",
       "sql-and-postgresql": "SQL and PostgreSQL",
+      "lab-celestial-bodies-database": "Build a Celestial Bodies Database",
       "bash-scripting": "Bash Scripting",
       "sql-and-bash": "SQL and Bash",
-      "git": "Git",
-      "review-relational-databases": "Relational Databases Review",
-      "lab-celestial-bodies-database": "Build a Celestial Bodies Database",
       "lab-world-cup-database": "Build a World Cup Database",
       "lab-salon-appointment-scheduler": "Build a Salon Appointment Scheduler",
+      "git": "Git",
       "lab-periodic-table-database": "Build a Periodic Table Database",
       "lab-number-guessing-game": "Build a Number Guessing Game",
+      "review-relational-databases": "Relational Databases Review",
       "relational-databases-certification-exam": "Relational Databases Certification Exam"
     },
     "blocks": {
@@ -4406,12 +4406,6 @@
           "In this 165-lesson workshop, you will learn the basics of a relational database by creating a PostgreSQL database filled with video game characters."
         ]
       },
-      "lab-celestial-bodies-database": {
-        "title": "Build a Celestial Bodies Database",
-        "intro": [
-          "For this project, you will build a database of celestial bodies using PostgreSQL."
-        ]
-      },
       "review-sql-and-postgresql": {
         "title": "SQL and PostgreSQL Review",
         "intro": [
@@ -4422,6 +4416,12 @@
         "title": "SQL and PostgreSQL Quiz",
         "intro": [
           "Test what you've learned about SQL and PostgreSQL with this quiz."
+        ]
+      },
+      "lab-celestial-bodies-database": {
+        "title": "Build a Celestial Bodies Database",
+        "intro": [
+          "For this project, you will build a database of celestial bodies using PostgreSQL."
         ]
       },
       "lecture-understanding-bash-scripting": {
@@ -4465,12 +4465,6 @@
           "In this 140-lesson workshop, you will complete your student database while diving deeper into SQL commands."
         ]
       },
-      "lab-world-cup-database": {
-        "title": "Build a World Cup Database",
-        "intro": [
-          "For this project, you will create a Bash script that enters information from World Cup games into PostgreSQL, then query the database for useful statistics."
-        ]
-      },
       "workshop-kitty-ipsum-translator": {
         "title": "Build a Kitty Ipsum Translator",
         "intro": [
@@ -4484,12 +4478,6 @@
           "In this 210-lesson workshop, you will build an interactive Bash program that stores rental information for your bike rental shop using PostgreSQL."
         ]
       },
-      "lab-salon-appointment-scheduler": {
-        "title": "Build a Salon Appointment Scheduler",
-        "intro": [
-          "For this lab, you will create an interactive Bash program that uses PostgreSQL to track the customers and appointments for your salon."
-        ]
-      },
       "review-bash-and-sql": {
         "title": "Bash and SQL Review",
         "intro": [
@@ -4499,6 +4487,18 @@
       "quiz-bash-and-sql": {
         "title": "Bash and SQL Quiz",
         "intro": ["Test what you've learned in this quiz on Bash and SQL."]
+      },
+      "lab-world-cup-database": {
+        "title": "Build a World Cup Database",
+        "intro": [
+          "For this project, you will create a Bash script that enters information from World Cup games into PostgreSQL, then query the database for useful statistics."
+        ]
+      },
+      "lab-salon-appointment-scheduler": {
+        "title": "Build a Salon Appointment Scheduler",
+        "intro": [
+          "For this lab, you will create an interactive Bash program that uses PostgreSQL to track the customers and appointments for your salon."
+        ]
       },
       "lecture-working-with-nano": {
         "title": "Working With Nano",
@@ -4528,6 +4528,14 @@
           "In this 240-lesson workshop, you will learn how Git keeps track of your code by creating an object containing commonly used SQL commands."
         ]
       },
+      "review-git": {
+        "title": "Git Review",
+        "intro": ["Review Git concepts to prepare for the upcoming quiz."]
+      },
+      "quiz-git": {
+        "title": "Git Quiz",
+        "intro": ["Test what you've learned on Git with this quiz."]
+      },
       "lab-periodic-table-database": {
         "title": "Build a Periodic Table Database",
         "intro": [
@@ -4540,24 +4548,10 @@
           "For this lab, you will use Bash scripting, PostgreSQL, and Git to create a number guessing game that runs in the terminal and saves user information."
         ]
       },
-      "review-git": {
-        "title": "Git Review",
-        "intro": ["Review Git concepts to prepare for the upcoming quiz."]
-      },
-      "quiz-git": {
-        "title": "Git Quiz",
-        "intro": ["Test what you've learned on Git with this quiz."]
-      },
       "review-relational-databases": {
         "title": "Relational Databases Review",
         "intro": [
           "Review relational databases concepts to prepare for the exam."
-        ]
-      },
-      "quiz-node-js-core-modules": {
-        "title": "NodeJS Core Modules Quiz",
-        "intro": [
-          "Test what you've learned about Node.js core modules with this quiz."
         ]
       },
       "exam-relational-databases-certification": {


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #XXXXX

Source order file:
`curriculum/structure/superblocks/relational-databases-v9.json`
`"quiz-node-js-core-modules"` is added back in #66292 in the right place
