### PR TITLE
fix(a11y): add initial focus to play button in speaking modal

### DIFF
--- a/client/src/templates/Challenges/components/speaking-modal.tsx
+++ b/client/src/templates/Challenges/components/speaking-modal.tsx
@@ -151,6 +151,7 @@ const SpeakingModal = ({
     useState<ComparisonResult | null>(null);
   const [hasStartedRecording, setHasStartedRecording] = useState(false);
   const [previouslyListening, setPreviouslyListening] = useState(false);
+  const playButtonRef = useRef<HTMLButtonElement | null>(null);
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const stopListeningTimeoutRef = useRef<
     ReturnType<typeof setTimeout> | undefined
@@ -311,7 +312,12 @@ const SpeakingModal = ({
   };
 
   return (
-    <Modal onClose={closeSpeakingModal} open={isSpeakingModalOpen} size='large'>
+    <Modal
+      onClose={closeSpeakingModal}
+      open={isSpeakingModalOpen}
+      size='large'
+      initialFocus={playButtonRef}
+    >
       <Modal.Header closeButtonClassNames='close'>
         {t('speaking-modal.heading')}
       </Modal.Header>
@@ -323,6 +329,7 @@ const SpeakingModal = ({
             {sentence}
           </p>
           <Button
+            ref={playButtonRef}
             size='medium'
             onClick={() => void handlePlay()}
             aria-describedby='speaking-sentence'

--- a/e2e/multiple-choice-question-challenge.spec.ts
+++ b/e2e/multiple-choice-question-challenge.spec.ts
@@ -47,11 +47,11 @@ test.describe('Multiple Choice Question Challenge - With Speaking Modal', () => 
 
     await expect(page.getByRole('dialog')).toBeVisible();
 
-    await expect(
-      page.getByRole('button', {
-        name: translations['speaking-modal']['play']
-      })
-    ).toBeVisible();
+    const playButton = page.getByRole('button', {
+      name: translations['speaking-modal']['play']
+    });
+    await expect(playButton).toBeVisible();
+    await expect(playButton).toBeFocused(); // The button is focused by default
     await expect(
       page.getByRole('button', {
         name: translations['speaking-modal']['record']


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR:
- Sets the initial focus to the play button in the speaking modal, so the users can start interacting with the main content quicker.
- Closes #62254

<details>
<summary>Screen recording</summary>

https://github.com/user-attachments/assets/318fefc7-f804-46d2-8842-431076340f0e

</details>

<!-- Feel free to add any additional description of changes below this line -->
