### PR TITLE
fix(curriculum): correct challengeType for lab-tower-of-hanoi from 23 to 27

### DIFF
--- a/curriculum/challenges/english/blocks/lab-tower-of-hanoi/68773ee26f332a80bc0295db.md
+++ b/curriculum/challenges/english/blocks/lab-tower-of-hanoi/68773ee26f332a80bc0295db.md
@@ -1,7 +1,7 @@
 ---
 id: 68773ee26f332a80bc0295db
 title: Implement the Tower of Hanoi Algorithm
-challengeType: 23
+challengeType: 27
 saveSubmissionToDB: true
 dashedName: implement-the-tower-of-hanoi-algorithm
 ---


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitHub Codespaces.

`lab-tower-of-hanoi` is a Python lab using a single `.py` file, so it should use `challengeType: 27` (`pyLab`) like all other single-file Python labs. The current value of `23` (`multifilePythonCertProject`) is only used by legacy Scientific Computing with Python cert projects and is inconsistent with the rest of the Python lab blocks.