### PR TITLE
refactor: add session-user endpoint

### DIFF
--- a/api/src/routes/protected/challenge.test.ts
+++ b/api/src/routes/protected/challenge.test.ts
@@ -2222,7 +2222,7 @@ describe('challengeRoutes', () => {
             (typeof getSessionUser)['response']['200']
           >['user'];
 
-          const res = (await superGet('/user/get-session-user')).body as {
+          const res = (await superGet('/user/session-user')).body as {
             user: GetSessionUserResponseBody;
           };
 

--- a/api/src/routes/protected/challenge.test.ts
+++ b/api/src/routes/protected/challenge.test.ts
@@ -2222,7 +2222,7 @@ describe('challengeRoutes', () => {
             (typeof getSessionUser)['response']['200']
           >['user'];
 
-          const res = (await superGet('/user/session-user')).body as {
+          const res = (await superGet('/user/get-session-user')).body as {
             user: GetSessionUserResponseBody;
           };
 

--- a/api/src/routes/protected/user.test.ts
+++ b/api/src/routes/protected/user.test.ts
@@ -891,7 +891,7 @@ describe('userRoutes', () => {
           data: { username: '' }
         });
 
-        const response = await superGet('/user/session-user');
+        const response = await superGet('/user/get-session-user');
 
         expect(response.body).toStrictEqual({ user: {}, result: '' });
         expect(response.statusCode).toBe(500);
@@ -900,13 +900,13 @@ describe('userRoutes', () => {
       // This should help debugging, since this the route returns this if
       // anything throws in the handler.
       test('GET does not return the error response if the request is valid', async () => {
-        const response = await superGet('/user/session-user');
+        const response = await superGet('/user/get-session-user');
 
         expect(response.body).not.toEqual({ user: {}, result: '' });
       });
 
       test('GET returns username as the result property', async () => {
-        const response = await superGet('/user/session-user');
+        const response = await superGet('/user/get-session-user');
 
         expect(response.body).toMatchObject({
           result: testUserData.username
@@ -926,7 +926,7 @@ describe('userRoutes', () => {
           joinDate: new ObjectId(testUser?.id).getTimestamp().toISOString()
         };
 
-        const response = await superGet('/user/session-user');
+        const response = await superGet('/user/get-session-user');
         const {
           user: { foobar }
         } = response.body as unknown as {
@@ -953,7 +953,7 @@ describe('userRoutes', () => {
         const tokens = await fastifyTestInstance.prisma.userToken.count();
         expect(tokens).toBe(1);
 
-        const response = await superGet('/user/session-user');
+        const response = await superGet('/user/get-session-user');
 
         const { userToken } = jwt.decode(
           response.body.user.foobar.userToken
@@ -970,7 +970,7 @@ describe('userRoutes', () => {
         const msUsernames = await fastifyTestInstance.prisma.msUsername.count();
         expect(msUsernames).toBe(1);
 
-        const response = await superGet('/user/session-user');
+        const response = await superGet('/user/get-session-user');
 
         const { msUsername } = response.body.user.foobar;
 
@@ -1053,7 +1053,7 @@ describe('userRoutes', () => {
           theme: 'default'
         };
 
-        const response = await superRequest('/user/session-user', {
+        const response = await superRequest('/user/get-session-user', {
           method: 'GET',
           setCookies
         });
@@ -1625,9 +1625,9 @@ Thanks and regards,
       });
     });
 
-    describe('/user/session-user', () => {
+    describe('/user/get-session-user', () => {
       test('GET returns 200 with empty user object for unauthenticated users', async () => {
-        const response = await superRequest('/user/session-user', {
+        const response = await superRequest('/user/get-session-user', {
           method: 'GET',
           setCookies
         });

--- a/api/src/routes/protected/user.test.ts
+++ b/api/src/routes/protected/user.test.ts
@@ -891,7 +891,7 @@ describe('userRoutes', () => {
           data: { username: '' }
         });
 
-        const response = await superGet('/user/get-session-user');
+        const response = await superGet('/user/session-user');
 
         expect(response.body).toStrictEqual({ user: {}, result: '' });
         expect(response.statusCode).toBe(500);
@@ -900,13 +900,13 @@ describe('userRoutes', () => {
       // This should help debugging, since this the route returns this if
       // anything throws in the handler.
       test('GET does not return the error response if the request is valid', async () => {
-        const response = await superGet('/user/get-session-user');
+        const response = await superGet('/user/session-user');
 
         expect(response.body).not.toEqual({ user: {}, result: '' });
       });
 
       test('GET returns username as the result property', async () => {
-        const response = await superGet('/user/get-session-user');
+        const response = await superGet('/user/session-user');
 
         expect(response.body).toMatchObject({
           result: testUserData.username
@@ -926,7 +926,7 @@ describe('userRoutes', () => {
           joinDate: new ObjectId(testUser?.id).getTimestamp().toISOString()
         };
 
-        const response = await superGet('/user/get-session-user');
+        const response = await superGet('/user/session-user');
         const {
           user: { foobar }
         } = response.body as unknown as {
@@ -953,7 +953,7 @@ describe('userRoutes', () => {
         const tokens = await fastifyTestInstance.prisma.userToken.count();
         expect(tokens).toBe(1);
 
-        const response = await superGet('/user/get-session-user');
+        const response = await superGet('/user/session-user');
 
         const { userToken } = jwt.decode(
           response.body.user.foobar.userToken
@@ -970,7 +970,7 @@ describe('userRoutes', () => {
         const msUsernames = await fastifyTestInstance.prisma.msUsername.count();
         expect(msUsernames).toBe(1);
 
-        const response = await superGet('/user/get-session-user');
+        const response = await superGet('/user/session-user');
 
         const { msUsername } = response.body.user.foobar;
 
@@ -1053,7 +1053,7 @@ describe('userRoutes', () => {
           theme: 'default'
         };
 
-        const response = await superRequest('/user/get-session-user', {
+        const response = await superRequest('/user/session-user', {
           method: 'GET',
           setCookies
         });
@@ -1625,8 +1625,18 @@ Thanks and regards,
       });
     });
 
-    describe('/user/get-session-user', () => {
+    describe('/user/session-user', () => {
       test('GET returns 200 with empty user object for unauthenticated users', async () => {
+        const response = await superRequest('/user/session-user', {
+          method: 'GET',
+          setCookies
+        });
+
+        expect(response.statusCode).toBe(200);
+        expect(response.body).toStrictEqual({ user: {}, result: '' });
+      });
+
+      test('GET legacy endpoint returns 200 with empty user object for unauthenticated users', async () => {
         const response = await superRequest('/user/get-session-user', {
           method: 'GET',
           setCookies

--- a/api/src/routes/protected/user.test.ts
+++ b/api/src/routes/protected/user.test.ts
@@ -891,7 +891,7 @@ describe('userRoutes', () => {
           data: { username: '' }
         });
 
-        const response = await superGet('/user/get-session-user');
+        const response = await superGet('/user/session-user');
 
         expect(response.body).toStrictEqual({ user: {}, result: '' });
         expect(response.statusCode).toBe(500);
@@ -900,13 +900,13 @@ describe('userRoutes', () => {
       // This should help debugging, since this the route returns this if
       // anything throws in the handler.
       test('GET does not return the error response if the request is valid', async () => {
-        const response = await superGet('/user/get-session-user');
+        const response = await superGet('/user/session-user');
 
         expect(response.body).not.toEqual({ user: {}, result: '' });
       });
 
       test('GET returns username as the result property', async () => {
-        const response = await superGet('/user/get-session-user');
+        const response = await superGet('/user/session-user');
 
         expect(response.body).toMatchObject({
           result: testUserData.username
@@ -926,7 +926,7 @@ describe('userRoutes', () => {
           joinDate: new ObjectId(testUser?.id).getTimestamp().toISOString()
         };
 
-        const response = await superGet('/user/get-session-user');
+        const response = await superGet('/user/session-user');
         const {
           user: { foobar }
         } = response.body as unknown as {
@@ -953,7 +953,7 @@ describe('userRoutes', () => {
         const tokens = await fastifyTestInstance.prisma.userToken.count();
         expect(tokens).toBe(1);
 
-        const response = await superGet('/user/get-session-user');
+        const response = await superGet('/user/session-user');
 
         const { userToken } = jwt.decode(
           response.body.user.foobar.userToken
@@ -970,7 +970,7 @@ describe('userRoutes', () => {
         const msUsernames = await fastifyTestInstance.prisma.msUsername.count();
         expect(msUsernames).toBe(1);
 
-        const response = await superGet('/user/get-session-user');
+        const response = await superGet('/user/session-user');
 
         const { msUsername } = response.body.user.foobar;
 
@@ -1053,7 +1053,7 @@ describe('userRoutes', () => {
           theme: 'default'
         };
 
-        const response = await superRequest('/user/get-session-user', {
+        const response = await superRequest('/user/session-user', {
           method: 'GET',
           setCookies
         });
@@ -1625,9 +1625,9 @@ Thanks and regards,
       });
     });
 
-    describe('/user/get-session-user', () => {
+    describe('/user/session-user', () => {
       test('GET returns 200 with empty user object for unauthenticated users', async () => {
-        const response = await superRequest('/user/get-session-user', {
+        const response = await superRequest('/user/session-user', {
           method: 'GET',
           setCookies
         });

--- a/api/src/routes/protected/user.ts
+++ b/api/src/routes/protected/user.ts
@@ -651,196 +651,203 @@ export const userGetRoutes: FastifyPluginCallbackTypebox = (
   _options,
   done
 ) => {
+  const getSessionUserHandler = async (
+    req: UpdateReqType<typeof schemas.getSessionUser>,
+    res: FastifyReply
+  ) => {
+    const logger = fastify.log.child({ req, res });
+    // This is one of the most requested routes. To avoid spamming the logs
+    // with this route, we'll log requests at the debug level.
+    logger.debug({ userId: req.user?.id });
+
+    // Handle unauthenticated users - this is not an error, it's how the client
+    // determines if they are signed in or not
+    if (!req.user?.id) {
+      logger.debug('Unauthenticated user requested session');
+      return { user: {}, result: '' };
+    }
+
+    try {
+      const userTokenP = fastify.prisma.userToken.findFirst({
+        where: { userId: req.user.id }
+      });
+
+      const userP = fastify.prisma.user.findUnique({
+        where: { id: req.user.id },
+        select: {
+          about: true,
+          acceptedPrivacyTerms: true,
+          completedChallenges: true,
+          completedDailyCodingChallenges: true,
+          completedExams: true,
+          currentChallengeId: true,
+          quizAttempts: true,
+          email: true,
+          emailVerified: true,
+          githubProfile: true,
+          id: true,
+          is2018DataVisCert: true,
+          is2018FullStackCert: true,
+          isA2EnglishCert: true,
+          isApisMicroservicesCert: true,
+          isBackEndCert: true,
+          isCheater: true,
+          isCollegeAlgebraPyCertV8: true,
+          isDataAnalysisPyCertV7: true,
+          isDataVisCert: true,
+          isDonating: true,
+          isFoundationalCSharpCertV8: true,
+          isFrontEndCert: true,
+          isFrontEndLibsCert: true,
+          isFullStackCert: true,
+          isHonest: true,
+          isInfosecCertV7: true,
+          isInfosecQaCert: true,
+          isJavascriptCertV9: true,
+          isJsAlgoDataStructCert: true,
+          isJsAlgoDataStructCertV8: true,
+          isMachineLearningPyCertV7: true,
+          isPythonCertV9: true,
+          isQaCertV7: true,
+          isRelationalDatabaseCertV8: true,
+          isRelationalDatabaseCertV9: true,
+          isRespWebDesignCert: true,
+          isRespWebDesignCertV9: true,
+          isSciCompPyCertV7: true,
+          isFrontEndLibsCertV9: true,
+          isBackEndDevApisCertV9: true,
+          isFullStackDeveloperCertV9: true,
+          isB1EnglishCert: true,
+          isA2SpanishCert: true,
+          isA2ChineseCert: true,
+          isA1ChineseCert: true,
+          keyboardShortcuts: true,
+          linkedin: true,
+          location: true,
+          name: true,
+          partiallyCompletedChallenges: true,
+          picture: true,
+          portfolio: true,
+          experience: true,
+          profileUI: true,
+          progressTimestamps: true,
+          savedChallenges: true,
+          sendQuincyEmail: true,
+          theme: true,
+          twitter: true,
+          bluesky: true,
+          username: true,
+          usernameDisplay: true,
+          website: true,
+          yearsTopContributor: true
+        }
+      });
+
+      const completedSurveysP = fastify.prisma.survey.findMany({
+        where: { userId: req.user.id }
+      });
+
+      const msUsernameP = fastify.prisma.msUsername.findFirst({
+        where: { userId: req.user.id }
+      });
+
+      const [userToken, user, completedSurveys, msUsername] = await Promise.all(
+        [userTokenP, userP, completedSurveysP, msUsernameP]
+      );
+
+      if (!user?.username) {
+        logger.error(`User ${req.user?.id} has no username`);
+        void res.code(500);
+        return { user: {}, result: '' };
+      }
+      // TODO: DRY this (the creation of the response body) and
+      // get-public-profile's response body creation.
+
+      const encodedToken = userToken
+        ? encodeUserToken(userToken.id)
+        : undefined;
+
+      const [flags, rest] = splitUser(user);
+
+      const {
+        email,
+        emailVerified,
+        username,
+        usernameDisplay,
+        completedChallenges,
+        completedDailyCodingChallenges,
+        progressTimestamps,
+        twitter,
+        bluesky,
+        profileUI,
+        currentChallengeId,
+        location,
+        name,
+        theme,
+        experience,
+        ...publicUser
+      } = rest;
+
+      await res.send({
+        user: {
+          [username]: {
+            ...removeNulls(publicUser),
+            sendQuincyEmail: publicUser.sendQuincyEmail,
+            ...normalizeFlags(flags),
+            picture: publicUser.picture ?? '',
+            email: email ?? '',
+            currentChallengeId: currentChallengeId ?? '',
+            completedChallenges: normalizeChallenges(completedChallenges),
+            completedChallengeCount: completedChallenges.length,
+            completedDailyCodingChallenges,
+            // This assertion is necessary until the database is normalized.
+            calendar: getCalendar(
+              progressTimestamps as ProgressTimestamp[] | null
+            ),
+            emailVerified: !!emailVerified,
+            // This assertion is necessary until the database is normalized.
+            points: getPoints(progressTimestamps as ProgressTimestamp[] | null),
+            profileUI: normalizeProfileUI(profileUI),
+            // TODO(Post-MVP) remove this and just use emailVerified
+            isEmailVerified: !!emailVerified,
+            joinDate: new ObjectId(user.id).getTimestamp().toISOString(),
+            location: location ?? '',
+            name: name ?? '',
+            theme: theme ?? 'default',
+            twitter: normalizeTwitter(twitter),
+            bluesky: normalizeBluesky(bluesky),
+            username,
+            usernameDisplay: usernameDisplay || username,
+            userToken: encodedToken,
+            completedSurveys: normalizeSurveys(completedSurveys),
+            experience: experience.map(removeNulls),
+            msUsername: msUsername?.msUsername
+          }
+        },
+        result: user.username
+      });
+    } catch (err) {
+      logger.error(err);
+      fastify.Sentry.captureException(err);
+      void res.code(500);
+      return { user: {}, result: '' };
+    }
+  };
+
   fastify.get(
     '/user/get-session-user',
     {
       schema: schemas.getSessionUser
     },
-    async (req, res) => {
-      const logger = fastify.log.child({ req, res });
-      // This is one of the most requested routes. To avoid spamming the logs
-      // with this route, we'll log requests at the debug level.
-      logger.debug({ userId: req.user?.id });
+    getSessionUserHandler
+  );
 
-      // Handle unauthenticated users - this is not an error, it's how the client
-      // determines if they are signed in or not
-      if (!req.user?.id) {
-        logger.debug('Unauthenticated user requested session');
-        return { user: {}, result: '' };
-      }
-
-      try {
-        const userTokenP = fastify.prisma.userToken.findFirst({
-          where: { userId: req.user.id }
-        });
-
-        const userP = fastify.prisma.user.findUnique({
-          where: { id: req.user.id },
-          select: {
-            about: true,
-            acceptedPrivacyTerms: true,
-            completedChallenges: true,
-            completedDailyCodingChallenges: true,
-            completedExams: true,
-            currentChallengeId: true,
-            quizAttempts: true,
-            email: true,
-            emailVerified: true,
-            githubProfile: true,
-            id: true,
-            is2018DataVisCert: true,
-            is2018FullStackCert: true,
-            isA2EnglishCert: true,
-            isApisMicroservicesCert: true,
-            isBackEndCert: true,
-            isCheater: true,
-            isCollegeAlgebraPyCertV8: true,
-            isDataAnalysisPyCertV7: true,
-            isDataVisCert: true,
-            isDonating: true,
-            isFoundationalCSharpCertV8: true,
-            isFrontEndCert: true,
-            isFrontEndLibsCert: true,
-            isFullStackCert: true,
-            isHonest: true,
-            isInfosecCertV7: true,
-            isInfosecQaCert: true,
-            isJavascriptCertV9: true,
-            isJsAlgoDataStructCert: true,
-            isJsAlgoDataStructCertV8: true,
-            isMachineLearningPyCertV7: true,
-            isPythonCertV9: true,
-            isQaCertV7: true,
-            isRelationalDatabaseCertV8: true,
-            isRelationalDatabaseCertV9: true,
-            isRespWebDesignCert: true,
-            isRespWebDesignCertV9: true,
-            isSciCompPyCertV7: true,
-            isFrontEndLibsCertV9: true,
-            isBackEndDevApisCertV9: true,
-            isFullStackDeveloperCertV9: true,
-            isB1EnglishCert: true,
-            isA2SpanishCert: true,
-            isA2ChineseCert: true,
-            isA1ChineseCert: true,
-            keyboardShortcuts: true,
-            linkedin: true,
-            location: true,
-            name: true,
-            partiallyCompletedChallenges: true,
-            picture: true,
-            portfolio: true,
-            experience: true,
-            profileUI: true,
-            progressTimestamps: true,
-            savedChallenges: true,
-            sendQuincyEmail: true,
-            theme: true,
-            twitter: true,
-            bluesky: true,
-            username: true,
-            usernameDisplay: true,
-            website: true,
-            yearsTopContributor: true
-          }
-        });
-
-        const completedSurveysP = fastify.prisma.survey.findMany({
-          where: { userId: req.user.id }
-        });
-
-        const msUsernameP = fastify.prisma.msUsername.findFirst({
-          where: { userId: req.user.id }
-        });
-
-        const [userToken, user, completedSurveys, msUsername] =
-          await Promise.all([
-            userTokenP,
-            userP,
-            completedSurveysP,
-            msUsernameP
-          ]);
-
-        if (!user?.username) {
-          logger.error(`User ${req.user?.id} has no username`);
-          void res.code(500);
-          return { user: {}, result: '' };
-        }
-        // TODO: DRY this (the creation of the response body) and
-        // get-public-profile's response body creation.
-
-        const encodedToken = userToken
-          ? encodeUserToken(userToken.id)
-          : undefined;
-
-        const [flags, rest] = splitUser(user);
-
-        const {
-          email,
-          emailVerified,
-          username,
-          usernameDisplay,
-          completedChallenges,
-          completedDailyCodingChallenges,
-          progressTimestamps,
-          twitter,
-          bluesky,
-          profileUI,
-          currentChallengeId,
-          location,
-          name,
-          theme,
-          experience,
-          ...publicUser
-        } = rest;
-
-        await res.send({
-          user: {
-            [username]: {
-              ...removeNulls(publicUser),
-              sendQuincyEmail: publicUser.sendQuincyEmail,
-              ...normalizeFlags(flags),
-              picture: publicUser.picture ?? '',
-              email: email ?? '',
-              currentChallengeId: currentChallengeId ?? '',
-              completedChallenges: normalizeChallenges(completedChallenges),
-              completedChallengeCount: completedChallenges.length,
-              completedDailyCodingChallenges,
-              // This assertion is necessary until the database is normalized.
-              calendar: getCalendar(
-                progressTimestamps as ProgressTimestamp[] | null
-              ),
-              emailVerified: !!emailVerified,
-              // This assertion is necessary until the database is normalized.
-              points: getPoints(
-                progressTimestamps as ProgressTimestamp[] | null
-              ),
-              profileUI: normalizeProfileUI(profileUI),
-              // TODO(Post-MVP) remove this and just use emailVerified
-              isEmailVerified: !!emailVerified,
-              joinDate: new ObjectId(user.id).getTimestamp().toISOString(),
-              location: location ?? '',
-              name: name ?? '',
-              theme: theme ?? 'default',
-              twitter: normalizeTwitter(twitter),
-              bluesky: normalizeBluesky(bluesky),
-              username,
-              usernameDisplay: usernameDisplay || username,
-              userToken: encodedToken,
-              completedSurveys: normalizeSurveys(completedSurveys),
-              experience: experience.map(removeNulls),
-              msUsername: msUsername?.msUsername
-            }
-          },
-          result: user.username
-        });
-      } catch (err) {
-        logger.error(err);
-        fastify.Sentry.captureException(err);
-        void res.code(500);
-        return { user: {}, result: '' };
-      }
-    }
+  fastify.get(
+    '/user/session-user',
+    {
+      schema: schemas.getSessionUser
+    },
+    getSessionUserHandler
   );
 
   done();

--- a/api/src/routes/protected/user.ts
+++ b/api/src/routes/protected/user.ts
@@ -652,7 +652,7 @@ export const userGetRoutes: FastifyPluginCallbackTypebox = (
   done
 ) => {
   fastify.get(
-    '/user/get-session-user',
+    '/user/session-user',
     {
       schema: schemas.getSessionUser
     },

--- a/api/src/routes/protected/user.ts
+++ b/api/src/routes/protected/user.ts
@@ -652,7 +652,7 @@ export const userGetRoutes: FastifyPluginCallbackTypebox = (
   done
 ) => {
   fastify.get(
-    '/user/session-user',
+    '/user/get-session-user',
     {
       schema: schemas.getSessionUser
     },

--- a/client/src/utils/ajax.ts
+++ b/client/src/utils/ajax.ts
@@ -153,7 +153,7 @@ export function getSessionUser(
   signal?: AbortSignal
 ): Promise<ResponseWithData<User | null>> {
   const responseWithData: Promise<ResponseWithData<ApiUserResponse>> = get(
-    '/user/session-user',
+    '/user/get-session-user',
     signal
   );
   // TODO: Once DB is migrated, no longer need to parse `files` -> `challengeFiles` etc.

--- a/client/src/utils/ajax.ts
+++ b/client/src/utils/ajax.ts
@@ -153,7 +153,7 @@ export function getSessionUser(
   signal?: AbortSignal
 ): Promise<ResponseWithData<User | null>> {
   const responseWithData: Promise<ResponseWithData<ApiUserResponse>> = get(
-    '/user/get-session-user',
+    '/user/session-user',
     signal
   );
   // TODO: Once DB is migrated, no longer need to parse `files` -> `challengeFiles` etc.

--- a/e2e/failed-updates.spec.ts
+++ b/e2e/failed-updates.spec.ts
@@ -35,7 +35,7 @@ test.describe('failed update flushing', () => {
   }) => {
     // Initially, the user has no completed challenges.
     const userRes = await request.get(
-      new URL('/user/get-session-user', process.env.API_LOCATION).toString()
+      new URL('/user/session-user', process.env.API_LOCATION).toString()
     );
     const completedChallenges = (await userRes.json()).user.developmentuser
       .completedChallenges;
@@ -74,7 +74,7 @@ test.describe('failed update flushing', () => {
     await submitRes;
 
     const updatedUserRes = await request.get(
-      new URL('/user/get-session-user', process.env.API_LOCATION).toString()
+      new URL('/user/session-user', process.env.API_LOCATION).toString()
     );
 
     // Now the user should have both completed challenges.

--- a/e2e/flash.spec.ts
+++ b/e2e/flash.spec.ts
@@ -43,7 +43,7 @@ test.describe('Flash Message component E2E test', () => {
 
   test('should be visible when a network error occurs', async ({ page }) => {
     await page.route(
-      '*/**/user/get-session-user',
+      '*/**/user/session-user',
       async route => await route.fulfill({ status: 500 })
     );
 

--- a/e2e/quincy-email-sign-up.spec.ts
+++ b/e2e/quincy-email-sign-up.spec.ts
@@ -150,7 +150,7 @@ test.describe('Email sign-up page when user is signed in', () => {
 
     // `sendQuincyEmail` is not set in the DB since the endpoint is mocked,
     // so we are overriding the user data once again to mimic the real behavior.
-    await page.route('*/**/user/get-session-user', async route => {
+    await page.route('*/**/user/session-user', async route => {
       const response = await route.fetch();
       const json = await response.json();
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Ref: #50734 (we'll close once the client use the new endpoint and the old endpoint is deprecated)

This PR supports the phased rollout by keeping both API endpoints live while moving the client to the new endpoint:

1. API serves both `/user/get-session-user` and `/user/session-user`.
2. Client + e2e tests use `/user/session-user`.
3. A follow-up PR can remove `/user/get-session-user` once the new client is fully deployed.

Implementation details:
- Added dual-route support in the API for session user.
- Updated API tests/challenge tests to use the new endpoint by default.
- Kept explicit legacy endpoint test coverage.
- Updated client/e2e references to the new endpoint.