### PR TITLE
fix(curriculum): remove before/after-user-code from first 5 rosetta challenges

### DIFF
--- a/curriculum/challenges/english/blocks/rosetta-code-challenges/594810f028c0303b75339acb.md
+++ b/curriculum/challenges/english/blocks/rosetta-code-challenges/594810f028c0303b75339acb.md
@@ -31,16 +31,11 @@ assert(Array.isArray(getFinalOpenedDoors(100)));
 `getFinalOpenedDoors` should produce the correct result.
 
 ```js
+const solution = [1, 4, 9, 16, 25, 36, 49, 64, 81, 100];
 assert.deepEqual(getFinalOpenedDoors(100), solution);
 ```
 
 # --seed--
-
-## --after-user-code--
-
-```js
-const solution = [1, 4, 9, 16, 25, 36, 49, 64, 81, 100];
-```
 
 ## --seed-contents--
 

--- a/curriculum/challenges/english/blocks/rosetta-code-challenges/594810f028c0303b75339acc.md
+++ b/curriculum/challenges/english/blocks/rosetta-code-challenges/594810f028c0303b75339acc.md
@@ -43,6 +43,12 @@ Some rules to keep in mind:
   <li>The function should be case-insensitive.</li>
 </ul>
 
+# --before-each--
+
+```js
+const words = ['bark', 'BooK', 'TReAT', 'COMMON', 'squAD', 'conFUSE'];
+```
+
 # --hints--
 
 `canMakeWord` should be a function.
@@ -94,12 +100,6 @@ assert(canMakeWord(words[5]));
 ```
 
 # --seed--
-
-## --after-user-code--
-
-```js
-const words = ['bark', 'BooK', 'TReAT', 'COMMON', 'squAD', 'conFUSE'];
-```
 
 ## --seed-contents--
 

--- a/curriculum/challenges/english/blocks/rosetta-code-challenges/594810f028c0303b75339ace.md
+++ b/curriculum/challenges/english/blocks/rosetta-code-challenges/594810f028c0303b75339ace.md
@@ -48,7 +48,7 @@ Passing in the values 3, -4, 1.5, and 5 should return 5.5.
 assert(testFn && testFn(5) === 5.5);
 ```
 
-## --before-each--
+# --before-all--
 
 ```js
 const testFn = typeof accumulator === 'function' && accumulator(3);

--- a/curriculum/challenges/english/blocks/rosetta-code-challenges/594810f028c0303b75339ace.md
+++ b/curriculum/challenges/english/blocks/rosetta-code-challenges/594810f028c0303b75339ace.md
@@ -48,7 +48,7 @@ Passing in the values 3, -4, 1.5, and 5 should return 5.5.
 assert(testFn && testFn(5) === 5.5);
 ```
 
-# --before-all--
+# --before-each--
 
 ```js
 const testFn = typeof accumulator === 'function' && accumulator(3);

--- a/curriculum/challenges/english/blocks/rosetta-code-challenges/594810f028c0303b75339ace.md
+++ b/curriculum/challenges/english/blocks/rosetta-code-challenges/594810f028c0303b75339ace.md
@@ -45,12 +45,17 @@ assert(typeof accumulator(0)(2) === 'number');
 Passing in the values 3, -4, 1.5, and 5 should return 5.5.
 
 ```js
-const testFn = typeof accumulator(3) === 'function' && accumulator(3);
+assert(testFn && testFn(5) === 5.5);
+```
+
+## --before-each--
+
+```js
+const testFn = typeof accumulator === 'function' && accumulator(3);
 if (testFn) {
   testFn(-4);
   testFn(1.5);
 }
-assert(testFn(5) === 5.5);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/rosetta-code-challenges/594810f028c0303b75339ace.md
+++ b/curriculum/challenges/english/blocks/rosetta-code-challenges/594810f028c0303b75339ace.md
@@ -45,20 +45,15 @@ assert(typeof accumulator(0)(2) === 'number');
 Passing in the values 3, -4, 1.5, and 5 should return 5.5.
 
 ```js
-assert(testFn(5) === 5.5);
-```
-
-# --seed--
-
-## --after-user-code--
-
-```js
 const testFn = typeof accumulator(3) === 'function' && accumulator(3);
 if (testFn) {
   testFn(-4);
   testFn(1.5);
 }
+assert(testFn(5) === 5.5);
 ```
+
+# --seed--
 
 ## --seed-contents--
 

