### PR TITLE
fix(curriculum): remove before/after-user-code from rosetta challenges 16-20

### DIFF
--- a/curriculum/challenges/english/blocks/rosetta-code-challenges/594ecc0d9a8cf816e3340187.md
+++ b/curriculum/challenges/english/blocks/rosetta-code-challenges/594ecc0d9a8cf816e3340187.md
@@ -29,6 +29,19 @@ Taxicab numbers are also known as:
 
 Write a function that returns the lowest `n` taxicab numbers. For each of the taxicab numbers, show the number as well as its constituent cubes.
 
+# --before-each--
+
+```js
+const res4 = [1729, 4104, 13832, 20683];
+const res25 = [
+  1729, 4104, 13832, 20683, 32832, 39312, 40033, 46683, 64232, 65728, 110656,
+  110808, 134379, 149389, 165464, 171288, 195841, 216027, 216125, 262656, 314496, 320264, 327763,
+  373464, 402597
+];
+
+const res39From20To29 = [314496, 320264, 327763, 373464, 402597, 439101, 443889, 513000, 513856];
+```
+
 # --hints--
 
 `taxicabNumbers` should be a function.
@@ -68,19 +81,6 @@ assert.deepEqual(taxicabNumbers(39).slice(20, 29), res39From20To29);
 ```
 
 # --seed--
-
-## --after-user-code--
-
-```js
-const res4 = [1729, 4104, 13832, 20683];
-const res25 = [
-  1729, 4104, 13832, 20683, 32832, 39312, 40033, 46683, 64232, 65728, 110656,
-  110808, 134379, 149389, 165464, 171288, 195841, 216027, 216125, 262656, 314496, 320264, 327763,
-  373464, 402597
-];
-
-const res39From20To29 = [314496, 320264, 327763, 373464, 402597, 439101, 443889, 513000, 513856];
-```
 
 ## --seed-contents--
 

--- a/curriculum/challenges/english/blocks/rosetta-code-challenges/594fa2746886f41f7d8bf225.md
+++ b/curriculum/challenges/english/blocks/rosetta-code-challenges/594fa2746886f41f7d8bf225.md
@@ -51,6 +51,41 @@ const libsSimple =
   bbb`;
 ```
 
+# --before-each--
+
+```js
+const libsSimple =
+  `aaa bbb
+  bbb`;
+
+const libsVHDL =
+  `des_system_lib   std synopsys std_cell_lib des_system_lib dw02 dw01 ramlib ieee
+  dw01             ieee dw01 dware gtech
+  dw02             ieee dw02 dware
+  dw03             std synopsys dware dw03 dw02 dw01 ieee gtech
+  dw04             dw04 ieee dw01 dware gtech
+  dw05             dw05 ieee dware
+  dw06             dw06 ieee dware
+  dw07             ieee dware
+  dware            ieee dware
+  gtech            ieee gtech
+  ramlib           std ieee
+  std_cell_lib     ieee std_cell_lib
+  synopsys`;
+
+const libsCustom =
+  `a b c d
+  b c d
+  d c
+  c base
+  base`;
+
+const libsUnorderable =
+  `TestLib Base MainLib
+  MainLib TestLib
+  Base`;
+```
+
 # --hints--
 
 `topologicalSort` should be a function.
@@ -90,41 +125,6 @@ assert.deepEqual(topologicalSort(libsUnorderable), ['Base']);
 ```
 
 # --seed--
-
-## --after-user-code--
-
-```js
-const libsSimple =
-  `aaa bbb
-  bbb`;
-
-const libsVHDL =
-  `des_system_lib   std synopsys std_cell_lib des_system_lib dw02 dw01 ramlib ieee
-  dw01             ieee dw01 dware gtech
-  dw02             ieee dw02 dware
-  dw03             std synopsys dware dw03 dw02 dw01 ieee gtech
-  dw04             dw04 ieee dw01 dware gtech
-  dw05             dw05 ieee dware
-  dw06             dw06 ieee dware
-  dw07             ieee dware
-  dware            ieee dware
-  gtech            ieee gtech
-  ramlib           std ieee
-  std_cell_lib     ieee std_cell_lib
-  synopsys`;
-
-const libsCustom =
-  `a b c d
-  b c d
-  d c
-  c base
-  base`;
-
-const libsUnorderable =
-  `TestLib Base MainLib
-  MainLib TestLib
-  Base`;
-```
 
 ## --seed-contents--
 

