### PR TITLE
Fix duplicate notes on superblock intro pages

### DIFF
--- a/client/src/templates/Introduction/components/super-block-intro.tsx
+++ b/client/src/templates/Introduction/components/super-block-intro.tsx
@@ -190,11 +190,13 @@ function SuperBlockIntro({
   return (
     <>
       <IntroTopDefault fsd={superBlock === SuperBlocks.FullStackDeveloperV9} />
-      <ConditionalDonationAlert
-        superBlock={superBlock}
-        onCertificationDonationAlertClick={onCertificationDonationAlertClick}
-        isDonating={isDonating}
-      />
+      {!superBlockNoteText && (
+        <ConditionalDonationAlert
+          superBlock={superBlock}
+          onCertificationDonationAlertClick={onCertificationDonationAlertClick}
+          isDonating={isDonating}
+        />
+      )}
     </>
   );
 }


### PR DESCRIPTION
Fixes #66217

The ConditionalDonationAlert was showing donation notes for unfinished
certifications even when they already had their own note in intro.json,
causing duplicate notes to appear on language superblock pages.

Now the donation alert is only shown when no superblock-specific note exists.