### PR TITLE
fix: language selector hidden on small screens in daily coding challenge

### DIFF
--- a/client/src/templates/Challenges/classic/classic.css
+++ b/client/src/templates/Challenges/classic/classic.css
@@ -142,6 +142,19 @@
   flex-shrink: 0;
 }
 
+#mobile-layout .daily-challenge-language-selector {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 3px;
+  padding: 10px 10px 0;
+}
+
+#mobile-layout .daily-challenge-language-selector button {
+  padding: 6px 12px;
+  border-width: 3px;
+  border-style: solid;
+}
+
 /* Need to narrow width of tabs to make room for preview toggle button */
 #mobile-layout[data-haspreview='true'] [role='tablist'] {
   width: calc(100% - 2rem);

--- a/client/src/templates/Challenges/classic/mobile-layout.tsx
+++ b/client/src/templates/Challenges/classic/mobile-layout.tsx
@@ -4,7 +4,9 @@ import { faWindowRestore } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { createSelector } from 'reselect';
 import { connect } from 'react-redux';
+import store from 'store';
 import { Tabs, TabsContent, TabsTrigger, TabsList } from '@freecodecamp/ui';
+import type { DailyCodingChallengeLanguages } from '../../../redux/prop-types';
 
 import {
   removePortalWindow,
@@ -22,8 +24,10 @@ import Notes from '../components/notes';
 import EditorTabs from './editor-tabs';
 
 interface MobileLayoutProps {
+  dailyCodingChallengeLanguage: DailyCodingChallengeLanguages;
   editor: JSX.Element | null;
   hasEditableBoundaries: boolean;
+  isDailyCodingChallenge: boolean;
   hasPreview: boolean;
   instructions: JSX.Element;
   notes: string;
@@ -34,6 +38,9 @@ interface MobileLayoutProps {
   showPreviewPane: boolean;
   toolPanel: ReactNode;
   removePortalWindow: () => void;
+  setDailyCodingChallengeLanguage: (
+    language: DailyCodingChallengeLanguages
+  ) => void;
   setShowPreviewPortal: (arg: boolean) => void;
   setShowPreviewPane: (arg: boolean) => void;
   portalWindow: null | Window;
@@ -148,9 +155,11 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
   render(): JSX.Element {
     const { currentTab } = this.state;
     const {
+      dailyCodingChallengeLanguage,
       hasEditableBoundaries,
       instructions,
       editor,
+      isDailyCodingChallenge,
       testOutput,
       hasPreview,
       notes,
@@ -160,6 +169,7 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
       showPreviewPortal,
       toolPanel,
       removePortalWindow,
+      setDailyCodingChallengeLanguage,
       setShowPreviewPane,
       setShowPreviewPortal,
       portalWindow,
@@ -169,6 +179,10 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
 
     const displayPreviewPane = hasPreview && showPreviewPane;
     const displayPreviewPortal = hasPreview && showPreviewPortal;
+    const handleLanguageChange = (language: DailyCodingChallengeLanguages) => {
+      store.set('dailyCodingChallengeLanguage', language);
+      setDailyCodingChallengeLanguage(language);
+    };
 
     const togglePane = (pane: string): void => {
       if (pane === 'showPreviewPane') {
@@ -221,6 +235,24 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
           onValueChange={this.switchTab}
           {...(hasPreview && { 'data-haspreview': 'true' })}
         >
+          {isDailyCodingChallenge && (
+            <div className='daily-challenge-language-selector'>
+              <button
+                aria-expanded={dailyCodingChallengeLanguage === 'javascript'}
+                disabled={dailyCodingChallengeLanguage === 'javascript'}
+                onClick={() => handleLanguageChange('javascript')}
+              >
+                JavaScript
+              </button>
+              <button
+                aria-expanded={dailyCodingChallengeLanguage === 'python'}
+                disabled={dailyCodingChallengeLanguage === 'python'}
+                onClick={() => handleLanguageChange('python')}
+              >
+                Python
+              </button>
+            </div>
+          )}
           <TabsList className='nav-lists'>
             {!hasEditableBoundaries && (
               <TabsTrigger value={tabs.instructions}>

--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -476,12 +476,14 @@ function ShowClassic({
         <Helmet title={windowTitle} />
         {isMobile ? (
           <MobileLayout
+            dailyCodingChallengeLanguage={dailyCodingChallengeLanguage}
             editor={renderEditor({
               isMobileLayout: true,
               isUsingKeyboardInTablist: usingKeyboardInTablist
             })}
             hasEditableBoundaries={hasEditableBoundaries}
             hasPreview={hasPreview}
+            isDailyCodingChallenge={isDailyCodingChallenge}
             instructions={renderInstructionsPanel({
               toolPanel: null,
               hasDemo: demoType === 'onClick'
@@ -503,6 +505,7 @@ function ShowClassic({
             toolPanel={
               <ToolPanel guideUrl={guideUrl} isMobile videoUrl={videoUrl} />
             }
+            setDailyCodingChallengeLanguage={setDailyCodingChallengeLanguage}
             updateUsingKeyboardInTablist={updateUsingKeyboardInTablist}
             usesMultifileEditor={usesMultifileEditor}
           />


### PR DESCRIPTION
### Fix: Language selector hidden on small screens

The Daily Coding Challenge language selector (JavaScript/Python) disappears when the viewport width is below ~765px due to responsive styling.

This change updates the layout so the selector remains visible on smaller screens while keeping the existing desktop layout unchanged.

### Checklist

* [x] I have read and followed the [[contribution guidelines](https://contribute.freecodecamp.org/)](https://contribute.freecodecamp.org).
* [x] I have read and followed the [[how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/)](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
* [x] My pull request targets the `main` branch of freeCodeCamp.
* [x] I have tested these changes locally.

Closes #66361

<img width="1854" height="1007" alt="Screenshot from 2026-03-11 20-28-11" src="https://github.com/user-attachments/assets/110b76f9-b6b6-47cb-b867-5a1f921416b3" />
<img width="618" height="970" alt="Screenshot from 2026-03-11 20-28-47" src="https://github.com/user-attachments/assets/3ad743b3-4011-4a64-9389-1f929698be69" />
<img width="538" height="971" alt="Screenshot from 2026-03-11 20-29-01" src="https://github.com/user-attachments/assets/f3ec876f-55e6-40ed-af7c-7ed09547360e" />
