### PR TITLE
fix(tools): improve curriculum build, but with correct caching

### DIFF
--- a/curriculum/package.json
+++ b/curriculum/package.json
@@ -27,7 +27,7 @@
   "author": "freeCodeCamp <team@freecodecamp.org>",
   "scripts": {
     "audit-challenges": "pnpm turbo setup && tsx ./src/challenge-auditor/index.ts",
-    "build": "tsc && tsx ./src/generate/build-curriculum",
+    "build": "node ./dist/generate/build-curriculum",
     "type-check": "tsc --noEmit",
     "create-empty-steps": "tsx --tsconfig ../tools/challenge-helper-scripts/tsconfig.json ../tools/challenge-helper-scripts/create-empty-steps",
     "create-next-challenge": "tsx --tsconfig ../tools/challenge-helper-scripts/tsconfig.json ../tools/challenge-helper-scripts/create-next-challenge",
@@ -46,6 +46,7 @@
     "reorder-tasks": "tsx --tsconfig ../tools/challenge-helper-scripts/tsconfig.json ../tools/challenge-helper-scripts/reorder-tasks",
     "update-challenge-order": "tsx --tsconfig ../tools/challenge-helper-scripts/tsconfig.json ../tools/challenge-helper-scripts/update-challenge-order",
     "update-step-titles": "tsx --tsconfig ../tools/challenge-helper-scripts/tsconfig.json ../tools/challenge-helper-scripts/update-step-titles",
+    "setup": "tsc",
     "test": "NODE_OPTIONS='--max-old-space-size=7168' pnpm test-gen && vitest run",
     "test:watch": "pnpm test-gen && vitest",
     "test-gen": "tsx ./src/test/utils/generate-block-tests.ts",

--- a/curriculum/turbo.json
+++ b/curriculum/turbo.json
@@ -6,6 +6,9 @@
       "outputs": ["dist/**", "generated/**"],
       "env": ["FCC_*", "SHOW_UPCOMING_CHANGES", "CURRICULUM_LOCALE"]
     },
+    "setup": {
+      "outputs": ["dist/**"]
+    },
     "test": {
       "passThroughEnv": ["VITEST_POOL_ID", "PUPPETEER_WS_ENDPOINT"],
       "env": ["FCC_*", "CURRICULUM_LOCALE", "SHOW_UPCOMING_CHANGES"]


### PR DESCRIPTION
This reverts commit fba37af181aac52a1e9dd92b66501e09fc55a9c2.

It restores https://github.com/freeCodeCamp/freeCodeCamp/pull/66321, but makes sure `setup`'s output (the compiled code) is cached.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->
