### PR TITLE
fix(client): handle navbar style in high contrast mode

### DIFF
--- a/client/src/components/Header/components/universal-nav.css
+++ b/client/src/components/Header/components/universal-nav.css
@@ -7,11 +7,18 @@
   height: var(--header-height);
   justify-content: space-between;
   padding: 0 5px;
+  forced-color-adjust: none;
 }
 
 @media (min-width: 401px) {
   .universal-nav {
     padding: 0 15px;
+  }
+}
+
+@media (forced-colors) {
+  .universal-nav {
+    background-color: var(--gray-90);
   }
 }
 

--- a/client/src/components/Header/components/universal-nav.css
+++ b/client/src/components/Header/components/universal-nav.css
@@ -481,6 +481,7 @@ li > button.nav-link-signout:not([aria-disabled='true']):is(:hover, :focus) {
   }
 
   .lang-button-nav svg path {
+    fill: none !important;
     stroke: ButtonText !important;
   }
 

--- a/client/src/components/Header/components/universal-nav.css
+++ b/client/src/components/Header/components/universal-nav.css
@@ -7,7 +7,6 @@
   height: var(--header-height);
   justify-content: space-between;
   padding: 0 5px;
-  forced-color-adjust: none;
 }
 
 @media (min-width: 401px) {
@@ -15,6 +14,7 @@
     padding: 0 15px;
   }
 }
+
 .universal-nav a {
   text-decoration: none;
 }
@@ -430,4 +430,46 @@ li > button.nav-link-signout:not([aria-disabled='true']):is(:hover, :focus) {
 
 #universal-nav button[aria-expanded='true'] + div {
   display: block;
+}
+
+/**
+ * High contrast mode support
+ *
+ * When the user enables a high contrast theme (e.g. Windows High Contrast),
+ * the browser overrides most colors. We add explicit borders and fills so
+ * navbar elements remain visually distinguishable.
+ */
+@media (forced-colors: active) {
+  .universal-nav {
+    border-bottom: 2px solid ButtonText;
+  }
+
+  .exposed-button-nav,
+  .lang-button-nav {
+    border: 1px solid ButtonText;
+  }
+
+  .nav-list {
+    border: 1px solid ButtonText;
+  }
+
+  .nav-link {
+    border-bottom: 1px solid ButtonText;
+  }
+
+  .nav-line {
+    border-top-color: ButtonText;
+  }
+
+  .universal-nav-logo svg {
+    fill: LinkText;
+  }
+
+  .avatar-container {
+    border-color: ButtonText;
+  }
+
+  .signup-btn {
+    border: 1px solid ButtonText;
+  }
 }

--- a/client/src/components/Header/components/universal-nav.css
+++ b/client/src/components/Header/components/universal-nav.css
@@ -15,13 +15,6 @@
     padding: 0 15px;
   }
 }
-
-@media (forced-colors) {
-  .universal-nav {
-    background-color: var(--gray-90);
-  }
-}
-
 .universal-nav a {
   text-decoration: none;
 }

--- a/client/src/components/Header/components/universal-nav.css
+++ b/client/src/components/Header/components/universal-nav.css
@@ -461,8 +461,27 @@ li > button.nav-link-signout:not([aria-disabled='true']):is(:hover, :focus) {
     border-top-color: ButtonText;
   }
 
+  /* The logo SVG uses inline fill="#ffffff" which the browser cannot
+     override automatically. forced-color-adjust: auto tells the browser
+     to remap colors, and the !important fill ensures the logo is visible
+     against the system background. */
   .universal-nav-logo svg {
-    fill: LinkText;
+    forced-color-adjust: auto;
+    fill: LinkText !important;
+  }
+
+  /* Override the hardcoded fill on <use> elements inside the logo */
+  .universal-nav-logo svg use {
+    fill: LinkText !important;
+  }
+
+  /* Ensure the language globe icon strokes are visible */
+  .lang-button-nav svg {
+    forced-color-adjust: auto;
+  }
+
+  .lang-button-nav svg path {
+    stroke: ButtonText !important;
   }
 
   .avatar-container {


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #58807

### Changes
This PR fixes the navbar becoming transparent/white in Windows high contrast mode by:

1. Adding `forced-color-adjust: none` to `.universal-nav` to prevent the browser from overriding theme colors.
2. Adding a `@media (forced-colors)` fallback that sets a solid dark background (`var(--gray-90)`) so the navbar remains visible and accessible.
