### PR TITLE
fix(curriculum): remove before/after-user-code from rosetta challenges 6-10

### DIFF
--- a/curriculum/challenges/english/blocks/rosetta-code-challenges/594810f028c0303b75339ad4.md
+++ b/curriculum/challenges/english/blocks/rosetta-code-challenges/594810f028c0303b75339ad4.md
@@ -21,6 +21,24 @@ must reference documentation indicating that the algorithm is something better
 than a simple minimum length algorithm.
 </pre>
 
+# --before-each--
+
+```js
+const text =
+`Wrap text using a more sophisticated algorithm such as the Knuth and Plass TeX algorithm.
+If your language provides this, you get easy extra credit,
+but you ''must reference documentation'' indicating that the algorithm
+is something better than a simple minimum length algorithm.`;
+
+const wrapped80 = wrap(text, 80);
+const wrapped42 = wrap(text, 42);
+
+const firstRow80 =
+    'Wrap text using a more sophisticated algorithm such as the Knuth and Plass TeX';
+
+const firstRow42 = 'Wrap text using a more sophisticated';
+```
+
 # --hints--
 
 `wrap` should be a function.
@@ -60,24 +78,6 @@ assert.equal(wrapped42.split('\n')[0], firstRow42);
 ```
 
 # --seed--
-
-## --after-user-code--
-
-```js
-const text =
-`Wrap text using a more sophisticated algorithm such as the Knuth and Plass TeX algorithm.
-If your language provides this, you get easy extra credit,
-but you ''must reference documentation'' indicating that the algorithm
-is something better than a simple minimum length algorithm.`;
-
-const wrapped80 = wrap(text, 80);
-const wrapped42 = wrap(text, 42);
-
-const firstRow80 =
-    'Wrap text using a more sophisticated algorithm such as the Knuth and Plass TeX';
-
-const firstRow42 = 'Wrap text using a more sophisticated';
-```
 
 ## --seed-contents--
 

--- a/curriculum/challenges/english/blocks/rosetta-code-challenges/594810f028c0303b75339ad5.md
+++ b/curriculum/challenges/english/blocks/rosetta-code-challenges/594810f028c0303b75339ad5.md
@@ -27,40 +27,39 @@ assert.equal(typeof Y((f) => (n) => n), 'function');
 factorial(1) should return 1.
 
 ```js
+var factorial = Y(f => n => (n > 1 ? n * f(n - 1) : 1));
 assert.equal(factorial(1), 1);
 ```
 
 factorial(2) should return 2.
 
 ```js
+var factorial = Y(f => n => (n > 1 ? n * f(n - 1) : 1));
 assert.equal(factorial(2), 2);
 ```
 
 factorial(3) should return 6.
 
 ```js
+var factorial = Y(f => n => (n > 1 ? n * f(n - 1) : 1));
 assert.equal(factorial(3), 6);
 ```
 
 factorial(4) should return 24.
 
 ```js
+var factorial = Y(f => n => (n > 1 ? n * f(n - 1) : 1));
 assert.equal(factorial(4), 24);
 ```
 
 factorial(10) should return 3628800.
 
 ```js
+var factorial = Y(f => n => (n > 1 ? n * f(n - 1) : 1));
 assert.equal(factorial(10), 3628800);
 ```
 
 # --seed--
-
-## --after-user-code--
-
-```js
-var factorial = Y(f => n => (n > 1 ? n * f(n - 1) : 1));
-```
 
 ## --seed-contents--
 

--- a/curriculum/challenges/english/blocks/rosetta-code-challenges/594810f028c0303b75339ad7.md
+++ b/curriculum/challenges/english/blocks/rosetta-code-challenges/594810f028c0303b75339ad7.md
@@ -88,41 +88,7 @@ If any pixels were set in this round of either step 1 or step 2 then all steps a
 
 Write a routine to perform Zhang-Suen thinning on the provided `image`, an array of strings, where each string represents single line of the image. In the string, `#` represents black pixel, and whitespace represents white pixel. Function should return thinned image, using the same representation.
 
