### PR TITLE
fix: wrap editor.focus() in requestAnimationFrame for Firefox compatibility

### DIFF
--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -1115,10 +1115,14 @@ const Editor = (props: EditorProps): JSX.Element => {
     if (!editor || !canFocusOnMountRef.current) return;
     if (!props.usesMultifileEditor) {
       // Only one editor? Focus it.
-      editor.focus();
+      requestAnimationFrame(() => {
+        editor.focus();
+      });
       canFocusOnMountRef.current = false;
     } else if (hasEditableRegion()) {
-      editor.focus();
+      requestAnimationFrame(() => {
+        editor.focus();
+      });
       canFocusOnMountRef.current = false;
     }
   }


### PR DESCRIPTION
## Problem
Firefox blocks programmatic `.focus()` calls that are not directly 
triggered by a user gesture. This caused the code editor to not 
auto-focus after each workshop step when using Firefox, while Chrome 
worked fine.

## Solution
Wrapped both `editor.focus()` calls in `requestAnimationFrame()` in 
`client/src/templates/Challenges/classic/editor.tsx`. 

This defers the focus call to the next animation frame, which Firefox 
allows, making the behavior consistent across browsers.

## Changes
- `client/src/templates/Challenges/classic/editor.tsx`: wrapped two 
  `editor.focus()` calls in `requestAnimationFrame()`

Checklist:


- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #66369
