### PR TITLE
fix(curriculum): update verb tense in task-86 hint message

### DIFF
--- a/curriculum/challenges/english/blocks/learn-how-to-manage-a-conversation/67e6d9c1c460d9cb00f55aa3.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-manage-a-conversation/67e6d9c1c460d9cb00f55aa3.md
@@ -76,7 +76,7 @@ Delay informing the team until the bug is fixed.
 
 ### --feedback--
 
-Jessica does not want to delay to inform the team.
+Jessica does not want to delay informing the team.
 
 ---
 


### PR DESCRIPTION
Fixes #65952

Changed "delay to inform" to "delay informing" in the Task 86 hint message, using the correct present participle form of the verb as described in the issue.

Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #65952