### PR TITLE
fix(curriculum): add opposite parameter validation tests

### DIFF
--- a/curriculum/challenges/english/blocks/lab-rpg-character/67d83df6f82eda3868dd2a84.md
+++ b/curriculum/challenges/english/blocks/lab-rpg-character/67d83df6f82eda3868dd2a84.md
@@ -68,6 +68,16 @@ for wrong_type in wrong_types:
 })
 ```
 
+When `create_character` is called with a first argument that is a string it should not return `The character name should be a string`.
+
+```js
+({
+    test: () => runPython(
+        `assert create_character('ren', 1, 2, 4) != 'The character name should be a string'`
+    )
+})
+```
+
 When `create_character` is called with a first argument that is an empty string, it should return `The character should have a name`.
 
 ```js
@@ -75,6 +85,18 @@ When `create_character` is called with a first argument that is an empty string,
     test: () => runPython(
         `
 assert create_character('', 4, 2, 1) == 'The character should have a name'
+`
+    )
+})
+```
+
+When `create_character` is called with a first argument that is not an empty string, it should not return `The character should have a name`.
+
+```js
+({
+    test: () => runPython(
+        `
+assert create_character('ren', 4, 2, 1) != 'The character should have a name'
 `
     )
 })
@@ -118,6 +140,18 @@ assert create_character('cha cha', 4, 1, 2) == 'The character name should not co
 })
 ```
 
+When `create_character` is called with a first argument that does not contain a space it should not return `The character name should not contain spaces`.
+
+```js
+({
+    test: () => runPython(
+        `
+assert create_character('chacha', 4, 2, 1) != 'The character name should not contain spaces'
+`
+    )
+})
+```
+
 When `create_character` is called with a second, third or fourth argument that is not an integer it should return `All stats should be integers`.
 
 ```js
@@ -129,6 +163,18 @@ for wrong_type in wrong_types:
     assert create_character('friend', wrong_type, 2, 1) == 'All stats should be integers'
     assert create_character('friend', 2, wrong_type, 1) == 'All stats should be integers'
     assert create_character('friend', 2, 1, wrong_type) == 'All stats should be integers'
+`
+    )
+})
+```
+
+When `create_character` is called with a second, third and fourth argument that are all integers it should not return `All stats should be integers`.
+
+```js
+({
+    test: () => runPython(
+        `
+assert create_character('friend', 4, 2, 1) != 'All stats should be integers'
 `
     )
 })
@@ -153,6 +199,18 @@ assert create_character('ren', 4, 4, -1) == expected
 })
 ```
 
+When `create_character` is called with a second, third and fourth argument that are all no less than `1` it should not return `All stats should be no less than 1`.
+
+```js
+({
+    test: () => runPython(
+        `
+assert create_character('ren', 4, 2, 1) != 'All stats should be no less than 1'
+`
+    )
+})
+```
+
 When `create_character` is called with a second, third or fourth argument that is higher than `4` it should return `All stats should be no more than 4`.
 
 ```js
@@ -167,6 +225,18 @@ assert create_character('ren', 1, 1, 5) == 'All stats should be no more than 4'
 })
 ```
 
+When `create_character` is called with a second, third and fourth argument that are all no more than `4` it should not return `All stats should be no more than 4`.
+
+```js
+({
+    test: () => runPython(
+        `
+assert create_character('ren', 4, 2, 1) != 'All stats should be no more than 4'
+`
+    )
+})
+```
+
 When `create_character` is called with a second, third or fourth argument that do not sum to `7` it should return `The character should start with 7 points`.
 
 ```js
@@ -176,6 +246,18 @@ When `create_character` is called with a second, third or fourth argument that d
 assert create_character('ren', 4, 4, 4) == 'The character should start with 7 points'
 assert create_character('ren', 1, 1, 1) == 'The character should start with 7 points'
 assert create_character('ren', 1, 2, 3) == 'The character should start with 7 points'
+`
+    )
+})
+```
+
+When `create_character` is called with a second, third and fourth argument that sum to `7` it should not return `The character should start with 7 points`.
+
+```js
+({
+    test: () => runPython(
+        `
+assert create_character('ren', 4, 2, 1) != 'The character should start with 7 points'
 `
     )
 })


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

This adds more tests to help campers in understanding why the tests do not pass