### PR TITLE
fix: incomplete html and css course names for catalog

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -4790,7 +4790,7 @@
     }
   },
   "html-forms-and-tables": {
-    "title": "HTML Forms and Tables",
+    "title": "Learn HTML Forms and Tables",
     "summary": [
       "Learn how to build accessible forms and data tables with semantic HTML."
     ],
@@ -6637,7 +6637,7 @@
     }
   },
   "html-and-accessibility": {
-    "title": "Accessibility",
+    "title": "Learn HTML and Accessibility",
     "summary": [
       "Learn how to write inclusive HTML using accessibility best practices and ARIA."
     ],
@@ -6731,7 +6731,7 @@
     }
   },
   "computer-basics": {
-    "title": "Computer Basics",
+    "title": "Learn Computer Basics",
     "summary": [
       "Build a foundation in computer, internet, and tooling basics for web development."
     ],
@@ -6773,7 +6773,7 @@
     }
   },
   "basic-css": {
-    "title": "Basic CSS",
+    "title": "Learn Basic CSS",
     "summary": [
       "Learn core CSS concepts and start styling real-world layouts."
     ],
@@ -6862,7 +6862,7 @@
     }
   },
   "design-for-developers": {
-    "title": "Design",
+    "title": "Introduction to UI/UX Design",
     "summary": [
       "Explore UI design fundamentals and user-centered design principles for developers."
     ],
@@ -6904,7 +6904,7 @@
     }
   },
   "absolute-and-relative-units": {
-    "title": "Absolute and Relative Units",
+    "title": "Learn Absolute and Relative Units in CSS",
     "summary": [
       "Understand when to use absolute and relative CSS units to build flexible layouts."
     ],
@@ -6939,7 +6939,7 @@
     }
   },
   "pseudo-classes-and-elements": {
-    "title": "Pseudo Classes and Elements",
+    "title": "Learn CSS Pseudo Classes and Elements",
     "summary": [
       "Use pseudo-classes and pseudo-elements to create richer, more interactive styles."
     ],
@@ -6988,7 +6988,7 @@
     }
   },
   "css-colors": {
-    "title": "Colors",
+    "title": "Learn CSS Colors",
     "summary": [
       "Work with CSS color formats and build cohesive color palettes."
     ],
@@ -7026,7 +7026,7 @@
     }
   },
   "styling-forms": {
-    "title": "Styling Forms",
+    "title": "Learn How to Style Forms using CSS",
     "summary": ["Apply CSS techniques to create clean, usable form layouts."],
     "intro": ["Style form elements to improve usability and visual clarity."],
     "blocks": {
@@ -7077,7 +7077,7 @@
     }
   },
   "css-box-model": {
-    "title": "The Box Model",
+    "title": "Learn the CSS Box Model",
     "summary": [
       "Master the CSS box model, spacing, and layout effects for precise designs."
     ],
@@ -7118,7 +7118,7 @@
     }
   },
   "css-flexbox": {
-    "title": "Flexbox",
+    "title": "Learn CSS Flexbox",
     "summary": [
       "Build responsive layouts using the Flexbox model and alignment tools."
     ],
@@ -7173,7 +7173,7 @@
     }
   },
   "css-typography": {
-    "title": "Typography",
+    "title": "Learn CSS Typography",
     "summary": [
       "Learn how to style text for readability, hierarchy, and visual balance."
     ],
@@ -7213,7 +7213,7 @@
     }
   },
   "css-and-accessibility": {
-    "title": "Accessibility",
+    "title": "Learn CSS and Accessibility",
     "summary": [
       "Apply CSS techniques that support accessible and inclusive interfaces."
     ],
@@ -7254,7 +7254,7 @@
     }
   },
   "css-positioning": {
-    "title": "Positioning",
+    "title": "Learn CSS Positioning",
     "summary": [
       "Use positioning and floats to control layout and element flow."
     ],
@@ -7294,7 +7294,7 @@
     }
   },
   "attribute-selectors": {
-    "title": "Attribute Selectors",
+    "title": "Learn CSS Attribute Selectors",
     "summary": ["Target elements precisely with CSS attribute selectors."],
     "intro": ["Select elements with precision using attribute selectors."],
     "blocks": {
@@ -7340,7 +7340,7 @@
     }
   },
   "responsive-design": {
-    "title": "Responsive Design",
+    "title": "Learn Responsive Design",
     "summary": [
       "Learn responsive design principles and build layouts that adapt to any screen."
     ],
@@ -7393,7 +7393,7 @@
     }
   },
   "css-variables": {
-    "title": "Variables",
+    "title": "Learn CSS Variables",
     "summary": ["Use CSS variables to build reusable, theme-friendly styles."],
     "intro": ["Create maintainable styles using CSS custom properties."],
     "blocks": {
@@ -7431,7 +7431,7 @@
     }
   },
   "css-grid": {
-    "title": "Grid",
+    "title": "Learn CSS Grid",
     "summary": ["Design complex layouts using the CSS Grid system."],
     "intro": ["Build multi-dimensional layouts with CSS Grid."],
     "blocks": {
@@ -7491,7 +7491,7 @@
     }
   },
   "css-animations": {
-    "title": "Animations",
+    "title": "Learn CSS Animations",
     "summary": ["Create engaging UI motion with accessible CSS animations."],
     "intro": [
       "Add motion with CSS animations while keeping usability in mind."

--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -6404,7 +6404,7 @@
       "Learn how to build simple webpages using HTML tags to add text, images, and links."
     ],
     "intro": [
-      "HTML stands for HyperText Markup Langauge and represents the content and structure for a web page. In this course, you will learn the basics of writing HTML."
+      "HTML stands for HyperText Markup Language and represents the content and structure for a web page. In this course, you will learn the basics of writing HTML."
     ],
     "blocks": {
       "workshop-curriculum-outline": {
@@ -7030,7 +7030,7 @@
     }
   },
   "styling-forms": {
-    "title": "Learn How to Style Forms using CSS",
+    "title": "Learn How to Style Forms Using CSS",
     "summary": ["Apply CSS techniques to create clean, usable form layouts."],
     "intro": ["Style form elements to improve usability and visual clarity."],
     "blocks": {

--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -6399,11 +6399,13 @@
     }
   },
   "basic-html": {
-    "title": "Basic HTML",
+    "title": "Learn Basic HTML",
     "summary": [
       "Learn how to build simple webpages using HTML tags to add text, images, and links."
     ],
-    "intro": ["Larger intro for the superblock page."],
+    "intro": [
+      "HTML stands for HyperText Markup Langauge and represents the content and structure for a web page. In this course, you will learn the basics of writing HTML."
+    ],
     "blocks": {
       "workshop-curriculum-outline": {
         "title": "Build a Curriculum Outline",
@@ -6548,11 +6550,13 @@
     }
   },
   "semantic-html": {
-    "title": "Semantic HTML",
+    "title": "Learn Semantic HTML",
     "summary": [
       "Discover how to write cleaner, more meaningful HTML using semantic tags that improve structure, accessibility, and SEO."
     ],
-    "intro": ["Larger intro for the superblock page."],
+    "intro": [
+      "In this interactive course, you will practice writing semantic HTML."
+    ],
     "blocks": {
       "lecture-importance-of-semantic-html": {
         "title": "Importance of Semantic HTML",

--- a/client/src/pages/learn/absolute-and-relative-units/index.md
+++ b/client/src/pages/learn/absolute-and-relative-units/index.md
@@ -1,9 +1,9 @@
 ---
-title: Absolute and Relative Units
+title: Learn Absolute and Relative Units in CSS
 superBlock: absolute-and-relative-units
 certification: absolute-and-relative-units
 ---
 
-## Absolute and Relative Units
+## Introduction to Learn Absolute and Relative Units in CSS
 
 Understand when to use absolute and relative CSS units to build flexible layouts.

--- a/client/src/pages/learn/attribute-selectors/index.md
+++ b/client/src/pages/learn/attribute-selectors/index.md
@@ -1,9 +1,9 @@
 ---
-title: Attribute Selectors
+title: Learn CSS Attribute Selectors
 superBlock: attribute-selectors
 certification: attribute-selectors
 ---
 
-## Attribute Selectors
+## Introduction to Learn CSS Attribute Selectors
 
 Target elements precisely with CSS attribute selectors.

--- a/client/src/pages/learn/basic-css/index.md
+++ b/client/src/pages/learn/basic-css/index.md
@@ -1,9 +1,9 @@
 ---
-title: Basic CSS
+title: Learn Basic CSS
 superBlock: basic-css
 certification: basic-css
 ---
 
-## Basic CSS
+## Learn Basic CSS
 
 Learn core CSS concepts and start styling real-world layouts.

--- a/client/src/pages/learn/basic-html/index.md
+++ b/client/src/pages/learn/basic-html/index.md
@@ -1,9 +1,9 @@
 ---
-title: Basic HTML
+title: Learn Basic HTML
 superBlock: basic-html
 certification: basic-html
 ---
 
-## Introduction to Basic HTML
+## Introduction to Learn Basic HTML
 
 Introduction to Basic HTML.

--- a/client/src/pages/learn/computer-basics/index.md
+++ b/client/src/pages/learn/computer-basics/index.md
@@ -1,9 +1,9 @@
 ---
-title: Computer Basics
+title: Learn Computer Basics
 superBlock: computer-basics
 certification: computer-basics
 ---
 
-## Computer Basics
+## Learn Computer Basics
 
 Build a foundation in computer, internet, and tooling basics for web development.

--- a/client/src/pages/learn/css-and-accessibility/index.md
+++ b/client/src/pages/learn/css-and-accessibility/index.md
@@ -1,9 +1,9 @@
 ---
-title: Accessibility
+title: Learn CSS and Accessibility
 superBlock: css-and-accessibility
 certification: css-and-accessibility
 ---
 
-## CSS and Accessibility
+## Introduction to Learn CSS and Accessibility
 
 Apply CSS techniques that support accessible and inclusive interfaces.

--- a/client/src/pages/learn/css-animations/index.md
+++ b/client/src/pages/learn/css-animations/index.md
@@ -1,9 +1,9 @@
 ---
-title: Animations
+title: Learn CSS Animations
 superBlock: css-animations
 certification: css-animations
 ---
 
-## CSS Animations
+## Introduction to Learn CSS Animations
 
 Create engaging UI motion with accessible CSS animations.

--- a/client/src/pages/learn/css-box-model/index.md
+++ b/client/src/pages/learn/css-box-model/index.md
@@ -1,9 +1,9 @@
 ---
-title: The Box Model
+title: Learn the CSS Box Model
 superBlock: css-box-model
 certification: css-box-model
 ---
 
-## CSS Box Model
+## Introduction to Learn the CSS Box Model
 
 Master the CSS box model, spacing, and layout effects for precise designs.

--- a/client/src/pages/learn/css-colors/index.md
+++ b/client/src/pages/learn/css-colors/index.md
@@ -1,9 +1,9 @@
 ---
-title: Colors
+title: Learn CSS Colors
 superBlock: css-colors
 certification: css-colors
 ---
 
-## CSS Colors
+## Introduction to Learn CSS Colors
 
 Work with CSS color formats and build cohesive color palettes.

--- a/client/src/pages/learn/css-flexbox/index.md
+++ b/client/src/pages/learn/css-flexbox/index.md
@@ -1,9 +1,9 @@
 ---
-title: Flexbox
+title: Learn CSS Flexbox
 superBlock: css-flexbox
 certification: css-flexbox
 ---
 
-## CSS Flexbox
+## Introduction to Learn CSS Flexbox
 
 Build responsive layouts using the Flexbox model and alignment tools.

--- a/client/src/pages/learn/css-grid/index.md
+++ b/client/src/pages/learn/css-grid/index.md
@@ -1,9 +1,9 @@
 ---
-title: Grid
+title: Learn CSS Grid
 superBlock: css-grid
 certification: css-grid
 ---
 
-## CSS Grid
+## Introduction to Learn CSS Grid
 
 Design complex layouts using the CSS Grid system.

--- a/client/src/pages/learn/css-positioning/index.md
+++ b/client/src/pages/learn/css-positioning/index.md
@@ -1,9 +1,9 @@
 ---
-title: Positioning
+title: Learn CSS Positioning
 superBlock: css-positioning
 certification: css-positioning
 ---
 
-## CSS Positioning
+## Introduction to Learn CSS Positioning
 
 Use positioning and floats to control layout and element flow.

--- a/client/src/pages/learn/css-typography/index.md
+++ b/client/src/pages/learn/css-typography/index.md
@@ -1,9 +1,9 @@
 ---
-title: Typography
+title: Learn CSS Typography
 superBlock: css-typography
 certification: css-typography
 ---
 
-## CSS Typography
+## Introduction to Learn CSS Typography
 
 Learn how to style text for readability, hierarchy, and visual balance.

--- a/client/src/pages/learn/css-variables/index.md
+++ b/client/src/pages/learn/css-variables/index.md
@@ -1,9 +1,9 @@
 ---
-title: Variables
+title: Learn CSS Variables
 superBlock: css-variables
 certification: css-variables
 ---
 
-## CSS Variables
+## Introduction to Learn CSS Variables
 
 Use CSS variables to build reusable, theme-friendly styles.

--- a/client/src/pages/learn/design-for-developers/index.md
+++ b/client/src/pages/learn/design-for-developers/index.md
@@ -1,9 +1,9 @@
 ---
-title: Design
+title: Introduction to UI/UX Design
 superBlock: design-for-developers
 certification: design-for-developers
 ---
 
-## Design for Developers
+## Introduction to UI/UX Design
 
 Explore UI design fundamentals and user-centered design principles for developers.

--- a/client/src/pages/learn/html-and-accessibility/index.md
+++ b/client/src/pages/learn/html-and-accessibility/index.md
@@ -1,9 +1,9 @@
 ---
-title: Accessibility
+title: Learn HTML and Accessibility
 superBlock: html-and-accessibility
 certification: html-and-accessibility
 ---
 
-## HTML and Accessibility
+## Learn HTML and Accessibility
 
 Learn how to write inclusive HTML using accessibility best practices and ARIA.

--- a/client/src/pages/learn/html-forms-and-tables/index.md
+++ b/client/src/pages/learn/html-forms-and-tables/index.md
@@ -1,9 +1,9 @@
 ---
-title: HTML Forms and Tables
+title: Learn HTML Forms and Tables
 superBlock: html-forms-and-tables
 certification: html-forms-and-tables
 ---
 
-## Introduction to HTML Forms and Tables
+## Introduction to Learn HTML Forms and Tables
 
 Learn how to build accessible forms and data tables with semantic HTML.

--- a/client/src/pages/learn/pseudo-classes-and-elements/index.md
+++ b/client/src/pages/learn/pseudo-classes-and-elements/index.md
@@ -1,9 +1,9 @@
 ---
-title: Pseudo Classes and Elements
+title: Learn CSS Pseudo Classes and Elements
 superBlock: pseudo-classes-and-elements
 certification: pseudo-classes-and-elements
 ---
 
-## Pseudo Classes and Elements
+## Learn CSS Pseudo Classes and Elements
 
 Use pseudo-classes and pseudo-elements to create richer, more interactive styles.

--- a/client/src/pages/learn/responsive-design/index.md
+++ b/client/src/pages/learn/responsive-design/index.md
@@ -1,9 +1,9 @@
 ---
-title: Responsive Design
+title: Learn Responsive Design
 superBlock: responsive-design
 certification: responsive-design
 ---
 
-## Responsive Design
+## Introduction to Learn Responsive Design
 
 Learn responsive design principles and build layouts that adapt to any screen.

--- a/client/src/pages/learn/semantic-html/index.md
+++ b/client/src/pages/learn/semantic-html/index.md
@@ -1,9 +1,9 @@
 ---
-title: Semantic HTML
+title: Learn Semantic HTML
 superBlock: semantic-html
 certification: semantic-html
 ---
 
-## Introduction to Semantic HTML
+## Introduction to Learn Semantic HTML
 
-Introduction to Semantic HTML.
+In this course, you will learn how to write semantic HTML.

--- a/client/src/pages/learn/styling-forms/index.md
+++ b/client/src/pages/learn/styling-forms/index.md
@@ -1,9 +1,9 @@
 ---
-title: Styling Forms
+title: Learn How to Style Forms using CSS
 superBlock: styling-forms
 certification: styling-forms
 ---
 
-## Styling Forms
+## Introduction to Learn How to Style Forms using CSS
 
 Apply CSS techniques to create clean, usable form layouts.

--- a/client/src/pages/learn/styling-forms/index.md
+++ b/client/src/pages/learn/styling-forms/index.md
@@ -4,6 +4,6 @@ superBlock: styling-forms
 certification: styling-forms
 ---
 
-## Introduction to Learn How to Style Forms using CSS
+## Introduction to Learn How to Style Forms Using CSS
 
 Apply CSS techniques to create clean, usable form layouts.


### PR DESCRIPTION
While working on another PR I noticed that some of the HTML and CSS courses names weren't complete and didn't follow the same naming structure as the other catalog items. 
So this PR resolves that.

<img width="1082" height="679" alt="Screenshot 2026-03-09 at 10 02 03 AM" src="https://github.com/user-attachments/assets/367d7cde-db9a-4721-8859-83062af85e77" />


Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.


