### PR TITLE
fix(curriculum): remove before/after-user-code from rosetta challenges 21-25

### DIFF
--- a/curriculum/challenges/english/blocks/rosetta-code-challenges/5951a53863c8a34f02bf1bdc.md
+++ b/curriculum/challenges/english/blocks/rosetta-code-challenges/5951a53863c8a34f02bf1bdc.md
@@ -98,6 +98,126 @@ Would return:
 **Note:** Sort the `pair` array by their `x` values in incrementing order.
 
 
+# --before-each--
+
+```js
+function getPoints1_() {
+  return [
+    new Point(0.748501, 4.09624),
+    new Point(3.00302, 5.26164),
+    new Point(3.61878, 9.52232),
+    new Point(7.46911, 4.71611),
+    new Point(5.7819, 2.69367),
+    new Point(2.34709, 8.74782),
+    new Point(2.87169, 5.97774),
+    new Point(6.33101, 0.463131),
+    new Point(7.46489, 4.6268),
+    new Point(1.45428, 0.087596)
+  ];
+}
+
+const answer1 = {
+  distance: 0.0894096443343775,
+  pair: [
+    { x: 7.46489, y: 4.6268 },
+    { x: 7.46911, y: 4.71611 }
+  ]
+};
+
+function getPoints2_() {
+  return [
+    new Point(37100, 13118),
+    new Point(37134, 1963),
+    new Point(37181, 2008),
+    new Point(37276, 21611),
+    new Point(37307, 9320)
+  ];
+}
+
+const answer2 = {
+  distance: 65.06919393998976,
+  pair: [
+    { x: 37134, y: 1963 },
+    { x: 37181, y: 2008 }
+  ]
+};
+
+function getPoints3_() {
+  return [
+    new Point(16910, 54699),
+    new Point(14773, 61107),
+    new Point(95547, 45344),
+    new Point(95951, 17573),
+    new Point(5824, 41072),
+    new Point(8769, 52562),
+    new Point(21182, 41881),
+    new Point(53226, 45749),
+    new Point(68180, 887),
+    new Point(29322, 44017),
+    new Point(46817, 64975),
+    new Point(10501, 483),
+    new Point(57094, 60703),
+    new Point(23318, 35472),
+    new Point(72452, 88070),
+    new Point(67775, 28659),
+    new Point(19450, 20518),
+    new Point(17314, 26927),
+    new Point(98088, 11164),
+    new Point(25050, 56835),
+    new Point(8364, 6892),
+    new Point(37868, 18382),
+    new Point(23723, 7701),
+    new Point(55767, 11569),
+    new Point(70721, 66707),
+    new Point(31863, 9837),
+    new Point(49358, 30795),
+    new Point(13041, 39744),
+    new Point(59635, 26523),
+    new Point(25859, 1292),
+    new Point(1551, 53890),
+    new Point(70316, 94479),
+    new Point(48549, 86338),
+    new Point(46413, 92747),
+    new Point(27186, 50426),
+    new Point(27591, 22655),
+    new Point(10905, 46153),
+    new Point(40408, 84202),
+    new Point(52821, 73520),
+    new Point(84865, 77388),
+    new Point(99819, 32527),
+    new Point(34404, 75657),
+    new Point(78457, 96615),
+    new Point(42140, 5564),
+    new Point(62175, 92342),
+    new Point(54958, 67112),
+    new Point(4092, 19709),
+    new Point(99415, 60298),
+    new Point(51090, 52158),
+    new Point(48953, 58567)
+  ];
+}
+
+const answer3 = {
+  distance: 6754.625082119658,
+  pair: [
+    { x: 46817, y: 64975 },
+    { x: 48953, y: 58567 }
+  ]
+};
+
+function getClosestPair1_() {
+  return getClosestPair(getPoints1_());
+}
+
+function getClosestPair2_() {
+  return getClosestPair(getPoints2_());
+}
+
+function getClosestPair3_() {
+  return getClosestPair(getPoints3_());
+}
+```
+
 # --hints--
 
 `getClosestPair` should be a function.
