### PR TITLE
fix(client): UI fix for navbar in high contrast mode

### DIFF
--- a/client/src/components/Header/components/universal-nav.css
+++ b/client/src/components/Header/components/universal-nav.css
@@ -172,7 +172,7 @@ li > button.nav-link-signout:not([aria-disabled='true']):is(:hover, :focus) {
 
 .nav-link .fa-external-link-alt {
   color: var(--gray-45);
-}
+
 
 .nav-link-supporter {
   color: var(--yellow-light);
@@ -420,7 +420,7 @@ li > button.nav-link-signout:not([aria-disabled='true']):is(:hover, :focus) {
   #universal-nav .login-btn-icon {
     display: none;
   }
-}
+
 
 /**
  * Handle submenu containers collapsed and expanded states
@@ -433,9 +433,8 @@ li > button.nav-link-signout:not([aria-disabled='true']):is(:hover, :focus) {
   display: block;
 }
 
-@media (force-colors: active){
-    .universal-nav{
-        background-color: #0a0a23;
-    }
+@media (force-colors: active) {
+  .universal-nav {
+    background-color: #0a0a23;
+  
 }
-

--- a/client/src/components/Header/components/universal-nav.css
+++ b/client/src/components/Header/components/universal-nav.css
@@ -436,5 +436,5 @@ li > button.nav-link-signout:not([aria-disabled='true']):is(:hover, :focus) {
 @media (force-colors: active) {
   .universal-nav {
     background-color: #0a0a23;
-  
+  }
 }

--- a/client/src/components/Header/components/universal-nav.css
+++ b/client/src/components/Header/components/universal-nav.css
@@ -7,6 +7,7 @@
   height: var(--header-height);
   justify-content: space-between;
   padding: 0 5px;
+  forced-color-adjust: none;
 }
 
 @media (min-width: 401px) {
@@ -431,3 +432,10 @@ li > button.nav-link-signout:not([aria-disabled='true']):is(:hover, :focus) {
 #universal-nav button[aria-expanded='true'] + div {
   display: block;
 }
+
+@media (force-colors: active){
+    .universal-nav{
+        background-color: #0a0a23;
+    }
+}
+

--- a/client/src/templates/Introduction/intro.css
+++ b/client/src/templates/Introduction/intro.css
@@ -59,6 +59,7 @@
 }
 
 .block-label-exam {
+  align-self: auto;
   border-color: var(--quaternary-color);
   color: var(--quaternary-color);
 }

--- a/client/src/templates/Introduction/intro.css
+++ b/client/src/templates/Introduction/intro.css
@@ -59,7 +59,6 @@
 }
 
 .block-label-exam {
-  align-self: auto;
   border-color: var(--quaternary-color);
   color: var(--quaternary-color);
 }


### PR DESCRIPTION
Checklist:
- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #58807

Changes were made to universal-nav.css to make the navbar visible in high contrast mode. Before this change, the navbar was not visible due to high contrast mode overriding styling colors, as described in the issue. With this fix, the navbar is presented just as it would be without being in high contrast mode. 

Without fix: 
<img width="1284" height="1085" alt="Screenshot 2026-03-07 173925" src="https://github.com/user-attachments/assets/44c27a1a-aaa8-42ef-a6b9-438e19d52b75" />


With fix:
<img width="1285" height="1191" alt="Screenshot 2026-03-07 173706" src="https://github.com/user-attachments/assets/f869a6ca-981e-4ffb-ab80-265775d512ad" />
