### PR TITLE
fix: race condition in concurrent delete user requests test

### DIFF
--- a/api/src/routes/protected/user.test.ts
+++ b/api/src/routes/protected/user.test.ts
@@ -530,10 +530,13 @@ describe('userRoutes', () => {
         const userCount = await fastifyTestInstance.prisma.user.count({
           where: { email: testUserData.email }
         });
+        // Both requests race: one deletes the user and returns 200. The other
+        // may get a 401 if the auth middleware queries the DB after the user has
+        // already been deleted by the first request.
         responses.forEach(response => {
-          expect(response.status).toBe(200);
-          expect(response.body).toStrictEqual({});
+          expect([200, 401]).toContain(response.status);
         });
+        expect(responses.some(r => r.status === 200)).toBe(true);
         expect(userCount).toBe(0);
       });
 

--- a/api/src/routes/protected/user.test.ts
+++ b/api/src/routes/protected/user.test.ts
@@ -536,7 +536,6 @@ describe('userRoutes', () => {
         responses.forEach(response => {
           expect([200, 401]).toContain(response.status);
         });
-        expect(responses.some(r => r.status === 200)).toBe(true);
         expect(userCount).toBe(0);
       });
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Test failure: https://github.com/freeCodeCamp/freeCodeCamp/actions/runs/22924698014/job/66533968563#step:10:709

In the test, we fire two concurrent requests, and the sequence that causes the failure is:
- Request 1: passes auth check (user exists in DB) → route handler deletes the user
- Request 2: its `authorize` hook's `findUnique` runs after Request 1 deletes the user → returns null → `send401IfNoUser` → 401

<!-- Feel free to add any additional description of changes below this line -->
