### PR TITLE
fix(challenge-helper-scripts): auto-derive help category from challenge lang

### DIFF
--- a/tools/challenge-helper-scripts/create-language-block.ts
+++ b/tools/challenge-helper-scripts/create-language-block.ts
@@ -8,7 +8,7 @@ import {
   SuperBlocks,
   languageSuperBlocks,
   chapterBasedSuperBlocks,
-  type ChallengeLang
+  ChallengeLang
 } from '@freecodecamp/shared/config/curriculum';
 
 import { BlockLayouts, BlockLabel } from '@freecodecamp/shared/config/blocks';
@@ -32,11 +32,11 @@ import {
 } from './helpers/create-project.js';
 import { getLangFromSuperBlock } from './helpers/get-lang-from-superblock.js';
 
-const helpCategories = [
-  'English',
-  'Chinese Curriculum',
-  'Spanish Curriculum'
-] as const;
+const langToHelpCategory: Record<ChallengeLang, string> = {
+  [ChallengeLang.English]: 'English',
+  [ChallengeLang.Chinese]: 'Chinese Curriculum',
+  [ChallengeLang.Spanish]: 'Spanish Curriculum'
+};
 
 type BlockInfo = {
   title: string;
@@ -391,14 +391,7 @@ void getAllBlocks()
       default: block
     });
 
-    const helpCategory = await select<string>({
-      message: 'Choose a help category',
-      default: 'English',
-      choices: helpCategories.map(value => ({
-        name: value,
-        value
-      }))
-    });
+    const helpCategory = langToHelpCategory[getLangFromSuperBlock(superBlock)];
 
     let blockLayout: string | undefined;
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Updates the `create-new-language-block` script to derive the help category value from the `lang` property, rather than asking the user to select the category from the list.

<!-- Feel free to add any additional description of changes below this line -->
