### PR TITLE
fix(curriculum): reorder intros for superblock responsive-web-design-v9

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -5108,14 +5108,15 @@
     ],
     "chapters": {
       "html": "HTML",
-      "css": "CSS",
       "computers": "Computers",
+      "css": "CSS",
       "responsive-web-design-certification-exam": "Responsive Web Design Certification Exam"
     },
     "modules": {
       "basic-html": "Basic HTML",
       "semantic-html": "Semantic HTML",
       "html-forms-and-tables": "Forms and Tables",
+      "lab-survey-form": "Build a Survey Form",
       "html-and-accessibility": "Accessibility",
       "review-html": "HTML Review",
       "computer-basics": "Computer Basics",
@@ -5127,20 +5128,19 @@
       "styling-forms": "Styling Forms",
       "css-box-model": "The Box Model",
       "css-flexbox": "Flexbox",
+      "lab-page-of-playing-cards": "Build a Page of Playing Cards",
       "css-typography": "Typography",
       "css-and-accessibility": "Accessibility",
-      "attribute-selectors": "Attribute Selectors",
       "css-positioning": "Positioning",
+      "attribute-selectors": "Attribute Selectors",
+      "lab-book-inventory-app": "Build a Book Inventory App",
       "responsive-design": "Responsive Design",
+      "lab-technical-documentation-page": "Build a Technical Documentation Page",
       "css-variables": "Variables",
       "css-grid": "Grid",
+      "lab-product-landing-page": "Build a Product Landing Page",
       "css-animations": "Animations",
       "review-css": "CSS Review",
-      "lab-survey-form": "Build a Survey Form",
-      "lab-page-of-playing-cards": "Build a Page of Playing Cards",
-      "lab-book-inventory-app": "Build a Book Inventory App",
-      "lab-technical-documentation-page": "Build a Technical Documentation Page",
-      "lab-product-landing-page": "Build a Product Landing Page",
       "responsive-web-design-certification-exam": "Responsive Web Design Certification Exam"
     },
     "blocks": {
@@ -5366,13 +5366,6 @@
           "You will practice working with labels, inputs, fieldsets, legends, textareas and buttons."
         ]
       },
-      "lab-survey-form": {
-        "title": "Build a Survey Form",
-        "intro": [
-          "In this lab, you'll review HTML forms by creating a survey form.",
-          "You'll practice working with the <code>label</code> element, the different <code>input</code> elements, the <code>required</code> attribute, and more. "
-        ]
-      },
       "lecture-working-with-tables": {
         "title": "Working with Tables",
         "intro": [
@@ -5410,6 +5403,13 @@
         "intro": [
           "The following quiz will test your knowledge of HTML tables, forms and commonly used HTML tools.",
           "If you're getting ready for the exam, there are several quiz sets available for practice. After completing a quiz, you can revisit this page to access a new set of questions."
+        ]
+      },
+      "lab-survey-form": {
+        "title": "Build a Survey Form",
+        "intro": [
+          "In this lab, you'll review HTML forms by creating a survey form.",
+          "You'll practice working with the <code>label</code> element, the different <code>input</code> elements, the <code>required</code> attribute, and more. "
         ]
       },
       "lecture-importance-of-accessibility-and-good-html-structure": {
@@ -5502,7 +5502,6 @@
           "Open up this page to review concepts around the basics of HTML elements, semantic HTML, tables, forms and accessibility."
         ]
       },
-      "qpra": { "title": "30", "intro": [] },
       "lecture-understanding-computer-internet-and-tooling-basics": {
         "title": "Understanding Computer, Internet, and Tooling Basics",
         "intro": [
@@ -5837,13 +5836,6 @@
           "You'll practice aligning elements using flexbox properties like <code>flex</code>, <code>flex-grow</code>, <code>order</code>, and more."
         ]
       },
