### PR TITLE
fix(package): exclude transform-spread from babel preset-env to preserve native spread behavior

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-shopping-list-app/67ff8eacd3d965670c9121f9.md
+++ b/curriculum/challenges/english/blocks/workshop-shopping-list-app/67ff8eacd3d965670c9121f9.md
@@ -54,7 +54,7 @@ const exports = {};
 const a = eval(script);
 const shoppingListString = exports.ShoppingList.toString();
 
-assert.match(shoppingListString, /var\s*toggleItem\s*=\s*useCallback\s*\(\s*function\s*\(\s*item\s*\)\s*{\s*(return)?\s+setSelectedItems\s*\(\s*function\s*\(prev\)\s*{\s*return\s+prev\.includes\(item\)\s*\?\s*prev\.filter\(function\s*\(i\)\s*\{\s*return\s+i\s!==\sitem;\s*\}\s*\)\s*:\s*\[\].concat\(_toConsumableArray\(prev\),\s+\[item\]\);\s*}\);?/);
+assert.match(shoppingListString, /var\s*toggleItem\s*=\s*useCallback\s*\(\s*function\s*\(\s*item\s*\)\s*{\s*(return)?\s+setSelectedItems\s*\(\s*function\s*\(prev\)\s*{\s*return\s+prev\.includes\(item\)\s*\?\s*prev\.filter\(function\s*\(i\)\s*\{\s*return\s+i\s!==\sitem;\s*\}\s*\)\s*:\s*\[\.\.\.prev,\s*item\];\s*}\);?/);
 ```
 
 You should add `setSelectedItems` as the only dependency in the dependencies array.

--- a/packages/challenge-builder/src/transformers.js
+++ b/packages/challenge-builder/src/transformers.js
@@ -69,7 +69,7 @@ async function loadPresetEnv() {
     );
 
   presetsJS = {
-    presets: [presetEnv]
+    presets: [[presetEnv, { exclude: ['transform-spread'] }]]
   };
 }
 
@@ -84,7 +84,7 @@ async function loadPresetReact() {
     );
 
   presetsJSX = {
-    presets: [presetEnv, presetReact]
+    presets: [[presetEnv, { exclude: ['transform-spread'] }], presetReact]
   };
 }
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.


Closes #62199

Excluded `transform-spread` from `@babel/preset-env` options in 
`loadPresetEnv()` and `loadPresetReact()`.

Screenshot : 

<img width="1919" height="801" alt="image" src="https://github.com/user-attachments/assets/ef8340cd-098e-40d4-a665-89bdd682e572" />
