### PR TITLE
fix(curriculum): updated verb tense

### DIFF
--- a/curriculum/challenges/english/blocks/learn-how-to-manage-a-conversation/67e6d9c1c460d9cb00f55aa3.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-manage-a-conversation/67e6d9c1c460d9cb00f55aa3.md
@@ -76,7 +76,7 @@ Delay informing the team until the bug is fixed.
 
 ### --feedback--
 
-Jessica does not want to delay to inform the team.
+Jessica does not want to delay informing the team.
 
 ---
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #65952

<!-- Feel free to add any additional description of changes below this line -->

updated from : "Jessica does not want to delay **to inform** the team." to "Jessica does not want to delay **informing** the team."