-      "lab-page-of-playing-cards": {
-        "title": "Build a Page of Playing Cards",
-        "intro": [
-          "In this lab, you'll use flexbox to create a webpage of playing cards.",
-          "You'll practice aligning elements using flexbox properties like <code>flex-direction</code>, <code>justify-content</code>, <code>align-self</code>, and more."
-        ]
-      },
       "review-css-flexbox": {
         "title": "CSS Flexbox Review",
         "intro": [
@@ -5854,6 +5846,13 @@
       "quiz-css-flexbox": {
         "title": "CSS Flexbox Quiz",
         "intro": ["Test what you've learned on CSS flexbox with this quiz."]
+      },
+      "lab-page-of-playing-cards": {
+        "title": "Build a Page of Playing Cards",
+        "intro": [
+          "In this lab, you'll use flexbox to create a webpage of playing cards.",
+          "You'll practice aligning elements using flexbox properties like <code>flex-direction</code>, <code>justify-content</code>, <code>align-self</code>, and more."
+        ]
       },
       "lecture-working-with-css-fonts": {
         "title": "Working with CSS Fonts",
@@ -5961,13 +5960,6 @@
           "In this workshop, you'll build a balance sheet using pseudo selectors. You'll learn how to change the style of an element when you hover over it with your mouse, and trigger other events on your webpage."
         ]
       },
-      "lab-book-inventory-app": {
-        "title": "Build a Book Inventory App",
-        "intro": [
-          "In this lab, you'll create a book inventory app.",
-          "You'll practice CSS attribute selectors like <code>[attribute]</code>, <code>[attribute=value]</code>, <code>[attribute~=value]</code>, and more."
-        ]
-      },
       "review-css-attribute-selectors": {
         "title": "CSS Attribute Selectors Review",
         "intro": [
@@ -5979,6 +5971,13 @@
         "title": "CSS Attribute Selectors Quiz",
         "intro": [
           "Test your knowledge of CSS attribute selectors with this quiz."
+        ]
+      },
+      "lab-book-inventory-app": {
+        "title": "Build a Book Inventory App",
+        "intro": [
+          "In this lab, you'll create a book inventory app.",
+          "You'll practice CSS attribute selectors like <code>[attribute]</code>, <code>[attribute=value]</code>, <code>[attribute~=value]</code>, and more."
         ]
       },
       "lecture-best-practices-for-responsive-web-design": {
@@ -5994,13 +5993,6 @@
           "In this workshop, you'll use CSS and responsive design to code a piano. You'll also practice media queries and pseudo selectors."
         ]
       },
-      "lab-technical-documentation-page": {
-        "title": "Build a Technical Documentation Page",
-        "intro": [
-          "In this lab, you'll build a technical documentation page to serve as instruction or reference for a topic.",
-          "You'll also practice media queries to create a responsive design."
-        ]
-      },
       "review-responsive-web-design": {
         "title": "Responsive Web Design Review",
         "intro": [
@@ -6012,6 +6004,13 @@
         "title": "Responsive Web Design Quiz",
         "intro": [
           "Test what you've learned about making your webpages responsive with this quiz."
+        ]
+      },
+      "lab-technical-documentation-page": {
+        "title": "Build a Technical Documentation Page",
+        "intro": [
+          "In this lab, you'll build a technical documentation page to serve as instruction or reference for a topic.",
+          "You'll also practice media queries to create a responsive design."
         ]
       },
       "lecture-working-with-css-variables": {
@@ -6070,12 +6069,6 @@
           "In this lecture, you'll learn how to debug CSS using your browser's developer tools and CSS validators."
         ]
       },
-      "lab-product-landing-page": {
-        "title": "Build a Product Landing Page",
-        "intro": [
-          "In this project, you'll build a product landing page to market a product of your choice."
-        ]
-      },
       "review-css-grid": {
         "title": "CSS Grid Review",
         "intro": [
@@ -6086,6 +6079,12 @@
       "quiz-css-grid": {
         "title": "CSS Grid Quiz",
         "intro": ["Test your knowledge of CSS Grid with this quiz."]
+      },
+      "lab-product-landing-page": {
+        "title": "Build a Product Landing Page",
+        "intro": [
+          "In this project, you'll build a product landing page to market a product of your choice."
+        ]
       },
       "lecture-animations-and-accessibility": {
         "title": "Animations and Accessibility",


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #XXXXX

Source order file:
`curriculum/structure/superblocks/responsive-web-design-v9.json`

Note: This PR also removes the extra 'qpra' key that doesn't exist in the structure file.
