### PR TITLE
Fix duplicated "from" in workshop-colorful-boxes

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-colorful-boxes/692f314d449329ba8bcd5d2e.md
+++ b/curriculum/challenges/english/blocks/workshop-colorful-boxes/692f314d449329ba8bcd5d2e.md
@@ -12,7 +12,7 @@ The `border-radius` property rounds the corners of an element's border. You can 
 - One value to apply to all four corners.
 - Two values, with the first value for top-left/bottom-right, and second for top-right/bottom-left.
 - Three values, corresponding to top-left, top-right/bottom-left, bottom-right.
-- Four values, which set the border radius clockwise starting from from top-left corner.
+- Four values, which set the border radius clockwise starting from top-left corner.
 
 Now add the property `border-radius` with the value `5px` to the `.box` selector.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #66384

<!-- Feel free to add any additional description of changes below this line -->
Removed duplicated "from" in challenge instructions (first timers only)