--- a/curriculum/challenges/english/blocks/rosetta-code-challenges/594faaab4e2a8626833e9c3d.md
+++ b/curriculum/challenges/english/blocks/rosetta-code-challenges/594faaab4e2a8626833e9c3d.md
@@ -46,6 +46,19 @@ and using `|` as a separator and `^` as escape character, your function should o
 <pre>  ['one|uno', '', 'three^^', 'four^|cuatro', '']
 </pre>
 
+# --before-each--
+
+```js
+const testStr1 = 'one^|uno||three^^^^|four^^^|^cuatro|';
+const res1 = ['one|uno', '', 'three^^', 'four^|cuatro', ''];
+
+const testStr2 = 'a@&bcd&ef&&@@hi';
+const res2 = ['a&bcd', 'ef', '', '@hi'];
+
+const testStr3 = 'hello^|world|how^are^you^|';
+const res3 = ['hello|world', 'howareyou|'];
+```
+
 # --hints--
 
 `tokenize` should be a function.
@@ -79,19 +92,6 @@ assert.deepEqual(tokenize(testStr3, '|', '^'), res3);
 ```
 
 # --seed--
-
-## --after-user-code--
-
-```js
-const testStr1 = 'one^|uno||three^^^^|four^^^|^cuatro|';
-const res1 = ['one|uno', '', 'three^^', 'four^|cuatro', ''];
-
-const testStr2 = 'a@&bcd&ef&&@@hi';
-const res2 = ['a&bcd', 'ef', '', '@hi'];
-
-const testStr3 = 'hello^|world|how^are^you^|';
-const res3 = ['hello|world', 'howareyou|']; 
-```
 
 ## --seed-contents--
 

--- a/curriculum/challenges/english/blocks/rosetta-code-challenges/595011cba5a81735713873bd.md
+++ b/curriculum/challenges/english/blocks/rosetta-code-challenges/595011cba5a81735713873bd.md
@@ -78,47 +78,7 @@ Top two ranking employees in each department by salary would be:
     { name: 'Claire Buckman', id: 'E39876', salary: 27800, dept: 'D101' } ] ]
 ```
 
-# --hints--
-
-`topRankPerGroup` should be a function.
-
-```js
-assert(typeof topRankPerGroup === 'function');
-```
-
-`topRankPerGroup` should return undefined on negative n values.
-
-```js
-assert(typeof topRankPerGroup(-1, []) === 'undefined');
-```
-
-For `topRankPerGroup(10, testData1, 'dept', 'salary')`, the first result in the first group should be `{ name: 'John Rappl', id: 'E21437', salary: 47000, dept: 'D050'}`.
-
-```js
-assert.deepEqual(res1[0][0], { name: 'John Rappl', id: 'E21437', salary: 47000, dept: 'D050'});
-```
-
-For `topRankPerGroup(10, testData1, 'dept', 'salary')`, the last result in the last group should be `{ name: 'Adam Smith', id: 'E63535', salary: 18000, dept: 'D202' }`.
-
-```js
-assert.deepEqual(res1[3][3], { name: 'Adam Smith', id: 'E63535', salary: 18000, dept: 'D202' });
-```
-
-`topRankPerGroup(1, ...)` should return only top ranking result per group.
-
-```js
-assert.equal(res2[2].length, 1);
-```
-
-`topRankPerGroup(2, ...)` should return two ranking results per group.
-
-```js
-assert.equal(res3[2][1].name, 'Maze Runner');
-```
-
-# --seed--
-
-## --after-user-code--
+# --before-each--
 
 ```js
 const testData1 = [
@@ -137,8 +97,6 @@ const testData1 = [
   { name: 'Timothy Grove', id: 'E16398', salary: 29900, dept: 'D190' }
 ];
 
-const res1 = topRankPerGroup(10, testData1, 'dept', 'salary');
-
 const testData2 = [
   { name: 'Friday 13th', genre: 'horror', rating: 9.9 },
   { name: "Nightmare on Elm's Street", genre: 'horror', rating: 5.7 },
@@ -147,9 +105,56 @@ const testData2 = [
   { name: 'Blade runner', genre: 'scifi', rating: 8.9 }
 ];
 
-const res2 = topRankPerGroup(1, testData2, 'genre', 'rating');
-const res3 = topRankPerGroup(2, testData2, 'genre', 'rating');
+function getResults_() {
+  return {
+    res1: topRankPerGroup(10, testData1, 'dept', 'salary'),
+    res2: topRankPerGroup(1, testData2, 'genre', 'rating'),
+    res3: topRankPerGroup(2, testData2, 'genre', 'rating')
+  };
+}
 ```
