### PR TITLE
fix(curriculum): replace 'method' with 'function' for module calls in…

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-modules/683ec7b778993c6971b56c83.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-modules/683ec7b778993c6971b56c83.md
@@ -54,10 +54,10 @@ Let's say that you want to import the `math` module. In that case, you would wri
 import math
 ```
 
-Then, if you need to call a method from that module in your Python script, you would use dot notation, with the name of the module followed by the name of the method:
+Then, if you need to call a function from that module in your Python script, you would use dot notation, with the name of the module followed by the name of the function:
 
 ```python
-module_name.method_name() 
+module_name.function_name() 
 ```
 
 For example, to get the square root of 36, you would write `math` followed by a dot and then `sqrt`, an abbreviation of square root, and within parentheses, you would pass any necessary arguments. In this case, we only need to pass in the number we want the square root of:

--- a/curriculum/challenges/english/blocks/review-dictionaries-and-sets/67f39babe1e2ec1fb6eea32a.md
+++ b/curriculum/challenges/english/blocks/review-dictionaries-and-sets/67f39babe1e2ec1fb6eea32a.md
@@ -313,10 +313,10 @@ print(5 in my_set) # True
 import module_name
 ```
 
-Then, if you need to call a method from that module, you would use dot notation, with the name of the module followed by the name of the method.
+Then, if you need to call a function from that module, you would use dot notation, with the name of the module followed by the name of the function.
 
 ```python
-module_name.method_name()
+module_name.function_name()
 ```
 
 For example, you would write the following in your code to import the `math` module and get the square root of 36:

--- a/curriculum/challenges/english/blocks/review-python/67f39e391c9b373069def02c.md
+++ b/curriculum/challenges/english/blocks/review-python/67f39e391c9b373069def02c.md
@@ -1862,10 +1862,10 @@ print(5 in my_set)
 import module_name
 ```
 
-Then, if you need to call a method from that module, you would use dot notation, with the name of the module followed by the name of the method.
+Then, if you need to call a function from that module, you would use dot notation, with the name of the module followed by the name of the function.
 
 ```python
-module_name.method_name()
+module_name.function_name()
 ```
 
 For example, you would write the following in your code to import the `math` module and get the square root of 36:


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #66388 

Functions from imported modules (e.g. `math.sqrt()`) are not methods — methods are bound to class instances. Updated the terminology in 3 affected files.
