### PR TITLE
refactor(api): rename get-session-user endpoint to session-user

### DIFF
--- a/api/src/routes/protected/challenge.test.ts
+++ b/api/src/routes/protected/challenge.test.ts
@@ -2222,7 +2222,7 @@ describe('challengeRoutes', () => {
             (typeof getSessionUser)['response']['200']
           >['user'];
 
-          const res = (await superGet('/user/get-session-user')).body as {
+          const res = (await superGet('/user/session-user')).body as {
             user: GetSessionUserResponseBody;
           };
 

--- a/api/src/routes/protected/user.test.ts
+++ b/api/src/routes/protected/user.test.ts
@@ -891,7 +891,7 @@ describe('userRoutes', () => {
           data: { username: '' }
         });
 
-        const response = await superGet('/user/get-session-user');
+        const response = await superGet('/user/session-user');
 
         expect(response.body).toStrictEqual({ user: {}, result: '' });
         expect(response.statusCode).toBe(500);
@@ -900,13 +900,13 @@ describe('userRoutes', () => {
       // This should help debugging, since this the route returns this if
       // anything throws in the handler.
       test('GET does not return the error response if the request is valid', async () => {
-        const response = await superGet('/user/get-session-user');
+        const response = await superGet('/user/session-user');
 
         expect(response.body).not.toEqual({ user: {}, result: '' });
       });
 
       test('GET returns username as the result property', async () => {
-        const response = await superGet('/user/get-session-user');
+        const response = await superGet('/user/session-user');
 
         expect(response.body).toMatchObject({
           result: testUserData.username
@@ -926,7 +926,7 @@ describe('userRoutes', () => {
           joinDate: new ObjectId(testUser?.id).getTimestamp().toISOString()
         };
 
-        const response = await superGet('/user/get-session-user');
+        const response = await superGet('/user/session-user');
         const {
           user: { foobar }
         } = response.body as unknown as {
@@ -953,7 +953,7 @@ describe('userRoutes', () => {
         const tokens = await fastifyTestInstance.prisma.userToken.count();
         expect(tokens).toBe(1);
 
-        const response = await superGet('/user/get-session-user');
+        const response = await superGet('/user/session-user');
 
         const { userToken } = jwt.decode(
           response.body.user.foobar.userToken
@@ -970,7 +970,7 @@ describe('userRoutes', () => {
         const msUsernames = await fastifyTestInstance.prisma.msUsername.count();
         expect(msUsernames).toBe(1);
 
-        const response = await superGet('/user/get-session-user');
+        const response = await superGet('/user/session-user');
 
         const { msUsername } = response.body.user.foobar;
 
@@ -1053,7 +1053,7 @@ describe('userRoutes', () => {
           theme: 'default'
         };
 
-        const response = await superRequest('/user/get-session-user', {
+        const response = await superRequest('/user/session-user', {
           method: 'GET',
           setCookies
         });
@@ -1625,9 +1625,9 @@ Thanks and regards,
       });
     });
 
-    describe('/user/get-session-user', () => {
+    describe('/user/session-user', () => {
       test('GET returns 200 with empty user object for unauthenticated users', async () => {
-        const response = await superRequest('/user/get-session-user', {
+        const response = await superRequest('/user/session-user', {
           method: 'GET',
           setCookies
         });

--- a/api/src/routes/protected/user.ts
+++ b/api/src/routes/protected/user.ts
@@ -652,7 +652,7 @@ export const userGetRoutes: FastifyPluginCallbackTypebox = (
   done
 ) => {
   fastify.get(
-    '/user/get-session-user',
+    '/user/session-user',
     {
       schema: schemas.getSessionUser
     },


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #50734

This PR contains only API route + API test updates for the endpoint rename from `/user/get-session-user` to `/user/session-user`.

Companion PR (client/e2e updates): https://github.com/freeCodeCamp/freeCodeCamp/pull/66330