@@ -109,14 +229,14 @@ assert(typeof getClosestPair === 'function');
 `getClosestPair(points1).distance` should be `0.0894096443343775`.
 
 ```js
-assert.equal(getClosestPair(points1).distance, answer1.distance);
+assert.equal(getClosestPair1_().distance, answer1.distance);
 ```
 
 `getClosestPair(points1).pair` should be `[ { x: 7.46489, y: 4.6268 }, { x: 7.46911, y: 4.71611 } ]`.
 
 ```js
 assert.deepEqual(
-  JSON.parse(JSON.stringify(getClosestPair(points1))).pair,
+  JSON.parse(JSON.stringify(getClosestPair1_())).pair,
   answer1.pair
 );
 ```
@@ -124,14 +244,14 @@ assert.deepEqual(
 `getClosestPair(points2).distance` should be `65.06919393998976`.
 
 ```js
-assert.equal(getClosestPair(points2).distance, answer2.distance);
+assert.equal(getClosestPair2_().distance, answer2.distance);
 ```
 
 `getClosestPair(points2).pair` should be `[ { x: 37134, y: 1963 }, { x: 37181, y: 2008 } ]`.
 
 ```js
 assert.deepEqual(
-  JSON.parse(JSON.stringify(getClosestPair(points2))).pair,
+  JSON.parse(JSON.stringify(getClosestPair2_())).pair,
   answer2.pair
 );
 ```
@@ -139,139 +259,19 @@ assert.deepEqual(
 `getClosestPair(points3).distance` should be `6754.625082119658`.
 
 ```js
-assert.equal(getClosestPair(points3).distance, answer3.distance);
+assert.equal(getClosestPair3_().distance, answer3.distance);
 ```
 
 `getClosestPair(points3).pair` should be `[ { x: 46817, y: 64975 }, { x: 48953, y: 58567 } ]`.
 
 ```js
 assert.deepEqual(
-  JSON.parse(JSON.stringify(getClosestPair(points3))).pair,
+  JSON.parse(JSON.stringify(getClosestPair3_())).pair,
   answer3.pair
 );
 ```
 
 # --seed--
-
-## --after-user-code--
-
-```js
-const points1 = [
-    new Point(0.748501, 4.09624),
-    new Point(3.00302, 5.26164),
-    new Point(3.61878,  9.52232),
-    new Point(7.46911,  4.71611),
-    new Point(5.7819,   2.69367),
-    new Point(2.34709,  8.74782),
-    new Point(2.87169,  5.97774),
-    new Point(6.33101,  0.463131),
-    new Point(7.46489,  4.6268),
-    new Point(1.45428,  0.087596)
-];
-
-const answer1 = {
-  distance: 0.0894096443343775,
-  pair: [
-    {
-      x: 7.46489,
-      y: 4.6268
-    },
-    {
-      x: 7.46911,
-      y: 4.71611
-    }
-  ]
-};
-
-const points2 = [
-  new Point(37100, 13118),
-  new Point(37134, 1963),
-  new Point(37181, 2008),
-  new Point(37276, 21611),
-  new Point(37307, 9320)
-];
-
-const answer2 = {
-  distance: 65.06919393998976,
-  pair: [
-    {
-      x: 37134,
-      y: 1963
-    },
-    {
-      x: 37181,
-      y: 2008
-    }
-  ]
-};
-
-const points3 = [
-  new Point(16910, 54699),
-  new Point(14773, 61107),
-  new Point(95547, 45344),
-  new Point(95951, 17573),
-  new Point(5824, 41072),
-  new Point(8769, 52562),
-  new Point(21182, 41881),
-  new Point(53226, 45749),
-  new Point(68180, 887),
-  new Point(29322, 44017),
-  new Point(46817, 64975),
-  new Point(10501, 483),
-  new Point(57094, 60703),
-  new Point(23318, 35472),
-  new Point(72452, 88070),
-  new Point(67775, 28659),
-  new Point(19450, 20518),
-  new Point(17314, 26927),
-  new Point(98088, 11164),
-  new Point(25050, 56835),
-  new Point(8364, 6892),
-  new Point(37868, 18382),
-  new Point(23723, 7701),
-  new Point(55767, 11569),
-  new Point(70721, 66707),
-  new Point(31863, 9837),
-  new Point(49358, 30795),
-  new Point(13041, 39744),
-  new Point(59635, 26523),
-  new Point(25859, 1292),
-  new Point(1551, 53890),
-  new Point(70316, 94479),
-  new Point(48549, 86338),
-  new Point(46413, 92747),
-  new Point(27186, 50426),
-  new Point(27591, 22655),
-  new Point(10905, 46153),
-  new Point(40408, 84202),
-  new Point(52821, 73520),
-  new Point(84865, 77388),
-  new Point(99819, 32527),
-  new Point(34404, 75657),
-  new Point(78457, 96615),
-  new Point(42140, 5564),
-  new Point(62175, 92342),
-  new Point(54958, 67112),
-  new Point(4092, 19709),
-  new Point(99415, 60298),
-  new Point(51090, 52158),
-  new Point(48953, 58567)
-];
-
-const answer3 = {
-  distance: 6754.625082119658,
-  pair: [
-    {
-      x: 46817,
-      y: 64975
-    },
-    {
-      x: 48953,
-      y: 58567
-    }
-  ]
-}
-```
 
 ## --seed-contents--
 

--- a/curriculum/challenges/english/blocks/rosetta-code-challenges/5951a53863c8a34f02bf1bdc.md
+++ b/curriculum/challenges/english/blocks/rosetta-code-challenges/5951a53863c8a34f02bf1bdc.md
@@ -98,7 +98,7 @@ Would return:
 **Note:** Sort the `pair` array by their `x` values in incrementing order.
 
 
-# --before-all--
+# --before-each--
 
 ```js
 function getPoints1_() {

--- a/curriculum/challenges/english/blocks/rosetta-code-challenges/5951a53863c8a34f02bf1bdc.md
+++ b/curriculum/challenges/english/blocks/rosetta-code-challenges/5951a53863c8a34f02bf1bdc.md
@@ -98,7 +98,7 @@ Would return:
 **Note:** Sort the `pair` array by their `x` values in incrementing order.
 
 
-# --before-each--
+# --before-all--
 
 ```js
 function getPoints1_() {

--- a/curriculum/challenges/english/blocks/rosetta-code-challenges/5951e88f64ebf159166a1176.md
+++ b/curriculum/challenges/english/blocks/rosetta-code-challenges/5951e88f64ebf159166a1176.md
@@ -31,6 +31,105 @@ Implement a function that takes a string of four digits as its argument, with ea
 | <code>solve24("6789");</code> | <code>(6\*8)/(9-7)</code> |
 | <code>solve24("1127");</code> | <code>(1+7)\*(2+1)</code> |
 
+# --before-each--
+
+```js
+const testCases_ = [
+  '4878',
+  '1234',
+  '6789',
+  '1127'
+];
+
+const OPERATORS_ = {
+  '+': (a, b) => a + b,
+  '-': (a, b) => a - b,
+  '*': (a, b) => a * b,
+  '/': (a, b) => a / b
+};
+
+const PRECEDENCE_ = {
+  '+': 1,
+  '-': 1,
+  '*': 2,
+  '/': 2
+};
+
+function evaluate_(expression) {
+  expression = expression.replace('/\\s+/g', '');
+  const stack = [];
+  let postfix = '';
+
+  // Convert from infix to postfix
+  let head = 0;
+  while (head < expression.length) {
+    let c = expression[head];
+    switch (c) {
+      case '(':
+        stack.push(c);
+        break;
+      case ')':
+        let last = stack.pop();
+        while (last !== '(') {
+          postfix += last;
+          last = stack.pop();
+        }
+        break;
+      case '+':
+      case '-':
+      case '*':
+      case '/':
+        while (stack.length && PRECEDENCE_[c] <= PRECEDENCE_[stack[stack.length - 1]]) {
+          postfix += stack.pop();
+        }
+        stack.push(c);
+        break;
+      case '0':
+      case '1':
+      case '2':
+      case '3':
+      case '4':
+      case '5':
+      case '6':
+      case '7':
+      case '8':
+      case '9':
+        postfix += c;
+        break;
+      default:
+        return false;
+    }
+    head++;
+  }
+
+  // Clear out stack
+  while (stack.length) {
+    postfix += stack.pop();
+  }
+
+  // Evaluate postfix
+  for (let c of postfix) {
+    switch (c) {
+      case '+':
+      case '-':
+      case '*':
+      case '/':
+        const b = +stack.pop();
+        const a = +stack.pop();
+        stack.push(OPERATORS_[c](a, b));
+        break;
+      default:
+        stack.push(c);
+    }
+  }
+  return stack.pop();
+}
+
+function isValidSolution_(userSolution) {
+  return evaluate_(userSolution) === 24;
+}
+```
+
 # --hints--
 
 `solve24` should be a function.
@@ -64,107 +163,6 @@ assert(isValidSolution_(solve24(testCases_[3])));
 ```
 
 # --seed--
-
-## --after-user-code--
-
-```js
-const testCases_ = [
-  '4878',
-  '1234',
-  '6789',
-  '1127'
-];
-
-const OPERATORS_ = {
-  "+": (a, b) => a + b,
-  "-": (a, b) => a - b,
-  "*": (a, b) => a * b,
-  "/": (a, b) => a / b,
-}
-
-const PRECEDENCE_ = {
-  "+": 1,
-  "-": 1,
-  "*": 2,
-  "/": 2,
-}
-
-function evaluate_(expression) {
-  expression = expression.replace('/\s+/g', '');
-  const stack = [];
-  let postfix = "";
-
-  // Convert from infix to postfix
-  let head = 0;
-  while (head < expression.length) {
-    let c = expression[head];
-    switch (c) {
-      case "(":
-        stack.push(c);
-        break;
-      case ")":
-        let last = stack.pop();
-        while (last !== "(") {
-          postfix += last;
-          last = stack.pop();
-        }
-        break;
-      case "+":
-      case "-":
-      case "*":
-      case "/":
-        while (stack.length &&
-               PRECEDENCE_[c] <= PRECEDENCE_[stack[stack.length-1]]) {
-          postfix += stack.pop();
-        }
-        stack.push(c);
-        break;
-      case "0":
-      case "1":
-      case "2":
-      case "3":
-      case "4":
-      case "5":
-      case "6":
-      case "7":
-      case "8":
-      case "9":
-        postfix += c;
-        break;
-      default:
-        return false;
-    }
-    head++;
-  }
-
-  // Clear out stack
-  while (stack.length) {
-    postfix += stack.pop();
-  }
-
-  // Evaluate postfix
-  for (let c of postfix) {
-    switch (c) {
-      case "+":
-      case "-":
-      case "*":
-      case "/":
-        const b = +stack.pop();
-        const a = +stack.pop();
-        stack.push(OPERATORS_[c](a, b));
-        break;
-      default:
-        stack.push(c);
-    }
-  }
-  return stack.pop();
-}
-
-// Check solution validity
-function isValidSolution_(userSolution) {
-  return evaluate_(userSolution) === 24;
-}
-```
 
 ## --seed-contents--
 

--- a/curriculum/challenges/english/blocks/rosetta-code-challenges/5951ed8945deab770972ae56.md
+++ b/curriculum/challenges/english/blocks/rosetta-code-challenges/5951ed8945deab770972ae56.md
@@ -16,6 +16,21 @@ For example, the parameters `(4, 'A', 'B', 'C')`, will result in nested array of
 
 Write a function that returns the moves to stack the objects in a nested array.
 
+# --before-each--
+
+```js
+const res3Moves = [['A', 'B'], ['A', 'C'], ['B', 'C'], ['A', 'B'], ['C', 'A'], ['C', 'B'], ['A', 'B']];
+const res7First10Moves = [['A', 'B'], ['A', 'C'], ['B', 'C'], ['A', 'B'], ['C', 'A'], ['C', 'B'], ['A', 'B'], ['A', 'C'], ['B', 'C'], ['B', 'A']];
+
+function getTowerResults_() {
+  return {
+    res3: towerOfHanoi(3, 'A', 'B', 'C'),
+    res5: towerOfHanoi(5, 'X', 'Y', 'Z'),
+    res7: towerOfHanoi(7, 'A', 'B', 'C')
+  };
+}
+```
+
 # --hints--
 
 `towerOfHanoi` should be a function.
@@ -27,37 +42,30 @@ assert(typeof towerOfHanoi === 'function');
 `towerOfHanoi(3, ...)` should return 7 moves.
 
 ```js
-assert(res3.length === 7);
+assert(getTowerResults_().res3.length === 7);
 ```
 
 `towerOfHanoi(3, 'A', 'B', 'C')` should return `[['A','B'], ['A','C'], ['B','C'], ['A','B'], ['C','A'], ['C','B'], ['A','B']]`.
 
 ```js
-assert.deepEqual(towerOfHanoi(3, 'A', 'B', 'C'), res3Moves);
+assert.deepEqual(getTowerResults_().res3, res3Moves);
 ```
 
 `towerOfHanoi(5, "X", "Y", "Z")` 10th move should be Y -> X.
 
 ```js
+const { res5 } = getTowerResults_();
 assert.deepEqual(res5[9], ['Y', 'X']);
 ```
 
 `towerOfHanoi(7, 'A', 'B', 'C')` first ten moves should be `[['A','B'], ['A','C'], ['B','C'], ['A','B'], ['C','A'], ['C','B'], ['A','B'], ['A','C'], ['B','C'], ['B','A']]`
 
 ```js
-assert.deepEqual(towerOfHanoi(7, 'A', 'B', 'C').slice(0, 10), res7First10Moves);
+const { res7 } = getTowerResults_();
+assert.deepEqual(res7.slice(0, 10), res7First10Moves);
 ```
 
 # --seed--
-
-## --after-user-code--
-
-```js
-const res3 = towerOfHanoi(3, 'A', 'B', 'C');
-const res3Moves = [['A', 'B'], ['A', 'C'], ['B', 'C'], ['A', 'B'], ['C', 'A'], ['C', 'B'], ['A', 'B']];
-const res5 = towerOfHanoi(5, 'X', 'Y', 'Z');
-const res7First10Moves = [['A', 'B'], ['A', 'C'], ['B', 'C'], ['A', 'B'], ['C', 'A'], ['C', 'B'], ['A', 'B'], ['A', 'C'], ['B', 'C'], ['B', 'A']];
-```
 
 ## --seed-contents--
 

--- a/curriculum/challenges/english/blocks/rosetta-code-challenges/595671d4d2cdc305f0d5b36f.md
+++ b/curriculum/challenges/english/blocks/rosetta-code-challenges/595671d4d2cdc305f0d5b36f.md
@@ -20,6 +20,28 @@ const hashObj = arrToObj(firstArr, secondArr);
 
 The hash object created from the arrays above will be `{1: "a", 2: "b", 3: "c"}`.
 
+# --before-each--
+
+```js
+const testCases = [
+  [[1, 2, 3, 4, 5], ['a', 'b', 'c', 'd', 'e']],
+  [[1, 2, 3, 4, 5], ['a', 'b', 'c', 'd']],
+  [[1, 2, 3], ['a', 'b', 'c', 'd', 'e']],
+  [['a', 'b', 'c', 'd', 'e'], [1, 2, 3, 4, 5]],
+  [['a', 'b', 'c', 'd', 'e'], [1, 2, 3, 4]],
+  [['a', 'b', 'c'], [1, 2, 3, 4, 5]]
+];
+
+const res = [
+  { 1: 'a', 2: 'b', 3: 'c', 4: 'd', 5: 'e' },
+  { 1: 'a', 2: 'b', 3: 'c', 4: 'd', 5: undefined },
+  { 1: 'a', 2: 'b', 3: 'c' },
+  { a: 1, b: 2, c: 3, d: 4, e: 5 },
+  { a: 1, b: 2, c: 3, d: 4, e: undefined },
+  { a: 1, b: 2, c: 3 }
+];
+```
+
 # --hints--
 
 `arrToObj` should be a function.
@@ -65,28 +87,6 @@ assert.deepEqual(arrToObj(...testCases[5]), res[5]);
 ```
 
 # --seed--
-
-## --after-user-code--
-
-```js
-const testCases = [
-  [[1, 2, 3, 4, 5], ['a', 'b', 'c', 'd', 'e']],
-  [[1, 2, 3, 4, 5], ['a', 'b', 'c', 'd']],
-  [[1, 2, 3], ['a', 'b', 'c', 'd', 'e']],
-  [['a', 'b', 'c', 'd', 'e'], [1, 2, 3, 4, 5]],
-  [['a', 'b', 'c', 'd', 'e'], [1, 2, 3, 4]],
-  [['a', 'b', 'c'], [1, 2, 3, 4, 5]]
-];
-
-const res = [
-  { 1: 'a', 2: 'b', 3: 'c', 4: 'd', 5: 'e' },
-  { 1: 'a', 2: 'b', 3: 'c', 4: 'd', 5: undefined },
-  { 1: 'a', 2: 'b', 3: 'c' },
-  { a: 1, b: 2, c: 3, d: 4, e: 5 },
-  { a: 1, b: 2, c: 3, d: 4, e: undefined },
-  { a: 1, b: 2, c: 3 }
-];
-```
 
 ## --seed-contents--
 

--- a/curriculum/challenges/english/blocks/rosetta-code-challenges/5956795bc9e2c415eb244de1.md
+++ b/curriculum/challenges/english/blocks/rosetta-code-challenges/5956795bc9e2c415eb244de1.md
@@ -152,14 +152,6 @@ assert(typeof hashJoin === 'function');
 `hashJoin([{ age: 27, name: "Jonah" }, { age: 18, name: "Alan" }, { age: 28, name: "Glory" }, { age: 18, name: "Popeye" }, { age: 28, name: "Alan" }], [{ character: "Jonah", nemesis: "Whales" }, { character: "Jonah", nemesis: "Spiders" }, { character: "Alan", nemesis: "Ghosts" }, { character:"Alan", nemesis: "Zombies" }, { character: "Glory", nemesis: "Buffy" }, { character: "Bob", nemesis: "foo" }])` should return `[{"A_age": 27,"A_name": "Jonah", "B_character": "Jonah", "B_nemesis": "Whales"}, {"A_age": 27,"A_name": "Jonah", "B_character": "Jonah", "B_nemesis": "Spiders"}, {"A_age": 18,"A_name": "Alan", "B_character": "Alan", "B_nemesis": "Ghosts"}, {"A_age": 18,"A_name": "Alan", "B_character": "Alan", "B_nemesis": "Zombies"}, {"A_age": 28,"A_name": "Glory", "B_character": "Glory", "B_nemesis": "Buffy"}, {"A_age": 28,"A_name": "Alan", "B_character": "Alan", "B_nemesis": "Ghosts"}, {"A_age": 28,"A_name": "Alan", "B_character": "Alan", "B_nemesis": "Zombies"}]`
 
 ```js
-assert.deepEqual(hashJoin(hash1, hash2), res);
-```
-
-# --seed--
-
-## --after-user-code--
-
-```js
 const hash1 = [
     { age: 27, name: 'Jonah' },
     { age: 18, name: 'Alan' },
@@ -189,7 +181,10 @@ const res = [
 
 const bench1 = [{ name: 'u2v7v', num: 1 }, { name: 'n53c8', num: 10 }, { name: 'oysce', num: 9 }, { name: '0mto2s', num: 1 }, { name: 'vkh5id', num: 4 }, { name: '5od0cf', num: 8 }, { name: 'uuulue', num: 10 }, { name: '3rgsbi', num: 9 }, { name: 'kccv35r', num: 4 }, { name: '80un74', num: 9 }, { name: 'h4pp3', num: 6 }, { name: '51bit', num: 7 }, { name: 'j9ndf', num: 8 }, { name: 'vf3u1', num: 10 }, { name: 'g0bw0om', num: 10 }, { name: 'j031x', num: 7 }, { name: 'ij3asc', num: 9 }, { name: 'byv83y', num: 8 }, { name: 'bjzp4k', num: 4 }, { name: 'f3kbnm', num: 10 }];
 const bench2 = [{ friend: 'o8b', num: 8 }, { friend: 'ye', num: 2 }, { friend: '32i', num: 5 }, { friend: 'uz', num: 3 }, { friend: 'a5k', num: 4 }, { friend: 'uad', num: 7 }, { friend: '3w5', num: 10 }, { friend: 'vw', num: 10 }, { friend: 'ah', num: 4 }, { friend: 'qv', num: 7 }, { friend: 'ozv', num: 2 }, { friend: '9ri', num: 10 }, { friend: '7nu', num: 4 }, { friend: 'w3', num: 9 }, { friend: 'tgp', num: 8 }, { friend: 'ibs', num: 1 }, { friend: 'ss7', num: 6 }, { friend: 'g44', num: 9 }, { friend: 'tab', num: 9 }, { friend: 'zem', num: 10 }];
+assert.deepEqual(hashJoin(hash1, hash2), res);
 ```
+
+# --seed--
 
 ## --seed-contents--
 


### PR DESCRIPTION
Continuation of #66344, limited to the next 5 Rosetta files (21-25).\n\nThis keeps the migration split into small, reviewable PRs.