### PR TITLE
refactor(curriculum): remove challenge caching

### DIFF
--- a/curriculum/src/build-superblock.ts
+++ b/curriculum/src/build-superblock.ts
@@ -1,5 +1,5 @@
-import { existsSync, readdirSync, statSync } from 'fs';
-import { join, resolve, basename } from 'path';
+import { existsSync, readdirSync } from 'fs';
+import { resolve } from 'path';
 import { isEmpty, cloneDeep } from 'lodash';
 import debug from 'debug';
 
@@ -8,8 +8,7 @@ import { createPoly } from '@freecodecamp/shared/utils/polyvinyl';
 import { isAuditedSuperBlock } from '@freecodecamp/shared/utils/is-audited';
 import {
   CommentDictionary,
-  translateCommentsInChallenge,
-  type Challenge as ParsedChallenge
+  translateCommentsInChallenge
 } from '../../tools/challenge-parser/translation-parser';
 import { SuperBlocks } from '@freecodecamp/shared/config/curriculum';
 import type { Chapter } from '@freecodecamp/shared/config/chapters';
@@ -43,13 +42,6 @@ interface Meta extends BlockStructure {
   superBlock: SuperBlocks;
   superOrder: number;
 }
-
-interface CachedChallenge {
-  challenge: ParsedChallenge;
-  mtime: number;
-}
-
-const challengeCache = new Map<string, CachedChallenge>();
 
 /**
  * Validates challenges against meta.json challengeOrder
@@ -339,33 +331,13 @@ export class BlockCreator {
 
     const challengePath = langUsed === 'english' ? englishPath : i18nPath;
 
-    const currentMtime = statSync(challengePath).mtimeMs;
-    const cached = challengeCache.get(challengePath);
-    const isCacheValid = cached && cached.mtime === currentMtime;
-
-    const challenge = isCacheValid
-      ? cached.challenge
-      : translateCommentsInChallenge(
-          await parser(challengePath),
-          langUsed,
-          this.commentTranslations
-        );
-
-    challenge.translationPending = this.lang !== 'english' && !isAudited;
-    // Add source location to allow tracing back to original file (necessary to
-    // update the client when files change)
-    challenge.sourceLocation = join(
-      basename(this.blockContentDir),
-      block,
-      filename
+    const challenge = translateCommentsInChallenge(
+      await parser(challengePath),
+      langUsed,
+      this.commentTranslations
     );
 
-    if (!isCacheValid) {
-      challengeCache.set(challengePath, {
-        challenge,
-        mtime: currentMtime
-      });
-    }
+    challenge.translationPending = this.lang !== 'english' && !isAudited;
 
     return finalizeChallenge(challenge, meta);
   }

--- a/curriculum/src/build-superblock.ts
+++ b/curriculum/src/build-superblock.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync } from 'fs';
+import { existsSync, readdirSync, statSync } from 'fs';
 import { join, resolve, basename } from 'path';
 import { isEmpty, cloneDeep } from 'lodash';
 import debug from 'debug';
@@ -44,7 +44,12 @@ interface Meta extends BlockStructure {
   superOrder: number;
 }
 
-const challengeCache = new Map<string, ParsedChallenge>();
+interface CachedChallenge {
+  challenge: ParsedChallenge;
+  mtime: number;
+}
+
+const challengeCache = new Map<string, CachedChallenge>();
 
 /**
  * Validates challenges against meta.json challengeOrder
@@ -334,15 +339,17 @@ export class BlockCreator {
 
     const challengePath = langUsed === 'english' ? englishPath : i18nPath;
 
-    const cachedChallenge = challengeCache.get(challengePath);
+    const currentMtime = statSync(challengePath).mtimeMs;
+    const cached = challengeCache.get(challengePath);
+    const isCacheValid = cached && cached.mtime === currentMtime;
 
-    const challenge =
-      cachedChallenge ??
-      translateCommentsInChallenge(
-        await parser(challengePath),
-        langUsed,
-        this.commentTranslations
-      );
+    const challenge = isCacheValid
+      ? cached.challenge
+      : translateCommentsInChallenge(
+          await parser(challengePath),
+          langUsed,
+          this.commentTranslations
+        );
 
     challenge.translationPending = this.lang !== 'english' && !isAudited;
     // Add source location to allow tracing back to original file (necessary to
@@ -353,7 +360,12 @@ export class BlockCreator {
       filename
     );
 
-    challengeCache.set(challengePath, challenge);
+    if (!isCacheValid) {
+      challengeCache.set(challengePath, {
+        challenge,
+        mtime: currentMtime
+      });
+    }
 
     return finalizeChallenge(challenge, meta);
   }


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.


This pr fixes hot-reload by storing file mtime alongside cached challenges. 
Cache is now invalidated when a file is modified, so edits reflect  immediately 
without restarting the server.