--- a/curriculum/challenges/english/blocks/rosetta-code-challenges/594810f028c0303b75339ad0.md
+++ b/curriculum/challenges/english/blocks/rosetta-code-challenges/594810f028c0303b75339ad0.md
@@ -46,35 +46,7 @@ For example, one of the lines from the `testText`, after justifying to the right
 '  column      are     separated   by     at    least      one    space.\n'
 ```
 
-# --hints--
-
-`formatText` should be a function.
-
-```js
-assert(typeof formatText === 'function');
-```
-
-`formatText(testText, 'right')` should produce text with columns justified to the right.
-
-```js
-assert.strictEqual(formatText(_testText, 'right'), rightAligned);
-```
-
-`formatText(testText, 'left')` should produce text with columns justified to the left.
-
-```js
-assert.strictEqual(formatText(_testText, 'left'), leftAligned);
-```
-
-`formatText(testText, 'center')` should produce text with columns justified to the center.
-
-```js
-assert.strictEqual(formatText(_testText, 'center'), centerAligned);
-```
-
-# --seed--
-
-## --after-user-code--
+# --before-each--
 
 ```js
 const _testText = [
@@ -123,6 +95,34 @@ const centerAligned = '  Given        a        text     file    of     many     
 'justified,   right    justified\n' +
 '    or       center   justified within  its   column. ';
 ```
+
+# --hints--
+
+`formatText` should be a function.
+
+```js
+assert(typeof formatText === 'function');
+```
+
+`formatText(testText, 'right')` should produce text with columns justified to the right.
+
+```js
+assert.strictEqual(formatText(_testText, 'right'), rightAligned);
+```
+
+`formatText(testText, 'left')` should produce text with columns justified to the left.
+
+```js
+assert.strictEqual(formatText(_testText, 'left'), leftAligned);
+```
+
+`formatText(testText, 'center')` should produce text with columns justified to the center.
+
+```js
+assert.strictEqual(formatText(_testText, 'center'), centerAligned);
+```
+
+# --seed--
 
 ## --seed-contents--
 

--- a/curriculum/challenges/english/blocks/rosetta-code-challenges/594810f028c0303b75339ad2.md
+++ b/curriculum/challenges/english/blocks/rosetta-code-challenges/594810f028c0303b75339ad2.md
@@ -31,19 +31,14 @@ assert.equal(crossProduct(), null);
 `crossProduct([1, 2, 3], [4, 5, 6])` should return `[-3, 6, -3]`.
 
 ```js
-assert.deepEqual(res12, exp12);
-```
-
-# --seed--
-
-## --after-user-code--
-
-```js
 const tv1 = [1, 2, 3];
 const tv2 = [4, 5, 6];
 const res12 = crossProduct(tv1, tv2);
 const exp12 = [-3, 6, -3];
+assert.deepEqual(res12, exp12);
 ```
+
+# --seed--
 
 ## --seed-contents--
 

--- a/curriculum/challenges/english/blocks/rosetta-code-challenges/594810f028c0303b75339ad2.md
+++ b/curriculum/challenges/english/blocks/rosetta-code-challenges/594810f028c0303b75339ad2.md
@@ -31,11 +31,16 @@ assert.equal(crossProduct(), null);
 `crossProduct([1, 2, 3], [4, 5, 6])` should return `[-3, 6, -3]`.
 
 ```js
+assert.deepEqual(res12, exp12);
+```
+
+## --before-each--
+
+```js
 const tv1 = [1, 2, 3];
 const tv2 = [4, 5, 6];
 const res12 = crossProduct(tv1, tv2);
 const exp12 = [-3, 6, -3];
-assert.deepEqual(res12, exp12);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/rosetta-code-challenges/594810f028c0303b75339ad2.md
+++ b/curriculum/challenges/english/blocks/rosetta-code-challenges/594810f028c0303b75339ad2.md
@@ -34,7 +34,7 @@ assert.equal(crossProduct(), null);
 assert.deepEqual(res12, exp12);
 ```
 
-## --before-each--
+# --before-each--
 
 ```js
 const tv1 = [1, 2, 3];


### PR DESCRIPTION
## Description
- migrate the `rosetta-code-challenges` superblock away from `--before-user-code--` / `--after-user-code--` wrappers
- keep learner-facing code in `# --seed--` only
- move required hidden setup into the hint test blocks so challenge behavior remains unchanged

## Testing
- `cd curriculum/src/test`
- `CURRICULUM_LOCALE=english ../../node_modules/.bin/vitest run --config vitest.config.mjs blocks-generated/rosetta-code-challenges.test.js`
- result: `801 passed, 0 failed`

Refs #57107
