### PR TITLE
fix(tools): use ObjectId filename in create-next-challenge and insert-challenge scripts

### DIFF
--- a/tools/challenge-helper-scripts/create-next-challenge.ts
+++ b/tools/challenge-helper-scripts/create-next-challenge.ts
@@ -14,7 +14,7 @@ const createNextChallenge = async () => {
   const challengeId = new ObjectId();
   const challengeText = template({ ...options, challengeId });
 
-  createChallengeFile(options.dashedName, challengeText, path);
+  createChallengeFile(challengeId.toString(), challengeText, path);
 
   const meta = getMetaData();
   meta.challengeOrder.push({

--- a/tools/challenge-helper-scripts/insert-challenge.ts
+++ b/tools/challenge-helper-scripts/insert-challenge.ts
@@ -27,7 +27,7 @@ const insertChallenge = async () => {
   const template = getTemplate(options.challengeType);
   const challengeId = new ObjectId();
   const challengeText = template({ ...options, challengeId });
-  createChallengeFile(options.dashedName, challengeText, path);
+  createChallengeFile(challengeId.toString(), challengeText, path);
 
   const meta = getMetaData();
   meta.challengeOrder.splice(indexToInsert, 0, {

--- a/tools/challenge-helper-scripts/utils.test.ts
+++ b/tools/challenge-helper-scripts/utils.test.ts
@@ -119,14 +119,15 @@ describe('Challenge utils helper scripts', () => {
   });
 
   describe('createChallengeFile util', () => {
-    it('should create the challenge', () => {
+    it('should create the challenge using an ObjectId string as the filename', () => {
       process.env.INIT_CWD = projectPath;
       const template = 'pretend this is a template';
+      const challengeId = new ObjectId();
 
-      createChallengeFile('hi', template);
-      // - Should write a file with a given name and template
+      createChallengeFile(challengeId.toString(), template);
+      // - Should write a file named after the ObjectId with the given template
       expect(fs.writeFileSync).toHaveBeenCalledWith(
-        `${projectPath}/hi.md`,
+        `${projectPath}/${challengeId.toString()}.md`,
         template
       );
     });


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #66354

## What changed and why

`create-next-challenge` and `insert-challenge` were writing new challenge files using the challenge's **dashed name** as the filename (e.g. `what-is-javascript.md`).

All v9/catalog blocks (`lecture`, `lab`, `learn`, `practice`, `warm-up`, etc.) use **ObjectId-based filenames** (e.g. `672d26385dbe73203c4dac81.md`). The old behaviour produced filenames inconsistent with the rest of the block, making the created file invisible in the challenge editor and out of sync with every other challenge in the block.

### Changes

- **`create-next-challenge.ts`** — pass `challengeId.toString()` instead of `options.dashedName` to `createChallengeFile`
- **`insert-challenge.ts`** — same fix
- **`utils.test.ts`** — updated the `createChallengeFile` test to assert an ObjectId-named file is written, matching the intended usage (consistent with how `create-next-task` and `insert-task` already call the function)

No changes were needed in `delete-challenge.ts` — it already locates files by scanning frontmatter `id`, so it works correctly regardless of filename convention.