### PR TITLE
refactor(client,curriculum): remove showSpeakingButton from challenge metadata

### DIFF
--- a/client/schema.gql
+++ b/client/schema.gql
@@ -378,7 +378,6 @@ type ChallengeNodeChallenge @derivedTypes {
   template: String
   transcript: String
   isExam: Boolean
-  showSpeakingButton: Boolean
   videoLocaleIds: ChallengeNodeChallengeVideoLocaleIds
   notes: String
   prerequisites: [ChallengeNodeChallengePrerequisites]

--- a/curriculum/challenges/english/blocks/learn-about-adverbial-phrases/67fe9b40ec6bdb9c8f891e4d.md
+++ b/curriculum/challenges/english/blocks/learn-about-adverbial-phrases/67fe9b40ec6bdb9c8f891e4d.md
@@ -3,7 +3,6 @@ id: 67fe9b40ec6bdb9c8f891e4d
 title: Task 19
 challengeType: 19
 dashedName: task-19
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-about-adverbial-phrases/68017ab60d2a18a4a49e81c1.md
+++ b/curriculum/challenges/english/blocks/learn-about-adverbial-phrases/68017ab60d2a18a4a49e81c1.md
@@ -3,7 +3,6 @@ id: 68017ab60d2a18a4a49e81c1
 title: Task 24
 challengeType: 19
 dashedName: task-24
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-about-adverbial-phrases/6801874351deead7df0b1c1f.md
+++ b/curriculum/challenges/english/blocks/learn-about-adverbial-phrases/6801874351deead7df0b1c1f.md
@@ -3,7 +3,6 @@ id: 6801874351deead7df0b1c1f
 title: Task 30
 challengeType: 19
 dashedName: task-30
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-about-adverbial-phrases/680a2ae4fff48d4e65e984f5.md
+++ b/curriculum/challenges/english/blocks/learn-about-adverbial-phrases/680a2ae4fff48d4e65e984f5.md
@@ -3,7 +3,6 @@ id: 680a2ae4fff48d4e65e984f5
 title: Task 54
 challengeType: 19
 dashedName: task-54
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-about-adverbial-phrases/680ae6fa6f3bb82a094cffcf.md
+++ b/curriculum/challenges/english/blocks/learn-about-adverbial-phrases/680ae6fa6f3bb82a094cffcf.md
@@ -3,7 +3,6 @@ id: 680ae6fa6f3bb82a094cffcf
 title: Task 91
 challengeType: 19
 dashedName: task-91
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-about-speculation-and-requests/67ee50c7f4b46e0d96f91996.md
+++ b/curriculum/challenges/english/blocks/learn-about-speculation-and-requests/67ee50c7f4b46e0d96f91996.md
@@ -3,7 +3,6 @@ id: 67ee50c7f4b46e0d96f91996
 title: Task 6
 challengeType: 19
 dashedName: task-6
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-about-speculation-and-requests/67ee6a289c4c8e1705d6af3f.md
+++ b/curriculum/challenges/english/blocks/learn-about-speculation-and-requests/67ee6a289c4c8e1705d6af3f.md
@@ -3,7 +3,6 @@ id: 67ee6a289c4c8e1705d6af3f
 title: Task 14
 challengeType: 19
 dashedName: task-14
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-about-speculation-and-requests/67ee7dab0f703d1cb716322a.md
+++ b/curriculum/challenges/english/blocks/learn-about-speculation-and-requests/67ee7dab0f703d1cb716322a.md
@@ -3,7 +3,6 @@ id: 67ee7dab0f703d1cb716322a
 title: Task 18
 challengeType: 19
 dashedName: task-18
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-about-speculation-and-requests/67eea4bdf9bcb42544573b98.md
+++ b/curriculum/challenges/english/blocks/learn-about-speculation-and-requests/67eea4bdf9bcb42544573b98.md
@@ -3,7 +3,6 @@ id: 67eea4bdf9bcb42544573b98
 title: Task 24
 challengeType: 19
 dashedName: task-24
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-about-speculation-and-requests/67ef899bfbdd8c0425bd477c.md
+++ b/curriculum/challenges/english/blocks/learn-about-speculation-and-requests/67ef899bfbdd8c0425bd477c.md
@@ -3,7 +3,6 @@ id: 67ef899bfbdd8c0425bd477c
 title: Task 31
 challengeType: 19
 dashedName: task-31
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-about-speculation-and-requests/67ef98ac61799b0c4812fcd4.md
+++ b/curriculum/challenges/english/blocks/learn-about-speculation-and-requests/67ef98ac61799b0c4812fcd4.md
@@ -3,7 +3,6 @@ id: 67ef98ac61799b0c4812fcd4
 title: Task 39
 challengeType: 19
 dashedName: task-39
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-about-speculation-and-requests/67efdfa59ffafb1f2a56381e.md
+++ b/curriculum/challenges/english/blocks/learn-about-speculation-and-requests/67efdfa59ffafb1f2a56381e.md
@@ -3,7 +3,6 @@ id: 67efdfa59ffafb1f2a56381e
 title: Task 55
 challengeType: 19
 dashedName: task-55
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-about-speculation-and-requests/67f007ad79ef192af858ecf6.md
+++ b/curriculum/challenges/english/blocks/learn-about-speculation-and-requests/67f007ad79ef192af858ecf6.md
@@ -3,7 +3,6 @@ id: 67f007ad79ef192af858ecf6
 title: Task 66
 challengeType: 19
 dashedName: task-66
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-about-speculation-and-requests/67f38fac88ead216c0db1dcb.md
+++ b/curriculum/challenges/english/blocks/learn-about-speculation-and-requests/67f38fac88ead216c0db1dcb.md
@@ -3,7 +3,6 @@ id: 67f38fac88ead216c0db1dcb
 title: Task 81
 challengeType: 19
 dashedName: task-81
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-about-speculation-and-requests/67f51f7b826c2b1a77042ec9.md
+++ b/curriculum/challenges/english/blocks/learn-about-speculation-and-requests/67f51f7b826c2b1a77042ec9.md
@@ -3,7 +3,6 @@ id: 67f51f7b826c2b1a77042ec9
 title: Task 100
 challengeType: 19
 dashedName: task-100
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-about-speculation-and-requests/67f6388c45b13e0b1fdc3f94.md
+++ b/curriculum/challenges/english/blocks/learn-about-speculation-and-requests/67f6388c45b13e0b1fdc3f94.md
@@ -3,7 +3,6 @@ id: 67f6388c45b13e0b1fdc3f94
 title: Task 127
 challengeType: 19
 dashedName: task-127
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-about-speculation-and-requests/67f6498972a39e11396f0b57.md
+++ b/curriculum/challenges/english/blocks/learn-about-speculation-and-requests/67f6498972a39e11396f0b57.md
@@ -3,7 +3,6 @@ id: 67f6498972a39e11396f0b57
 title: Task 133
 challengeType: 19
 dashedName: task-133
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-common-phrasal-verbs-and-idioms/684880a8013eb380020ce86e.md
+++ b/curriculum/challenges/english/blocks/learn-common-phrasal-verbs-and-idioms/684880a8013eb380020ce86e.md
@@ -3,7 +3,6 @@ id: 684880a8013eb380020ce86e
 title: Task 11
 challengeType: 19
 dashedName: task-11
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-common-phrasal-verbs-and-idioms/685342965ee0c916aff8dccf.md
+++ b/curriculum/challenges/english/blocks/learn-common-phrasal-verbs-and-idioms/685342965ee0c916aff8dccf.md
@@ -3,7 +3,6 @@ id: 685342965ee0c916aff8dccf
 title: Task 40
 challengeType: 19
 dashedName: task-40
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-common-phrasal-verbs-and-idioms/68558d2ba6e832d4c80d31d2.md
+++ b/curriculum/challenges/english/blocks/learn-common-phrasal-verbs-and-idioms/68558d2ba6e832d4c80d31d2.md
@@ -3,7 +3,6 @@ id: 68558d2ba6e832d4c80d31d2
 title: Task 63
 challengeType: 19
 dashedName: task-63
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-common-phrasal-verbs-and-idioms/6855d29ac4339430c2ce4c5d.md
+++ b/curriculum/challenges/english/blocks/learn-common-phrasal-verbs-and-idioms/6855d29ac4339430c2ce4c5d.md
@@ -3,7 +3,6 @@ id: 6855d29ac4339430c2ce4c5d
 title: Task 68
 challengeType: 19
 dashedName: task-68
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-common-phrasal-verbs-and-idioms/6856ddea73ea5fafe4d65cfc.md
+++ b/curriculum/challenges/english/blocks/learn-common-phrasal-verbs-and-idioms/6856ddea73ea5fafe4d65cfc.md
@@ -3,7 +3,6 @@ id: 6856ddea73ea5fafe4d65cfc
 title: Task 95
 challengeType: 19
 dashedName: task-95
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-common-phrasal-verbs-and-idioms/68594b7c7d2f0383614c229c.md
+++ b/curriculum/challenges/english/blocks/learn-common-phrasal-verbs-and-idioms/68594b7c7d2f0383614c229c.md
@@ -3,7 +3,6 @@ id: 68594b7c7d2f0383614c229c
 title: Task 118
 challengeType: 19
 dashedName: task-118
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-common-phrasal-verbs-and-idioms/685a992e26a88484990d4bae.md
+++ b/curriculum/challenges/english/blocks/learn-common-phrasal-verbs-and-idioms/685a992e26a88484990d4bae.md
@@ -3,7 +3,6 @@ id: 685a992e26a88484990d4bae
 title: Task 129
 challengeType: 19
 dashedName: task-129
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-determiners-and-advanced-use-of-articles/6810bf24a1a0f21735ab6f5c.md
+++ b/curriculum/challenges/english/blocks/learn-determiners-and-advanced-use-of-articles/6810bf24a1a0f21735ab6f5c.md
@@ -3,7 +3,6 @@ id: 6810bf24a1a0f21735ab6f5c
 title: Task 14
 challengeType: 19
 dashedName: task-14
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-determiners-and-advanced-use-of-articles/6810f38cc72d5c299834f066.md
+++ b/curriculum/challenges/english/blocks/learn-determiners-and-advanced-use-of-articles/6810f38cc72d5c299834f066.md
@@ -3,7 +3,6 @@ id: 6810f38cc72d5c299834f066
 title: Task 37
 challengeType: 19
 dashedName: task-37
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-determiners-and-advanced-use-of-articles/6811e08c2100310d037c1da2.md
+++ b/curriculum/challenges/english/blocks/learn-determiners-and-advanced-use-of-articles/6811e08c2100310d037c1da2.md
@@ -3,7 +3,6 @@ id: 6811e08c2100310d037c1da2
 title: Task 51
 challengeType: 19
 dashedName: task-51
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-determiners-and-advanced-use-of-articles/68123fda8ea2b820cd03d645.md
+++ b/curriculum/challenges/english/blocks/learn-determiners-and-advanced-use-of-articles/68123fda8ea2b820cd03d645.md
@@ -3,7 +3,6 @@ id: 68123fda8ea2b820cd03d645
 title: Task 68
 challengeType: 19
 dashedName: task-68
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-determiners-and-advanced-use-of-articles/681249882481cd275894253a.md
+++ b/curriculum/challenges/english/blocks/learn-determiners-and-advanced-use-of-articles/681249882481cd275894253a.md
@@ -3,7 +3,6 @@ id: 681249882481cd275894253a
 title: Task 76
 challengeType: 19
 dashedName: task-76
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-determiners-and-advanced-use-of-articles/68124c96feedb02a36e80a26.md
+++ b/curriculum/challenges/english/blocks/learn-determiners-and-advanced-use-of-articles/68124c96feedb02a36e80a26.md
@@ -3,7 +3,6 @@ id: 68124c96feedb02a36e80a26
 title: Task 81
 challengeType: 19
 dashedName: task-81
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-determiners-and-advanced-use-of-articles/68134a431c759b0bd9a37724.md
+++ b/curriculum/challenges/english/blocks/learn-determiners-and-advanced-use-of-articles/68134a431c759b0bd9a37724.md
@@ -3,7 +3,6 @@ id: 68134a431c759b0bd9a37724
 title: Task 96
 challengeType: 19
 dashedName: task-96
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-determiners-and-advanced-use-of-articles/68148a77e42df60e2dc5b39a.md
+++ b/curriculum/challenges/english/blocks/learn-determiners-and-advanced-use-of-articles/68148a77e42df60e2dc5b39a.md
@@ -3,7 +3,6 @@ id: 68148a77e42df60e2dc5b39a
 title: Task 123
 challengeType: 19
 dashedName: task-123
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-determiners-and-advanced-use-of-articles/6814b06705018b1b48b9a61e.md
+++ b/curriculum/challenges/english/blocks/learn-determiners-and-advanced-use-of-articles/6814b06705018b1b48b9a61e.md
@@ -3,7 +3,6 @@ id: 6814b06705018b1b48b9a61e
 title: Task 136
 challengeType: 19
 dashedName: task-136
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-determiners-and-advanced-use-of-articles/6814bb535c1d8721082ee6e8.md
+++ b/curriculum/challenges/english/blocks/learn-determiners-and-advanced-use-of-articles/6814bb535c1d8721082ee6e8.md
@@ -3,7 +3,6 @@ id: 6814bb535c1d8721082ee6e8
 title: Task 143
 challengeType: 19
 dashedName: task-143
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-future-continuous-while-describing-actions/675052373a1887aaa89c9a22.md
+++ b/curriculum/challenges/english/blocks/learn-future-continuous-while-describing-actions/675052373a1887aaa89c9a22.md
@@ -3,7 +3,6 @@ id: 675052373a1887aaa89c9a22
 title: Task 10
 challengeType: 19
 dashedName: task-10
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-future-continuous-while-describing-actions/675963eadf3bcf2ae50f74fe.md
+++ b/curriculum/challenges/english/blocks/learn-future-continuous-while-describing-actions/675963eadf3bcf2ae50f74fe.md
@@ -3,7 +3,6 @@ id: 675963eadf3bcf2ae50f74fe
 title: Task 39
 challengeType: 19
 dashedName: task-39
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-future-continuous-while-describing-actions/675d87ed627c734d9ee5c028.md
+++ b/curriculum/challenges/english/blocks/learn-future-continuous-while-describing-actions/675d87ed627c734d9ee5c028.md
@@ -3,7 +3,6 @@ id: 675d87ed627c734d9ee5c028
 title: Task 59
 challengeType: 19
 dashedName: task-59
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-future-continuous-while-describing-actions/675e6dfe0160bb66faa60a68.md
+++ b/curriculum/challenges/english/blocks/learn-future-continuous-while-describing-actions/675e6dfe0160bb66faa60a68.md
@@ -3,7 +3,6 @@ id: 675e6dfe0160bb66faa60a68
 title: Task 67
 challengeType: 19
 dashedName: task-67
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-future-continuous-while-describing-actions/675fba2a32b4aa625e2f7940.md
+++ b/curriculum/challenges/english/blocks/learn-future-continuous-while-describing-actions/675fba2a32b4aa625e2f7940.md
@@ -3,7 +3,6 @@ id: 675fba2a32b4aa625e2f7940
 title: Task 91
 challengeType: 19
 dashedName: task-91
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-future-continuous-while-describing-actions/675fbfc6fa824c820a7e49d4.md
+++ b/curriculum/challenges/english/blocks/learn-future-continuous-while-describing-actions/675fbfc6fa824c820a7e49d4.md
@@ -3,7 +3,6 @@ id: 675fbfc6fa824c820a7e49d4
 title: Task 94
 challengeType: 19
 dashedName: task-94
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-clarify-misunderstandings/67e54854c319e4146d72adc0.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-clarify-misunderstandings/67e54854c319e4146d72adc0.md
@@ -3,7 +3,6 @@ id: 67e54854c319e4146d72adc0
 title: Task 12
 challengeType: 19
 dashedName: task-12
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-clarify-misunderstandings/67e7d19684efbf43472f4523.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-clarify-misunderstandings/67e7d19684efbf43472f4523.md
@@ -3,7 +3,6 @@ id: 67e7d19684efbf43472f4523
 title: Task 21
 challengeType: 19
 dashedName: task-21
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-clarify-misunderstandings/67e91f52fd59f2714900771e.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-clarify-misunderstandings/67e91f52fd59f2714900771e.md
@@ -3,7 +3,6 @@ id: 67e91f52fd59f2714900771e
 title: Task 35
 challengeType: 19
 dashedName: task-35
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-clarify-misunderstandings/67ee55fc3acce677b739b11d.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-clarify-misunderstandings/67ee55fc3acce677b739b11d.md
@@ -3,7 +3,6 @@ id: 67ee55fc3acce677b739b11d
 title: Task 58
 challengeType: 19
 dashedName: task-58
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-clarify-misunderstandings/67ee6b7386839d2a397bce37.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-clarify-misunderstandings/67ee6b7386839d2a397bce37.md
@@ -3,7 +3,6 @@ id: 67ee6b7386839d2a397bce37
 title: Task 67
 challengeType: 19
 dashedName: task-67
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-clarify-misunderstandings/67f0ed8953222d5cdbbab506.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-clarify-misunderstandings/67f0ed8953222d5cdbbab506.md
@@ -3,7 +3,6 @@ id: 67f0ed8953222d5cdbbab506
 title: Task 86
 challengeType: 19
 dashedName: task-86
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-clarify-misunderstandings/67f1e6283649d77895dbf244.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-clarify-misunderstandings/67f1e6283649d77895dbf244.md
@@ -3,7 +3,6 @@ id: 67f1e6283649d77895dbf244
 title: Task 104
 challengeType: 19
 dashedName: task-104
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-clarify-misunderstandings/67f22fec0caa41b1f37ab3b6.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-clarify-misunderstandings/67f22fec0caa41b1f37ab3b6.md
@@ -3,7 +3,6 @@ id: 67f22fec0caa41b1f37ab3b6
 title: Task 114
 challengeType: 19
 dashedName: task-114
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-describe-places-and-events/66a95b3449d2504dc05ce288.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-describe-places-and-events/66a95b3449d2504dc05ce288.md
@@ -3,7 +3,6 @@ id: 66a95b3449d2504dc05ce288
 title: Task 24
 challengeType: 19
 dashedName: task-24
-showSpeakingButton: true
 lang: en-US
 ---
 <!--

--- a/curriculum/challenges/english/blocks/learn-how-to-describe-places-and-events/66b4f8f6c1af973bdfdc0228.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-describe-places-and-events/66b4f8f6c1af973bdfdc0228.md
@@ -3,7 +3,6 @@ id: 66b4f8f6c1af973bdfdc0228
 title: Task 49
 challengeType: 19
 dashedName: task-49
-showSpeakingButton: true
 lang: en-US
 ---
 <!--

--- a/curriculum/challenges/english/blocks/learn-how-to-describe-places-and-events/66b52aaddea73da83ef5d442.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-describe-places-and-events/66b52aaddea73da83ef5d442.md
@@ -3,7 +3,6 @@ id: 66b52aaddea73da83ef5d442
 title: Task 61
 challengeType: 19
 dashedName: task-61
-showSpeakingButton: true
 lang: en-US
 ---
 <!--

--- a/curriculum/challenges/english/blocks/learn-how-to-describe-places-and-events/66b52e590bc0b3b589a6801f.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-describe-places-and-events/66b52e590bc0b3b589a6801f.md
@@ -3,7 +3,6 @@ id: 66b52e590bc0b3b589a6801f
 title: Task 65
 challengeType: 19
 dashedName: task-65
-showSpeakingButton: true
 lang: en-US
 ---
 <!--

--- a/curriculum/challenges/english/blocks/learn-how-to-describe-places-and-events/66b53396686499c925a826c1.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-describe-places-and-events/66b53396686499c925a826c1.md
@@ -3,7 +3,6 @@ id: 66b53396686499c925a826c1
 title: Task 73
 challengeType: 19
 dashedName: task-73
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-describe-places-and-events/66b53552b8d63ad06881bd50.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-describe-places-and-events/66b53552b8d63ad06881bd50.md
@@ -3,7 +3,6 @@ id: 66b53552b8d63ad06881bd50
 title: Task 75
 challengeType: 19
 dashedName: task-75
-showSpeakingButton: true
 lang: en-US
 ---
 <!--

--- a/curriculum/challenges/english/blocks/learn-how-to-describe-places-and-events/66b569e6e765c10dd91dd683.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-describe-places-and-events/66b569e6e765c10dd91dd683.md
@@ -3,7 +3,6 @@ id: 66b569e6e765c10dd91dd683
 title: Task 80
 challengeType: 19
 dashedName: task-80
-showSpeakingButton: true
 lang: en-US
 ---
 <!--

--- a/curriculum/challenges/english/blocks/learn-how-to-describe-places-and-events/66b56d36cc47571a0e2a3dc5.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-describe-places-and-events/66b56d36cc47571a0e2a3dc5.md
@@ -3,7 +3,6 @@ id: 66b56d36cc47571a0e2a3dc5
 title: Task 84
 challengeType: 19
 dashedName: task-84
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-describe-places-and-events/66b570ffdeeb7828167283fd.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-describe-places-and-events/66b570ffdeeb7828167283fd.md
@@ -3,7 +3,6 @@ id: 66b570ffdeeb7828167283fd
 title: Task 89
 challengeType: 19
 dashedName: task-89
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-describe-places-and-events/66c4f338d6b658809576ae77.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-describe-places-and-events/66c4f338d6b658809576ae77.md
@@ -3,7 +3,6 @@ id: 66c4f338d6b658809576ae77
 title: Task 117
 challengeType: 19
 dashedName: task-117
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-describe-places-and-events/66c507bef7c69ac73fbc82cc.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-describe-places-and-events/66c507bef7c69ac73fbc82cc.md
@@ -3,7 +3,6 @@ id: 66c507bef7c69ac73fbc82cc
 title: Task 124
 challengeType: 19
 dashedName: task-124
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-describe-places-and-events/66c616d281199cda967c144d.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-describe-places-and-events/66c616d281199cda967c144d.md
@@ -3,7 +3,6 @@ id: 66c616d281199cda967c144d
 title: Task 128
 challengeType: 19
 dashedName: task-128
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-describe-places-and-events/66c61dee09da09f603fa3dbc.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-describe-places-and-events/66c61dee09da09f603fa3dbc.md
@@ -3,7 +3,6 @@ id: 66c61dee09da09f603fa3dbc
 title: Task 133
 challengeType: 19
 dashedName: task-133
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-describe-places-and-events/66c62b0c65018625985a897d.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-describe-places-and-events/66c62b0c65018625985a897d.md
@@ -3,7 +3,6 @@ id: 66c62b0c65018625985a897d
 title: Task 145
 challengeType: 19
 dashedName: task-145
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-express-agreement/679b7597814cfe0657acb4f5.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-express-agreement/679b7597814cfe0657acb4f5.md
@@ -3,7 +3,6 @@ id: 679b7597814cfe0657acb4f5
 title: Task 10
 challengeType: 19
 dashedName: task-10
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-express-agreement/67a75d6b2e42aaefbc7d0d27.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-express-agreement/67a75d6b2e42aaefbc7d0d27.md
@@ -3,7 +3,6 @@ id: 67a75d6b2e42aaefbc7d0d27
 title: Task 22
 challengeType: 19
 dashedName: task-22
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-express-agreement/67a8ae3c3710410d1bf9569c.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-express-agreement/67a8ae3c3710410d1bf9569c.md
@@ -3,7 +3,6 @@ id: 67a8ae3c3710410d1bf9569c
 title: Task 31
 challengeType: 19
 dashedName: task-31
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-express-agreement/67b1ddf392f98642178927d4.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-express-agreement/67b1ddf392f98642178927d4.md
@@ -3,7 +3,6 @@ id: 67b1ddf392f98642178927d4
 title: Task 62
 challengeType: 19
 dashedName: task-62
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-express-agreement/67b2f4c60e993343e5f499e6.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-express-agreement/67b2f4c60e993343e5f499e6.md
@@ -3,7 +3,6 @@ id: 67b2f4c60e993343e5f499e6
 title: Task 74
 challengeType: 19
 dashedName: task-74
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-express-agreement/67b4820e52af174c730e5aa1.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-express-agreement/67b4820e52af174c730e5aa1.md
@@ -3,7 +3,6 @@ id: 67b4820e52af174c730e5aa1
 title: Task 99
 challengeType: 19
 dashedName: task-99
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-express-agreement/67b5b02b5759d517626403fd.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-express-agreement/67b5b02b5759d517626403fd.md
@@ -3,7 +3,6 @@ id: 67b5b02b5759d517626403fd
 title: Task 108
 challengeType: 19
 dashedName: task-108
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-express-agreement/67b70843a1f069708b3bdd22.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-express-agreement/67b70843a1f069708b3bdd22.md
@@ -3,7 +3,6 @@ id: 67b70843a1f069708b3bdd22
 title: Task 118
 challengeType: 19
 dashedName: task-118
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-express-concerns/67c489951e48c78cf71ad387.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-express-concerns/67c489951e48c78cf71ad387.md
@@ -3,7 +3,6 @@ id: 67c489951e48c78cf71ad387
 title: Task 12
 challengeType: 19
 dashedName: task-12
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-express-concerns/67c4c0089f19c7068b1cde29.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-express-concerns/67c4c0089f19c7068b1cde29.md
@@ -3,7 +3,6 @@ id: 67c4c0089f19c7068b1cde29
 title: Task 23
 challengeType: 19
 dashedName: task-23
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-express-concerns/67c4e2ba3c427051461d43aa.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-express-concerns/67c4e2ba3c427051461d43aa.md
@@ -3,7 +3,6 @@ id: 67c4e2ba3c427051461d43aa
 title: Task 29
 challengeType: 19
 dashedName: task-29
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-express-concerns/67c5f02457a210d5d369edd0.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-express-concerns/67c5f02457a210d5d369edd0.md
@@ -3,7 +3,6 @@ id: 67c5f02457a210d5d369edd0
 title: Task 39
 challengeType: 19
 dashedName: task-39
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-express-concerns/67c712596d91bcd364b3cf0d.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-express-concerns/67c712596d91bcd364b3cf0d.md
@@ -3,7 +3,6 @@ id: 67c712596d91bcd364b3cf0d
 title: Task 60
 challengeType: 19
 dashedName: task-60
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-express-concerns/67c744876e38a4508887d5a5.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-express-concerns/67c744876e38a4508887d5a5.md
@@ -3,7 +3,6 @@ id: 67c744876e38a4508887d5a5
 title: Task 69
 challengeType: 19
 dashedName: task-69
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-express-concerns/67c7792851d126dc00b5c9e6.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-express-concerns/67c7792851d126dc00b5c9e6.md
@@ -3,7 +3,6 @@ id: 67c7792851d126dc00b5c9e6
 title: Task 78
 challengeType: 19
 dashedName: task-78
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-express-concerns/67c8cca767fad7d91d6f18ec.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-express-concerns/67c8cca767fad7d91d6f18ec.md
@@ -3,7 +3,6 @@ id: 67c8cca767fad7d91d6f18ec
 title: Task 90
 challengeType: 19
 dashedName: task-90
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-express-concerns/67c8d4d492bf46094b60e494.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-express-concerns/67c8d4d492bf46094b60e494.md
@@ -3,7 +3,6 @@ id: 67c8d4d492bf46094b60e494
 title: Task 94
 challengeType: 19
 dashedName: task-94
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-express-concerns/67c9d7b7631ddc74d18ce2bf.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-express-concerns/67c9d7b7631ddc74d18ce2bf.md
@@ -3,7 +3,6 @@ id: 67c9d7b7631ddc74d18ce2bf
 title: Task 112
 challengeType: 19
 dashedName: task-112
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-express-concerns/67caf8354f5a73e414bf0fd6.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-express-concerns/67caf8354f5a73e414bf0fd6.md
@@ -3,7 +3,6 @@ id: 67caf8354f5a73e414bf0fd6
 title: Task 133
 challengeType: 19
 dashedName: task-133
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-express-concerns/67cb0202feb48313372cbcfa.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-express-concerns/67cb0202feb48313372cbcfa.md
@@ -3,7 +3,6 @@ id: 67cb0202feb48313372cbcfa
 title: Task 138
 challengeType: 19
 dashedName: task-138
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-express-concerns/67cb2551afd7e0428cbb6d1d.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-express-concerns/67cb2551afd7e0428cbb6d1d.md
@@ -3,7 +3,6 @@ id: 67cb2551afd7e0428cbb6d1d
 title: Task 143
 challengeType: 19
 dashedName: task-143
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-express-decisions-based-on-comparisons/67cacf4fe18b471e19ffd5d9.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-express-decisions-based-on-comparisons/67cacf4fe18b471e19ffd5d9.md
@@ -3,7 +3,6 @@ id: 67cacf4fe18b471e19ffd5d9
 title: Task 36
 challengeType: 19
 dashedName: task-36
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-express-decisions-based-on-comparisons/67cbbab067ec663e43da234d.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-express-decisions-based-on-comparisons/67cbbab067ec663e43da234d.md
@@ -3,7 +3,6 @@ id: 67cbbab067ec663e43da234d
 title: Task 43
 challengeType: 19
 dashedName: task-43
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-express-decisions-based-on-comparisons/67d2cf65ca86f929c07f45b2.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-express-decisions-based-on-comparisons/67d2cf65ca86f929c07f45b2.md
@@ -3,7 +3,6 @@ id: 67d2cf65ca86f929c07f45b2
 title: Task 69
 challengeType: 19
 dashedName: task-69
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-express-decisions-based-on-comparisons/67d4335d6ba10d72a83ac860.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-express-decisions-based-on-comparisons/67d4335d6ba10d72a83ac860.md
@@ -3,7 +3,6 @@ id: 67d4335d6ba10d72a83ac860
 title: Task 89
 challengeType: 19
 dashedName: task-89
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-express-decisions-based-on-comparisons/67d78acc1a10bf3a2093a064.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-express-decisions-based-on-comparisons/67d78acc1a10bf3a2093a064.md
@@ -3,7 +3,6 @@ id: 67d78acc1a10bf3a2093a064
 title: Task 115
 challengeType: 19
 dashedName: task-115
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-express-decisions-based-on-comparisons/67d7f39f2e403d5da82fa90c.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-express-decisions-based-on-comparisons/67d7f39f2e403d5da82fa90c.md
@@ -3,7 +3,6 @@ id: 67d7f39f2e403d5da82fa90c
 title: Task 131
 challengeType: 19
 dashedName: task-131
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-express-disagreement/67a9f64823ab730da3376358.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-express-disagreement/67a9f64823ab730da3376358.md
@@ -3,7 +3,6 @@ id: 67a9f64823ab730da3376358
 title: Task 6
 challengeType: 19
 dashedName: task-6
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-express-disagreement/67ac73910ad52c09dca4cef9.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-express-disagreement/67ac73910ad52c09dca4cef9.md
@@ -3,7 +3,6 @@ id: 67ac73910ad52c09dca4cef9
 title: Task 19
 challengeType: 19
 dashedName: task-19
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-express-disagreement/67acb31f4e94b6106c23df4d.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-express-disagreement/67acb31f4e94b6106c23df4d.md
@@ -3,7 +3,6 @@ id: 67acb31f4e94b6106c23df4d
 title: Task 23
 challengeType: 19
 dashedName: task-23
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-express-disagreement/67acba69e4ad2d139946ec4f.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-express-disagreement/67acba69e4ad2d139946ec4f.md
@@ -3,7 +3,6 @@ id: 67acba69e4ad2d139946ec4f
 title: Task 27
 challengeType: 19
 dashedName: task-27
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-express-disagreement/67adad520eb3ba05f8a1af1b.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-express-disagreement/67adad520eb3ba05f8a1af1b.md
@@ -3,7 +3,6 @@ id: 67adad520eb3ba05f8a1af1b
 title: Task 33
 challengeType: 19
 dashedName: task-33
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-express-disagreement/67adb2cc1242e808fbe147f5.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-express-disagreement/67adb2cc1242e808fbe147f5.md
@@ -3,7 +3,6 @@ id: 67adb2cc1242e808fbe147f5
 title: Task 37
 challengeType: 19
 dashedName: task-37
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-express-disagreement/67af056e4736950749ec51ff.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-express-disagreement/67af056e4736950749ec51ff.md
@@ -3,7 +3,6 @@ id: 67af056e4736950749ec51ff
 title: Task 40
 challengeType: 19
 dashedName: task-40
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-express-disagreement/67b9ad4e516f8a086cd5d347.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-express-disagreement/67b9ad4e516f8a086cd5d347.md
@@ -3,7 +3,6 @@ id: 67b9ad4e516f8a086cd5d347
 title: Task 60
 challengeType: 19
 dashedName: task-60
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-express-disagreement/67b9e5cc7dd4de10631bca9b.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-express-disagreement/67b9e5cc7dd4de10631bca9b.md
@@ -3,7 +3,6 @@ id: 67b9e5cc7dd4de10631bca9b
 title: Task 66
 challengeType: 19
 dashedName: task-66
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-express-disagreement/67b9f0086ae43b1587811d2c.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-express-disagreement/67b9f0086ae43b1587811d2c.md
@@ -3,7 +3,6 @@ id: 67b9f0086ae43b1587811d2c
 title: Task 72
 challengeType: 19
 dashedName: task-72
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-express-disagreement/67baf4bde9454d078861e5c7.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-express-disagreement/67baf4bde9454d078861e5c7.md
@@ -3,7 +3,6 @@ id: 67baf4bde9454d078861e5c7
 title: Task 77
 challengeType: 19
 dashedName: task-77
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-express-disagreement/67bb02a99bb2420ddad31b17.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-express-disagreement/67bb02a99bb2420ddad31b17.md
@@ -3,7 +3,6 @@ id: 67bb02a99bb2420ddad31b17
 title: Task 84
 challengeType: 19
 dashedName: task-84
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-express-disagreement/67bf2a74d2a4840d481299e0.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-express-disagreement/67bf2a74d2a4840d481299e0.md
@@ -3,7 +3,6 @@ id: 67bf2a74d2a4840d481299e0
 title: Task 101
 challengeType: 19
 dashedName: task-101
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-express-disagreement/67bf373e5c27271202945cad.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-express-disagreement/67bf373e5c27271202945cad.md
@@ -3,7 +3,6 @@ id: 67bf373e5c27271202945cad
 title: Task 106
 challengeType: 19
 dashedName: task-106
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-express-disagreement/67c03cc799e8b90a04e78bc1.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-express-disagreement/67c03cc799e8b90a04e78bc1.md
@@ -3,7 +3,6 @@ id: 67c03cc799e8b90a04e78bc1
 title: Task 111
 challengeType: 19
 dashedName: task-111
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-express-disagreement/67c062e09ddb0010a46c233e.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-express-disagreement/67c062e09ddb0010a46c233e.md
@@ -3,7 +3,6 @@ id: 67c062e09ddb0010a46c233e
 title: Task 117
 challengeType: 19
 dashedName: task-117
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-express-disagreement/67c06e7c22aba916592604a8.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-express-disagreement/67c06e7c22aba916592604a8.md
@@ -3,7 +3,6 @@ id: 67c06e7c22aba916592604a8
 title: Task 124
 challengeType: 19
 dashedName: task-124
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-express-disagreement/67c0764e4d542e1a0249e0d2.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-express-disagreement/67c0764e4d542e1a0249e0d2.md
@@ -3,7 +3,6 @@ id: 67c0764e4d542e1a0249e0d2
 title: Task 128
 challengeType: 19
 dashedName: task-128
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-manage-a-conversation/67dc3e08edb3923cf86151ec.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-manage-a-conversation/67dc3e08edb3923cf86151ec.md
@@ -3,7 +3,6 @@ id: 67dc3e08edb3923cf86151ec
 title: Task 7
 challengeType: 19
 dashedName: task-7
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-manage-a-conversation/67dc4a9c9f028d7ce4142490.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-manage-a-conversation/67dc4a9c9f028d7ce4142490.md
@@ -3,7 +3,6 @@ id: 67dc4a9c9f028d7ce4142490
 title: Task 12
 challengeType: 19
 dashedName: task-12
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-manage-a-conversation/67dd5dacf47e8ed984dc90da.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-manage-a-conversation/67dd5dacf47e8ed984dc90da.md
@@ -3,7 +3,6 @@ id: 67dd5dacf47e8ed984dc90da
 title: Task 17
 challengeType: 19
 dashedName: task-17
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-manage-a-conversation/67dd9df075882b30da414a84.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-manage-a-conversation/67dd9df075882b30da414a84.md
@@ -3,7 +3,6 @@ id: 67dd9df075882b30da414a84
 title: Task 22
 challengeType: 19
 dashedName: task-22
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-manage-a-conversation/67ddaa99f47b4c73b567dbe3.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-manage-a-conversation/67ddaa99f47b4c73b567dbe3.md
@@ -3,7 +3,6 @@ id: 67ddaa99f47b4c73b567dbe3
 title: Task 28
 challengeType: 19
 dashedName: task-28
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-manage-a-conversation/67e5a26a0833643ed7c41759.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-manage-a-conversation/67e5a26a0833643ed7c41759.md
@@ -3,7 +3,6 @@ id: 67e5a26a0833643ed7c41759
 title: Task 48
 challengeType: 19
 dashedName: task-48
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-manage-a-conversation/67e5b22aaf9f129649be3fd9.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-manage-a-conversation/67e5b22aaf9f129649be3fd9.md
@@ -3,7 +3,6 @@ id: 67e5b22aaf9f129649be3fd9
 title: Task 57
 challengeType: 19
 dashedName: task-57
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-manage-a-conversation/67e695e0c3759e0240a976ef.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-manage-a-conversation/67e695e0c3759e0240a976ef.md
@@ -3,7 +3,6 @@ id: 67e695e0c3759e0240a976ef
 title: Task 64
 challengeType: 19
 dashedName: task-64
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-manage-a-conversation/67e6a0742481f03cdd8485c3.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-manage-a-conversation/67e6a0742481f03cdd8485c3.md
@@ -3,7 +3,6 @@ id: 67e6a0742481f03cdd8485c3
 title: Task 71
 challengeType: 19
 dashedName: task-71
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-manage-a-conversation/67f05b27e13f3333efd9167c.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-manage-a-conversation/67f05b27e13f3333efd9167c.md
@@ -3,7 +3,6 @@ id: 67f05b27e13f3333efd9167c
 title: Task 112
 challengeType: 19
 dashedName: task-112
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-manage-a-conversation/67f06151744ee95acd3440e3.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-manage-a-conversation/67f06151744ee95acd3440e3.md
@@ -3,7 +3,6 @@ id: 67f06151744ee95acd3440e3
 title: Task 116
 challengeType: 19
 dashedName: task-116
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-manage-a-conversation/67f069b4d8dce18b274f3b85.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-manage-a-conversation/67f069b4d8dce18b274f3b85.md
@@ -3,7 +3,6 @@ id: 67f069b4d8dce18b274f3b85
 title: Task 121
 challengeType: 19
 dashedName: task-121
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-plan-future-events/673ba128855f6e78cd392dab.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-plan-future-events/673ba128855f6e78cd392dab.md
@@ -3,7 +3,6 @@ id: 673ba128855f6e78cd392dab
 title: Task 8
 challengeType: 19
 dashedName: task-8
-showSpeakingButton: true
 lang: en-US
 ---
 <!-- (Audio) Jake: Maria, the next system update is scheduled for this Saturday at 2 AM. It's crucial to enhance our firewall settings to prevent any potential DoS attacks. -->

--- a/curriculum/challenges/english/blocks/learn-how-to-plan-future-events/673bab51ecb42c369eb6b37b.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-plan-future-events/673bab51ecb42c369eb6b37b.md
@@ -3,7 +3,6 @@ id: 673bab51ecb42c369eb6b37b
 title: Task 14
 challengeType: 19
 dashedName: task-14
-showSpeakingButton: true
 lang: en-US
 ---
 <!-- (Audio) Maria: Yes, Jake, I've reviewed the timetable. The server downtime starts exactly when the user traffic is at its lowest, correct? -->

--- a/curriculum/challenges/english/blocks/learn-how-to-plan-future-events/67506e16a9e0bdaad7267c35.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-plan-future-events/67506e16a9e0bdaad7267c35.md
@@ -3,7 +3,6 @@ id: 67506e16a9e0bdaad7267c35
 title: Task 33
 challengeType: 19
 dashedName: task-33
-showSpeakingButton: true
 lang: en-US
 ---
 <!-- (Audio) Maria: Great, and when does the team perform the final checks? -->

--- a/curriculum/challenges/english/blocks/learn-how-to-plan-future-events/6750775f2b0832e88216e98c.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-plan-future-events/6750775f2b0832e88216e98c.md
@@ -3,7 +3,6 @@ id: 6750775f2b0832e88216e98c
 title: Task 40
 challengeType: 19
 dashedName: task-40
-showSpeakingButton: true
 lang: en-US
 ---
 <!-- (Audio) Maria: Perfect. And the training session for the new security protocols, when is that planned? -->

--- a/curriculum/challenges/english/blocks/learn-how-to-plan-future-events/675325cfea799165252500d4.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-plan-future-events/675325cfea799165252500d4.md
@@ -3,7 +3,6 @@ id: 675325cfea799165252500d4
 title: Task 58
 challengeType: 19
 dashedName: task-58
-showSpeakingButton: true
 lang: en-US
 ---
 <!-- (Audio) Jake: Sarah, I just found out that we've had a phishing attack on our system. It looks like someone will need to notify the team and take immediate action. -->

--- a/curriculum/challenges/english/blocks/learn-how-to-plan-future-events/675329bc0e2bfa7f1c4f7411.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-plan-future-events/675329bc0e2bfa7f1c4f7411.md
@@ -3,7 +3,6 @@ id: 675329bc0e2bfa7f1c4f7411
 title: Task 61
 challengeType: 19
 dashedName: task-61
-showSpeakingButton: true
 lang: en-US
 ---
 <!-- (Audio) Sarah: Oh no! Do you know where it originated from? -->

--- a/curriculum/challenges/english/blocks/learn-how-to-plan-future-events/67533335139a96bd1eb18395.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-plan-future-events/67533335139a96bd1eb18395.md
@@ -3,7 +3,6 @@ id: 67533335139a96bd1eb18395
 title: Task 66
 challengeType: 19
 dashedName: task-66
-showSpeakingButton: true
 lang: en-US
 ---
 <!-- Jake: Not yet, but I think it came from an email link. We need to investigate quickly. I'll send out a warning to everyone right away. -->

--- a/curriculum/challenges/english/blocks/learn-how-to-plan-future-events/67535e02fd808570ca6cb599.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-plan-future-events/67535e02fd808570ca6cb599.md
@@ -3,7 +3,6 @@ id: 67535e02fd808570ca6cb599
 title: Task 69
 challengeType: 19
 dashedName: task-69
-showSpeakingButton: true
 lang: en-US
 ---
 <!-- (Audio) Sarah: Do you think it will affect our project deadlines? -->

--- a/curriculum/challenges/english/blocks/learn-how-to-plan-future-events/67575a0d4b966da41383050b.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-plan-future-events/67575a0d4b966da41383050b.md
@@ -3,7 +3,6 @@ id: 67575a0d4b966da41383050b
 title: Task 86
 challengeType: 19
 dashedName: task-86
-showSpeakingButton: true
 lang: en-US
 ---
 <!-- (Audio) Can you coordinate with the IT support team for that? -->

--- a/curriculum/challenges/english/blocks/learn-how-to-plan-future-events/675c92e9a6133659ccad5424.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-plan-future-events/675c92e9a6133659ccad5424.md
@@ -3,7 +3,6 @@ id: 675c92e9a6133659ccad5424
 title: Task 90
 challengeType: 19
 dashedName: task-90
-showSpeakingButton: true
 lang: en-US
 ---
 <!-- (Audio) Sarah: How do you think our clients will react to this news? -->

--- a/curriculum/challenges/english/blocks/learn-how-to-plan-future-events/6761ecb48889faa066740143.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-plan-future-events/6761ecb48889faa066740143.md
@@ -3,7 +3,6 @@ id: 6761ecb48889faa066740143
 title: Task 109
 challengeType: 19
 dashedName: task-109
-showSpeakingButton: true
 lang: en-US
 ---
 <!-- (audio) Jake: I've been looking into our database security, and I think we're going to need some additional measures to prevent SQL injection attacks. -->

--- a/curriculum/challenges/english/blocks/learn-how-to-plan-future-events/6762dceeac22841f223b0101.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-plan-future-events/6762dceeac22841f223b0101.md
@@ -3,7 +3,6 @@ id: 6762dceeac22841f223b0101
 title: Task 119
 challengeType: 19
 dashedName: task-119
-showSpeakingButton: true
 lang: en-US
 ---
 <!-- (audio) Jake: We're going to implement parameterized queries to minimize the risk. This should reduce the chances of unauthorized access to our data. -->

--- a/curriculum/challenges/english/blocks/learn-how-to-plan-future-events/676325dfad1ee0784c7f1a5e.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-plan-future-events/676325dfad1ee0784c7f1a5e.md
@@ -3,7 +3,6 @@ id: 676325dfad1ee0784c7f1a5e
 title: Task 129
 challengeType: 19
 dashedName: task-129
-showSpeakingButton: true
 lang: en-US
 ---
 <!-- (audio) Maria: I'm going to inform the team about the upcoming training. -->

--- a/curriculum/challenges/english/blocks/learn-how-to-plan-future-events/67632f1219de712fcf37d295.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-plan-future-events/67632f1219de712fcf37d295.md
@@ -3,7 +3,6 @@ id: 67632f1219de712fcf37d295
 title: Task 135
 challengeType: 19
 dashedName: task-135
-showSpeakingButton: true
 lang: en-US
 ---
 <!-- (audio) Jake: We're going to monitor the database activity more closely. This will help us catch any suspicious patterns early. -->

--- a/curriculum/challenges/english/blocks/learn-how-to-plan-future-events/676338a796ace16be009e9d6.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-plan-future-events/676338a796ace16be009e9d6.md
@@ -3,7 +3,6 @@ id: 676338a796ace16be009e9d6
 title: Task 140
 challengeType: 19
 dashedName: task-140
-showSpeakingButton: true
 lang: en-US
 ---
 <!-- (audio) Maria: Are we going to share this information with other departments? -->

--- a/curriculum/challenges/english/blocks/learn-how-to-share-feedback/67895b64a6b0269eef113585.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-share-feedback/67895b64a6b0269eef113585.md
@@ -3,7 +3,6 @@ id: 67895b64a6b0269eef113585
 title: Task 7
 challengeType: 19
 dashedName: task-7
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-share-feedback/67975b22725c58c73f04776c.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-share-feedback/67975b22725c58c73f04776c.md
@@ -3,7 +3,6 @@ id: 67975b22725c58c73f04776c
 title: Task 13
 challengeType: 19
 dashedName: task-13
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-share-feedback/6798ef53b440d6f55a285876.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-share-feedback/6798ef53b440d6f55a285876.md
@@ -3,7 +3,6 @@ id: 6798ef53b440d6f55a285876
 title: Task 40
 challengeType: 19
 dashedName: task-40
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-share-feedback/679aa85d3d2c92ecd9d90a19.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-share-feedback/679aa85d3d2c92ecd9d90a19.md
@@ -3,7 +3,6 @@ id: 679aa85d3d2c92ecd9d90a19
 title: Task 46
 challengeType: 19
 dashedName: task-46
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-share-feedback/679ad34ab51fae414488c26d.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-share-feedback/679ad34ab51fae414488c26d.md
@@ -3,7 +3,6 @@ id: 679ad34ab51fae414488c26d
 title: Task 51
 challengeType: 19
 dashedName: task-51
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-share-feedback/679af17fec7fe32dc07acb34.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-share-feedback/679af17fec7fe32dc07acb34.md
@@ -3,7 +3,6 @@ id: 679af17fec7fe32dc07acb34
 title: Task 54
 challengeType: 19
 dashedName: task-54
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-share-feedback/679b01d0f4ee91da2b282783.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-share-feedback/679b01d0f4ee91da2b282783.md
@@ -3,7 +3,6 @@ id: 679b01d0f4ee91da2b282783
 title: Task 62
 challengeType: 19
 dashedName: task-62
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-share-feedback/679ce79d606b9e89318e3fdc.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-share-feedback/679ce79d606b9e89318e3fdc.md
@@ -3,7 +3,6 @@ id: 679ce79d606b9e89318e3fdc
 title: Task 78
 challengeType: 19
 dashedName: task-78
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-share-feedback/679d23f6bc437b851c30fe45.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-share-feedback/679d23f6bc437b851c30fe45.md
@@ -3,7 +3,6 @@ id: 679d23f6bc437b851c30fe45
 title: Task 89
 challengeType: 19
 dashedName: task-89
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-share-feedback/679d3ec2813bc2963a4d65e5.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-share-feedback/679d3ec2813bc2963a4d65e5.md
@@ -3,7 +3,6 @@ id: 679d3ec2813bc2963a4d65e5
 title: Task 98
 challengeType: 19
 dashedName: task-98
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-share-feedback/679d63808d5e8fd63664ad8a.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-share-feedback/679d63808d5e8fd63664ad8a.md
@@ -3,7 +3,6 @@ id: 679d63808d5e8fd63664ad8a
 title: Task 107
 challengeType: 19
 dashedName: task-107
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-share-feedback/679d7933d4aac5a10157ec74.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-share-feedback/679d7933d4aac5a10157ec74.md
@@ -3,7 +3,6 @@ id: 679d7933d4aac5a10157ec74
 title: Task 114
 challengeType: 19
 dashedName: task-114
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-share-your-opinion/678c8f6deb9e3d2beaa01b76.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-share-your-opinion/678c8f6deb9e3d2beaa01b76.md
@@ -3,7 +3,6 @@ id: 678c8f6deb9e3d2beaa01b76
 title: Task 25
 challengeType: 19
 dashedName: task-25
-showSpeakingButton: true
 lang: en-US
 ---
 <!-- (audio) Tom: I find JavaScript more flexible. And it's the go-to language for front-end development. -->

--- a/curriculum/challenges/english/blocks/learn-how-to-share-your-opinion/678e4e4d897d24c0c14dcf70.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-share-your-opinion/678e4e4d897d24c0c14dcf70.md
@@ -3,7 +3,6 @@ id: 678e4e4d897d24c0c14dcf70
 title: Task 58
 challengeType: 19
 dashedName: task-58
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-share-your-opinion/679a4c63d0359989fff275df.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-share-your-opinion/679a4c63d0359989fff275df.md
@@ -3,7 +3,6 @@ id: 679a4c63d0359989fff275df
 title: Task 7
 challengeType: 19
 dashedName: task-7
-showSpeakingButton: true
 lang: en-US
 ---
 <!-- (audio) Linda: I think Python is the best language for beginners. It's easy to learn, and it has tons of libraries, especially for design work. -->

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-numbers-with-a-coworker/6846b4d65edf660de4f25ad0.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-numbers-with-a-coworker/6846b4d65edf660de4f25ad0.md
@@ -3,7 +3,6 @@ id: 6846b4d65edf660de4f25ad0
 title: Task 5
 challengeType: 19
 dashedName: task-5
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-numbers-with-a-coworker/6846d7d73703121a7ed28e14.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-numbers-with-a-coworker/6846d7d73703121a7ed28e14.md
@@ -3,7 +3,6 @@ id: 6846d7d73703121a7ed28e14
 title: Task 15
 challengeType: 19
 dashedName: task-15
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-numbers-with-a-coworker/6846e487d8674c20a78aa056.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-numbers-with-a-coworker/6846e487d8674c20a78aa056.md
@@ -3,7 +3,6 @@ id: 6846e487d8674c20a78aa056
 title: Task 23
 challengeType: 19
 dashedName: task-23
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-numbers-with-a-coworker/6846f8b04bfda3295feecab3.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-numbers-with-a-coworker/6846f8b04bfda3295feecab3.md
@@ -3,7 +3,6 @@ id: 6846f8b04bfda3295feecab3
 title: Task 31
 challengeType: 19
 dashedName: task-31
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-numbers-with-a-coworker/6847f7cbabbbd3402e286b51.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-numbers-with-a-coworker/6847f7cbabbbd3402e286b51.md
@@ -3,7 +3,6 @@ id: 6847f7cbabbbd3402e286b51
 title: Task 52
 challengeType: 19
 dashedName: task-52
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-numbers-with-a-coworker/684807ddeaf6ff49dbfe16b8.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-numbers-with-a-coworker/684807ddeaf6ff49dbfe16b8.md
@@ -3,7 +3,6 @@ id: 684807ddeaf6ff49dbfe16b8
 title: Task 61
 challengeType: 19
 dashedName: task-61
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-numbers-with-a-coworker/684814821ca09151c7408480.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-numbers-with-a-coworker/684814821ca09151c7408480.md
@@ -3,7 +3,6 @@ id: 684814821ca09151c7408480
 title: Task 69
 challengeType: 19
 dashedName: task-69
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-numbers-with-a-coworker/684827048e056a591d938565.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-numbers-with-a-coworker/684827048e056a591d938565.md
@@ -3,7 +3,6 @@ id: 684827048e056a591d938565
 title: Task 78
 challengeType: 19
 dashedName: task-78
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-numbers-with-a-coworker/6848358b012fc05ee8c675ca.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-numbers-with-a-coworker/6848358b012fc05ee8c675ca.md
@@ -3,7 +3,6 @@ id: 6848358b012fc05ee8c675ca
 title: Task 85
 challengeType: 19
 dashedName: task-85
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-numbers-with-a-coworker/68492ed72e1ea17540593913.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-numbers-with-a-coworker/68492ed72e1ea17540593913.md
@@ -3,7 +3,6 @@ id: 68492ed72e1ea17540593913
 title: Task 106
 challengeType: 19
 dashedName: task-106
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-numbers-with-a-coworker/684956730f9eb1899f8f9b98.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-numbers-with-a-coworker/684956730f9eb1899f8f9b98.md
@@ -3,7 +3,6 @@ id: 684956730f9eb1899f8f9b98
 title: Task 129
 challengeType: 19
 dashedName: task-129
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-activities/66c8e81ea3c2852de8ce7916.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-activities/66c8e81ea3c2852de8ce7916.md
@@ -3,7 +3,6 @@ id: 66c8e81ea3c2852de8ce7916
 title: Task 5
 challengeType: 19
 dashedName: task-5
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-activities/66c8f7c121fffe684273d118.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-activities/66c8f7c121fffe684273d118.md
@@ -3,7 +3,6 @@ id: 66c8f7c121fffe684273d118
 title: Task 13
 challengeType: 19
 dashedName: task-13
-showSpeakingButton: true
 lang: en-US
 ---
 <!-- (Audio) James: Have we fixed anything like this before? -->

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-activities/66c8f8da3f29c96cc6c99672.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-activities/66c8f8da3f29c96cc6c99672.md
@@ -3,7 +3,6 @@ id: 66c8f8da3f29c96cc6c99672
 title: Task 14
 challengeType: 19
 dashedName: task-14
-showSpeakingButton: true
 lang: en-US
 ---
 <!-- (Audio) James: Have we fixed anything like this before? -->

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-activities/66c90257fb09ca9514c1a489.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-activities/66c90257fb09ca9514c1a489.md
@@ -3,7 +3,6 @@ id: 66c90257fb09ca9514c1a489
 title: Task 24
 challengeType: 19
 dashedName: task-24
-showSpeakingButton: true
 lang: en-US
 ---
 <!-- (Audio) James: Have we received any detailed reports from users about this issue? -->

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-activities/66ce18ac4976d71ccc981bfb.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-activities/66ce18ac4976d71ccc981bfb.md
@@ -3,7 +3,6 @@ id: 66ce18ac4976d71ccc981bfb
 title: Task 32
 challengeType: 19
 dashedName: task-32
-showSpeakingButton: true
 lang: en-US
 ---
 <!-- (Audio) James: Has the development team been informed about this? -->

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-activities/66d9fef978f6ae28bd20ca34.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-activities/66d9fef978f6ae28bd20ca34.md
@@ -3,7 +3,6 @@ id: 66d9fef978f6ae28bd20ca34
 title: Task 47
 challengeType: 19
 dashedName: task-47
-showSpeakingButton: true
 lang: en-US
 ---
 <!--

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-activities/66db690a4859eaa462fd4862.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-activities/66db690a4859eaa462fd4862.md
@@ -3,7 +3,6 @@ id: 66db690a4859eaa462fd4862
 title: Task 64
 challengeType: 19
 dashedName: task-64
-showSpeakingButton: true
 lang: en-US
 ---
 <!--

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-activities/66df66f819d8815b87cd7020.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-activities/66df66f819d8815b87cd7020.md
@@ -3,7 +3,6 @@ id: 66df66f819d8815b87cd7020
 title: Task 71
 challengeType: 19
 dashedName: task-71
-showSpeakingButton: true
 lang: en-US
 ---
 <!--

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-activities/66df67fbc511f65f20cdc8d3.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-activities/66df67fbc511f65f20cdc8d3.md
@@ -3,7 +3,6 @@ id: 66df67fbc511f65f20cdc8d3
 title: Task 72
 challengeType: 19
 dashedName: task-72
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-activities/66df6d5aca93ea73a788b86b.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-activities/66df6d5aca93ea73a788b86b.md
@@ -3,7 +3,6 @@ id: 66df6d5aca93ea73a788b86b
 title: Task 78
 challengeType: 19
 dashedName: task-78
-showSpeakingButton: true
 lang: en-US
 ---
 <!--

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-activities/672bea62ee1bd94363435d0c.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-activities/672bea62ee1bd94363435d0c.md
@@ -3,7 +3,6 @@ id: 672bea62ee1bd94363435d0c
 title: Task 97
 challengeType: 19
 dashedName: task-97
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-activities/67326b6decb085616cce2be8.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-activities/67326b6decb085616cce2be8.md
@@ -3,7 +3,6 @@ id: 67326b6decb085616cce2be8
 title: Task 122
 challengeType: 19
 dashedName: task-122
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/67050a8becee6d10619fa5ff.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/67050a8becee6d10619fa5ff.md
@@ -3,7 +3,6 @@ id: 67050a8becee6d10619fa5ff
 title: Task 5
 challengeType: 19
 dashedName: task-5
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/6705425a4b3df216cb6de9a7.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/6705425a4b3df216cb6de9a7.md
@@ -3,7 +3,6 @@ id: 6705425a4b3df216cb6de9a7
 title: Task 17
 challengeType: 19
 dashedName: task-17
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/67055f5c9bdb8e1999102827.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/67055f5c9bdb8e1999102827.md
@@ -3,7 +3,6 @@ id: 67055f5c9bdb8e1999102827
 title: Task 23
 challengeType: 19
 dashedName: task-23
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/6705638c3791881aed186e9d.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/6705638c3791881aed186e9d.md
@@ -3,7 +3,6 @@ id: 6705638c3791881aed186e9d
 title: Task 27
 challengeType: 19
 dashedName: task-27
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/6710bc2f9f242e03ebeccbe9.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/6710bc2f9f242e03ebeccbe9.md
@@ -3,7 +3,6 @@ id: 6710bc2f9f242e03ebeccbe9
 title: Task 51
 challengeType: 19
 dashedName: task-51
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/671775f2f55c4c066193a1c1.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/671775f2f55c4c066193a1c1.md
@@ -3,7 +3,6 @@ id: 671775f2f55c4c066193a1c1
 title: Task 68
 challengeType: 19
 dashedName: task-68
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/6717b5c73e81e8101bed0ea2.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/6717b5c73e81e8101bed0ea2.md
@@ -3,7 +3,6 @@ id: 6717b5c73e81e8101bed0ea2
 title: Task 75
 challengeType: 19
 dashedName: task-75
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/671f7592e571ad05716b2c67.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/671f7592e571ad05716b2c67.md
@@ -3,7 +3,6 @@ id: 671f7592e571ad05716b2c67
 title: Task 87
 challengeType: 19
 dashedName: task-87
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/671f75e368cbd505a301ca7d.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/671f75e368cbd505a301ca7d.md
@@ -3,7 +3,6 @@ id: 671f75e368cbd505a301ca7d
 title: Task 90
 challengeType: 19
 dashedName: task-90
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/671f765a22e32e05d4f5074e.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/671f765a22e32e05d4f5074e.md
@@ -3,7 +3,6 @@ id: 671f765a22e32e05d4f5074e
 title: Task 93
 challengeType: 19
 dashedName: task-93
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/67460b84234b70a4772d2094.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-talk-about-past-experiences/67460b84234b70a4772d2094.md
@@ -3,7 +3,6 @@ id: 67460b84234b70a4772d2094
 title: Task 33
 challengeType: 19
 dashedName: task-33
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-use-adjectives-in-conversations/680b59e44a61d8ed6120e749.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-adjectives-in-conversations/680b59e44a61d8ed6120e749.md
@@ -3,7 +3,6 @@ id: 680b59e44a61d8ed6120e749
 title: Task 5
 challengeType: 19
 dashedName: task-5
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-use-adjectives-in-conversations/680cd0dc631fb330a2105d96.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-adjectives-in-conversations/680cd0dc631fb330a2105d96.md
@@ -3,7 +3,6 @@ id: 680cd0dc631fb330a2105d96
 title: Task 31
 challengeType: 19
 dashedName: task-31
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-use-adjectives-in-conversations/681c7f1a60eb91fb164580d0.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-adjectives-in-conversations/681c7f1a60eb91fb164580d0.md
@@ -3,7 +3,6 @@ id: 681c7f1a60eb91fb164580d0
 title: Task 65
 challengeType: 19
 dashedName: task-65
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-use-adjectives-in-conversations/681f25c0965e0e1fcec64061.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-adjectives-in-conversations/681f25c0965e0e1fcec64061.md
@@ -3,7 +3,6 @@ id: 681f25c0965e0e1fcec64061
 title: Task 80
 challengeType: 19
 dashedName: task-80
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-use-adjectives-in-conversations/6822f8a2b32f8d049aa460bb.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-adjectives-in-conversations/6822f8a2b32f8d049aa460bb.md
@@ -3,7 +3,6 @@ id: 6822f8a2b32f8d049aa460bb
 title: Task 115
 challengeType: 19
 dashedName: task-115
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-use-adjectives-in-conversations/68245ff536bf712da0d69bbc.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-adjectives-in-conversations/68245ff536bf712da0d69bbc.md
@@ -3,7 +3,6 @@ id: 68245ff536bf712da0d69bbc
 title: Task 132
 challengeType: 19
 dashedName: task-132
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-use-conditionals/677f90f45518530670ca5114.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-conditionals/677f90f45518530670ca5114.md
@@ -3,7 +3,6 @@ id: 677f90f45518530670ca5114
 title: Task 3
 challengeType: 19
 dashedName: task-3
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-use-conditionals/677f93114e9f0c08773806ac.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-conditionals/677f93114e9f0c08773806ac.md
@@ -3,7 +3,6 @@ id: 677f93114e9f0c08773806ac
 title: Task 10
 challengeType: 19
 dashedName: task-10
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-use-conditionals/677f991400370c0a848a57d6.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-conditionals/677f991400370c0a848a57d6.md
@@ -3,7 +3,6 @@ id: 677f991400370c0a848a57d6
 title: Task 13
 challengeType: 19
 dashedName: task-13
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-use-conditionals/677f9eee05eb8a0f34c3ba47.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-conditionals/677f9eee05eb8a0f34c3ba47.md
@@ -3,7 +3,6 @@ id: 677f9eee05eb8a0f34c3ba47
 title: Task 26
 challengeType: 19
 dashedName: task-26
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-use-conditionals/677fa099289c8f10bf926f09.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-conditionals/677fa099289c8f10bf926f09.md
@@ -3,7 +3,6 @@ id: 677fa099289c8f10bf926f09
 title: Task 31
 challengeType: 19
 dashedName: task-31
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-use-conditionals/677fbb832baa361f969be478.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-conditionals/677fbb832baa361f969be478.md
@@ -3,7 +3,6 @@ id: 677fbb832baa361f969be478
 title: Task 52
 challengeType: 19
 dashedName: task-52
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-use-conditionals/677fe67ccc6a2726782e274d.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-conditionals/677fe67ccc6a2726782e274d.md
@@ -3,7 +3,6 @@ id: 677fe67ccc6a2726782e274d
 title: Task 61
 challengeType: 19
 dashedName: task-61
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-use-conditionals/677feff132d56d2a40d6c4f1.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-conditionals/677feff132d56d2a40d6c4f1.md
@@ -3,7 +3,6 @@ id: 677feff132d56d2a40d6c4f1
 title: Task 65
 challengeType: 19
 dashedName: task-65
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-use-conditionals/6784cc760a89e854dc55e4d2.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-conditionals/6784cc760a89e854dc55e4d2.md
@@ -3,7 +3,6 @@ id: 6784cc760a89e854dc55e4d2
 title: Task 93
 challengeType: 19
 dashedName: task-93
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-use-conditionals/678507620156985b70c81f9f.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-conditionals/678507620156985b70c81f9f.md
@@ -3,7 +3,6 @@ id: 678507620156985b70c81f9f
 title: Task 97
 challengeType: 19
 dashedName: task-97
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-use-conditionals/67850ffc432b605f3d7d7187.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-conditionals/67850ffc432b605f3d7d7187.md
@@ -3,7 +3,6 @@ id: 67850ffc432b605f3d7d7187
 title: Task 101
 challengeType: 19
 dashedName: task-101
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-use-conditionals/678514dc7a9a57619631abd8.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-conditionals/678514dc7a9a57619631abd8.md
@@ -3,7 +3,6 @@ id: 678514dc7a9a57619631abd8
 title: Task 104
 challengeType: 19
 dashedName: task-104
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-use-conditionals/678553a759feaa680cf381ab.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-conditionals/678553a759feaa680cf381ab.md
@@ -3,7 +3,6 @@ id: 678553a759feaa680cf381ab
 title: Task 109
 challengeType: 19
 dashedName: task-109
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-use-conditionals/678559c204808d6c6706556c.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-conditionals/678559c204808d6c6706556c.md
@@ -3,7 +3,6 @@ id: 678559c204808d6c6706556c
 title: Task 114
 challengeType: 19
 dashedName: task-114
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-use-conditionals/67900eeff58f3aba1b5267b0.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-conditionals/67900eeff58f3aba1b5267b0.md
@@ -3,7 +3,6 @@ id: 67900eeff58f3aba1b5267b0
 title: Task 19
 challengeType: 19
 dashedName: task-19
-showSpeakingButton: true
 lang: en-US
 ---
 <!-- (audio) Mark: Sometimes if the BIOS is corrupted, it prevents the computer from starting. If that's the case, it can be tricky to fix. -->

--- a/curriculum/challenges/english/blocks/learn-how-to-use-modal-verbs/67d3fba28a7b770be2fef2ce.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-modal-verbs/67d3fba28a7b770be2fef2ce.md
@@ -3,7 +3,6 @@ id: 67d3fba28a7b770be2fef2ce
 title: Task 6
 challengeType: 19
 dashedName: task-6
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-use-modal-verbs/67d4097fa7bcb81182b974cb.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-modal-verbs/67d4097fa7bcb81182b974cb.md
@@ -3,7 +3,6 @@ id: 67d4097fa7bcb81182b974cb
 title: Task 13
 challengeType: 19
 dashedName: task-13
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-use-modal-verbs/67d41aa54267bf1955c58fa7.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-modal-verbs/67d41aa54267bf1955c58fa7.md
@@ -3,7 +3,6 @@ id: 67d41aa54267bf1955c58fa7
 title: Task 21
 challengeType: 19
 dashedName: task-21
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-use-modal-verbs/67d41dd48484681b02482510.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-modal-verbs/67d41dd48484681b02482510.md
@@ -3,7 +3,6 @@ id: 67d41dd48484681b02482510
 title: Task 23
 challengeType: 19
 dashedName: task-23
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-use-modal-verbs/67d54c51c3f2772696a05a31.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-modal-verbs/67d54c51c3f2772696a05a31.md
@@ -3,7 +3,6 @@ id: 67d54c51c3f2772696a05a31
 title: Task 34
 challengeType: 19
 dashedName: task-34
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-use-modal-verbs/67d554f5f3411e2aa9118e05.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-modal-verbs/67d554f5f3411e2aa9118e05.md
@@ -3,7 +3,6 @@ id: 67d554f5f3411e2aa9118e05
 title: Task 38
 challengeType: 19
 dashedName: task-38
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-use-modal-verbs/67d560759cc85f3031977692.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-modal-verbs/67d560759cc85f3031977692.md
@@ -3,7 +3,6 @@ id: 67d560759cc85f3031977692
 title: Task 44
 challengeType: 19
 dashedName: task-44
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-use-modal-verbs/67d58715562a4f42449f580e.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-modal-verbs/67d58715562a4f42449f580e.md
@@ -3,7 +3,6 @@ id: 67d58715562a4f42449f580e
 title: Task 61
 challengeType: 19
 dashedName: task-61
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-use-modal-verbs/67d599679bb7ba48f5ce25ad.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-modal-verbs/67d599679bb7ba48f5ce25ad.md
@@ -3,7 +3,6 @@ id: 67d599679bb7ba48f5ce25ad
 title: Task 69
 challengeType: 19
 dashedName: task-69
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-use-modal-verbs/67d5a34ddf37aa4e560ca2f3.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-modal-verbs/67d5a34ddf37aa4e560ca2f3.md
@@ -3,7 +3,6 @@ id: 67d5a34ddf37aa4e560ca2f3
 title: Task 74
 challengeType: 19
 dashedName: task-74
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-use-modal-verbs/67d6a204243dc159d5612daa.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-modal-verbs/67d6a204243dc159d5612daa.md
@@ -3,7 +3,6 @@ id: 67d6a204243dc159d5612daa
 title: Task 84
 challengeType: 19
 dashedName: task-84
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-use-modal-verbs/67d6ab3b236dd15df5c2570f.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-modal-verbs/67d6ab3b236dd15df5c2570f.md
@@ -3,7 +3,6 @@ id: 67d6ab3b236dd15df5c2570f
 title: Task 89
 challengeType: 19
 dashedName: task-89
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-use-modal-verbs/67d6b3051709626262b52c8f.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-modal-verbs/67d6b3051709626262b52c8f.md
@@ -3,7 +3,6 @@ id: 67d6b3051709626262b52c8f
 title: Task 94
 challengeType: 19
 dashedName: task-94
-showSpeakingButton: true
 lang: en-US
 ---
 <!-- (audio) James: It's possible. If we get a lot of users at once, the servers could get overwhelmed. We may need to scale up to handle the load. -->

--- a/curriculum/challenges/english/blocks/learn-how-to-use-modal-verbs/67d7ea1803a3c97802263d54.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-modal-verbs/67d7ea1803a3c97802263d54.md
@@ -3,7 +3,6 @@ id: 67d7ea1803a3c97802263d54
 title: Task 111
 challengeType: 19
 dashedName: task-111
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-use-modal-verbs/67d808875f706787fb47d4ee.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-modal-verbs/67d808875f706787fb47d4ee.md
@@ -3,7 +3,6 @@ id: 67d808875f706787fb47d4ee
 title: Task 124
 challengeType: 19
 dashedName: task-124
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-use-modal-verbs/67d81e8afbcfb390dd7fc1e0.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-modal-verbs/67d81e8afbcfb390dd7fc1e0.md
@@ -3,7 +3,6 @@ id: 67d81e8afbcfb390dd7fc1e0
 title: Task 133
 challengeType: 19
 dashedName: task-133
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-use-modal-verbs/67d83609f2715198a3c89200.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-modal-verbs/67d83609f2715198a3c89200.md
@@ -3,7 +3,6 @@ id: 67d83609f2715198a3c89200
 title: Task 140
 challengeType: 19
 dashedName: task-140
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-use-modal-verbs/67d83e1d03559a9d9d4ef9fd.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-modal-verbs/67d83e1d03559a9d9d4ef9fd.md
@@ -3,7 +3,6 @@ id: 67d83e1d03559a9d9d4ef9fd
 title: Task 145
 challengeType: 19
 dashedName: task-145
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-use-modal-verbs/67d8483c305f05a47c2ace10.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-modal-verbs/67d8483c305f05a47c2ace10.md
@@ -3,7 +3,6 @@ id: 67d8483c305f05a47c2ace10
 title: Task 152
 challengeType: 19
 dashedName: task-152
-showSpeakingButton: true
 lang: en-US
 ---
 <!-- (audio) Lisa: Let me know if you find anything unusual in the logs. -->

--- a/curriculum/challenges/english/blocks/learn-how-to-use-prepositions-according-to-context/6839a3caa7e89685e478a7bd.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-prepositions-according-to-context/6839a3caa7e89685e478a7bd.md
@@ -3,7 +3,6 @@ id: 6839a3caa7e89685e478a7bd
 title: Task 14
 challengeType: 19
 dashedName: task-14
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-use-prepositions-according-to-context/683fd6955b04971b1182b0cd.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-prepositions-according-to-context/683fd6955b04971b1182b0cd.md
@@ -3,7 +3,6 @@ id: 683fd6955b04971b1182b0cd
 title: Task 42
 challengeType: 19
 dashedName: task-42
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-use-prepositions-according-to-context/68557008a40efb11fa809c4b.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-prepositions-according-to-context/68557008a40efb11fa809c4b.md
@@ -3,7 +3,6 @@ id: 68557008a40efb11fa809c4b
 title: Task 93
 challengeType: 19
 dashedName: task-93
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-use-prepositions-according-to-context/685688a2206741326d1baf46.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-prepositions-according-to-context/685688a2206741326d1baf46.md
@@ -3,7 +3,6 @@ id: 685688a2206741326d1baf46
 title: Task 103
 challengeType: 19
 dashedName: task-103
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-use-prepositions-according-to-context/6857bb86af51f44e77e1c90b.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-prepositions-according-to-context/6857bb86af51f44e77e1c90b.md
@@ -3,7 +3,6 @@ id: 6857bb86af51f44e77e1c90b
 title: Task 135
 challengeType: 19
 dashedName: task-135
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-use-prepositions-according-to-context/685809182b4523083294eb26.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-prepositions-according-to-context/685809182b4523083294eb26.md
@@ -3,7 +3,6 @@ id: 685809182b4523083294eb26
 title: Task 150
 challengeType: 19
 dashedName: task-150
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-use-reported-speech/68272eda823b28e0f3504236.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-reported-speech/68272eda823b28e0f3504236.md
@@ -3,7 +3,6 @@ id: 68272eda823b28e0f3504236
 title: Task 5
 challengeType: 19
 dashedName: task-5
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-use-reported-speech/682e6df0d4a357cf3f2e989a.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-reported-speech/682e6df0d4a357cf3f2e989a.md
@@ -3,7 +3,6 @@ id: 682e6df0d4a357cf3f2e989a
 title: Task 22
 challengeType: 19
 dashedName: task-22
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-use-reported-speech/682f1565a50e553d51c91ee9.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-reported-speech/682f1565a50e553d51c91ee9.md
@@ -3,7 +3,6 @@ id: 682f1565a50e553d51c91ee9
 title: Task 29
 challengeType: 19
 dashedName: task-29
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-use-reported-speech/682f218f8d26107f3ce0864b.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-reported-speech/682f218f8d26107f3ce0864b.md
@@ -3,7 +3,6 @@ id: 682f218f8d26107f3ce0864b
 title: Task 36
 challengeType: 19
 dashedName: task-36
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-use-reported-speech/68307d03e70004eb66f25d7f.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-reported-speech/68307d03e70004eb66f25d7f.md
@@ -3,7 +3,6 @@ id: 68307d03e70004eb66f25d7f
 title: Task 62
 challengeType: 19
 dashedName: task-62
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-use-reported-speech/68309feab6f39b6d990049a6.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-reported-speech/68309feab6f39b6d990049a6.md
@@ -3,7 +3,6 @@ id: 68309feab6f39b6d990049a6
 title: Task 75
 challengeType: 19
 dashedName: task-75
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-use-reported-speech/6830a7c783da8e9670f9f606.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-reported-speech/6830a7c783da8e9670f9f606.md
@@ -3,7 +3,6 @@ id: 6830a7c783da8e9670f9f606
 title: Task 82
 challengeType: 19
 dashedName: task-82
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-use-reported-speech/68385e451b980e9e99d2c765.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-reported-speech/68385e451b980e9e99d2c765.md
@@ -3,7 +3,6 @@ id: 68385e451b980e9e99d2c765
 title: Task 106
 challengeType: 19
 dashedName: task-106
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-use-reported-speech/6838bc27830fcffdf3128076.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-reported-speech/6838bc27830fcffdf3128076.md
@@ -3,7 +3,6 @@ id: 6838bc27830fcffdf3128076
 title: Task 111
 challengeType: 19
 dashedName: task-111
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-how-to-use-reported-speech/6838feaafafc34499e5ae580.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-reported-speech/6838feaafafc34499e5ae580.md
@@ -3,7 +3,6 @@ id: 6838feaafafc34499e5ae580
 title: Task 116
 challengeType: 19
 dashedName: task-116
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-present-perfect-while-talking-about-accessibility/6717b20b952c096b3dee0834.md
+++ b/curriculum/challenges/english/blocks/learn-present-perfect-while-talking-about-accessibility/6717b20b952c096b3dee0834.md
@@ -3,7 +3,6 @@ id: 6717b20b952c096b3dee0834
 title: Task 10
 challengeType: 19
 dashedName: task-10
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-present-perfect-while-talking-about-accessibility/671a40b415343c1f26e0c005.md
+++ b/curriculum/challenges/english/blocks/learn-present-perfect-while-talking-about-accessibility/671a40b415343c1f26e0c005.md
@@ -3,7 +3,6 @@ id: 671a40b415343c1f26e0c005
 title: Task 21
 challengeType: 19
 dashedName: task-21
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-present-perfect-while-talking-about-accessibility/671f8cdb0d31cb710d7ad031.md
+++ b/curriculum/challenges/english/blocks/learn-present-perfect-while-talking-about-accessibility/671f8cdb0d31cb710d7ad031.md
@@ -3,7 +3,6 @@ id: 671f8cdb0d31cb710d7ad031
 title: Task 44
 challengeType: 19
 dashedName: task-44
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-present-perfect-while-talking-about-accessibility/671f9aa56463ab7f6d98325f.md
+++ b/curriculum/challenges/english/blocks/learn-present-perfect-while-talking-about-accessibility/671f9aa56463ab7f6d98325f.md
@@ -3,7 +3,6 @@ id: 671f9aa56463ab7f6d98325f
 title: Task 51
 challengeType: 19
 dashedName: task-51
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-present-perfect-while-talking-about-accessibility/672dec93f008b3d8169568e8.md
+++ b/curriculum/challenges/english/blocks/learn-present-perfect-while-talking-about-accessibility/672dec93f008b3d8169568e8.md
@@ -3,7 +3,6 @@ id: 672dec93f008b3d8169568e8
 title: Task 108
 challengeType: 19
 dashedName: task-108
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/challenges/english/blocks/learn-present-perfect-while-talking-about-accessibility/673df0c78bdd11c7195010cb.md
+++ b/curriculum/challenges/english/blocks/learn-present-perfect-while-talking-about-accessibility/673df0c78bdd11c7195010cb.md
@@ -3,7 +3,6 @@ id: 673df0c78bdd11c7195010cb
 title: Task 88
 challengeType: 19
 dashedName: task-88
-showSpeakingButton: true
 lang: en-US
 ---
 

--- a/curriculum/schema/__snapshots__/challenge-schema.test.mjs.snap
+++ b/curriculum/schema/__snapshots__/challenge-schema.test.mjs.snap
@@ -2015,9 +2015,6 @@ exports[`challenge schema > should not be changed without informing the mobile t
       },
       "type": "object",
     },
-    "showSpeakingButton": {
-      "type": "boolean",
-    },
     "solutions": {
       "items": [
         {

--- a/curriculum/schema/challenge-schema.js
+++ b/curriculum/schema/challenge-schema.js
@@ -359,7 +359,6 @@ export const schema = Joi.object().keys({
         'array.unique': 'Dialogues must not have overlapping times.'
       })
   }),
-  showSpeakingButton: Joi.bool(),
   // This is only to be used for dynamic client updates.
   sourceLocation: Joi.string(),
   solutions: Joi.array().items(Joi.array().items(fileJoi).min(1)),


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Removes `showSpeakingButton` boolean.

This property was added when we were implementing the speaking modal. But we ended up using the audio ID as the source of truth for controlling the button display (the button does not show up if audio ID is missing). So this `showSpeakingButton` is now dead code.

<!-- Feel free to add any additional description of changes below this line -->
