### PR TITLE
feat: improve interactive editor console output

### DIFF
--- a/client/src/templates/Challenges/components/interactive-console.tsx
+++ b/client/src/templates/Challenges/components/interactive-console.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { useSandpackConsole } from '@codesandbox/sandpack-react';
+
+type LogEntry = {
+  id: string;
+  method: string;
+  data: unknown[];
+};
+
+interface InteractiveConsoleProps {
+  'data-playwright-test-label'?: string;
+  style?: React.CSSProperties;
+}
+
+function formatPrimitive(value: unknown): string {
+  if (value === null || value === undefined) return String(value);
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean')
+    return String(value);
+  if (Array.isArray(value)) return `[Array(${value.length})]`;
+  if (typeof value === 'object') return '{…}';
+  return JSON.stringify(value);
+}
+
+function formatValue(value: unknown): string {
+  if (value === null || value === undefined) return String(value);
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean')
+    return String(value);
+
+  if (typeof value === 'object') {
+    const obj = value as Record<string, unknown>;
+    const ctorName =
+      (obj as { constructor?: { name?: string } }).constructor?.name ??
+      'Object';
+
+    const entries = Object.entries(obj).filter(
+      ([key]) => key !== 'constructor' && key !== '__proto__'
+    );
+
+    const inner = entries
+      .map(([key, v]) => `${key}: ${formatPrimitive(v)}`)
+      .join(', ');
+
+    if (ctorName && ctorName !== 'Object') {
+      return `${ctorName} { ${inner} }`;
+    }
+
+    return `{ ${inner} }`;
+  }
+
+  return JSON.stringify(value);
+}
+
+const InteractiveConsole: React.FC<InteractiveConsoleProps> = props => {
+  const { logs } = useSandpackConsole({
+    resetOnPreviewRestart: true
+  });
+
+  const castLogs = (logs as unknown as LogEntry[]) ?? [];
+
+  return (
+    <div
+      data-playwright-test-label={props['data-playwright-test-label']}
+      style={{
+        fontFamily: 'monospace',
+        fontSize: '0.9rem',
+        backgroundColor: '#0a0a23',
+        color: '#ffffff',
+        padding: '0.5rem',
+        overflow: 'auto',
+        ...props.style
+      }}
+    >
+      {castLogs.map(log => (
+        <div key={log.id}>
+          {log.data.map((item, index) => (
+            <span key={index}>
+              {index > 0 ? ' ' : ''}
+              {formatValue(item)}
+            </span>
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+InteractiveConsole.displayName = 'InteractiveConsole';
+
+export default InteractiveConsole;

--- a/client/src/templates/Challenges/components/interactive-editor.tsx
+++ b/client/src/templates/Challenges/components/interactive-editor.tsx
@@ -1,7 +1,6 @@
 import React, { useMemo } from 'react';
 import {
   FileTabs,
-  SandpackConsole,
   SandpackLayout,
   SandpackPreview,
   SandpackProvider,
@@ -9,6 +8,7 @@ import {
 } from '@codesandbox/sandpack-react';
 import { freeCodeCampDark } from '@codesandbox/sandpack-themes';
 import './interactive-editor.css';
+import InteractiveConsole from './interactive-console';
 import CustomMonacoEditor from './custom-monaco-editor';
 
 export interface InteractiveFile {
@@ -106,11 +106,10 @@ const InteractiveEditor = ({ files }: Props) => {
                     data-playwright-test-label='sp-preview'
                     style={{ flex: 1.5 }}
                   />
-                  <SandpackConsole
+                  <InteractiveConsole
                     data-playwright-test-label='sp-console'
                     style={{
-                      flex: 1,
-                      overflow: 'scroll'
+                      flex: 1
                     }}
                   />
                 </>
@@ -118,10 +117,7 @@ const InteractiveEditor = ({ files }: Props) => {
                 <SandpackPreview />
               )
             ) : (
-              <SandpackConsole
-                data-playwright-test-label='sp-console'
-                standalone={true}
-              />
+              <InteractiveConsole data-playwright-test-label='sp-console' />
             )}
           </SandpackStack>
         </SandpackLayout>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #66302

<!-- Feel free to add any additional description of changes below this line -->

This updates the interactive editor to use a custom console built on `useSandpackConsole` instead of `SandpackConsole`.

When logging class instances (e.g. `Pizza` or `Movie`), the console output is now closer to Node/Chrome: it shows the constructor name and own properties, but does not include extra constructor/prototype metadata (such as `constructor: { name: "Pizza" }`). This matches the expected output in the JS v9 classes lectures and avoids confusing learners.

I attempted to run the client tests locally; the full suite fails on my setup due to missing monorepo packages (`@freecodecamp/shared/...`) and `client/config/env.json`.