### PR TITLE
feat(learn): add loading spinner for workshop project previews

### DIFF
--- a/client/src/templates/Challenges/components/project-preview-modal.css
+++ b/client/src/templates/Challenges/components/project-preview-modal.css
@@ -3,4 +3,18 @@
   padding: 0;
   min-height: 70vh;
   height: 70vh;
+  position: relative;
+}
+
+.project-preview-loader {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: var(--theme-color);
+  z-index: 10;
 }

--- a/client/src/templates/Challenges/components/project-preview-modal.tsx
+++ b/client/src/templates/Challenges/components/project-preview-modal.tsx
@@ -8,8 +8,12 @@ import {
   setEditorFocusability,
   projectPreviewMounted
 } from '../redux/actions';
-import { isProjectPreviewModalOpenSelector } from '../redux/selectors';
+import {
+  isProjectPreviewModalOpenSelector,
+  isProjectPreviewLoadingSelector
+} from '../redux/selectors';
 import { projectPreviewId } from '../utils/frame';
+import Loader from '../../../components/helpers/loader';
 import Preview from './preview';
 
 import './project-preview-modal.css';
@@ -26,10 +30,12 @@ interface Props {
   setEditorFocusability: (focusability: boolean) => void;
   previewTitle: string;
   closeText: string;
+  isProjectPreviewLoading: boolean;
 }
 
 const mapStateToProps = (state: unknown) => ({
-  isOpen: isProjectPreviewModalOpenSelector(state) as boolean
+  isOpen: isProjectPreviewModalOpenSelector(state) as boolean,
+  isProjectPreviewLoading: isProjectPreviewLoadingSelector(state) as boolean
 });
 const mapDispatchToProps = {
   closeModal,
@@ -44,7 +50,8 @@ function ProjectPreviewModal({
   challengeData = null,
   setEditorFocusability,
   previewTitle,
-  closeText
+  closeText,
+  isProjectPreviewLoading
 }: Props): JSX.Element {
   useEffect(() => {
     if (isOpen) setEditorFocusability(false);
@@ -65,6 +72,11 @@ function ProjectPreviewModal({
           previewId={projectPreviewId}
           previewMounted={() => projectPreviewMounted({ challengeData })}
         />
+        {isProjectPreviewLoading && (
+          <div className='project-preview-loader'>
+            <Loader />
+          </div>
+        )}
       </Modal.Body>
       <Modal.Footer>
         <Button

--- a/client/src/templates/Challenges/redux/action-types.js
+++ b/client/src/templates/Challenges/redux/action-types.js
@@ -34,6 +34,7 @@ export const actionTypes = createTypes(
     'setUserCompletedExam',
     'previewMounted',
     'projectPreviewMounted',
+    'projectPreviewBuilt',
     'storePortalWindow',
     'removePortalWindow',
     'challengeMounted',

--- a/client/src/templates/Challenges/redux/actions.js
+++ b/client/src/templates/Challenges/redux/actions.js
@@ -49,6 +49,9 @@ export const previewMounted = createAction(actionTypes.previewMounted);
 export const projectPreviewMounted = createAction(
   actionTypes.projectPreviewMounted
 );
+export const projectPreviewBuilt = createAction(
+  actionTypes.projectPreviewBuilt
+);
 
 export const storePortalWindow = createAction(actionTypes.storePortalWindow);
 export const removePortalWindow = createAction(actionTypes.removePortalWindow);

--- a/client/src/templates/Challenges/redux/execute-challenge-saga.js
+++ b/client/src/templates/Challenges/redux/execute-challenge-saga.js
@@ -50,6 +50,7 @@ import {
   initLogs,
   logsToConsole,
   openModal,
+  projectPreviewBuilt,
   updateConsole,
   updateLogs,
   updateTests
@@ -384,6 +385,8 @@ function* previewProjectSolutionSaga({ payload }) {
   } catch (err) {
     console.error('Unable to show project preview');
     console.error(err);
+  } finally {
+    yield put(projectPreviewBuilt());
   }
 }
 

--- a/client/src/templates/Challenges/redux/index.js
+++ b/client/src/templates/Challenges/redux/index.js
@@ -58,7 +58,8 @@ const initialState = {
   successMessage: 'Happy Coding!',
   isAdvancing: false,
   chapterSlug: '',
-  isSubmitting: false
+  isSubmitting: false,
+  isProjectPreviewLoading: false
 };
 
 export const epics = [completionEpic, createQuestionEpic, codeStorageEpic];
@@ -252,6 +253,14 @@ export const reducer = handleActions(
     [actionTypes.setUserCompletedExam]: (state, { payload }) => ({
       ...state,
       userCompletedExam: payload
+    }),
+    [actionTypes.projectPreviewMounted]: state => ({
+      ...state,
+      isProjectPreviewLoading: true
+    }),
+    [actionTypes.projectPreviewBuilt]: state => ({
+      ...state,
+      isProjectPreviewLoading: false
     }),
     [actionTypes.closeModal]: (state, { payload }) => ({
       ...state,

--- a/client/src/templates/Challenges/redux/selectors.js
+++ b/client/src/templates/Challenges/redux/selectors.js
@@ -194,3 +194,5 @@ export const canFocusEditorSelector = state => state[ns].canFocusEditor;
 export const visibleEditorsSelector = state => state[ns].visibleEditors;
 export const showPreviewPortalSelector = state => state[ns].showPreviewPortal;
 export const showPreviewPaneSelector = state => state[ns].showPreviewPane;
+export const isProjectPreviewLoadingSelector = state =>
+  state[ns].isProjectPreviewLoading;

--- a/curriculum/challenges/english/blocks/workshop-balance-sheet/62018c3e94434a71af1d5eaa.md
+++ b/curriculum/challenges/english/blocks/workshop-balance-sheet/62018c3e94434a71af1d5eaa.md
@@ -7,7 +7,9 @@ dashedName: step-53
 
 # --description--
 
-Create a selector to target your `td` elements within your table body. Give them a width to fill the viewport, with a minimum and maximum of `4rem`. This approach ensures that the width is fixed, whereas setting `width` specifically would allow the elements to shrink to the container.
+Create a selector to target the `td` elements within your `tbody`. 
+
+To ensure your columns have a consistent width across the different `table` elements, you can use a "greedy" width approach. Set the `width` to `100vw` — this forces the cells to try and take up as much horizontal space as possible. Then, use the `min-width` and `max-width` properties to clamp that width to exactly `4rem`. This combination ensures the cells are always `4rem` wide, regardless of the content or the table's container width.
 
 # --hints--
 


### PR DESCRIPTION
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #62408

This adds a loading spinner (`<Loader />`) to the "What you will build" modal for React-based workshop challenges. 
By tracking the iframe build status via a new `isProjectPreviewLoading` Redux state (toggled by the `projectPreviewMounted` and a new `projectPreviewBuilt` action), this prevents the modal from appearing completely blank and confusing the user while the project loads.