### PR TITLE
fix(curriculum): remove before/after-user-code from rosetta challenges 31-35

### DIFF
--- a/curriculum/challenges/english/blocks/rosetta-code-challenges/59669d08d75b60482359409f.md
+++ b/curriculum/challenges/english/blocks/rosetta-code-challenges/59669d08d75b60482359409f.md
@@ -46,14 +46,6 @@ assert(getDateFormats().length === 2);
 `getDateFormats` should return the correct date in the right format
 
 ```js
-assert.deepEqual(getDateFormats(), dates, equalsMessage);
-```
-
-# --seed--
-
-## --after-user-code--
-
-```js
 const getDateSolution = () => {
   const date = new Date();
   const weekdays = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
@@ -65,7 +57,10 @@ const getDateSolution = () => {
 
 const dates = getDateSolution();
 const equalsMessage = `message: <code>getDataFormats()</code> should return <code>["${dates[0]}", "${dates[1]}"]</code>.`;
+assert.deepEqual(getDateFormats(), dates, equalsMessage);
 ```
+
+# --seed--
 
 ## --seed-contents--
 

--- a/curriculum/challenges/english/blocks/rosetta-code-challenges/5966f99c45e8976909a85575.md
+++ b/curriculum/challenges/english/blocks/rosetta-code-challenges/5966f99c45e8976909a85575.md
@@ -14,6 +14,13 @@ A company decides that whenever Xmas falls on a Sunday they will give their work
 
 Write a function that takes a start year and an end year and return an array of all the years where the 25th of December will be a Sunday.
 
+# --before-each--
+
+```js
+const firstSolution = [1977, 1983, 1988, 1994, 2005, 2011, 2016];
+const secondSolution = [2011, 2016, 2022, 2033, 2039, 2044, 2050, 2061, 2067, 2072, 2078, 2089, 2095, 2101, 2107, 2112, 2118];
+```
+
 # --hints--
 
 `findXmasSunday` should be a function.
@@ -41,13 +48,6 @@ assert.deepEqual(findXmasSunday(2008, 2121), secondSolution);
 ```
 
 # --seed--
-
-## --after-user-code--
-
-```js
-const firstSolution = [1977, 1983, 1988, 1994, 2005, 2011, 2016];
-const secondSolution = [2011, 2016, 2022, 2033, 2039, 2044, 2050, 2061, 2067, 2072, 2078, 2089, 2095, 2101, 2107, 2112, 2118];
-```
 
 ## --seed-contents--
 

--- a/curriculum/challenges/english/blocks/rosetta-code-challenges/59694356a6e7011f7f1c5f4e.md
+++ b/curriculum/challenges/english/blocks/rosetta-code-challenges/59694356a6e7011f7f1c5f4e.md
@@ -79,6 +79,30 @@ The algorithm follows:
 
 Write a function to take a deal number and deal cards in the same order as this algorithm. The function must return a two dimensional array representing the FreeCell board.
 
+# --before-each--
+
+```js
+const replaceThis = 3;
+const game1 = [
+  ['JD', '2D', '9H', 'JC', '5D', '7H', '7C', '5H'],
+  ['KD', 'KC', '9S', '5S', 'AD', 'QC', 'KH', '3H'],
+  ['2S', 'KS', '9D', 'QD', 'JS', 'AS', 'AH', '3C'],
+  ['4C', '5C', 'TS', 'QH', '4H', 'AC', '4D', '7S'],
+  ['3S', 'TD', '4S', 'TH', '8H', '2C', 'JH', '7D'],
+  ['6D', '8S', '8D', 'QS', '6C', '3D', '8C', 'TC'],
+  ['6S', '9C', '2H', '6H']
+];
+const game617 = [
+  ['7D', 'AD', '5C', '3S', '5S', '8C', '2D', 'AH'],
+  ['TD', '7S', 'QD', 'AC', '6D', '8H', 'AS', 'KH'],
+  ['TH', 'QC', '3H', '9D', '6S', '8D', '3D', 'TC'],
+  ['KD', '5H', '9S', '3C', '8S', '7H', '4D', 'JS'],
+  ['4C', 'QS', '9C', '9H', '7C', '6H', '2C', '2S'],
+  ['4S', 'TS', '2H', '5D', 'JC', '6C', 'JH', 'QH'],
+  ['JD', 'KS', 'KC', '4H']
+];
+```
+
 # --hints--
 
 `dealFreeCell` should be a function.
@@ -112,30 +136,6 @@ assert.deepEqual(dealFreeCell(617), game617);
 ```
 
 # --seed--