-# --hints--
-
-`thinImage` should be a function.
-
-```js
-assert.equal(typeof thinImage, 'function');
-```
-
-`thinImage` should return an array.
-
-```js
-assert(Array.isArray(thinImage(_testImage1)));
-```
-
-`thinImage` should return an array of strings.
-
-```js
-assert.equal(typeof thinImage(_testImage1)[0], 'string');
-```
-
-`thinImage(testImage1)` should return a thinned image as in the example.
-
-```js
-assert.deepEqual(thinImage(_testImage1), expected1);
-```
-
-`thinImage(testImage2)` should return a thinned image.
-
-```js
-assert.deepEqual(thinImage(_testImage2), expected2);
-```
-
-# --seed--
-
-## --after-user-code--
+# --before-each--
 
 ```js
 const _testImage1 = [
@@ -167,7 +133,8 @@ const _testImage2 = [
   ' ########     ####### ######    ################## ###### ',
   ' ########     ####### ######      ################ ###### ',
   ' ########     ####### ######         ############# ###### ',
-  '                                                          '];
+  '                                                          '
+];
 const expected2 = [
   '                                                          ',
   '                                                          ',
@@ -189,6 +156,40 @@ const expected2 = [
   '                                                          '
 ];
 ```
+
+# --hints--
+
+`thinImage` should be a function.
+
+```js
+assert.equal(typeof thinImage, 'function');
+```
+
+`thinImage` should return an array.
+
+```js
+assert(Array.isArray(thinImage(_testImage1)));
+```
+
+`thinImage` should return an array of strings.
+
+```js
+assert.equal(typeof thinImage(_testImage1)[0], 'string');
+```
+
+`thinImage(testImage1)` should return a thinned image as in the example.
+
+```js
+assert.deepEqual(thinImage(_testImage1), expected1);
+```
+
+`thinImage(testImage2)` should return a thinned image.
+
+```js
+assert.deepEqual(thinImage(_testImage2), expected2);
+```
+
+# --seed--
 
 ## --seed-contents--
 

--- a/curriculum/challenges/english/blocks/rosetta-code-challenges/594810f028c0303b75339ad8.md
+++ b/curriculum/challenges/english/blocks/rosetta-code-challenges/594810f028c0303b75339ad8.md
@@ -24,6 +24,20 @@ For example, for the input `5`, the following result should be produced:
 
 Write a function that takes the size of the zig-zag matrix, and returns the corresponding matrix as two-dimensional array.
 
+# --before-each--
+
+```js
+const zm1 = [[0]];
+const zm2 = [[0, 1], [2, 3]];
+const zm5 = [
+  [0, 1, 5, 6, 14],
+  [2, 4, 7, 13, 15],
+  [3, 8, 12, 16, 21],
+  [9, 11, 17, 20, 22],
+  [10, 18, 19, 23, 24]
+];
+```
+
 # --hints--
 
 ZigZagMatrix should be a function.
@@ -63,20 +77,6 @@ assert.deepEqual(ZigZagMatrix(5), zm5);
 ```
 
 # --seed--
-
-## --after-user-code--
-
-```js
-const zm1 = [[0]];
-const zm2 = [[0, 1], [2, 3]];
-const zm5 = [
-  [0, 1, 5, 6, 14],
-  [2, 4, 7, 13, 15],
-  [3, 8, 12, 16, 21],
-  [9, 11, 17, 20, 22],
-  [10, 18, 19, 23, 24]
-];
-```
 
 ## --seed-contents--
 

--- a/curriculum/challenges/english/blocks/rosetta-code-challenges/5949b579404977fbaefcd737.md
+++ b/curriculum/challenges/english/blocks/rosetta-code-challenges/5949b579404977fbaefcd737.md
@@ -25,6 +25,27 @@ The sum of the divisors for the first value, **1184**, is **1210** and the sum o
 
 Calculate and show here the Amicable pairs below 20,000 (there are eight).
 
+# --before-each--
+
+```js
+const answer300 = [[220, 284]];
+const answer3000 = [
+  [220, 284],
+  [1184, 1210],
+  [2620, 2924]
+];
+const answer20000 = [
+  [220, 284],
+  [1184, 1210],
+  [2620, 2924],
+  [5020, 5564],
+  [6232, 6368],
+  [10744, 10856],
+  [12285, 14595],
+  [17296, 18416]
+];
+```
+
 # --hints--
 
 `amicablePairsUpTo` should be a function.
@@ -52,27 +73,6 @@ assert.deepEqual(amicablePairsUpTo(20000), answer20000);
 ```
 
 # --seed--
-
-## --after-user-code--
-
-```js
-const answer300 = [[220, 284]];
-const answer3000 = [
-  [220, 284],
-  [1184, 1210],
-  [2620, 2924]
-];
-const answer20000 = [
-  [220, 284],
-  [1184, 1210],
-  [2620, 2924],
-  [5020, 5564],
-  [6232, 6368],
-  [10744, 10856],
-  [12285, 14595],
-  [17296, 18416]
-];
-```
 
 ## --seed-contents--
 


### PR DESCRIPTION
Continuation of #66344, limited to the next 5 Rosetta files (6-10).