+
+# --hints--
+
+`topRankPerGroup` should be a function.
+
+```js
+assert(typeof topRankPerGroup === 'function');
+```
+
+`topRankPerGroup` should return undefined on negative n values.
+
+```js
+assert(typeof topRankPerGroup(-1, []) === 'undefined');
+```
+
+For `topRankPerGroup(10, testData1, 'dept', 'salary')`, the first result in the first group should be `{ name: 'John Rappl', id: 'E21437', salary: 47000, dept: 'D050'}`.
+
+```js
+assert.deepEqual(getResults_().res1[0][0], { name: 'John Rappl', id: 'E21437', salary: 47000, dept: 'D050'});
+```
+
+For `topRankPerGroup(10, testData1, 'dept', 'salary')`, the last result in the last group should be `{ name: 'Adam Smith', id: 'E63535', salary: 18000, dept: 'D202' }`.
+
+```js
+assert.deepEqual(getResults_().res1[3][3], { name: 'Adam Smith', id: 'E63535', salary: 18000, dept: 'D202' });
+```
+
+`topRankPerGroup(1, ...)` should return only top ranking result per group.
+
+```js
+const { res2 } = getResults_();
+assert.equal(res2[2].length, 1);
+```
+
+`topRankPerGroup(2, ...)` should return two ranking results per group.
+
+```js
+const { res3 } = getResults_();
+assert.equal(res3[2][1].name, 'Maze Runner');
+```
+
+# --seed--
 
 ## --seed-contents--
 

--- a/curriculum/challenges/english/blocks/rosetta-code-challenges/5951815dd895584b06884620.md
+++ b/curriculum/challenges/english/blocks/rosetta-code-challenges/5951815dd895584b06884620.md
@@ -41,6 +41,25 @@ Implement a function that takes two points and a radius and returns the two circ
 0.1234, 0.9876    0.1234, 0.9876    0.0
 </pre>
 
+# --before-each--
+
+```js
+const testCases = [
+  [[0.1234, 0.9876], [0.8765, 0.2345], 2.0],
+  [[0.0000, 2.0000], [0.0000, 0.0000], 1.0],
+  [[0.1234, 0.9876], [0.1234, 0.9876], 2.0],
+  [[0.1234, 0.9876], [0.8765, 0.2345], 0.5],
+  [[0.1234, 0.9876], [0.1234, 0.9876], 0.0]
+];
+const answers = [
+  [[1.8631, 1.9742], [-0.8632, -0.7521]],
+  [0, 1],
+  'Coincident point. Infinite solutions',
+  'No intersection. Points further apart than circle diameter',
+  'Radius Zero'
+];
+```
+
 # --hints--
 
 `getCircles` should be a function.
@@ -80,25 +99,6 @@ assert.deepEqual(getCircles(...testCases[4]), answers[4]);
 ```
 
 # --seed--
-
-## --after-user-code--
-
-```js
-const testCases = [
-  [[0.1234, 0.9876], [0.8765, 0.2345], 2.0],
-  [[0.0000, 2.0000], [0.0000, 0.0000], 1.0],
-  [[0.1234, 0.9876], [0.1234, 0.9876], 2.0],
-  [[0.1234, 0.9876], [0.8765, 0.2345], 0.5],
-  [[0.1234, 0.9876], [0.1234, 0.9876], 0.0]
-];
-const answers = [
-  [[1.8631, 1.9742], [-0.8632, -0.7521]],
-  [0, 1],
-  'Coincident point. Infinite solutions',
-  'No intersection. Points further apart than circle diameter',
-  'Radius Zero'
-];
-```
 
 ## --seed-contents--
 


### PR DESCRIPTION
Continuation of #66344, limited to the next 5 Rosetta files (16-20).\n\nThis keeps the migration split into small, reviewable PRs.