-
-## --after-user-code--
-
-```js
-const replaceThis = 3;
-const game1 = [
-  ['JD', '2D', '9H', 'JC', '5D', '7H', '7C', '5H'],
-  ['KD', 'KC', '9S', '5S', 'AD', 'QC', 'KH', '3H'],
-  ['2S', 'KS', '9D', 'QD', 'JS', 'AS', 'AH', '3C'],
-  ['4C', '5C', 'TS', 'QH', '4H', 'AC', '4D', '7S'],
-  ['3S', 'TD', '4S', 'TH', '8H', '2C', 'JH', '7D'],
-  ['6D', '8S', '8D', 'QS', '6C', '3D', '8C', 'TC'],
-  ['6S', '9C', '2H', '6H']
-];
-const game617 = [
-  ['7D', 'AD', '5C', '3S', '5S', '8C', '2D', 'AH'],
-  ['TD', '7S', 'QD', 'AC', '6D', '8H', 'AS', 'KH'],
-  ['TH', 'QC', '3H', '9D', '6S', '8D', '3D', 'TC'],
-  ['KD', '5H', '9S', '3C', '8S', '7H', '4D', 'JS'],
-  ['4C', 'QS', '9C', '9H', '7C', '6H', '2C', '2S'],
-  ['4S', 'TS', '2H', '5D', 'JC', '6C', 'JH', 'QH'],
-  ['JD', 'KS', 'KC', '4H']
-];
-```
 
 ## --seed-contents--
 

--- a/curriculum/challenges/english/blocks/rosetta-code-challenges/596a8888ab7c01048de257d5.md
+++ b/curriculum/challenges/english/blocks/rosetta-code-challenges/596a8888ab7c01048de257d5.md
@@ -19,6 +19,20 @@ This task will not test for:
   <li>Prototype copying</li>
 </ul>
 
+# --before-each--
+
+```js
+const obj1 = { test: 'test' };
+const obj2 = {
+  t: 'test',
+  a: ['an', 'array']
+};
+const obj3 = {
+  t: 'try',
+  o: obj2
+};
+```
+
 # --hints--
 
 `deepcopy` should be a function.
@@ -52,20 +66,6 @@ assert.deepEqual(deepcopy(obj3), obj3);
 ```
 
 # --seed--
-
-## --after-user-code--
-
-```js
-const obj1 = { test: 'test' };
-const obj2 = {
-  t: 'test',
-  a: ['an', 'array']
-};
-const obj3 = {
-  t: 'try',
-  o: obj2
-};
-```
 
 ## --seed-contents--
 

--- a/curriculum/challenges/english/blocks/rosetta-code-challenges/596e414344c3b2872167f0fe.md
+++ b/curriculum/challenges/english/blocks/rosetta-code-challenges/596e414344c3b2872167f0fe.md
@@ -32,6 +32,13 @@ Test your function with the following series of inputs showing your output here 
 
 **Note:** Assume words are non-empty strings of uppercase characters for this task.
 
+# --before-each--
+
+```js
+const testCases = [[], ["ABC"], ["ABC", "DEF"], ["ABC", "DEF", "G", "H"]];
+const results = ["{}", "{ABC}", "{ABC and DEF}", "{ABC, DEF, G and H}"];
+```
+
 # --hints--
 
 `quibble` should be a function.
@@ -71,13 +78,6 @@ assert.equal(quibble(testCases[3]), results[3]);
 ```
 
 # --seed--
-
-## --after-user-code--
-
-```js
-const testCases = [[], ["ABC"], ["ABC", "DEF"], ["ABC", "DEF", "G", "H"]];
-const results = ["{}", "{ABC}", "{ABC and DEF}", "{ABC, DEF, G and H}"];
-```
 
 ## --seed-contents--
 


### PR DESCRIPTION
Continuation of #66344, limited to the next 5 Rosetta files (31-35).