### PR TITLE
fix(curriculum): clarify step descriptions in employee profile generator workshop

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-employee-profile-generator/694bf6eb530e19a9c48c59f2.md
+++ b/curriculum/challenges/english/blocks/workshop-employee-profile-generator/694bf6eb530e19a9c48c59f2.md
@@ -7,7 +7,7 @@ dashedName: step-11
 
 # --description--
 
-Now complete the sentence by concatenating the string ` years old` to the end of `employee_info`. Remember to include a space at the beginning of your string.
+Now complete the sentence by updating the `employee_info` assignment to also concatenate the string ` years old` at the end. Remember to include a space at the beginning of your string.
 
 Finally, print `employee_info`.
 

--- a/curriculum/challenges/english/blocks/workshop-employee-profile-generator/694bf6eb530e19a9c48c59f5.md
+++ b/curriculum/challenges/english/blocks/workshop-employee-profile-generator/694bf6eb530e19a9c48c59f5.md
@@ -65,7 +65,6 @@ address += ', Apartment 4B'
 employee_age = 28
 employee_info = full_name + ' is ' + str(employee_age) + ' years old'
 print(employee_info)
-years_experience = 5
 experience_years = 5
 experience_info = 'Experience: ' + str(experience_years) + ' years'
 print(experience_info)

--- a/curriculum/challenges/english/blocks/workshop-employee-profile-generator/694bf6eb530e19a9c48c59f6.md
+++ b/curriculum/challenges/english/blocks/workshop-employee-profile-generator/694bf6eb530e19a9c48c59f6.md
@@ -66,7 +66,6 @@ address += ', Apartment 4B'
 employee_age = 28
 employee_info = full_name + ' is ' + str(employee_age) + ' years old'
 print(employee_info)
-years_experience = 5
 experience_years = 5
 experience_info = 'Experience: ' + str(experience_years) + ' years'
 print(experience_info)

--- a/curriculum/challenges/english/blocks/workshop-employee-profile-generator/694bf6eb530e19a9c48c59f7.md
+++ b/curriculum/challenges/english/blocks/workshop-employee-profile-generator/694bf6eb530e19a9c48c59f7.md
@@ -48,7 +48,6 @@ address += ', Apartment 4B'
 employee_age = 28
 employee_info = full_name + ' is ' + str(employee_age) + ' years old'
 print(employee_info)
-years_experience = 5
 experience_years = 5
 experience_info = 'Experience: ' + str(experience_years) + ' years'
 print(experience_info)
@@ -86,7 +85,7 @@ position = 'Data Analyst'
 salary = 75000
 employee_card = f'Employee: {full_name} | Age: {employee_age} | Position: {position} | Salary: ${salary}'
 print(employee_card)
-employee_code = 'DEV-2024-JD-001'
+employee_code = 'DEV-2026-JD-001'
 department = employee_code[0:3]
 print(department)
 year_code = employee_code[4:8]

--- a/curriculum/challenges/english/blocks/workshop-employee-profile-generator/695fd3dde03273875e5d6709.md
+++ b/curriculum/challenges/english/blocks/workshop-employee-profile-generator/695fd3dde03273875e5d6709.md
@@ -7,13 +7,13 @@ dashedName: step-9
 
 # --description--
 
-Now try to concatenate `employee_age` to the end of your `employee_info` string.
+Update the `employee_info` assignment to also concatenate `employee_age` at the end.
 
 Once you've done so, you'll see a `TypeError` in the terminal. In the next step, you'll work on fixing it.
 
 # --hints--
 
-You should concatenate `employee_age` to the end of `employee_info`.
+You should update the `employee_info` assignment to concatenate `employee_age` at the end.
 
 ```js
 const regex = /^employee_info\s*=\s*full_name\s*\+\s*(["']) is \1\s*\+\s*employee_age\s*$/m;  


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Updated steps 9 and 11 trying to clarify to work on the same line
Removed orphaned `years_experience = 5` from seeds in steps 16, 17, and 18. It was never introduced in any step and never used;
Updated `employee_code` value in the step 18 solution from `'DEV-2024-JD-001'` to `'DEV-2026-JD-001'` to match the seed